### PR TITLE
Add Kiosker blackout details sensors

### DIFF
--- a/homeassistant/components/kiosker/icons.json
+++ b/homeassistant/components/kiosker/icons.json
@@ -63,7 +63,7 @@
         "default": "mdi:button-cursor"
       },
       "blackout_expire": {
-        "default": "mdi:timer-outline"
+        "default": "mdi:clock-end"
       },
       "blackout_foreground": {
         "default": "mdi:palette-outline"

--- a/homeassistant/components/kiosker/icons.json
+++ b/homeassistant/components/kiosker/icons.json
@@ -50,8 +50,35 @@
       "ambient_light": {
         "default": "mdi:brightness-6"
       },
+      "blackout_background": {
+        "default": "mdi:palette"
+      },
+      "blackout_button_background": {
+        "default": "mdi:palette"
+      },
+      "blackout_button_foreground": {
+        "default": "mdi:palette-outline"
+      },
+      "blackout_button_text": {
+        "default": "mdi:button-cursor"
+      },
+      "blackout_expire": {
+        "default": "mdi:timer-outline"
+      },
+      "blackout_foreground": {
+        "default": "mdi:palette-outline"
+      },
+      "blackout_icon": {
+        "default": "mdi:emoticon-outline"
+      },
+      "blackout_sound": {
+        "default": "mdi:music-note"
+      },
       "blackout_state": {
         "default": "mdi:monitor-off"
+      },
+      "blackout_text": {
+        "default": "mdi:text"
       },
       "last_interaction": {
         "default": "mdi:gesture-tap"

--- a/homeassistant/components/kiosker/sensor.py
+++ b/homeassistant/components/kiosker/sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -10,7 +10,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import PERCENTAGE, UnitOfTime
+from homeassistant.const import PERCENTAGE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
@@ -82,11 +82,10 @@ SENSORS: tuple[KioskerSensorEntityDescription, ...] = (
     KioskerSensorEntityDescription(
         key="blackoutExpire",
         translation_key="blackout_expire",
-        native_unit_of_measurement=UnitOfTime.SECONDS,
-        device_class=SensorDeviceClass.DURATION,
+        device_class=SensorDeviceClass.TIMESTAMP,
         entity_registry_enabled_default=False,
         value_fn=lambda x: (
-            round(x.blackout.expire)
+            x.status.last_update + timedelta(seconds=x.blackout.expire)
             if x.blackout and x.blackout.expire is not None
             else None
         ),

--- a/homeassistant/components/kiosker/sensor.py
+++ b/homeassistant/components/kiosker/sensor.py
@@ -4,23 +4,21 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
 
-from kiosker import Status
-
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import PERCENTAGE
+from homeassistant.const import PERCENTAGE, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
 from . import KioskerConfigEntry
+from .coordinator import KioskerData
 from .entity import KioskerEntity
 
-# Coordinator-based platform; no per-entity polling concurrency needed
 PARALLEL_UPDATES = 0
 
 
@@ -28,7 +26,7 @@ PARALLEL_UPDATES = 0
 class KioskerSensorEntityDescription(SensorEntityDescription):
     """Kiosker sensor description."""
 
-    value_fn: Callable[[Status], StateType | datetime | None]
+    value_fn: Callable[[KioskerData], StateType | datetime | None]
 
 
 SENSORS: tuple[KioskerSensorEntityDescription, ...] = (
@@ -37,25 +35,85 @@ SENSORS: tuple[KioskerSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.BATTERY,
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda x: x.battery_level,
+        value_fn=lambda x: x.status.battery_level,
     ),
     KioskerSensorEntityDescription(
         key="lastInteraction",
         translation_key="last_interaction",
         device_class=SensorDeviceClass.TIMESTAMP,
-        value_fn=lambda x: x.last_interaction,
+        value_fn=lambda x: x.status.last_interaction,
     ),
     KioskerSensorEntityDescription(
         key="lastMotion",
         translation_key="last_motion",
         device_class=SensorDeviceClass.TIMESTAMP,
-        value_fn=lambda x: x.last_motion,
+        value_fn=lambda x: x.status.last_motion,
     ),
     KioskerSensorEntityDescription(
         key="ambientLight",
         translation_key="ambient_light",
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda x: x.ambient_light,
+        value_fn=lambda x: x.status.ambient_light,
+    ),
+    KioskerSensorEntityDescription(
+        key="blackoutText",
+        translation_key="blackout_text",
+        entity_registry_enabled_default=False,
+        value_fn=lambda x: x.blackout.text if x.blackout else None,
+    ),
+    KioskerSensorEntityDescription(
+        key="blackoutIcon",
+        translation_key="blackout_icon",
+        entity_registry_enabled_default=False,
+        value_fn=lambda x: x.blackout.icon if x.blackout else None,
+    ),
+    KioskerSensorEntityDescription(
+        key="blackoutBackground",
+        translation_key="blackout_background",
+        entity_registry_enabled_default=False,
+        value_fn=lambda x: x.blackout.background if x.blackout else None,
+    ),
+    KioskerSensorEntityDescription(
+        key="blackoutForeground",
+        translation_key="blackout_foreground",
+        entity_registry_enabled_default=False,
+        value_fn=lambda x: x.blackout.foreground if x.blackout else None,
+    ),
+    KioskerSensorEntityDescription(
+        key="blackoutExpire",
+        translation_key="blackout_expire",
+        native_unit_of_measurement=UnitOfTime.SECONDS,
+        device_class=SensorDeviceClass.DURATION,
+        entity_registry_enabled_default=False,
+        value_fn=lambda x: (
+            round(x.blackout.expire)
+            if x.blackout and x.blackout.expire is not None
+            else None
+        ),
+    ),
+    KioskerSensorEntityDescription(
+        key="blackoutButtonBackground",
+        translation_key="blackout_button_background",
+        entity_registry_enabled_default=False,
+        value_fn=lambda x: x.blackout.buttonBackground if x.blackout else None,
+    ),
+    KioskerSensorEntityDescription(
+        key="blackoutButtonForeground",
+        translation_key="blackout_button_foreground",
+        entity_registry_enabled_default=False,
+        value_fn=lambda x: x.blackout.buttonForeground if x.blackout else None,
+    ),
+    KioskerSensorEntityDescription(
+        key="blackoutButtonText",
+        translation_key="blackout_button_text",
+        entity_registry_enabled_default=False,
+        value_fn=lambda x: x.blackout.buttonText if x.blackout else None,
+    ),
+    KioskerSensorEntityDescription(
+        key="blackoutSound",
+        translation_key="blackout_sound",
+        entity_registry_enabled_default=False,
+        value_fn=lambda x: x.blackout.sound if x.blackout else None,
     ),
 )
 
@@ -81,4 +139,4 @@ class KioskerSensor(KioskerEntity, SensorEntity):
     @property
     def native_value(self) -> StateType | datetime | None:
         """Return the native value of the sensor."""
-        return self.entity_description.value_fn(self.coordinator.data.status)
+        return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/kiosker/strings.json
+++ b/homeassistant/components/kiosker/strings.json
@@ -92,6 +92,33 @@
       "ambient_light": {
         "name": "Ambient light"
       },
+      "blackout_background": {
+        "name": "Blackout background color"
+      },
+      "blackout_button_background": {
+        "name": "Blackout button background color"
+      },
+      "blackout_button_foreground": {
+        "name": "Blackout button foreground color"
+      },
+      "blackout_button_text": {
+        "name": "Blackout button text"
+      },
+      "blackout_expire": {
+        "name": "Blackout expire"
+      },
+      "blackout_foreground": {
+        "name": "Blackout foreground color"
+      },
+      "blackout_icon": {
+        "name": "Blackout icon"
+      },
+      "blackout_sound": {
+        "name": "Blackout sound"
+      },
+      "blackout_text": {
+        "name": "Blackout text"
+      },
       "last_interaction": {
         "name": "Last interaction"
       },

--- a/homeassistant/components/kiosker/strings.json
+++ b/homeassistant/components/kiosker/strings.json
@@ -105,7 +105,7 @@
         "name": "Blackout button text"
       },
       "blackout_expire": {
-        "name": "Blackout expire"
+        "name": "Blackout expiry"
       },
       "blackout_foreground": {
         "name": "Blackout foreground color"

--- a/tests/components/kiosker/snapshots/test_sensor.ambr
+++ b/tests/components/kiosker/snapshots/test_sensor.ambr
@@ -107,6 +107,461 @@
     'state': '85',
   })
 # ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_background_color-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.kiosker_a98be1ce_blackout_background_color',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Blackout background color',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Blackout background color',
+    'platform': 'kiosker',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'blackout_background',
+    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutBackground',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_background_color-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kiosker A98BE1CE Blackout background color',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kiosker_a98be1ce_blackout_background_color',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '#B10A10',
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_button_background_color-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.kiosker_a98be1ce_blackout_button_background_color',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Blackout button background color',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Blackout button background color',
+    'platform': 'kiosker',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'blackout_button_background',
+    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutButtonBackground',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_button_background_color-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kiosker A98BE1CE Blackout button background color',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kiosker_a98be1ce_blackout_button_background_color',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '#c21c1c',
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_button_foreground_color-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.kiosker_a98be1ce_blackout_button_foreground_color',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Blackout button foreground color',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Blackout button foreground color',
+    'platform': 'kiosker',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'blackout_button_foreground',
+    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutButtonForeground',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_button_foreground_color-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kiosker A98BE1CE Blackout button foreground color',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kiosker_a98be1ce_blackout_button_foreground_color',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '#36E20B',
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_button_text-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.kiosker_a98be1ce_blackout_button_text',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Blackout button text',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Blackout button text',
+    'platform': 'kiosker',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'blackout_button_text',
+    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutButtonText',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_button_text-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kiosker A98BE1CE Blackout button text',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kiosker_a98be1ce_blackout_button_text',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Dismiss me',
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_expire-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.kiosker_a98be1ce_blackout_expire',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Blackout expire',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
+    'original_icon': None,
+    'original_name': 'Blackout expire',
+    'platform': 'kiosker',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'blackout_expire',
+    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutExpire',
+    'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_expire-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'Kiosker A98BE1CE Blackout expire',
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kiosker_a98be1ce_blackout_expire',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '60',
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_foreground_color-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.kiosker_a98be1ce_blackout_foreground_color',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Blackout foreground color',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Blackout foreground color',
+    'platform': 'kiosker',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'blackout_foreground',
+    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutForeground',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_foreground_color-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kiosker A98BE1CE Blackout foreground color',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kiosker_a98be1ce_blackout_foreground_color',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '#f0fA12',
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_icon-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.kiosker_a98be1ce_blackout_icon',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Blackout icon',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Blackout icon',
+    'platform': 'kiosker',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'blackout_icon',
+    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutIcon',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_icon-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kiosker A98BE1CE Blackout icon',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kiosker_a98be1ce_blackout_icon',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'star.fill',
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_sound-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.kiosker_a98be1ce_blackout_sound',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Blackout sound',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Blackout sound',
+    'platform': 'kiosker',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'blackout_sound',
+    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutSound',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_sound-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kiosker A98BE1CE Blackout sound',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kiosker_a98be1ce_blackout_sound',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1007',
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_text-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.kiosker_a98be1ce_blackout_text',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Blackout text',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Blackout text',
+    'platform': 'kiosker',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'blackout_text',
+    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutText',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_text-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kiosker A98BE1CE Blackout text',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kiosker_a98be1ce_blackout_text',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Hello world',
+  })
+# ---
 # name: test_all_entities[sensor.kiosker_a98be1ce_last_interaction-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/kiosker/snapshots/test_sensor.ambr
