### PR TITLE
Add brightness_pct to set_level action

### DIFF
--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -519,7 +519,9 @@ class AbstractTemplateLight(AbstractTemplateEntity, LightEntity):
         common_params = {}
 
         if ATTR_BRIGHTNESS in kwargs:
-            common_params["brightness"] = kwargs[ATTR_BRIGHTNESS]
+            brightness = kwargs[ATTR_BRIGHTNESS]
+            common_params["brightness"] = brightness
+            common_params["brightness_pct"] = round(brightness / 255 * 100)
 
         if ATTR_TRANSITION in kwargs and self._supports_transition is True:
             common_params["transition"] = kwargs[ATTR_TRANSITION]

--- a/tests/components/template/test_light.py
+++ b/tests/components/template/test_light.py
@@ -674,9 +674,13 @@ async def test_off_action_optimistic(
     "style",
     [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
 )
+@pytest.mark.parametrize(
+    ("brightness", "brightness_pct"),
+    [(2, 1), (255, 100), (124, 49)],
+)
 @pytest.mark.usefixtures("setup_state_light")
 async def test_level_action_no_template(
-    hass: HomeAssistant, calls: list[ServiceCall]
+    hass: HomeAssistant, brightness: int, brightness_pct: int, calls: list[ServiceCall]
 ) -> None:
     """Test setting brightness with optimistic template."""
     state = hass.states.get(TEST_LIGHT.entity_id)
@@ -686,14 +690,14 @@ async def test_level_action_no_template(
         hass,
         calls,
         SERVICE_TURN_ON,
-        {ATTR_BRIGHTNESS: 124},
-        {ATTR_BRIGHTNESS: 124, ATTR_BRIGHTNESS_PCT: 49},
+        {ATTR_BRIGHTNESS: brightness},
+        {ATTR_BRIGHTNESS: brightness, ATTR_BRIGHTNESS_PCT: brightness_pct},
         "set_level",
     )
 
     state = hass.states.get(TEST_LIGHT.entity_id)
     assert state.state == STATE_ON
-    assert state.attributes["brightness"] == 124
+    assert state.attributes["brightness"] == brightness
     assert state.attributes["color_mode"] == ColorMode.BRIGHTNESS
     assert state.attributes["supported_color_modes"] == [ColorMode.BRIGHTNESS]
     assert state.attributes["supported_features"] == 0

--- a/tests/components/template/test_light.py
+++ b/tests/components/template/test_light.py
@@ -8,6 +8,7 @@ from syrupy.assertion import SnapshotAssertion
 from homeassistant.components import light, template
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
+    ATTR_BRIGHTNESS_PCT,
     ATTR_COLOR_TEMP_KELVIN,
     ATTR_EFFECT,
     ATTR_HS_COLOR,
@@ -67,7 +68,10 @@ ON_OFF_ACTIONS = {
 }
 
 
-BRIGHTNESS_DATA = {"brightness": "{{ brightness }}"}
+BRIGHTNESS_DATA = {
+    "brightness": "{{ brightness }}",
+    "brightness_pct": "{{ brightness_pct }}",
+}
 SET_LEVEL_ACTION = make_test_action("set_level", BRIGHTNESS_DATA)
 ON_OFF_SET_LEVEL_ACTIONS = {
     **ON_OFF_ACTIONS,
@@ -683,7 +687,7 @@ async def test_level_action_no_template(
         calls,
         SERVICE_TURN_ON,
         {ATTR_BRIGHTNESS: 124},
-        {ATTR_BRIGHTNESS: 124},
+        {ATTR_BRIGHTNESS: 124, ATTR_BRIGHTNESS_PCT: 49},
         "set_level",
     )
 

--- a/tests/components/template/test_light.py
+++ b/tests/components/template/test_light.py
@@ -676,7 +676,7 @@ async def test_off_action_optimistic(
 )
 @pytest.mark.parametrize(
     ("brightness", "brightness_pct"),
-    [(2, 1), (255, 100), (124, 49)],
+    [(2, 1), (255, 100), (124, 49), (1, 0), (254, 100)],
 )
 @pytest.mark.usefixtures("setup_state_light")
 async def test_level_action_no_template(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `brightness_pct` as a usable value in `set_level` action.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45806
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
