### PR TITLE
Add individual code owner for Fluss

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -574,8 +574,8 @@ CLAUDE.md @home-assistant/core
 /tests/components/flo/ @dmulcahey
 /homeassistant/components/flume/ @ChrisMandich @bdraco @jeeftor
 /tests/components/flume/ @ChrisMandich @bdraco @jeeftor
-/homeassistant/components/fluss/ @fluss
-/tests/components/fluss/ @fluss
+/homeassistant/components/fluss/ @Marcello17
+/tests/components/fluss/ @Marcello17
 /homeassistant/components/flux_led/ @icemanch
 /tests/components/flux_led/ @icemanch
 /homeassistant/components/forecast_solar/ @klaasnicolaas @frenck

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -574,8 +574,8 @@ CLAUDE.md @home-assistant/core
 /tests/components/flo/ @dmulcahey
 /homeassistant/components/flume/ @ChrisMandich @bdraco @jeeftor
 /tests/components/flume/ @ChrisMandich @bdraco @jeeftor
-/homeassistant/components/fluss/ @Marcello17
-/tests/components/fluss/ @Marcello17
+/homeassistant/components/fluss/ @fluss @Marcello17
+/tests/components/fluss/ @fluss @Marcello17
 /homeassistant/components/flux_led/ @icemanch
 /tests/components/flux_led/ @icemanch
 /homeassistant/components/forecast_solar/ @klaasnicolaas @frenck

--- a/homeassistant/components/fluss/manifest.json
+++ b/homeassistant/components/fluss/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "fluss",
   "name": "Fluss+",
-  "codeowners": ["@fluss"],
+  "codeowners": ["@Marcello17"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/fluss",
   "iot_class": "cloud_polling",

--- a/homeassistant/components/fluss/manifest.json
+++ b/homeassistant/components/fluss/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "fluss",
   "name": "Fluss+",
-  "codeowners": ["@Marcello17"],
+  "codeowners": ["@fluss", "@Marcello17"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/fluss",
   "iot_class": "cloud_polling",


### PR DESCRIPTION
## Breaking change


## Proposed change

Add an individual maintainer account (`@Marcello17`) as a `fluss` integration code owner, alongside the existing `@fluss` GitHub organization handle.

The `integration-owner` quality scale rule, and Home Assistant's CODEOWNERS tooling, are built around an individual contributor who acts as the integration's steward and is auto-requested for review / notified on related issues and PRs. GitHub does not auto-request reviews or send notifications for an organization handle the same way it does for a user account, so naming an individual ensures the stewardship and notification behavior the rule relies on actually works. The `@fluss` organization is kept as well so both remain listed as code owners.

Changes:
- `homeassistant/components/fluss/manifest.json`: `codeowners` changed from `["@fluss"]` to `["@fluss", "@Marcello17"]`.
- `CODEOWNERS`: regenerated via `python3 -m script.hassfest`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
