### PR TITLE
Fix homeassistant hardware unique id migration

### DIFF
--- a/homeassistant/components/homeassistant_connect_zbt2/__init__.py
+++ b/homeassistant/components/homeassistant_connect_zbt2/__init__.py
@@ -135,7 +135,24 @@ async def async_migrate_entry(
             )
 
             if canonical.entry_id != config_entry.entry_id:
-                # The canonical entry's migration will remove this duplicate.
+                if canonical.minor_version < 2:
+                    # The canonical entry has not been migrated yet and its
+                    # migration will remove this duplicate.
+                    return False
+
+                # The canonical entry is already fully migrated and will not run
+                # a migration that removes this duplicate, so remove it here. The
+                # entry can't remove itself while its setup lock is held, so
+                # schedule the removal instead.
+                _LOGGER.debug(
+                    "Removing duplicate config entry %s for serial %s in favor of %s",
+                    config_entry.entry_id,
+                    serial_number,
+                    canonical.entry_id,
+                )
+                hass.async_create_task(
+                    hass.config_entries.async_remove(config_entry.entry_id)
+                )
                 return False
 
             for duplicate in duplicates:

--- a/homeassistant/components/homeassistant_sky_connect/__init__.py
+++ b/homeassistant/components/homeassistant_sky_connect/__init__.py
@@ -239,7 +239,24 @@ async def async_migrate_entry(
             )
 
             if canonical.entry_id != config_entry.entry_id:
-                # The canonical entry's migration will remove this duplicate.
+                if canonical.minor_version < 5:
+                    # The canonical entry has not been migrated yet and its
+                    # migration will remove this duplicate.
+                    return False
+
+                # The canonical entry is already fully migrated and will not run
+                # a migration that removes this duplicate, so remove it here. The
+                # entry can't remove itself while its setup lock is held, so
+                # schedule the removal instead.
+                _LOGGER.warning(
+                    "Removing duplicate config entry %s for serial %s in favor of %s",
+                    config_entry.entry_id,
+                    serial_number,
+                    canonical.entry_id,
+                )
+                hass.async_create_task(
+                    hass.config_entries.async_remove(config_entry.entry_id)
+                )
                 return False
 
             for duplicate in duplicates:

--- a/tests/components/homeassistant_connect_zbt2/test_init.py
+++ b/tests/components/homeassistant_connect_zbt2/test_init.py
@@ -234,6 +234,75 @@ async def test_config_entry_migration_v2_prefers_active_entry(
     assert active_entry.unique_id == serial_number
 
 
+async def test_config_entry_migration_v2_removes_duplicates_of_migrated_entry(
+    hass: HomeAssistant,
+) -> None:
+    """Test v1.2 migration removes duplicates of an already migrated entry.
+
+    A migrated entry (minor version 2) never runs the migration again, so the
+    remaining minor version 1 duplicates have to remove themselves instead of
+    relying on the canonical entry's migration to remove them.
+    """
+    serial_number = "E072A1D90104"
+    data = {
+        "device": "/dev/serial/by-id/usb-Nabu_Casa_ZBT-2_E072A1D90104-if00",
+        "firmware": "spinel",
+        "firmware_version": (
+            "SL-OPENTHREAD/2.7.2.0_GitHub-fb0446f53; EFR32; Feb 24 2026 00:58:55"
+        ),
+        "manufacturer": "Nabu Casa",
+        "pid": "831A",
+        "product": "ZBT-2",
+        "serial_number": serial_number,
+        "vid": "303A",
+    }
+
+    older_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="303A:831A_E072A1D90104_Nabu Casa_ZBT-2 - Nabu Casa ZBT-2",
+        source="usb",
+        data=dict(data),
+        version=1,
+        minor_version=1,
+    )
+    older_entry.add_to_hass(hass)
+
+    duplicate_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="303A:831A_E072A1D90104_Nabu Casa_ZBT-2",
+        source="import",
+        data=dict(data),
+        version=1,
+        minor_version=1,
+    )
+    duplicate_entry.add_to_hass(hass)
+
+    migrated_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=serial_number,
+        source="import",
+        data=dict(data),
+        version=1,
+        minor_version=2,
+    )
+    migrated_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.homeassistant_connect_zbt2.os.path.exists",
+        return_value=True,
+    ):
+        await async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done()
+
+    remaining_entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(remaining_entries) == 1
+    assert remaining_entries[0].entry_id == migrated_entry.entry_id
+    assert remaining_entries[0].minor_version == 2
+    assert remaining_entries[0].unique_id == serial_number
+    assert hass.config_entries.async_get_entry(older_entry.entry_id) is None
+    assert hass.config_entries.async_get_entry(duplicate_entry.entry_id) is None
+
+
 async def test_setup_fails_on_missing_usb_port(hass: HomeAssistant) -> None:
     """Test setup failing when the USB port is missing."""
 

