### PR TITLE
Add ability to suppress redundant image file writing to disk & flag for debug image generation

### DIFF
--- a/homeassistant/components/seven_segments/image_processing.py
+++ b/homeassistant/components/seven_segments/image_processing.py
@@ -133,14 +133,13 @@ class ImageProcessingSsocr(ImageProcessingEntity):
         """Process the image."""
         input_data = None
 
-        with io.BytesIO(image) as stream:
-            with Image.open(stream) as img:
-                if self._write_file:
-                    img.save(self.filepath, "png")
-                else:
-                    with io.BytesIO() as out_stream:
-                        img.save(out_stream, "png")
-                        input_data = out_stream.getvalue()
+        with io.BytesIO(image) as stream, Image.open(stream) as img:
+            if self._write_file:
+                img.save(self.filepath, "png")
+            else:
+                with io.BytesIO() as out_stream:
+                    img.save(out_stream, "png")
+                    input_data = out_stream.getvalue()
 
         with subprocess.Popen(
             self._command,

--- a/homeassistant/components/seven_segments/image_processing.py
+++ b/homeassistant/components/seven_segments/image_processing.py
@@ -90,7 +90,7 @@ class ImageProcessingSsocr(ImageProcessingEntity):
         self._write_file = config[CONF_WRITE_FILE]
         self._debug_image = config[CONF_DEBUG_IMAGE]
 
-        safe_name = self._attr_name.replace(' ', '_')
+        safe_name = self._attr_name.replace(" ", "_")
         self.filepath = os.path.join(
             hass.config.config_dir,
             f"ssocr-{safe_name}.png",

--- a/homeassistant/components/seven_segments/image_processing.py
+++ b/homeassistant/components/seven_segments/image_processing.py
@@ -30,6 +30,8 @@ CONF_THRESHOLD = "threshold"
 CONF_WIDTH = "width"
 CONF_X_POS = "x_position"
 CONF_Y_POS = "y_position"
+CONF_WRITE_FILE = "write_file"
+CONF_DEBUG_IMAGE = "debug_image"
 
 DEFAULT_BINARY = "ssocr"
 
@@ -44,6 +46,8 @@ PLATFORM_SCHEMA = IMAGE_PROCESSING_PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_WIDTH, default=0): cv.positive_int,
         vol.Optional(CONF_X_POS, default=0): cv.string,
         vol.Optional(CONF_Y_POS, default=0): cv.positive_int,
+        vol.Optional(CONF_WRITE_FILE, default=True): cv.boolean,
+        vol.Optional(CONF_DEBUG_IMAGE, default=False): cv.boolean,
     }
 )
 
@@ -83,10 +87,19 @@ class ImageProcessingSsocr(ImageProcessingEntity):
             self._attr_name = f"SevenSegment OCR {split_entity_id(camera_entity)[1]}"
         self._attr_state = None
 
+        self._write_file = config[CONF_WRITE_FILE]
+        self._debug_image = config[CONF_DEBUG_IMAGE]
+
+        safe_name = self._attr_name.replace(' ', '_')
         self.filepath = os.path.join(
             hass.config.config_dir,
-            f"ssocr-{self._attr_name.replace(' ', '_')}.png",
+            f"ssocr-{safe_name}.png",
         )
+        self.debug_filepath = os.path.join(
+            hass.config.config_dir,
+            f"ssocr-debug-{safe_name}.png",
+        )
+
         crop = [
             "crop",
             str(config[CONF_X_POS]),
@@ -107,21 +120,36 @@ class ImageProcessingSsocr(ImageProcessingEntity):
             *rotate,
             *extra_arguments,
         ]
-        self._command.append(self.filepath)
+
+        if self._debug_image:
+            self._command.append(f"--debug-image={self.debug_filepath}")
+
+        if self._write_file:
+            self._command.append(self.filepath)
+        else:
+            self._command.append("-")
 
     def process_image(self, image: bytes) -> None:
         """Process the image."""
-        stream = io.BytesIO(image)
-        img = Image.open(stream)
-        img.save(self.filepath, "png")
+        input_data = None
+
+        with io.BytesIO(image) as stream:
+            with Image.open(stream) as img:
+                if self._write_file:
+                    img.save(self.filepath, "png")
+                else:
+                    with io.BytesIO() as out_stream:
+                        img.save(out_stream, "png")
+                        input_data = out_stream.getvalue()
 
         with subprocess.Popen(
             self._command,
+            stdin=subprocess.PIPE if not self._write_file else None,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             close_fds=False,  # Required for posix_spawn
         ) as ocr:
-            out = ocr.communicate()
+            out = ocr.communicate(input=input_data)
             if out[0] != b"":
                 self._attr_state = out[0].strip().decode("utf-8")
             else:

--- a/homeassistant/components/seven_segments/image_processing.py
+++ b/homeassistant/components/seven_segments/image_processing.py
@@ -91,7 +91,7 @@ class ImageProcessingSsocr(ImageProcessingEntity):
         self._write_file = config[CONF_WRITE_FILE]
         self._debug_image = config[CONF_DEBUG_IMAGE]
 
