### PR TITLE
Add reauthentication flow to Yoto

### DIFF
--- a/homeassistant/components/yoto/__init__.py
+++ b/homeassistant/components/yoto/__init__.py
@@ -36,7 +36,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: YotoConfigEntry) -> bool
     try:
         await session.async_ensure_token_valid()
     except OAuth2TokenRequestReauthError as err:
-        raise ConfigEntryAuthFailed from err
+        raise ConfigEntryAuthFailed(
+            translation_domain=DOMAIN,
+            translation_key="authentication_failed",
+        ) from err
     except (aiohttp.ClientError, OAuth2TokenRequestError) as err:
         raise ConfigEntryNotReady from err
 

--- a/homeassistant/components/yoto/__init__.py
+++ b/homeassistant/components/yoto/__init__.py
@@ -4,7 +4,12 @@ import aiohttp
 
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady, OAuth2TokenRequestError
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryNotReady,
+    OAuth2TokenRequestError,
+    OAuth2TokenRequestReauthError,
+)
 from homeassistant.helpers.config_entry_oauth2_flow import (
     ImplementationUnavailableError,
     OAuth2Session,
@@ -30,6 +35,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: YotoConfigEntry) -> bool
 
     try:
         await session.async_ensure_token_valid()
+    except OAuth2TokenRequestReauthError as err:
+        raise ConfigEntryAuthFailed from err
     except (aiohttp.ClientError, OAuth2TokenRequestError) as err:
         raise ConfigEntryNotReady from err
 

--- a/homeassistant/components/yoto/config_flow.py
+++ b/homeassistant/components/yoto/config_flow.py
@@ -56,7 +56,7 @@ class YotoOAuth2FlowHandler(
         await self.async_set_unique_id(user_id)
 
         if self.source == SOURCE_REAUTH:
-            self._abort_if_unique_id_mismatch(reason="wrong_account")
+            self._abort_if_unique_id_mismatch()
             return self.async_update_reload_and_abort(
                 self._get_reauth_entry(), data=data
             )

--- a/homeassistant/components/yoto/config_flow.py
+++ b/homeassistant/components/yoto/config_flow.py
@@ -1,11 +1,12 @@
 """Config flow for the Yoto integration."""
 
+from collections.abc import Mapping
 import logging
 from typing import Any
 
 from yoto_api import YotoError, get_account_id
 
-from homeassistant.config_entries import ConfigFlowResult
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlowResult
 from homeassistant.helpers import config_entry_oauth2_flow
 
 from .const import _LOGGER, DOMAIN, YOTO_AUDIENCE, YOTO_SCOPES
@@ -31,6 +32,20 @@ class YotoOAuth2FlowHandler(
             "scope": " ".join(YOTO_SCOPES),
         }
 
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Perform reauth upon an API authentication error."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Confirm reauth and restart the OAuth2 authorization."""
+        if user_input is None:
+            return self.async_show_form(step_id="reauth_confirm")
+        return await self.async_step_user()
+
     async def async_oauth_create_entry(self, data: dict[str, Any]) -> ConfigFlowResult:
         """Identify the Yoto account from the access token."""
         try:
@@ -39,5 +54,12 @@ class YotoOAuth2FlowHandler(
             return self.async_abort(reason="oauth_unauthorized")
 
         await self.async_set_unique_id(user_id)
+
+        if self.source == SOURCE_REAUTH:
+            self._abort_if_unique_id_mismatch(reason="wrong_account")
+            return self.async_update_reload_and_abort(
+                self._get_reauth_entry(), data=data
+            )
+
         self._abort_if_unique_id_configured()
         return self.async_create_entry(title="Yoto", data=data)

--- a/homeassistant/components/yoto/coordinator.py
+++ b/homeassistant/components/yoto/coordinator.py
@@ -3,12 +3,17 @@
 from datetime import datetime
 
 import aiohttp
-from yoto_api import Token, YotoClient, YotoError, YotoPlayer
+from yoto_api import AuthenticationError, Token, YotoClient, YotoError, YotoPlayer
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady, OAuth2TokenRequestError
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryNotReady,
+    OAuth2TokenRequestError,
+    OAuth2TokenRequestReauthError,
+)
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.config_entry_oauth2_flow import OAuth2Session
 from homeassistant.helpers.event import async_track_time_interval
@@ -57,6 +62,8 @@ class YotoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, YotoPlayer]]):
         """Set up the coordinator."""
         try:
             await self.client.refresh()