+++ b/tests/components/kiosker/snapshots/test_sensor.ambr
@@ -1,4 +1,404 @@
 # serializer version: 1
+# name: test_all_entities[sensor.kiosker_a98be1ce-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.kiosker_a98be1ce',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'kiosker',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'blackout_text',
+    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutText',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kiosker A98BE1CE',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kiosker_a98be1ce',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Hello world',
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.kiosker_a98be1ce_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'kiosker',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'blackout_icon',
+    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutIcon',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kiosker A98BE1CE',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kiosker_a98be1ce_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'star.fill',
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.kiosker_a98be1ce_3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'kiosker',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'blackout_background',
+    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutBackground',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kiosker A98BE1CE',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kiosker_a98be1ce_3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '#B10A10',
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_4-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.kiosker_a98be1ce_4',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'kiosker',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'blackout_foreground',
+    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutForeground',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_4-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kiosker A98BE1CE',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kiosker_a98be1ce_4',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '#f0fA12',
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_5-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.kiosker_a98be1ce_5',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'kiosker',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'blackout_button_background',
+    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutButtonBackground',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_5-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kiosker A98BE1CE',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kiosker_a98be1ce_5',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '#c21c1c',
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_6-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.kiosker_a98be1ce_6',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'kiosker',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'blackout_button_foreground',
+    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutButtonForeground',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_6-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kiosker A98BE1CE',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kiosker_a98be1ce_6',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '#36E20B',
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_7-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.kiosker_a98be1ce_7',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'kiosker',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'blackout_button_text',
+    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutButtonText',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_7-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kiosker A98BE1CE',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kiosker_a98be1ce_7',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Dismiss me',
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_8-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.kiosker_a98be1ce_8',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'kiosker',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'blackout_sound',
+    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutSound',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_8-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kiosker A98BE1CE',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kiosker_a98be1ce_8',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1007',
+  })
+# ---
 # name: test_all_entities[sensor.kiosker_a98be1ce_ambient_light-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -107,7 +507,7 @@
     'state': '85',
   })
 # ---
-# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_background_color-entry]
+# name: test_all_entities[sensor.kiosker_a98be1ce_duration-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -121,7 +521,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.kiosker_a98be1ce_blackout_background_color',
+    'entity_id': 'sensor.kiosker_a98be1ce_duration',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -129,207 +529,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Blackout background color',
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Blackout background color',
-    'platform': 'kiosker',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'blackout_background',
-    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutBackground',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_background_color-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Kiosker A98BE1CE Blackout background color',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.kiosker_a98be1ce_blackout_background_color',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '#B10A10',
-  })
-# ---
-# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_button_background_color-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.kiosker_a98be1ce_blackout_button_background_color',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Blackout button background color',
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Blackout button background color',
-    'platform': 'kiosker',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'blackout_button_background',
-    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutButtonBackground',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_button_background_color-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Kiosker A98BE1CE Blackout button background color',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.kiosker_a98be1ce_blackout_button_background_color',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '#c21c1c',
-  })
-# ---
-# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_button_foreground_color-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.kiosker_a98be1ce_blackout_button_foreground_color',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Blackout button foreground color',
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Blackout button foreground color',
-    'platform': 'kiosker',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'blackout_button_foreground',
-    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutButtonForeground',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_button_foreground_color-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Kiosker A98BE1CE Blackout button foreground color',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.kiosker_a98be1ce_blackout_button_foreground_color',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '#36E20B',
-  })
-# ---
-# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_button_text-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.kiosker_a98be1ce_blackout_button_text',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Blackout button text',
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Blackout button text',
-    'platform': 'kiosker',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'blackout_button_text',
-    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutButtonText',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_button_text-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Kiosker A98BE1CE Blackout button text',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.kiosker_a98be1ce_blackout_button_text',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'Dismiss me',
-  })
-# ---
-# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_expire-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.kiosker_a98be1ce_blackout_expire',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Blackout expire',
+    'object_id_base': 'Duration',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -337,7 +537,7 @@
     }),
     'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
     'original_icon': None,
