### PR TITLE
Store product type in gardena_bluetooth config entry

### DIFF
--- a/homeassistant/components/gardena_bluetooth/__init__.py
+++ b/homeassistant/components/gardena_bluetooth/__init__.py
@@ -14,6 +14,7 @@ from homeassistant.const import CONF_ADDRESS, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
+from .const import CONF_PRODUCT_TYPE
 from .coordinator import (
     DeviceUnavailable,
     GardenaBluetoothConfigEntry,
@@ -36,8 +37,8 @@ PRODUCTS_SCAN_TIMEOUT = 10
 PRODUCT_TYPE_TIMEOUT = 30
 
 
-async def async_get_product_type(hass: HomeAssistant, address: str) -> ProductType:
-    """Get a product type for the given address."""
+async def async_get_product(hass: HomeAssistant, address: str) -> ManufacturerData:
+    """Get manufacturer data for the given address via active scan."""
 
     data = ManufacturerData()
 
@@ -59,7 +60,7 @@ async def async_get_product_type(hass: HomeAssistant, address: str) -> ProductTy
             mode=bluetooth.BluetoothScanningMode.ACTIVE,
             timeout=PRODUCT_TYPE_TIMEOUT,
         )
-    return data.product_type
+    return data
 
 
 async def async_get_products(hass: HomeAssistant) -> dict[str, ManufacturerData]:
@@ -92,6 +93,21 @@ async def async_get_products(hass: HomeAssistant) -> dict[str, ManufacturerData]
     return products
 
 
+async def async_migrate_product_type(
+    hass: HomeAssistant, entry: GardenaBluetoothConfigEntry
+) -> GardenaBluetoothConfigEntry:
+    """Discover product type for old entries and upgrade them to minor version 2."""
+    mfg = await async_get_product(hass, entry.data[CONF_ADDRESS])
+    if mfg.product_type is ProductType.UNKNOWN:
+        raise ConfigEntryNotReady("Unable to find product type")
+    hass.config_entries.async_update_entry(
+        entry,
+        data={**entry.data, CONF_PRODUCT_TYPE: mfg.product_type.name},
+        minor_version=2,
+    )
+    return entry
+
+
 def get_connection(hass: HomeAssistant, address: str) -> CachedConnection:
     """Set up a cached client that keeps connection after last use."""
 
@@ -111,11 +127,11 @@ async def async_setup_entry(
 ) -> bool:
     """Set up Gardena Bluetooth from a config entry."""
 
-    address = entry.data[CONF_ADDRESS]
+    if entry.minor_version < 2:
+        entry = await async_migrate_product_type(hass, entry)
 
-    product_type = await async_get_product_type(hass, address)
-    if product_type is ProductType.UNKNOWN:
-        raise ConfigEntryNotReady("Unable to find product type")
+    address = entry.data[CONF_ADDRESS]
+    product_type = ProductType[entry.data[CONF_PRODUCT_TYPE]]
 
     client = Client(get_connection(hass, address), product_type)
 

--- a/homeassistant/components/gardena_bluetooth/config_flow.py
+++ b/homeassistant/components/gardena_bluetooth/config_flow.py
@@ -6,7 +6,7 @@ from typing import Any
 from gardena_bluetooth.client import Client
 from gardena_bluetooth.const import PRODUCT_NAMES, DeviceInformation
 from gardena_bluetooth.exceptions import CharacteristicNotFound, CommunicationFailure
-from gardena_bluetooth.parse import ProductType
+from gardena_bluetooth.parse import ManufacturerData, ProductType
 import voluptuous as vol
 
 from homeassistant.components.bluetooth import BluetoothServiceInfo
@@ -14,8 +14,8 @@ from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_ADDRESS
 from homeassistant.data_entry_flow import AbortFlow
 
