### PR TITLE
Fix Mitsubishi Comfort cross-VLAN discovery and add manual IP entry

### DIFF
--- a/homeassistant/components/mitsubishi_comfort/__init__.py
+++ b/homeassistant/components/mitsubishi_comfort/__init__.py
@@ -13,7 +13,12 @@ from mitsubishi_comfort.exceptions import AuthenticationError, DeviceConnectionE
 
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryError,
+    ConfigEntryNotReady,
+)
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
@@ -62,7 +67,7 @@ async def async_setup_entry(
         await account.login()
         devices = await account.discover_devices()
     except AuthenticationError as err:
-        raise ConfigEntryError("Mitsubishi cloud authentication failed") from err
+        raise ConfigEntryAuthFailed("Mitsubishi cloud authentication failed") from err
     except DeviceConnectionError as err:
         raise ConfigEntryNotReady("Cannot reach Mitsubishi cloud") from err
 
@@ -102,20 +107,40 @@ async def async_setup_entry(
         if not address or not info.password or not info.crypto_serial:
             # No LAN address yet: the device is registered, so DHCP discovery
             # supplies its IP and reloads the entry to add it.
-            _LOGGER.debug("Device %s has no known LAN address yet", info.label)
+            _LOGGER.warning("Device %s has no known LAN address yet", info.label)
             continue
         device = _make_device(info, serial, address, session)
         coordinators[serial] = MitsubishiComfortCoordinator(
             hass, entry, device, info.mac
         )
 
+    if not coordinators and devices:
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            "no_device_addresses",
+            is_fixable=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="no_device_addresses",
+        )
+    elif coordinators:
+        ir.async_delete_issue(hass, DOMAIN, "no_device_addresses")
+
     await asyncio.gather(
         *(c.async_config_entry_first_refresh() for c in coordinators.values())
     )
 
     entry.runtime_data = coordinators
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
+
+
+async def _async_update_listener(
+    hass: HomeAssistant, entry: MitsubishiComfortConfigEntry
+) -> None:
+    """Handle options update."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(

--- a/homeassistant/components/mitsubishi_comfort/__init__.py
+++ b/homeassistant/components/mitsubishi_comfort/__init__.py
@@ -18,8 +18,7 @@ from homeassistant.exceptions import (
     ConfigEntryError,
     ConfigEntryNotReady,
 )
-from homeassistant.helpers import issue_registry as ir
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, issue_registry as ir
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import (

--- a/homeassistant/components/mitsubishi_comfort/climate.py
+++ b/homeassistant/components/mitsubishi_comfort/climate.py
@@ -212,6 +212,7 @@ class MitsubishiComfortClimate(MitsubishiComfortEntity, ClimateEntity):
             ClimateEntityFeature.TARGET_TEMPERATURE
             | ClimateEntityFeature.FAN_MODE
             | ClimateEntityFeature.TURN_OFF
+            | ClimateEntityFeature.TURN_ON
         )
         if Mode.AUTO in self._device.supported_modes:
             features |= ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
@@ -285,3 +286,10 @@ class MitsubishiComfortClimate(MitsubishiComfortEntity, ClimateEntity):
     async def async_turn_off(self) -> None:
         """Turn the entity off."""
         await self.async_set_hvac_mode(HVACMode.OFF)
+
+    async def async_turn_on(self) -> None:
+        """Turn the entity on."""
+        for mode in (HVACMode.HEAT_COOL, HVACMode.COOL, HVACMode.HEAT):
+            if mode in self.hvac_modes:
+                await self.async_set_hvac_mode(mode)
+                return

--- a/homeassistant/components/mitsubishi_comfort/config_flow.py
+++ b/homeassistant/components/mitsubishi_comfort/config_flow.py
@@ -7,8 +7,14 @@ from mitsubishi_comfort import MitsubishiCloudAccount
 from mitsubishi_comfort.exceptions import AuthenticationError, DeviceConnectionError
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigFlow,
+    ConfigFlowResult,
+    OptionsFlow,
+)
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
@@ -29,6 +35,14 @@ class MitsubishiComfortConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle config flow for Mitsubishi Comfort."""
 
     VERSION = 1
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: ConfigEntry,
+    ) -> MitsubishiComfortOptionsFlow:
+        """Get the options flow for this handler."""
+        return MitsubishiComfortOptionsFlow()
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -111,3 +125,53 @@ class MitsubishiComfortConfigFlow(ConfigFlow, domain=DOMAIN):
             )
             self.hass.config_entries.async_schedule_reload(entry.entry_id)
         return self.async_abort(reason="already_configured")
