### PR TITLE
Add dynamic and stale device handling to Yoto

### DIFF
--- a/homeassistant/components/yoto/__init__.py
+++ b/homeassistant/components/yoto/__init__.py
@@ -10,6 +10,7 @@ from homeassistant.exceptions import (
     OAuth2TokenRequestError,
     OAuth2TokenRequestReauthError,
 )
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.config_entry_oauth2_flow import (
     ImplementationUnavailableError,
     OAuth2Session,
@@ -61,3 +62,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: YotoConfigEntry) -> bool
 async def async_unload_entry(hass: HomeAssistant, entry: YotoConfigEntry) -> bool:
     """Unload a Yoto config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant,
+    entry: YotoConfigEntry,
+    device_entry: dr.DeviceEntry,
+) -> bool:
+    """Allow deleting a device whose player is no longer in the account."""
+    coordinator = entry.runtime_data
+    return not any(
+        identifier[0] == DOMAIN and identifier[1] in coordinator.data
+        for identifier in device_entry.identifiers
+    )

--- a/homeassistant/components/yoto/__init__.py
+++ b/homeassistant/components/yoto/__init__.py
@@ -10,7 +10,6 @@ from homeassistant.exceptions import (
     OAuth2TokenRequestError,
     OAuth2TokenRequestReauthError,
 )
-from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.config_entry_oauth2_flow import (
     ImplementationUnavailableError,
     OAuth2Session,
@@ -62,16 +61,3 @@ async def async_setup_entry(hass: HomeAssistant, entry: YotoConfigEntry) -> bool
 async def async_unload_entry(hass: HomeAssistant, entry: YotoConfigEntry) -> bool:
     """Unload a Yoto config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-
-
-async def async_remove_config_entry_device(
-    hass: HomeAssistant,
-    entry: YotoConfigEntry,
-    device_entry: dr.DeviceEntry,
-) -> bool:
-    """Allow deleting a device whose player is no longer in the account."""
-    coordinator = entry.runtime_data
-    return not any(
-        identifier[0] == DOMAIN and identifier[1] in coordinator.data
-        for identifier in device_entry.identifiers
-    )

--- a/homeassistant/components/yoto/binary_sensor.py
+++ b/homeassistant/components/yoto/binary_sensor.py
@@ -11,7 +11,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntityDescription,
 )
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import YotoConfigEntry, YotoDataUpdateCoordinator
@@ -58,11 +58,23 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Yoto binary sensor platform."""
     coordinator = entry.runtime_data
-    async_add_entities(
-        YotoBinarySensor(coordinator, player, description)
-        for player in coordinator.client.players.values()
-        for description in BINARY_SENSORS
-    )
+    known_players: set[str] = set()
+
+    @callback
+    def _add_players() -> None:
+        current = set(coordinator.data)
+        new_players = current - known_players
+        known_players.clear()
+        known_players.update(current)
+        if new_players:
+            async_add_entities(
+                YotoBinarySensor(coordinator, coordinator.data[player_id], description)
+                for player_id in new_players
+                for description in BINARY_SENSORS
+            )
+
+    entry.async_on_unload(coordinator.async_add_listener(_add_players))
+    _add_players()
 
 
 class YotoBinarySensor(YotoPlayerEntity, BinarySensorEntity):

--- a/homeassistant/components/yoto/coordinator.py
+++ b/homeassistant/components/yoto/coordinator.py
@@ -14,6 +14,7 @@ from homeassistant.exceptions import (
     OAuth2TokenRequestError,
     OAuth2TokenRequestReauthError,
 )
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.config_entry_oauth2_flow import OAuth2Session
 from homeassistant.helpers.event import async_track_time_interval
@@ -46,6 +47,7 @@ class YotoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, YotoPlayer]]):
         )
         self._session = session
         self.client = YotoClient(session=async_get_clientsession(hass))
+        self._subscribed_players: set[str] = set()
         self._sync_token()
 
     def _sync_token(self) -> None:
@@ -87,6 +89,8 @@ class YotoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, YotoPlayer]]):
                 translation_placeholders={"error": str(err)},
             ) from err
 
+        self._subscribed_players = set(self.client.players)
+
         # The MQTT data/status topic is not pushed spontaneously; the firmware
         # only emits it in response to a command/status/request publish.
         self.config_entry.async_on_unload(
@@ -127,7 +131,32 @@ class YotoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, YotoPlayer]]):
                 translation_placeholders={"error": str(err)},
             ) from err
 
+        await self._async_sync_subscriptions()
+        self._remove_stale_devices()
         return self.client.players
+
+    async def _async_sync_subscriptions(self) -> None:
+        """Subscribe new players to MQTT events and unsubscribe removed ones."""
+        current = set(self.client.players)
+        for device_id in current - self._subscribed_players:
+            await self.client.subscribe_player_events(device_id)
+        for device_id in self._subscribed_players - current:
+            await self.client.unsubscribe_player_events(device_id)
+        self._subscribed_players = current
+
+    def _remove_stale_devices(self) -> None:
+        """Drop devices for players no longer returned by the account."""
+        device_registry = dr.async_get(self.hass)
+        for device in dr.async_entries_for_config_entry(
+            device_registry, self.config_entry.entry_id
+        ):
+            player_id = next(
+                (ident[1] for ident in device.identifiers if ident[0] == DOMAIN), None
+            )
+            if player_id is not None and player_id not in self.client.players:
+                device_registry.async_update_device(
+                    device.id, remove_config_entry_id=self.config_entry.entry_id
+                )
 
     async def _async_load_library(self) -> None:
         """Load the card library and groups; failures only affect browsing."""

--- a/homeassistant/components/yoto/coordinator.py
+++ b/homeassistant/components/yoto/coordinator.py
@@ -138,10 +138,14 @@ class YotoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, YotoPlayer]]):
     async def _async_sync_subscriptions(self) -> None:
         """Subscribe new players to MQTT events and unsubscribe removed ones."""
         current = set(self.client.players)
-        for device_id in current - self._subscribed_players:
-            await self.client.subscribe_player_events(device_id)
-        for device_id in self._subscribed_players - current:
-            await self.client.unsubscribe_player_events(device_id)
+        try:
+            for device_id in current - self._subscribed_players:
+                await self.client.subscribe_player_events(device_id)
+            for device_id in self._subscribed_players - current:
+                await self.client.unsubscribe_player_events(device_id)
+        except YotoError as err:
+            _LOGGER.warning("Could not update Yoto event subscriptions: %s", err)
+            return
         self._subscribed_players = current
 
     def _remove_stale_devices(self) -> None:

--- a/homeassistant/components/yoto/media_player.py
+++ b/homeassistant/components/yoto/media_player.py
@@ -16,7 +16,7 @@ from homeassistant.components.media_player import (
     MediaPlayerState,
     MediaType,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -47,10 +47,22 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Yoto media player platform."""
     coordinator = entry.runtime_data
-    async_add_entities(
-        YotoMediaPlayer(coordinator, player)
-        for player in coordinator.client.players.values()
-    )
+    known_players: set[str] = set()
+
+    @callback
+    def _add_players() -> None:
+        current = set(coordinator.data)
+        new_players = current - known_players
+        known_players.clear()
+        known_players.update(current)
+        if new_players:
+            async_add_entities(
+                YotoMediaPlayer(coordinator, coordinator.data[player_id])
+                for player_id in new_players
+            )
+
+    entry.async_on_unload(coordinator.async_add_listener(_add_players))
+    _add_players()
 
 
 class YotoMediaPlayer(YotoPlayerEntity, MediaPlayerEntity):

--- a/homeassistant/components/yoto/number.py
+++ b/homeassistant/components/yoto/number.py
@@ -11,7 +11,7 @@ from homeassistant.components.number import (
     NumberMode,
 )
 from homeassistant.const import PERCENTAGE, EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import YotoConfigEntry, YotoDataUpdateCoordinator
