### PR TITLE
Use roboorck device capabilities to determine which entities are supported

### DIFF
--- a/homeassistant/components/roborock/binary_sensor.py
+++ b/homeassistant/components/roborock/binary_sensor.py
@@ -4,6 +4,8 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from roborock.data import CleanFluidStatus, RoborockStateCode
+from roborock.data.v1.v1_containers import StatusField, StatusV2
+from roborock.devices.traits.v1 import PropertiesApi
 from roborock.roborock_message import RoborockZeoProtocol
 
 from homeassistant.components.binary_sensor import (
@@ -38,6 +40,9 @@ class RoborockBinarySensorDescription(BinarySensorEntityDescription):
     is_dock_entity: bool = False
     """Whether this sensor is for the dock."""
 
+    support_fn: Callable[[PropertiesApi], bool] = lambda _: True
+    """Function to determine if binary sensor is supported by the device."""
+
 
 @dataclass(frozen=True, kw_only=True)
 class RoborockBinarySensorDescriptionA01(BinarySensorEntityDescription):
@@ -55,6 +60,9 @@ BINARY_SENSOR_DESCRIPTIONS = [
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda data: data.status.dry_status,
         is_dock_entity=True,
+        support_fn=lambda api: api.device_features.is_field_supported(
+            StatusV2, StatusField.DRY_STATUS
+        ),
     ),
     RoborockBinarySensorDescription(
         key="water_box_carriage_status",
@@ -62,6 +70,7 @@ BINARY_SENSOR_DESCRIPTIONS = [
         device_class=BinarySensorDeviceClass.CONNECTIVITY,
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda data: data.status.water_box_carriage_status,
+        support_fn=lambda api: api.device_features.is_support_water_mode,
     ),
     RoborockBinarySensorDescription(
         key="water_box_status",
@@ -69,6 +78,7 @@ BINARY_SENSOR_DESCRIPTIONS = [
         device_class=BinarySensorDeviceClass.CONNECTIVITY,
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda data: data.status.water_box_status,
+        support_fn=lambda api: api.device_features.is_support_water_mode,
     ),
     RoborockBinarySensorDescription(
         key="water_shortage",
@@ -76,6 +86,7 @@ BINARY_SENSOR_DESCRIPTIONS = [
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda data: data.status.water_shortage_status,
+        support_fn=lambda api: api.device_features.is_support_water_mode,
     ),
     RoborockBinarySensorDescription(
         key="dirty_box_full",
@@ -84,6 +95,7 @@ BINARY_SENSOR_DESCRIPTIONS = [
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda data: data.status.dirty_water_box_status,
         is_dock_entity=True,
+        support_fn=lambda api: api.wash_towel_mode is not None,
     ),
     RoborockBinarySensorDescription(
         key="clean_box_empty",
@@ -92,6 +104,7 @@ BINARY_SENSOR_DESCRIPTIONS = [
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda data: data.status.clear_water_box_status,
         is_dock_entity=True,
+        support_fn=lambda api: api.wash_towel_mode is not None,
     ),
     RoborockBinarySensorDescription(
         key="clean_fluid_empty",
@@ -104,6 +117,10 @@ BINARY_SENSOR_DESCRIPTIONS = [
             else None
         ),
         is_dock_entity=True,
+        support_fn=lambda api: (
+            api.wash_towel_mode is not None
+            and api.device_features.is_clean_fluid_delivery_supported
+        ),
     ),
     RoborockBinarySensorDescription(
         key="in_cleaning",
@@ -157,12 +174,7 @@ async def async_setup_entry(
         )
         for coordinator in config_entry.runtime_data.v1
         for description in BINARY_SENSOR_DESCRIPTIONS
-        # Note: Currently coordinator.data is always available
-        # on startup but won't be in the future
-        if (
-            coordinator.data is not None
-            and description.value_fn(coordinator.data) is not None
-        )
+        if description.support_fn(coordinator.properties_api)
     ]
     entities.extend(
         RoborockBinarySensorEntityA01(

--- a/homeassistant/components/roborock/button.py
+++ b/homeassistant/components/roborock/button.py
@@ -7,7 +7,6 @@ import itertools
 import logging
 from typing import Any
 
-from roborock.device_features import is_wash_n_fill_dock
 from roborock.devices.traits.v1.consumeable import ConsumableAttribute
 from roborock.exceptions import RoborockException
 from roborock.roborock_message import RoborockZeoProtocol
@@ -47,11 +46,6 @@ class RoborockButtonDescription(ButtonEntityDescription):
     is_supported: Callable[[RoborockDataUpdateCoordinator], bool] = lambda _: True
 
 
-def _supports_dock_consumables(coordinator: RoborockDataUpdateCoordinator) -> bool:
-    dock_type = coordinator.properties_api.status.dock_type
-    return dock_type is not None and is_wash_n_fill_dock(dock_type)
-
-
 CONSUMABLE_BUTTON_DESCRIPTIONS = [
     RoborockButtonDescription(
         key="reset_sensor_consumable",
@@ -88,7 +82,9 @@ CONSUMABLE_BUTTON_DESCRIPTIONS = [
         entity_category=EntityCategory.CONFIG,
         entity_registry_enabled_default=False,
         is_dock_entity=True,
-        is_supported=_supports_dock_consumables,
+        is_supported=lambda coordinator: (
+            coordinator.properties_api.wash_towel_mode is not None
+        ),
     ),
     RoborockButtonDescription(
         key="reset_dock_cleaning_brush_consumable",
@@ -97,7 +93,9 @@ CONSUMABLE_BUTTON_DESCRIPTIONS = [
         entity_category=EntityCategory.CONFIG,
         entity_registry_enabled_default=False,
         is_dock_entity=True,
-        is_supported=_supports_dock_consumables,
+        is_supported=lambda coordinator: (
+            coordinator.properties_api.wash_towel_mode is not None
+        ),
     ),
 ]
 

--- a/homeassistant/components/roborock/sensor.py
+++ b/homeassistant/components/roborock/sensor.py
@@ -19,6 +19,7 @@ from roborock.data import (
 )
 from roborock.data.b01_q10.b01_q10_code_mappings import YXDeviceState
 from roborock.devices.traits.b01.q10.status import StatusTrait as Q10StatusTrait
+from roborock.devices.traits.v1 import PropertiesApi
 from roborock.roborock_message import RoborockDyadDataProtocol, RoborockZeoProtocol
 
 from homeassistant.components.sensor import (
@@ -63,6 +64,9 @@ class RoborockSensorDescription(SensorEntityDescription):
 
     # If it is a dock entity
     is_dock_entity: bool = False
+
+    support_fn: Callable[[PropertiesApi], bool] = lambda _: True
+    """Function to determine if sensor is supported by the device."""
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -131,6 +135,7 @@ SENSOR_DESCRIPTIONS = [
         value_fn=lambda data: data.consumable.cleaning_brush_time_left,
         entity_category=EntityCategory.DIAGNOSTIC,
         is_dock_entity=True,
+        support_fn=lambda api: api.wash_towel_mode is not None,
     ),
     RoborockSensorDescription(
         native_unit_of_measurement=UnitOfTime.HOURS,
@@ -140,6 +145,7 @@ SENSOR_DESCRIPTIONS = [
         value_fn=lambda data: data.consumable.strainer_time_left,
         entity_category=EntityCategory.DIAGNOSTIC,
         is_dock_entity=True,
+        support_fn=lambda api: api.wash_towel_mode is not None,
     ),
     RoborockSensorDescription(
         native_unit_of_measurement=UnitOfTime.SECONDS,
@@ -234,15 +240,14 @@ SENSOR_DESCRIPTIONS = [
         entity_category=EntityCategory.DIAGNOSTIC,
         device_class=SensorDeviceClass.TIMESTAMP,
     ),
-    # Only available on some newer models
     RoborockSensorDescription(
         key="clean_percent",
         translation_key="clean_percent",
         value_fn=lambda data: data.status.clean_percent,
         entity_category=EntityCategory.DIAGNOSTIC,
         native_unit_of_measurement=PERCENTAGE,
+        support_fn=lambda api: api.device_features.is_support_clean_estimate,
     ),
-    # Only available with more than just the basic dock
     RoborockSensorDescription(
         key="dock_error",
         translation_key="dock_error",
@@ -251,6 +256,9 @@ SENSOR_DESCRIPTIONS = [
         device_class=SensorDeviceClass.ENUM,
         options=RoborockDockErrorCode.keys(),
         is_dock_entity=True,
+        # Only available with more than just the basic dock. Dust collection
+        # mode is a proxy for any more complex dock type (e.g. Auto-empty).
+        support_fn=lambda api: api.dust_collection_mode is not None,
     ),
     RoborockSensorDescription(
         key="mop_clean_remaining",
@@ -261,6 +269,7 @@ SENSOR_DESCRIPTIONS = [
         translation_key="mop_drying_remaining_time",
         entity_category=EntityCategory.DIAGNOSTIC,
         is_dock_entity=True,
+        support_fn=lambda api: api.device_features.is_supported_drying,
     ),
 ]
 
@@ -536,12 +545,7 @@ async def async_setup_entry(
         )
         for coordinator in coordinators.v1
         for description in SENSOR_DESCRIPTIONS
-        # Note: Currently coordinator.data is always available
-        # on startup but won't be in the future
-        if (
-            coordinator.data is not None
-            and description.value_fn(coordinator.data) is not None
-        )
+        if description.support_fn(coordinator.properties_api)
     ]
     entities.extend(RoborockCurrentRoom(coordinator) for coordinator in coordinators.v1)
     entities.extend(

--- a/tests/components/roborock/conftest.py
+++ b/tests/components/roborock/conftest.py
@@ -7,7 +7,7 @@ import logging
 import pathlib
 import tempfile
 from typing import Any
-from unittest.mock import AsyncMock, Mock, PropertyMock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, PropertyMock, patch
 
 import pytest
 from roborock import (
@@ -41,6 +41,7 @@ from roborock.devices.traits.v1.clean_summary import CleanSummaryTrait
 from roborock.devices.traits.v1.command import CommandTrait
 from roborock.devices.traits.v1.common import V1TraitMixin
 from roborock.devices.traits.v1.consumeable import ConsumableTrait
+from roborock.devices.traits.v1.device_features import DeviceFeaturesTrait
 from roborock.devices.traits.v1.do_not_disturb import DoNotDisturbTrait
 from roborock.devices.traits.v1.dust_collection_mode import DustCollectionModeTrait
 from roborock.devices.traits.v1.home import HomeTrait
@@ -344,6 +345,18 @@ def make_home_trait(
     return home_trait
 
 
+def make_device_features() -> Mock:
+    """Create fake device features."""
+    device_features = MagicMock(spec=DeviceFeaturesTrait)
+    device_features.is_supported_drying = True
+    device_features.is_support_water_mode = True
+    device_features.is_clean_fluid_delivery_supported = True
+    device_features.is_support_clean_estimate = True
+    device_features.is_clean_route_setting_supported = True
+    device_features.is_field_supported.return_value = True
+    return device_features
+
+
 def create_v1_properties(network_info: NetworkInfo) -> AsyncMock:
     """Create v1 properties for each fake device."""
     v1_properties = AsyncMock(spec=PropertiesApi)
@@ -351,6 +364,7 @@ def create_v1_properties(network_info: NetworkInfo) -> AsyncMock:
         trait_spec=StatusTrait,
         dataclass_template=STATUS,
     )
+    v1_properties.device_features = make_device_features()
     _fan_speed_mapping = {m.code: m.value for m in VacuumModes}
     _water_mode_mapping = {m.code: m.value for m in WaterModes}
     _mop_route_mapping = {m.code: m.value for m in CleanRoutes}

--- a/tests/components/roborock/snapshots/test_binary_sensor.ambr
+++ b/tests/components/roborock/snapshots/test_binary_sensor.ambr
@@ -152,6 +152,57 @@
     'state': 'on',
   })
 # ---
+# name: test_binary_sensors[binary_sensor.roborock_s7_2_dock_cleaning_fluid-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.roborock_s7_2_dock_cleaning_fluid',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Cleaning fluid',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': None,
+    'original_name': 'Cleaning fluid',
+    'platform': 'roborock',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'clean_fluid_empty',
+    'unique_id': 'clean_fluid_empty_device_2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.roborock_s7_2_dock_cleaning_fluid-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Roborock S7 2 Dock Cleaning fluid',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.roborock_s7_2_dock_cleaning_fluid',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_binary_sensors[binary_sensor.roborock_s7_2_dock_dirty_water_box-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -201,6 +252,57 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.roborock_s7_2_dock_mop_drying-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.roborock_s7_2_dock_mop_drying',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Mop drying',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Mop drying',
+    'platform': 'roborock',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'mop_drying_status',
+    'unique_id': 'dry_status_device_2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.roborock_s7_2_dock_mop_drying-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Roborock S7 2 Dock Mop drying',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.roborock_s7_2_dock_mop_drying',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
   })
 # ---
 # name: test_binary_sensors[binary_sensor.roborock_s7_2_mop_attached-entry]
@@ -509,6 +611,57 @@
     'state': 'on',
   })
 # ---
+# name: test_binary_sensors[binary_sensor.roborock_s7_maxv_dock_cleaning_fluid-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.roborock_s7_maxv_dock_cleaning_fluid',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Cleaning fluid',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': None,
+    'original_name': 'Cleaning fluid',
+    'platform': 'roborock',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'clean_fluid_empty',
+    'unique_id': 'clean_fluid_empty_abc123',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.roborock_s7_maxv_dock_cleaning_fluid-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Roborock S7 MaxV Dock Cleaning fluid',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.roborock_s7_maxv_dock_cleaning_fluid',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_binary_sensors[binary_sensor.roborock_s7_maxv_dock_dirty_water_box-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -558,6 +711,57 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.roborock_s7_maxv_dock_mop_drying-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.roborock_s7_maxv_dock_mop_drying',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Mop drying',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Mop drying',
+    'platform': 'roborock',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'mop_drying_status',
+    'unique_id': 'dry_status_abc123',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.roborock_s7_maxv_dock_mop_drying-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Roborock S7 MaxV Dock Mop drying',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.roborock_s7_maxv_dock_mop_drying',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
   })
 # ---
 # name: test_binary_sensors[binary_sensor.roborock_s7_maxv_mop_attached-entry]

--- a/tests/components/roborock/snapshots/test_sensor.ambr
+++ b/tests/components/roborock/snapshots/test_sensor.ambr
@@ -1624,6 +1624,57 @@
     'state': '21.0',
   })
 # ---
+# name: test_sensors[sensor.roborock_s7_2_cleaning_progress-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.roborock_s7_2_cleaning_progress',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Cleaning progress',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Cleaning progress',
+    'platform': 'roborock',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'clean_percent',
+    'unique_id': 'clean_percent_device_2',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensors[sensor.roborock_s7_2_cleaning_progress-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Roborock S7 2 Cleaning progress',
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.roborock_s7_2_cleaning_progress',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
 # name: test_sensors[sensor.roborock_s7_2_cleaning_time-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -1875,6 +1926,64 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '235',
+  })
+# ---
+# name: test_sensors[sensor.roborock_s7_2_dock_mop_drying_remaining_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.roborock_s7_2_dock_mop_drying_remaining_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Mop drying remaining time',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfTime.HOURS: 'h'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
+    'original_icon': None,
+    'original_name': 'Mop drying remaining time',
+    'platform': 'roborock',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'mop_drying_remaining_time',
+    'unique_id': 'mop_clean_remaining_device_2',
+    'unit_of_measurement': <UnitOfTime.HOURS: 'h'>,
+  })
+# ---
+# name: test_sensors[sensor.roborock_s7_2_dock_mop_drying_remaining_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'Roborock S7 2 Dock Mop drying remaining time',
+      'unit_of_measurement': <UnitOfTime.HOURS: 'h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.roborock_s7_2_dock_mop_drying_remaining_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
   })
 # ---
 # name: test_sensors[sensor.roborock_s7_2_dock_strainer_time_left-entry]
@@ -2835,6 +2944,57 @@
     'state': '21.0',
   })
 # ---
