### PR TITLE
Add audio volume level support to SmartThings

### DIFF
--- a/homeassistant/components/smartthings/number.py
+++ b/homeassistant/components/smartthings/number.py
@@ -300,6 +300,6 @@ class SmartThingsAudioVolumeLevelEntity(SmartThingsEntity, NumberEntity):
         """Set the value."""
         await self.execute_device_command(
             Capability.SAMSUNG_CE_AUDIO_VOLUME_LEVEL,
-            Command.VOLUME_LEVEL,
+            Command.SET_VOLUME_LEVEL,
             int(value),
         )

--- a/homeassistant/components/smartthings/number.py
+++ b/homeassistant/components/smartthings/number.py
@@ -244,6 +244,7 @@ class SmartThingsRefrigeratorTemperatureNumberEntity(SmartThingsEntity, NumberEn
             int(value),
         )
 
+
 class SmartThingsAudioVolumeLevelEntity(SmartThingsEntity, NumberEntity):
     """Define a SmartThings number."""
 

--- a/homeassistant/components/smartthings/number.py
+++ b/homeassistant/components/smartthings/number.py
@@ -46,6 +46,14 @@ async def async_setup_entry(
         ].value
         is not None
     )
+    entities.extend(
+        SmartThingsAudioVolumeEntity(entry_data.client, device)
+        for device in entry_data.devices.values()
+        if (
+            Capability.SAMSUNG_CE_AUDIO_VOLUME_LEVEL in device.status[MAIN]
+            and Capability.AUDIO_VOLUME not in device.status[MAIN]
+        )
+    )
     async_add_entities(entities)
 
 
