### PR TITLE
Bump uiprotect to 11.10.0

### DIFF
--- a/homeassistant/components/unifiprotect/manifest.json
+++ b/homeassistant/components/unifiprotect/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "loggers": ["uiprotect"],
   "quality_scale": "platinum",
-  "requirements": ["uiprotect==11.8.0"]
+  "requirements": ["uiprotect==11.10.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3249,7 +3249,7 @@ uasiren==0.0.1
 uhooapi==1.2.8
 
 # homeassistant.components.unifiprotect
-uiprotect==11.8.0
+uiprotect==11.10.0
 
 # homeassistant.components.landisgyr_heat_meter
 ultraheat-api==0.6.1


### PR DESCRIPTION
## Breaking change

## Proposed change

Bump `uiprotect` from `11.8.0` to `11.10.0`.

Folds in both releases since 11.8.0 (the 11.9.0-only bump #173275 was closed in
favor of shipping 11.9.0 + 11.10.0 together):

- **11.9.0** – `api`: **Cache RTSPS streams on the public bootstrap**
  (uilibs/uiprotect#969) — per-camera RTSPS stream cache on the public
  bootstrap, additive groundwork for serving camera streams from the public
  Integration API.
- **11.10.0** – `api`: **Keep the public RTSPS cache never-empty via in-place
  refresh** (uilibs/uiprotect#971) — refreshes affected cache entries in place
  on camera reconnect / WS resync instead of dropping or clearing them, so a
  synchronous consumer reading `public_bootstrap.rtsps_streams` never reads
  `None` on a network blip or NVR restart.

No breaking changes – both releases are minor/patch with no `BREAKING CHANGE`
footers, and the cached RTSPS surface is additive. The integration constructs
the client exactly as before. The full `unifiprotect` test suite passes locally
against 11.10.0 (437 passed).

https://github.com/uilibs/uiprotect/compare/v11.8.0...v11.10.0

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