-from . import async_get_product_type, async_get_products, get_connection
-from .const import DOMAIN
+from . import async_get_product, async_get_products, get_connection
+from .const import CONF_PRODUCT_TYPE, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,11 +33,12 @@ class GardenaBluetoothConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Gardena Bluetooth."""
 
     VERSION = 1
+    MINOR_VERSION = 2
 
     def __init__(self) -> None:
         """Initialize the config flow."""
-        self.devices: dict[str, str] = {}
         self.address: str | None
+        self.devices: dict[str, ManufacturerData] = {}
 
     async def async_read_data(self):
         """Try to connect to device and extract information."""
@@ -53,19 +54,23 @@ class GardenaBluetoothConfigFlow(ConfigFlow, domain=DOMAIN):
         finally:
             await client.disconnect()
 
-        return {CONF_ADDRESS: self.address}
+        assert self.address in self.devices
+        return {
+            CONF_ADDRESS: self.address,
+            CONF_PRODUCT_TYPE: self.devices[self.address].product_type.name,
+        }
 
     async def async_step_bluetooth(
         self, discovery_info: BluetoothServiceInfo
     ) -> ConfigFlowResult:
         """Handle the bluetooth discovery step."""
         _LOGGER.debug("Discovered device: %s", discovery_info)
-        product_type = await async_get_product_type(self.hass, discovery_info.address)
-        if product_type not in _SUPPORTED_PRODUCT_TYPES:
+        mfg = await async_get_product(self.hass, discovery_info.address)
+        self.devices[discovery_info.address] = mfg
+        if mfg.product_type not in _SUPPORTED_PRODUCT_TYPES:
             return self.async_abort(reason="no_devices_found")
 
         self.address = discovery_info.address
-        self.devices = {discovery_info.address: PRODUCT_NAMES[product_type]}
         await self.async_set_unique_id(self.address)
         self._abort_if_unique_id_configured()
         return await self.async_step_confirm()
@@ -75,7 +80,7 @@ class GardenaBluetoothConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Confirm discovery."""
         assert self.address
-        title = self.devices[self.address]
+        title = PRODUCT_NAMES[self.devices[self.address].product_type]
 
         if user_input is not None:
             data = await self.async_read_data()
@@ -102,24 +107,24 @@ class GardenaBluetoothConfigFlow(ConfigFlow, domain=DOMAIN):
             return await self.async_step_confirm()
 
         current = self._async_current_ids(include_ignore=False)
-        devices = await async_get_products(self.hass)
+        self.devices = await async_get_products(self.hass)
 
         # Keep selection sorted by address to ensure stable tests
-        self.devices = {
+        devices = {
             address: PRODUCT_NAMES[data.product_type]
-            for address in sorted(devices)
+            for address in sorted(self.devices)
             if address not in current
-            and (data := devices[address]).product_type in _SUPPORTED_PRODUCT_TYPES
+            and (data := self.devices[address]).product_type in _SUPPORTED_PRODUCT_TYPES
         }
 
-        if not self.devices:
+        if not devices:
             return self.async_abort(reason="no_devices_found")
 
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_ADDRESS): vol.In(self.devices),
+                    vol.Required(CONF_ADDRESS): vol.In(devices),
                 },
             ),
         )

--- a/homeassistant/components/gardena_bluetooth/const.py
+++ b/homeassistant/components/gardena_bluetooth/const.py
@@ -1,3 +1,4 @@
 """Constants for the Gardena Bluetooth integration."""
 
 DOMAIN = "gardena_bluetooth"
+CONF_PRODUCT_TYPE = "product_type"

--- a/tests/components/gardena_bluetooth/__init__.py
+++ b/tests/components/gardena_bluetooth/__init__.py
@@ -2,7 +2,9 @@
 
 from unittest.mock import patch
 
-from homeassistant.components.gardena_bluetooth.const import DOMAIN
+from gardena_bluetooth.parse import ManufacturerData
+
+from homeassistant.components.gardena_bluetooth.const import CONF_PRODUCT_TYPE, DOMAIN
 from homeassistant.const import CONF_ADDRESS, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.service_info.bluetooth import BluetoothServiceInfo