-    'original_name': 'Blackout expire',
+    'original_name': 'Duration',
     'platform': 'kiosker',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -347,219 +547,19 @@
     'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
   })
 # ---
-# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_expire-state]
+# name: test_all_entities[sensor.kiosker_a98be1ce_duration-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'duration',
-      'friendly_name': 'Kiosker A98BE1CE Blackout expire',
+      'friendly_name': 'Kiosker A98BE1CE Duration',
       'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.kiosker_a98be1ce_blackout_expire',
+    'entity_id': 'sensor.kiosker_a98be1ce_duration',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '60',
-  })
-# ---
-# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_foreground_color-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.kiosker_a98be1ce_blackout_foreground_color',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Blackout foreground color',
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Blackout foreground color',
-    'platform': 'kiosker',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'blackout_foreground',
-    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutForeground',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_foreground_color-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Kiosker A98BE1CE Blackout foreground color',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.kiosker_a98be1ce_blackout_foreground_color',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '#f0fA12',
-  })
-# ---
-# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_icon-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.kiosker_a98be1ce_blackout_icon',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Blackout icon',
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Blackout icon',
-    'platform': 'kiosker',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'blackout_icon',
-    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutIcon',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_icon-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Kiosker A98BE1CE Blackout icon',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.kiosker_a98be1ce_blackout_icon',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'star.fill',
-  })
-# ---
-# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_sound-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.kiosker_a98be1ce_blackout_sound',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Blackout sound',
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Blackout sound',
-    'platform': 'kiosker',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'blackout_sound',
-    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutSound',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_sound-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Kiosker A98BE1CE Blackout sound',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.kiosker_a98be1ce_blackout_sound',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '1007',
-  })
-# ---
-# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_text-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.kiosker_a98be1ce_blackout_text',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Blackout text',
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Blackout text',
-    'platform': 'kiosker',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'blackout_text',
-    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutText',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_text-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Kiosker A98BE1CE Blackout text',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.kiosker_a98be1ce_blackout_text',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'Hello world',
   })
 # ---
 # name: test_all_entities[sensor.kiosker_a98be1ce_last_interaction-entry]