-        safe_name = self._attr_name.replace(' ', '_')
+        safe_name = self._attr_name.replace(" ", "_")
         self.filepath = os.path.join(
             hass.config.config_dir,
             f"ssocr-{safe_name}.png",

--- a/homeassistant/components/seven_segments/image_processing.py
+++ b/homeassistant/components/seven_segments/image_processing.py
@@ -31,6 +31,8 @@ CONF_THRESHOLD = "threshold"
 CONF_WIDTH = "width"
 CONF_X_POS = "x_position"
 CONF_Y_POS = "y_position"
+CONF_WRITE_FILE = "write_file"
+CONF_DEBUG_IMAGE = "debug_image"
 
 DEFAULT_BINARY = "ssocr"
 
@@ -45,6 +47,8 @@ PLATFORM_SCHEMA = IMAGE_PROCESSING_PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_WIDTH, default=0): cv.positive_int,
         vol.Optional(CONF_X_POS, default=0): cv.string,
         vol.Optional(CONF_Y_POS, default=0): cv.positive_int,
+        vol.Optional(CONF_WRITE_FILE, default=True): cv.boolean,
+        vol.Optional(CONF_DEBUG_IMAGE, default=False): cv.boolean,
     }
 )
 
@@ -84,10 +88,19 @@ class ImageProcessingSsocr(ImageProcessingEntity):
             self._attr_name = f"SevenSegment OCR {split_entity_id(camera_entity)[1]}"
         self._attr_state = None
 
+        self._write_file = config[CONF_WRITE_FILE]
+        self._debug_image = config[CONF_DEBUG_IMAGE]
+
+        safe_name = self._attr_name.replace(' ', '_')
         self.filepath = os.path.join(
             hass.config.config_dir,
-            f"ssocr-{self._attr_name.replace(' ', '_')}.png",
+            f"ssocr-{safe_name}.png",
         )
+        self.debug_filepath = os.path.join(
+            hass.config.config_dir,
+            f"ssocr-debug-{safe_name}.png",
+        )
+
         crop = [
             "crop",
             str(config[CONF_X_POS]),
@@ -108,22 +121,37 @@ class ImageProcessingSsocr(ImageProcessingEntity):
             *rotate,
             *extra_arguments,
         ]
-        self._command.append(self.filepath)
+
+        if self._debug_image:
+            self._command.append(f"--debug-image={self.debug_filepath}")
+
+        if self._write_file:
+            self._command.append(self.filepath)
+        else:
+            self._command.append("-")
 
     @override
     def process_image(self, image: bytes) -> None:
         """Process the image."""
-        stream = io.BytesIO(image)
-        img = Image.open(stream)
-        img.save(self.filepath, "png")
+        input_data = None
+
+        with io.BytesIO(image) as stream:
+            with Image.open(stream) as img:
+                if self._write_file:
+                    img.save(self.filepath, "png")
+                else:
+                    with io.BytesIO() as out_stream:
+                        img.save(out_stream, "png")
+                        input_data = out_stream.getvalue()
 
         with subprocess.Popen(
             self._command,
+            stdin=subprocess.PIPE if not self._write_file else None,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             close_fds=False,  # Required for posix_spawn
         ) as ocr:
-            out = ocr.communicate()
+            out = ocr.communicate(input=input_data)
             if out[0] != b"":
                 self._attr_state = out[0].strip().decode("utf-8")
             else:

--- a/homeassistant/components/seven_segments/image_processing.py
+++ b/homeassistant/components/seven_segments/image_processing.py
@@ -135,14 +135,13 @@ class ImageProcessingSsocr(ImageProcessingEntity):
         """Process the image."""
         input_data = None
 
-        with io.BytesIO(image) as stream:
-            with Image.open(stream) as img:
-                if self._write_file:
-                    img.save(self.filepath, "png")
-                else:
-                    with io.BytesIO() as out_stream:
-                        img.save(out_stream, "png")
-                        input_data = out_stream.getvalue()
+        with io.BytesIO(image) as stream, Image.open(stream) as img:
+            if self._write_file:
+                img.save(self.filepath, "png")
+            else:
+                with io.BytesIO() as out_stream:
+                    img.save(out_stream, "png")
+                    input_data = out_stream.getvalue()
 
         with subprocess.Popen(
             self._command,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The current Seven Segments OCR integration writes a file to the disk every time it processes a frame. This constant disk I/O causes unnecessary wear and tear on SD cards and other storage types. (Like the Raspberry Pi)

This PR introduces the ability to pass the image data directly to ssocr via STDIN, bypassing the disk. To ensure full backward compatibility for existing users, this is controlled by a new boolean configuration variable write_file which defaults to True. When set to False, the image is processed purely in memory.

Also, this PR exposes ssocr's native --debug-image argument through a new debug_image configuration variable (default False), which is useful for troubleshooting OCR boundaries and thresholding. The reason I have added a specific flag for this, rather than have someone use the extra configuration section is because if we do not specify a safe filename if there are multiple instances of this integration they will overwrite each other, so a new flag is needed.
Here is an example of the debug image:
<img width="412" height="136" alt="Screenshot 2026-06-08 at 7 19 03 PM" src="https://github.com/user-attachments/assets/26b10868-ca27-45ec-9584-84a9a51ada23" />

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

I can add documentation for the new flags, not sure if that would come before or after this PR.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