@@ -91,10 +93,13 @@ UNSUPPORTED_GROUP_SERVICE_INFO = BluetoothServiceInfo(
 
 def get_config_entry(service_info: BluetoothServiceInfo) -> MockConfigEntry:
     """Construct a config entry for a given discovery."""
+    mfg_bytes = service_info.manufacturer_data.get(ManufacturerData.company, b"")
+    product_type = ManufacturerData.decode(mfg_bytes).product_type
     return MockConfigEntry(
         domain=DOMAIN,
-        data={CONF_ADDRESS: service_info.address},
+        data={CONF_ADDRESS: service_info.address, CONF_PRODUCT_TYPE: product_type.name},
         unique_id=service_info.address,
+        minor_version=2,
     )
 
 

--- a/tests/components/gardena_bluetooth/conftest.py
+++ b/tests/components/gardena_bluetooth/conftest.py
@@ -14,7 +14,7 @@ from gardena_bluetooth.parse import Characteristic, Service
 import pytest
 
 from homeassistant.components import bluetooth
-from homeassistant.components.gardena_bluetooth import async_get_product_type
+from homeassistant.components.gardena_bluetooth import async_get_product
 from homeassistant.components.gardena_bluetooth.const import DOMAIN
 from homeassistant.components.gardena_bluetooth.coordinator import SCAN_INTERVAL
 from homeassistant.core import HomeAssistant
@@ -177,24 +177,18 @@ def enable_all_entities(entity_registry_enabled_by_default: None) -> None:
 
 
 @pytest.fixture
-def get_product_type_event() -> Generator[asyncio.Event]:
-    """Track product type data requests with an event."""
+def get_product_event() -> Generator[asyncio.Event]:
+    """Track product data requests with an event."""
 
     event = asyncio.Event()
 
     async def _get(*args, **kwargs):
         event.set()
-        return await async_get_product_type(*args, **kwargs)
+        return await async_get_product(*args, **kwargs)
 
-    with (
-        patch(
-            "homeassistant.components.gardena_bluetooth.async_get_product_type",
-            wraps=_get,
-        ),
-        patch(
-            "homeassistant.components.gardena_bluetooth.config_flow.async_get_product_type",
-            wraps=_get,
-        ),
+    with patch(
+        "homeassistant.components.gardena_bluetooth.async_get_product",
+        wraps=_get,
     ):
         yield event
 

--- a/tests/components/gardena_bluetooth/snapshots/test_config_flow.ambr
+++ b/tests/components/gardena_bluetooth/snapshots/test_config_flow.ambr
@@ -37,17 +37,19 @@
     }),
     'data': dict({
       'address': '00000000-0000-0000-0000-000000000001',
+      'product_type': 'WATER_COMPUTER',
     }),
     'description': None,
     'description_placeholders': None,
     'flow_id': <ANY>,
     'handler': 'gardena_bluetooth',
-    'minor_version': 1,
+    'minor_version': 2,
     'options': dict({
     }),
     'result': ConfigEntrySnapshot({
       'data': dict({
         'address': '00000000-0000-0000-0000-000000000001',
+        'product_type': 'WATER_COMPUTER',
       }),
       'disabled_by': None,
       'discovery_keys': dict({
@@ -61,7 +63,7 @@
       }),
       'domain': 'gardena_bluetooth',
       'entry_id': <ANY>,
-      'minor_version': 1,
+      'minor_version': 2,
       'options': dict({
       }),
       'pref_disable_new_entities': False,
@@ -196,24 +198,26 @@
     }),
     'data': dict({
       'address': '00000000-0000-0000-0000-000000000001',
+      'product_type': 'WATER_COMPUTER',
     }),
     'description': None,
     'description_placeholders': None,
     'flow_id': <ANY>,
     'handler': 'gardena_bluetooth',
