### PR TITLE
Fix HomeKit crash on integer device trigger subtypes

### DIFF
--- a/homeassistant/components/homekit/type_triggers.py
+++ b/homeassistant/components/homekit/type_triggers.py
@@ -46,7 +46,7 @@ class DeviceTriggerAccessory(HomeAccessory):
         ent_reg = er.async_get(self.hass)
         for idx, trigger in enumerate(device_triggers):
             type_: str = trigger["type"]
-            subtype: str | None = trigger.get("subtype")
+            subtype: str | int | None = trigger.get("subtype")
             unique_id = f"{type_}-{subtype or ''}"
             entity_id: str | None = None
             if (entity_id_or_uuid := trigger.get("entity_id")) and (
@@ -61,7 +61,7 @@ class DeviceTriggerAccessory(HomeAccessory):
                 trigger_name_parts.append(state.name)
             trigger_name_parts.append(type_.replace("_", " ").title())
             if subtype:
-                trigger_name_parts.append(subtype.replace("_", " ").title())
+                trigger_name_parts.append(str(subtype).replace("_", " ").title())
             trigger_name = cleanup_name_for_homekit(" ".join(trigger_name_parts))
             serv_stateless_switch = self.add_preload_service(
                 SERV_STATELESS_PROGRAMMABLE_SWITCH,

--- a/tests/components/homekit/test_type_triggers.py
+++ b/tests/components/homekit/test_type_triggers.py
@@ -80,3 +80,55 @@ async def test_programmable_switch_button_fires_on_trigger(
         assert char.display_name == CHAR_PROGRAMMABLE_SWITCH_EVENT
     await acc.stop()
     await hass.async_block_till_done()
+
+
+async def test_programmable_switch_with_integer_subtype(
+    hass: HomeAssistant,
+    hk_driver,
+    demo_cleanup,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test DeviceTriggerAccessory handles a non-string (integer) trigger subtype.
+
+    Integrations such as Hue provide the button number as an ``int`` subtype.
+    This previously raised ``AttributeError: 'int' object has no attribute
+    'replace'`` and aborted setup of the whole HomeKit bridge.
+
+    Regression test for https://github.com/home-assistant/core/issues/93834
+    """
+    demo_config_entry = MockConfigEntry(domain="domain")
+    demo_config_entry.add_to_hass(hass)
+    assert await async_setup_component(hass, "homeassistant", {})
+    assert await async_setup_component(hass, "demo", {"demo": {}})
+    await hass.async_block_till_done()
+    hass.states.async_set("light.ceiling_lights", STATE_OFF)
+    await hass.async_block_till_done()
+
+    entry = entity_registry.async_get("light.ceiling_lights")
+    assert entry is not None
+    device_id = entry.device_id
+
+    # An integration such as Hue uses the button number (an int) as the subtype.
+    device_triggers = [
+        {
+            "platform": "device",
+            "domain": "hue",
+            "device_id": device_id,
+            "type": "remote_button_short_release",
+            "subtype": 1,
+        }
+    ]
+    acc = DeviceTriggerAccessory(
+        hass,
+        hk_driver,
+        "DeviceTriggerAccessory",
+        None,
+        1,
+        None,
+        device_id=device_id,
+        device_triggers=device_triggers,
+    )
+
+    switch_service = acc.get_service(SERV_STATELESS_PROGRAMMABLE_SWITCH)
+    configured_name_char = switch_service.get_characteristic(CHAR_CONFIGURED_NAME)
+    assert configured_name_char.value == "Remote Button Short Release 1"


### PR DESCRIPTION
## Proposed change

`DeviceTriggerAccessory` builds the programmable-switch name from a device trigger's `type` and `subtype`, annotating `subtype: str | None` and calling `subtype.replace("_", " ").title()`.

However, some integrations provide a non-string subtype. The Hue integration (`hue/v2/device_trigger.py`) declares `vol.Required(CONF_SUBTYPE): vol.Union(int, str)` and uses the button number (`resource.metadata.control_id`) — an `int` — as the subtype. When such a device is exposed via the HomeKit bridge, `int.replace` raises:

```
AttributeError: 'int' object has no attribute 'replace'
```

This happens in `_async_add_trigger_accessories`, so the exception aborts setup of the **entire HomeKit bridge** — every Hue dimmer (and any other device with an integer subtype) silently disappears from HomeKit, and automations in the Home app that depend on those programmable switches stop working.

This coerces the subtype to a string when constructing the trigger name (and widens the type hint to `str | int | None`). No behavior change for existing string subtypes.

Fixes #93834 (also reported in #146384).

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes issue #93834 (auto-closed as stale without a fix; still reproducible on current `dev`).

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist].
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr