### PR TITLE
Add xy color to template lights

### DIFF
--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -16,6 +16,7 @@ from homeassistant.components.light import (
     ATTR_RGBW_COLOR,
     ATTR_RGBWW_COLOR,
     ATTR_TRANSITION,
+    ATTR_XY_COLOR,
     DEFAULT_MAX_KELVIN,
     DEFAULT_MIN_KELVIN,
     DOMAIN as LIGHT_DOMAIN,
@@ -26,7 +27,14 @@ from homeassistant.components.light import (
     filter_supported_color_modes,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_EFFECT, CONF_HS, CONF_NAME, CONF_RGB, CONF_STATE
+from homeassistant.const import (
+    CONF_EFFECT,
+    CONF_HS,
+    CONF_NAME,
+    CONF_RGB,
+    CONF_STATE,
+    CONF_XY,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_platform import (
@@ -74,6 +82,7 @@ CONF_ON_ACTION = "turn_on"
 CONF_SUPPORTS_TRANSITION = "supports_transition"
 CONF_TEMPERATURE_ACTION = "set_temperature"
 CONF_TEMPERATURE = "temperature"
+CONF_XY_ACTION = "set_xy"
 
 DEFAULT_MIN_MIREDS = 153
 DEFAULT_MAX_MIREDS = 500
@@ -90,6 +99,7 @@ SCRIPT_FIELDS = (
     CONF_RGBW_ACTION,
     CONF_RGBWW_ACTION,
     CONF_TEMPERATURE_ACTION,
+    CONF_XY_ACTION,
 )
 
 LIGHT_COMMON_SCHEMA = vol.Schema(
@@ -115,6 +125,8 @@ LIGHT_COMMON_SCHEMA = vol.Schema(
         vol.Optional(CONF_SUPPORTS_TRANSITION): cv.template,
         vol.Optional(CONF_TEMPERATURE_ACTION): cv.SCRIPT_SCHEMA,
         vol.Optional(CONF_TEMPERATURE): cv.template,
+        vol.Optional(CONF_XY): cv.template,
+        vol.Optional(CONF_XY_ACTION): cv.SCRIPT_SCHEMA,
     }
 )
 
@@ -184,8 +196,19 @@ def _string_to_list(result: str) -> list[float]:
     return [float(v) for v in result.split(",")]
 
 
-def hs_color_list(entity: AbstractTemplateLight) -> Callable[[Any], list[int] | None]:
-    """Convert the result to a list of numbers that represent hue and saturation."""
+def two_color_list(
+    entity: AbstractTemplateLight,
+    option: str,
+    option_one: str,
+    min_1: int,
+    max_1: int,
+    option_two: str,
+    min_2: int,
+    max_2: int,
+) -> Callable[[Any], list[int] | None]:
+    """Convert the result to a list of 2 numbers that represent a color."""
+
+    option_range = f"({min_1}-{max_1}, {min_2}-{max_2})"
 
     def convert(result: Any) -> list[int] | None:
         if template_validators.check_result_for_none(result):
@@ -200,15 +223,15 @@ def hs_color_list(entity: AbstractTemplateLight) -> Callable[[Any], list[int] | 
             and len(result) == 2
             and all(isinstance(value, (int, float)) for value in result)
         ):
-            hue, saturation = result
-            if not (0 <= hue <= 360) or not (0 <= saturation <= 100):
+            one, two = result
+            if not (min_1 <= one <= max_1) or not (min_2 <= two <= max_2):
                 template_validators.log_validation_result_error(
                     entity,
-                    CONF_HS,
+                    option,
                     result,
                     (
-                        "expected a hue value between 0 and 360 and "
-                        "a saturation value between 0 and 100: (0-360, 0-100)"
+                        f"expected an {option_one} value between {min_1} and {max_1} and "
+                        f"a {option_two} value between {min_2} and {max_2}: {option_range}"
                     ),
                 )
                 return None
@@ -217,9 +240,9 @@ def hs_color_list(entity: AbstractTemplateLight) -> Callable[[Any], list[int] | 
 
         template_validators.log_validation_result_error(
             entity,
-            CONF_HS,
+            option,
             result,
-            "expected a list of numbers: (0-360, 0-100)",
+            f"expected a list of numbers: {option_range}",
         )
         return None
 
@@ -299,7 +322,7 @@ class AbstractTemplateLight(AbstractTemplateEntity, LightEntity):
         self.setup_template(
             CONF_HS,
             "_attr_hs_color",
-            hs_color_list(self),
+            two_color_list(self, CONF_HS, "hue", 0, 360, "saturation", 0, 100),
             self._update_color("_attr_hs_color", ColorMode.HS),
             render_complex=True,
         )
@@ -317,6 +340,15 @@ class AbstractTemplateLight(AbstractTemplateEntity, LightEntity):
                 self._update_color(attribute, colormode),
                 render_complex=True,
             )
+
+        # Setup XY Color
+        self.setup_template(
+            CONF_XY,
+            "_attr_xy_color",
+            two_color_list(self, CONF_XY, "x", 0, 1, "y", 0, 1),
+            self._update_color("_attr_xy_color", ColorMode.XY),
+            render_complex=True,
+        )
 
         # Setup Effect templates
         self.setup_template(
@@ -371,6 +403,7 @@ class AbstractTemplateLight(AbstractTemplateEntity, LightEntity):
             (CONF_RGB_ACTION, ColorMode.RGB),
             (CONF_RGBW_ACTION, ColorMode.RGBW),
             (CONF_RGBWW_ACTION, ColorMode.RGBWW),
+            (CONF_XY_ACTION, ColorMode.XY),
         ):
             if (action_config := config.get(action_id)) is not None:
                 self.add_script(action_id, action_config, name, DOMAIN)
@@ -482,6 +515,15 @@ class AbstractTemplateLight(AbstractTemplateEntity, LightEntity):
             )
             optimistic_set = True
 
+        if CONF_XY not in self._templates and ATTR_XY_COLOR in kwargs:
+            self._set_optimistic_color(
+                "xy color",
+                "_attr_xy_color",
+                kwargs[ATTR_XY_COLOR],
+                ColorMode.XY,
+            )
+            optimistic_set = True
+
         if optimistic_set and not self._attr_assumed_state:
             # If we are optmistically setting color or level but the state template
             # has not rendered, optimisically set the state to 'on'.
@@ -507,6 +549,7 @@ class AbstractTemplateLight(AbstractTemplateEntity, LightEntity):
             (CONF_RGB, "_attr_rgb_color"),
             (CONF_RGBW, "_attr_rgbw_color"),
             (CONF_RGBWW, "_attr_rgbww_color"),
+            (CONF_XY, "_attr_xy_color"),
         ):
             if attribute == attr:
                 continue
@@ -614,6 +657,17 @@ class AbstractTemplateLight(AbstractTemplateEntity, LightEntity):
             common_params["r"] = int(rgb_value[0])
             common_params["g"] = int(rgb_value[1])
             common_params["b"] = int(rgb_value[2])
+
+            return (script, common_params)
+
+        if (
+            ATTR_XY_COLOR in kwargs
+            and (script := CONF_XY_ACTION) in self._action_scripts
+        ):
+            xy_value = kwargs[ATTR_XY_COLOR]
+            common_params["xy"] = xy_value
+            common_params["x"] = float(xy_value[0])
+            common_params["y"] = float(xy_value[1])
 
             return (script, common_params)
 

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -205,12 +205,12 @@ def two_color_list(
     option_two: str,
     min_2: int,
     max_2: int,
-) -> Callable[[Any], list[int] | None]:
+) -> Callable[[Any], list[int | float] | None]:
     """Convert the result to a list of 2 numbers that represent a color."""
 
     option_range = f"({min_1}-{max_1}, {min_2}-{max_2})"
 
-    def convert(result: Any) -> list[int] | None:
+    def convert(result: Any) -> list[int | float] | None:
         if template_validators.check_result_for_none(result):
             return None
 
@@ -230,8 +230,8 @@ def two_color_list(
                     option,
                     result,
                     (
-                        f"expected an {option_one} value between {min_1} and {max_1} and "
-                        f"a {option_two} value between {min_2} and {max_2}: {option_range}"
+                        f"expected {option_one} value between {min_1} and {max_1} and "
+                        f"{option_two} value between {min_2} and {max_2}: {option_range}"
                     ),
                 )
                 return None
@@ -322,7 +322,7 @@ class AbstractTemplateLight(AbstractTemplateEntity, LightEntity):
         self.setup_template(
             CONF_HS,
             "_attr_hs_color",
-            two_color_list(self, CONF_HS, "hue", 0, 360, "saturation", 0, 100),
+            two_color_list(self, CONF_HS, "a hue", 0, 360, "a saturation", 0, 100),
             self._update_color("_attr_hs_color", ColorMode.HS),
             render_complex=True,
         )
@@ -345,7 +345,7 @@ class AbstractTemplateLight(AbstractTemplateEntity, LightEntity):
         self.setup_template(
             CONF_XY,
             "_attr_xy_color",
-            two_color_list(self, CONF_XY, "x", 0, 1, "y", 0, 1),
+            two_color_list(self, CONF_XY, "an x", 0, 1, "a y", 0, 1),
             self._update_color("_attr_xy_color", ColorMode.XY),
             render_complex=True,
         )

--- a/tests/components/template/test_light.py
+++ b/tests/components/template/test_light.py
@@ -15,6 +15,7 @@ from homeassistant.components.light import (
     ATTR_RGBW_COLOR,
     ATTR_RGBWW_COLOR,
     ATTR_TRANSITION,
+    ATTR_XY_COLOR,
     ColorMode,
     LightEntityFeature,
 )
@@ -128,6 +129,18 @@ ON_OFF_RGBWW_ACTIONS = {
     **RGBWW_ACTION,
 }
 
+XY_ACTION = make_test_action(
+    "set_xy",
+    {
+        "x": "{{ x }}",
+        "y": "{{ y }}",
+    },
+)
+ON_OFF_XY_ACTIONS = {
+    **ON_OFF_ACTIONS,
+    **XY_ACTION,
+}
+
 SET_EFFECT_ACTION = make_test_action("set_effect", {"effect": "{{ effect }}"})
 
 TRANSITION_DATA = {"transition": "{{ transition }}"}
@@ -152,6 +165,7 @@ ALL_COLOR_ACTIONS = {
     **RGB_ACTION,
     **RGBW_ACTION,
     **RGBWW_ACTION,
+    **XY_ACTION,
 }
 
 
@@ -921,6 +935,14 @@ async def test_entity_picture_template(hass: HomeAssistant) -> None:
             {"r": 160, "g": 78, "b": 192, "cw": 25, "ww": 50},
             ColorMode.RGBWW,
         ),
