### PR TITLE
Raise an error when a Mitsubishi Comfort command is rejected

### DIFF
--- a/homeassistant/components/mitsubishi_comfort/climate.py
+++ b/homeassistant/components/mitsubishi_comfort/climate.py
@@ -1,6 +1,7 @@
 """Climate entity for Mitsubishi Comfort integration."""
 
-from typing import Any
+import logging
+from typing import Any, NoReturn
 
 from mitsubishi_comfort import FanSpeed, IndoorUnit, Mode, VaneDirection
 
@@ -14,10 +15,14 @@ from homeassistant.components.climate import (
 )
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from .const import DOMAIN
 from .coordinator import MitsubishiComfortConfigEntry, MitsubishiComfortCoordinator
 from .entity import MitsubishiComfortEntity
+
+_LOGGER = logging.getLogger(__name__)
 
 _MODE_TO_HVAC: dict[str, HVACMode] = {
     "off": HVACMode.OFF,
@@ -219,32 +224,47 @@ class MitsubishiComfortClimate(MitsubishiComfortEntity, ClimateEntity):
             features |= ClimateEntityFeature.SWING_MODE
         return features
 
+    def _command_failed(self, translation_key: str) -> NoReturn:
+        """Raise a translated error after the device rejects a command."""
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key=translation_key,
+            translation_placeholders={"device_name": self._device.name},
+        )
+
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set the HVAC mode."""
         lib_mode = _HVAC_TO_MODE.get(hvac_mode)
         if lib_mode is None:
+            _LOGGER.debug("Ignoring unsupported HVAC mode %s", hvac_mode)
             return
         result = await self._device.set_mode(lib_mode)
-        if result.success:
-            self._optimistic[_OPT_MODE] = result.value
-            self.async_write_ha_state()
+        if not result.success:
+            self._command_failed("set_hvac_mode_failed")
+        self._optimistic[_OPT_MODE] = result.value
+        self.async_write_ha_state()
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set the target temperature."""
         mode = self._effective_mode
         wrote = False
+        failed = False
 
         if ATTR_TARGET_TEMP_HIGH in kwargs:
             result = await self._device.set_cool_setpoint(kwargs[ATTR_TARGET_TEMP_HIGH])
             if result.success:
                 self._optimistic[_OPT_COOL_SETPOINT] = result.value
                 wrote = True
+            else:
+                failed = True
 
         if ATTR_TARGET_TEMP_LOW in kwargs:
             result = await self._device.set_heat_setpoint(kwargs[ATTR_TARGET_TEMP_LOW])
             if result.success:
                 self._optimistic[_OPT_HEAT_SETPOINT] = result.value
                 wrote = True
+            else:
+                failed = True
 
         temp = kwargs.get(ATTR_TEMPERATURE)
         if temp is not None:
@@ -253,34 +273,51 @@ class MitsubishiComfortClimate(MitsubishiComfortEntity, ClimateEntity):
                 if result.success:
                     self._optimistic[_OPT_COOL_SETPOINT] = result.value
                     wrote = True
+                else:
+                    failed = True
             elif mode in ("heat", "autoHeat"):
                 result = await self._device.set_heat_setpoint(temp)
                 if result.success:
                     self._optimistic[_OPT_HEAT_SETPOINT] = result.value
                     wrote = True
+                else:
+                    failed = True
+            else:
+                _LOGGER.debug(
+                    "Ignoring temperature for %s: no setpoint applies in mode %s",
+                    self._device.name,
+                    mode,
+                )
 
+        # Apply whatever succeeded before surfacing the failure to the user.
         if wrote:
             self.async_write_ha_state()