+# name: test_sensors[sensor.roborock_s7_maxv_cleaning_progress-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.roborock_s7_maxv_cleaning_progress',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Cleaning progress',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Cleaning progress',
+    'platform': 'roborock',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'clean_percent',
+    'unique_id': 'clean_percent_abc123',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensors[sensor.roborock_s7_maxv_cleaning_progress-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Roborock S7 MaxV Cleaning progress',
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.roborock_s7_maxv_cleaning_progress',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
 # name: test_sensors[sensor.roborock_s7_maxv_cleaning_time-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -3086,6 +3246,64 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '235',
+  })
+# ---
+# name: test_sensors[sensor.roborock_s7_maxv_dock_mop_drying_remaining_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.roborock_s7_maxv_dock_mop_drying_remaining_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Mop drying remaining time',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfTime.HOURS: 'h'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
+    'original_icon': None,
+    'original_name': 'Mop drying remaining time',
+    'platform': 'roborock',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'mop_drying_remaining_time',
+    'unique_id': 'mop_clean_remaining_abc123',
+    'unit_of_measurement': <UnitOfTime.HOURS: 'h'>,
+  })
+# ---
+# name: test_sensors[sensor.roborock_s7_maxv_dock_mop_drying_remaining_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'Roborock S7 MaxV Dock Mop drying remaining time',
+      'unit_of_measurement': <UnitOfTime.HOURS: 'h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.roborock_s7_maxv_dock_mop_drying_remaining_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
   })
 # ---
 # name: test_sensors[sensor.roborock_s7_maxv_dock_strainer_time_left-entry]

