### PR TITLE
Set PARALLEL_UPDATES for Fluss platforms

### DIFF
--- a/homeassistant/components/fluss/button.py
+++ b/homeassistant/components/fluss/button.py
@@ -8,6 +8,8 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from .coordinator import FlussApiClientError, FlussConfigEntry
 from .entity import FlussEntity
 
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/homeassistant/components/fluss/cover.py
+++ b/homeassistant/components/fluss/cover.py
@@ -15,7 +15,7 @@ from .const import DOMAIN
 from .coordinator import FlussApiClientError, FlussConfigEntry
 from .entity import FlussEntity
 
-PARALLEL_UPDATES = 0
+PARALLEL_UPDATES = 1
 
 STATUS_OPEN = "Open"
 STATUS_CLOSED = "Closed"

--- a/homeassistant/components/fluss/quality_scale.yaml
+++ b/homeassistant/components/fluss/quality_scale.yaml
@@ -28,7 +28,7 @@ rules:
   docs-installation-parameters: done
   integration-owner: done
   log-when-unavailable: done
-  parallel-updates: todo
+  parallel-updates: done
   reauthentication-flow: todo
   test-coverage: todo
   # Gold


### PR DESCRIPTION
## Breaking change


## Proposed change

Set `PARALLEL_UPDATES` on both `fluss` entity platforms, satisfying the Silver-tier `parallel-updates` quality scale rule.

- `button.py`: add `PARALLEL_UPDATES = 1` (was unset).
- `cover.py`: change `PARALLEL_UPDATES = 0` to `1` for consistency.

Both platforms are action/command platforms, not read-only: a button press triggers the gate/garage motor (`async_trigger_device`) and the cover open/close commands (`async_open_device` / `async_close_device`) do the same on devices that report an open/closed status. Reads are centralized in the `DataUpdateCoordinator`, so the only calls gated by `PARALLEL_UPDATES` are these write commands to the Fluss cloud API. Serializing them (`1`) avoids bursting concurrent command requests at the cloud service when, for example, multiple gates are operated by a single automation. The added latency is negligible for physical gate/garage actuators.

`quality_scale.yaml` is updated to mark `parallel-updates` as `done`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