+
+
+class MitsubishiComfortOptionsFlow(OptionsFlow):
+    """Handle options for Mitsubishi Comfort."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage device IP addresses."""
+        addresses: dict[str, str] = dict(
+            self.config_entry.data.get(CONF_ADDRESSES, {})
+        )
+
+        if user_input is not None:
+            new_addresses: dict[str, str] = {}
+            for key, ip_val in user_input.items():
+                ip_val = ip_val.strip()
+                if ip_val:
+                    new_addresses[key] = ip_val
+
+            self.hass.config_entries.async_update_entry(
+                self.config_entry,
+                data={**self.config_entry.data, CONF_ADDRESSES: new_addresses},
+            )
+            return self.async_create_entry(data={})
+
+        dev_reg = dr.async_get(self.hass)
+        schema_dict: dict = {}
+        device_names: list[str] = []
+
+        for dev_entry in dr.async_entries_for_config_entry(
+            dev_reg, self.config_entry.entry_id
+        ):
+            for conn_type, conn_id in dev_entry.connections:
+                if conn_type == dr.CONNECTION_NETWORK_MAC:
+                    mac = dr.format_mac(conn_id)
+                    current_ip = addresses.get(mac, "")
+                    schema_dict[
+                        vol.Optional(mac, default=current_ip)
+                    ] = str
+                    device_names.append(dev_entry.name or mac)
+
+        if not schema_dict:
+            return self.async_abort(reason="no_devices")
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(schema_dict),
+            description_placeholders={"devices": ", ".join(device_names)},
+        )