--- a/tests/components/homeassistant_sky_connect/test_init.py
+++ b/tests/components/homeassistant_sky_connect/test_init.py
@@ -306,6 +306,79 @@ async def test_config_entry_migration_v5_prefers_active_entry(
     assert active_entry.unique_id == serial_number
 
 
+async def test_config_entry_migration_v5_removes_duplicates_of_migrated_entry(
+    hass: HomeAssistant,
+) -> None:
+    """Test v1.5 migration removes duplicates of an already migrated entry.
+
+    A migrated entry (minor version 5) never runs the migration again, so the
+    remaining minor version 4 duplicates have to remove themselves instead of
+    relying on the canonical entry's migration to remove them.
+    """
+    serial_number = "9e2adbd75b8beb119fe564a0f320645d"
+    data = {
+        "description": "SkyConnect v1.0",
+        "device": (
+            "/dev/serial/by-id/"
+            "usb-Nabu_Casa_SkyConnect_v1.0_9e2adbd75b8beb119fe564a0f320645d-if00-port0"
+        ),
+        "vid": "10C4",
+        "pid": "EA60",
+        "serial_number": serial_number,
+        "manufacturer": "Nabu Casa",
+        "product": "SkyConnect v1.0",
+        "firmware": "ezsp",
+        "firmware_version": "7.4.4.0",
+    }
+
+    older_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=(
+            "10C4:EA60_9e2adbd75b8beb119fe564a0f320645d_Nabu Casa_SkyConnect v1.0"
+        ),
+        source="usb",
+        data=dict(data),
+        version=1,
+        minor_version=4,
+    )
+    older_entry.add_to_hass(hass)
+
+    duplicate_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="10C4:EA60_9e2adbd75b8beb119fe564a0f320645d_Nabu_Casa_SkyConnect",
+        source="import",
+        data=dict(data),
+        version=1,
+        minor_version=4,
+    )
+    duplicate_entry.add_to_hass(hass)
+
+    migrated_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=serial_number,
+        source="import",
+        data=dict(data),
+        version=1,
+        minor_version=5,
+    )
+    migrated_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.homeassistant_sky_connect.os.path.exists",
+        return_value=True,
+    ):
+        await async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done()
+
+    remaining = hass.config_entries.async_entries(DOMAIN)
+    assert len(remaining) == 1
+    assert remaining[0].entry_id == migrated_entry.entry_id
+    assert remaining[0].minor_version == 5
+    assert remaining[0].unique_id == serial_number
+    assert hass.config_entries.async_get_entry(older_entry.entry_id) is None
+    assert hass.config_entries.async_get_entry(duplicate_entry.entry_id) is None
+
+
 async def test_setup_fails_on_missing_usb_port(hass: HomeAssistant) -> None:
     """Test setup failing when the USB port is missing."""
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- We missed to handle the case when there was already a config entry with latest minor version. Then the non migrated config entries that were supposed to be removed, would be left hanging, with migration error.
- See https://github.com/home-assistant/core/issues/172232#issuecomment-4646548787 for an analysis.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #172232
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