@@ -92,11 +92,23 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Yoto number platform."""
     coordinator = entry.runtime_data
-    async_add_entities(
-        YotoNumber(coordinator, player, description)
-        for player in coordinator.client.players.values()
-        for description in NUMBERS
-    )
+    known_players: set[str] = set()
+
+    @callback
+    def _add_players() -> None:
+        current = set(coordinator.data)
+        new_players = current - known_players
+        known_players.clear()
+        known_players.update(current)
+        if new_players:
+            async_add_entities(
+                YotoNumber(coordinator, coordinator.data[player_id], description)
+                for player_id in new_players
+                for description in NUMBERS
+            )
+
+    entry.async_on_unload(coordinator.async_add_listener(_add_players))
+    _add_players()
 
 
 class YotoNumber(YotoConfigEntity, NumberEntity):

--- a/homeassistant/components/yoto/quality_scale.yaml
+++ b/homeassistant/components/yoto/quality_scale.yaml
@@ -56,7 +56,7 @@ rules:
   docs-supported-functions: done
   docs-troubleshooting: done
   docs-use-cases: done
-  dynamic-devices: todo
+  dynamic-devices: done
   entity-category: done
   entity-device-class: done
   entity-disabled-by-default:
@@ -70,8 +70,8 @@ rules:
     comment: Authorization is the only configuration; reauth covers re-linking the account.
   repair-issues:
     status: exempt
-    comment: Auth failures go through the reauth flow; other errors are transient and retried by the coordinator.
-  stale-devices: todo
+    comment: No repair issues are raised yet.
+  stale-devices: done
 
   # Platinum
   async-dependency: done

--- a/homeassistant/components/yoto/quality_scale.yaml
+++ b/homeassistant/components/yoto/quality_scale.yaml
@@ -70,7 +70,7 @@ rules:
     comment: Authorization is the only configuration; reauth covers re-linking the account.
   repair-issues:
     status: exempt
-    comment: No repair issues are raised yet.
+    comment: Auth failures go through the reauth flow; other errors are transient and retried by the coordinator.
   stale-devices: done
 
   # Platinum

--- a/homeassistant/components/yoto/select.py
+++ b/homeassistant/components/yoto/select.py
@@ -13,7 +13,7 @@ from yoto_api import (
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import YotoConfigEntry, YotoDataUpdateCoordinator
@@ -65,12 +65,26 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Yoto select platform."""
     coordinator = entry.runtime_data
-    async_add_entities(
-        YotoSelect(coordinator, player, description)
-        for player in coordinator.client.players.values()
-        for description in SELECTS
-        if description.supported_fn(caps_for(player.device))
-    )
+    known_players: set[str] = set()
+
+    @callback
+    def _add_players() -> None:
+        current = set(coordinator.data)
+        new_players = current - known_players
+        known_players.clear()
+        known_players.update(current)
+        if new_players:
+            async_add_entities(
+                YotoSelect(coordinator, coordinator.data[player_id], description)
+                for player_id in new_players
+                for description in SELECTS
+                if description.supported_fn(
+                    caps_for(coordinator.data[player_id].device)
+                )
+            )
+
+    entry.async_on_unload(coordinator.async_add_listener(_add_players))
+    _add_players()
 
 
 class YotoSelect(YotoConfigEntity, SelectEntity):