--- a/homeassistant/components/mitsubishi_comfort/config_flow.py
+++ b/homeassistant/components/mitsubishi_comfort/config_flow.py
@@ -134,9 +134,7 @@ class MitsubishiComfortOptionsFlow(OptionsFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Manage device IP addresses."""
-        addresses: dict[str, str] = dict(
-            self.config_entry.data.get(CONF_ADDRESSES, {})
-        )
+        addresses: dict[str, str] = dict(self.config_entry.data.get(CONF_ADDRESSES, {}))
 
         if user_input is not None:
             new_addresses: dict[str, str] = {}
@@ -162,9 +160,7 @@ class MitsubishiComfortOptionsFlow(OptionsFlow):
                 if conn_type == dr.CONNECTION_NETWORK_MAC:
                     mac = dr.format_mac(conn_id)
                     current_ip = addresses.get(mac, "")
-                    schema_dict[
-                        vol.Optional(mac, default=current_ip)
-                    ] = str
+                    schema_dict[vol.Optional(mac, default=current_ip)] = str
                     device_names.append(dev_entry.name or mac)
 
         if not schema_dict:

--- a/homeassistant/components/mitsubishi_comfort/strings.json
+++ b/homeassistant/components/mitsubishi_comfort/strings.json
@@ -22,23 +22,6 @@
       }
     }
   },
-  "issues": {
-    "no_device_addresses": {
-      "title": "Mitsubishi devices found but no local addresses available",
-      "description": "Your Mitsubishi Comfort account has devices, but Home Assistant cannot determine their local IP addresses. This usually happens when devices are on a different network (VLAN) than Home Assistant. Go to the integration options to manually enter device IP addresses."
-    }
-  },
-  "options": {
-    "step": {
-      "init": {
-        "title": "Device IP Addresses",
-        "description": "Enter the local IP address for each device. Leave blank to use DHCP discovery. Devices: {devices}"
-      }
-    },
-    "abort": {
-      "no_devices": "No devices found in the device registry"
-    }
-  },
   "exceptions": {
     "communication_error": {
       "message": "Error communicating with {device_name}"
@@ -48,6 +31,23 @@
     },
     "update_failed": {
       "message": "{device_name} returned no data"
+    }
+  },
+  "issues": {
+    "no_device_addresses": {
+      "description": "Your Mitsubishi Comfort account has devices, but Home Assistant cannot determine their local IP addresses. This usually happens when devices are on a different network (VLAN) than Home Assistant. Go to the integration options to manually enter device IP addresses.",
+      "title": "Mitsubishi devices found but no local addresses available"
+    }
+  },
+  "options": {
+    "abort": {
+      "no_devices": "No devices found in the device registry"
+    },
+    "step": {
+      "init": {
+        "description": "Enter the local IP address for each device. Leave blank to use DHCP discovery. Devices: {devices}",
+        "title": "Device IP Addresses"
+      }
     }
   }
 }

--- a/homeassistant/components/mitsubishi_comfort/strings.json
+++ b/homeassistant/components/mitsubishi_comfort/strings.json
@@ -22,6 +22,23 @@
       }
     }
   },
+  "issues": {
+    "no_device_addresses": {
+      "title": "Mitsubishi devices found but no local addresses available",
+      "description": "Your Mitsubishi Comfort account has devices, but Home Assistant cannot determine their local IP addresses. This usually happens when devices are on a different network (VLAN) than Home Assistant. Go to the integration options to manually enter device IP addresses."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Device IP Addresses",
+        "description": "Enter the local IP address for each device. Leave blank to use DHCP discovery. Devices: {devices}"
+      }
+    },
+    "abort": {
+      "no_devices": "No devices found in the device registry"
+    }
+  },
   "exceptions": {
     "communication_error": {
       "message": "Error communicating with {device_name}"

--- a/tests/components/mitsubishi_comfort/snapshots/test_climate.ambr
+++ b/tests/components/mitsubishi_comfort/snapshots/test_climate.ambr
@@ -51,7 +51,7 @@
     'platform': 'mitsubishi_comfort',
     'previous_unique_id': None,
     'suggested_object_id': None,
-    'supported_features': <ClimateEntityFeature: 171>,
+    'supported_features': <ClimateEntityFeature: 427>,
     'translation_key': None,
     'unique_id': 'SERIAL001',
     'unit_of_measurement': None,
@@ -80,7 +80,7 @@
       ]),
       'max_temp': 30.0,
       'min_temp': 18.0,
-      'supported_features': <ClimateEntityFeature: 171>,
+      'supported_features': <ClimateEntityFeature: 427>,
       'swing_mode': 'auto',
       'swing_modes': list([
         'horizontal',


### PR DESCRIPTION
## Breaking change

N/A - No breaking changes. Existing DHCP-based discovery continues to work. This adds a new options flow as a fallback.

## Proposed change

The Mitsubishi Comfort integration relies solely on DHCP `registered_devices` discovery to resolve device LAN IPs after cloud-based device discovery. This fails silently when devices are on a different VLAN/subnet than Home Assistant — a common setup for IoT devices. Users see their devices discovered (with serial numbers) but get zero entities and no errors, even with debug logging enabled.

This PR adds:
1. **Options flow for manual IP entry** — Users can now enter device IPs directly, bypassing DHCP discovery entirely. This is the essential fix for cross-VLAN setups.
2. **Warning log + repair issue** — When devices are found in the cloud but have no local addresses, a WARNING is logged (was DEBUG) and a repair issue is created guiding users to the options flow.
3. **`ConfigEntryAuthFailed`** — Auth failures now use the correct exception type, enabling future reauthentication flow (marked TODO in quality_scale.yaml).
4. **`ClimateEntityFeature.TURN_ON`** — Adds the missing TURN_ON feature flag alongside existing TURN_OFF, fixing `climate.turn_on` for voice assistants and automations.

The underlying `mitsubishi-comfort` library already has a `probe_candidate_ips()` function for active discovery, but wiring that in is left for a follow-up PR.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Dependency upgrade
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #173199
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

🤖 Generated with [Claude Code](https://claude.com/claude-code)