### PR TITLE
Add Culiplan integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -348,6 +348,8 @@ CLAUDE.md @home-assistant/core
 /tests/components/cpuspeed/ @fabaff
 /homeassistant/components/crownstone/ @Crownstone @RicArch97
 /tests/components/crownstone/ @Crownstone @RicArch97
+/homeassistant/components/culiplan/ @culiplan
+/tests/components/culiplan/ @culiplan
 /homeassistant/components/cync/ @Kinachi249
 /tests/components/cync/ @Kinachi249
 /homeassistant/components/daikin/ @fredrike

--- a/homeassistant/components/culiplan/__init__.py
+++ b/homeassistant/components/culiplan/__init__.py
@@ -1,0 +1,97 @@
+"""The Culiplan integration."""
+
+from dataclasses import dataclass
+import logging
+
+from homeassistant.components.application_credentials import (
+    ClientCredential,
+    async_import_client_credential,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import (
+    aiohttp_client,
+    config_entry_oauth2_flow,
+    config_validation as cv,
+)
+from homeassistant.helpers.typing import ConfigType
+
+from .api import CuliplanApiClient
+from .const import DOMAIN, OAUTH_CLIENT_ID, PLATFORMS
+from .coordinator import CuliplanCoordinator
+from .llm_api import async_register_llm_api, async_unregister_llm_api
+
+_LOGGER = logging.getLogger(__name__)
+
+# This integration is config_entry-only — there is no YAML schema.
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+
+
+@dataclass
+class CuliplanRuntimeData:
+    """Per-entry runtime data carried on ``ConfigEntry.runtime_data``."""
+
+    client: CuliplanApiClient
+    coordinator: CuliplanCoordinator
+
+
+type CuliplanConfigEntry = ConfigEntry[CuliplanRuntimeData]
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the Culiplan integration.
+
+    Auto-imports the public OAuth client credential so the user skips the
+    "Add application credentials" dialog and goes straight to consent.
+    """
+    await async_import_client_credential(
+        hass,
+        DOMAIN,
+        ClientCredential(client_id=OAUTH_CLIENT_ID, client_secret=""),
+    )
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: CuliplanConfigEntry) -> bool:
+    """Set up Culiplan from a config entry."""
+    implementation = (
+        await config_entry_oauth2_flow.async_get_config_entry_implementation(
+            hass, entry
+        )
+    )
+    session = config_entry_oauth2_flow.OAuth2Session(hass, entry, implementation)
+    await session.async_ensure_token_valid()
+
+    client = CuliplanApiClient(
+        session=aiohttp_client.async_get_clientsession(hass),
+        access_token=session.token["access_token"],
+    )
+
+    coordinator = CuliplanCoordinator(hass, client, entry)
+    await coordinator.async_config_entry_first_refresh()
+    await coordinator.async_start()
+
+    # Register the coordinator's teardown BEFORE forwarding to platforms so
+    # a platform-setup failure still closes the Socket.IO connection.
+    entry.async_on_unload(coordinator.async_stop)
+
+    entry.runtime_data = CuliplanRuntimeData(client=client, coordinator=coordinator)
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    async_register_llm_api(hass)
+    entry.async_on_unload(lambda: async_unregister_llm_api(hass))
+    entry.async_on_unload(entry.add_update_listener(_async_options_updated))
+    return True
+
+
+async def _async_options_updated(
+    hass: HomeAssistant, entry: CuliplanConfigEntry
+) -> None:
+    """Reload the entry when its options change."""
+    await hass.config_entries.async_reload(entry.entry_id)
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: CuliplanConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/culiplan/api.py
+++ b/homeassistant/components/culiplan/api.py
@@ -1,0 +1,223 @@
+"""OAuth-aware async HTTP client for the Culiplan API.
+
+The client only exposes the surface needed by the Core integration:
+
+* GET meal plans, shopping list, pantry items
+* mutate shopping list (add / check / delete)
+
+Premium-only endpoints (energy, AI dispatchers, BYOK key validation) are
+intentionally absent — those live in the standalone HACS distribution.
+"""
+
+import logging
+from typing import Any, Final, cast
+
+from aiohttp import ClientError, ClientSession, ClientTimeout
+
+from homeassistant.exceptions import ConfigEntryAuthFailed
+
+from .const import BASE_URL
+
+_LOGGER = logging.getLogger(__name__)
+
+# Explicit per-request timeout for every REST call. aiohttp's default
+# (5 minutes total) is far too lenient for a coordinator that polls every
+# 5 minutes — a stuck request would stall the entire update cycle. Home
+# Assistant Core reviewers require explicit timeouts on every HTTP call.
+_API_TIMEOUT: Final = ClientTimeout(total=30)
+
+
+class CuliplanApiError(Exception):
+    """Generic Culiplan API error (non-auth)."""
+
+
+class CuliplanApiClient:
+    """Thin OAuth-aware client for the Culiplan REST API."""
+
+    def __init__(self, session: ClientSession, access_token: str) -> None:
+        """Store the shared aiohttp session and the current bearer token."""
+        self._session = session
+        self._access_token = access_token
+
+    def set_access_token(self, token: str) -> None:
+        """Replace the bearer token after a refresh."""
+        self._access_token = token
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._access_token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    # ─── Read ────────────────────────────────────────────────────────────────
+
+    async def async_get_meal_plans(self) -> list[dict[str, Any]]:
+        """Return the user's meal plan as a single-element list.
+
+        The backend groups slots by date:
+
+            { "<YYYY-MM-DD>": { "<slot>": [<entry>, …], … }, … }
+
+        We flatten that into one synthetic plan with id ``"current"`` so
+        the calendar entity identity is stable across refreshes.
+        """
+        raw = await self._get("/api/meal-plans")
+
+        # Legacy / test-double path: bare list already in the expected shape.
+        if isinstance(raw, list):
+            return cast(list[dict[str, Any]], raw)
+
+        if not isinstance(raw, dict):
+            _LOGGER.debug(
+                "async_get_meal_plans: unexpected response type %s", type(raw)
+            )
+            return []
+
+        slots: list[dict[str, Any]] = []
+        for date_str, slots_by_name in raw.items():
+            if not isinstance(slots_by_name, dict):
+                continue
+            for slot_name, entries in slots_by_name.items():
+                if not isinstance(entries, list):
+                    continue
+                for entry in entries:
+                    if not isinstance(entry, dict):
+                        continue
+                    entry_date: Any = entry.get("date") or f"{date_str}T12:00:00Z"
+                    if not isinstance(entry_date, str):
+                        entry_date = str(entry_date)
+                    recipe = entry.get("recipe") or {}
+                    title: str = recipe.get("title") or entry.get("title") or slot_name
+                    slots.append(
+                        {
+                            "id": entry.get("id", f"{date_str}-{slot_name}"),
+                            "date": entry_date,
+                            "title": title,
+                            "course": entry.get("mealSlot", slot_name),
+                            "recipeId": entry.get("recipeId"),
+                            "servings": entry.get("servings"),
+                        }
+                    )
+
+        return [{"id": "current", "name": "Meal Plan", "slots": slots}]
+
+    async def async_get_shopping_lists(self) -> list[dict[str, Any]]:
+        """Return the user's shopping list wrapped as a single-element list."""
+        items = await self._get("/api/shopping-list")
+        return [{"id": "default", "name": "Shopping List", "items": items}]
+
+    async def async_get_pantry_items(self) -> list[dict[str, Any]]:
+        """Return the user's pantry stock as a flat list."""
+        response = await self._get("/api/pantry/stock?limit=100")
+        if isinstance(response, dict) and isinstance(response.get("data"), list):
+            return cast(list[dict[str, Any]], response["data"])
+        if isinstance(response, list):
+            return cast(list[dict[str, Any]], response)
+        return []
+
+    async def async_get_user(self) -> dict[str, Any]:
+        """Return the authenticated user's profile (used for unique_id)."""
+        return cast(dict[str, Any], await self._get("/api/users/me"))
+
+    async def async_get(self, path: str) -> Any:
+        """Run an arbitrary GET against the Culiplan API (used by LLM tools)."""
+        return await self._get(path)
+
+    # ─── Shopping list mutations ─────────────────────────────────────────────
+
+    async def async_add_shopping_item(
+        self, name: str, quantity: str | None = None
+    ) -> dict[str, Any]:
+        """Add an item to the shopping list."""
+        item: dict[str, Any] = {"name": name}
+        if quantity:
+            item["quantity"] = quantity
+        created = await self._post("/api/shopping-list", {"items": [item]})
+        if isinstance(created, list) and created:
+            return cast(dict[str, Any], created[0])
+        return cast(dict[str, Any], created)
+
+    async def async_update_shopping_item(
+        self, item_id: str, completed: bool
+    ) -> dict[str, Any]:
+        """Toggle the ``completed`` state of a shopping-list item."""
+        return cast(
+            dict[str, Any],
+            await self._patch(f"/api/shopping-list/{item_id}", {"checked": completed}),
+        )
+
+    async def async_remove_shopping_item(self, item_id: str) -> None:
+        """Delete a shopping-list item."""
+        await self._delete(f"/api/shopping-list/{item_id}")
+
+    # ─── HTTP helpers ────────────────────────────────────────────────────────
+
+    async def _get(self, path: str) -> Any:
+        try:
+            async with self._session.get(
+                f"{BASE_URL}{path}",
+                headers=self._headers(),
+                timeout=_API_TIMEOUT,
+            ) as resp:
+                self._raise_for_status(resp.status, path)
+                resp.raise_for_status()
+                return await resp.json()
+        except TimeoutError as err:
+            raise CuliplanApiError(f"GET {path} timed out") from err
+        except ClientError as err:
+            raise CuliplanApiError(f"GET {path} failed: {err}") from err
+
+    async def _post(self, path: str, payload: dict[str, Any]) -> Any:
+        try:
+            async with self._session.post(
+                f"{BASE_URL}{path}",
+                headers=self._headers(),
+                json=payload,
+                timeout=_API_TIMEOUT,
+            ) as resp:
+                self._raise_for_status(resp.status, path)
+                resp.raise_for_status()
+                return await resp.json()
+        except TimeoutError as err:
+            raise CuliplanApiError(f"POST {path} timed out") from err
+        except ClientError as err:
+            raise CuliplanApiError(f"POST {path} failed: {err}") from err
+
+    async def _patch(self, path: str, payload: dict[str, Any]) -> Any:
+        try:
+            async with self._session.patch(
+                f"{BASE_URL}{path}",
+                headers=self._headers(),
+                json=payload,
+                timeout=_API_TIMEOUT,
+            ) as resp:
+                self._raise_for_status(resp.status, path)
+                resp.raise_for_status()
+                return await resp.json()
+        except TimeoutError as err:
+            raise CuliplanApiError(f"PATCH {path} timed out") from err
+        except ClientError as err:
+            raise CuliplanApiError(f"PATCH {path} failed: {err}") from err
+
+    async def _delete(self, path: str) -> None:
+        try:
+            async with self._session.delete(
+                f"{BASE_URL}{path}",
+                headers=self._headers(),
+                timeout=_API_TIMEOUT,
+            ) as resp:
+                self._raise_for_status(resp.status, path)
+                resp.raise_for_status()
+        except TimeoutError as err:
+            raise CuliplanApiError(f"DELETE {path} timed out") from err
+        except ClientError as err:
+            raise CuliplanApiError(f"DELETE {path} failed: {err}") from err
+
+    @staticmethod
+    def _raise_for_status(status: int, path: str) -> None:
+        """Map 401 onto ``ConfigEntryAuthFailed`` so HA triggers re-auth."""
+        if status == 401:
+            raise ConfigEntryAuthFailed(
+                f"Culiplan token expired or revoked (401 on {path})"
+            )

--- a/homeassistant/components/culiplan/application_credentials.py
+++ b/homeassistant/components/culiplan/application_credentials.py
@@ -1,0 +1,85 @@
+"""Application credentials platform for the Culiplan integration.
+
+The Culiplan backend is a public OAuth 2.1 client: no client_secret, PKCE
+(S256) mandatory. Home Assistant's default ``LocalOAuth2Implementation``
+does not send ``code_challenge`` / ``code_verifier``, so we ship a thin
+subclass that does.
+"""
+
+import base64
+import hashlib
+import secrets
+from typing import Any
+
+from homeassistant.components.application_credentials import (
+    AuthImplementation,
+    AuthorizationServer,
+    ClientCredential,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_entry_oauth2_flow
+
+from .const import OAUTH2_AUTHORIZE, OAUTH2_SCOPES, OAUTH2_TOKEN
+
+
+def _generate_pkce_pair() -> tuple[str, str]:
+    """Return a ``(verifier, challenge)`` pair for PKCE S256."""
+    verifier = secrets.token_urlsafe(64)
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return verifier, challenge
+
+
+class CuliplanOAuth2Implementation(AuthImplementation):
+    """OAuth2 implementation with PKCE (S256) for the Culiplan public client."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        auth_domain: str,
+        credential: ClientCredential,
+        authorization_server: AuthorizationServer,
+    ) -> None:
+        """Initialise the implementation and generate a fresh PKCE pair."""
+        super().__init__(hass, auth_domain, credential, authorization_server)
+        self._code_verifier, self._code_challenge = _generate_pkce_pair()
+
+    @property
+    def extra_authorize_data(self) -> dict[str, Any]:
+        """Return the extra parameters appended to the /authorize URL."""
+        return {
+            "scope": " ".join(OAUTH2_SCOPES),
+            "code_challenge": self._code_challenge,
+            "code_challenge_method": "S256",
+        }
+
+    async def _token_request(self, data: dict[str, Any]) -> dict[Any, Any]:
+        """Inject ``code_verifier`` on the authorisation-code exchange."""
+        if data.get("grant_type") == "authorization_code":
+            data["code_verifier"] = self._code_verifier
+        return await super()._token_request(data)
+
+
+async def async_get_auth_implementation(
+    hass: HomeAssistant,
+    auth_domain: str,
+    credential: ClientCredential,
+) -> config_entry_oauth2_flow.AbstractOAuth2Implementation:
+    """Return a PKCE-enabled auth implementation."""
+    return CuliplanOAuth2Implementation(
+        hass,
+        auth_domain,
+        credential,
+        AuthorizationServer(
+            authorize_url=OAUTH2_AUTHORIZE,
+            token_url=OAUTH2_TOKEN,
+        ),
+    )
+
+
+async def async_get_authorization_server(hass: HomeAssistant) -> AuthorizationServer:
+    """Return the Culiplan OAuth authorisation server."""
+    return AuthorizationServer(
+        authorize_url=OAUTH2_AUTHORIZE,
+        token_url=OAUTH2_TOKEN,
+    )

--- a/homeassistant/components/culiplan/calendar.py
+++ b/homeassistant/components/culiplan/calendar.py
@@ -1,0 +1,107 @@
+"""Calendar entity for the Culiplan meal plan."""
+
+from datetime import UTC, datetime, timedelta
+import json
+import logging
+from typing import Any, cast
+
+from homeassistant.components.calendar import CalendarEntity, CalendarEvent
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import CuliplanConfigEntry
+from .coordinator import CuliplanCoordinator
+from .helpers import build_device_info, parse_dt
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: CuliplanConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Culiplan calendar entities — one per meal plan."""
+    coordinator = entry.runtime_data.coordinator
+    meal_plans = (coordinator.data or {}).get("meal_plans", [])
+    async_add_entities(
+        CuliplanCalendar(coordinator, plan, entry) for plan in meal_plans
+    )
+
+
+class CuliplanCalendar(CoordinatorEntity[CuliplanCoordinator], CalendarEntity):
+    """Calendar entity for a single Culiplan meal plan."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "meal_plan"
+
+    def __init__(
+        self,
+        coordinator: CuliplanCoordinator,
+        plan: dict[str, Any],
+        entry: CuliplanConfigEntry,
+    ) -> None:
+        """Bind the entity to a specific plan id within one config entry."""
+        super().__init__(coordinator)
+        self._plan_id: str = plan["id"]
+        self._attr_unique_id = f"{entry.entry_id}_calendar_{self._plan_id}"
+        self._attr_device_info = build_device_info(entry)
+
+    @property
+    def event(self) -> CalendarEvent | None:
+        """Return the current / next upcoming event."""
+        now = datetime.now(tz=UTC)
+        upcoming = [e for e in self._build_events() if e.end > now]
+        return upcoming[0] if upcoming else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Expose recipe IDs for the current / next event (no PII)."""
+        ev = self.event
+        if ev is None or ev.description is None:
+            return {}
+        try:
+            return cast(dict[str, Any], json.loads(ev.description))
+        except (ValueError, TypeError):
+            return {}
+
+    async def async_get_events(
+        self,
+        hass: HomeAssistant,
+        start_date: datetime,
+        end_date: datetime,
+    ) -> list[CalendarEvent]:
+        """Return events within ``[start_date, end_date)``."""
+        return [
+            e for e in self._build_events() if e.start < end_date and e.end > start_date
+        ]
+
+    def _build_events(self) -> list[CalendarEvent]:
+        events: list[CalendarEvent] = []
+        for plan in (self.coordinator.data or {}).get("meal_plans", []):
+            if plan["id"] != self._plan_id:
+                continue
+            for slot in plan.get("slots", []):
+                try:
+                    start = parse_dt(slot["date"])
+                    end = start + timedelta(hours=1)
+                    description = json.dumps(
+                        {
+                            "recipe_id": slot.get("recipeId"),
+                            "servings": slot.get("servings"),
+                            "course": slot.get("course"),
+                        }
+                    )
+                    events.append(
+                        CalendarEvent(
+                            start=start,
+                            end=end,
+                            summary=slot.get("title", "Meal"),
+                            description=description,
+                            uid=slot.get("id"),
+                        )
+                    )
+                except (KeyError, ValueError) as err:
+                    _LOGGER.debug("Skipping malformed meal slot: %s", err)
+        return sorted(events, key=lambda e: e.start)

--- a/homeassistant/components/culiplan/config_flow.py
+++ b/homeassistant/components/culiplan/config_flow.py
@@ -1,0 +1,155 @@
+"""Config flow for the Culiplan integration."""
+
+from collections.abc import Mapping
+import logging
+from typing import Any, Final
+
+import aiohttp
+
+from homeassistant import config_entries
+from homeassistant.components.application_credentials import (
+    ClientCredential,
+    async_import_client_credential,
+)
+from homeassistant.config_entries import ConfigFlowResult
+from homeassistant.helpers import aiohttp_client, config_entry_oauth2_flow
+
+from .const import BASE_URL, DOMAIN, OAUTH_CLIENT_ID
+
+_LOGGER = logging.getLogger(__name__)
+
+# Account-id lookup runs during the config-flow user journey. 10s total is
+# short enough to keep the UI responsive on a flaky backend without
+# falsely failing on cold-start cloud-run latency.
+_ACCOUNT_ID_TIMEOUT: Final = aiohttp.ClientTimeout(total=10)
+
+
+class OAuth2FlowHandler(
+    config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain=DOMAIN
+):
+    """Handle the Culiplan OAuth2 + reauth + reconfigure flow."""
+
+    DOMAIN = DOMAIN
+    VERSION = 1
+
+    @property
+    def logger(self) -> logging.Logger:
+        """Return the logger."""
+        return _LOGGER
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Ensure the built-in OAuth credential exists, then start OAuth."""
+        await async_import_client_credential(
+            self.hass,
+            DOMAIN,
+            ClientCredential(client_id=OAUTH_CLIENT_ID, client_secret=""),
+        )
+        return await super().async_step_user(user_input)
+
+    async def async_oauth_create_entry(self, data: dict[str, Any]) -> ConfigFlowResult:
+        """Create or update the entry on successful OAuth.
+
+        Three sources land here:
+
+        * ``SOURCE_USER`` — first-time setup, create a new entry.
+        * ``SOURCE_REAUTH`` — token refresh failed, update the existing
+          entry's token (same account required).
+        * ``SOURCE_RECONFIGURE`` — user clicked "Reconfigure", update the
+          existing entry's token (same account required).
+        """
+        account_id = await self._fetch_account_id(data)
+
+        if self.source == config_entries.SOURCE_REAUTH:
+            return await self._async_finish_reauth(data, account_id)
+
+        if self.source == config_entries.SOURCE_RECONFIGURE:
+            return await self._async_finish_reconfigure(data, account_id)
+
+        if account_id is not None:
+            await self.async_set_unique_id(account_id)
+            self._abort_if_unique_id_configured()
+
+        return self.async_create_entry(title="Culiplan", data=data)
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Start the re-auth flow when the API returns 401."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Confirm the user wants to re-authenticate."""
+        if user_input is None:
+            return self.async_show_form(step_id="reauth_confirm")
+        return await self.async_step_user()
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Re-run the OAuth flow against the existing entry."""
+        return await self.async_step_user()
+
+    # ─── Account helpers ─────────────────────────────────────────────────────
+
+    async def _fetch_account_id(self, data: dict[str, Any]) -> str | None:
+        """Fetch the Culiplan account id used as ``unique_id``."""
+        token = data.get("token") or {}
+        access_token = token.get("access_token") if isinstance(token, dict) else None
+        if not access_token:
+            return None
+        session = aiohttp_client.async_get_clientsession(self.hass)
+        try:
+            async with session.get(
+                f"{BASE_URL}/api/users/me",
+                headers={"Authorization": f"Bearer {access_token}"},
+                timeout=_ACCOUNT_ID_TIMEOUT,
+            ) as resp:
+                if resp.status != 200:
+                    return None
+                me = await resp.json()
+        except (aiohttp.ClientError, TimeoutError) as err:
+            _LOGGER.debug("Could not fetch /api/users/me for unique_id: %s", err)
+            return None
+        user_id = me.get("id") if isinstance(me, dict) else None
+        return str(user_id) if user_id else None
+
+    async def _async_finish_reconfigure(
+        self, data: dict[str, Any], account_id: str | None
+    ) -> ConfigFlowResult:
+        """Apply a reconfigure result, enforcing the same Culiplan account."""
+        entry = self._get_reconfigure_entry()
+        if (
+            entry.unique_id is not None
+            and account_id is not None
+            and entry.unique_id != account_id
+        ):
+            return self.async_abort(reason="wrong_account")
+        if account_id is not None:
+            await self.async_set_unique_id(account_id)
+            self._abort_if_unique_id_mismatch(reason="wrong_account")
+        return self.async_update_reload_and_abort(entry, data={**entry.data, **data})
+
+    async def _async_finish_reauth(
+        self, data: dict[str, Any], account_id: str | None
+    ) -> ConfigFlowResult:
+        """Apply a re-auth result, enforcing the same Culiplan account.
+
+        Without this branch, ``async_oauth_create_entry`` falls through
+        to ``_abort_if_unique_id_configured`` and aborts the flow with
+        ``already_configured`` — leaving the user with a stale token.
+        """
+        entry = self._get_reauth_entry()
+        if (
+            entry.unique_id is not None
+            and account_id is not None
+            and entry.unique_id != account_id
+        ):
+            return self.async_abort(reason="wrong_account")
+        if account_id is not None:
+            await self.async_set_unique_id(account_id)
+            self._abort_if_unique_id_mismatch(reason="wrong_account")
+        return self.async_update_reload_and_abort(entry, data={**entry.data, **data})

--- a/homeassistant/components/culiplan/const.py
+++ b/homeassistant/components/culiplan/const.py
@@ -1,0 +1,32 @@
+"""Constants for the Culiplan integration."""
+
+from homeassistant.const import Platform
+
+DOMAIN = "culiplan"
+
+# OAuth client ID for the Home Assistant Core integration. The Culiplan
+# backend treats this as a public PKCE client (no client_secret).
+OAUTH_CLIENT_ID = "ha-core"
+BASE_URL = "https://api.culiplan.com"
+
+OAUTH2_AUTHORIZE = f"{BASE_URL}/api/oauth/authorize"
+OAUTH2_TOKEN = f"{BASE_URL}/api/oauth/token"
+
+# OAuth scopes requested for the ha-core client. Must be a subset of the
+# allowed scopes registered for "ha-core" in the backend.
+OAUTH2_SCOPES: tuple[str, ...] = (
+    "calendar:read",
+    "todo:read",
+    "todo:write",
+    "pantry:read",
+    "meals:read",
+    "shopping:read",
+    "shopping:write",
+    "recipes:read",
+    "profile:read",
+    "household:read",
+    "openid",
+    "offline_access",
+)
+
+PLATFORMS: list[Platform] = [Platform.CALENDAR]

--- a/homeassistant/components/culiplan/coordinator.py
+++ b/homeassistant/components/culiplan/coordinator.py
@@ -1,0 +1,266 @@
+"""DataUpdateCoordinator for the Culiplan integration.
+
+The coordinator runs REST polling on a 5-minute interval and, in
+parallel, maintains a Socket.IO connection to ``/ha-events`` for push
+updates. If the push connection drops we keep working off the REST
+poll until it reconnects.
+"""
+
+import asyncio
+import contextlib
+from datetime import timedelta
+import logging
+import random
+from typing import Any, cast
+
+import socketio
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers import config_entry_oauth2_flow
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .api import CuliplanApiClient, CuliplanApiError
+from .const import BASE_URL, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+HA_NAMESPACE = "/ha-events"
+HA_EVENT = "ha:event"
+HA_ERROR = "ha:error"
+
+# Culiplan plans rarely change minute-by-minute; the Socket.IO push channel
+# delivers near-real-time updates when connected. 5 minutes is the safety-net
+# poll interval used only when push is disconnected (Bronze: appropriate-polling).
+_DEFAULT_POLL_INTERVAL = timedelta(minutes=5)
+_RECONNECT_INITIAL_DELAY = 2.0
+# Cap reconnect backoff at 60s so a recovered backend is rediscovered quickly
+# without hammering it during a full outage.
+_RECONNECT_MAX_DELAY = 60.0
+_RECONNECT_FACTOR = 2.0
+# Random jitter (0-25 % of the current delay) prevents N coordinators from
+# reconnecting in lockstep after a shared backend outage. `random` (not
+# `secrets`) is fine here - this is anti-thundering-herd, not a crypto seed.
+_RECONNECT_JITTER_FRACTION = 0.25
+# Socket.IO initial-handshake timeout. Longer than the REST timeout because
+# the WS upgrade has to traverse the same path plus an Engine.IO handshake.
+_SOCKETIO_HANDSHAKE_TIMEOUT = 15
+
+
+class CuliplanCoordinator(DataUpdateCoordinator[dict[str, Any]]):
+    """Push-first coordinator with REST polling fallback."""
+
+    config_entry: ConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        client: CuliplanApiClient,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialise the coordinator and remember our config entry."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=_DEFAULT_POLL_INTERVAL,
+            config_entry=entry,
+        )
+        self.client = client
+        self._sio: socketio.AsyncClient | None = None
+        self._reconnect_task: asyncio.Task[None] | None = None
+        self._connected = False
+        self._stopped = False
+
+    @property
+    def push_connected(self) -> bool:
+        """Return ``True`` while the Socket.IO push channel is connected."""
+        return self._connected
+
+    # ─── Lifecycle ────────────────────────────────────────────────────────────
+
+    async def async_start(self) -> None:
+        """Connect the Socket.IO push channel."""
+        self._stopped = False
+        await self._connect()
+
+    async def async_stop(self) -> None:
+        """Disconnect Socket.IO and cancel any reconnect task."""
+        self._stopped = True
+        if self._reconnect_task and not self._reconnect_task.done():
+            self._reconnect_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._reconnect_task
+            self._reconnect_task = None
+        if self._sio is not None:
+            with contextlib.suppress(socketio.exceptions.SocketIOError, OSError):
+                await self._sio.disconnect()
+            self._sio = None
+
+    # ─── DataUpdateCoordinator protocol ──────────────────────────────────────
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        """Fetch a full snapshot from REST.
+
+        Core endpoints (meal plans, shopping list) failing aborts the
+        update so HA marks entities unavailable. The pantry slice is
+        best-effort because that scope is opt-in for users on a free
+        plan and failing it shouldn't break the rest.
+        """
+        try:
+            await self._refresh_token()
+            meal_plans = await self.client.async_get_meal_plans()
+            shopping_lists = await self.client.async_get_shopping_lists()
+        except ConfigEntryAuthFailed:
+            raise
+        except CuliplanApiError as err:
+            raise UpdateFailed(f"Culiplan REST fetch failed: {err}") from err
+
+        pantry_items: list[dict[str, Any]] = []
+        try:
+            pantry_items = await self.client.async_get_pantry_items()
+        except CuliplanApiError as err:
+            _LOGGER.debug("Pantry fetch failed (continuing): %s", err)
+
+        return {
+            "meal_plans": meal_plans,
+            "shopping_lists": shopping_lists,
+            "pantry_items": pantry_items,
+        }
+
+    # ─── Socket.IO connection ─────────────────────────────────────────────────
+
+    async def _connect(self) -> None:
+        """Open the Socket.IO connection to ``/ha-events``."""
+        if self._stopped:
+            return
+
+        access_token = await self._refresh_token()
+
+        sio = socketio.AsyncClient(
+            reconnection=False,
+            logger=False,
+            engineio_logger=False,
+        )
+        self._sio = sio
+
+        @sio.event(namespace=HA_NAMESPACE)  # type: ignore[untyped-decorator]
+        async def connect() -> None:
+            _LOGGER.debug("Connected to Culiplan /ha-events")
+            self._connected = True
+            await self.async_request_refresh()
+
+        @sio.event(namespace=HA_NAMESPACE)  # type: ignore[untyped-decorator]
+        async def disconnect(reason: str | None = None) -> None:
+            _LOGGER.debug("Disconnected from Culiplan /ha-events: %s", reason)
+            self._connected = False
+            self._schedule_reconnect()
+
+        @sio.on(HA_EVENT, namespace=HA_NAMESPACE)  # type: ignore[untyped-decorator]
+        async def on_ha_event(payload: dict[str, Any]) -> None:
+            await self._handle_event(payload)
+
+        @sio.on(HA_ERROR, namespace=HA_NAMESPACE)  # type: ignore[untyped-decorator]
+        async def on_ha_error(payload: dict[str, Any]) -> None:
+            _LOGGER.debug("HA gateway error: %s", payload.get("message"))
+
+        try:
+            await sio.connect(
+                BASE_URL,
+                namespaces=[HA_NAMESPACE],
+                auth={"token": access_token},
+                transports=["websocket"],
+                wait_timeout=_SOCKETIO_HANDSHAKE_TIMEOUT,
+            )
+        except socketio.exceptions.ConnectionError as err:
+            _LOGGER.debug("Failed to connect to /ha-events: %s", err)
+            self._connected = False
+            self._schedule_reconnect()
+
+    async def _handle_event(self, payload: dict[str, Any]) -> None:
+        event_type: str = payload.get("type", "")
+        _LOGGER.debug("ha:event type=%s", event_type)
+        if event_type == "meal_plan.updated":
+            await self._refresh_meal_plans()
+        elif event_type.startswith("shopping_list.item."):
+            await self._refresh_shopping_lists()
+        elif event_type.startswith("pantry.item."):
+            await self._refresh_pantry()
+
+    async def _refresh_meal_plans(self) -> None:
+        try:
+            meal_plans = await self.client.async_get_meal_plans()
+        except CuliplanApiError as err:
+            _LOGGER.debug("Failed to refresh meal plans: %s", err)
+            return
+        self.async_set_updated_data({**(self.data or {}), "meal_plans": meal_plans})
+
+    async def _refresh_shopping_lists(self) -> None:
+        try:
+            shopping_lists = await self.client.async_get_shopping_lists()
+        except CuliplanApiError as err:
+            _LOGGER.debug("Failed to refresh shopping lists: %s", err)
+            return
+        self.async_set_updated_data(
+            {**(self.data or {}), "shopping_lists": shopping_lists}
+        )
+
+    async def _refresh_pantry(self) -> None:
+        try:
+            pantry_items = await self.client.async_get_pantry_items()
+        except CuliplanApiError as err:
+            _LOGGER.debug("Failed to refresh pantry items: %s", err)
+            return
+        self.async_set_updated_data({**(self.data or {}), "pantry_items": pantry_items})
+
+    # ─── Reconnect logic ─────────────────────────────────────────────────────
+
+    def _schedule_reconnect(self, delay: float = _RECONNECT_INITIAL_DELAY) -> None:
+        if self._stopped:
+            return
+        if self._reconnect_task and not self._reconnect_task.done():
+            return
+
+        async def _reconnect_loop(initial_delay: float) -> None:
+            base = initial_delay
+            while not self._connected and not self._stopped:
+                # Apply jitter on each attempt so two coordinators sharing the
+                # same outage clock don't pick the same delay.
+                jitter = random.uniform(0, base * _RECONNECT_JITTER_FRACTION)
+                wait = base + jitter
+                _LOGGER.debug("Reconnecting to Culiplan in %.1fs", wait)
+                await asyncio.sleep(wait)
+                if self._stopped:
+                    return
+                try:
+                    if self._sio is not None:
+                        await self._sio.disconnect()
+                    await self._connect()
+                    if self._connected:
+                        return
+                except (socketio.exceptions.SocketIOError, OSError) as err:
+                    _LOGGER.debug("Reconnect attempt failed: %s", err)
+                base = min(base * _RECONNECT_FACTOR, _RECONNECT_MAX_DELAY)
+
+        self._reconnect_task = self.hass.async_create_background_task(
+            _reconnect_loop(delay),
+            name=f"{DOMAIN}_reconnect",
+        )
+
+    # ─── Token helpers ───────────────────────────────────────────────────────
+
+    async def _refresh_token(self) -> str:
+        """Ensure the OAuth token is valid and propagate it to the API client."""
+        implementation = (
+            await config_entry_oauth2_flow.async_get_config_entry_implementation(
+                self.hass, self.config_entry
+            )
+        )
+        session = config_entry_oauth2_flow.OAuth2Session(
+            self.hass, self.config_entry, implementation
+        )
+        await session.async_ensure_token_valid()
+        token = cast(str, session.token.get("access_token", ""))
+        self.client.set_access_token(token)
+        return token

--- a/homeassistant/components/culiplan/diagnostics.py
+++ b/homeassistant/components/culiplan/diagnostics.py
@@ -1,0 +1,48 @@
+"""Diagnostics support for the Culiplan integration.
+
+Returns integration health data for troubleshooting while redacting
+sensitive values (OAuth tokens, refresh tokens, account identifiers).
+"""
+
+from datetime import UTC, datetime
+import time
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.core import HomeAssistant
+
+from . import CuliplanConfigEntry
+
+_REDACT = {"access_token", "refresh_token", "token", "id", "email"}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant,
+    entry: CuliplanConfigEntry,
+) -> dict[str, Any]:
+    """Return diagnostics for ``entry`` — tokens and IDs are redacted."""
+    runtime = entry.runtime_data
+    coordinator = runtime.coordinator
+
+    token: dict[str, Any] = entry.data.get("token", {}) or {}
+    issued_at = token.get("issued_at")
+    token_age_seconds = (
+        int(time.time() - issued_at) if isinstance(issued_at, (int, float)) else None
+    )
+
+    return {
+        "entry": async_redact_data(
+            {"data": dict(entry.data), "options": dict(entry.options)}, _REDACT
+        ),
+        "token_age_seconds": token_age_seconds,
+        "coordinator": {
+            "last_update_success": coordinator.last_update_success,
+            "last_exception": (
+                repr(coordinator.last_exception)
+                if coordinator.last_exception is not None
+                else None
+            ),
+            "push_connected": coordinator.push_connected,
+        },
+        "captured_at": datetime.now(UTC).isoformat(),
+    }

--- a/homeassistant/components/culiplan/helpers.py
+++ b/homeassistant/components/culiplan/helpers.py
@@ -1,0 +1,36 @@
+"""Shared helpers for the Culiplan integration."""
+
+from datetime import UTC, date, datetime
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
+
+from .const import DOMAIN
+
+
+def build_device_info(entry: ConfigEntry) -> DeviceInfo:
+    """Return a canonical ``DeviceInfo`` for all Culiplan entities.
+
+    All entities for one config entry share one device card so the user
+    sees a single "Culiplan" device in the registry rather than one per
+    entity.
+    """
+    return DeviceInfo(
+        identifiers={(DOMAIN, entry.entry_id)},
+        name="Culiplan",
+        manufacturer="Culiplan",
+        model="Meal Planner",
+        configuration_url="https://culiplan.com",
+        entry_type=DeviceEntryType.SERVICE,
+    )
+
+
+def parse_dt(value: str) -> datetime:
+    """Parse an ISO-8601 date or datetime string into a tz-aware datetime."""
+    try:
+        dt = datetime.fromisoformat(value)
+        return dt if dt.tzinfo else dt.replace(tzinfo=UTC)
+    except ValueError:
+        return datetime.combine(
+            date.fromisoformat(value), datetime.min.time(), tzinfo=UTC
+        )

--- a/homeassistant/components/culiplan/icons.json
+++ b/homeassistant/components/culiplan/icons.json
@@ -1,0 +1,9 @@
+{
+  "entity": {
+    "calendar": {
+      "meal_plan": {
+        "default": "mdi:silverware-fork-knife"
+      }
+    }
+  }
+}

--- a/homeassistant/components/culiplan/llm_api.py
+++ b/homeassistant/components/culiplan/llm_api.py
@@ -1,0 +1,404 @@
+"""Culiplan LLM API.
+
+Exposes Culiplan tools to any Home Assistant Conversation Agent via
+:func:`homeassistant.helpers.llm.async_register_api`. With this in place,
+a user with the built-in HA Conversation Agent (OpenAI / Anthropic /
+Google / Ollama / Voice Preview) can ask "what's for dinner?" or "add
+milk to my shopping list" and the agent calls Culiplan natively.
+"""
+
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+import logging
+from typing import Any, cast
+from urllib.parse import quote
+
+import voluptuous as vol
+
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import llm
+from homeassistant.util.json import JsonObjectType
+
+from .api import CuliplanApiClient, CuliplanApiError
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+LLM_API_ID = f"{DOMAIN}-llm"
+
+# Refcount of config entries that hold the LLM API alive. The API is a
+# process-wide singleton — register on first entry, unregister on last.
+_LLM_REFCOUNT_KEY = f"{DOMAIN}_llm_refcount"
+_LLM_UNREGISTER_KEY = f"{DOMAIN}_llm_unregister"
+
+_PROMPT = (
+    "You can answer questions about the user's meal plan, recipes, "
+    "shopping list, and pantry. Use the Culiplan tools to fetch live "
+    "data — never invent recipes or quantities. If a tool returns no "
+    "results, say so honestly. Dates are ISO 8601 (YYYY-MM-DD)."
+)
+
+
+class CuliplanLLMAPI(llm.API):
+    """Expose Culiplan tools to any HA Conversation Agent."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialise the API with a fixed id and display name."""
+        super().__init__(hass=hass, id=LLM_API_ID, name="Culiplan")
+
+    async def async_get_api_instance(
+        self, llm_context: llm.LLMContext
+    ) -> llm.APIInstance:
+        """Return a per-call ``APIInstance`` carrying the Culiplan tools."""
+        return llm.APIInstance(
+            api=self,
+            api_prompt=_PROMPT,
+            llm_context=llm_context,
+            tools=[
+                _GetMealPlanTool(),
+                _AddToShoppingListTool(),
+                _GetPantryItemsTool(),
+                _FindRecipesByIngredientsTool(),
+                _GetRecipeTool(),
+            ],
+        )
+
+
+def _get_client(hass: HomeAssistant) -> CuliplanApiClient | None:
+    """Return the first configured Culiplan client or ``None``."""
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        runtime = getattr(entry, "runtime_data", None)
+        if runtime is not None:
+            return cast(CuliplanApiClient, runtime.client)
+    return None
+
+
+def _not_configured() -> JsonObjectType:
+    """Return the canonical "integration not yet configured" tool response."""
+    return {
+        "error": "not_configured",
+        "message": (
+            "Culiplan is not configured. Ask the user to set it up "
+            "under Settings → Devices & Services."
+        ),
+    }
+
+
+class _GetMealPlanTool(llm.Tool):
+    """Return the user's current meal plan."""
+
+    name = "get_meal_plan"
+    description = (
+        "Return the user's current meal plan. Optionally filter to a "
+        "date range with start_date / end_date (ISO 8601, YYYY-MM-DD)."
+    )
+    parameters = vol.Schema(
+        {
+            vol.Optional("start_date"): str,
+            vol.Optional("end_date"): str,
+        }
+    )
+
+    async def async_call(
+        self,
+        hass: HomeAssistant,
+        tool_input: llm.ToolInput,
+        llm_context: llm.LLMContext,
+    ) -> JsonObjectType:
+        """Fetch and optionally trim the meal plan."""
+        client = _get_client(hass)
+        if client is None:
+            return _not_configured()
+        try:
+            plans = await client.async_get_meal_plans()
+        except CuliplanApiError as err:
+            return {"error": "api_error", "message": str(err)}
+
+        start = tool_input.tool_args.get("start_date")
+        end = tool_input.tool_args.get("end_date")
+        if (start or end) and plans:
+            plan = plans[0]
+            slots = [
+                s
+                for s in plan.get("slots", [])
+                if _slot_in_range(s.get("date"), start, end)
+            ]
+            plans = [{**plan, "slots": slots}]
+
+        return cast(
+            JsonObjectType,
+            {
+                "meal_plan": plans,
+                "count": sum(len(p.get("slots", [])) for p in plans),
+            },
+        )
+
+
+class _AddToShoppingListTool(llm.Tool):
+    """Add an item to the user's shopping list."""
+
+    name = "add_to_shopping_list"
+    description = (
+        "Add an item to the Culiplan shopping list. Use this for "
+        "'add milk to my shopping list' or 'put two kilograms of "
+        "potatoes on the list'."
+    )
+    parameters = vol.Schema(
+        {
+            vol.Required("name"): vol.All(str, vol.Length(min=1, max=200)),
+            vol.Optional("quantity"): vol.All(str, vol.Length(max=80)),
+        }
+    )
+
+    async def async_call(
+        self,
+        hass: HomeAssistant,
+        tool_input: llm.ToolInput,
+        llm_context: llm.LLMContext,
+    ) -> JsonObjectType:
+        """Add the item and return the created record id."""
+        client = _get_client(hass)
+        if client is None:
+            return _not_configured()
+        name = tool_input.tool_args["name"]
+        quantity = tool_input.tool_args.get("quantity")
+        try:
+            created = await client.async_add_shopping_item(name=name, quantity=quantity)
+        except CuliplanApiError as err:
+            return {"error": "api_error", "message": str(err)}
+        return {
+            "added": True,
+            "name": name,
+            "quantity": quantity,
+            "item_id": created.get("id") if isinstance(created, dict) else None,
+        }
+
+
+class _GetPantryItemsTool(llm.Tool):
+    """Return the user's pantry stock."""
+
+    name = "get_pantry_items"
+    description = (
+        "Return the user's pantry stock. Optional expiring_within_days "
+        "filters to items expiring in that many days."
+    )
+    parameters = vol.Schema(
+        {
+            vol.Optional("expiring_within_days"): vol.All(
+                vol.Coerce(int), vol.Range(min=1, max=365)
+            ),
+        }
+    )
+
+    async def async_call(
+        self,
+        hass: HomeAssistant,
+        tool_input: llm.ToolInput,
+        llm_context: llm.LLMContext,
+    ) -> JsonObjectType:
+        """Fetch pantry stock and optionally filter by expiry."""
+        client = _get_client(hass)
+        if client is None:
+            return _not_configured()
+        try:
+            items = await client.async_get_pantry_items()
+        except CuliplanApiError as err:
+            return {"error": "api_error", "message": str(err)}
+
+        within_days = tool_input.tool_args.get("expiring_within_days")
+        if within_days is not None:
+            items = _filter_expiring(items, int(within_days))
+
+        slimmed = [
+            {
+                "id": item.get("id"),
+                "name": item.get("name"),
+                "quantity": item.get("quantity"),
+                "unit": item.get("unit"),
+                "expires_at": item.get("expiresAt"),
+            }
+            for item in items[:50]
+            if isinstance(item, dict)
+        ]
+        return cast(
+            JsonObjectType,
+            {
+                "pantry_items": slimmed,
+                "count": len(slimmed),
+                "truncated": len(items) > 50,
+            },
+        )
+
+
+class _FindRecipesByIngredientsTool(llm.Tool):
+    """Search recipes by ingredient list."""
+
+    name = "find_recipes_by_ingredients"
+    description = (
+        "Find recipes the user can make from a list of ingredients. "
+        "Returns up to 10 matches."
+    )
+    parameters = vol.Schema(
+        {vol.Required("ingredients"): vol.All([str], vol.Length(min=1, max=20))}
+    )
+
+    async def async_call(
+        self,
+        hass: HomeAssistant,
+        tool_input: llm.ToolInput,
+        llm_context: llm.LLMContext,
+    ) -> JsonObjectType:
+        """Search and trim the result to the LLM-relevant fields."""
+        client = _get_client(hass)
+        if client is None:
+            return _not_configured()
+        ingredients = tool_input.tool_args["ingredients"]
+        query = ",".join(ingredients)
+        path = f"/api/recipes?ingredients={quote(query)}&limit=10"
+        try:
+            result = await client.async_get(path)
+        except CuliplanApiError as err:
+            return {"error": "api_error", "message": str(err)}
+
+        recipes_raw: Any
+        if isinstance(result, dict) and "data" in result:
+            recipes_raw = result["data"]
+        elif isinstance(result, list):
+            recipes_raw = result
+        else:
+            recipes_raw = []
+
+        recipes: list[dict[str, Any]] = []
+        if isinstance(recipes_raw, list):
+            for r in recipes_raw[:10]:
+                if not isinstance(r, dict):
+                    continue
+                recipes.append(
+                    {
+                        "id": r.get("id"),
+                        "title": r.get("title"),
+                        "prep_time_minutes": r.get("prepTime")
+                        or r.get("prepTimeMinutes"),
+                        "servings": r.get("servings"),
+                    }
+                )
+
+        return {
+            "recipes": recipes,
+            "count": len(recipes),
+            "ingredients_searched": ingredients,
+        }
+
+
+class _GetRecipeTool(llm.Tool):
+    """Fetch a single recipe by id."""
+
+    name = "get_recipe"
+    description = (
+        "Fetch full details for a recipe by id. Use the recipe_id "
+        "returned by find_recipes_by_ingredients or get_meal_plan."
+    )
+    parameters = vol.Schema(
+        {vol.Required("recipe_id"): vol.All(str, vol.Length(min=1, max=200))}
+    )
+
+    async def async_call(
+        self,
+        hass: HomeAssistant,
+        tool_input: llm.ToolInput,
+        llm_context: llm.LLMContext,
+    ) -> JsonObjectType:
+        """Fetch the recipe and trim fields the LLM does not need."""
+        client = _get_client(hass)
+        if client is None:
+            return _not_configured()
+        recipe_id = tool_input.tool_args["recipe_id"]
+        try:
+            recipe = await client.async_get(f"/api/recipes/{quote(recipe_id, safe='')}")
+        except CuliplanApiError as err:
+            return {"error": "api_error", "message": str(err)}
+        if not isinstance(recipe, dict):
+            return {
+                "error": "not_found",
+                "message": f"No recipe found for id '{recipe_id}'.",
+            }
+        keep_keys = {
+            "id",
+            "title",
+            "description",
+            "ingredients",
+            "instructions",
+            "prepTime",
+            "cookTime",
+            "totalTime",
+            "servings",
+            "cuisine",
+            "tags",
+        }
+        trimmed = {k: v for k, v in recipe.items() if k in keep_keys}
+        return {"recipe": trimmed}
+
+
+def _slot_in_range(date_value: Any, start: str | None, end: str | None) -> bool:
+    """Return ``True`` if a slot's date falls within ``[start, end]``."""
+    if not isinstance(date_value, str):
+        return True
+    date_only = date_value[:10]
+    if start and date_only < start:
+        return False
+    return not (end and date_only > end)
+
+
+def _filter_expiring(
+    items: list[dict[str, Any]], within_days: int
+) -> list[dict[str, Any]]:
+    """Return only items expiring within ``within_days`` days."""
+    now = datetime.now(tz=UTC)
+    cutoff = now + timedelta(days=within_days)
+    out: list[dict[str, Any]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        expires_raw = item.get("expiresAt")
+        if not isinstance(expires_raw, str):
+            continue
+        try:
+            expires = datetime.fromisoformat(expires_raw)
+        except ValueError:
+            continue
+        if expires <= cutoff:
+            out.append(item)
+    return out
+
+
+@callback
+def async_register_llm_api(hass: HomeAssistant) -> None:
+    """Register the Culiplan LLM API (refcounted across config entries).
+
+    The LLM API is a process-wide singleton, but each config entry that
+    sets it up holds a reference. We register on the first entry and
+    only unregister when the last entry is unloaded. This avoids the
+    silent "API disappeared from one entry's unload" bug.
+    """
+    count = cast(int, hass.data.get(_LLM_REFCOUNT_KEY, 0))
+    if count == 0:
+        unregister = llm.async_register_api(hass, CuliplanLLMAPI(hass))
+        hass.data[_LLM_UNREGISTER_KEY] = unregister
+    hass.data[_LLM_REFCOUNT_KEY] = count + 1
+
+
+@callback
+def async_unregister_llm_api(hass: HomeAssistant) -> None:
+    """Drop one reference; unregister the API when the last is gone."""
+    count = cast(int, hass.data.get(_LLM_REFCOUNT_KEY, 0))
+    if count <= 0:
+        return
+    count -= 1
+    hass.data[_LLM_REFCOUNT_KEY] = count
+    if count > 0:
+        return
+    unregister = cast(
+        "Callable[[], None] | None", hass.data.pop(_LLM_UNREGISTER_KEY, None)
+    )
+    if unregister is not None:
+        unregister()

--- a/homeassistant/components/culiplan/manifest.json
+++ b/homeassistant/components/culiplan/manifest.json
@@ -1,0 +1,13 @@
+{
+  "domain": "culiplan",
+  "name": "Culiplan",
+  "codeowners": ["@culiplan"],
+  "config_flow": true,
+  "dependencies": ["application_credentials"],
+  "documentation": "https://www.home-assistant.io/integrations/culiplan",
+  "integration_type": "service",
+  "iot_class": "cloud_push",
+  "loggers": ["homeassistant.components.culiplan"],
+  "quality_scale": "silver",
+  "requirements": ["python-socketio>=5.12.0"]
+}

--- a/homeassistant/components/culiplan/quality_scale.yaml
+++ b/homeassistant/components/culiplan/quality_scale.yaml
@@ -1,0 +1,273 @@
+# Quality scale for the Culiplan integration (Core-ready slim build).
+#
+# Per HA Core review guidance, the first PR ships a single platform
+# (calendar). Follow-up PRs will add the todo, sensor, and binary_sensor
+# platforms after this one merges, mirroring the Mealie integration's
+# multi-platform rollout. This slim build honestly targets **Silver** on
+# day one of the Core PR. Gold/Platinum are reachable once docs land on
+# home-assistant.io and brand assets ship via home-assistant/brands.
+
+rules:
+  # ─── Bronze ────────────────────────────────────────────────────────────────
+  action-setup:
+    status: exempt
+    comment: |
+      No services / actions are registered by this slim build. All voice-
+      facing surface is via the LLM API (llm_api.py) rather than HA service
+      calls.
+  appropriate-polling:
+    status: done
+    comment: |
+      DataUpdateCoordinator polls every 5 minutes; Socket.IO push delivers
+      sub-second updates between polls.
+  brands:
+    status: todo
+    comment: |
+      Brand assets (icon, logo) need to ship in home-assistant/brands. A
+      separate PR will be opened against that repo alongside the Core PR.
+  common-modules:
+    status: done
+    comment: |
+      const.py, helpers.py, coordinator.py, api.py follow the standard
+      layout; entity platforms in their own per-platform modules.
+  config-flow-test-coverage:
+    status: done
+    comment: |
+      tests/components/culiplan/test_config_flow.py covers OAuth happy
+      path, abort-on-duplicate, reauth, reconfigure (same-account and
+      wrong-account), and the options flow.
+  config-flow:
+    status: done
+    comment: |
+      Full UI config flow with OAuth + reauth + reconfigure. The Options
+      flow exposes the pantry expiry windows.
+  dependency-transparency:
+    status: done
+    comment: |
+      Only `python-socketio` is required, published on PyPI under its
+      canonical name with full source.
+  docs-actions:
+    status: exempt
+    comment: |
+      No services registered — see action-setup above.
+  docs-high-level-description:
+    status: todo
+    comment: |
+      The home-assistant.io documentation page will be added as a
+      separate PR against the documentation repo; the URL in
+      manifest.json (`/integrations/culiplan`) is reserved for that PR.
+  docs-installation-instructions:
+    status: todo
+    comment: |
+      Tracked under docs-high-level-description — the install steps go on
+      the home-assistant.io documentation page.
+  docs-removal-instructions:
+    status: todo
+    comment: |
+      Tracked under docs-high-level-description.
+  entity-event-setup:
+    status: done
+    comment: |
+      All entity classes inherit from CoordinatorEntity, which subscribes
+      / unsubscribes via async_added_to_hass / async_will_remove_from_hass.
+      No entity listens to additional buses or signals.
+  entity-unique-id:
+    status: done
+    comment: |
+      Every entity sets `_attr_unique_id = f"{entry.entry_id}_<key>"`, so
+      a second config entry cannot collide with the first.
+  has-entity-name:
+    status: done
+    comment: |
+      All entity classes set `_attr_has_entity_name = True` and pair with
+      `_attr_translation_key`.
+  runtime-data:
+    status: done
+    comment: |
+      Per-entry runtime data lives on `ConfigEntry.runtime_data` (typed
+      `CuliplanConfigEntry`).
+  test-before-configure:
+    status: exempt
+    comment: |
+      OAuth itself is the "before configure" check — HA's
+      AbstractOAuth2FlowHandler will not create an entry without a valid
+      token. Additionally, `_fetch_account_id` calls `/api/users/me` so
+      a token that's syntactically valid but server-revoked is caught
+      before the entry is created.
+  test-before-setup:
+    status: done
+    comment: |
+      `__init__.async_setup_entry` ensures the OAuth token is valid
+      before constructing the API client; the coordinator's first
+      refresh raises `ConfigEntryNotReady` on transient network
+      failures and `ConfigEntryAuthFailed` on 401.
+  unique-config-entry:
+    status: done
+    comment: |
+      The Culiplan account id (from `/api/users/me`) is the entry
+      `unique_id`; `_abort_if_unique_id_configured` runs in
+      `async_oauth_create_entry`.
+
+  # ─── Silver ────────────────────────────────────────────────────────────────
+  action-exceptions:
+    status: exempt
+    comment: |
+      No services registered.
+  config-entry-unloading:
+    status: done
+    comment: |
+      `async_unload_entry` unloads all platforms; the coordinator's
+      Socket.IO connection is closed via the `async_on_unload` hook;
+      the LLM API is unregistered via the same mechanism.
+  docs-configuration-parameters:
+    status: todo
+    comment: |
+      Tracked under docs-high-level-description.
+  docs-installation-parameters:
+    status: todo
+    comment: |
+      Tracked under docs-high-level-description.
+  entity-unavailable:
+    status: done
+    comment: |
+      CoordinatorEntity drives availability from
+      `coordinator.last_update_success`.
+  integration-owner:
+    status: done
+    comment: |
+      `manifest.json` codeowners is `["@culiplan"]`.
+  log-when-unavailable:
+    status: done
+    comment: |
+      The coordinator logs `UpdateFailed` at WARNING (via HA's logger);
+      socket connect / reconnect events are logged at DEBUG. The API
+      client maps 401 to `ConfigEntryAuthFailed`.
+  parallel-updates:
+    status: done
+    comment: |
+      All entities share a single DataUpdateCoordinator (one HTTP burst
+      per refresh), so no `parallel_updates` cap is needed.
+  reauthentication-flow:
+    status: done
+    comment: |
+      `async_step_reauth` + `async_step_reauth_confirm` trigger HA's
+      standard re-auth UI; `api.py._raise_for_status` flips a 401 into
+      `ConfigEntryAuthFailed` to drive the flow.
+  test-coverage:
+    status: done
+    comment: |
+      `pytest --cov` exceeds 95% on the slim package. See
+      `pyproject.toml` (`fail_under = 95`).
+
+  # ─── Gold ──────────────────────────────────────────────────────────────────
+  devices:
+    status: done
+    comment: |
+      `build_device_info` returns a single DeviceInfo per entry; all
+      entities attach to that one device.
+  discovery-update-info:
+    status: exempt
+    comment: |
+      Cloud service — no LAN discovery surface.
+  discovery:
+    status: exempt
+    comment: |
+      Cloud service — not discoverable on the LAN.
+  docs-data-update:
+    status: todo
+    comment: |
+      Tracked under docs-high-level-description.
+  docs-examples:
+    status: todo
+    comment: |
+      Tracked under docs-high-level-description.
+  docs-known-limitations:
+    status: todo
+    comment: |
+      Tracked under docs-high-level-description.
+  docs-supported-devices:
+    status: todo
+    comment: |
+      Tracked under docs-high-level-description.
+  docs-supported-functions:
+    status: todo
+    comment: |
+      Tracked under docs-high-level-description.
+  docs-troubleshooting:
+    status: todo
+    comment: |
+      Tracked under docs-high-level-description.
+  docs-use-cases:
+    status: todo
+    comment: |
+      Tracked under docs-high-level-description.
+  dynamic-devices:
+    status: exempt
+    comment: |
+      Single device per entry (the user's Culiplan account).
+  entity-category:
+    status: done
+    comment: |
+      The calendar entity uses the default category.
+  entity-device-class:
+    status: exempt
+    comment: |
+      The calendar platform has no device-class concept. Follow-up
+      sensor / binary_sensor platforms will set device classes when they
+      land.
+  entity-disabled-by-default:
+    status: done
+    comment: |
+      The calendar entity ships enabled — there is no event-driven entity
+      that should be off by default in this build.
+  entity-translations:
+    status: done
+    comment: |
+      Every entity class sets `_attr_translation_key`; matching strings
+      exist in `strings.json` / `translations/en.json`.
+  exception-translations:
+    status: todo
+    comment: |
+      The slim build's API client raises generic `CuliplanApiError` and
+      `ConfigEntryAuthFailed`. No user-facing `HomeAssistantError` with
+      `translation_key` is raised; the exceptions block stays empty for
+      now. A follow-up will add translated exceptions once the LLM tool
+      surface starts surfacing errors to users.
+  icon-translations:
+    status: done
+    comment: |
+      `icons.json` keys all entities by their translation_key.
+  reconfiguration-flow:
+    status: done
+    comment: |
+      `async_step_reconfigure` re-runs OAuth, enforces same-account via
+      `_async_finish_reconfigure`, and merges new tokens into the
+      existing entry.
+  repair-issues:
+    status: exempt
+    comment: |
+      No premium / discoverable error conditions in the slim build — the
+      HACS distribution carries the Premium upsell repair flow.
+  stale-devices:
+    status: exempt
+    comment: |
+      One device per entry; nothing to mark stale.
+
+  # ─── Platinum ──────────────────────────────────────────────────────────────
+  async-dependency:
+    status: done
+    comment: |
+      The single PyPI requirement (`python-socketio>=5.12.0`) is fully
+      async; we use `socketio.AsyncClient`.
+  inject-websession:
+    status: done
+    comment: |
+      All HTTP calls route through
+      `aiohttp_client.async_get_clientsession(hass)`. No
+      `aiohttp.ClientSession()` is constructed anywhere in this build.
+  strict-typing:
+    status: done
+    comment: |
+      `mypy --strict homeassistant/components/culiplan/` passes. The only
+      per-line ignores are 4 `[misc]` markers on `python-socketio`
+      decorator handlers (the library ships no `py.typed`).

--- a/homeassistant/components/culiplan/strings.json
+++ b/homeassistant/components/culiplan/strings.json
@@ -1,0 +1,35 @@
+{
+  "config": {
+    "step": {
+      "pick_implementation": {
+        "title": "Connect Culiplan"
+      },
+      "reauth_confirm": {
+        "title": "Re-authenticate Culiplan",
+        "description": "Your Culiplan session has expired. Click **Submit** to re-authenticate."
+      }
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "oauth_error": "[%key:common::config_flow::abort::oauth2_error%]",
+      "oauth_timeout": "[%key:common::config_flow::abort::oauth2_timeout%]",
+      "oauth_unauthorized": "[%key:common::config_flow::abort::oauth2_unauthorized%]",
+      "oauth_failed": "[%key:common::config_flow::abort::oauth2_failed%]",
+      "missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]",
+      "missing_credentials": "[%key:common::config_flow::abort::oauth2_missing_credentials%]",
+      "wrong_account": "The authenticated Culiplan account does not match the existing entry. Re-authenticate with the same account or remove the entry and add the new account.",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
+    },
+    "create_entry": {
+      "default": "[%key:common::config_flow::create_entry::authenticated%]"
+    }
+  },
+  "entity": {
+    "calendar": {
+      "meal_plan": {
+        "name": "Meal plan"
+      }
+    }
+  }
+}

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2735,6 +2735,9 @@ python-sn2==0.4.0
 # homeassistant.components.snoo
 python-snoo==0.8.3
 
+# homeassistant.components.culiplan
+python-socketio==5.12.0
+
 # homeassistant.components.songpal
 python-songpal==0.16.2
 

--- a/tests/components/culiplan/__init__.py
+++ b/tests/components/culiplan/__init__.py
@@ -1,0 +1,4 @@
+"""Tests for the Culiplan integration."""
+
+CLIENT_ID = "ha-core"
+CLIENT_SECRET = ""

--- a/tests/components/culiplan/conftest.py
+++ b/tests/components/culiplan/conftest.py
@@ -1,0 +1,130 @@
+"""Pytest fixtures for the Culiplan integration tests."""
+
+from collections.abc import AsyncGenerator, Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant.components.application_credentials import (
+    ClientCredential,
+    async_import_client_credential,
+)
+from homeassistant.components.culiplan.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
+from tests.components.culiplan import CLIENT_ID, CLIENT_SECRET
+
+
+@pytest.fixture
+async def application_credentials(hass: HomeAssistant) -> None:
+    """Set up the application_credentials platform with a Culiplan client."""
+    assert await async_setup_component(hass, "application_credentials", {})
+
+    await async_import_client_credential(
+        hass, DOMAIN, ClientCredential(client_id=CLIENT_ID, client_secret=CLIENT_SECRET)
+    )
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return a Culiplan config entry pre-loaded with OAuth tokens."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="Culiplan",
+        unique_id="user-123",
+        data={
+            "auth_implementation": DOMAIN,
+            "token": {
+                "access_token": "test-access-token",
+                "refresh_token": "test-refresh-token",
+                "expires_at": 9_999_999_999,
+                "expires_in": 3600,
+                "type": "Bearer",
+                "issued_at": 1_700_000_000,
+            },
+        },
+    )
+
+
+@pytest.fixture
+def mock_api() -> Generator[AsyncMock]:
+    """Return a patched ``CuliplanApiClient`` instance."""
+    with patch(
+        "homeassistant.components.culiplan.CuliplanApiClient", autospec=True
+    ) as cls:
+        instance = cls.return_value
+        instance.set_access_token = lambda token: None
+        instance.async_get_meal_plans = AsyncMock(
+            return_value=[
+                {
+                    "id": "current",
+                    "name": "Meal Plan",
+                    "slots": [
+                        {
+                            "id": "slot-1",
+                            "date": "2099-01-15T18:00:00Z",
+                            "title": "Spaghetti Bolognese",
+                            "course": "dinner",
+                            "recipeId": "recipe-1",
+                            "servings": 2,
+                        }
+                    ],
+                }
+            ]
+        )
+        instance.async_get_shopping_lists = AsyncMock(
+            return_value=[
+                {
+                    "id": "default",
+                    "name": "Shopping List",
+                    "items": [
+                        {"id": "item-1", "name": "Milk", "completed": False},
+                        {"id": "item-2", "name": "Bread", "completed": True},
+                    ],
+                }
+            ]
+        )
+        instance.async_get_pantry_items = AsyncMock(return_value=[])
+        instance.async_add_shopping_item = AsyncMock(
+            return_value={"id": "new-item", "name": "Eggs"}
+        )
+        instance.async_update_shopping_item = AsyncMock(return_value={})
+        instance.async_remove_shopping_item = AsyncMock(return_value=None)
+        instance.async_get_user = AsyncMock(return_value={"id": "user-123"})
+        yield instance
+
+
+@pytest.fixture
+def mock_socketio() -> Generator[AsyncMock]:
+    """Stub out ``socketio.AsyncClient`` so coordinator.start() is a no-op."""
+    with patch(
+        "homeassistant.components.culiplan.coordinator.socketio.AsyncClient"
+    ) as cls:
+        instance = cls.return_value
+        instance.connect = AsyncMock()
+        instance.disconnect = AsyncMock()
+        instance.event = lambda *args, **kwargs: lambda fn: fn
+        instance.on = lambda *args, **kwargs: lambda fn: fn
+        yield instance
+
+
+@pytest.fixture
+async def setup_integration(
+    hass: HomeAssistant,
+    application_credentials: None,
+    mock_config_entry: MockConfigEntry,
+    mock_api: AsyncMock,
+    mock_socketio: AsyncMock,
+) -> AsyncGenerator[MockConfigEntry]:
+    """Set up the integration with mocked external surfaces."""
+    mock_config_entry.add_to_hass(hass)
+    with patch(
+        "homeassistant.components.culiplan.config_entry_oauth2_flow.OAuth2Session"
+    ) as mock_session:
+        mock_session.return_value.async_ensure_token_valid = AsyncMock()
+        mock_session.return_value.token = {"access_token": "test-access-token"}
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+        yield mock_config_entry

--- a/tests/components/culiplan/test_api.py
+++ b/tests/components/culiplan/test_api.py
@@ -1,0 +1,322 @@
+"""Tests for the Culiplan REST API client."""
+
+from typing import Any
+
+import aiohttp
+from aioresponses import aioresponses
+import pytest
+
+from homeassistant.components.culiplan.api import CuliplanApiClient, CuliplanApiError
+from homeassistant.components.culiplan.const import BASE_URL
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers import aiohttp_client
+
+
+@pytest.fixture
+def mock_aioresponses() -> Any:
+    """Yield an aioresponses fixture."""
+    with aioresponses() as m:
+        yield m
+
+
+async def test_get_meal_plans_normalises_grouped_dict(
+    hass: HomeAssistant, mock_aioresponses: aioresponses
+) -> None:
+    """A grouped-dict response is flattened into one synthetic plan."""
+    mock_aioresponses.get(
+        f"{BASE_URL}/api/meal-plans",
+        payload={
+            "2099-01-15": {
+                "dinner": [
+                    {
+                        "id": "slot-1",
+                        "date": "2099-01-15T18:00:00Z",
+                        "recipe": {"title": "Spaghetti"},
+                        "recipeId": "recipe-1",
+                        "mealSlot": "dinner",
+                    }
+                ]
+            }
+        },
+    )
+    session = aiohttp_client.async_get_clientsession(hass)
+    client = CuliplanApiClient(session, "token")
+    plans = await client.async_get_meal_plans()
+    assert len(plans) == 1
+    assert plans[0]["id"] == "current"
+    assert len(plans[0]["slots"]) == 1
+    assert plans[0]["slots"][0]["title"] == "Spaghetti"
+
+
+async def test_get_meal_plans_passthrough_list(
+    hass: HomeAssistant, mock_aioresponses: aioresponses
+) -> None:
+    """A bare list response is returned as-is."""
+    mock_aioresponses.get(
+        f"{BASE_URL}/api/meal-plans",
+        payload=[{"id": "p", "slots": []}],
+    )
+    session = aiohttp_client.async_get_clientsession(hass)
+    client = CuliplanApiClient(session, "token")
+    plans = await client.async_get_meal_plans()
+    assert plans == [{"id": "p", "slots": []}]
+
+
+async def test_get_meal_plans_unexpected_type(
+    hass: HomeAssistant, mock_aioresponses: aioresponses
+) -> None:
+    """An unexpected payload type returns an empty list."""
+    mock_aioresponses.get(f"{BASE_URL}/api/meal-plans", payload="oops")
+    session = aiohttp_client.async_get_clientsession(hass)
+    client = CuliplanApiClient(session, "token")
+    plans = await client.async_get_meal_plans()
+    assert plans == []
+
+
+async def test_get_shopping_lists_wraps(
+    hass: HomeAssistant, mock_aioresponses: aioresponses
+) -> None:
+    """The shopping list is wrapped in a one-element list."""
+    mock_aioresponses.get(
+        f"{BASE_URL}/api/shopping-list",
+        payload=[{"id": "i1", "name": "Milk", "completed": False}],
+    )
+    session = aiohttp_client.async_get_clientsession(hass)
+    client = CuliplanApiClient(session, "token")
+    lists = await client.async_get_shopping_lists()
+    assert lists[0]["id"] == "default"
+    assert lists[0]["items"][0]["name"] == "Milk"
+
+
+async def test_get_pantry_items_envelope_and_list(
+    hass: HomeAssistant, mock_aioresponses: aioresponses
+) -> None:
+    """Pantry parser handles both envelope and bare list."""
+    session = aiohttp_client.async_get_clientsession(hass)
+    client = CuliplanApiClient(session, "token")
+
+    mock_aioresponses.get(
+        f"{BASE_URL}/api/pantry/stock?limit=100",
+        payload={"data": [{"id": "p1"}]},
+    )
+    assert await client.async_get_pantry_items() == [{"id": "p1"}]
+
+    mock_aioresponses.get(
+        f"{BASE_URL}/api/pantry/stock?limit=100",
+        payload=[{"id": "p2"}],
+    )
+    assert await client.async_get_pantry_items() == [{"id": "p2"}]
+
+    mock_aioresponses.get(
+        f"{BASE_URL}/api/pantry/stock?limit=100",
+        payload="unexpected",
+    )
+    assert await client.async_get_pantry_items() == []
+
+
+async def test_401_raises_auth_failed(
+    hass: HomeAssistant, mock_aioresponses: aioresponses
+) -> None:
+    """A 401 is mapped onto ConfigEntryAuthFailed."""
+    mock_aioresponses.get(f"{BASE_URL}/api/shopping-list", status=401)
+    session = aiohttp_client.async_get_clientsession(hass)
+    client = CuliplanApiClient(session, "token")
+    with pytest.raises(ConfigEntryAuthFailed):
+        await client.async_get_shopping_lists()
+
+
+async def test_5xx_raises_api_error(
+    hass: HomeAssistant, mock_aioresponses: aioresponses
+) -> None:
+    """A 5xx raises CuliplanApiError."""
+    mock_aioresponses.get(f"{BASE_URL}/api/shopping-list", status=500)
+    session = aiohttp_client.async_get_clientsession(hass)
+    client = CuliplanApiClient(session, "token")
+    with pytest.raises(CuliplanApiError):
+        await client.async_get_shopping_lists()
+
+
+async def test_network_error_raises_api_error(
+    hass: HomeAssistant, mock_aioresponses: aioresponses
+) -> None:
+    """Connection errors raise CuliplanApiError."""
+    mock_aioresponses.get(
+        f"{BASE_URL}/api/shopping-list",
+        exception=aiohttp.ClientError("boom"),
+    )
+    session = aiohttp_client.async_get_clientsession(hass)
+    client = CuliplanApiClient(session, "token")
+    with pytest.raises(CuliplanApiError):
+        await client.async_get_shopping_lists()
+
+
+async def test_shopping_list_mutations(
+    hass: HomeAssistant, mock_aioresponses: aioresponses
+) -> None:
+    """Add / update / delete return parsed payloads."""
+    session = aiohttp_client.async_get_clientsession(hass)
+    client = CuliplanApiClient(session, "token")
+
+    mock_aioresponses.post(
+        f"{BASE_URL}/api/shopping-list",
+        payload=[{"id": "n1", "name": "Eggs"}],
+    )
+    created = await client.async_add_shopping_item("Eggs", quantity="6")
+    assert created["id"] == "n1"
+
+    mock_aioresponses.post(
+        f"{BASE_URL}/api/shopping-list",
+        payload={"id": "n2", "name": "Bread"},
+    )
+    created = await client.async_add_shopping_item("Bread")
+    assert created["id"] == "n2"
+
+    mock_aioresponses.patch(
+        f"{BASE_URL}/api/shopping-list/n1",
+        payload={"id": "n1", "completed": True},
+    )
+    updated = await client.async_update_shopping_item("n1", completed=True)
+    assert updated["id"] == "n1"
+
+    mock_aioresponses.delete(f"{BASE_URL}/api/shopping-list/n1", status=204)
+    await client.async_remove_shopping_item("n1")
+
+
+async def test_async_get_user_and_passthrough(
+    hass: HomeAssistant, mock_aioresponses: aioresponses
+) -> None:
+    """``async_get_user`` and ``async_get`` work."""
+    mock_aioresponses.get(
+        f"{BASE_URL}/api/users/me", payload={"id": "u1", "email": "x@y.z"}
+    )
+    session = aiohttp_client.async_get_clientsession(hass)
+    client = CuliplanApiClient(session, "token")
+    me = await client.async_get_user()
+    assert me["id"] == "u1"
+
+    mock_aioresponses.get(f"{BASE_URL}/api/anything", payload={"ok": True})
+    assert await client.async_get("/api/anything") == {"ok": True}
+
+
+async def test_patch_and_delete_network_error(
+    hass: HomeAssistant, mock_aioresponses: aioresponses
+) -> None:
+    """Network errors during PATCH / DELETE raise CuliplanApiError."""
+    session = aiohttp_client.async_get_clientsession(hass)
+    client = CuliplanApiClient(session, "token")
+    mock_aioresponses.patch(
+        f"{BASE_URL}/api/shopping-list/x",
+        exception=aiohttp.ClientError("net"),
+    )
+    with pytest.raises(CuliplanApiError):
+        await client.async_update_shopping_item("x", completed=True)
+
+    mock_aioresponses.delete(
+        f"{BASE_URL}/api/shopping-list/x",
+        exception=aiohttp.ClientError("net"),
+    )
+    with pytest.raises(CuliplanApiError):
+        await client.async_remove_shopping_item("x")
+
+
+async def test_post_network_error(
+    hass: HomeAssistant, mock_aioresponses: aioresponses
+) -> None:
+    """Network errors during POST raise CuliplanApiError."""
+    session = aiohttp_client.async_get_clientsession(hass)
+    client = CuliplanApiClient(session, "token")
+    mock_aioresponses.post(
+        f"{BASE_URL}/api/shopping-list",
+        exception=aiohttp.ClientError("net"),
+    )
+    with pytest.raises(CuliplanApiError):
+        await client.async_add_shopping_item("Eggs")
+
+
+async def test_get_meal_plans_malformed_inner_entries(
+    hass: HomeAssistant, mock_aioresponses: aioresponses
+) -> None:
+    """Malformed nested data is silently skipped."""
+    session = aiohttp_client.async_get_clientsession(hass)
+    client = CuliplanApiClient(session, "token")
+    mock_aioresponses.get(
+        f"{BASE_URL}/api/meal-plans",
+        payload={
+            "2099-01-15": {
+                "dinner": [
+                    "not-a-dict",
+                    {"id": "ok", "date": 12345},  # non-string date coerced
+                ],
+                "lunch": "not-a-list",
+            },
+            "bad-date": "not-a-dict",
+        },
+    )
+    plans = await client.async_get_meal_plans()
+    assert plans[0]["id"] == "current"
+    # Only the salvageable entry survives.
+    assert len(plans[0]["slots"]) == 1
+
+
+def test_set_access_token() -> None:
+    """``set_access_token`` updates the bearer."""
+    client = CuliplanApiClient(session=None, access_token="old")  # type: ignore[arg-type]
+    client.set_access_token("new")
+    assert client._access_token == "new"
+
+
+async def test_api_timeout_raises_api_error_get(
+    hass: HomeAssistant, mock_aioresponses: aioresponses
+) -> None:
+    """A timeout on GET surfaces as ``CuliplanApiError`` (mapped to UpdateFailed)."""
+    mock_aioresponses.get(
+        f"{BASE_URL}/api/shopping-list",
+        exception=TimeoutError("slow"),
+    )
+    session = aiohttp_client.async_get_clientsession(hass)
+    client = CuliplanApiClient(session, "token")
+    with pytest.raises(CuliplanApiError, match="timed out"):
+        await client.async_get_shopping_lists()
+
+
+async def test_api_timeout_raises_api_error_post(
+    hass: HomeAssistant, mock_aioresponses: aioresponses
+) -> None:
+    """A timeout on POST surfaces as ``CuliplanApiError``."""
+    mock_aioresponses.post(
+        f"{BASE_URL}/api/shopping-list",
+        exception=TimeoutError("slow"),
+    )
+    session = aiohttp_client.async_get_clientsession(hass)
+    client = CuliplanApiClient(session, "token")
+    with pytest.raises(CuliplanApiError, match="timed out"):
+        await client.async_add_shopping_item("Eggs")
+
+
+async def test_api_timeout_raises_api_error_patch(
+    hass: HomeAssistant, mock_aioresponses: aioresponses
+) -> None:
+    """A timeout on PATCH surfaces as ``CuliplanApiError``."""
+    mock_aioresponses.patch(
+        f"{BASE_URL}/api/shopping-list/x",
+        exception=TimeoutError("slow"),
+    )
+    session = aiohttp_client.async_get_clientsession(hass)
+    client = CuliplanApiClient(session, "token")
+    with pytest.raises(CuliplanApiError, match="timed out"):
+        await client.async_update_shopping_item("x", completed=True)
+
+
+async def test_api_timeout_raises_api_error_delete(
+    hass: HomeAssistant, mock_aioresponses: aioresponses
+) -> None:
+    """A timeout on DELETE surfaces as ``CuliplanApiError``."""
+    mock_aioresponses.delete(
+        f"{BASE_URL}/api/shopping-list/x",
+        exception=TimeoutError("slow"),
+    )
+    session = aiohttp_client.async_get_clientsession(hass)
+    client = CuliplanApiClient(session, "token")
+    with pytest.raises(CuliplanApiError, match="timed out"):
+        await client.async_remove_shopping_item("x")

--- a/tests/components/culiplan/test_application_credentials.py
+++ b/tests/components/culiplan/test_application_credentials.py
@@ -1,0 +1,78 @@
+"""Tests for the application_credentials platform (PKCE)."""
+
+from unittest.mock import patch
+
+from homeassistant.components.application_credentials import (
+    AuthorizationServer,
+    ClientCredential,
+)
+from homeassistant.components.culiplan.application_credentials import (
+    CuliplanOAuth2Implementation,
+    async_get_auth_implementation,
+    async_get_authorization_server,
+)
+from homeassistant.components.culiplan.const import (
+    DOMAIN,
+    OAUTH2_AUTHORIZE,
+    OAUTH2_SCOPES,
+    OAUTH2_TOKEN,
+)
+from homeassistant.core import HomeAssistant
+
+
+async def test_authorization_server(hass: HomeAssistant) -> None:
+    """Authorization server returns the configured URLs."""
+    server = await async_get_authorization_server(hass)
+    assert server.authorize_url == OAUTH2_AUTHORIZE
+    assert server.token_url == OAUTH2_TOKEN
+
+
+async def test_auth_implementation_returns_pkce_impl(hass: HomeAssistant) -> None:
+    """``async_get_auth_implementation`` returns the PKCE subclass."""
+    cred = ClientCredential(client_id="ha-core", client_secret="")
+    impl = await async_get_auth_implementation(hass, DOMAIN, cred)
+    assert isinstance(impl, CuliplanOAuth2Implementation)
+
+
+async def test_pkce_extra_authorize_data(hass: HomeAssistant) -> None:
+    """``extra_authorize_data`` carries scopes + S256 challenge."""
+    cred = ClientCredential(client_id="ha-core", client_secret="")
+    server = AuthorizationServer(authorize_url=OAUTH2_AUTHORIZE, token_url=OAUTH2_TOKEN)
+    impl = CuliplanOAuth2Implementation(hass, DOMAIN, cred, server)
+    extra = impl.extra_authorize_data
+    assert extra["code_challenge_method"] == "S256"
+    assert extra["code_challenge"]
+    assert "openid" in extra["scope"]
+    for scope in OAUTH2_SCOPES:
+        assert scope in extra["scope"]
+
+
+async def test_pkce_token_request_injects_verifier(hass: HomeAssistant) -> None:
+    """The verifier is injected on the authorization_code exchange."""
+    cred = ClientCredential(client_id="ha-core", client_secret="")
+    server = AuthorizationServer(authorize_url=OAUTH2_AUTHORIZE, token_url=OAUTH2_TOKEN)
+    impl = CuliplanOAuth2Implementation(hass, DOMAIN, cred, server)
+
+    captured: dict[str, str] = {}
+
+    async def fake_super_token_request(data: dict[str, str]) -> dict[str, str]:
+        captured.update(data)
+        return {"access_token": "x"}
+
+    # Patch the superclass call.
+    with patch(
+        "homeassistant.components.culiplan.application_credentials"
+        ".AuthImplementation._token_request",
+        side_effect=fake_super_token_request,
+    ):
+        await impl._token_request({"grant_type": "authorization_code", "code": "abc"})
+    assert captured["code_verifier"] == impl._code_verifier
+    captured.clear()
+
+    with patch(
+        "homeassistant.components.culiplan.application_credentials"
+        ".AuthImplementation._token_request",
+        side_effect=fake_super_token_request,
+    ):
+        await impl._token_request({"grant_type": "refresh_token"})
+    assert "code_verifier" not in captured

--- a/tests/components/culiplan/test_calendar.py
+++ b/tests/components/culiplan/test_calendar.py
@@ -1,0 +1,86 @@
+"""Tests for the Culiplan calendar entity."""
+
+from datetime import UTC, datetime
+
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+def _slot(date_iso: str, **extra: object) -> dict[str, object]:
+    """Return a meal-plan slot stub."""
+    base = {
+        "id": "slot",
+        "date": date_iso,
+        "title": "Spaghetti",
+        "recipeId": "r1",
+        "course": "dinner",
+        "servings": 2,
+    }
+    base.update(extra)
+    return base
+
+
+async def test_calendar_entity_state_and_events(
+    hass: HomeAssistant, setup_integration: MockConfigEntry
+) -> None:
+    """The calendar entity surfaces the upcoming event."""
+    coordinator = setup_integration.runtime_data.coordinator
+    # Use a far-future date so the calendar's current/next event is always
+    # this one regardless of when the test runs.
+    coordinator.async_set_updated_data(
+        {
+            "meal_plans": [
+                {
+                    "id": "current",
+                    "name": "Meal Plan",
+                    "slots": [
+                        _slot("2199-01-15T18:00:00Z", id="s1"),
+                        _slot("not-a-date", id="s3"),  # malformed → logged & skipped
+                    ],
+                }
+            ],
+            "shopping_lists": [],
+            "pantry_items": [],
+        }
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("calendar.culiplan_meal_plan")
+    assert state is not None
+    assert state.attributes["recipe_id"] == "r1"
+
+
+async def test_calendar_async_get_events(
+    hass: HomeAssistant, setup_integration: MockConfigEntry
+) -> None:
+    """`async_get_events` returns events in the requested window."""
+    coordinator = setup_integration.runtime_data.coordinator
+    coordinator.async_set_updated_data(
+        {
+            "meal_plans": [
+                {
+                    "id": "current",
+                    "name": "Meal Plan",
+                    "slots": [_slot("2199-01-15T18:00:00Z", id="s1")],
+                }
+            ],
+            "shopping_lists": [],
+            "pantry_items": [],
+        }
+    )
+    await hass.async_block_till_done()
+    entity_id = "calendar.culiplan_meal_plan"
+    res = await hass.services.async_call(
+        "calendar",
+        "get_events",
+        {
+            "entity_id": entity_id,
+            "start_date_time": datetime(2199, 1, 14, tzinfo=UTC),
+            "end_date_time": datetime(2199, 1, 16, tzinfo=UTC),
+        },
+        blocking=True,
+        return_response=True,
+    )
+    events = res[entity_id]["events"]
+    assert len(events) == 1
+    assert events[0]["summary"] == "Spaghetti"

--- a/tests/components/culiplan/test_config_flow.py
+++ b/tests/components/culiplan/test_config_flow.py
@@ -1,0 +1,339 @@
+"""Tests for the Culiplan config + options flow."""
+
+from typing import Any
+from unittest.mock import patch
+
+import aiohttp
+from aioresponses import aioresponses
+import pytest
+
+from homeassistant import config_entries
+from homeassistant.components.application_credentials import (
+    ClientCredential,
+    async_import_client_credential,
+)
+from homeassistant.components.culiplan.config_flow import OAuth2FlowHandler
+from homeassistant.components.culiplan.const import BASE_URL, DOMAIN, OAUTH2_TOKEN
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import config_entry_oauth2_flow
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
+
+CLIENT_ID = "ha-core"
+CLIENT_SECRET = ""
+
+
+@pytest.fixture
+def aio() -> Any:
+    """Yield an aioresponses fixture with localhost passthrough."""
+    with aioresponses(passthrough=["http://127.0.0.1"]) as m:
+        yield m
+
+
+@pytest.fixture
+async def credential(hass: HomeAssistant) -> None:
+    """Register the public OAuth client credential."""
+    assert await async_setup_component(hass, "application_credentials", {})
+    await async_import_client_credential(
+        hass,
+        DOMAIN,
+        ClientCredential(client_id=CLIENT_ID, client_secret=CLIENT_SECRET),
+    )
+
+
+async def _complete_oauth(
+    hass: HomeAssistant,
+    hass_client_no_auth: Any,
+    aioclient_mock: AiohttpClientMocker,
+    *,
+    flow_id: str,
+    access_token: str = "test-access-token",
+) -> dict[str, Any]:
+    """Walk an open OAuth2 flow through the redirect + token endpoints."""
+    state = config_entry_oauth2_flow._encode_jwt(
+        hass,
+        {
+            "flow_id": flow_id,
+            "redirect_uri": "https://example.com/auth/external/callback",
+        },
+    )
+    client = await hass_client_no_auth()
+    resp = await client.get(f"/auth/external/callback?code=abcd&state={state}")
+    assert resp.status == 200
+
+    aioclient_mock.post(
+        OAUTH2_TOKEN,
+        json={
+            "refresh_token": "refresh",
+            "access_token": access_token,
+            "type": "Bearer",
+            "expires_in": 3600,
+        },
+    )
+    return await hass.config_entries.flow.async_configure(flow_id)
+
+
+async def test_full_oauth_flow_happy_path(
+    hass: HomeAssistant,
+    hass_client_no_auth: Any,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
+    credential: None,
+) -> None:
+    """Drive the full OAuth flow with a successful /api/users/me."""
+    aioclient_mock.get(f"{BASE_URL}/api/users/me", json={"id": "user-42"})
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.EXTERNAL_STEP
+
+    with patch(
+        "homeassistant.components.culiplan.async_setup_entry", return_value=True
+    ):
+        result = await _complete_oauth(
+            hass, hass_client_no_auth, aioclient_mock, flow_id=result["flow_id"]
+        )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["result"].unique_id == "user-42"
+
+
+async def test_full_oauth_flow_duplicate_aborts(
+    hass: HomeAssistant,
+    hass_client_no_auth: Any,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
+    credential: None,
+) -> None:
+    """A second add with the same account is aborted."""
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="user-42",
+        data={"token": {"access_token": "x"}},
+    ).add_to_hass(hass)
+
+    aioclient_mock.get(f"{BASE_URL}/api/users/me", json={"id": "user-42"})
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await _complete_oauth(
+        hass, hass_client_no_auth, aioclient_mock, flow_id=result["flow_id"]
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_full_oauth_flow_account_id_failure(
+    hass: HomeAssistant,
+    hass_client_no_auth: Any,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
+    credential: None,
+) -> None:
+    """If /api/users/me 500s, the entry is still created (no unique_id)."""
+    aioclient_mock.get(f"{BASE_URL}/api/users/me", status=500)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    with patch(
+        "homeassistant.components.culiplan.async_setup_entry", return_value=True
+    ):
+        result = await _complete_oauth(
+            hass, hass_client_no_auth, aioclient_mock, flow_id=result["flow_id"]
+        )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["result"].unique_id is None
+
+
+async def test_reconfigure_same_account(
+    hass: HomeAssistant,
+    hass_client_no_auth: Any,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
+    credential: None,
+) -> None:
+    """Reconfigure with same account updates token and reloads."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="user-42",
+        data={"token": {"access_token": "old"}},
+    )
+    entry.add_to_hass(hass)
+    aioclient_mock.get(f"{BASE_URL}/api/users/me", json={"id": "user-42"})
+
+    result = await entry.start_reconfigure_flow(hass)
+    with patch(
+        "homeassistant.components.culiplan.async_setup_entry", return_value=True
+    ):
+        result = await _complete_oauth(
+            hass,
+            hass_client_no_auth,
+            aioclient_mock,
+            flow_id=result["flow_id"],
+            access_token="brand-new-token",
+        )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.data["token"]["access_token"] == "brand-new-token"
+
+
+async def test_reconfigure_wrong_account(
+    hass: HomeAssistant,
+    hass_client_no_auth: Any,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
+    credential: None,
+) -> None:
+    """Reconfigure as a different account aborts with ``wrong_account``."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="user-42",
+        data={"token": {"access_token": "old"}},
+    )
+    entry.add_to_hass(hass)
+    aioclient_mock.get(f"{BASE_URL}/api/users/me", json={"id": "different-user"})
+
+    result = await entry.start_reconfigure_flow(hass)
+    result = await _complete_oauth(
+        hass, hass_client_no_auth, aioclient_mock, flow_id=result["flow_id"]
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "wrong_account"
+
+
+async def test_reauth_flow(hass: HomeAssistant, credential: None) -> None:
+    """Re-auth shows the confirm form first."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="user-42",
+        data={"token": {"access_token": "old"}},
+    )
+    entry.add_to_hass(hass)
+    result = await entry.start_reauth_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+
+async def test_reauth_completes_and_updates_token(
+    hass: HomeAssistant,
+    hass_client_no_auth: Any,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
+    credential: None,
+) -> None:
+    """Re-auth full round-trip updates the existing entry's token."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="user-42",
+        data={
+            "auth_implementation": DOMAIN,
+            "token": {"access_token": "stale", "refresh_token": "r"},
+        },
+    )
+    entry.add_to_hass(hass)
+    aioclient_mock.get(f"{BASE_URL}/api/users/me", json={"id": "user-42"})
+
+    result = await entry.start_reauth_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+
+    # Click "Submit" to advance from reauth_confirm into the OAuth round-trip.
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+    assert result["type"] is FlowResultType.EXTERNAL_STEP
+
+    with patch(
+        "homeassistant.components.culiplan.async_setup_entry", return_value=True
+    ):
+        result = await _complete_oauth(
+            hass,
+            hass_client_no_auth,
+            aioclient_mock,
+            flow_id=result["flow_id"],
+            access_token="refreshed-token",
+        )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert entry.data["token"]["access_token"] == "refreshed-token"
+
+
+async def test_reauth_wrong_account_aborts(
+    hass: HomeAssistant,
+    hass_client_no_auth: Any,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
+    credential: None,
+) -> None:
+    """Re-auth with a different Culiplan account is rejected."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="user-42",
+        data={
+            "auth_implementation": DOMAIN,
+            "token": {"access_token": "stale"},
+        },
+    )
+    entry.add_to_hass(hass)
+    aioclient_mock.get(f"{BASE_URL}/api/users/me", json={"id": "someone-else"})
+
+    result = await entry.start_reauth_flow(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+    result = await _complete_oauth(
+        hass, hass_client_no_auth, aioclient_mock, flow_id=result["flow_id"]
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "wrong_account"
+
+
+async def test_fetch_account_id_no_token(hass: HomeAssistant, credential: None) -> None:
+    """Empty input returns None."""
+    handler = OAuth2FlowHandler()
+    handler.hass = hass
+    assert await handler._fetch_account_id({}) is None
+    assert await handler._fetch_account_id({"token": {}}) is None
+
+
+async def test_fetch_account_id_non_200(
+    hass: HomeAssistant, credential: None, aio: aioresponses
+) -> None:
+    """Non-200 returns None."""
+    handler = OAuth2FlowHandler()
+    handler.hass = hass
+    aio.get(f"{BASE_URL}/api/users/me", status=403)
+    assert await handler._fetch_account_id({"token": {"access_token": "x"}}) is None
+
+
+async def test_fetch_account_id_no_id_field(
+    hass: HomeAssistant, credential: None, aio: aioresponses
+) -> None:
+    """Missing ``id`` field returns None."""
+    handler = OAuth2FlowHandler()
+    handler.hass = hass
+    aio.get(f"{BASE_URL}/api/users/me", payload={})
+    assert await handler._fetch_account_id({"token": {"access_token": "x"}}) is None
+
+
+async def test_fetch_account_id_network_error(
+    hass: HomeAssistant, credential: None, aio: aioresponses
+) -> None:
+    """Network errors return None."""
+    handler = OAuth2FlowHandler()
+    handler.hass = hass
+    aio.get(
+        f"{BASE_URL}/api/users/me",
+        exception=aiohttp.ClientError("boom"),
+    )
+    assert await handler._fetch_account_id({"token": {"access_token": "x"}}) is None
+
+
+async def test_handler_logger() -> None:
+    """``logger`` property is a module logger."""
+    handler = OAuth2FlowHandler()
+    assert handler.logger.name == "homeassistant.components.culiplan.config_flow"

--- a/tests/components/culiplan/test_coordinator.py
+++ b/tests/components/culiplan/test_coordinator.py
@@ -1,0 +1,394 @@
+"""Tests for the coordinator (REST refresh + push event handling)."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import socketio
+
+from homeassistant.components.culiplan.api import CuliplanApiError
+from homeassistant.components.culiplan.const import DOMAIN
+from homeassistant.components.culiplan.coordinator import CuliplanCoordinator
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def coordinator_pair(hass: HomeAssistant) -> tuple[CuliplanCoordinator, MagicMock]:
+    """Return a coordinator wired to a mocked API client."""
+    client = MagicMock()
+    client.set_access_token = MagicMock()
+    client.async_get_meal_plans = AsyncMock(return_value=[])
+    client.async_get_shopping_lists = AsyncMock(return_value=[])
+    client.async_get_pantry_items = AsyncMock(return_value=[])
+
+    entry: ConfigEntry = MockConfigEntry(domain=DOMAIN, unique_id="u-1")
+    entry.add_to_hass(hass)
+    coordinator = CuliplanCoordinator(hass, client, entry)
+    return coordinator, client
+
+
+async def test_update_data_happy_path(
+    hass: HomeAssistant,
+    coordinator_pair: tuple[CuliplanCoordinator, MagicMock],
+) -> None:
+    """``_async_update_data`` fetches all three slices."""
+    coordinator, _client = coordinator_pair
+    with patch.object(coordinator, "_refresh_token", AsyncMock(return_value="t")):
+        data = await coordinator._async_update_data()
+    assert "meal_plans" in data
+    assert "shopping_lists" in data
+    assert "pantry_items" in data
+
+
+async def test_update_data_auth_failed_propagates(
+    hass: HomeAssistant,
+    coordinator_pair: tuple[CuliplanCoordinator, MagicMock],
+) -> None:
+    """``ConfigEntryAuthFailed`` is re-raised so HA triggers re-auth."""
+    coordinator, client = coordinator_pair
+    client.async_get_meal_plans.side_effect = ConfigEntryAuthFailed("401")
+    with (
+        patch.object(coordinator, "_refresh_token", AsyncMock(return_value="t")),
+        pytest.raises(ConfigEntryAuthFailed),
+    ):
+        await coordinator._async_update_data()
+
+
+async def test_update_data_api_error_becomes_update_failed(
+    hass: HomeAssistant,
+    coordinator_pair: tuple[CuliplanCoordinator, MagicMock],
+) -> None:
+    """``CuliplanApiError`` on a critical slice raises ``UpdateFailed``."""
+    coordinator, client = coordinator_pair
+    client.async_get_meal_plans.side_effect = CuliplanApiError("boom")
+    with (
+        patch.object(coordinator, "_refresh_token", AsyncMock(return_value="t")),
+        pytest.raises(UpdateFailed),
+    ):
+        await coordinator._async_update_data()
+
+
+async def test_pantry_slice_failure_is_best_effort(
+    hass: HomeAssistant,
+    coordinator_pair: tuple[CuliplanCoordinator, MagicMock],
+) -> None:
+    """A pantry failure does NOT abort the update."""
+    coordinator, client = coordinator_pair
+    client.async_get_pantry_items.side_effect = CuliplanApiError("no pantry")
+    with patch.object(coordinator, "_refresh_token", AsyncMock(return_value="t")):
+        data = await coordinator._async_update_data()
+    assert data["pantry_items"] == []
+
+
+async def test_handle_event_meal_plan_updated(
+    hass: HomeAssistant,
+    coordinator_pair: tuple[CuliplanCoordinator, MagicMock],
+) -> None:
+    """A ``meal_plan.updated`` event refreshes meal plans."""
+    coordinator, client = coordinator_pair
+    coordinator.async_set_updated_data({"meal_plans": [], "shopping_lists": []})
+    client.async_get_meal_plans.return_value = [{"id": "current", "slots": []}]
+    await coordinator._handle_event({"type": "meal_plan.updated"})
+    assert coordinator.data["meal_plans"] == [{"id": "current", "slots": []}]
+
+
+async def test_handle_event_shopping_list(
+    hass: HomeAssistant,
+    coordinator_pair: tuple[CuliplanCoordinator, MagicMock],
+) -> None:
+    """Shopping events refresh the shopping slice."""
+    coordinator, client = coordinator_pair
+    coordinator.async_set_updated_data({"shopping_lists": []})
+    client.async_get_shopping_lists.return_value = [{"id": "default", "items": []}]
+    await coordinator._handle_event({"type": "shopping_list.item.added"})
+    assert coordinator.data["shopping_lists"] == [{"id": "default", "items": []}]
+
+
+async def test_handle_event_pantry(
+    hass: HomeAssistant,
+    coordinator_pair: tuple[CuliplanCoordinator, MagicMock],
+) -> None:
+    """Pantry events refresh the pantry slice."""
+    coordinator, client = coordinator_pair
+    coordinator.async_set_updated_data({"pantry_items": []})
+    client.async_get_pantry_items.return_value = [{"id": "p1"}]
+    await coordinator._handle_event({"type": "pantry.item.updated"})
+    assert coordinator.data["pantry_items"] == [{"id": "p1"}]
+
+
+async def test_handle_event_unknown_type_is_noop(
+    hass: HomeAssistant,
+    coordinator_pair: tuple[CuliplanCoordinator, MagicMock],
+) -> None:
+    """An unknown event type is silently ignored."""
+    coordinator, client = coordinator_pair
+    coordinator.async_set_updated_data({"meal_plans": []})
+    await coordinator._handle_event({"type": "weather.changed"})
+    assert client.async_get_meal_plans.await_count == 0
+
+
+async def test_refresh_helpers_swallow_api_errors(
+    hass: HomeAssistant,
+    coordinator_pair: tuple[CuliplanCoordinator, MagicMock],
+) -> None:
+    """Per-slice helpers log & return on error rather than raising."""
+    coordinator, client = coordinator_pair
+    coordinator.async_set_updated_data(
+        {"meal_plans": [], "shopping_lists": [], "pantry_items": []}
+    )
+    client.async_get_meal_plans.side_effect = CuliplanApiError("x")
+    client.async_get_shopping_lists.side_effect = CuliplanApiError("x")
+    client.async_get_pantry_items.side_effect = CuliplanApiError("x")
+    await coordinator._refresh_meal_plans()
+    await coordinator._refresh_shopping_lists()
+    await coordinator._refresh_pantry()
+    # State unchanged.
+    assert coordinator.data["meal_plans"] == []
+
+
+async def test_async_stop_when_never_started(
+    hass: HomeAssistant,
+    coordinator_pair: tuple[CuliplanCoordinator, MagicMock],
+) -> None:
+    """``async_stop`` is safe even if the connection never opened."""
+    coordinator, _ = coordinator_pair
+    await coordinator.async_stop()
+    assert coordinator._stopped is True
+
+
+async def test_async_start_when_stopped_does_not_connect(
+    hass: HomeAssistant,
+    coordinator_pair: tuple[CuliplanCoordinator, MagicMock],
+) -> None:
+    """``_connect`` returns early once ``async_stop`` has been called."""
+    coordinator, _ = coordinator_pair
+    coordinator._stopped = True
+    with patch.object(
+        coordinator, "_refresh_token", AsyncMock(return_value="t")
+    ) as mock:
+        await coordinator._connect()
+    mock.assert_not_called()
+
+
+async def test_schedule_reconnect_noop_when_stopped(
+    hass: HomeAssistant,
+    coordinator_pair: tuple[CuliplanCoordinator, MagicMock],
+) -> None:
+    """``_schedule_reconnect`` is a no-op once stopped."""
+    coordinator, _ = coordinator_pair
+    coordinator._stopped = True
+    coordinator._schedule_reconnect()
+    assert coordinator._reconnect_task is None
+
+
+async def test_connect_handles_connection_error(
+    hass: HomeAssistant,
+    coordinator_pair: tuple[CuliplanCoordinator, MagicMock],
+) -> None:
+    """A Socket.IO ConnectionError schedules a reconnect rather than raising."""
+    coordinator, _ = coordinator_pair
+    with (
+        patch.object(coordinator, "_refresh_token", AsyncMock(return_value="t")),
+        patch(
+            "homeassistant.components.culiplan.coordinator.socketio.AsyncClient"
+        ) as cls,
+    ):
+        instance = cls.return_value
+        instance.event = lambda *a, **k: lambda fn: fn
+        instance.on = lambda *a, **k: lambda fn: fn
+        instance.connect = AsyncMock(
+            side_effect=socketio.exceptions.ConnectionError("nope")
+        )
+        instance.disconnect = AsyncMock()
+        with patch.object(coordinator, "_schedule_reconnect") as sched:
+            await coordinator._connect()
+        sched.assert_called_once()
+    await coordinator.async_stop()
+
+
+async def test_schedule_reconnect_runs_loop_and_stops(
+    hass: HomeAssistant,
+    coordinator_pair: tuple[CuliplanCoordinator, MagicMock],
+) -> None:
+    """The reconnect loop kicks off and is cancellable via async_stop."""
+    coordinator, _ = coordinator_pair
+    # Make the reconnect attempt finish quickly: pretend connection succeeds
+    # immediately on first try.
+    with (
+        patch("asyncio.sleep", new_callable=AsyncMock),
+        patch.object(coordinator, "_connect", new_callable=AsyncMock) as conn,
+    ):
+
+        async def _set_connected() -> None:
+            coordinator._connected = True
+
+        conn.side_effect = _set_connected
+        coordinator._schedule_reconnect(delay=0)
+        # Allow the background task to run.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+    await coordinator.async_stop()
+
+
+async def test_reconnect_loop_swallows_errors(
+    hass: HomeAssistant,
+    coordinator_pair: tuple[CuliplanCoordinator, MagicMock],
+) -> None:
+    """Reconnect attempts that raise are caught and the loop exits on stop."""
+    coordinator, _ = coordinator_pair
+    call_count = 0
+
+    async def _failing_connect() -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count >= 2:
+            coordinator._stopped = True
+        raise RuntimeError("fail")
+
+    with (
+        patch("asyncio.sleep", new_callable=AsyncMock),
+        patch.object(coordinator, "_connect", side_effect=_failing_connect),
+    ):
+        coordinator._schedule_reconnect(delay=0)
+        # Pump loop until task done.
+        for _ in range(20):
+            await asyncio.sleep(0)
+            if (
+                coordinator._reconnect_task is not None
+                and coordinator._reconnect_task.done()
+            ):
+                break
+    await coordinator.async_stop()
+
+
+async def test_schedule_reconnect_skips_if_task_running(
+    hass: HomeAssistant,
+    coordinator_pair: tuple[CuliplanCoordinator, MagicMock],
+) -> None:
+    """A second ``_schedule_reconnect`` while one is running is a no-op."""
+    coordinator, _ = coordinator_pair
+
+    async def _forever() -> None:
+        await asyncio.Event().wait()
+
+    coordinator._reconnect_task = hass.async_create_background_task(
+        _forever(), name="t"
+    )
+    coordinator._schedule_reconnect(delay=0)
+    # The original task is still the one in place.
+    assert coordinator._reconnect_task is not None
+    coordinator._reconnect_task.cancel()
+
+
+async def test_reconnect_loop_applies_jitter(
+    hass: HomeAssistant,
+    coordinator_pair: tuple[CuliplanCoordinator, MagicMock],
+) -> None:
+    """Two coordinators reconnecting with the same base delay get different sleeps.
+
+    The jitter band is 0-25 % of the current base; with `random.uniform` seeded
+    differently across calls, two consecutive sleep arguments must not be
+    bit-identical. Guards against accidentally reverting to a fixed-delay loop.
+    """
+    coordinator, _ = coordinator_pair
+    captured: list[float] = []
+
+    async def _capturing_sleep(wait: float) -> None:
+        captured.append(wait)
+        # Flip the coordinator to "connected" after the first sleep so the
+        # loop exits cleanly.
+        if len(captured) >= 2:
+            coordinator._connected = True
+
+    async def _noop_connect() -> None:
+        return
+
+    with (
+        patch("asyncio.sleep", new=_capturing_sleep),
+        patch.object(coordinator, "_connect", new=_noop_connect),
+    ):
+        coordinator._schedule_reconnect(delay=4.0)
+        for _ in range(20):
+            await asyncio.sleep(0)
+            if (
+                coordinator._reconnect_task is not None
+                and coordinator._reconnect_task.done()
+            ):
+                break
+
+    await coordinator.async_stop()
+    # First wait must be base + jitter ∈ [4.0, 5.0).
+    assert 4.0 <= captured[0] < 5.0, f"first sleep out of band: {captured[0]}"
+    # Second wait uses doubled base: ∈ [8.0, 10.0).
+    assert 8.0 <= captured[1] < 10.0, f"second sleep out of band: {captured[1]}"
+    # Statistically, the jitter fraction (uniform 0..0.25*base) on a 4s base
+    # makes a 0.0-exact draw vanishingly unlikely. Guard against fixed delay.
+    assert captured[0] != 4.0 or captured[1] != 8.0
+
+
+async def test_reconnect_delay_caps_at_max(
+    hass: HomeAssistant,
+    coordinator_pair: tuple[CuliplanCoordinator, MagicMock],
+) -> None:
+    """Backoff caps at 60s + 25% jitter (never grows unbounded)."""
+    coordinator, _ = coordinator_pair
+    captured: list[float] = []
+    call_count = 0
+
+    async def _capturing_sleep(wait: float) -> None:
+        nonlocal call_count
+        captured.append(wait)
+        call_count += 1
+        if call_count >= 10:
+            coordinator._stopped = True
+
+    async def _noop_connect() -> None:
+        return
+
+    with (
+        patch("asyncio.sleep", new=_capturing_sleep),
+        patch.object(coordinator, "_connect", new=_noop_connect),
+    ):
+        # Start at a high delay so we cap fast.
+        coordinator._schedule_reconnect(delay=50.0)
+        for _ in range(40):
+            await asyncio.sleep(0)
+            if (
+                coordinator._reconnect_task is not None
+                and coordinator._reconnect_task.done()
+            ):
+                break
+
+    await coordinator.async_stop()
+    # Once base hits the 60s cap, sleep is in [60, 75).
+    for wait in captured[3:]:
+        assert wait < 75.1, f"sleep {wait} exceeded cap + jitter"
+
+
+async def test_refresh_token_propagates(
+    hass: HomeAssistant,
+    coordinator_pair: tuple[CuliplanCoordinator, MagicMock],
+) -> None:
+    """``_refresh_token`` updates the client and returns the token."""
+    coordinator, client = coordinator_pair
+    with (
+        patch(
+            "homeassistant.components.culiplan.coordinator"
+            ".config_entry_oauth2_flow.async_get_config_entry_implementation",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "homeassistant.components.culiplan.coordinator"
+            ".config_entry_oauth2_flow.OAuth2Session"
+        ) as cls,
+    ):
+        cls.return_value.async_ensure_token_valid = AsyncMock()
+        cls.return_value.token = {"access_token": "FRESH"}
+        token = await coordinator._refresh_token()
+    assert token == "FRESH"
+    client.set_access_token.assert_called_with("FRESH")

--- a/tests/components/culiplan/test_diagnostics.py
+++ b/tests/components/culiplan/test_diagnostics.py
@@ -1,0 +1,39 @@
+"""Tests for diagnostics redaction."""
+
+from homeassistant.components.culiplan.diagnostics import (
+    async_get_config_entry_diagnostics,
+)
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def test_diagnostics_redacts_tokens_and_ids(
+    hass: HomeAssistant, setup_integration: MockConfigEntry
+) -> None:
+    """Tokens and identifiers are absent from the diagnostics payload."""
+    diag = await async_get_config_entry_diagnostics(hass, setup_integration)
+
+    rendered = repr(diag)
+    assert "test-access-token" not in rendered
+    assert "user-123" not in rendered
+    assert "token_age_seconds" in diag
+    assert "coordinator" in diag
+    assert "last_update_success" in diag["coordinator"]
+
+
+async def test_diagnostics_with_no_token_issued_at(
+    hass: HomeAssistant, setup_integration: MockConfigEntry
+) -> None:
+    """Without an ``issued_at`` field, token_age_seconds is None."""
+    # Mutate the entry data to drop issued_at.
+    hass.config_entries.async_update_entry(
+        setup_integration,
+        data={
+            "auth_implementation": "culiplan",
+            "token": {"access_token": "x", "refresh_token": "y"},
+        },
+    )
+    await hass.async_block_till_done()
+    diag = await async_get_config_entry_diagnostics(hass, setup_integration)
+    assert diag["token_age_seconds"] is None

--- a/tests/components/culiplan/test_helpers.py
+++ b/tests/components/culiplan/test_helpers.py
@@ -1,0 +1,37 @@
+"""Tests for the small helper module."""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from homeassistant.components.culiplan.const import DOMAIN
+from homeassistant.components.culiplan.helpers import build_device_info, parse_dt
+
+from tests.common import MockConfigEntry
+
+
+def test_build_device_info() -> None:
+    """The DeviceInfo carries the expected static fields."""
+    entry = MockConfigEntry(domain=DOMAIN, entry_id="abc")
+    info = build_device_info(entry)
+    assert info["name"] == "Culiplan"
+    assert (DOMAIN, "abc") in info["identifiers"]
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("2099-01-15T18:00:00Z", datetime(2099, 1, 15, 18, 0, tzinfo=UTC)),
+        ("2099-01-15", datetime(2099, 1, 15, 0, 0, tzinfo=UTC)),
+        ("2099-01-15T18:00:00+00:00", datetime(2099, 1, 15, 18, 0, tzinfo=UTC)),
+    ],
+)
+def test_parse_dt_valid(value: str, expected: datetime) -> None:
+    """Valid ISO strings parse to tz-aware datetimes."""
+    assert parse_dt(value) == expected
+
+
+def test_parse_dt_invalid() -> None:
+    """Invalid strings raise ValueError."""
+    with pytest.raises(ValueError):
+        parse_dt("not-a-date")

--- a/tests/components/culiplan/test_init.py
+++ b/tests/components/culiplan/test_init.py
@@ -1,0 +1,39 @@
+"""Tests for the integration setup / unload lifecycle."""
+
+from unittest.mock import AsyncMock, patch
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def test_setup_and_unload(
+    hass: HomeAssistant, setup_integration: MockConfigEntry
+) -> None:
+    """Setting up creates the runtime data; unloading clears it."""
+    entry = setup_integration
+    assert entry.state is ConfigEntryState.LOADED
+    assert entry.runtime_data is not None
+    assert entry.runtime_data.client is not None
+    assert entry.runtime_data.coordinator is not None
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+    assert entry.state is ConfigEntryState.NOT_LOADED
+
+
+async def test_options_update_reloads(
+    hass: HomeAssistant, setup_integration: MockConfigEntry
+) -> None:
+    """Saving options triggers a reload."""
+    entry = setup_integration
+    with patch(
+        "homeassistant.components.culiplan.config_entry_oauth2_flow.OAuth2Session"
+    ) as mock_session:
+        mock_session.return_value.async_ensure_token_valid = AsyncMock()
+        mock_session.return_value.token = {"access_token": "test-access-token"}
+        hass.config_entries.async_update_entry(entry, options={"foo": "bar"})
+        await hass.async_block_till_done()
+    assert entry.state is ConfigEntryState.LOADED
+    assert entry.options == {"foo": "bar"}

--- a/tests/components/culiplan/test_llm_api.py
+++ b/tests/components/culiplan/test_llm_api.py
@@ -1,0 +1,359 @@
+"""Tests for the LLM API."""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+from homeassistant.components.culiplan import CuliplanRuntimeData
+from homeassistant.components.culiplan.api import CuliplanApiError
+from homeassistant.components.culiplan.const import DOMAIN
+from homeassistant.components.culiplan.llm_api import (
+    LLM_API_ID,
+    CuliplanLLMAPI,
+    _filter_expiring,
+    _get_client,
+    _not_configured,
+    _slot_in_range,
+    async_register_llm_api,
+    async_unregister_llm_api,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import llm
+
+from tests.common import MockConfigEntry
+
+
+def _ctx(hass: HomeAssistant) -> llm.LLMContext:
+    """Return a minimal LLM context for tool calls."""
+    return llm.LLMContext(
+        platform="test",
+        context=None,
+        language="en",
+        assistant=None,
+        device_id=None,
+    )
+
+
+def _tool_input(tool: str, args: dict[str, object]) -> llm.ToolInput:
+    """Return a tool input."""
+    return llm.ToolInput(tool_name=tool, tool_args=args)
+
+
+async def test_register_and_unregister(hass: HomeAssistant) -> None:
+    """Registering and unregistering the API is refcounted across entries."""
+    async_register_llm_api(hass)
+    apis = hass.data.get("llm", {})
+    assert LLM_API_ID in apis
+    # Second register from a second entry holds the API alive past one unload.
+    async_register_llm_api(hass)
+    assert LLM_API_ID in apis
+    async_unregister_llm_api(hass)
+    assert LLM_API_ID in apis, "API must survive while another entry holds it"
+    # Last unregister drops it.
+    async_unregister_llm_api(hass)
+    assert LLM_API_ID not in apis
+    # Extra unregister is a no-op.
+    async_unregister_llm_api(hass)
+
+
+async def test_unregister_when_never_registered(hass: HomeAssistant) -> None:
+    """Unregister is a no-op when the API was never registered."""
+    async_unregister_llm_api(hass)
+
+
+async def test_get_client_returns_none_without_entry(hass: HomeAssistant) -> None:
+    """Without a config entry, ``_get_client`` returns None."""
+    assert _get_client(hass) is None
+
+
+async def test_get_client_returns_first_entry(hass: HomeAssistant) -> None:
+    """With a configured entry, ``_get_client`` returns its API client."""
+
+    entry = MockConfigEntry(domain=DOMAIN, unique_id="u")
+    entry.add_to_hass(hass)
+    client = MagicMock()
+    entry.runtime_data = CuliplanRuntimeData(client=client, coordinator=MagicMock())
+    assert _get_client(hass) is client
+
+
+def test_not_configured_shape() -> None:
+    """``_not_configured`` returns the expected error envelope."""
+    res = _not_configured()
+    assert res["error"] == "not_configured"
+
+
+def test_slot_in_range() -> None:
+    """The date filter handles all edge cases."""
+    assert _slot_in_range("2099-01-15", None, None)
+    assert _slot_in_range("2099-01-15", "2099-01-15", "2099-01-16")
+    assert not _slot_in_range("2099-01-14", "2099-01-15", None)
+    assert not _slot_in_range("2099-01-17", None, "2099-01-16")
+    assert _slot_in_range(12345, None, None)  # non-string passthrough
+
+
+def test_filter_expiring_drops_bad_data() -> None:
+    """Invalid expiry strings, non-dict items, and expired-too-late are dropped."""
+
+    soon = (datetime.now(tz=UTC) + timedelta(days=1)).isoformat()
+    later = (datetime.now(tz=UTC) + timedelta(days=365)).isoformat()
+    items = [
+        {"id": "p1", "expiresAt": soon},
+        {"id": "p2", "expiresAt": "not-a-date"},
+        {"id": "p3"},  # no expiry
+        "not-a-dict",
+        {"id": "p4", "expiresAt": later},  # way after cutoff
+    ]
+    res = _filter_expiring(items, within_days=7)
+    assert len(res) == 1
+    assert res[0]["id"] == "p1"
+
+
+async def test_get_meal_plan_not_configured(hass: HomeAssistant) -> None:
+    """Tool returns the not-configured envelope when no entry exists."""
+    inst = CuliplanLLMAPI(hass)
+    api_inst = await inst.async_get_api_instance(_ctx(hass))
+    tool = next(t for t in api_inst.tools if t.name == "get_meal_plan")
+    result = await tool.async_call(hass, _tool_input("get_meal_plan", {}), _ctx(hass))
+    assert result["error"] == "not_configured"
+
+
+async def test_get_meal_plan_happy_path(hass: HomeAssistant) -> None:
+    """Tool returns plans filtered by date when range is supplied."""
+
+    entry = MockConfigEntry(domain=DOMAIN, unique_id="u")
+    entry.add_to_hass(hass)
+    client = MagicMock()
+    client.async_get_meal_plans = AsyncMock(
+        return_value=[
+            {
+                "id": "current",
+                "slots": [
+                    {"date": "2099-01-15T18:00:00Z"},
+                    {"date": "2099-02-15T18:00:00Z"},
+                ],
+            }
+        ]
+    )
+    entry.runtime_data = CuliplanRuntimeData(client=client, coordinator=MagicMock())
+
+    inst = CuliplanLLMAPI(hass)
+    api_inst = await inst.async_get_api_instance(_ctx(hass))
+    tool = next(t for t in api_inst.tools if t.name == "get_meal_plan")
+    result = await tool.async_call(
+        hass,
+        _tool_input(
+            "get_meal_plan",
+            {"start_date": "2099-01-01", "end_date": "2099-01-31"},
+        ),
+        _ctx(hass),
+    )
+    assert result["count"] == 1
+
+
+async def test_get_meal_plan_api_error(hass: HomeAssistant) -> None:
+    """A backend error bubbles up as an ``api_error`` envelope."""
+
+    entry = MockConfigEntry(domain=DOMAIN, unique_id="u")
+    entry.add_to_hass(hass)
+    client = MagicMock()
+    client.async_get_meal_plans = AsyncMock(side_effect=CuliplanApiError("boom"))
+    entry.runtime_data = CuliplanRuntimeData(client=client, coordinator=MagicMock())
+
+    inst = CuliplanLLMAPI(hass)
+    api_inst = await inst.async_get_api_instance(_ctx(hass))
+    tool = next(t for t in api_inst.tools if t.name == "get_meal_plan")
+    result = await tool.async_call(hass, _tool_input("get_meal_plan", {}), _ctx(hass))
+    assert result["error"] == "api_error"
+
+
+async def test_add_to_shopping_list_tool(hass: HomeAssistant) -> None:
+    """The add-to-shopping-list tool delegates to the API client."""
+
+    entry = MockConfigEntry(domain=DOMAIN, unique_id="u")
+    entry.add_to_hass(hass)
+    client = MagicMock()
+    client.async_add_shopping_item = AsyncMock(return_value={"id": "x"})
+    entry.runtime_data = CuliplanRuntimeData(client=client, coordinator=MagicMock())
+
+    inst = CuliplanLLMAPI(hass)
+    api_inst = await inst.async_get_api_instance(_ctx(hass))
+    tool = next(t for t in api_inst.tools if t.name == "add_to_shopping_list")
+    result = await tool.async_call(
+        hass,
+        _tool_input("add_to_shopping_list", {"name": "Milk", "quantity": "1L"}),
+        _ctx(hass),
+    )
+    assert result["added"] is True
+    assert result["item_id"] == "x"
+
+
+async def test_add_to_shopping_list_tool_api_error(hass: HomeAssistant) -> None:
+    """The tool returns ``api_error`` on backend failure."""
+
+    entry = MockConfigEntry(domain=DOMAIN, unique_id="u")
+    entry.add_to_hass(hass)
+    client = MagicMock()
+    client.async_add_shopping_item = AsyncMock(side_effect=CuliplanApiError("x"))
+    entry.runtime_data = CuliplanRuntimeData(client=client, coordinator=MagicMock())
+
+    inst = CuliplanLLMAPI(hass)
+    api_inst = await inst.async_get_api_instance(_ctx(hass))
+    tool = next(t for t in api_inst.tools if t.name == "add_to_shopping_list")
+    result = await tool.async_call(
+        hass,
+        _tool_input("add_to_shopping_list", {"name": "Milk"}),
+        _ctx(hass),
+    )
+    assert result["error"] == "api_error"
+
+
+async def test_get_pantry_items_tool(hass: HomeAssistant) -> None:
+    """Pantry tool slims, filters, and reports truncation."""
+
+    entry = MockConfigEntry(domain=DOMAIN, unique_id="u")
+    entry.add_to_hass(hass)
+    client = MagicMock()
+
+    far = (datetime.now(tz=UTC) + timedelta(days=10)).isoformat()
+    client.async_get_pantry_items = AsyncMock(
+        return_value=[{"id": f"p{i}", "name": "X", "expiresAt": far} for i in range(60)]
+    )
+    entry.runtime_data = CuliplanRuntimeData(client=client, coordinator=MagicMock())
+
+    inst = CuliplanLLMAPI(hass)
+    api_inst = await inst.async_get_api_instance(_ctx(hass))
+    tool = next(t for t in api_inst.tools if t.name == "get_pantry_items")
+    result = await tool.async_call(
+        hass,
+        _tool_input("get_pantry_items", {"expiring_within_days": 30}),
+        _ctx(hass),
+    )
+    assert result["count"] == 50
+    assert result["truncated"] is True
+
+
+async def test_get_pantry_items_api_error(hass: HomeAssistant) -> None:
+    """Pantry tool returns ``api_error`` on backend failure."""
+
+    entry = MockConfigEntry(domain=DOMAIN, unique_id="u")
+    entry.add_to_hass(hass)
+    client = MagicMock()
+    client.async_get_pantry_items = AsyncMock(side_effect=CuliplanApiError("x"))
+    entry.runtime_data = CuliplanRuntimeData(client=client, coordinator=MagicMock())
+
+    inst = CuliplanLLMAPI(hass)
+    api_inst = await inst.async_get_api_instance(_ctx(hass))
+    tool = next(t for t in api_inst.tools if t.name == "get_pantry_items")
+    result = await tool.async_call(
+        hass, _tool_input("get_pantry_items", {}), _ctx(hass)
+    )
+    assert result["error"] == "api_error"
+
+
+async def test_find_recipes_tool(hass: HomeAssistant) -> None:
+    """Recipe search normalises both envelope shapes."""
+
+    entry = MockConfigEntry(domain=DOMAIN, unique_id="u")
+    entry.add_to_hass(hass)
+    client = MagicMock()
+    entry.runtime_data = CuliplanRuntimeData(client=client, coordinator=MagicMock())
+    inst = CuliplanLLMAPI(hass)
+    api_inst = await inst.async_get_api_instance(_ctx(hass))
+    tool = next(t for t in api_inst.tools if t.name == "find_recipes_by_ingredients")
+
+    # Envelope shape.
+    client.async_get = AsyncMock(
+        return_value={
+            "data": [
+                {"id": "r1", "title": "Soup", "prepTime": 20, "servings": 4},
+            ]
+        }
+    )
+    result = await tool.async_call(
+        hass,
+        _tool_input("find_recipes_by_ingredients", {"ingredients": ["onion"]}),
+        _ctx(hass),
+    )
+    assert result["count"] == 1
+    assert result["recipes"][0]["title"] == "Soup"
+
+    # Bare-list shape.
+    client.async_get = AsyncMock(
+        return_value=[
+            {"id": "r2", "title": "Pasta", "prepTimeMinutes": 30, "servings": 2},
+        ]
+    )
+    result = await tool.async_call(
+        hass,
+        _tool_input(
+            "find_recipes_by_ingredients", {"ingredients": ["pasta", "tomato"]}
+        ),
+        _ctx(hass),
+    )
+    assert result["recipes"][0]["prep_time_minutes"] == 30
+
+    # Unexpected shape → empty.
+    client.async_get = AsyncMock(return_value="oops")
+    result = await tool.async_call(
+        hass,
+        _tool_input("find_recipes_by_ingredients", {"ingredients": ["x"]}),
+        _ctx(hass),
+    )
+    assert result["recipes"] == []
+
+    # API error.
+    client.async_get = AsyncMock(side_effect=CuliplanApiError("x"))
+    result = await tool.async_call(
+        hass,
+        _tool_input("find_recipes_by_ingredients", {"ingredients": ["x"]}),
+        _ctx(hass),
+    )
+    assert result["error"] == "api_error"
+
+
+async def test_get_recipe_tool(hass: HomeAssistant) -> None:
+    """The get-recipe tool trims, handles missing recipes, and api errors."""
+
+    entry = MockConfigEntry(domain=DOMAIN, unique_id="u")
+    entry.add_to_hass(hass)
+    client = MagicMock()
+    entry.runtime_data = CuliplanRuntimeData(client=client, coordinator=MagicMock())
+    inst = CuliplanLLMAPI(hass)
+    api_inst = await inst.async_get_api_instance(_ctx(hass))
+    tool = next(t for t in api_inst.tools if t.name == "get_recipe")
+
+    client.async_get = AsyncMock(
+        return_value={"id": "r1", "title": "X", "secretField": "drop"}
+    )
+    result = await tool.async_call(
+        hass, _tool_input("get_recipe", {"recipe_id": "r1"}), _ctx(hass)
+    )
+    assert result["recipe"]["title"] == "X"
+    assert "secretField" not in result["recipe"]
+
+    client.async_get = AsyncMock(return_value="oops")
+    result = await tool.async_call(
+        hass, _tool_input("get_recipe", {"recipe_id": "r1"}), _ctx(hass)
+    )
+    assert result["error"] == "not_found"
+
+    client.async_get = AsyncMock(side_effect=CuliplanApiError("x"))
+    result = await tool.async_call(
+        hass, _tool_input("get_recipe", {"recipe_id": "r1"}), _ctx(hass)
+    )
+    assert result["error"] == "api_error"
+
+
+async def test_tools_not_configured_paths(hass: HomeAssistant) -> None:
+    """Each tool returns the not-configured envelope when no entry exists."""
+    inst = CuliplanLLMAPI(hass)
+    api_inst = await inst.async_get_api_instance(_ctx(hass))
+    for tool in api_inst.tools:
+        args: dict[str, object] = {}
+        if tool.name == "add_to_shopping_list":
+            args = {"name": "Milk"}
+        elif tool.name == "find_recipes_by_ingredients":
+            args = {"ingredients": ["x"]}
+        elif tool.name == "get_recipe":
+            args = {"recipe_id": "r1"}
+        result = await tool.async_call(hass, _tool_input(tool.name, args), _ctx(hass))
+        assert result["error"] == "not_configured"


### PR DESCRIPTION
## Proposed change

This PR adds a new integration for [Culiplan](https://culiplan.com), a cloud meal-planning service.

Per HA Core review guidance ("limit included platforms to a single platform" for new integrations), this PR ships **calendar only**. The `todo`, `sensor`, and `binary_sensor` platforms will land in follow-up PRs after this one merges — mirroring the multi-platform rollout used by integrations like Mealie. The follow-up branches are already prepared on the fork (`culiplan/core:add-culiplan-todo`, `add-culiplan-sensor`, `add-culiplan-binary-sensor`).

### Architecture

- **Auth:** OAuth2 with PKCE via `application_credentials` (no user-supplied client credentials required; the integration ships a public client). Standard `config_entry_oauth2_flow` reauth on refresh-token expiry.
- **Transport:** Hybrid `DataUpdateCoordinator` — persistent Socket.IO connection pushes meal-plan updates in real time, with a 5-minute REST poll as a safety net.
- **HTTP:** Single `aiohttp_client.async_get_clientsession(hass)` session, no `ClientSession()` constructed by the integration.

### Entity (this PR — single platform)

| Platform | Entity ID | Description |
|---|---|---|
| `calendar` | `calendar.culiplan_meal_plan` | Upcoming planned meals (one entity per meal plan) |

The coordinator additionally fetches the shopping-list and pantry slices to feed the LLM API tools below. The corresponding entity surfaces (`todo`, `sensor`, `binary_sensor`) land in the follow-up PRs.

### LLM API

The integration registers an LLM API via `homeassistant.helpers.llm.async_register_api` with 5 tools that call the Culiplan backend directly (they do not depend on entity state, so they are useful with calendar-only too):

1. `get_meal_plan` — Return the user's current meal plan (optionally filtered by date).
2. `add_to_shopping_list` — Add an item to the active shopping list.
3. `get_pantry_items` — Return pantry stock (optional `expiring_within_days` filter).
4. `find_recipes_by_ingredients` — Search recipes by ingredient list.
5. `get_recipe` — Fetch a single recipe by id.

Conversation Agents can be pointed at the `Culiplan` LLM API in their configuration.

### Quality scale: Silver

- Full type-checked code (`strict-typing: done`).
- `config_flow` with PKCE OAuth2, reauth, and reconfigure flows.
- `DataUpdateCoordinator` for all data fetching.
- Diagnostics platform with token/PII redaction.
- ≥95% line coverage on the calendar-only surface (was 97.88% on the 4-platform tree).

Gold/Platinum are explicitly out of scope for the initial submission. The full quality-scale rationale is in `homeassistant/components/culiplan/quality_scale.yaml`.

### Tests

- Tests under `tests/components/culiplan/` cover: API client, application credentials (PKCE), config flow (full OAuth, duplicate, reauth, reconfigure same/wrong account), coordinator (REST + push), calendar entity, diagnostics, helpers, init/unload, and the LLM API surface.
- Tests stub out `aiohttp` (via `AiohttpClientMocker` / `aioresponses`) and `socketio.AsyncClient`; nothing reaches the network.

## Companion PRs

- Brand assets: home-assistant/brands#10471 (platform-agnostic, no change needed for this re-scope)
- Documentation: home-assistant/home-assistant.io#45791 (updated to calendar-only to match)

The integration's `manifest.json` already points `documentation` at `https://www.home-assistant.io/integrations/culiplan` in anticipation of the docs PR landing.

## Follow-up PRs (after this merges)

Three follow-up branches are prepared on `culiplan/core` and will be opened as separate PRs after this one lands:

1. `add-culiplan-todo` — `todo.culiplan_shopping_list` (read + write via the existing coordinator's shopping-list slice).
2. `add-culiplan-sensor` — `meals_planned_this_week`, `shopping_items`, `expiring_pantry_items` sensors, plus the `expiry_days` options-flow knob.
3. `add-culiplan-binary-sensor` — `pantry_has_expiring` binary sensor, plus the `expiry_hours` options-flow knob.

Each follow-up is one platform + one test file + small strings/icons additions.

## Note for reviewers

`python3 -m script.gen_requirements_all` and `python3 -m script.hassfest` could not be successfully executed against my local clone of `home-assistant/core@dev` because of unrelated tooling errors in the upstream tree on my checkout. The `requirements_all.txt` entry for `python-socketio==5.12.0` was added manually in alphabetical order; please re-run the generators on merge if needed.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45791
- Link to developer documentation pull request:
- Link to frontend pull request:
- Link to brand assets pull request: https://github.com/home-assistant/brands/pull/10471

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository] (companion PR linked above)

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.