--- a/homeassistant/components/yoto/sensor.py
+++ b/homeassistant/components/yoto/sensor.py
@@ -12,7 +12,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import PERCENTAGE, EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
@@ -74,11 +74,23 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Yoto sensor platform."""
     coordinator = entry.runtime_data
-    async_add_entities(
-        YotoSensor(coordinator, player, description)
-        for player in coordinator.client.players.values()
-        for description in SENSORS
-    )
+    known_players: set[str] = set()
+
+    @callback
+    def _add_players() -> None:
+        current = set(coordinator.data)
+        new_players = current - known_players
+        known_players.clear()
+        known_players.update(current)
+        if new_players:
+            async_add_entities(
+                YotoSensor(coordinator, coordinator.data[player_id], description)
+                for player_id in new_players
+                for description in SENSORS
+            )
+
+    entry.async_on_unload(coordinator.async_add_listener(_add_players))
+    _add_players()
 
 
 class YotoSensor(YotoPlayerEntity, SensorEntity):

--- a/homeassistant/components/yoto/switch.py
+++ b/homeassistant/components/yoto/switch.py
@@ -8,7 +8,7 @@ from yoto_api import Capabilities, PlayerConfig, YotoPlayer, caps_for
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import YotoConfigEntry, YotoDataUpdateCoordinator
@@ -72,12 +72,26 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Yoto switch platform."""
     coordinator = entry.runtime_data
-    async_add_entities(
-        YotoSwitch(coordinator, player, description)
-        for player in coordinator.client.players.values()
-        for description in SWITCHES
-        if description.supported_fn(caps_for(player.device))
-    )
+    known_players: set[str] = set()
+
+    @callback
+    def _add_players() -> None:
+        current = set(coordinator.data)
+        new_players = current - known_players
+        known_players.clear()
+        known_players.update(current)
+        if new_players:
+            async_add_entities(
+                YotoSwitch(coordinator, coordinator.data[player_id], description)
+                for player_id in new_players
+                for description in SWITCHES
+                if description.supported_fn(
+                    caps_for(coordinator.data[player_id].device)
+                )
+            )
+
+    entry.async_on_unload(coordinator.async_add_listener(_add_players))
+    _add_players()
 
 
 class YotoSwitch(YotoConfigEntity, SwitchEntity):

