### PR TITLE
Fix roomba charging state and add charging binary sensor

### DIFF
--- a/homeassistant/components/roomba/binary_sensor.py
+++ b/homeassistant/components/roomba/binary_sensor.py
@@ -21,7 +21,7 @@ async def async_setup_entry(
     domain_data = config_entry.runtime_data
     roomba = domain_data.roomba
     blid = domain_data.blid
-    entities: list[IRobotEntity] = [RoombaCharging(roomba, blid)]
+    entities: list[BinarySensorEntity] = [RoombaCharging(roomba, blid)]
     status = roomba_reported_state(roomba).get("bin", {})
     if "full" in status:
         entities.append(RoombaBinStatus(roomba, blid))

--- a/homeassistant/components/roomba/binary_sensor.py
+++ b/homeassistant/components/roomba/binary_sensor.py
@@ -1,6 +1,9 @@
 """Roomba binary sensor entities."""
 
-from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -18,10 +21,11 @@ async def async_setup_entry(
     domain_data = config_entry.runtime_data
     roomba = domain_data.roomba
     blid = domain_data.blid
+    entities: list[IRobotEntity] = [RoombaCharging(roomba, blid)]
     status = roomba_reported_state(roomba).get("bin", {})
     if "full" in status:
-        roomba_vac = RoombaBinStatus(roomba, blid)
-        async_add_entities([roomba_vac])
+        entities.append(RoombaBinStatus(roomba, blid))
+    async_add_entities(entities)
 
 
 class RoombaBinStatus(IRobotEntity, BinarySensorEntity):
@@ -42,3 +46,28 @@ class RoombaBinStatus(IRobotEntity, BinarySensorEntity):
     def new_state_filter(self, new_state):
         """Filter the new state."""
         return "bin" in new_state
+
+
+class RoombaCharging(IRobotEntity, BinarySensorEntity):
+    """Class to hold Roomba charging status."""
+
+    _attr_device_class = BinarySensorDeviceClass.BATTERY_CHARGING
+
+    @property
+    def unique_id(self) -> str:
+        """Return the ID of this sensor."""
+        return f"charging_{self._blid}"
+
+    @property
+    def is_on(self) -> bool:
+        """Return the state of the sensor."""
+        return (
+            roomba_reported_state(self.vacuum)
+            .get("cleanMissionStatus", {})
+            .get("phase")
+            == "charge"
+        )
+
+    def new_state_filter(self, new_state):
+        """Filter the new state."""
+        return "cleanMissionStatus" in new_state

--- a/homeassistant/components/roomba/vacuum.py
+++ b/homeassistant/components/roomba/vacuum.py
@@ -130,7 +130,10 @@ class IRobotVacuum(IRobotEntity, StateVacuumEntity):
             state = STATE_MAP[phase]
         except KeyError:
             return VacuumActivity.ERROR
-        if cycle != "none" and state in (VacuumActivity.IDLE, VacuumActivity.DOCKED):
+        # A robot stopped in the middle of a mission is paused, but one that is
+        # docked to recharge mid-mission stays docked (the charging binary
+        # sensor distinguishes it from a user-initiated pause on the floor).
+        if cycle != "none" and state is VacuumActivity.IDLE:
             state = VacuumActivity.PAUSED
         return state
 

--- a/tests/components/roomba/conftest.py
+++ b/tests/components/roomba/conftest.py
@@ -54,6 +54,9 @@ def mock_roomba() -> Generator[AsyncMock]:
         }
     }
     mock_roomba.roomba_connected = True
