### PR TITLE
Clean up redundant URL parsing in the Overkiz

### DIFF
--- a/homeassistant/components/overkiz/climate/atlantic_pass_apc_heating_zone.py
+++ b/homeassistant/components/overkiz/climate/atlantic_pass_apc_heating_zone.py
@@ -98,8 +98,10 @@ class AtlanticPassAPCHeatingZone(OverkizEntity, ClimateEntity):
         super().__init__(device_url, coordinator)
 
         # Temperature sensor use the same base_device_url and use the n+1 index
-        self.temperature_device = self.executor.linked_device(
-            int(self.index_device_url) + 1
+        self.temperature_device = (
+            self.executor.linked_device(subsystem_id + 1)
+            if (subsystem_id := self.device.identifier.subsystem_id) is not None
+            else None
         )
 
     @property

--- a/homeassistant/components/overkiz/entity.py
+++ b/homeassistant/components/overkiz/entity.py
@@ -26,10 +26,6 @@ class OverkizEntity(CoordinatorEntity[OverkizDataUpdateCoordinator]):
         """Initialize the device."""
         super().__init__(coordinator)
         self.device_url = device_url
-        split_device_url = self.device_url.split("#")
-        self.base_device_url = split_device_url[0]
-        if len(split_device_url) == 2:
-            self.index_device_url = split_device_url[1]
         self.executor = OverkizExecutor(device_url, coordinator)
 
         self._attr_assumed_state = not self.device.states
@@ -63,7 +59,7 @@ class OverkizEntity(CoordinatorEntity[OverkizDataUpdateCoordinator]):
     @property
     def is_sub_device(self) -> bool:
         """Return True if device is a sub device."""
-        return "#" in self.device_url and not self.device_url.endswith("#1")
+        return self.device.identifier.is_sub_device
 
     @property
     def device(self) -> Device:
@@ -79,7 +75,7 @@ class OverkizEntity(CoordinatorEntity[OverkizDataUpdateCoordinator]):
             # Only return the url of the base device, to inherit device name
             # and model from parent device.
             return DeviceInfo(
-                identifiers={(DOMAIN, self.executor.base_device_url)},
+                identifiers={(DOMAIN, self.device.identifier.base_device_url)},
             )
 
         manufacturer = (
@@ -104,7 +100,7 @@ class OverkizEntity(CoordinatorEntity[OverkizDataUpdateCoordinator]):
         )
 
         return DeviceInfo(
-            identifiers={(DOMAIN, self.executor.base_device_url)},
+            identifiers={(DOMAIN, self.device.identifier.base_device_url)},
             name=self.device.label,
             manufacturer=str(manufacturer),
             model=str(model),
@@ -115,7 +111,7 @@ class OverkizEntity(CoordinatorEntity[OverkizDataUpdateCoordinator]):
             model_id=self.device.widget,
             hw_version=self.device.controllable_name,
             suggested_area=suggested_area,
-            via_device=(DOMAIN, self.executor.get_gateway_id()),
+            via_device=(DOMAIN, self.device.identifier.gateway_id),
             configuration_url=self.coordinator.client.server_config.configuration_url,
         )
 

--- a/homeassistant/components/overkiz/entity.py
+++ b/homeassistant/components/overkiz/entity.py
@@ -31,7 +31,7 @@ class OverkizEntity(CoordinatorEntity[OverkizDataUpdateCoordinator]):
         self._attr_assumed_state = not self.device.states
         self._attr_unique_id = self.device.device_url
 
-        if self.is_sub_device:
+        if self.device.identifier.is_sub_device:
             # In case of sub entity, use the provided label as name
             self._attr_name = self.device.label
 
@@ -57,11 +57,6 @@ class OverkizEntity(CoordinatorEntity[OverkizDataUpdateCoordinator]):
         return False
 
     @property
-    def is_sub_device(self) -> bool:
-        """Return True if device is a sub device."""
-        return self.device.identifier.is_sub_device
-
-    @property
     def device(self) -> Device:
         """Return Overkiz device linked to this entity."""
         return self.coordinator.data[self.device_url]
@@ -71,7 +66,7 @@ class OverkizEntity(CoordinatorEntity[OverkizDataUpdateCoordinator]):
         # Some devices, such as the Smart Thermostat have several devices
         # in one physical device, with same device url, terminated by '#' and a number.
         # In this case, we use the base device url as the device identifier.
-        if self.is_sub_device:
+        if self.device.identifier.is_sub_device:
             # Only return the url of the base device, to inherit device name
             # and model from parent device.
             return DeviceInfo(
@@ -130,7 +125,7 @@ class OverkizDescriptiveEntity(OverkizEntity):
         self.entity_description = description
         self._attr_unique_id = f"{super().unique_id}-{self.entity_description.key}"
 
-        if self.is_sub_device:
+        if self.device.identifier.is_sub_device:
             # In case of sub device, use the provided label
             # and append the name of the type of entity
             self._attr_name = f"{self.device.label} {description.name}"

--- a/homeassistant/components/overkiz/executor.py
+++ b/homeassistant/components/overkiz/executor.py
@@ -1,7 +1,6 @@
 """Class for helpers and communication with the OverKiz API."""
 
 from typing import Any
-from urllib.parse import urlparse
 
 from pyoverkiz.enums import OverkizCommand, Protocol
 from pyoverkiz.exceptions import BaseOverkizError
@@ -34,7 +33,6 @@ class OverkizExecutor:
         """Initialize the executor."""
         self.device_url = device_url
         self.coordinator = coordinator
-        self.base_device_url = self.device_url.split("#")[0]
 
     @property
     def device(self) -> Device:
@@ -43,7 +41,9 @@ class OverkizExecutor:
 
     def linked_device(self, index: int) -> Device | None:
         """Return Overkiz device sharing the same base url."""
-        return self.coordinator.data.get(f"{self.base_device_url}#{index}")
+        return self.coordinator.data.get(
+            f"{self.device.identifier.base_device_url}#{index}"
+        )
 
     def select_command(self, *commands: str) -> str | None:
         """Select first existing command in a list of commands."""
@@ -169,11 +169,3 @@ class OverkizExecutor:
     async def async_cancel_execution(self, exec_id: str) -> None:
         """Cancel running execution via execution id."""
         await self.coordinator.client.cancel_execution(exec_id)
-
-    def get_gateway_id(self) -> str:
-        """Retrieve gateway id from device url.
-
-        device URL (<protocol>://<gatewayId>/<deviceAddress>[#<subsystemId>])
-        """
-        url = urlparse(self.device_url)
-        return url.netloc

--- a/homeassistant/components/overkiz/sensor.py
+++ b/homeassistant/components/overkiz/sensor.py
@@ -652,5 +652,5 @@ class OverkizHomeKitSetupCodeSensor(OverkizEntity, SensorEntity):
         # but it makes more sense to show this at the gateway device
         # in the entity registry.
         return DeviceInfo(
-            identifiers={(DOMAIN, self.executor.get_gateway_id())},
+            identifiers={(DOMAIN, self.device.identifier.gateway_id)},
         )


### PR DESCRIPTION
## Proposed change
pyOverkiz 2.0.0 exposes a parsed device.identifier (DeviceIdentifier) with base_device_url, gateway_id, subsystem_id, and is_sub_device. This PR simplifies the logic in HA, and delegates this to the library.

- Removed OverkizExecutor.base_device_url and the get_gateway_id() method. 
- Removed the manual device_url.split("#") parsing (base_device_url / index_device_url) from OverkizEntity. 
- Removed the OverkizEntity.is_sub_device property, using device.identifier.is_sub_device directly. -
-  Updated call sites in entity.py, sensor.py, and climate/atlantic_pass_apc_heating_zone.py. 

No functional changes, and existing tests all pass.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