--- a/homeassistant/components/yoto/time.py
+++ b/homeassistant/components/yoto/time.py
@@ -8,7 +8,7 @@ from yoto_api import PlayerConfig, YotoPlayer
 
 from homeassistant.components.time import TimeEntity, TimeEntityDescription
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import YotoConfigEntry, YotoDataUpdateCoordinator
@@ -53,11 +53,23 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Yoto time platform."""
     coordinator = entry.runtime_data
-    async_add_entities(
-        YotoTime(coordinator, player, description)
-        for player in coordinator.client.players.values()
-        for description in TIME_ENTITIES
-    )
+    known_players: set[str] = set()
+
+    @callback
+    def _add_players() -> None:
+        current = set(coordinator.data)
+        new_players = current - known_players
+        known_players.clear()
+        known_players.update(current)
+        if new_players:
+            async_add_entities(
+                YotoTime(coordinator, coordinator.data[player_id], description)
+                for player_id in new_players
+                for description in TIME_ENTITIES
+            )
+
+    entry.async_on_unload(coordinator.async_add_listener(_add_players))
+    _add_players()
 
 
 class YotoTime(YotoConfigEntity, TimeEntity):

--- a/tests/components/yoto/test_init.py
+++ b/tests/components/yoto/test_init.py
@@ -5,8 +5,9 @@ from unittest.mock import MagicMock, Mock, patch
 import aiohttp
 from freezegun.api import FrozenDateTimeFactory
 import pytest
-from yoto_api import AuthenticationError, YotoAPIError, YotoError
+from yoto_api import AuthenticationError, Device, YotoAPIError, YotoError, YotoPlayer
 
+from homeassistant.components.yoto import async_remove_config_entry_device
 from homeassistant.components.yoto.const import (
     DOMAIN,
     SCAN_INTERVAL,
@@ -18,11 +19,13 @@ from homeassistant.exceptions import (
     OAuth2TokenRequestError,
     OAuth2TokenRequestReauthError,
 )
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.config_entry_oauth2_flow import (
     ImplementationUnavailableError,
 )
 
 from . import setup_integration
+from .conftest import PLAYER_ID
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -316,3 +319,82 @@ async def test_periodic_poll_fails_on_api_error(
 
     coordinator = mock_config_entry.runtime_data
     assert coordinator.last_update_success is False
+
+
+def _build_second_player() -> YotoPlayer:
+    """Build a second Yoto player discovered after setup."""
+    return YotoPlayer(
+        device=Device(
+            device_id="player-2",
+            name="Playroom Yoto",
+            device_type="v3",
+            device_family="v3",
+            generation="gen3",
+        ),
+        is_online=True,
+    )
+
+
+async def test_dynamic_device_added(
+    hass: HomeAssistant,
+    mock_yoto_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A player discovered after setup gets its entity without a reload."""
+    await setup_integration(hass, mock_config_entry)
+    assert hass.states.get("media_player.nursery_yoto") is not None
+    assert hass.states.get("media_player.playroom_yoto") is None
+
+    mock_yoto_client.players["player-2"] = _build_second_player()
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("media_player.playroom_yoto") is not None
+    mock_yoto_client.subscribe_player_events.assert_called_once_with("player-2")
+
+
+async def test_stale_device_removed(
+    hass: HomeAssistant,
+    mock_yoto_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A player removed from the account has its device dropped."""
+    await setup_integration(hass, mock_config_entry)
+    assert (
+        device_registry.async_get_device(identifiers={(DOMAIN, PLAYER_ID)}) is not None
+    )
+
+    mock_yoto_client.players.clear()
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert device_registry.async_get_device(identifiers={(DOMAIN, PLAYER_ID)}) is None
+    mock_yoto_client.unsubscribe_player_events.assert_called_once_with(PLAYER_ID)
+
+
+async def test_remove_config_entry_device(
+    hass: HomeAssistant,
+    mock_yoto_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """A device is removable only once its player is gone from the account."""
+    await setup_integration(hass, mock_config_entry)
+
+    present = device_registry.async_get_device(identifiers={(DOMAIN, PLAYER_ID)})
+    assert present is not None
+    assert (
+        await async_remove_config_entry_device(hass, mock_config_entry, present)
+        is False
+    )
+
+    gone = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={(DOMAIN, "gone-player")},
+    )
+    assert await async_remove_config_entry_device(hass, mock_config_entry, gone) is True

--- a/tests/components/yoto/test_init.py
+++ b/tests/components/yoto/test_init.py
@@ -351,6 +351,7 @@ async def test_dynamic_device_added(
     await hass.async_block_till_done()
 
     assert hass.states.get("media_player.playroom_yoto") is not None
+    assert hass.states.get("time.playroom_yoto_day_mode_start") is not None
     mock_yoto_client.subscribe_player_events.assert_called_once_with("player-2")
 
 

--- a/tests/components/yoto/test_init.py
+++ b/tests/components/yoto/test_init.py
@@ -7,7 +7,6 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 from yoto_api import AuthenticationError, Device, YotoAPIError, YotoError, YotoPlayer
 
-from homeassistant.components.yoto import async_remove_config_entry_device
 from homeassistant.components.yoto.const import (
     DOMAIN,
     SCAN_INTERVAL,
@@ -375,26 +374,3 @@ async def test_stale_device_removed(
 
     assert device_registry.async_get_device(identifiers={(DOMAIN, PLAYER_ID)}) is None
     mock_yoto_client.unsubscribe_player_events.assert_called_once_with(PLAYER_ID)
-
-
-async def test_remove_config_entry_device(
-    hass: HomeAssistant,
-    mock_yoto_client: MagicMock,
-    mock_config_entry: MockConfigEntry,
-    device_registry: dr.DeviceRegistry,
-) -> None:
-    """A device is removable only once its player is gone from the account."""
-    await setup_integration(hass, mock_config_entry)
-
-    present = device_registry.async_get_device(identifiers={(DOMAIN, PLAYER_ID)})
-    assert present is not None
-    assert (
-        await async_remove_config_entry_device(hass, mock_config_entry, present)
-        is False
-    )
-
-    gone = device_registry.async_get_or_create(
-        config_entry_id=mock_config_entry.entry_id,
-        identifiers={(DOMAIN, "gone-player")},
-    )
-    assert await async_remove_config_entry_device(hass, mock_config_entry, gone) is True

--- a/tests/components/yoto/test_init.py
+++ b/tests/components/yoto/test_init.py
@@ -354,6 +354,33 @@ async def test_dynamic_device_added(
     mock_yoto_client.subscribe_player_events.assert_called_once_with("player-2")
 
 
+async def test_subscription_failure_does_not_fail_refresh(
+    hass: HomeAssistant,
+    mock_yoto_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A subscription error keeps the refreshed data and retries next cycle."""
+    await setup_integration(hass, mock_config_entry)
+    mock_yoto_client.players["player-2"] = _build_second_player()
+    mock_yoto_client.subscribe_player_events.side_effect = YotoAPIError("boom")
+
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("media_player.playroom_yoto") is not None
+    assert mock_config_entry.runtime_data.last_update_success is True
+
+    mock_yoto_client.subscribe_player_events.side_effect = None
+    mock_yoto_client.subscribe_player_events.reset_mock()
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    mock_yoto_client.subscribe_player_events.assert_called_once_with("player-2")
+
+
 async def test_stale_device_removed(
     hass: HomeAssistant,
     mock_yoto_client: MagicMock,

--- a/tests/components/yoto/test_init.py
+++ b/tests/components/yoto/test_init.py
@@ -356,6 +356,7 @@ async def test_dynamic_device_added(
     assert hass.states.get("time.playroom_yoto_day_mode_start") is not None
     assert hass.states.get("number.playroom_yoto_day_mode_brightness") is not None
     assert hass.states.get("select.playroom_yoto_day_mode_color") is not None
+    assert hass.states.get("switch.playroom_yoto_bluetooth_pairing") is not None
     mock_yoto_client.subscribe_player_events.assert_called_once_with("player-2")
 
 

--- a/tests/components/yoto/test_init.py
+++ b/tests/components/yoto/test_init.py
@@ -354,6 +354,8 @@ async def test_dynamic_device_added(
     assert hass.states.get("binary_sensor.playroom_yoto_charging") is not None
     assert hass.states.get("sensor.playroom_yoto_battery") is not None
     assert hass.states.get("time.playroom_yoto_day_mode_start") is not None
+    assert hass.states.get("number.playroom_yoto_day_mode_brightness") is not None
+    assert hass.states.get("select.playroom_yoto_day_mode_color") is not None
     mock_yoto_client.subscribe_player_events.assert_called_once_with("player-2")
 
 

--- a/tests/components/yoto/test_init.py
+++ b/tests/components/yoto/test_init.py
@@ -351,6 +351,7 @@ async def test_dynamic_device_added(
     await hass.async_block_till_done()
 
     assert hass.states.get("media_player.playroom_yoto") is not None
+    assert hass.states.get("binary_sensor.playroom_yoto_charging") is not None
     assert hass.states.get("sensor.playroom_yoto_battery") is not None
     assert hass.states.get("time.playroom_yoto_day_mode_start") is not None
     mock_yoto_client.subscribe_player_events.assert_called_once_with("player-2")

--- a/tests/components/yoto/test_init.py
+++ b/tests/components/yoto/test_init.py
@@ -351,6 +351,7 @@ async def test_dynamic_device_added(
     await hass.async_block_till_done()
 
     assert hass.states.get("media_player.playroom_yoto") is not None
+    assert hass.states.get("sensor.playroom_yoto_battery") is not None
     assert hass.states.get("time.playroom_yoto_day_mode_start") is not None
     mock_yoto_client.subscribe_player_events.assert_called_once_with("player-2")
 


### PR DESCRIPTION
## Proposed change

Handle Yoto players added to or removed from an account after setup.

- New players get their `media_player` entity on the next refresh.
- Players removed from the account have their device removed.
- MQTT event subscriptions are kept in sync with the player list.

Implements the `dynamic-devices` and `stale-devices` quality scale rules.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