+    mock_roomba.current_state = "Charging"
+    mock_roomba.error_code = 0
+    mock_roomba.error_message = None
 
     with patch(
         "homeassistant.components.roomba.RoombaFactory.create_roomba",

--- a/tests/components/roomba/snapshots/test_binary_sensor.ambr
+++ b/tests/components/roomba/snapshots/test_binary_sensor.ambr
@@ -1,0 +1,102 @@
+# serializer version: 1
+# name: test_entities[binary_sensor.test_roomba_bin_full-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_roomba_bin_full',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Bin full',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Bin full',
+    'platform': 'roomba',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'bin_full',
+    'unique_id': 'bin_blid123',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[binary_sensor.test_roomba_bin_full-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Test Roomba Bin full',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_roomba_bin_full',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_entities[binary_sensor.test_roomba_charging-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_roomba_charging',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Charging',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.BATTERY_CHARGING: 'battery_charging'>,
+    'original_icon': None,
+    'original_name': 'Charging',
+    'platform': 'roomba',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'charging_blid123',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[binary_sensor.test_roomba_charging-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery_charging',
+      'friendly_name': 'Test Roomba Charging',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_roomba_charging',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---

--- a/tests/components/roomba/test_binary_sensor.py
+++ b/tests/components/roomba/test_binary_sensor.py
@@ -1,0 +1,56 @@
+"""Tests for the Roomba binary sensor platform."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.const import STATE_OFF, STATE_ON, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_entities(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_roomba: AsyncMock,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test roomba binary sensor entities."""
+    with patch("homeassistant.components.roomba.PLATFORMS", [Platform.BINARY_SENSOR]):
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    ("phase", "expected"),
+    [
+        ("charge", STATE_ON),
+        ("run", STATE_OFF),
+    ],
+)
+async def test_charging(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_roomba: AsyncMock,
+    phase: str,
+    expected: str,
+) -> None:
+    """Test the charging binary sensor reflects the dock charge phase."""
+    mock_roomba.master_state["state"]["reported"]["cleanMissionStatus"]["phase"] = phase
+
+    with patch("homeassistant.components.roomba.PLATFORMS", [Platform.BINARY_SENSOR]):
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test_roomba_charging")
+    assert state is not None
+    assert state.state == expected

--- a/tests/components/roomba/test_vacuum.py
+++ b/tests/components/roomba/test_vacuum.py
@@ -1,0 +1,54 @@
+"""Tests for the Roomba vacuum platform."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant.components.vacuum import VacuumActivity
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+ENTITY_ID = "vacuum.test_roomba"
+
+
+@pytest.mark.parametrize(
+    ("phase", "cycle", "expected"),
+    [
+        ("charge", "none", VacuumActivity.DOCKED),
+        # Docked to recharge in the middle of a mission stays docked instead of
+        # being reported as paused (regression test for #148287).
+        ("charge", "clean", VacuumActivity.DOCKED),
+        ("hmMidMsn", "clean", VacuumActivity.CLEANING),
+        ("hmPostMsn", "clean", VacuumActivity.RETURNING),
+        ("run", "clean", VacuumActivity.CLEANING),
+        ("pause", "clean", VacuumActivity.PAUSED),
+        # Stopped on the floor mid-mission is a paused state.
+        ("stop", "clean", VacuumActivity.PAUSED),
+        ("stop", "none", VacuumActivity.IDLE),
+        ("stuck", "clean", VacuumActivity.ERROR),
+    ],
+)
+async def test_vacuum_activity(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_roomba: AsyncMock,
+    phase: str,
+    cycle: str,
+    expected: VacuumActivity,
+) -> None:
+    """Test the vacuum activity mapping from the reported mission status."""
+    mock_roomba.master_state["state"]["reported"]["cleanMissionStatus"] = {
+        "cycle": cycle,
+        "phase": phase,
+    }
+
+    with patch("homeassistant.components.roomba.PLATFORMS", [Platform.VACUUM]):
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == expected


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fixes the iRobot Roomba integration reporting an incorrect state when the vacuum is charging, and adds a dedicated charging binary sensor. Two related problems were reported in #148287 (a copy of the earlier #84064):

1. **Incorrect state while charging mid-mission.** When a Roomba returns to its dock to recharge in the middle of a cleaning cycle, the robot reports `phase: "charge"` (→ `DOCKED`) while the mission `cycle` is still active. The previous logic unconditionally overrode any `IDLE`/`DOCKED` state to `PAUSED` whenever a cycle was active, so a robot that was physically docked and charging was reported as `paused` — indistinguishable from a user pausing the robot in the middle of a room. The override is now narrowed to apply to the `IDLE` state only, so a docked-and-recharging robot correctly reports `docked`. A robot stopped on the floor mid-mission still reports `paused`, and a user pause (`phase: "pause"`) was never affected by this branch.

2. **No way to tell whether the robot is charging.** There was previously no charging indicator (the original issue notes users had to resort to template/derivative sensors). A new `binary_sensor` with the `battery_charging` device class is added, driven by the dock charge phase (`cleanMissionStatus.phase == "charge"`). Combined with the state fix, automations can now distinguish "docked and charging mid-clean" from "paused on the floor".

Tests were added for the activity mapping (including the regression case) and for the new charging binary sensor.

### Test results

Verified locally against a real Roomba: https://cleanshot.com/share/KnFM6yJn

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #148287
- This PR is related to issue: #84064
- Link to documentation pull request: home-assistant/home-assistant.io#45818
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
