### PR TITLE
Optimistic UI updates for Vistapool write entities

### DIFF
--- a/homeassistant/components/vistapool/button.py
+++ b/homeassistant/components/vistapool/button.py
@@ -67,7 +67,4 @@ class VistapoolLEDPulseButton(VistapoolEntity, ButtonEntity):
                 translation_key="set_failed",
                 translation_placeholders={"entity": self.entity_id},
             ) from err
-        # Optimistically reflect the just-written value so a rapid second press
-        # doesn't read the stale off-state before the Firestore push round-trips.
-        self.coordinator.data.setdefault("light", {})["status"] = 1
-        self.coordinator.async_set_updated_data(self.coordinator.data)
+        self.coordinator.apply_optimistic(_LIGHT_STATUS_PATH, 1)

--- a/homeassistant/components/vistapool/coordinator.py
+++ b/homeassistant/components/vistapool/coordinator.py
@@ -81,3 +81,22 @@ class VistapoolDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     def get_value(self, path: str, default: Any = None) -> Any:
         """Get nested data using dot-notation path."""
         return AquariteClient.get_value(self.data, path, default)
+
+    def apply_optimistic(self, value_path: str, value: Any) -> None:
+        """Reflect a just-written value before the Firestore push round-trips.
+
+        Hayward's cloud takes several seconds to acknowledge a write back
+        through Firestore, which would make the UI feel laggy. Writing into
+        coordinator.data after a successful REST call gives entities instant
+        feedback; the next snapshot from Firestore overwrites it harmlessly.
+        """
+        keys = value_path.split(".")
+        target: dict[str, Any] = self.data
+        for key in keys[:-1]:
+            child = target.get(key)
+            if not isinstance(child, dict):
+                child = {}
+                target[key] = child
+            target = child
+        target[keys[-1]] = value
+        self.async_set_updated_data(self.data)

--- a/homeassistant/components/vistapool/light.py
+++ b/homeassistant/components/vistapool/light.py
@@ -71,3 +71,4 @@ class VistapoolLight(VistapoolEntity, LightEntity):
                 translation_key="set_failed",
                 translation_placeholders={"entity": self.entity_id},
             ) from err
+        self.coordinator.apply_optimistic(_VALUE_PATH, value)

--- a/homeassistant/components/vistapool/number.py
+++ b/homeassistant/components/vistapool/number.py
@@ -233,3 +233,4 @@ class VistapoolNumber(VistapoolEntity, NumberEntity):
                 translation_key="set_failed",
                 translation_placeholders={"entity": self.entity_id},
             ) from err
+        self.coordinator.apply_optimistic(self.entity_description.value_path, raw)

--- a/tests/components/vistapool/test_init.py
+++ b/tests/components/vistapool/test_init.py
@@ -103,6 +103,26 @@ async def test_setup_entry_subscribe_failure(
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
+async def test_apply_optimistic_creates_missing_intermediate_dicts(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_vistapool_client: AsyncMock,
+) -> None:
+    """Test apply_optimistic walks through and creates missing intermediate dicts."""
+    mock_vistapool_client.fetch_pool_data.return_value = {"existing": "scalar"}
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = next(iter(mock_config_entry.runtime_data.coordinators.values()))
+    coordinator.apply_optimistic("filtration.intel.temp", 27)
+    coordinator.apply_optimistic("existing.nested.key", 1)
+
+    assert coordinator.data["filtration"]["intel"]["temp"] == 27
+    assert coordinator.data["existing"] == {"nested": {"key": 1}}
+
+
 async def test_unload_entry(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,

--- a/tests/components/vistapool/test_light.py
+++ b/tests/components/vistapool/test_light.py
@@ -98,6 +98,43 @@ async def test_light_set_value(
     )
 
 
+@pytest.mark.parametrize(
+    ("service", "initial_status", "initial_state", "expected_state"),
+    [
+        pytest.param(SERVICE_TURN_ON, 0, STATE_OFF, STATE_ON, id="turn_on"),
+        pytest.param(SERVICE_TURN_OFF, 1, STATE_ON, STATE_OFF, id="turn_off"),
+    ],
+)
+async def test_light_optimistic_state(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_vistapool_client: AsyncMock,
+    mock_pool_data: dict[str, Any],
+    service: str,
+    initial_status: int,
+    initial_state: str,
+    expected_state: str,
+) -> None:
+    """Test the entity state reflects the just-written value before the Firestore push."""
+    mock_pool_data["light"] = {"status": initial_status}
+    mock_vistapool_client.fetch_pool_data.return_value = mock_pool_data
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("light.my_pool_light").state == initial_state
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        service,
+        {ATTR_ENTITY_ID: "light.my_pool_light"},
+        blocking=True,
+    )
+
+    assert hass.states.get("light.my_pool_light").state == expected_state
+
+
 async def test_light_set_value_raises_on_api_error(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,

--- a/tests/components/vistapool/test_number.py
+++ b/tests/components/vistapool/test_number.py
@@ -232,6 +232,7 @@ async def test_number_set_value(
     mock_vistapool_client.set_value.assert_awaited_once_with(
         "ABCDEF1234567890", expected_path, expected_raw
     )
+    assert hass.states.get(entity_id).state == str(float(user_value))
     value_arg = mock_vistapool_client.set_value.await_args.args[2]
     assert isinstance(value_arg, int)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Vistapool's cloud round-trip is 5-10 seconds end to end: REST ack → controller execution → Firestore document write → `on_snapshot` push back to Home Assistant. Until the snapshot lands, light and number entities still report the old state, which makes the UI feel unresponsive ("I tapped the light and nothing happened").

Add `coordinator.apply_optimistic(value_path, value)` that writes the just-acknowledged value straight into `coordinator.data` and fires `async_set_updated_data`, so entities flip immediately. When the real Firestore push arrives a few seconds later, it lands on the same value with no jitter. If the cloud silently fails to deliver the command (offline controller), the next genuine snapshot corrects the state — same recovery behavior as any other optimistic write entity in core.

The LED-pulse button already did this inline; the helper replaces that and is now also called from:

- `light.async_turn_on` / `light.async_turn_off`
- `number.async_set_native_value`

New tests:

- `test_light_optimistic_state` — parametrized over turn_on/turn_off, asserts the entity flips immediately after the service call without waiting for any simulated push.
- `test_number_set_value` — extended to assert the entity state reflects the user-set value right after the service call.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr