### PR TITLE
Fix Netatmo climate KeyError when BTicino Smarther is in cooling mode

### DIFF
--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -280,7 +280,9 @@ class NetatmoThermostat(NetatmoRoomEntity, ClimateEntity):
             return
 
         if data["event_type"] == EVENT_TYPE_THERM_MODE:
-            self._attr_preset_mode = NETATMO_MAP_PRESET[home[EVENT_TYPE_THERM_MODE]]
+            self._attr_preset_mode = NETATMO_MAP_PRESET.get(
+                home.get(EVENT_TYPE_THERM_MODE), PRESET_SCHEDULE
+            )
             self._attr_hvac_mode = HVAC_MAP_NETATMO[self._attr_preset_mode]
             if self._attr_preset_mode == PRESET_FROST_GUARD:
                 self._attr_target_temperature = self._hg_temperature
@@ -422,9 +424,12 @@ class NetatmoThermostat(NetatmoRoomEntity, ClimateEntity):
         self._hg_temperature = self.home.get_hg_temp()
         self._attr_current_temperature = self.device.therm_measured_temperature
         self._attr_target_temperature = self.device.therm_setpoint_temperature
-        self._attr_preset_mode = NETATMO_MAP_PRESET[
-            getattr(self.device, "therm_setpoint_mode", STATE_NETATMO_SCHEDULE)
-        ]
+        self._attr_preset_mode = NETATMO_MAP_PRESET.get(
+            getattr(self.device, "therm_setpoint_mode", None)
+            or getattr(self.device, "cooling_setpoint_mode", None)
+            or STATE_NETATMO_SCHEDULE,
+            PRESET_SCHEDULE,
+        )
         self._attr_hvac_mode = HVAC_MAP_NETATMO[self._attr_preset_mode]
         self._away = self._attr_hvac_mode == HVAC_MAP_NETATMO[STATE_NETATMO_AWAY]
 


### PR DESCRIPTION
## Problem

When a BTicino Smarther thermostat is in cooling mode, the Netatmo API only populates `cooling_setpoint_mode`; `therm_setpoint_mode` is `None`. The current code does:

```python
self._attr_preset_mode = NETATMO_MAP_PRESET[
    getattr(self.device, "therm_setpoint_mode", STATE_NETATMO_SCHEDULE)
]
```

`getattr()` returns `None` (not the fallback default) because the attribute **exists** on the object — it is just `None`. `None` is not a key in `NETATMO_MAP_PRESET`, which raises a `KeyError` that prevents the entity from loading entirely.

Fixes #118336.

## Changes

- `async_update_callback`: fall back to `cooling_setpoint_mode` when `therm_setpoint_mode` is `None`, then fall back to `STATE_NETATMO_SCHEDULE`. Use `.get()` so an unrecognized mode value never raises a `KeyError`.
- `handle_event` (`EVENT_TYPE_THERM_MODE` branch): same defensive `.get()` treatment for event payloads.

## Testing

Tested on a home with two BTicino Smarther SC thermostats (kitchen + bedroom) that were stuck in `unavailable` state during summer (cooling mode active). After applying this patch and reloading the integration both entities loaded correctly.