@@ -233,5 +241,64 @@ class SmartThingsRefrigeratorTemperatureNumberEntity(SmartThingsEntity, NumberEn
         await self.execute_device_command(
             Capability.THERMOSTAT_COOLING_SETPOINT,
             Command.SET_COOLING_SETPOINT,
+            int(value),
+        )
+
+class SmartThingsAudioVolumeEntity(SmartThingsEntity, NumberEntity):
+    """Define a SmartThings number."""
+
+    _attr_translation_key = "audio_volume"
+    _attr_native_step = 1.0
+    _attr_mode = NumberMode.SLIDER
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(self, client: SmartThings, device: FullDevice) -> None:
+        """Initialize the instance."""
+        super().__init__(
+            client, device, {Capability.SAMSUNG_CE_AUDIO_VOLUME_LEVEL}, component=MAIN
+        )
+        self._attr_unique_id = (
+            f"{device.device.device_id}_audio_volume"
+            f"_{Capability.SAMSUNG_CE_AUDIO_VOLUME_LEVEL}"
+            f"_{Attribute.VOLUME_LEVEL}"
+            f"_{Attribute.VOLUME_LEVEL}"
+        )
+
+    @property
+    def options(self) -> list[int]:
+        """Return the list of options."""
+        volume_range = self.get_attribute_value(
+            Capability.SAMSUNG_CE_AUDIO_VOLUME_LEVEL,
+            Attribute.VOLUME_LEVEL_RANGE,
+        )
+        min_value = volume_range["minimum"]
+        max_value = volume_range["maximum"]
+        step = volume_range["step"]
+        return list(range(min_value, max_value + 1, step))
+
+    @property
+    def native_value(self) -> int:
+        """Return the current value."""
+        return int(
+            self.get_attribute_value(
+                Capability.SAMSUNG_CE_AUDIO_VOLUME_LEVEL, Attribute.VOLUME_LEVEL
+            )
+        )
+
+    @property
+    def native_min_value(self) -> float:
+        """Return the minimum value."""
+        return min(self.options)
+
+    @property
+    def native_max_value(self) -> float:
+        """Return the maximum value."""
+        return max(self.options)
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the value."""
+        await self.execute_device_command(
+            Capability.SAMSUNG_CE_AUDIO_VOLUME_LEVEL,
+            Command.VOLUME_LEVEL,
             int(value),
         )

--- a/homeassistant/components/smartthings/number.py
+++ b/homeassistant/components/smartthings/number.py
@@ -258,7 +258,7 @@ class SmartThingsAudioVolumeLevelEntity(SmartThingsEntity, NumberEntity):
             client, device, {Capability.SAMSUNG_CE_AUDIO_VOLUME_LEVEL}, component=MAIN
         )
         self._attr_unique_id = (
-            f"{device.device.device_id}_audio_volume"
+            f"{device.device.device_id}_{MAIN}"
             f"_{Capability.SAMSUNG_CE_AUDIO_VOLUME_LEVEL}"
             f"_{Attribute.VOLUME_LEVEL}"
             f"_{Attribute.VOLUME_LEVEL}"

--- a/homeassistant/components/smartthings/number.py
+++ b/homeassistant/components/smartthings/number.py
@@ -47,7 +47,7 @@ async def async_setup_entry(
         is not None
     )
     entities.extend(
-        SmartThingsAudioVolumeEntity(entry_data.client, device)
+        SmartThingsAudioVolumeLevelEntity(entry_data.client, device)
         for device in entry_data.devices.values()
         if (
             Capability.SAMSUNG_CE_AUDIO_VOLUME_LEVEL in device.status[MAIN]
@@ -244,10 +244,10 @@ class SmartThingsRefrigeratorTemperatureNumberEntity(SmartThingsEntity, NumberEn
             int(value),
         )
 
-class SmartThingsAudioVolumeEntity(SmartThingsEntity, NumberEntity):
+class SmartThingsAudioVolumeLevelEntity(SmartThingsEntity, NumberEntity):
     """Define a SmartThings number."""
 
-    _attr_translation_key = "audio_volume"
+    _attr_translation_key = "audio_volume_level"
     _attr_native_step = 1.0
     _attr_mode = NumberMode.SLIDER
     _attr_entity_category = EntityCategory.CONFIG

--- a/homeassistant/components/smartthings/strings.json
+++ b/homeassistant/components/smartthings/strings.json
@@ -234,6 +234,9 @@
       }
     },
     "number": {
+      "audio_volume_level": {
+        "name": "Audio volume level"
+      },
       "cool_select_plus_temperature": {
         "name": "CoolSelect+ temperature"
       },

--- a/tests/components/smartthings/snapshots/test_number.ambr
+++ b/tests/components/smartthings/snapshots/test_number.ambr
@@ -424,6 +424,120 @@
     'state': '2.0',
   })
 # ---
+# name: test_all_entities[da_rvc_map_01011][number.robot_vacuum_audio_volume_level-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 3,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.robot_vacuum_audio_volume_level',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Audio volume level',
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'audio_volume_level',
+    'unique_id': '05accb39-2017-c98b-a5ab-04a81f4d3d9a_main_audio_volume_level_volumeLevel_volumeLevel',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[da_rvc_map_01011][number.robot_vacuum_audio_volume_level-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Robot vacuum Audio volume level',
+      'max': 3,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.robot_vacuum_audio_volume_level',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_all_entities[da_wm_wd_01011][number.trockner_audio_volume_level-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 3,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.trockner_audio_volume_level',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Audio volume level',
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'audio_volume_level',
+    'unique_id': '3d39866c-7716-5259-44f0-fd7025efd85f_main_audio_volume_level_volumeLevel_volumeLevel',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[da_wm_wd_01011][number.trockner_audio_volume_level-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Trockner Audio volume level',
+      'max': 3,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.trockner_audio_volume_level',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '3',
+  })
+# ---
 # name: test_all_entities[da_ref_normal_01011_onedoor][number.lodowka_target_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -525,6 +639,63 @@
     'translation_key': 'washer_rinse_cycles',
     'unique_id': 'f984b91d-f250-9d42-3436-33f09a422a47_main_custom.washerRinseCycles_washerRinseCycles_washerRinseCycles',
     'unit_of_measurement': 'cycles',
+  })
+# ---
+# name: test_all_entities[da_wm_wm_01011][number.machine_a_laver_audio_volume_level-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 1,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.machine_a_laver_audio_volume_level',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Audio volume level',
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'audio_volume_level',
+    'unique_id': 'b854ca5f-dc54-140d-6349-758b4d973c41_main_audio_volume_level_volumeLevel_volumeLevel',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[da_wm_wm_01011][number.machine_a_laver_audio_volume_level-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Machine à Laver Audio volume level',
+      'max': 1,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.machine_a_laver_audio_volume_level',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
   })
 # ---
 # name: test_all_entities[da_wm_wm_000001][number.theater_washer_rinse_cycles-state]


### PR DESCRIPTION
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
This is an alternative to @mik-laj's https://github.com/home-assistant/core/pull/162523 with significantly fewer changes. I've got a DA-WM-WM-01011 (WW90DB8U95GHU3) and really want to silence it at night.

* Add number entity for audio volume level control
* Update translations and test snapshots


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/41787
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
