### PR TITLE
Rework Advantage Air binary_sensor and sensor tests to use snapshots

### DIFF
--- a/tests/components/advantage_air/__init__.py
+++ b/tests/components/advantage_air/__init__.py
@@ -3,7 +3,7 @@
 from unittest.mock import AsyncMock, patch
 
 from homeassistant.components.advantage_air.const import DOMAIN
-from homeassistant.const import CONF_IP_ADDRESS, CONF_PORT
+from homeassistant.const import CONF_IP_ADDRESS, CONF_PORT, Platform
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, load_json_object_fixture
@@ -44,7 +44,9 @@ def patch_update(return_value=True, side_effect=None):
     )
 
 
-async def add_mock_config(hass: HomeAssistant) -> MockConfigEntry:
+async def add_mock_config(
+    hass: HomeAssistant, platforms: list[Platform] | None = None
+) -> MockConfigEntry:
     """Create a fake Advantage Air Config Entry."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -54,6 +56,10 @@ async def add_mock_config(hass: HomeAssistant) -> MockConfigEntry:
     )
 
     entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(entry.entry_id)
+    if platforms is None:
+        await hass.config_entries.async_setup(entry.entry_id)
+    else:
+        with patch("homeassistant.components.advantage_air.PLATFORMS", platforms):
+            await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
     return entry

--- a/tests/components/advantage_air/snapshots/test_binary_sensor.ambr
+++ b/tests/components/advantage_air/snapshots/test_binary_sensor.ambr
@@ -1,0 +1,759 @@
+# serializer version: 1
+# name: test_binary_sensor_platform[binary_sensor.myauto_filter-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.myauto_filter',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Filter',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': None,
+    'original_name': 'Filter',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac3-filter',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensor_platform[binary_sensor.myauto_filter-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'myauto Filter',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.myauto_filter',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_binary_sensor_platform[binary_sensor.mytemp_filter-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.mytemp_filter',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Filter',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': None,
+    'original_name': 'Filter',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac2-filter',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensor_platform[binary_sensor.mytemp_filter-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'mytemp Filter',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.mytemp_filter',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_binary_sensor_platform[binary_sensor.mytemp_zone_a_motion-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.mytemp_zone_a_motion',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Zone A motion',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.MOTION: 'motion'>,
+    'original_icon': None,
+    'original_name': 'Zone A motion',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac2-z01-motion',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensor_platform[binary_sensor.mytemp_zone_a_motion-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'motion',
+      'friendly_name': 'mytemp Zone A motion',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.mytemp_zone_a_motion',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_binary_sensor_platform[binary_sensor.mytemp_zone_a_myzone-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.mytemp_zone_a_myzone',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Zone A myZone',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Zone A myZone',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac2-z01-myzone',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensor_platform[binary_sensor.mytemp_zone_a_myzone-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'mytemp Zone A myZone',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.mytemp_zone_a_myzone',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_binary_sensor_platform[binary_sensor.mytemp_zone_b_motion-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.mytemp_zone_b_motion',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Zone B motion',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.MOTION: 'motion'>,
+    'original_icon': None,
+    'original_name': 'Zone B motion',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac2-z02-motion',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensor_platform[binary_sensor.mytemp_zone_b_motion-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'motion',
+      'friendly_name': 'mytemp Zone B motion',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.mytemp_zone_b_motion',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_binary_sensor_platform[binary_sensor.mytemp_zone_b_myzone-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.mytemp_zone_b_myzone',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Zone B myZone',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Zone B myZone',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac2-z02-myzone',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensor_platform[binary_sensor.mytemp_zone_b_myzone-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'mytemp Zone B myZone',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.mytemp_zone_b_myzone',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_binary_sensor_platform[binary_sensor.myzone_filter-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.myzone_filter',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Filter',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': None,
+    'original_name': 'Filter',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac1-filter',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensor_platform[binary_sensor.myzone_filter-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'myzone Filter',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.myzone_filter',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_binary_sensor_platform[binary_sensor.myzone_zone_3_motion-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.myzone_zone_3_motion',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Zone 3 motion',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.MOTION: 'motion'>,
+    'original_icon': None,
+    'original_name': 'Zone 3 motion',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac1-z03-motion',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensor_platform[binary_sensor.myzone_zone_3_motion-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'motion',
+      'friendly_name': 'myzone Zone 3 motion',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.myzone_zone_3_motion',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_binary_sensor_platform[binary_sensor.myzone_zone_3_myzone-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.myzone_zone_3_myzone',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Zone 3 myZone',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Zone 3 myZone',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac1-z03-myzone',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensor_platform[binary_sensor.myzone_zone_3_myzone-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'myzone Zone 3 myZone',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.myzone_zone_3_myzone',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_binary_sensor_platform[binary_sensor.myzone_zone_4_myzone-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.myzone_zone_4_myzone',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Zone 4 myZone',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Zone 4 myZone',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac1-z04-myzone',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensor_platform[binary_sensor.myzone_zone_4_myzone-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'myzone Zone 4 myZone',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.myzone_zone_4_myzone',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_binary_sensor_platform[binary_sensor.myzone_zone_5_myzone-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.myzone_zone_5_myzone',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Zone 5 myZone',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Zone 5 myZone',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac1-z05-myzone',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensor_platform[binary_sensor.myzone_zone_5_myzone-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'myzone Zone 5 myZone',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.myzone_zone_5_myzone',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_binary_sensor_platform[binary_sensor.myzone_zone_closed_with_sensor_motion-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.myzone_zone_closed_with_sensor_motion',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Zone closed with Sensor motion',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.MOTION: 'motion'>,
+    'original_icon': None,
+    'original_name': 'Zone closed with Sensor motion',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac1-z02-motion',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensor_platform[binary_sensor.myzone_zone_closed_with_sensor_motion-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'motion',
+      'friendly_name': 'myzone Zone closed with Sensor motion',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.myzone_zone_closed_with_sensor_motion',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_binary_sensor_platform[binary_sensor.myzone_zone_closed_with_sensor_myzone-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.myzone_zone_closed_with_sensor_myzone',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Zone closed with Sensor myZone',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Zone closed with Sensor myZone',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac1-z02-myzone',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensor_platform[binary_sensor.myzone_zone_closed_with_sensor_myzone-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'myzone Zone closed with Sensor myZone',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.myzone_zone_closed_with_sensor_myzone',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_binary_sensor_platform[binary_sensor.myzone_zone_open_with_sensor_motion-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.myzone_zone_open_with_sensor_motion',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Zone open with Sensor motion',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.MOTION: 'motion'>,
+    'original_icon': None,
+    'original_name': 'Zone open with Sensor motion',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac1-z01-motion',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensor_platform[binary_sensor.myzone_zone_open_with_sensor_motion-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'motion',
+      'friendly_name': 'myzone Zone open with Sensor motion',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.myzone_zone_open_with_sensor_motion',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_binary_sensor_platform[binary_sensor.myzone_zone_open_with_sensor_myzone-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.myzone_zone_open_with_sensor_myzone',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Zone open with Sensor myZone',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Zone open with Sensor myZone',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac1-z01-myzone',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensor_platform[binary_sensor.myzone_zone_open_with_sensor_myzone-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'myzone Zone open with Sensor myZone',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.myzone_zone_open_with_sensor_myzone',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---

--- a/tests/components/advantage_air/snapshots/test_sensor.ambr
+++ b/tests/components/advantage_air/snapshots/test_sensor.ambr
@@ -1,0 +1,1489 @@
+# serializer version: 1
+# name: test_sensor_platform[sensor.myauto_time_to_off-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.myauto_time_to_off',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Time to Off',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:timer-off-outline',
+    'original_name': 'Time to Off',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac3-timetoOff',
+    'unit_of_measurement': 'min',
+  })
+# ---
+# name: test_sensor_platform[sensor.myauto_time_to_off-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'myauto Time to Off',
+      'icon': 'mdi:timer-off-outline',
+      'unit_of_measurement': 'min',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.myauto_time_to_off',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensor_platform[sensor.myauto_time_to_on-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.myauto_time_to_on',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Time to On',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:timer-off-outline',
+    'original_name': 'Time to On',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac3-timetoOn',
+    'unit_of_measurement': 'min',
+  })
+# ---
+# name: test_sensor_platform[sensor.myauto_time_to_on-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'myauto Time to On',
+      'icon': 'mdi:timer-off-outline',
+      'unit_of_measurement': 'min',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.myauto_time_to_on',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensor_platform[sensor.mytemp_time_to_off-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.mytemp_time_to_off',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Time to Off',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:timer-off-outline',
+    'original_name': 'Time to Off',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac2-timetoOff',
+    'unit_of_measurement': 'min',
+  })
+# ---
+# name: test_sensor_platform[sensor.mytemp_time_to_off-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'mytemp Time to Off',
+      'icon': 'mdi:timer-off-outline',
+      'unit_of_measurement': 'min',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mytemp_time_to_off',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensor_platform[sensor.mytemp_time_to_on-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.mytemp_time_to_on',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Time to On',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:timer-outline',
+    'original_name': 'Time to On',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac2-timetoOn',
+    'unit_of_measurement': 'min',
+  })
+# ---
+# name: test_sensor_platform[sensor.mytemp_time_to_on-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'mytemp Time to On',
+      'icon': 'mdi:timer-outline',
+      'unit_of_measurement': 'min',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mytemp_time_to_on',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '20',
+  })
+# ---
+# name: test_sensor_platform[sensor.mytemp_zone_a_signal-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.mytemp_zone_a_signal',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Zone A signal',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:wifi-strength-2',
+    'original_name': 'Zone A signal',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac2-z01-signal',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensor_platform[sensor.mytemp_zone_a_signal-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'mytemp Zone A signal',
+      'icon': 'mdi:wifi-strength-2',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mytemp_zone_a_signal',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '40',
+  })
+# ---
+# name: test_sensor_platform[sensor.mytemp_zone_a_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.mytemp_zone_a_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Zone A temperature',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Zone A temperature',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac2-z01-temp',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensor_platform[sensor.mytemp_zone_a_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'mytemp Zone A temperature',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mytemp_zone_a_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '25',
+  })
+# ---
+# name: test_sensor_platform[sensor.mytemp_zone_a_vent-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.mytemp_zone_a_vent',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Zone A vent',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:fan',
+    'original_name': 'Zone A vent',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac2-z01-vent',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensor_platform[sensor.mytemp_zone_a_vent-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'mytemp Zone A vent',
+      'icon': 'mdi:fan',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mytemp_zone_a_vent',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '100',
+  })
+# ---
+# name: test_sensor_platform[sensor.mytemp_zone_b_signal-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.mytemp_zone_b_signal',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Zone B signal',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:wifi-strength-outline',
+    'original_name': 'Zone B signal',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac2-z02-signal',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensor_platform[sensor.mytemp_zone_b_signal-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'mytemp Zone B signal',
+      'icon': 'mdi:wifi-strength-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mytemp_zone_b_signal',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '10',
+  })
+# ---
+# name: test_sensor_platform[sensor.mytemp_zone_b_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.mytemp_zone_b_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Zone B temperature',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Zone B temperature',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac2-z02-temp',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensor_platform[sensor.mytemp_zone_b_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'mytemp Zone B temperature',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mytemp_zone_b_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '26',
+  })
+# ---
+# name: test_sensor_platform[sensor.mytemp_zone_b_vent-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.mytemp_zone_b_vent',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Zone B vent',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:fan',
+    'original_name': 'Zone B vent',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac2-z02-vent',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensor_platform[sensor.mytemp_zone_b_vent-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'mytemp Zone B vent',
+      'icon': 'mdi:fan',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mytemp_zone_b_vent',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '50',
+  })
+# ---
+# name: test_sensor_platform[sensor.myzone_time_to_off-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.myzone_time_to_off',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Time to Off',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:timer-outline',
+    'original_name': 'Time to Off',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac1-timetoOff',
+    'unit_of_measurement': 'min',
+  })
+# ---
+# name: test_sensor_platform[sensor.myzone_time_to_off-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'myzone Time to Off',
+      'icon': 'mdi:timer-outline',
+      'unit_of_measurement': 'min',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.myzone_time_to_off',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '10',
+  })
+# ---
+# name: test_sensor_platform[sensor.myzone_time_to_on-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.myzone_time_to_on',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Time to On',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:timer-off-outline',
+    'original_name': 'Time to On',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac1-timetoOn',
+    'unit_of_measurement': 'min',
+  })
+# ---
+# name: test_sensor_platform[sensor.myzone_time_to_on-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'myzone Time to On',
+      'icon': 'mdi:timer-off-outline',
+      'unit_of_measurement': 'min',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.myzone_time_to_on',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensor_platform[sensor.myzone_zone_3_signal-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.myzone_zone_3_signal',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Zone 3 signal',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:wifi-strength-1',
+    'original_name': 'Zone 3 signal',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac1-z03-signal',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensor_platform[sensor.myzone_zone_3_signal-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'myzone Zone 3 signal',
+      'icon': 'mdi:wifi-strength-1',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.myzone_zone_3_signal',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '25',
+  })
+# ---
+# name: test_sensor_platform[sensor.myzone_zone_3_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.myzone_zone_3_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Zone 3 temperature',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Zone 3 temperature',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac1-z03-temp',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensor_platform[sensor.myzone_zone_3_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'myzone Zone 3 temperature',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.myzone_zone_3_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '25',
+  })
+# ---
+# name: test_sensor_platform[sensor.myzone_zone_3_vent-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.myzone_zone_3_vent',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Zone 3 vent',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:fan-off',
+    'original_name': 'Zone 3 vent',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac1-z03-vent',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensor_platform[sensor.myzone_zone_3_vent-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'myzone Zone 3 vent',
+      'icon': 'mdi:fan-off',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.myzone_zone_3_vent',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensor_platform[sensor.myzone_zone_4_signal-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.myzone_zone_4_signal',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Zone 4 signal',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:wifi-strength-3',
+    'original_name': 'Zone 4 signal',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac1-z04-signal',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensor_platform[sensor.myzone_zone_4_signal-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'myzone Zone 4 signal',
+      'icon': 'mdi:wifi-strength-3',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.myzone_zone_4_signal',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '75',
+  })
+# ---
+# name: test_sensor_platform[sensor.myzone_zone_4_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.myzone_zone_4_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Zone 4 temperature',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Zone 4 temperature',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac1-z04-temp',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensor_platform[sensor.myzone_zone_4_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'myzone Zone 4 temperature',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.myzone_zone_4_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '25',
+  })
+# ---
+# name: test_sensor_platform[sensor.myzone_zone_4_vent-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.myzone_zone_4_vent',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Zone 4 vent',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:fan-off',
+    'original_name': 'Zone 4 vent',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac1-z04-vent',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensor_platform[sensor.myzone_zone_4_vent-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'myzone Zone 4 vent',
+      'icon': 'mdi:fan-off',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.myzone_zone_4_vent',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensor_platform[sensor.myzone_zone_5_signal-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.myzone_zone_5_signal',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Zone 5 signal',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:wifi-strength-4',
+    'original_name': 'Zone 5 signal',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac1-z05-signal',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensor_platform[sensor.myzone_zone_5_signal-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'myzone Zone 5 signal',
+      'icon': 'mdi:wifi-strength-4',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.myzone_zone_5_signal',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '100',
+  })
+# ---
+# name: test_sensor_platform[sensor.myzone_zone_5_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.myzone_zone_5_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Zone 5 temperature',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Zone 5 temperature',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac1-z05-temp',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensor_platform[sensor.myzone_zone_5_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'myzone Zone 5 temperature',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.myzone_zone_5_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '25',
+  })
+# ---
+# name: test_sensor_platform[sensor.myzone_zone_5_vent-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.myzone_zone_5_vent',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Zone 5 vent',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:fan-off',
+    'original_name': 'Zone 5 vent',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac1-z05-vent',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensor_platform[sensor.myzone_zone_5_vent-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'myzone Zone 5 vent',
+      'icon': 'mdi:fan-off',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.myzone_zone_5_vent',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensor_platform[sensor.myzone_zone_closed_with_sensor_signal-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.myzone_zone_closed_with_sensor_signal',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Zone closed with Sensor signal',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:wifi-strength-outline',
+    'original_name': 'Zone closed with Sensor signal',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac1-z02-signal',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensor_platform[sensor.myzone_zone_closed_with_sensor_signal-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'myzone Zone closed with Sensor signal',
+      'icon': 'mdi:wifi-strength-outline',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.myzone_zone_closed_with_sensor_signal',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '10',
+  })
+# ---
+# name: test_sensor_platform[sensor.myzone_zone_closed_with_sensor_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.myzone_zone_closed_with_sensor_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Zone closed with Sensor temperature',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Zone closed with Sensor temperature',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac1-z02-temp',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensor_platform[sensor.myzone_zone_closed_with_sensor_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'myzone Zone closed with Sensor temperature',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.myzone_zone_closed_with_sensor_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '25',
+  })
+# ---
+# name: test_sensor_platform[sensor.myzone_zone_closed_with_sensor_vent-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.myzone_zone_closed_with_sensor_vent',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Zone closed with Sensor vent',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:fan-off',
+    'original_name': 'Zone closed with Sensor vent',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac1-z02-vent',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensor_platform[sensor.myzone_zone_closed_with_sensor_vent-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'myzone Zone closed with Sensor vent',
+      'icon': 'mdi:fan-off',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.myzone_zone_closed_with_sensor_vent',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensor_platform[sensor.myzone_zone_open_with_sensor_signal-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.myzone_zone_open_with_sensor_signal',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Zone open with Sensor signal',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:wifi-strength-2',
+    'original_name': 'Zone open with Sensor signal',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac1-z01-signal',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensor_platform[sensor.myzone_zone_open_with_sensor_signal-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'myzone Zone open with Sensor signal',
+      'icon': 'mdi:wifi-strength-2',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.myzone_zone_open_with_sensor_signal',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '40',
+  })
+# ---
+# name: test_sensor_platform[sensor.myzone_zone_open_with_sensor_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.myzone_zone_open_with_sensor_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Zone open with Sensor temperature',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Zone open with Sensor temperature',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac1-z01-temp',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensor_platform[sensor.myzone_zone_open_with_sensor_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'myzone Zone open with Sensor temperature',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.myzone_zone_open_with_sensor_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '25',
+  })
+# ---
+# name: test_sensor_platform[sensor.myzone_zone_open_with_sensor_vent-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.myzone_zone_open_with_sensor_vent',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Zone open with Sensor vent',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:fan',
+    'original_name': 'Zone open with Sensor vent',
+    'platform': 'advantage_air',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uniqueid-ac1-z01-vent',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensor_platform[sensor.myzone_zone_open_with_sensor_vent-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'myzone Zone open with Sensor vent',
+      'icon': 'mdi:fan',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.myzone_zone_open_with_sensor_vent',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '100',
+  })
+# ---

--- a/tests/components/advantage_air/test_binary_sensor.py
+++ b/tests/components/advantage_air/test_binary_sensor.py
@@ -1,109 +1,27 @@
 """Test the Advantage Air Binary Sensor Platform."""
 
-from datetime import timedelta
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
-from homeassistant.const import STATE_OFF, STATE_ON
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
-from homeassistant.util import dt as dt_util
 
 from . import add_mock_config
 
-from tests.common import async_fire_time_changed
+from tests.common import snapshot_platform
 
 
-async def test_binary_sensor_async_setup_entry(
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_binary_sensor_platform(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
     mock_get: AsyncMock,
 ) -> None:
-    """Test binary sensor setup."""
+    """Test binary sensor platform."""
 
-    await add_mock_config(hass)
-
-    # Test First Air Filter
-    entity_id = "binary_sensor.myzone_filter"
-    state = hass.states.get(entity_id)
-    assert state
-    assert state.state == STATE_OFF
-
-    entry = entity_registry.async_get(entity_id)
-    assert entry
-    assert entry.unique_id == "uniqueid-ac1-filter"
-
-    # Test Second Air Filter
-    entity_id = "binary_sensor.mytemp_filter"
-    state = hass.states.get(entity_id)
-    assert state
-    assert state.state == STATE_ON
-
-    entry = entity_registry.async_get(entity_id)
-    assert entry
-    assert entry.unique_id == "uniqueid-ac2-filter"
-
-    # Test First Motion Sensor
-    entity_id = "binary_sensor.myzone_zone_open_with_sensor_motion"
-    state = hass.states.get(entity_id)
-    assert state
-    assert state.state == STATE_ON
-
-    entry = entity_registry.async_get(entity_id)
-    assert entry
-    assert entry.unique_id == "uniqueid-ac1-z01-motion"
-
-    # Test Second Motion Sensor
-    entity_id = "binary_sensor.myzone_zone_closed_with_sensor_motion"
-    state = hass.states.get(entity_id)
-    assert state
-    assert state.state == STATE_OFF
-
-    entry = entity_registry.async_get(entity_id)
-    assert entry
-    assert entry.unique_id == "uniqueid-ac1-z02-motion"
-
-    # Test First MyZone Sensor (disabled by default)
-    entity_id = "binary_sensor.myzone_zone_open_with_sensor_myzone"
-
-    assert not hass.states.get(entity_id)
-
-    mock_get.reset_mock()
-
-    with patch("homeassistant.config_entries.RELOAD_AFTER_UPDATE_DELAY", 1):
-        entity_registry.async_update_entity(entity_id=entity_id, disabled_by=None)
-        await hass.async_block_till_done()
-
-        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=2))
-        await hass.async_block_till_done(wait_background_tasks=True)
-        assert len(mock_get.mock_calls) == 1
-
-    state = hass.states.get(entity_id)
-    assert state
-    assert state.state == STATE_ON
-
-    entry = entity_registry.async_get(entity_id)
-    assert entry
-    assert entry.unique_id == "uniqueid-ac1-z01-myzone"
-
-    # Test Second Motion Sensor (disabled by default)
-    entity_id = "binary_sensor.myzone_zone_closed_with_sensor_myzone"
-
-    assert not hass.states.get(entity_id)
-
-    mock_get.reset_mock()
-
-    with patch("homeassistant.config_entries.RELOAD_AFTER_UPDATE_DELAY", 1):
-        entity_registry.async_update_entity(entity_id=entity_id, disabled_by=None)
-        await hass.async_block_till_done()
-
-        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=2))
-        await hass.async_block_till_done(wait_background_tasks=True)
-        assert len(mock_get.mock_calls) == 1
-
-    state = hass.states.get(entity_id)
-    assert state
-    assert state.state == STATE_OFF
-
-    entry = entity_registry.async_get(entity_id)
-    assert entry
-    assert entry.unique_id == "uniqueid-ac1-z02-myzone"
+    entry = await add_mock_config(hass, [Platform.BINARY_SENSOR])
+    await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)

--- a/tests/components/advantage_air/test_climate.py
+++ b/tests/components/advantage_air/test_climate.py
@@ -1,12 +1,20 @@
 """Test the Advantage Air Climate Platform."""
 
+from copy import deepcopy
 from unittest.mock import AsyncMock
 
 from advantage_air import ApiError
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.advantage_air.climate import ADVANTAGE_AIR_MYAUTO
+from homeassistant.components.advantage_air.climate import (
+    ADVANTAGE_AIR_MYAUTO,
+    ADVANTAGE_AIR_MYZONE,
+)
+from homeassistant.components.advantage_air.coordinator import (
+    ADVANTAGE_AIR_SYNC_INTERVAL,
+)
 from homeassistant.components.climate import (
     ATTR_CURRENT_TEMPERATURE,
     ATTR_FAN_MODE,
@@ -32,7 +40,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 
-from . import add_mock_config
+from . import TEST_SYSTEM_DATA, add_mock_config
+
+from tests.common import async_fire_time_changed
 
 
 async def test_climate_myzone_main(
@@ -265,3 +275,31 @@ async def test_climate_async_failed_update(
         )
 
     mock_update.assert_called_once()
+
+
+async def test_climate_preset_follows_coordinator(
+    hass: HomeAssistant,
+    mock_get: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test the preset updates when changed externally between coordinator refreshes."""
+
+    await add_mock_config(hass)
+
+    entity_id = "climate.myzone"
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.attributes[ATTR_PRESET_MODE] == ADVANTAGE_AIR_MYZONE
+
+    # Simulate the preset being switched to MyAuto on the device itself
+    updated_data = deepcopy(TEST_SYSTEM_DATA)
+    updated_data["aircons"]["ac1"]["info"]["myAutoModeEnabled"] = True
+    mock_get.return_value = updated_data
+
+    freezer.tick(ADVANTAGE_AIR_SYNC_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.attributes[ATTR_PRESET_MODE] == ADVANTAGE_AIR_MYAUTO

--- a/tests/components/advantage_air/test_sensor.py
+++ b/tests/components/advantage_air/test_sensor.py
@@ -1,140 +1,64 @@
 """Test the Advantage Air Sensor Platform."""
 
-from datetime import timedelta
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.advantage_air.const import DOMAIN
 from homeassistant.components.advantage_air.sensor import (
     ADVANTAGE_AIR_SET_COUNTDOWN_VALUE,
 )
-from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
-from homeassistant.util import dt as dt_util
 
 from . import add_mock_config
 
-from tests.common import async_fire_time_changed
+from tests.common import snapshot_platform
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_sensor_platform(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
     mock_get: AsyncMock,
-    mock_update: AsyncMock,
 ) -> None:
     """Test sensor platform."""
 
-    await add_mock_config(hass)
-
-    # Test First TimeToOn Sensor
-    entity_id = "sensor.myzone_time_to_on"
-    state = hass.states.get(entity_id)
-    assert state
-    assert int(state.state) == 0
-
-    entry = entity_registry.async_get(entity_id)
-    assert entry
-    assert entry.unique_id == "uniqueid-ac1-timetoOn"
-
-    value = 20
-
-    await hass.services.async_call(
-        DOMAIN,
-        "set_time_to",
-        {ATTR_ENTITY_ID: [entity_id], ADVANTAGE_AIR_SET_COUNTDOWN_VALUE: value},
-        blocking=True,
-    )
-    mock_update.assert_called_once()
-    mock_update.reset_mock()
-
-    # Test First TimeToOff Sensor
-    entity_id = "sensor.myzone_time_to_off"
-    state = hass.states.get(entity_id)
-    assert state
-    assert int(state.state) == 10
-
-    entry = entity_registry.async_get(entity_id)
-    assert entry
-    assert entry.unique_id == "uniqueid-ac1-timetoOff"
-
-    value = 0
-    await hass.services.async_call(
-        DOMAIN,
-        "set_time_to",
-        {ATTR_ENTITY_ID: [entity_id], ADVANTAGE_AIR_SET_COUNTDOWN_VALUE: value},
-        blocking=True,
-    )
-    mock_update.assert_called_once()
-    mock_update.reset_mock()
-
-    # Test First Zone Vent Sensor
-    entity_id = "sensor.myzone_zone_open_with_sensor_vent"
-    state = hass.states.get(entity_id)
-    assert state
-    assert int(state.state) == 100
-
-    entry = entity_registry.async_get(entity_id)
-    assert entry
-    assert entry.unique_id == "uniqueid-ac1-z01-vent"
-
-    # Test Second Zone Vent Sensor
-    entity_id = "sensor.myzone_zone_closed_with_sensor_vent"
-    state = hass.states.get(entity_id)
-    assert state
-    assert int(state.state) == 0
-
-    entry = entity_registry.async_get(entity_id)
-    assert entry
-    assert entry.unique_id == "uniqueid-ac1-z02-vent"
-
-    # Test First Zone Signal Sensor
-    entity_id = "sensor.myzone_zone_open_with_sensor_signal"
-    state = hass.states.get(entity_id)
-    assert state
-    assert int(state.state) == 40
-
-    entry = entity_registry.async_get(entity_id)
-    assert entry
-    assert entry.unique_id == "uniqueid-ac1-z01-signal"
-
-    # Test Second Zone Signal Sensor
-    entity_id = "sensor.myzone_zone_closed_with_sensor_signal"
-    state = hass.states.get(entity_id)
-    assert state
-    assert int(state.state) == 10
-
-    entry = entity_registry.async_get(entity_id)
-    assert entry
-    assert entry.unique_id == "uniqueid-ac1-z02-signal"
+    entry = await add_mock_config(hass, [Platform.SENSOR])
+    await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)
 
 
-async def test_sensor_platform_disabled_entity(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, mock_get: AsyncMock
+async def test_sensor_set_time_to(
+    hass: HomeAssistant,
+    mock_get: AsyncMock,
+    mock_update: AsyncMock,
 ) -> None:
-    """Test sensor platform disabled entity."""
+    """Test the set_time_to action."""
 
-    await add_mock_config(hass)
+    await add_mock_config(hass, [Platform.SENSOR])
 
-    # Test First Zone Temp Sensor (disabled by default)
-    entity_id = "sensor.myzone_zone_open_with_sensor_temperature"
+    await hass.services.async_call(
+        DOMAIN,
+        "set_time_to",
+        {
+            ATTR_ENTITY_ID: ["sensor.myzone_time_to_on"],
+            ADVANTAGE_AIR_SET_COUNTDOWN_VALUE: 20,
+        },
+        blocking=True,
+    )
+    mock_update.assert_called_once()
+    mock_update.reset_mock()
 
-    assert not hass.states.get(entity_id)
-
-    mock_get.reset_mock()
-
-    with patch("homeassistant.config_entries.RELOAD_AFTER_UPDATE_DELAY", 1):
-        entity_registry.async_update_entity(entity_id=entity_id, disabled_by=None)
-        await hass.async_block_till_done(wait_background_tasks=True)
-
-        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=2))
-        await hass.async_block_till_done(wait_background_tasks=True)
-        assert len(mock_get.mock_calls) == 1
-
-    state = hass.states.get(entity_id)
-    assert state
-    assert int(state.state) == 25
-
-    entry = entity_registry.async_get(entity_id)
-    assert entry
-    assert entry.unique_id == "uniqueid-ac1-z01-temp"
+    await hass.services.async_call(
+        DOMAIN,
+        "set_time_to",
+        {
+            ATTR_ENTITY_ID: ["sensor.myzone_time_to_off"],
+            ADVANTAGE_AIR_SET_COUNTDOWN_VALUE: 0,
+        },
+        blocking=True,
+    )
+    mock_update.assert_called_once()


### PR DESCRIPTION
## Breaking change

## Proposed change
Modernise the testing for Advantage Air by reworking the `binary_sensor` and `sensor` platform tests to use the standard `snapshot_platform` helper together with the `@pytest.mark.usefixtures("entity_registry_enabled_by_default")` fixture. This removes the brittle "enable a disabled entity and wait for a reload" dance that made these tests flaky, and gives full snapshot coverage of every entity's registry entry and state.

The `set_time_to` action coverage is retained as a focused behavioural test.

This is a fresh take on #129763 (which went stale). It addresses the review feedback from that PR:
- Uses the standard `snapshot_platform` helper instead of a bespoke `assert_entities` helper.
- Replaces the climate coordinator-refresh test so it asserts the observable preset change after a refresh, rather than patching the private `_async_configure_preset` method.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