-    'minor_version': 1,
+    'minor_version': 2,
     'options': dict({
     }),
     'result': ConfigEntrySnapshot({
       'data': dict({
         'address': '00000000-0000-0000-0000-000000000001',
+        'product_type': 'WATER_COMPUTER',
       }),
       'disabled_by': None,
       'discovery_keys': dict({
       }),
       'domain': 'gardena_bluetooth',
       'entry_id': <ANY>,
-      'minor_version': 1,
+      'minor_version': 2,
       'options': dict({
       }),
       'pref_disable_new_entities': False,

--- a/tests/components/gardena_bluetooth/test_init.py
+++ b/tests/components/gardena_bluetooth/test_init.py
@@ -156,6 +156,25 @@ async def test_migrate_config_entry_product_type_delayed(
 
 
 @pytest.mark.usefixtures("constant_advertisements")
+async def test_migrate_config_entry_product_type_fails(
+    hass: HomeAssistant,
+) -> None:
+    """Test migration fails when no advertisement with a known product type is found."""
+
+    legacy_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_ADDRESS: WATER_TIMER_SERVICE_INFO.address},
+        unique_id=WATER_TIMER_SERVICE_INFO.address,
+    )
+    legacy_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(legacy_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert legacy_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+@pytest.mark.usefixtures("constant_advertisements")
 async def test_setup_retry(
     hass: HomeAssistant, mock_entry: MockConfigEntry, mock_client: Mock
 ) -> None:

--- a/tests/components/gardena_bluetooth/test_init.py
+++ b/tests/components/gardena_bluetooth/test_init.py
@@ -16,8 +16,9 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.gardena_bluetooth import DeviceUnavailable
-from homeassistant.components.gardena_bluetooth.const import DOMAIN
+from homeassistant.components.gardena_bluetooth.const import CONF_PRODUCT_TYPE, DOMAIN
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_ADDRESS
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.util import utcnow
@@ -95,34 +96,63 @@ async def test_setup(
     assert device == snapshot
 
 
-async def test_setup_delayed_product(
+@pytest.mark.usefixtures("constant_advertisements")
+async def test_migrate_config_entry_product_type(
     hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-    mock_entry: MockConfigEntry,
     mock_read_char_raw: dict[str, bytes],
-    get_product_type_event: asyncio.Event,
-    snapshot: SnapshotAssertion,
 ) -> None:
-    """Test setup creates expected devices."""
+    """Test migration: product type resolved immediately from existing advertisement."""
 
     mock_read_char_raw[Battery.battery_level.uuid] = Battery.battery_level.encode(100)
 
-    mock_entry.add_to_hass(hass)
+    inject_bluetooth_service_info(hass, WATER_TIMER_SERVICE_INFO)
+
+    legacy_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_ADDRESS: WATER_TIMER_SERVICE_INFO.address},
+        unique_id=WATER_TIMER_SERVICE_INFO.address,
+    )
+    legacy_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(legacy_entry.entry_id) is True
+
+    assert legacy_entry.minor_version == 2
+    assert legacy_entry.data[CONF_PRODUCT_TYPE] == "WATER_COMPUTER"
+
+
+async def test_migrate_config_entry_product_type_delayed(
+    hass: HomeAssistant,
+    mock_read_char_raw: dict[str, bytes],
+    get_product_event: asyncio.Event,
+) -> None:
+    """Test migration: product type discovered via active scan after a delay."""
+
+    mock_read_char_raw[Battery.battery_level.uuid] = Battery.battery_level.encode(100)
+
+    legacy_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_ADDRESS: WATER_TIMER_SERVICE_INFO.address},
+        unique_id=WATER_TIMER_SERVICE_INFO.address,
+    )
+    legacy_entry.add_to_hass(hass)
     await hass.async_block_till_done()
 
-    get_product_type_event.clear()
+    get_product_event.clear()
 
     async with asyncio.TaskGroup() as tg:
         setup_task = tg.create_task(
-            hass.config_entries.async_setup(mock_entry.entry_id)
+            hass.config_entries.async_setup(legacy_entry.entry_id)
         )
 
-        await get_product_type_event.wait()
-        assert mock_entry.state is ConfigEntryState.SETUP_IN_PROGRESS
+        await get_product_event.wait()
+        assert legacy_entry.state is ConfigEntryState.SETUP_IN_PROGRESS
         inject_bluetooth_service_info(hass, MISSING_MANUFACTURER_DATA_SERVICE_INFO)
         inject_bluetooth_service_info(hass, WATER_TIMER_SERVICE_INFO)
 
         assert await setup_task is True
+
+    assert legacy_entry.minor_version == 2
+    assert legacy_entry.data[CONF_PRODUCT_TYPE] == "WATER_COMPUTER"
 
 
 @pytest.mark.usefixtures("constant_advertisements")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Store the product type in the config entry to avoid the need to wait for this on each entry startup.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