+        except AuthenticationError as err:
+            raise ConfigEntryAuthFailed from err
         except YotoError as err:
             raise ConfigEntryNotReady(
                 translation_domain=DOMAIN,
@@ -93,6 +100,8 @@ class YotoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, YotoPlayer]]):
 
         try:
             await self._session.async_ensure_token_valid()
+        except OAuth2TokenRequestReauthError as err:
+            raise ConfigEntryAuthFailed from err
         except (aiohttp.ClientError, OAuth2TokenRequestError) as err:
             raise UpdateFailed(
                 translation_domain=DOMAIN,
@@ -104,6 +113,8 @@ class YotoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, YotoPlayer]]):
 
         try:
             await self.client.refresh()
+        except AuthenticationError as err:
+            raise ConfigEntryAuthFailed from err
         except YotoError as err:
             raise UpdateFailed(
                 translation_domain=DOMAIN,

--- a/homeassistant/components/yoto/coordinator.py
+++ b/homeassistant/components/yoto/coordinator.py
@@ -63,7 +63,10 @@ class YotoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, YotoPlayer]]):
         try:
             await self.client.refresh()
         except AuthenticationError as err:
-            raise ConfigEntryAuthFailed from err
+            raise ConfigEntryAuthFailed(
+                translation_domain=DOMAIN,
+                translation_key="authentication_failed",
+            ) from err
         except YotoError as err:
             raise ConfigEntryNotReady(
                 translation_domain=DOMAIN,
@@ -101,7 +104,10 @@ class YotoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, YotoPlayer]]):
         try:
             await self._session.async_ensure_token_valid()
         except OAuth2TokenRequestReauthError as err:
-            raise ConfigEntryAuthFailed from err
+            raise ConfigEntryAuthFailed(
+                translation_domain=DOMAIN,
+                translation_key="authentication_failed",
+            ) from err
         except (aiohttp.ClientError, OAuth2TokenRequestError) as err:
             raise UpdateFailed(
                 translation_domain=DOMAIN,
@@ -114,7 +120,10 @@ class YotoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, YotoPlayer]]):
         try:
             await self.client.refresh()
         except AuthenticationError as err:
-            raise ConfigEntryAuthFailed from err
+            raise ConfigEntryAuthFailed(
+                translation_domain=DOMAIN,
+                translation_key="authentication_failed",
+            ) from err
         except YotoError as err:
             raise UpdateFailed(
                 translation_domain=DOMAIN,

--- a/homeassistant/components/yoto/quality_scale.yaml
+++ b/homeassistant/components/yoto/quality_scale.yaml
@@ -40,7 +40,7 @@ rules:
   integration-owner: done
   log-when-unavailable: done
   parallel-updates: done
-  reauthentication-flow: todo
+  reauthentication-flow: done
   test-coverage: done
 
   # Gold

--- a/homeassistant/components/yoto/strings.json
+++ b/homeassistant/components/yoto/strings.json
@@ -11,8 +11,8 @@
       "oauth_timeout": "[%key:common::config_flow::abort::oauth2_timeout%]",
       "oauth_unauthorized": "[%key:common::config_flow::abort::oauth2_unauthorized%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
-      "user_rejected_authorize": "[%key:common::config_flow::abort::oauth2_user_rejected_authorize%]",
-      "wrong_account": "The reauthorized account does not match the original Yoto account. Please log in with the same account."
+      "unique_id_mismatch": "The reauthorized account does not match the original Yoto account. Please log in with the same account.",
+      "user_rejected_authorize": "[%key:common::config_flow::abort::oauth2_user_rejected_authorize%]"
     },
     "create_entry": {
       "default": "[%key:common::config_flow::create_entry::authenticated%]"

--- a/homeassistant/components/yoto/strings.json
+++ b/homeassistant/components/yoto/strings.json
@@ -10,7 +10,9 @@
       "oauth_failed": "[%key:common::config_flow::abort::oauth2_failed%]",
       "oauth_timeout": "[%key:common::config_flow::abort::oauth2_timeout%]",
       "oauth_unauthorized": "[%key:common::config_flow::abort::oauth2_unauthorized%]",
-      "user_rejected_authorize": "[%key:common::config_flow::abort::oauth2_user_rejected_authorize%]"
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "user_rejected_authorize": "[%key:common::config_flow::abort::oauth2_user_rejected_authorize%]",
+      "wrong_account": "The reauthorized account does not match the original Yoto account. Please log in with the same account."
     },
     "create_entry": {
       "default": "[%key:common::config_flow::create_entry::authenticated%]"
@@ -27,6 +29,10 @@
           "implementation": "[%key:common::config_flow::description::implementation%]"
         },
         "title": "[%key:common::config_flow::title::oauth2_pick_implementation%]"
