### PR TITLE
Remove not needed guards for integration migrations from future versions

### DIFF
--- a/homeassistant/components/airos/__init__.py
+++ b/homeassistant/components/airos/__init__.py
@@ -116,10 +116,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: AirOSConfigEntry) -> boo
 async def async_migrate_entry(hass: HomeAssistant, entry: AirOSConfigEntry) -> bool:
     """Migrate old config entry."""
 
-    # This means the user has downgraded from a future version
-    if entry.version > 2:
-        return False
-
     # 1.1 Migrate config_entry to add advanced ssl settings
     if entry.version == 1 and entry.minor_version == 1:
         new_minor_version = 2

--- a/homeassistant/components/alexa_devices/__init__.py
+++ b/homeassistant/components/alexa_devices/__init__.py
@@ -65,10 +65,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: AmazonConfigEntry) -> bo
 async def async_migrate_entry(hass: HomeAssistant, entry: AmazonConfigEntry) -> bool:
     """Migrate old entry."""
 
-    if entry.version > 1:
-        # This means the user has downgraded from a future version
-        return False
-
     if entry.version == 1 and entry.minor_version < 3:
         if CONF_SITE in entry.data:
             # Site in data (wrong place), just move to login data

--- a/homeassistant/components/anova/__init__.py
+++ b/homeassistant/components/anova/__init__.py
@@ -75,10 +75,6 @@ async def async_migrate_entry(hass: HomeAssistant, entry: AnovaConfigEntry) -> b
     """Migrate entry."""
     _LOGGER.debug("Migrating from version %s:%s", entry.version, entry.minor_version)
 
-    if entry.version > 1:
-        # This means the user has downgraded from a future version
-        return False
-
     if entry.version == 1 and entry.minor_version == 1:
         new_data = {**entry.data}
         if CONF_DEVICES in new_data:

--- a/homeassistant/components/anthropic/__init__.py
+++ b/homeassistant/components/anthropic/__init__.py
@@ -178,10 +178,6 @@ async def async_migrate_entry(hass: HomeAssistant, entry: AnthropicConfigEntry) 
     """Migrate entry."""
     LOGGER.debug("Migrating from version %s:%s", entry.version, entry.minor_version)
 
-    if entry.version > 2:
-        # This means the user has downgraded from a future version
-        return False
-
     if entry.version == 2 and entry.minor_version == 1:
         # Correct broken device migration in Home Assistant Core 2025.7.0b0-2025.7.0b1
         device_registry = dr.async_get(hass)

--- a/homeassistant/components/bsblan/__init__.py
+++ b/homeassistant/components/bsblan/__init__.py
@@ -230,10 +230,6 @@ async def async_migrate_entry(hass: HomeAssistant, entry: BSBLanConfigEntry) -> 
         entry.minor_version,
     )
 
-    if entry.version > 1:
-        # Downgraded from a future version; cannot migrate.
-        return False
-
     # 1.1 -> 1.2: Add CONF_HEATING_CIRCUITS. Attempt to discover available
     # heating circuits from the device; fall back to [1] (pre-multi-circuit
     # default) if the device is unreachable or the endpoint is unsupported.

--- a/homeassistant/components/comelit/__init__.py
+++ b/homeassistant/components/comelit/__init__.py
@@ -87,10 +87,6 @@ async def async_migrate_entry(
 ) -> bool:
     """Migrate old entry."""
 
-    if config_entry.version > 1:
-        # This means the user has downgraded from a future version
-        return False
-
     if config_entry.version == 1 and config_entry.minor_version == 1:
         device_registry = dr.async_get(hass)
 

--- a/homeassistant/components/derivative/__init__.py
+++ b/homeassistant/components/derivative/__init__.py
@@ -54,10 +54,6 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         config_entry.minor_version,
     )
 
-    if config_entry.version > 1:
-        # This means the user has downgraded from a future version
-        return False
-
     if config_entry.version == 1:
         if config_entry.minor_version < 2:
             new_options = {**config_entry.options}

--- a/homeassistant/components/dnsip/__init__.py
+++ b/homeassistant/components/dnsip/__init__.py
@@ -111,10 +111,6 @@ async def async_migrate_entry(
 ) -> bool:
     """Migrate old entry to a newer version."""
 
