### PR TITLE
Add exclusive option to Keyboard Remote

### DIFF
--- a/homeassistant/components/keyboard_remote/__init__.py
+++ b/homeassistant/components/keyboard_remote/__init__.py
@@ -35,6 +35,7 @@ TYPE = "type"
 EMULATE_KEY_HOLD = "emulate_key_hold"
 EMULATE_KEY_HOLD_DELAY = "emulate_key_hold_delay"
 EMULATE_KEY_HOLD_REPEAT = "emulate_key_hold_repeat"
+EXCLUSIVE = "exclusive"
 
 DEVINPUT = "/dev/input"
 
@@ -47,6 +48,7 @@ CONFIG_SCHEMA = vol.Schema(
                     {
                         vol.Exclusive(DEVICE_DESCRIPTOR, DEVICE_ID_GROUP): cv.string,
                         vol.Exclusive(DEVICE_NAME, DEVICE_ID_GROUP): cv.string,
+                        vol.Optional(EXCLUSIVE, default=True): cv.boolean,
                         vol.Optional(TYPE, default=["key_up"]): vol.All(
                             cv.ensure_list, [vol.In(KEY_VALUE)]
                         ),
@@ -250,6 +252,7 @@ class KeyboardRemote:
             self.emulate_key_hold = dev_block[EMULATE_KEY_HOLD]
             self.emulate_key_hold_delay = dev_block[EMULATE_KEY_HOLD_DELAY]
             self.emulate_key_hold_repeat = dev_block[EMULATE_KEY_HOLD_REPEAT]
+            self.exclusive = dev_block[EXCLUSIVE]
             self.monitor_task = None
             self.dev = None
             self.config_descriptor = dev_block.get(DEVICE_DESCRIPTOR)
@@ -302,8 +305,9 @@ class KeyboardRemote:
         async def async_device_stop_monitoring(self):
             """Stop event monitoring task and issue event."""
             if self.monitor_task is not None:
-                with suppress(OSError):
-                    await self.hass.async_add_executor_job(self.dev.ungrab)
+                if self.exclusive:
+                    with suppress(OSError):
+                        await self.hass.async_add_executor_job(self.dev.ungrab)
                 # monitoring of the device form the event loop and closing of the
                 # device has to occur before cancelling the task to avoid
                 # triggering unhandled exceptions inside evdev coroutines
@@ -334,8 +338,11 @@ class KeyboardRemote:
             repeat_tasks = {}
 
             try:
-                _LOGGER.debug("Start device monitoring")
-                await self.hass.async_add_executor_job(self.dev.grab)
+                if self.exclusive:
+                    _LOGGER.debug("Start exclusive monitoring of %s", self.dev.path)
+                    await self.hass.async_add_executor_job(self.dev.grab)
+                else:
+                    _LOGGER.debug("Start non-exclusive monitoring of %s", self.dev.path)
                 async for event in self.dev.async_read_loop():
                     if event.type is ecodes.EV_KEY:
                         if event.value in self.key_values:


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

No.

## Proposed change

By default, [`evdev.InputDevice.grab()][1] is called to grab the device
exclusively. This prevents other clients from receiving events from the
input device, which may break some scenarios (e.g., using a gamepad
both as a remote control and to play a game).
    
More generally, documentation of [`libevdev_grab()`][2] explicitly says:
    
> This is generally a bad idea. Don't do this.
    
Add an `exclusive` option (boolean, default: true) to preserve the
original behavior while allowing users to opt out of the exclusive grab
when they need to share the device with other applications.
    
[1]: https://python-evdev.readthedocs.io/en/latest/apidoc.html#evdev.device.InputDevice.grab
[2]: https://www.freedesktop.org/software/libevdev/doc/latest/group__init.html#ga5d434af74fee20f273db568e2cbbd13f

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]: https://github.com/home-assistant/home-assistant.io/pull/45795

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
