### PR TITLE
Fix except syntax, validation errors, and typos

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -35,7 +35,7 @@ from . import (
 # Pre-import frontend deps which have no requirements here to avoid
 # loading them at run time and blocking the event loop. We do this ahead
 # of time so that we do not have to flag frontend deps with `import_executor`
-# as it would create a thundering heard of executor jobs trying to import
+# as it would create a thundering herd of executor jobs trying to import
 # frontend deps at the same time.
 from .components import (
     api as api_pre_import,  # noqa: F401

--- a/homeassistant/components/automation/config.py
+++ b/homeassistant/components/automation/config.py
@@ -302,7 +302,7 @@ async def _try_async_validate_config_item(
     """Validate config item."""
     try:
         return await _async_validate_config_item(hass, config, False, True)
-    except vol.Invalid, HomeAssistantError:
+    except (vol.Invalid, HomeAssistantError):  # fmt: skip
         return None
 
 

--- a/homeassistant/components/input_number/__init__.py
+++ b/homeassistant/components/input_number/__init__.py
@@ -53,7 +53,7 @@ def _cv_input_number(cfg):
     maximum = cfg.get(CONF_MAX)
     if minimum >= maximum:
         raise vol.Invalid(
-            f"Maximum ({minimum}) is not greater than minimum ({maximum})"
+            f"Maximum ({maximum}) must be greater than minimum ({minimum})"
         )
     state = cfg.get(CONF_INITIAL)
     if state is not None and (state < minimum or state > maximum):

--- a/homeassistant/components/input_text/__init__.py
+++ b/homeassistant/components/input_text/__init__.py
@@ -70,7 +70,7 @@ def _cv_input_text(config: dict[str, Any]) -> dict[str, Any]:
     maximum: int = config[CONF_MAX]
     if minimum > maximum:
         raise vol.Invalid(
-            f"Max len ({minimum}) is not greater than min len ({maximum})"
+            f"Max len ({maximum}) must not be smaller than min len ({minimum})"
         )
     state: str | None = config.get(CONF_INITIAL)
     if state is not None and (len(state) < minimum or len(state) > maximum):

--- a/homeassistant/components/shell_command/__init__.py
+++ b/homeassistant/components/shell_command/__init__.py
@@ -129,7 +129,7 @@ def _make_handler(
                 stderr_data,
             )
         if process.returncode != 0:
-            _LOGGER.exception(
+            _LOGGER.error(
                 "Error running command: `%s`, return code: %s", cmd, process.returncode
             )
 

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -53,7 +53,7 @@ _LOGGER = logging.getLogger(__name__)
 
 #
 # Integration.get_component will check preload platforms and
-# try to import the code to avoid a thundering heard of import
+# try to import the code to avoid a thundering herd of import
 # executor jobs later in the startup process.
 #
 # default platforms are prepopulated in this list to ensure that


### PR DESCRIPTION
Fixes #173206. Corrects Python 2-style except in
  automation config, swapped variable names in input_number/input_text error messages, LOGGER.exception misuse in shell_command, and
  'thundering heard' typos.