--- a/tests/components/kiosker/snapshots/test_sensor.ambr
+++ b/tests/components/kiosker/snapshots/test_sensor.ambr
@@ -1,404 +1,4 @@
 # serializer version: 1
-# name: test_all_entities[sensor.kiosker_a98be1ce-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.kiosker_a98be1ce',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'kiosker',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'blackout_text',
-    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutText',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_all_entities[sensor.kiosker_a98be1ce-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Kiosker A98BE1CE',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.kiosker_a98be1ce',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'Hello world',
-  })
-# ---
-# name: test_all_entities[sensor.kiosker_a98be1ce_2-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.kiosker_a98be1ce_2',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'kiosker',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'blackout_icon',
-    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutIcon',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_all_entities[sensor.kiosker_a98be1ce_2-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Kiosker A98BE1CE',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.kiosker_a98be1ce_2',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'star.fill',
-  })
-# ---
-# name: test_all_entities[sensor.kiosker_a98be1ce_3-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.kiosker_a98be1ce_3',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'kiosker',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'blackout_background',
-    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutBackground',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_all_entities[sensor.kiosker_a98be1ce_3-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Kiosker A98BE1CE',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.kiosker_a98be1ce_3',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '#B10A10',
-  })
-# ---
-# name: test_all_entities[sensor.kiosker_a98be1ce_4-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.kiosker_a98be1ce_4',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'kiosker',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'blackout_foreground',
-    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutForeground',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_all_entities[sensor.kiosker_a98be1ce_4-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Kiosker A98BE1CE',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.kiosker_a98be1ce_4',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '#f0fA12',
-  })
-# ---
-# name: test_all_entities[sensor.kiosker_a98be1ce_5-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.kiosker_a98be1ce_5',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'kiosker',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'blackout_button_background',
-    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutButtonBackground',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_all_entities[sensor.kiosker_a98be1ce_5-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Kiosker A98BE1CE',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.kiosker_a98be1ce_5',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '#c21c1c',
-  })
-# ---
-# name: test_all_entities[sensor.kiosker_a98be1ce_6-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.kiosker_a98be1ce_6',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'kiosker',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'blackout_button_foreground',
-    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutButtonForeground',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_all_entities[sensor.kiosker_a98be1ce_6-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Kiosker A98BE1CE',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.kiosker_a98be1ce_6',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '#36E20B',
-  })
-# ---
-# name: test_all_entities[sensor.kiosker_a98be1ce_7-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.kiosker_a98be1ce_7',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'kiosker',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'blackout_button_text',
-    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutButtonText',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_all_entities[sensor.kiosker_a98be1ce_7-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Kiosker A98BE1CE',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.kiosker_a98be1ce_7',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'Dismiss me',
-  })
-# ---
-# name: test_all_entities[sensor.kiosker_a98be1ce_8-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.kiosker_a98be1ce_8',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'kiosker',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'blackout_sound',
-    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutSound',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_all_entities[sensor.kiosker_a98be1ce_8-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Kiosker A98BE1CE',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.kiosker_a98be1ce_8',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '1007',
-  })
-# ---
 # name: test_all_entities[sensor.kiosker_a98be1ce_ambient_light-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -507,7 +107,7 @@
     'state': '85',
   })
 # ---
