### PR TITLE
Use query_dns from aiodns in dnsip

### DIFF
--- a/homeassistant/components/dnsip/__init__.py
+++ b/homeassistant/components/dnsip/__init__.py
@@ -51,7 +51,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: DnsIPConfigEntry) -> boo
             tcp_port=entry.options[CONF_PORT],
             udp_port=entry.options[CONF_PORT],
         )
-        queries.append(resolver_ipv4.query(hostname, "A"))
+        queries.append(resolver_ipv4.query_dns(hostname, "A"))
 
     if entry.data[CONF_IPV6]:
         resolver_ipv6 = aiodns.DNSResolver(
@@ -59,7 +59,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: DnsIPConfigEntry) -> boo
             tcp_port=entry.options[CONF_PORT_IPV6],
             udp_port=entry.options[CONF_PORT_IPV6],
         )
-        queries.append(resolver_ipv6.query(hostname, "AAAA"))
+        queries.append(resolver_ipv6.query_dns(hostname, "AAAA"))
 
     async def _close_resolvers() -> None:
         if resolver_ipv4 is not None:

--- a/homeassistant/components/dnsip/config_flow.py
+++ b/homeassistant/components/dnsip/config_flow.py
@@ -72,7 +72,7 @@ async def async_validate_hostname(
             _resolver = aiodns.DNSResolver(
                 nameservers=[resolver], udp_port=port, tcp_port=port
             )
-            result = bool(await _resolver.query(hostname, qtype))
+            result = bool(await _resolver.query_dns(hostname, qtype))
 
         return result
 

--- a/homeassistant/components/dnsip/sensor.py
+++ b/homeassistant/components/dnsip/sensor.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Literal
 
 import aiodns
 from aiodns.error import DNSError
+import pycares
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.const import CONF_NAME, CONF_PORT
@@ -148,7 +149,7 @@ class WanIpSensor(SensorEntity):
         response = None
         try:
             async with asyncio.timeout(10):
-                response = await self._resolver.query(self.hostname, self.querytype)
+                response = await self._resolver.query_dns(self.hostname, self.querytype)
         except TimeoutError as err:
             _LOGGER.debug("Timeout while resolving host: %s", err)
             await self._resolver.close()
@@ -157,9 +158,19 @@ class WanIpSensor(SensorEntity):
             await self._resolver.close()
 
         if response:
-            sorted_ips = sort_ips(
-                [res.host for res in response], querytype=self.querytype
-            )
+            if TYPE_CHECKING:
+                assert all(
+                    isinstance(res.data, (pycares.ARecordData, pycares.AAAARecordData))
+                    for res in response.answer
+                )
+            _ips = []
+            for res in response.answer:
+                if TYPE_CHECKING:
+                    assert isinstance(
+                        res.data, (pycares.ARecordData, pycares.AAAARecordData)
+                    )
+                _ips.append(res.data.addr)
+            sorted_ips = sort_ips(_ips, querytype=self.querytype)
             self._attr_native_value = sorted_ips[0]
             self._attr_extra_state_attributes["ip_addresses"] = sorted_ips
             self._attr_available = True

--- a/tests/components/dnsip/__init__.py
+++ b/tests/components/dnsip/__init__.py
@@ -1,5 +1,7 @@
 """Tests for the DNS IP integration."""
 
+import pycares
+
 
 class QueryResult:
     """Return Query results."""
@@ -23,19 +25,68 @@ class RetrieveDNS:
         self.error = error
         self._closed = False
 
-    async def query(self, hostname, qtype) -> list[QueryResult]:
-        """Return information."""
+    async def query_dns(
+        self, host: str, qtype: str, qclass: str | None = None
+    ) -> pycares.DNSResult:
+        """Return dns information."""
         if self.error:
             raise self.error
         if qtype == "AAAA":
-            results = [
-                QueryResult("2001:db8:77::face:b00c"),
-                QueryResult("2001:db8:77::dead:beef"),
-                QueryResult("2001:db8::77:dead:beef"),
-                QueryResult("2001:db8:66::dead:beef"),
-            ]
+            results = pycares.DNSResult(
+                answer=[
+                    pycares.DNSRecord(
+                        name="test",
+                        type=pycares.QUERY_TYPE_AAAA,
+                        record_class=pycares.QUERY_CLASS_IN,
+                        data=pycares.AAAARecordData(addr="2001:db8:77::face:b00c"),
+                        ttl=60,
+                    ),
+                    pycares.DNSRecord(
+                        name="test",
+                        type=pycares.QUERY_TYPE_AAAA,
+                        record_class=pycares.QUERY_CLASS_IN,
+                        data=pycares.AAAARecordData(addr="2001:db8:77::dead:beef"),
+                        ttl=60,
+                    ),
+                    pycares.DNSRecord(
+                        name="test",
+                        type=pycares.QUERY_TYPE_AAAA,
+                        record_class=pycares.QUERY_CLASS_IN,
+                        data=pycares.AAAARecordData(addr="2001:db8::77:dead:beef"),
+                        ttl=60,
+                    ),
+                    pycares.DNSRecord(
+                        name="test",
+                        type=pycares.QUERY_TYPE_AAAA,
+                        record_class=pycares.QUERY_CLASS_IN,
+                        data=pycares.AAAARecordData(addr="2001:db8:66::dead:beef"),
+                        ttl=60,
+                    ),
+                ],
+                authority=[],
+                additional=[],
+            )
         else:
-            results = [QueryResult("1.2.3.4"), QueryResult("1.1.1.1")]
+            results = pycares.DNSResult(
+                answer=[
+                    pycares.DNSRecord(
+                        name="test",
+                        type=pycares.QUERY_TYPE_A,
+                        record_class=pycares.QUERY_CLASS_IN,
+                        data=pycares.ARecordData(addr="1.2.3.4"),
+                        ttl=60,
+                    ),
+                    pycares.DNSRecord(
+                        name="test",
+                        type=pycares.QUERY_TYPE_A,
+                        record_class=pycares.QUERY_CLASS_IN,
+                        data=pycares.ARecordData(addr="1.1.1.1"),
+                        ttl=60,
+                    ),
+                ],
+                authority=[],
+                additional=[],
+            )
         return results
 
     @property


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change


## Proposed change
Migrate `dnsip` to use `query_dns` instead of `query`.
https://github.com/aio-libs/aiodns#migrating-from-aiodns-3x

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository. 