+        (
+            ON_OFF_XY_ACTIONS,
+            ATTR_XY_COLOR,
+            (0.2, 0.5),
+            "set_xy",
+            {"x": 0.2, "y": 0.5},
+            ColorMode.XY,
+        ),
     ],
 )
 @pytest.mark.usefixtures("setup_single_action_light")
@@ -1121,6 +1143,44 @@ async def test_rgbww_template(
     assert state.attributes["supported_features"] == 0
 
 
+@pytest.mark.parametrize(
+    ("count", "extra_config", "attribute"), [(1, ON_OFF_XY_ACTIONS, "xy")]
+)
+@pytest.mark.parametrize(
+    "style", [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER]
+)
+@pytest.mark.parametrize(
+    ("expected_color", "attribute_template", "expected_color_mode"),
+    [
+        ((0.2, 0.5), "{{(0.2, 0.5)}}", ColorMode.XY),
+        ((0.2, 0.5), "(0.2, 0.5)", ColorMode.XY),
+        ((0.2, 0.5), "{{[0.2, 0.5]}}", ColorMode.XY),
+        (None, "{{(1.1, 0.5)}}", ColorMode.XY),
+        (None, "{{(0.5, 1.1)}}", ColorMode.XY),
+        (None, "{{(-0.1, 0.5)}}", ColorMode.XY),
+        (None, "{{(0.5, -0.1)}}", ColorMode.XY),
+        (None, "{{x - 12}}", ColorMode.XY),
+        (None, "", ColorMode.XY),
+        (None, "{{ none }}", ColorMode.XY),
+        (None, "{{('one','two')}}", ColorMode.XY),
+    ],
+)
+@pytest.mark.usefixtures("setup_single_attribute_light")
+async def test_xy_template(
+    hass: HomeAssistant,
+    expected_color: tuple[int, int, int, int, int] | None,
+    expected_color_mode: ColorMode,
+) -> None:
+    """Test the xy template."""
+    await async_trigger(hass, TEST_STATE_ENTITY_ID, STATE_ON)
+    state = hass.states.get(TEST_LIGHT.entity_id)
+    assert state.attributes.get("xy_color") == expected_color
+    assert state.state == STATE_ON
+    assert state.attributes["color_mode"] == expected_color_mode
+    assert state.attributes["supported_color_modes"] == [ColorMode.XY]
+    assert state.attributes["supported_features"] == 0
+
+
 @pytest.mark.parametrize("count", [1])
 @pytest.mark.parametrize(
     ("config", "style"),
@@ -1151,6 +1211,15 @@ async def test_all_colors_mode_no_template(
     state = hass.states.get(TEST_LIGHT.entity_id)
     assert state.attributes.get("hs_color") is None
 
+    supported_color_modes = [
+        ColorMode.COLOR_TEMP,
+        ColorMode.HS,
+        ColorMode.RGB,
+        ColorMode.RGBW,
+        ColorMode.RGBWW,
+        ColorMode.XY,
+    ]
+
     await _call_and_assert_action(
         hass,
         calls,
@@ -1164,13 +1233,7 @@ async def test_all_colors_mode_no_template(
     assert state.attributes["color_mode"] == ColorMode.HS
     assert state.attributes["color_temp_kelvin"] is None
     assert state.attributes["hs_color"] == (40, 50)
-    assert state.attributes["supported_color_modes"] == [
-        ColorMode.COLOR_TEMP,
-        ColorMode.HS,
-        ColorMode.RGB,
-        ColorMode.RGBW,
-        ColorMode.RGBWW,
-    ]
+    assert state.attributes["supported_color_modes"] == supported_color_modes
     assert state.attributes["supported_features"] == 0
 
     await _call_and_assert_action(
@@ -1186,13 +1249,7 @@ async def test_all_colors_mode_no_template(
     assert state.attributes["color_mode"] == ColorMode.COLOR_TEMP
     assert state.attributes["color_temp_kelvin"] == 8130
     assert "hs_color" in state.attributes  # Color temp represented as hs_color
-    assert state.attributes["supported_color_modes"] == [
-        ColorMode.COLOR_TEMP,
-        ColorMode.HS,
-        ColorMode.RGB,
-        ColorMode.RGBW,
-        ColorMode.RGBWW,
-    ]
+    assert state.attributes["supported_color_modes"] == supported_color_modes
     assert state.attributes["supported_features"] == 0
 
     await _call_and_assert_action(
@@ -1208,13 +1265,7 @@ async def test_all_colors_mode_no_template(
     assert state.attributes["color_mode"] == ColorMode.RGB
     assert state.attributes["color_temp_kelvin"] is None
     assert state.attributes["rgb_color"] == (160, 78, 192)
-    assert state.attributes["supported_color_modes"] == [
-        ColorMode.COLOR_TEMP,
-        ColorMode.HS,
-        ColorMode.RGB,
-        ColorMode.RGBW,
-        ColorMode.RGBWW,
-    ]
+    assert state.attributes["supported_color_modes"] == supported_color_modes
     assert state.attributes["supported_features"] == 0
 
     await _call_and_assert_action(
@@ -1230,13 +1281,7 @@ async def test_all_colors_mode_no_template(
     assert state.attributes["color_mode"] == ColorMode.RGBW
     assert state.attributes["color_temp_kelvin"] is None
     assert state.attributes["rgbw_color"] == (160, 78, 192, 25)
-    assert state.attributes["supported_color_modes"] == [
-        ColorMode.COLOR_TEMP,
-        ColorMode.HS,
-        ColorMode.RGB,
-        ColorMode.RGBW,
-        ColorMode.RGBWW,
-    ]
+    assert state.attributes["supported_color_modes"] == supported_color_modes
     assert state.attributes["supported_features"] == 0
 
     await _call_and_assert_action(
@@ -1252,13 +1297,7 @@ async def test_all_colors_mode_no_template(
     assert state.attributes["color_mode"] == ColorMode.RGBWW
     assert state.attributes["color_temp_kelvin"] is None
     assert state.attributes["rgbww_color"] == (160, 78, 192, 25, 55)
-    assert state.attributes["supported_color_modes"] == [
-        ColorMode.COLOR_TEMP,
-        ColorMode.HS,
-        ColorMode.RGB,
-        ColorMode.RGBW,
-        ColorMode.RGBWW,
-    ]
+    assert state.attributes["supported_color_modes"] == supported_color_modes
     assert state.attributes["supported_features"] == 0
 
     await _call_and_assert_action(
@@ -1274,13 +1313,7 @@ async def test_all_colors_mode_no_template(
     assert state.attributes["color_mode"] == ColorMode.HS
     assert state.attributes["color_temp_kelvin"] is None
     assert state.attributes["hs_color"] == (10, 20)
-    assert state.attributes["supported_color_modes"] == [
-        ColorMode.COLOR_TEMP,
-        ColorMode.HS,
-        ColorMode.RGB,
-        ColorMode.RGBW,
-        ColorMode.RGBWW,
-    ]
+    assert state.attributes["supported_color_modes"] == supported_color_modes
     assert state.attributes["supported_features"] == 0
 
     await _call_and_assert_action(
@@ -1296,13 +1329,22 @@ async def test_all_colors_mode_no_template(
     assert state.attributes["color_mode"] == ColorMode.COLOR_TEMP
     assert state.attributes["color_temp_kelvin"] == 4273
     assert "hs_color" in state.attributes  # Color temp represented as hs_color
-    assert state.attributes["supported_color_modes"] == [
-        ColorMode.COLOR_TEMP,
-        ColorMode.HS,
-        ColorMode.RGB,
-        ColorMode.RGBW,
-        ColorMode.RGBWW,
-    ]
+    assert state.attributes["supported_color_modes"] == supported_color_modes
+    assert state.attributes["supported_features"] == 0
+
+    await _call_and_assert_action(
+        hass,
+        calls,
+        SERVICE_TURN_ON,
+        {ATTR_XY_COLOR: (0.2, 0.5)},
+        {"x": 0.2, "y": 0.5},
+        "set_xy",
+    )
+
+    state = hass.states.get(TEST_LIGHT.entity_id)
+    assert state.attributes["color_mode"] == ColorMode.XY
+    assert state.attributes["xy_color"] == (0.2, 0.5)
+    assert state.attributes["supported_color_modes"] == supported_color_modes
     assert state.attributes["supported_features"] == 0
 
 

--- a/tests/components/template/test_light.py
+++ b/tests/components/template/test_light.py
@@ -1168,7 +1168,7 @@ async def test_rgbww_template(
 @pytest.mark.usefixtures("setup_single_attribute_light")
 async def test_xy_template(
     hass: HomeAssistant,
-    expected_color: tuple[int, int, int, int, int] | None,
+    expected_color: tuple[float, float] | None,
     expected_color_mode: ColorMode,
 ) -> None:
     """Test the xy template."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds xy color to template lights per feature request: https://github.com/orgs/home-assistant/discussions/3077

Adds `xy` template that expects the a 2 length tuple/list that represents x y color.
Adds `set_xy` action with `x`, `y`, and `xy` as usable variables in the actions. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # 
- This PR is related to issue: 
- Link to documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/45817
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