+        if failed:
+            self._command_failed("set_temperature_failed")
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set the fan mode."""
         speed = _FAN_SPEED_MAP.get(fan_mode)
         if speed is None:
+            _LOGGER.debug("Ignoring unsupported fan mode %s", fan_mode)
             return
         result = await self._device.set_fan_speed(speed)
-        if result.success:
-            self._optimistic[_OPT_FAN_SPEED] = result.value
-            self.async_write_ha_state()
+        if not result.success:
+            self._command_failed("set_fan_mode_failed")
+        self._optimistic[_OPT_FAN_SPEED] = result.value
+        self.async_write_ha_state()
 
     async def async_set_swing_mode(self, swing_mode: str) -> None:
         """Set the swing mode."""
         direction = _VANE_DIR_MAP.get(swing_mode)
         if direction is None:
+            _LOGGER.debug("Ignoring unsupported swing mode %s", swing_mode)
             return
         result = await self._device.set_vane_direction(direction)
-        if result.success:
-            self._optimistic[_OPT_VANE_DIRECTION] = result.value
-            self.async_write_ha_state()
+        if not result.success:
+            self._command_failed("set_swing_mode_failed")
+        self._optimistic[_OPT_VANE_DIRECTION] = result.value
+        self.async_write_ha_state()
 
     async def async_turn_off(self) -> None:
         """Turn the entity off."""

--- a/homeassistant/components/mitsubishi_comfort/strings.json
+++ b/homeassistant/components/mitsubishi_comfort/strings.json
@@ -29,6 +29,18 @@
     "no_devices": {
       "message": "No devices were found in your Mitsubishi Comfort account"
     },
+    "set_fan_mode_failed": {
+      "message": "{device_name} did not accept the requested fan mode"
+    },
+    "set_hvac_mode_failed": {
+      "message": "{device_name} did not accept the requested HVAC mode"
+    },
+    "set_swing_mode_failed": {
+      "message": "{device_name} did not accept the requested swing mode"
+    },
+    "set_temperature_failed": {
+      "message": "{device_name} did not accept the requested temperature"
+    },
     "update_failed": {
       "message": "{device_name} returned no data"
     }

--- a/tests/components/mitsubishi_comfort/test_climate.py
+++ b/tests/components/mitsubishi_comfort/test_climate.py
@@ -1,5 +1,6 @@
 """Tests for the Mitsubishi Comfort climate entity."""
 
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
@@ -440,13 +441,26 @@ async def test_set_temperature_high_low(
     assert state.attributes[ATTR_TARGET_TEMP_LOW] == 19.0
 
 
+@pytest.mark.parametrize(
+    ("device_mode", "fail_method", "kept_temperature"),
+    [
+        pytest.param("cool", "set_cool_setpoint", 24.0, id="cool"),
+        pytest.param("heat", "set_heat_setpoint", 21.0, id="heat"),
+    ],
+)
 async def test_set_temperature_failed_raises_and_keeps_state(
     hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
     setup_climate: MagicMock,
+    device_mode: str,
+    fail_method: str,
+    kept_temperature: float,
 ) -> None:
     """Test a failed set_temperature raises and keeps the reported setpoint."""
     device = setup_climate
-    device.set_cool_setpoint = AsyncMock(return_value=CommandResult(success=False))
+    device.status = _make_device_status(mode=device_mode)
+    await _refresh(hass, freezer)
+    setattr(device, fail_method, AsyncMock(return_value=CommandResult(success=False)))
 
     with pytest.raises(HomeAssistantError) as err:
         await hass.services.async_call(
@@ -457,7 +471,60 @@ async def test_set_temperature_failed_raises_and_keeps_state(
         )
 
     assert err.value.translation_key == "set_temperature_failed"
-    assert hass.states.get(ENTITY_ID).attributes[ATTR_TEMPERATURE] == 24.0
+    assert hass.states.get(ENTITY_ID).attributes[ATTR_TEMPERATURE] == kept_temperature
+
+
+async def test_set_temperature_range_failed_raises(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    setup_climate: MagicMock,
+) -> None:
+    """Test a failed high/low set_temperature in auto mode raises."""
+    device = setup_climate
+    device.status = _make_device_status(mode="auto")
+    await _refresh(hass, freezer)
+    device.set_cool_setpoint = AsyncMock(return_value=CommandResult(success=False))
+    device.set_heat_setpoint = AsyncMock(return_value=CommandResult(success=False))
+
+    with pytest.raises(HomeAssistantError) as err:
+        await hass.services.async_call(
+            "climate",
+            "set_temperature",
+            {
+                ATTR_ENTITY_ID: ENTITY_ID,
+                ATTR_TARGET_TEMP_HIGH: 25.0,
+                ATTR_TARGET_TEMP_LOW: 19.0,
+            },
+            blocking=True,
+        )
+
+    assert err.value.translation_key == "set_temperature_failed"
+
+
+async def test_set_temperature_no_applicable_setpoint(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    setup_climate: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test set_temperature in a mode with no matching setpoint is ignored and logged."""
+    device = setup_climate
+    device.status = _make_device_status(mode="dry")
+    await _refresh(hass, freezer)
+
+    with caplog.at_level(
+        logging.DEBUG, logger="homeassistant.components.mitsubishi_comfort"
+    ):
+        await hass.services.async_call(
+            "climate",
+            "set_temperature",
+            {ATTR_ENTITY_ID: ENTITY_ID, ATTR_TEMPERATURE: 22.0},
+            blocking=True,
+        )
+
+    device.set_cool_setpoint.assert_not_awaited()
+    device.set_heat_setpoint.assert_not_awaited()
+    assert "no setpoint applies" in caplog.text
 
 
 @pytest.mark.parametrize(
@@ -529,6 +596,28 @@ async def test_set_fan_mode_unknown(
         )
 
 
+async def test_set_fan_mode_unmapped_returns(
+    hass: HomeAssistant,
+    setup_climate: MagicMock,
+) -> None:
+    """Test a supported fan mode missing from the speed map does not call the device."""
+    device = setup_climate
+
+    with patch.dict(
+        "homeassistant.components.mitsubishi_comfort.climate._FAN_SPEED_MAP",
+        {"auto": FanSpeed.AUTO},
+        clear=True,
+    ):
+        await hass.services.async_call(
+            "climate",
+            "set_fan_mode",
+            {ATTR_ENTITY_ID: ENTITY_ID, ATTR_FAN_MODE: "quiet"},
+            blocking=True,
+        )
+
+    device.set_fan_speed.assert_not_awaited()
+
+
 async def test_set_fan_mode_failed_raises_and_keeps_state(
     hass: HomeAssistant,
     setup_climate: MagicMock,
@@ -582,6 +671,28 @@ async def test_set_swing_mode_unknown(
             {ATTR_ENTITY_ID: ENTITY_ID, ATTR_SWING_MODE: "unknown_direction"},
             blocking=True,
         )
+
+
+async def test_set_swing_mode_unmapped_returns(
+    hass: HomeAssistant,
+    setup_climate: MagicMock,
+) -> None:
+    """Test a supported swing mode missing from the direction map does not call the device."""
+    device = setup_climate
+
+    with patch.dict(
+        "homeassistant.components.mitsubishi_comfort.climate._VANE_DIR_MAP",
+        {"auto": VaneDirection.AUTO},
+        clear=True,
+    ):
+        await hass.services.async_call(
+            "climate",
+            "set_swing_mode",
+            {ATTR_ENTITY_ID: ENTITY_ID, ATTR_SWING_MODE: "horizontal"},
+            blocking=True,
+        )
+
+    device.set_vane_direction.assert_not_awaited()
 
 
 async def test_set_swing_mode_failed_raises_and_keeps_state(

--- a/tests/components/mitsubishi_comfort/test_climate.py
+++ b/tests/components/mitsubishi_comfort/test_climate.py
@@ -29,7 +29,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 
 from .conftest import _make_device_status
@@ -319,21 +319,23 @@ async def test_set_hvac_mode(
     assert hass.states.get(ENTITY_ID).state == HVACMode.HEAT
 
 
-async def test_set_hvac_mode_failed_keeps_state(
+async def test_set_hvac_mode_failed_raises_and_keeps_state(
     hass: HomeAssistant,
     setup_climate: MagicMock,
 ) -> None:
-    """Test failed set_hvac_mode does not change reported state."""
+    """Test a failed set_hvac_mode raises and keeps state."""
     device = setup_climate
     device.set_mode = AsyncMock(return_value=CommandResult(success=False))
 
-    await hass.services.async_call(
-        "climate",
-        "set_hvac_mode",
-        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_HVAC_MODE: HVACMode.HEAT},
-        blocking=True,
-    )
+    with pytest.raises(HomeAssistantError) as err:
+        await hass.services.async_call(
+            "climate",
+            "set_hvac_mode",
+            {ATTR_ENTITY_ID: ENTITY_ID, ATTR_HVAC_MODE: HVACMode.HEAT},
+            blocking=True,
+        )
 
+    assert err.value.translation_key == "set_hvac_mode_failed"
     assert hass.states.get(ENTITY_ID).state == HVACMode.COOL
 
 
@@ -438,21 +440,23 @@ async def test_set_temperature_high_low(
     assert state.attributes[ATTR_TARGET_TEMP_LOW] == 19.0
 
 
-async def test_set_temperature_failed_keeps_state(
+async def test_set_temperature_failed_raises_and_keeps_state(
     hass: HomeAssistant,
     setup_climate: MagicMock,
 ) -> None:
-    """Test failed set_temperature does not change reported setpoint."""
+    """Test a failed set_temperature raises and keeps the reported setpoint."""
     device = setup_climate
     device.set_cool_setpoint = AsyncMock(return_value=CommandResult(success=False))
 
-    await hass.services.async_call(
-        "climate",
-        "set_temperature",
-        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_TEMPERATURE: 22.0},
-        blocking=True,
-    )
+    with pytest.raises(HomeAssistantError) as err:
+        await hass.services.async_call(
+            "climate",
+            "set_temperature",
+            {ATTR_ENTITY_ID: ENTITY_ID, ATTR_TEMPERATURE: 22.0},
+            blocking=True,
+        )
 
+    assert err.value.translation_key == "set_temperature_failed"
     assert hass.states.get(ENTITY_ID).attributes[ATTR_TEMPERATURE] == 24.0
 
 
@@ -525,21 +529,23 @@ async def test_set_fan_mode_unknown(
         )
 
 
-async def test_set_fan_mode_failed_keeps_state(
+async def test_set_fan_mode_failed_raises_and_keeps_state(
     hass: HomeAssistant,
     setup_climate: MagicMock,
 ) -> None:
-    """Test failed set_fan_mode does not change reported fan mode."""
+    """Test a failed set_fan_mode raises and keeps the reported fan mode."""
     device = setup_climate
     device.set_fan_speed = AsyncMock(return_value=CommandResult(success=False))
 
-    await hass.services.async_call(
-        "climate",
-        "set_fan_mode",
-        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_FAN_MODE: "quiet"},
-        blocking=True,
-    )
+    with pytest.raises(HomeAssistantError) as err:
+        await hass.services.async_call(
+            "climate",
+            "set_fan_mode",
+            {ATTR_ENTITY_ID: ENTITY_ID, ATTR_FAN_MODE: "quiet"},
+            blocking=True,
+        )
 
+    assert err.value.translation_key == "set_fan_mode_failed"
     assert hass.states.get(ENTITY_ID).attributes[ATTR_FAN_MODE] == "auto"
 
 
@@ -578,21 +584,23 @@ async def test_set_swing_mode_unknown(
         )
 
 
-async def test_set_swing_mode_failed_keeps_state(
+async def test_set_swing_mode_failed_raises_and_keeps_state(
     hass: HomeAssistant,
     setup_climate: MagicMock,
 ) -> None:
-    """Test failed set_swing_mode does not change reported swing mode."""
+    """Test a failed set_swing_mode raises and keeps the reported swing mode."""
     device = setup_climate
     device.set_vane_direction = AsyncMock(return_value=CommandResult(success=False))
 
-    await hass.services.async_call(
-        "climate",
-        "set_swing_mode",
-        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_SWING_MODE: "swing"},
-        blocking=True,
-    )
+    with pytest.raises(HomeAssistantError) as err:
+        await hass.services.async_call(
+            "climate",
+            "set_swing_mode",
+            {ATTR_ENTITY_ID: ENTITY_ID, ATTR_SWING_MODE: "swing"},
+            blocking=True,
+        )
 
+    assert err.value.translation_key == "set_swing_mode_failed"
     assert hass.states.get(ENTITY_ID).attributes[ATTR_SWING_MODE] == "auto"
 
 
@@ -613,6 +621,25 @@ async def test_turn_off(
 
     device.set_mode.assert_awaited_once_with(Mode.OFF)
     assert hass.states.get(ENTITY_ID).state == HVACMode.OFF
+
+
+async def test_turn_off_failed_raises(
+    hass: HomeAssistant,
+    setup_climate: MagicMock,
+) -> None:
+    """Test a failed turn_off (which routes through set_hvac_mode) raises."""
+    device = setup_climate
+    device.set_mode = AsyncMock(return_value=CommandResult(success=False))
+
+    with pytest.raises(HomeAssistantError) as err:
+        await hass.services.async_call(
+            "climate",
+            "turn_off",
+            {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+
+    assert err.value.translation_key == "set_hvac_mode_failed"
 
 
 # -- Optimistic state cleared on next refresh --


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Split out from #173270.

When a `climate` command (`set_hvac_mode`, `set_temperature`, `set_fan_mode`,
`set_swing_mode`) is rejected by the device, the integration previously
swallowed the failure: it left the reported state unchanged and gave the user
no feedback, so a failed command looked like a no-op.

Raise a translated `HomeAssistantError` instead so the user sees that the device
rejected the command. `set_temperature` still applies whichever setpoints
succeeded before surfacing the failure. Unsupported modes (no mapping) continue
to be ignored, now with a debug log line.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #173199
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