-# name: test_all_entities[sensor.kiosker_a98be1ce_duration-entry]
+# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_background_color-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -521,7 +121,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.kiosker_a98be1ce_duration',
+    'entity_id': 'sensor.kiosker_a98be1ce_blackout_background_color',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -529,37 +129,433 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Duration',
+    'object_id_base': 'Blackout background color',
     'options': dict({
-      'sensor': dict({
-        'suggested_display_precision': 2,
-      }),
     }),
-    'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
+    'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Duration',
+    'original_name': 'Blackout background color',
+    'platform': 'kiosker',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'blackout_background',
+    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutBackground',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_background_color-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kiosker A98BE1CE Blackout background color',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kiosker_a98be1ce_blackout_background_color',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '#B10A10',
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_button_background_color-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.kiosker_a98be1ce_blackout_button_background_color',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Blackout button background color',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Blackout button background color',
+    'platform': 'kiosker',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'blackout_button_background',
+    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutButtonBackground',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_button_background_color-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kiosker A98BE1CE Blackout button background color',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kiosker_a98be1ce_blackout_button_background_color',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '#c21c1c',
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_button_foreground_color-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.kiosker_a98be1ce_blackout_button_foreground_color',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Blackout button foreground color',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Blackout button foreground color',
+    'platform': 'kiosker',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'blackout_button_foreground',
+    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutButtonForeground',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_button_foreground_color-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kiosker A98BE1CE Blackout button foreground color',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kiosker_a98be1ce_blackout_button_foreground_color',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '#36E20B',
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_button_text-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.kiosker_a98be1ce_blackout_button_text',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Blackout button text',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Blackout button text',
+    'platform': 'kiosker',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'blackout_button_text',
+    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutButtonText',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_button_text-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kiosker A98BE1CE Blackout button text',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kiosker_a98be1ce_blackout_button_text',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Dismiss me',
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_expiry-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.kiosker_a98be1ce_blackout_expiry',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Blackout expiry',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Blackout expiry',
     'platform': 'kiosker',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'blackout_expire',
     'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutExpire',
