### PR TITLE
Bump yoto-api to 4.0.2

### DIFF
--- a/homeassistant/components/yoto/coordinator.py
+++ b/homeassistant/components/yoto/coordinator.py
@@ -131,7 +131,7 @@ class YotoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, YotoPlayer]]):
         # Fire-and-forget: the data/status response lands via the on_update
         # callback later, which already triggers async_set_updated_data.
         for device_id in list(self.client.players):
-            await self.client.request_status_push(device_id)
+            await self.client.request_player_status(device_id)
 
     def _mqtt_event(self, _player: YotoPlayer) -> None:
         """Handle a real-time update pushed by the Yoto MQTT broker."""

--- a/homeassistant/components/yoto/manifest.json
+++ b/homeassistant/components/yoto/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_push",
   "loggers": ["yoto_api"],
   "quality_scale": "bronze",
-  "requirements": ["yoto-api==4.0.1"]
+  "requirements": ["yoto-api==4.0.2"]
 }

--- a/homeassistant/components/yoto/manifest.json
+++ b/homeassistant/components/yoto/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_push",
   "loggers": ["yoto_api"],
   "quality_scale": "bronze",
-  "requirements": ["yoto-api==3.2.0"]
+  "requirements": ["yoto-api==4.0.0"]
 }

--- a/homeassistant/components/yoto/manifest.json
+++ b/homeassistant/components/yoto/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_push",
   "loggers": ["yoto_api"],
   "quality_scale": "bronze",
-  "requirements": ["yoto-api==4.0.0"]
+  "requirements": ["yoto-api==4.0.1"]
 }

--- a/homeassistant/components/yoto/media_player.py
+++ b/homeassistant/components/yoto/media_player.py
@@ -85,7 +85,7 @@ class YotoMediaPlayer(YotoEntity, MediaPlayerEntity):
     @property
     def available(self) -> bool:
         """Return whether the player is reachable through the Yoto cloud."""
-        return super().available and bool(self.player.status.is_online)
+        return super().available and bool(self.player.is_online)
 
     @property
     def state(self) -> MediaPlayerState:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3430,7 +3430,7 @@ yeelightsunflower==0.0.10
 yolink-api==0.6.5
 
 # homeassistant.components.yoto
-yoto-api==3.2.0
+yoto-api==4.0.0
 
 # homeassistant.components.youless
 youless-api==2.2.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3430,7 +3430,7 @@ yeelightsunflower==0.0.10
 yolink-api==0.6.5
 
 # homeassistant.components.yoto
-yoto-api==4.0.0
+yoto-api==4.0.1
 
 # homeassistant.components.youless
 youless-api==2.2.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3430,7 +3430,7 @@ yeelightsunflower==0.0.10
 yolink-api==0.6.5
 
 # homeassistant.components.yoto
-yoto-api==4.0.1
+yoto-api==4.0.2
 
 # homeassistant.components.youless
 youless-api==2.2.0

--- a/tests/components/yoto/conftest.py
+++ b/tests/components/yoto/conftest.py
@@ -15,7 +15,6 @@ from yoto_api import (
     PlaybackEvent,
     PlaybackStatus,
     PlayerInfo,
-    PlayerStatus,
     Track,
     YotoPlayer,
 )
@@ -80,16 +79,15 @@ def _build_player() -> YotoPlayer:
             device_family="v3",
             generation="gen3",
         ),
+        is_online=True,
         devices_refreshed_at=now,
         info_refreshed_at=now,
         last_event_received_at=now,
     )
     player.info = PlayerInfo(
-        device_id=PLAYER_ID,
         firmware_version="v2.17.5",
         mac="aa:bb:cc:dd:ee:ff",
     )
-    player.status = PlayerStatus(device_id=PLAYER_ID, is_online=True)
     player.last_event = PlaybackEvent(
         player_id=PLAYER_ID,
         playback_status=PlaybackStatus.PLAYING,

--- a/tests/components/yoto/test_init.py
+++ b/tests/components/yoto/test_init.py
@@ -85,13 +85,13 @@ async def test_status_push_tick(
     """The status-push timer publishes a request every 60 s."""
     mock_yoto_client.is_mqtt_connected = True
     await setup_integration(hass, mock_config_entry)
-    mock_yoto_client.request_status_push.reset_mock()
+    mock_yoto_client.request_player_status.reset_mock()
 
     freezer.tick(STATUS_PUSH_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    mock_yoto_client.request_status_push.assert_called_once_with("player-test")
+    mock_yoto_client.request_player_status.assert_called_once_with("player-test")
 
 
 async def test_status_push_skipped_when_mqtt_disconnected(
@@ -102,14 +102,14 @@ async def test_status_push_skipped_when_mqtt_disconnected(
 ) -> None:
     """The status-push timer is a no-op while MQTT is reconnecting."""
     await setup_integration(hass, mock_config_entry)
-    mock_yoto_client.request_status_push.reset_mock()
+    mock_yoto_client.request_player_status.reset_mock()
     mock_yoto_client.is_mqtt_connected = False
 
     freezer.tick(STATUS_PUSH_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    mock_yoto_client.request_status_push.assert_not_called()
+    mock_yoto_client.request_player_status.assert_not_called()
 
 
 async def test_periodic_poll_refreshes_players(

--- a/tests/components/yoto/test_media_player.py
+++ b/tests/components/yoto/test_media_player.py
@@ -145,7 +145,7 @@ async def test_state_unavailable_when_offline(
 ) -> None:
     """When the player reports offline the entity is unavailable."""
     player = next(iter(mock_yoto_client.players.values()))
-    player.status.is_online = False
+    player.is_online = False
 
     await setup_integration(hass, mock_config_entry)
 


### PR DESCRIPTION
## Proposed change

Bump `yoto-api` from `3.2.0` to `4.0.2` and adapt the integration to the refactored status API: `player.status.is_online` is now `player.is_online`, and `request_status_push()` is renamed to `request_player_status()`. No user-facing change.

Changelog: https://github.com/cdnninja/yoto_api/compare/v3.2.0...v4.0.2

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

