### PR TITLE
Bump pydaikin to 2.18.1

### DIFF
--- a/homeassistant/components/daikin/manifest.json
+++ b/homeassistant/components/daikin/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["pydaikin"],
-  "requirements": ["pydaikin==2.17.2"],
+  "requirements": ["pydaikin==2.18.1"],
   "zeroconf": ["_dkapi._tcp.local."]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2084,7 +2084,7 @@ pycsspeechtts==1.0.8
 pycync==0.5.0
 
 # homeassistant.components.daikin
-pydaikin==2.17.2
+pydaikin==2.18.1
 
 # homeassistant.components.danfoss_air
 pydanfossair==0.1.0


### PR DESCRIPTION
## Proposed change

Version bump pydaikin to 2.18.1.

Changelogs:
- https://github.com/fredrike/pydaikin/releases/tag/v.2.18.0-final
- https://github.com/fredrike/pydaikin/releases/tag/v2.18.1

Full diff: https://github.com/fredrike/pydaikin/compare/v2.17.2...v2.18.1

The 2.18.0 release includes [fredrike/pydaikin#99](https://github.com/fredrike/pydaikin/pull/99), which serializes HTTP requests to BRP069-series Wi-Fi modules via `MAX_CONCURRENT_REQUEST=1`. These modules can only handle a single concurrent HTTP connection, and the previous parallel-request behaviour caused intermittent `ServerDisconnectedError` / `BadHttpMessage` surfacing in Home Assistant as `Exception in TaskGroup: Server disconnected` and as `Timeout fetching ... data` after long stalls.

This bug is tracked upstream and downstream in:
- [fredrike/pydaikin#22](https://github.com/fredrike/pydaikin/issues/22) (closed — root cause + fix description)
- [fredrike/pydaikin#25](https://github.com/fredrike/pydaikin/issues/25) (open — request for HA bump)
- [home-assistant/core#129707](https://github.com/home-assistant/core/issues/129707) (open — 305s timeouts fetching Daikin data)

v2.18.1 follows up with a small fix released 2026-02-25.

## Type of change

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue: home-assistant/core#129707, fredrike/pydaikin#25
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