+      },
+      "reauth_confirm": {
+        "description": "The Yoto integration needs to re-authenticate your account.",
+        "title": "[%key:common::config_flow::title::reauth%]"
       }
     }
   },

--- a/homeassistant/components/yoto/strings.json
+++ b/homeassistant/components/yoto/strings.json
@@ -37,6 +37,9 @@
     }
   },
   "exceptions": {
+    "authentication_failed": {
+      "message": "Yoto credentials are no longer valid. Please reauthenticate your account."
+    },
     "card_detail_failed": {
       "message": "Could not load Yoto card details: {error}"
     },

--- a/tests/components/yoto/test_config_flow.py
+++ b/tests/components/yoto/test_config_flow.py
@@ -192,7 +192,7 @@ async def test_reauth_flow(
 @pytest.mark.usefixtures(
     "current_request_with_host", "setup_credentials", "mock_setup_entry"
 )
-async def test_reauth_wrong_account(
+async def test_reauth_unique_id_mismatch(
     hass: HomeAssistant,
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
@@ -213,7 +213,7 @@ async def test_reauth_wrong_account(
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "wrong_account"
+    assert result["reason"] == "unique_id_mismatch"
 
 
 @pytest.mark.usefixtures("current_request_with_host", "setup_credentials")

--- a/tests/components/yoto/test_config_flow.py
+++ b/tests/components/yoto/test_config_flow.py
@@ -1,13 +1,20 @@
 """Tests for the Yoto config flow."""
 
 from http import HTTPStatus
+from unittest.mock import MagicMock
 from urllib.parse import parse_qs, urlparse
 
 import jwt
 import pytest
+from yoto_api import AuthenticationError
 
 from homeassistant.components.yoto.const import DOMAIN, YOTO_AUDIENCE, YOTO_SCOPES
-from homeassistant.config_entries import SOURCE_DHCP, SOURCE_USER
+from homeassistant.config_entries import (
+    SOURCE_DHCP,
+    SOURCE_REAUTH,
+    SOURCE_USER,
+    ConfigEntryState,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import config_entry_oauth2_flow
@@ -207,6 +214,46 @@ async def test_reauth_wrong_account(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "wrong_account"
+
+
+@pytest.mark.usefixtures("current_request_with_host", "setup_credentials")
+async def test_reauth_recovers_failed_entry(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    mock_yoto_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """A successful reauth reloads an entry that failed to authenticate."""
+    mock_config_entry.add_to_hass(hass)
+    mock_yoto_client.refresh.side_effect = AuthenticationError("denied")
+
+    assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+    assert flows[0]["context"]["source"] == SOURCE_REAUTH
+
+    mock_yoto_client.refresh.side_effect = None
+
+    result = await hass.config_entries.flow.async_configure(flows[0]["flow_id"], {})
+    assert result["type"] is FlowResultType.EXTERNAL_STEP
+
+    await _complete_callback(
+        hass,
+        result,
+        hass_client_no_auth,
+        aioclient_mock,
+        refresh_token="new-refresh-token",
+    )
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    await hass.async_block_till_done()
+    assert mock_config_entry.state is ConfigEntryState.LOADED
 
 
 @pytest.mark.parametrize(

--- a/tests/components/yoto/test_config_flow.py
+++ b/tests/components/yoto/test_config_flow.py
@@ -149,6 +149,66 @@ async def test_already_configured(
     assert result["reason"] == "already_configured"
 
 
+@pytest.mark.usefixtures(
+    "current_request_with_host", "setup_credentials", "mock_setup_entry"
+)
+async def test_reauth_flow(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Reauthorizing the same account updates the existing entry's token."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reauth_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    assert result["type"] is FlowResultType.EXTERNAL_STEP
+
+    await _complete_callback(
+        hass,
+        result,
+        hass_client_no_auth,
+        aioclient_mock,
+        refresh_token="new-refresh-token",
+    )
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert mock_config_entry.data["token"]["refresh_token"] == "new-refresh-token"
+
+
+@pytest.mark.usefixtures(
+    "current_request_with_host", "setup_credentials", "mock_setup_entry"
+)
+async def test_reauth_wrong_account(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Reauthorizing with a different account aborts."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reauth_flow(hass)
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    other_token = jwt.encode(
+        {"sub": "auth0|other-user"}, "test-secret-long-enough-for-hmac-sha256"
+    )
+    await _complete_callback(
+        hass, result, hass_client_no_auth, aioclient_mock, access_token=other_token
+    )
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "wrong_account"
+
+
 @pytest.mark.parametrize(
     "access_token",
     [

--- a/tests/components/yoto/test_init.py
+++ b/tests/components/yoto/test_init.py
@@ -223,6 +223,29 @@ async def test_poll_reauth_on_authentication_error(
     )
 
 
+@pytest.mark.usefixtures("mock_yoto_client")
+async def test_poll_reauth_on_invalid_refresh_token(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """An unrecoverable token refresh during the poll starts a reauth flow."""
+    await setup_integration(hass, mock_config_entry)
+
+    with patch(
+        "homeassistant.helpers.config_entry_oauth2_flow.OAuth2Session.async_ensure_token_valid",
+        side_effect=OAuth2TokenRequestReauthError(request_info=Mock(), domain=DOMAIN),
+    ):
+        freezer.tick(SCAN_INTERVAL)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+    assert any(
+        flow["context"]["source"] == SOURCE_REAUTH
+        for flow in hass.config_entries.flow.async_progress()
+    )
+
+
 async def test_setup_retries_when_mqtt_unavailable(
     hass: HomeAssistant,
     mock_yoto_client: MagicMock,

--- a/tests/components/yoto/test_init.py
+++ b/tests/components/yoto/test_init.py
@@ -5,16 +5,19 @@ from unittest.mock import MagicMock, Mock, patch
 import aiohttp
 from freezegun.api import FrozenDateTimeFactory
 import pytest
-from yoto_api import YotoAPIError, YotoError
+from yoto_api import AuthenticationError, YotoAPIError, YotoError
 
 from homeassistant.components.yoto.const import (
     DOMAIN,
     SCAN_INTERVAL,
     STATUS_PUSH_INTERVAL,
 )
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import OAuth2TokenRequestError
+from homeassistant.exceptions import (
+    OAuth2TokenRequestError,
+    OAuth2TokenRequestReauthError,
+)
 from homeassistant.helpers.config_entry_oauth2_flow import (
     ImplementationUnavailableError,
 )
@@ -163,6 +166,61 @@ async def test_setup_retries_on_token_validation_error(
         await setup_integration(hass, mock_config_entry)
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_setup_reauth_on_invalid_refresh_token(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """An unrecoverable token refresh at setup starts a reauth flow."""
+    with patch(
+        "homeassistant.helpers.config_entry_oauth2_flow.OAuth2Session.async_ensure_token_valid",
+        side_effect=OAuth2TokenRequestReauthError(request_info=Mock(), domain=DOMAIN),
+    ):
+        await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+    assert any(
+        flow["context"]["source"] == SOURCE_REAUTH
+        for flow in hass.config_entries.flow.async_progress()
+    )
+
+
+async def test_setup_reauth_on_authentication_error(
+    hass: HomeAssistant,
+    mock_yoto_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """A rejected access token at setup starts a reauth flow."""
+    mock_yoto_client.refresh.side_effect = AuthenticationError("denied")
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+    assert any(
+        flow["context"]["source"] == SOURCE_REAUTH
+        for flow in hass.config_entries.flow.async_progress()
+    )
+
+
+async def test_poll_reauth_on_authentication_error(
+    hass: HomeAssistant,
+    mock_yoto_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A rejected access token during the poll starts a reauth flow."""
+    await setup_integration(hass, mock_config_entry)
+    mock_yoto_client.refresh.side_effect = AuthenticationError("denied")
+
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert any(
+        flow["context"]["source"] == SOURCE_REAUTH
+        for flow in hass.config_entries.flow.async_progress()
+    )
 
 
 async def test_setup_retries_when_mqtt_unavailable(


### PR DESCRIPTION
## Proposed change

Add a reauthentication flow so a Yoto account can be re-linked without removing and re-adding the integration. When the OAuth token can no longer be refreshed, or the Yoto API rejects it, Home Assistant starts a reauth flow that restarts the authorization. It verifies the same account is used (aborts with `wrong_account` otherwise) and works with both application credentials and Nabu Casa cloud credentials.

Implements the `reauthentication-flow` quality scale rule (Silver).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