-    if config_entry.version > 1:
-        # This means the user has downgraded from a future version
-        return False
-
     if config_entry.version < 2 and config_entry.minor_version < 2:
         _LOGGER.debug(
             "Migrating configuration from version %s.%s",

--- a/homeassistant/components/elevenlabs/__init__.py
+++ b/homeassistant/components/elevenlabs/__init__.py
@@ -98,10 +98,6 @@ async def async_migrate_entry(
         config_entry.minor_version,
     )
 
-    if config_entry.version > 1:
-        # This means the user has downgraded from a future version
-        return False
-
     if config_entry.version == 1:
         new_options = {**config_entry.options}
 

--- a/homeassistant/components/epson/__init__.py
+++ b/homeassistant/components/epson/__init__.py
@@ -88,10 +88,6 @@ async def async_migrate_entry(
         config_entry.minor_version,
     )
 
-    if config_entry.version > 1 or config_entry.minor_version > 1:
-        # This means the user has downgraded from a future version
-        return False
-
     if config_entry.version == 1 and config_entry.minor_version == 1:
         new_data = {**config_entry.data}
         new_data[CONF_CONNECTION_TYPE] = HTTP

--- a/homeassistant/components/file/__init__.py
+++ b/homeassistant/components/file/__init__.py
@@ -53,9 +53,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Migrate config entry."""
-    if config_entry.version > 2:
-        # Downgraded from future
-        return False
 
     if config_entry.version < 2:
         # Move optional fields from data to options in config entry

--- a/homeassistant/components/fujitsu_fglair/__init__.py
+++ b/homeassistant/components/fujitsu_fglair/__init__.py
@@ -48,8 +48,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: FGLairConfigEntry) -> b
 
 async def async_migrate_entry(hass: HomeAssistant, entry: FGLairConfigEntry) -> bool:
     """Migrate old entry."""
-    if entry.version > 1:
-        return False
 
     if entry.version == 1:
         new_data = {**entry.data}

--- a/homeassistant/components/fyta/__init__.py
+++ b/homeassistant/components/fyta/__init__.py
@@ -65,10 +65,6 @@ async def async_migrate_entry(
     """Migrate old entry."""
     _LOGGER.debug("Migrating from version %s", config_entry.version)
 
-    if config_entry.version > 1:
-        # This means the user has downgraded from a future version
-        return False
-
     if config_entry.version == 1:
         if config_entry.minor_version < 2:
             new = {**config_entry.data}

--- a/homeassistant/components/generic/__init__.py
+++ b/homeassistant/components/generic/__init__.py
@@ -59,10 +59,6 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Migrate entry."""
     _LOGGER.debug("Migrating from version %s:%s", entry.version, entry.minor_version)
 
-    if entry.version > 2:
-        # This means the user has downgraded from a future version
-        return False
-
     if entry.version == 1:
         # Migrate to advanced section
         new_options = {**entry.options}

--- a/homeassistant/components/generic_hygrostat/__init__.py
+++ b/homeassistant/components/generic_hygrostat/__init__.py
@@ -148,9 +148,6 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         "Migrating from version %s.%s", config_entry.version, config_entry.minor_version
     )
 
-    if config_entry.version > 1:
-        # This means the user has downgraded from a future version
-        return False
     if config_entry.version == 1:
         options = {**config_entry.options}
         if config_entry.minor_version < 2:

--- a/homeassistant/components/generic_thermostat/__init__.py
+++ b/homeassistant/components/generic_thermostat/__init__.py
@@ -76,9 +76,6 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         "Migrating from version %s.%s", config_entry.version, config_entry.minor_version
     )
 
-    if config_entry.version > 1:
-        # This means the user has downgraded from a future version
-        return False
     if config_entry.version == 1:
         options = {**config_entry.options}
         if config_entry.minor_version < 2:

--- a/homeassistant/components/goodwe/__init__.py
+++ b/homeassistant/components/goodwe/__init__.py
@@ -98,10 +98,6 @@ async def async_migrate_entry(
 ) -> bool:
     """Migrate old config entries."""
 
-    if config_entry.version > 2:
-        # This means the user has downgraded from a future version
-        return False
-
     if config_entry.version == 1:
         # Update from version 1 to version 2 adding the PROTOCOL to the config entry
         host = config_entry.data[CONF_HOST]