--- a/tests/components/roborock/test_button.py
+++ b/tests/components/roborock/test_button.py
@@ -4,7 +4,6 @@ from unittest.mock import Mock
 
 import pytest
 from roborock import RoborockException
-from roborock.data import RoborockDockTypeCode
 from roborock.devices.traits.v1.consumeable import ConsumableAttribute
 from roborock.exceptions import RoborockTimeout
 from syrupy.assertion import SnapshotAssertion
@@ -46,15 +45,8 @@ async def test_buttons(
 
 @pytest.fixture
 def non_wash_n_fill_dock(fake_vacuum: FakeDevice) -> None:
-    """Override dock_type to a non-wash-n-fill value so dock buttons are gated out."""
-    status = fake_vacuum.v1_properties.status
-    original_refresh = status.refresh.side_effect
-
-    async def patched_refresh() -> None:
-        await original_refresh()
-        status.dock_type = RoborockDockTypeCode.auto_empty_dock
-
-    status.refresh.side_effect = patched_refresh
+    """Disable wash towel mode to indicate this device has no wash functions."""
+    fake_vacuum.v1_properties.wash_towel_mode = None
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update Roboroock to use device capabilities to determine which entities are supported, rather than relying on the coordinator already having refreshed data. This is to prepare for dynamic devices where we don't necessarily want to init and refresh the coordinator in init, but instead discover devices and create all entities dynamically. (future PR)

This has the side effect of making more entities available since some fields like error fields may not always be set unless there is an error, and are now available. The tests also show extra entities set where the tests previously did not setup a value.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