-    'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[sensor.kiosker_a98be1ce_duration-state]
+# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_expiry-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'Kiosker A98BE1CE Duration',
-      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+      'device_class': 'timestamp',
+      'friendly_name': 'Kiosker A98BE1CE Blackout expiry',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.kiosker_a98be1ce_duration',
+    'entity_id': 'sensor.kiosker_a98be1ce_blackout_expiry',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '60',
+    'state': '2025-01-01T12:06:00+00:00',
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_foreground_color-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.kiosker_a98be1ce_blackout_foreground_color',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Blackout foreground color',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Blackout foreground color',
+    'platform': 'kiosker',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'blackout_foreground',
+    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutForeground',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_foreground_color-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kiosker A98BE1CE Blackout foreground color',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kiosker_a98be1ce_blackout_foreground_color',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '#f0fA12',
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_icon-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.kiosker_a98be1ce_blackout_icon',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Blackout icon',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Blackout icon',
+    'platform': 'kiosker',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'blackout_icon',
+    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutIcon',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_icon-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kiosker A98BE1CE Blackout icon',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kiosker_a98be1ce_blackout_icon',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'star.fill',
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_sound-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.kiosker_a98be1ce_blackout_sound',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Blackout sound',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Blackout sound',
+    'platform': 'kiosker',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'blackout_sound',
+    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutSound',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_sound-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kiosker A98BE1CE Blackout sound',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kiosker_a98be1ce_blackout_sound',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1007',
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_text-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.kiosker_a98be1ce_blackout_text',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Blackout text',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Blackout text',
+    'platform': 'kiosker',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'blackout_text',
+    'unique_id': 'A98BE1CE-5FE7-4A8D-B2C3-123456789ABC_blackoutText',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.kiosker_a98be1ce_blackout_text-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Kiosker A98BE1CE Blackout text',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kiosker_a98be1ce_blackout_text',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Hello world',
   })
 # ---
 # name: test_all_entities[sensor.kiosker_a98be1ce_last_interaction-entry]

--- a/tests/components/kiosker/test_sensor.py
+++ b/tests/components/kiosker/test_sensor.py
@@ -1,5 +1,6 @@
 """Test the Kiosker sensors."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from syrupy.assertion import SnapshotAssertion
@@ -21,6 +22,31 @@ async def test_all_entities(
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test all entities."""
+    mock_kiosker_api.blackout_get.return_value = SimpleNamespace(
+        visible=True,
+        dismissible=True,
+        text="Hello world",
+        icon="star.fill",
+        background="#B10A10",
+        foreground="#f0fA12",
+        expire=60,
+        buttonBackground="#c21c1c",
+        buttonForeground="#36E20B",
+        buttonText="Dismiss me",
+        sound="1007",
+    )
+
     with patch("homeassistant.components.kiosker._PLATFORMS", [Platform.SENSOR]):
         await setup_integration(hass, mock_config_entry)
+
+        for entity_entry in er.async_entries_for_config_entry(
+            entity_registry, mock_config_entry.entry_id
+        ):
+            if entity_entry.disabled_by is not None:
+                entity_registry.async_update_entity(
+                    entity_entry.entity_id, disabled_by=None
+                )
+        await hass.config_entries.async_reload(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)

--- a/tests/components/kiosker/test_sensor.py
+++ b/tests/components/kiosker/test_sensor.py
@@ -3,6 +3,7 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.const import Platform
@@ -14,6 +15,7 @@ from . import setup_integration
 from tests.common import MockConfigEntry, snapshot_platform
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_all_entities(
     hass: HomeAssistant,
     snapshot: SnapshotAssertion,
@@ -38,15 +40,5 @@ async def test_all_entities(
 
     with patch("homeassistant.components.kiosker._PLATFORMS", [Platform.SENSOR]):
         await setup_integration(hass, mock_config_entry)
-
-        for entity_entry in er.async_entries_for_config_entry(
-            entity_registry, mock_config_entry.entry_id
-        ):
-            if entity_entry.disabled_by is not None:
-                entity_registry.async_update_entity(
-                    entity_entry.entity_id, disabled_by=None
-                )
-        await hass.config_entries.async_reload(mock_config_entry.entry_id)
-        await hass.async_block_till_done()
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds multiple blackout detail sensor. The sensors will be None if there is no active blackout. The sensors is disabled by default because the information is highly specific and mostly not needed.

* blackoutText: Text on blackout
* blackoutIcon: SFSymbol name
* blackoutBackground: Background color HEX
* blackoutForeground: Foreground color HEX
* blackoutExpire: Seconds to the blackout expires
* blackoutButtonBackground: Dimiss button background color HEX
* blackoutButtonForeground: Dimiss button foreground color HEX
* blackoutButtonText: Dimiss button text
* blackoutSound: The systemSoundID that was played when the blackout appeared

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45821#issuecomment-4653613320
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