--- a/homeassistant/components/google_generative_ai_conversation/__init__.py
+++ b/homeassistant/components/google_generative_ai_conversation/__init__.py
@@ -226,10 +226,6 @@ async def async_migrate_entry(
     """Migrate entry."""
     LOGGER.debug("Migrating from version %s:%s", entry.version, entry.minor_version)
 
-    if entry.version > 2:
-        # This means the user has downgraded from a future version
-        return False
-
     if entry.version == 2 and entry.minor_version == 1:
         # Add TTS subentry which was missing in 2025.7.0b0
         if not any(

--- a/homeassistant/components/history_stats/__init__.py
+++ b/homeassistant/components/history_stats/__init__.py
@@ -100,9 +100,6 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         "Migrating from version %s.%s", config_entry.version, config_entry.minor_version
     )
 
-    if config_entry.version > 1:
-        # This means the user has downgraded from a future version
-        return False
     if config_entry.version == 1:
         options = {**config_entry.options}
         if config_entry.minor_version < 2:

--- a/homeassistant/components/homeassistant_connect_zbt2/__init__.py
+++ b/homeassistant/components/homeassistant_connect_zbt2/__init__.py
@@ -108,10 +108,6 @@ async def async_migrate_entry(
         config_entry.minor_version,
     )
 
-    if config_entry.version > 1:
-        # This means the user has downgraded from a future version
-        return False
-
     if config_entry.version == 1:
         if config_entry.minor_version == 1:
             serial_number = config_entry.data[SERIAL_NUMBER]

--- a/homeassistant/components/homeassistant_sky_connect/__init__.py
+++ b/homeassistant/components/homeassistant_sky_connect/__init__.py
@@ -140,10 +140,6 @@ async def async_migrate_entry(
         "Migrating from version %s.%s", config_entry.version, config_entry.minor_version
     )
 
-    if config_entry.version > 1:
-        # This means the user has downgraded from a future version
-        return False
-
     if config_entry.version == 1:
         if config_entry.minor_version == 1:
             # Add-on startup with type service get started before

--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -126,8 +126,6 @@ async def async_migrate_entry(
     hass: HomeAssistant, config_entry: config_entries.ConfigEntry
 ) -> bool:
     """Migrate the config entry from version 1 to version 2."""
-    if config_entry.version > 2:
-        return False
 
     if config_entry.version == 1:
         _LOGGER.debug("Migrating HomematicIP Cloud config entry to version 2")

--- a/homeassistant/components/integration/__init__.py
+++ b/homeassistant/components/integration/__init__.py
@@ -49,9 +49,6 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         "Migrating from version %s.%s", config_entry.version, config_entry.minor_version
     )
 
-    if config_entry.version > 1:
-        # This means the user has downgraded from a future version
-        return False
     if config_entry.version == 1:
         options = {**config_entry.options}
         if config_entry.minor_version < 2:

--- a/homeassistant/components/islamic_prayer_times/__init__.py
+++ b/homeassistant/components/islamic_prayer_times/__init__.py
@@ -52,9 +52,6 @@ async def async_migrate_entry(
     """Migrate old entry."""
     _LOGGER.debug("Migrating from version %s", config_entry.version)
 
-    if config_entry.version > 1:
-        # This means the user has downgraded from a future version
-        return False
     if config_entry.version == 1:
         new = {**config_entry.data}
         if config_entry.minor_version < 2:

--- a/homeassistant/components/jewish_calendar/__init__.py
+++ b/homeassistant/components/jewish_calendar/__init__.py
@@ -131,10 +131,6 @@ async def async_migrate_entry(
             return {"new_unique_id": new_unique_id}
         return None
 
-    if config_entry.version > 2:
-        # This means the user has downgraded from a future version
-        return False
-
     if config_entry.version == 1:
         await er.async_migrate_entries(hass, config_entry.entry_id, update_unique_id)
         hass.config_entries.async_update_entry(config_entry, version=2)

--- a/homeassistant/components/lamarzocco/__init__.py
+++ b/homeassistant/components/lamarzocco/__init__.py
@@ -217,9 +217,6 @@ async def async_migrate_entry(
     hass: HomeAssistant, entry: LaMarzoccoConfigEntry
 ) -> bool:
     """Migrate config entry."""
-    if entry.version > 4:
-        # guard against downgrade from a future version
-        return False
 
     if entry.version in (1, 2):
         _LOGGER.error(

--- a/homeassistant/components/litterrobot/__init__.py
+++ b/homeassistant/components/litterrobot/__init__.py
@@ -48,9 +48,6 @@ async def async_migrate_entry(
         entry.minor_version,
     )
 
-    if entry.version > 1:
-        return False
-
     if entry.minor_version < 2:
         account = Account(websession=async_get_clientsession(hass))
         try:

--- a/homeassistant/components/mold_indicator/__init__.py
+++ b/homeassistant/components/mold_indicator/__init__.py
@@ -99,10 +99,6 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         config_entry.minor_version,
     )
 
-    if config_entry.version > 1:
-        # This means the user has downgraded from a future version
-        return False
-
     if config_entry.version == 1:
         if config_entry.minor_version < 2:
             # Remove the mold indicator config entry from the source device

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -467,10 +467,6 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     _LOGGER.debug("Migrating from version %s.%s", entry.version, entry.minor_version)
     data: dict[str, Any] = dict(entry.data)
     options: dict[str, Any] = dict(entry.options)
-    if entry.version > 2 or (entry.version == 2 and entry.minor_version > 1):
-        # This means the user has downgraded from a future version
-        # We allow read support for version 2.1
-        return False
 
     if entry.version == 1 and entry.minor_version < 2:
         # Can be removed when the config entry is bumped to version 2.1

--- a/homeassistant/components/nina/__init__.py
+++ b/homeassistant/components/nina/__init__.py
@@ -44,9 +44,6 @@ async def async_migrate_entry(hass: HomeAssistant, entry: NinaConfigEntry) -> bo
     minor_version = entry.minor_version
 
     _LOGGER.debug("Migrating from version %s.%s", version, minor_version)
-    if entry.version > 1:
-        # This means the user has downgraded from a future version
-        return False
 
     new_data: dict[str, Any] = {**entry.data, CONF_FILTERS: {}}
 

--- a/homeassistant/components/nmap_tracker/__init__.py
+++ b/homeassistant/components/nmap_tracker/__init__.py
@@ -116,10 +116,6 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "Migrating configuration from version %s.%s", entry.version, entry.minor_version
     )
 
-    if entry.version > 1:
-        # This means the user has downgraded from a future version
-        return False
-
     if entry.version == 1:
         new_options = {**entry.options}
         if entry.minor_version < 2:

--- a/homeassistant/components/ollama/__init__.py
+++ b/homeassistant/components/ollama/__init__.py
@@ -236,10 +236,6 @@ async def async_migrate_entry(hass: HomeAssistant, entry: OllamaConfigEntry) -> 
     """Migrate entry."""
     _LOGGER.debug("Migrating from version %s:%s", entry.version, entry.minor_version)
 
-    if entry.version > 3:
-        # This means the user has downgraded from a future version
-        return False
-
     if entry.version == 2 and entry.minor_version == 1:
         # Correct broken device migration in Home Assistant Core 2025.7.0b0-2025.7.0b1
         device_registry = dr.async_get(hass)

--- a/homeassistant/components/onedrive/__init__.py
+++ b/homeassistant/components/onedrive/__init__.py
@@ -133,9 +133,6 @@ async def _migrate_backup_files(client: OneDriveClient, backup_folder_id: str) -
 
 async def async_migrate_entry(hass: HomeAssistant, entry: OneDriveConfigEntry) -> bool:
     """Migrate old entry."""
-    if entry.version > 1:
-        # This means the user has downgraded from a future version
-        return False
 
     if (version := entry.version) == 1 and (minor_version := entry.minor_version) == 1:
         _LOGGER.debug(

--- a/homeassistant/components/open_router/__init__.py
+++ b/homeassistant/components/open_router/__init__.py
@@ -63,9 +63,6 @@ async def async_migrate_entry(
     """Migrate config entry."""
     LOGGER.debug("Migrating from version %s.%s", entry.version, entry.minor_version)
 
-    if entry.version > 1 or (entry.version == 1 and entry.minor_version > 2):
-        return False
-
     if entry.version == 1 and entry.minor_version < 2:
         for subentry in entry.subentries.values():
             if CONF_WEB_SEARCH in subentry.data:

--- a/homeassistant/components/openai_conversation/__init__.py
+++ b/homeassistant/components/openai_conversation/__init__.py
@@ -428,10 +428,6 @@ async def async_migrate_entry(hass: HomeAssistant, entry: OpenAIConfigEntry) -> 
     """Migrate entry."""
     LOGGER.debug("Migrating from version %s:%s", entry.version, entry.minor_version)
 
-    if entry.version > 2:
-        # This means the user has downgraded from a future version
-        return False
-
     if entry.version == 2 and entry.minor_version == 1:
         # Correct broken device migration in Home Assistant Core 2025.7.0b0-2025.7.0b1
         device_registry = dr.async_get(hass)

--- a/homeassistant/components/overkiz/__init__.py
+++ b/homeassistant/components/overkiz/__init__.py
@@ -201,8 +201,6 @@ async def async_migrate_entry(
     hass: HomeAssistant, entry: OverkizDataConfigEntry
 ) -> bool:
     """Migrate old entry."""
-    if entry.version > 1:
-        return False
 
     if entry.version == 1 and entry.minor_version < 2:
         await _async_migrate_strenum_unique_ids(hass, entry)

--- a/homeassistant/components/roborock/__init__.py
+++ b/homeassistant/components/roborock/__init__.py
@@ -253,9 +253,6 @@ async def async_migrate_entry(hass: HomeAssistant, entry: RoborockConfigEntry) -
         entry.version,
         entry.minor_version,
     )
-    if entry.version > 1:
-        # Downgrade from future version
-        return False
 
     # 1->2: Migrate from unique id as email address to unique id as rruid
     if entry.minor_version == 1:

--- a/homeassistant/components/russound_rio/__init__.py
+++ b/homeassistant/components/russound_rio/__init__.py
@@ -115,9 +115,6 @@ async def async_migrate_entry(
     hass: HomeAssistant, config_entry: RussoundConfigEntry
 ) -> bool:
     """Migrate old entry."""
-    if config_entry.version > 2:
-        # This means the user has downgraded from a future version
-        return False
 
     if config_entry.version == 1:
         (

--- a/homeassistant/components/satel_integra/__init__.py
+++ b/homeassistant/components/satel_integra/__init__.py
@@ -121,10 +121,6 @@ async def async_migrate_entry(
         config_entry.minor_version,
     )
 
-    if config_entry.version > 2:
-        # This means the user has downgraded from a future version
-        return False
-
     # 1.2 Migrate subentries to include configured numbers to title
     if config_entry.version == 1 and config_entry.minor_version == 1:
         for subentry in config_entry.subentries.values():

--- a/homeassistant/components/scrape/__init__.py
+++ b/homeassistant/components/scrape/__init__.py
@@ -153,10 +153,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ScrapeConfigEntry) -> bo
 async def async_migrate_entry(hass: HomeAssistant, entry: ScrapeConfigEntry) -> bool:
     """Migrate old entry."""
 
-    if entry.version > 2:
-        # Don't migrate from future version
-        return False
-
     if entry.version == 1:
         old_to_new_sensor_id = {}
         for sensor_config in entry.options[SENSOR_DOMAIN]:

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -134,8 +134,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def async_migrate_entry(hass: HomeAssistant, entry: ShellyConfigEntry) -> bool:
     """Migrate old config entries."""
-    if entry.version > 1 or (entry.version == 1 and entry.minor_version > 3):
-        return False
+
     if entry.minor_version < 3:
         # One-time flip of explicit Active scanning to Auto so existing
         # installs get the new battery-friendly default; Passive stays

--- a/homeassistant/components/smhi/__init__.py
+++ b/homeassistant/components/smhi/__init__.py
@@ -47,10 +47,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: SMHIConfigEntry) -> boo
 async def async_migrate_entry(hass: HomeAssistant, entry: SMHIConfigEntry) -> bool:
     """Migrate old entry."""
 
-    if entry.version > 3:
-        # Downgrade from future version
-        return False
-
     if entry.version == 1:
         new_data = {
             CONF_NAME: entry.data[CONF_NAME],

--- a/homeassistant/components/solarlog/__init__.py
+++ b/homeassistant/components/solarlog/__init__.py
@@ -93,10 +93,6 @@ async def async_migrate_entry(
     """Migrate old entry."""
     _LOGGER.debug("Migrating from version %s", config_entry.version)
 
-    if config_entry.version > 1:
-        # This means the user has downgraded from a future version
-        return False
-
     if config_entry.version == 1:
         if config_entry.minor_version < 2:
             # migrate old entity unique id

--- a/homeassistant/components/sql/__init__.py
+++ b/homeassistant/components/sql/__init__.py
@@ -108,10 +108,6 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Migrate old entry."""
     _LOGGER.debug("Migrating from version %s.%s", entry.version, entry.minor_version)
 
-    if entry.version > 1:
-        # This means the user has downgraded from a future version
-        return False
-
     if entry.version == 1:
         old_options = {**entry.options}
         new_data = {}

--- a/homeassistant/components/statistics/__init__.py
+++ b/homeassistant/components/statistics/__init__.py
@@ -57,9 +57,6 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         "Migrating from version %s.%s", config_entry.version, config_entry.minor_version
     )
 
-    if config_entry.version > 1:
-        # This means the user has downgraded from a future version
-        return False
     if config_entry.version == 1:
         options = {**config_entry.options}
         if config_entry.minor_version < 2:

--- a/homeassistant/components/suez_water/__init__.py
+++ b/homeassistant/components/suez_water/__init__.py
@@ -41,9 +41,6 @@ async def async_migrate_entry(
         config_entry.minor_version,
     )
 
-    if config_entry.version > 2:
-        return False
-
     if config_entry.version == 1:
         # Migrate to version 2
         counter_id = config_entry.data.get(CONF_COUNTER_ID)

--- a/homeassistant/components/swiss_public_transport/__init__.py
+++ b/homeassistant/components/swiss_public_transport/__init__.py
@@ -120,10 +120,6 @@ async def async_migrate_entry(
     """Migrate config entry."""
     _LOGGER.debug("Migrating from version %s", config_entry.version)
 
-    if config_entry.version > 3:
-        # This means the user has downgraded from a future version
-        return False
-
     if config_entry.version == 1 and config_entry.minor_version == 1:
         # Remove wrongly registered devices and entries
         new_unique_id = unique_id_from_config(config_entry.data)

--- a/homeassistant/components/switch_as_x/__init__.py
+++ b/homeassistant/components/switch_as_x/__init__.py
@@ -81,9 +81,6 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         "Migrating from version %s.%s", config_entry.version, config_entry.minor_version
     )
 
-    if config_entry.version > 1:
-        # This means the user has downgraded from a future version
-        return False
     if config_entry.version == 1:
         options = {**config_entry.options}
         if config_entry.minor_version < 2:

--- a/homeassistant/components/system_bridge/__init__.py
+++ b/homeassistant/components/system_bridge/__init__.py
@@ -28,7 +28,6 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.typing import ConfigType
 
-from .config_flow import SystemBridgeConfigFlow
 from .const import DATA_WAIT_TIMEOUT, DOMAIN, MODULES
 from .coordinator import SystemBridgeConfigEntry, SystemBridgeDataUpdateCoordinator
 from .services import async_setup_services
@@ -214,9 +213,6 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         config_entry.version,
         config_entry.minor_version,
     )
-
-    if config_entry.version > SystemBridgeConfigFlow.VERSION:
-        return False
 
     if config_entry.minor_version < 2:
         # Migrate to CONF_TOKEN, which was added in 1.2

--- a/homeassistant/components/systemmonitor/__init__.py
+++ b/homeassistant/components/systemmonitor/__init__.py
@@ -74,10 +74,6 @@ async def async_migrate_entry(
 ) -> bool:
     """Migrate old entry."""
 
-    if entry.version > 1:
-        # This means the user has downgraded from a future version
-        return False
-
     if entry.version == 1 and entry.minor_version < 3:
         new_options = {**entry.options}
         if entry.minor_version == 1:

--- a/homeassistant/components/tedee/__init__.py
+++ b/homeassistant/components/tedee/__init__.py
@@ -134,9 +134,6 @@ async def async_migrate_entry(
     hass: HomeAssistant, config_entry: TedeeConfigEntry
 ) -> bool:
     """Migrate old entry."""
-    if config_entry.version > 1:
-        # This means the user has downgraded from a future version
-        return False
 
     version = config_entry.version
     minor_version = config_entry.minor_version

--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -691,10 +691,6 @@ async def async_migrate_entry(
         minor_version,
     )
 
-    if config_entry.version > 1:
-        # This means the user has downgraded from a future version
-        return False
-
     # version 1.1: to add default API endpoint
     if version == 1 and minor_version == 1:
         new_data = {**config_entry.data}

--- a/homeassistant/components/template/__init__.py
+++ b/homeassistant/components/template/__init__.py
@@ -163,10 +163,6 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         config_entry.minor_version,
     )
 
-    if config_entry.version > 1:
-        # This means the user has downgraded from a future version
-        return False
-
     if config_entry.version == 1:
         if config_entry.minor_version < 2:
             # Remove the template config entry from the source device

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -453,9 +453,6 @@ async def async_migrate_entry(
     hass: HomeAssistant, config_entry: TeslemetryConfigEntry
 ) -> bool:
     """Migrate config entry."""
-    if config_entry.version > 2:
-        # This means the user has downgraded from a future version
-        return False
 
     if config_entry.version == 1:
         access_token = config_entry.data[CONF_ACCESS_TOKEN]

--- a/homeassistant/components/threshold/__init__.py
+++ b/homeassistant/components/threshold/__init__.py
@@ -50,9 +50,6 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         "Migrating from version %s.%s", config_entry.version, config_entry.minor_version
     )
 
-    if config_entry.version > 1:
-        # This means the user has downgraded from a future version
-        return False
     if config_entry.version == 1:
         options = {**config_entry.options}
         if config_entry.minor_version < 2:

--- a/homeassistant/components/tradfri/__init__.py
+++ b/homeassistant/components/tradfri/__init__.py
@@ -182,10 +182,6 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         config_entry.minor_version,
     )
 
-    if config_entry.version > 1:
-        # This means the user has downgraded from a future version
-        return False
-
     if config_entry.version == 1:
         # Migrate to version 2
         migrate_config_entry_and_identifiers(hass, config_entry)

--- a/homeassistant/components/trafikverket_train/__init__.py
+++ b/homeassistant/components/trafikverket_train/__init__.py
@@ -54,10 +54,6 @@ async def async_migrate_entry(hass: HomeAssistant, entry: TVTrainConfigEntry) ->
     """Migrate config entry."""
     _LOGGER.debug("Migrating from version %s", entry.version)
 
-    if entry.version > 2:
-        # This means the user has downgraded from a future version
-        return False
-
     if entry.version == 1:
         if entry.minor_version == 1:
             # Remove unique id

--- a/homeassistant/components/trend/__init__.py
+++ b/homeassistant/components/trend/__init__.py
@@ -56,9 +56,6 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         "Migrating from version %s.%s", config_entry.version, config_entry.minor_version
     )
 
-    if config_entry.version > 1:
-        # This means the user has downgraded from a future version
-        return False
     if config_entry.version == 1:
         options = {**config_entry.options}
         if config_entry.minor_version < 2:

--- a/homeassistant/components/unifiprotect/__init__.py
+++ b/homeassistant/components/unifiprotect/__init__.py
@@ -238,9 +238,6 @@ async def async_migrate_entry(hass: HomeAssistant, entry: UFPConfigEntry) -> boo
     """Migrate entry."""
     _LOGGER.debug("Migrating configuration from version %s", entry.version)
 
-    if entry.version > 1:
-        return False
-
     if entry.version == 1:
         options = dict(entry.options)
         if CONF_ALLOW_EA in options:

--- a/homeassistant/components/utility_meter/__init__.py
+++ b/homeassistant/components/utility_meter/__init__.py
@@ -253,10 +253,6 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         "Migrating from version %s.%s", config_entry.version, config_entry.minor_version
     )
 
-    if config_entry.version > 2:
-        # This means the user has downgraded from a future version
-        return False
-
     if config_entry.version == 1:
         new = {**config_entry.options}
         new[CONF_METER_PERIODICALLY_RESETTING] = True

--- a/homeassistant/components/vicare/__init__.py
+++ b/homeassistant/components/vicare/__init__.py
@@ -55,8 +55,6 @@ async def async_migrate_entry(
     hass: HomeAssistant, config_entry: ViCareConfigEntry
 ) -> bool:
     """Migrate old entry."""
-    if config_entry.version > 2:
-        return False
 
     if config_entry.version == 1 and config_entry.minor_version < 2:
         _LOGGER.debug("Migrating ViCare config entry from version 1.1 to 1.2")

--- a/homeassistant/components/vodafone_station/__init__.py
+++ b/homeassistant/components/vodafone_station/__init__.py
@@ -38,10 +38,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: VodafoneConfigEntry) -> 
 async def async_migrate_entry(hass: HomeAssistant, entry: VodafoneConfigEntry) -> bool:
     """Migrate old entry."""
 
-    if entry.version > 1:
-        # This means the user has downgraded from a future version
-        return False
-
     if entry.version == 1 and entry.minor_version == 1:
         _LOGGER.debug(
             "Migrating from version %s.%s", entry.version, entry.minor_version

--- a/homeassistant/components/wled/__init__.py
+++ b/homeassistant/components/wled/__init__.py
@@ -81,10 +81,6 @@ async def async_migrate_entry(
         config_entry.minor_version,
     )
 
-    if config_entry.version > 1:
-        # The user has downgraded from a future version
-        return False
-
     if config_entry.version == 1:
         if config_entry.minor_version < 2:
             # 1.2: Normalize unique ID to be lowercase MAC address without separators.

--- a/homeassistant/components/workday/__init__.py
+++ b/homeassistant/components/workday/__init__.py
@@ -74,10 +74,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: WorkdayConfigEntry) -> 
 async def async_migrate_entry(hass: HomeAssistant, entry: WorkdayConfigEntry) -> bool:
     """Migrate old config entry."""
 
-    # This means the user has downgraded from a future version
-    if entry.version > 1:
-        return False
-
     if entry.version == 1 and entry.minor_version == 1:
         # By keeping name in the data, it's enough to bump the minor version
         hass.config_entries.async_update_entry(

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -33,7 +33,6 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.typing import ConfigType
 
 from . import homeassistant_hardware, repairs, websocket_api
-from .config_flow import ZhaConfigFlowHandler
 from .const import (
     CONF_BAUDRATE,
     CONF_CUSTOM_QUIRKS_PATH,
@@ -309,10 +308,6 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         config_entry.version,
         config_entry.minor_version,
     )
-
-    if config_entry.version > ZhaConfigFlowHandler.VERSION:
-        # This means the user has downgraded from a future major version
-        return False
 
     if config_entry.version == 1:
         data = {

--- a/tests/components/mqtt/test_config_flow.py
+++ b/tests/components/mqtt/test_config_flow.py
@@ -2631,7 +2631,6 @@ async def test_migrate_config_entry(
         "options",
     ),
     [
-        (2, 2, MOCK_ENTRY_DATA, MOCK_ENTRY_OPTIONS),
         (3, 1, MOCK_ENTRY_DATA, MOCK_ENTRY_OPTIONS),
     ],
 )

--- a/tests/components/shelly/test_init.py
+++ b/tests/components/shelly/test_init.py
@@ -663,16 +663,9 @@ async def test_migrate_ble_scanner_mode(
     assert entry.options.get(CONF_BLE_SCANNER_MODE) == expected_mode
 
 
-@pytest.mark.parametrize(
-    ("entry_version", "entry_minor_version"),
-    [(2, 1), (1, 4)],
-    ids=["future_major", "future_minor"],
-)
 async def test_migrate_ble_scanner_mode_future_version(
     hass: HomeAssistant,
     mock_rpc_device: Mock,
-    entry_version: int,
-    entry_minor_version: int,
 ) -> None:
     """Future versions are not downgraded."""
     entry = MockConfigEntry(
@@ -686,16 +679,45 @@ async def test_migrate_ble_scanner_mode_future_version(
         unique_id=MOCK_MAC,
         options={CONF_BLE_SCANNER_MODE: BLEScannerMode.ACTIVE},
         title="Test name",
-        version=entry_version,
-        minor_version=entry_minor_version,
+        version=2,
+        minor_version=1,
     )
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done(wait_background_tasks=True)
 
     assert entry.state is ConfigEntryState.MIGRATION_ERROR
-    assert entry.version == entry_version
-    assert entry.minor_version == entry_minor_version
+    assert entry.version == 2
+    assert entry.minor_version == 1
+    assert entry.options[CONF_BLE_SCANNER_MODE] == BLEScannerMode.ACTIVE
+
+
+async def test_migrate_ble_scanner_mode_future_minor_version(
+    hass: HomeAssistant,
+    mock_rpc_device: Mock,
+) -> None:
+    """Future minor versions are not downgraded."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "192.168.1.37",
+            CONF_SLEEP_PERIOD: 0,
+            CONF_MODEL: MODEL_PLUS_2PM,
+            "gen": 2,
+        },
+        unique_id=MOCK_MAC,
+        options={CONF_BLE_SCANNER_MODE: BLEScannerMode.ACTIVE},
+        title="Test name",
+        version=1,
+        minor_version=4,
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert entry.version == 1
+    assert entry.minor_version == 4
     assert entry.options[CONF_BLE_SCANNER_MODE] == BLEScannerMode.ACTIVE
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change


## Proposed change
Downgrading from a future config entry version was never allowed and is now handled centrally (#173184).
This removes all the unnecessary guards in individual integrations.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository. 