### PR TITLE
Bump uiprotect to 11.8.0

### DIFF
--- a/homeassistant/components/unifiprotect/manifest.json
+++ b/homeassistant/components/unifiprotect/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "loggers": ["uiprotect"],
   "quality_scale": "platinum",
-  "requirements": ["uiprotect==11.7.0"]
+  "requirements": ["uiprotect==11.8.0"]
 }

--- a/homeassistant/components/unifiprotect/manifest.json
+++ b/homeassistant/components/unifiprotect/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "loggers": ["uiprotect"],
   "quality_scale": "platinum",
-  "requirements": ["uiprotect==11.3.0"]
+  "requirements": ["uiprotect==11.7.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3246,7 +3246,7 @@ uasiren==0.0.1
 uhooapi==1.2.8
 
 # homeassistant.components.unifiprotect
-uiprotect==11.7.0
+uiprotect==11.8.0
 
 # homeassistant.components.landisgyr_heat_meter
 ultraheat-api==0.6.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3246,7 +3246,7 @@ uasiren==0.0.1
 uhooapi==1.2.8
 
 # homeassistant.components.unifiprotect
-uiprotect==11.3.0
+uiprotect==11.7.0
 
 # homeassistant.components.landisgyr_heat_meter
 ultraheat-api==0.6.1


### PR DESCRIPTION
## Breaking change

## Proposed change

Bump `uiprotect` from `11.3.0` to `11.8.0`.

Two relevant changes:

- A **public-only (API-key-only) client mode** (uilibs/uiprotect#938) — the
  groundwork for running the UniFi Protect integration purely on the official
  public Integration API.
- A **fix for the `LCDMessage` schema mismatch** (uilibs/uiprotect#963) that
  caused `'LCDMessage' object has no attribute 'text'` on some doorbell
  firmwares, destabilizing the websocket update handler. This closes #163793.

Changes since 11.3.0:

- **11.3.1** – Bugfix: skip unknown event types on the live stream
  (robustness against newer firmware event types).
- **11.4.0** – Dedicated public models for camera/light/sensor/chime.
- **11.5.0** – Typed `subscribe_devices()` device-state lifecycle (new public-API
  primitive); removed the dead Sphinx docs stack and dropped the
  `starlette`/`uvicorn` transitive dependencies.
- **11.6.0** – `api`: **Support public-only (API-key-only) client mode**
  (uilibs/uiprotect#938, `72c4a7a`). Also: re-raised the `av` dependency floor
  to `>=17.0.1` (the HA blocker home-assistant/core#172892 has landed) and docs/test cleanups.
- **11.7.0** – Typed `ArmedModeError` raised when an operation is rejected
  because the alarm is armed; test cleanup.
- **11.7.1** – `data`: **default `LCDMessage.text`** so a doorbell sending
  `lcdMessage` with a type but no text no longer raises (uilibs/uiprotect#963).
- **11.8.0** – `api`: public-stream helpers for a thin HA integration
  (uilibs/uiprotect#965) — additive groundwork for serving camera streams from
  the public API.

No breaking changes – all releases are minor/patch with no `BREAKING CHANGE`
footers. The integration constructs the client with username/password exactly
as before; the new public-only mode, public models, `ArmedModeError`, and
public-stream helpers are additive. The full `unifiprotect` test suite passes
locally against 11.8.0 (437 passed).

https://github.com/uilibs/uiprotect/compare/v11.3.0...v11.8.0

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #163793
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
