### PR TITLE
Adjust pylint checker to prevent invalid use of Platform enum

### DIFF
--- a/pylint/plugins/pylint_home_assistant/checkers/domain_constant.py
+++ b/pylint/plugins/pylint_home_assistant/checkers/domain_constant.py
@@ -1,4 +1,8 @@
-"""Plugin to encourage correct use of DOMAIN constants in tests."""
+"""Plugin to prevent incorrect use of Platform enum in tests.
+
+This plugin checks for common test helper functions and methods
+where a domain is expected, and ensures the argument is not a Platform.
+"""
 
 from dataclasses import dataclass
 
@@ -15,7 +19,6 @@ class ArgumentCheckInfo:
 
     position: int | None
     name: str
-    allow_iterable: bool = False
 
 
 _FUNCTION_CHECKS: list[tuple[str, ArgumentCheckInfo]] = [
@@ -27,11 +30,8 @@ _METHOD_CHECKS: list[tuple[str, str, ArgumentCheckInfo]] = [
     ("hass.config_entries.flow", "async_init", ArgumentCheckInfo(0, "handler")),
     ("hass.services", "async_call", ArgumentCheckInfo(0, "domain")),
     ("hass.services", "call", ArgumentCheckInfo(0, "domain")),
-    ("hass.states", "async_entity_ids", ArgumentCheckInfo(0, "domain_filter", True)),
+    ("hass.states", "async_entity_ids", ArgumentCheckInfo(0, "domain_filter")),
 ]
-
-_DOMAIN_CONSTANTS: set[str] = {"DOMAIN", "domain"}
-_DOMAIN_SUFFIXES: tuple[str, ...] = ("_DOMAIN", "_domain")
 
 
 def _check_call_node_domain_arguments(node: nodes.Call) -> nodes.NodeNG | None:
@@ -73,18 +73,19 @@ def _check_call_node_domain_argument(
             None,
         )
 
-    if argument_node and not _check_domain_argument(
-        argument_node, arg_info.allow_iterable
-    ):
+    if argument_node and not _check_domain_argument(argument_node):
         return argument_node
 
     return None
 
 
-def _check_domain_argument(arg_node: nodes.NodeNG, allow_iterable: bool) -> bool:
+def _check_domain_argument(arg_node: nodes.NodeNG) -> bool:
     """Ensure the argument node is a domain constant or variable.
 
-    We allow:
+    We currently only disallow `Platform.Xyz`
+
+    The plugin can be extended in the future to improve consistencey and
+    only allow certain patterns for domain arguments, such as:
         - x.DOMAIN/x.domain attribute (including *_DOMAIN/*_domain)
         - DOMAIN/domain name (including *_DOMAIN/*_domain)
         - string literals
@@ -94,29 +95,10 @@ def _check_domain_argument(arg_node: nodes.NodeNG, allow_iterable: bool) -> bool
     """
     match arg_node:
         case nodes.Attribute():
-            if (
-                attrname := arg_node.attrname
-            ) in _DOMAIN_CONSTANTS or attrname.endswith(_DOMAIN_SUFFIXES):
-                return True
-        case nodes.Const():
-            if isinstance(arg_node.value, str):
-                return True
-        case nodes.Name():
-            if (node_name := arg_node.name) in _DOMAIN_CONSTANTS or node_name.endswith(
-                _DOMAIN_SUFFIXES
-            ):
-                return True
-        case nodes.Subscript():
-            # Ignore subscripts like dict["key"]
-            return True
-        case nodes.Tuple():
-            if allow_iterable:
-                return all(
-                    _check_domain_argument(element, allow_iterable=False)
-                    for element in arg_node.elts
-                )
+            if arg_node.expr.as_string() == "Platform":
+                return False
 
-    return False
+    return True
 
 
 class DomainConstantChecker(BaseChecker):

--- a/pylint/plugins/pylint_home_assistant/checkers/domain_constant.py
+++ b/pylint/plugins/pylint_home_assistant/checkers/domain_constant.py
@@ -84,7 +84,7 @@ def _check_domain_argument(arg_node: nodes.NodeNG) -> bool:
 
     We currently only disallow `Platform.Xyz`
 
-    The plugin can be extended in the future to improve consistencey and
+    The plugin can be extended in the future to improve consistency and
     only allow certain patterns for domain arguments, such as:
         - x.DOMAIN/x.domain attribute (including *_DOMAIN/*_domain)
         - DOMAIN/domain name (including *_DOMAIN/*_domain)

--- a/pylint/plugins/pylint_home_assistant/checkers/domain_constant.py
+++ b/pylint/plugins/pylint_home_assistant/checkers/domain_constant.py
@@ -84,8 +84,9 @@ def _check_domain_argument(arg_node: nodes.NodeNG) -> bool:
 
     We currently only disallow `Platform.Xyz`
 
-    The plugin can be extended in the future to improve consistency and
-    only allow certain patterns for domain arguments, such as:
+    The plugin can be extended in the future (see #173374) to improve
+    consistency and only allow certain patterns for domain arguments,
+    such as:
         - x.DOMAIN/x.domain attribute (including *_DOMAIN/*_domain)
         - DOMAIN/domain name (including *_DOMAIN/*_domain)
         - string literals

--- a/pylint/plugins/pylint_home_assistant/checkers/domain_constant.py
+++ b/pylint/plugins/pylint_home_assistant/checkers/domain_constant.py
@@ -19,6 +19,7 @@ class ArgumentCheckInfo:
 
     position: int | None
     name: str
+    allow_iterable: bool = False
 
 
 _FUNCTION_CHECKS: list[tuple[str, ArgumentCheckInfo]] = [
@@ -30,7 +31,7 @@ _METHOD_CHECKS: list[tuple[str, str, ArgumentCheckInfo]] = [
     ("hass.config_entries.flow", "async_init", ArgumentCheckInfo(0, "handler")),
     ("hass.services", "async_call", ArgumentCheckInfo(0, "domain")),
     ("hass.services", "call", ArgumentCheckInfo(0, "domain")),
-    ("hass.states", "async_entity_ids", ArgumentCheckInfo(0, "domain_filter")),
+    ("hass.states", "async_entity_ids", ArgumentCheckInfo(0, "domain_filter", True)),
 ]
 
 
@@ -73,13 +74,15 @@ def _check_call_node_domain_argument(
             None,
         )
 
-    if argument_node and not _check_domain_argument(argument_node):
+    if argument_node and not _check_domain_argument(
+        argument_node, arg_info.allow_iterable
+    ):
         return argument_node
 
     return None
 
 
-def _check_domain_argument(arg_node: nodes.NodeNG) -> bool:
+def _check_domain_argument(arg_node: nodes.NodeNG, allow_iterable: bool = True) -> bool:
     """Ensure the argument node is a domain constant or variable.
 
     We currently only disallow `Platform.Xyz`
@@ -98,6 +101,12 @@ def _check_domain_argument(arg_node: nodes.NodeNG) -> bool:
         case nodes.Attribute():
             if arg_node.expr.as_string() == "Platform":
                 return False
+        case nodes.Tuple():
+            if allow_iterable:
+                return all(
+                    _check_domain_argument(element, allow_iterable=False)
+                    for element in arg_node.elts
+                )
 
     return True
 

--- a/tests/pylint/test_domain_constant.py
+++ b/tests/pylint/test_domain_constant.py
@@ -233,9 +233,9 @@ def test_no_warning(
     [
         pytest.param(
             """
-async_setup_component(hass, Platform.OTHER, {})
+async_setup_component(hass, Platform.Something, {})
 """,
-            ("Platform.OTHER", "async_setup_component"),
+            ("Platform.Something", "async_setup_component"),
             id="attribute_platform",
         ),
     ],

--- a/tests/pylint/test_domain_constant.py
+++ b/tests/pylint/test_domain_constant.py
@@ -146,6 +146,72 @@ hass.services.unrelated("other")
 """,
             id="unrelated_method",
         ),
+        pytest.param(
+            """
+async_setup_component(hass, OTHER, {})
+""",
+            id="name_not_domain",
+        ),
+        pytest.param(
+            """
+async_setup_component(hass, sensor.OTHER, {})
+""",
+            id="attribute_not_domain",
+        ),
+        pytest.param(
+            """
+async_setup_component(hass, 5, {})
+""",
+            id="non_string_constant",
+        ),
+        pytest.param(
+            """
+async_mock_service(hass, OTHER, "service")
+""",
+            id="async_mock_service",
+        ),
+        pytest.param(
+            """
+MockConfigEntry(domain=OTHER)
+""",
+            id="mock_config_entry_kwarg",
+        ),
+        pytest.param(
+            """
+hass.services.async_call(OTHER, "service")
+""",
+            id="services_async_call",
+        ),
+        pytest.param(
+            """
+hass.services.call(OTHER, "service")
+""",
+            id="services_call",
+        ),
+        pytest.param(
+            """
+hass.config_entries.flow.async_init(OTHER)
+""",
+            id="flow_async_init_positional",
+        ),
+        pytest.param(
+            """
+hass.config_entries.flow.async_init(handler=OTHER)
+""",
+            id="flow_async_init_kwarg",
+        ),
+        pytest.param(
+            """
+hass.states.async_entity_ids(OTHER)
+""",
+            id="async_entity_ids",
+        ),
+        pytest.param(
+            """
+hass.states.async_entity_ids((DOMAIN, OTHER))
+""",
+            id="async_entity_ids_tuple",
+        ),
     ],
 )
 def test_no_warning(
@@ -167,80 +233,10 @@ def test_no_warning(
     [
         pytest.param(
             """
-async_setup_component(hass, OTHER, {})
+async_setup_component(hass, Platform.OTHER, {})
 """,
-            ("OTHER", "async_setup_component"),
-            id="name_not_domain",
-        ),
-        pytest.param(
-            """
-async_setup_component(hass, sensor.OTHER, {})
-""",
-            ("sensor.OTHER", "async_setup_component"),
-            id="attribute_not_domain",
-        ),
-        pytest.param(
-            """
-async_setup_component(hass, 5, {})
-""",
-            ("5", "async_setup_component"),
-            id="non_string_constant",
-        ),
-        pytest.param(
-            """
-async_mock_service(hass, OTHER, "service")
-""",
-            ("OTHER", "async_mock_service"),
-            id="async_mock_service",
-        ),
-        pytest.param(
-            """
-MockConfigEntry(domain=OTHER)
-""",
-            ("OTHER", "MockConfigEntry"),
-            id="mock_config_entry_kwarg",
-        ),
-        pytest.param(
-            """
-hass.services.async_call(OTHER, "service")
-""",
-            ("OTHER", "hass.services.async_call"),
-            id="services_async_call",
-        ),
-        pytest.param(
-            """
-hass.services.call(OTHER, "service")
-""",
-            ("OTHER", "hass.services.call"),
-            id="services_call",
-        ),
-        pytest.param(
-            """
-hass.config_entries.flow.async_init(OTHER)
-""",
-            ("OTHER", "hass.config_entries.flow.async_init"),
-            id="flow_async_init_positional",
-        ),
-        pytest.param(
-            """
-hass.config_entries.flow.async_init(handler=OTHER)
-""",
-            ("OTHER", "hass.config_entries.flow.async_init"),
-            id="flow_async_init_kwarg",
-        ),
-        pytest.param(
-            """
-hass.states.async_entity_ids(OTHER)
-""",
-            ("OTHER", "hass.states.async_entity_ids"),
-            id="async_entity_ids",
-        ),
-        pytest.param(
-            """
-hass.states.async_entity_ids((DOMAIN, OTHER))
-""",
-            ("(DOMAIN, OTHER)", "hass.states.async_entity_ids"),
-            id="async_entity_ids_tuple",
+            ("Platform.OTHER", "async_setup_component"),
+            id="attribute_platform",
         ),
     ],
 )

--- a/tests/pylint/test_domain_constant.py
+++ b/tests/pylint/test_domain_constant.py
@@ -174,7 +174,7 @@ async_mock_service(hass, OTHER, "service")
             """
 MockConfigEntry(domain=OTHER)
 """,
-            id="mock_config_entry_kwarg_other_other",
+            id="mock_config_entry_kwarg_other",
         ),
         pytest.param(
             """

--- a/tests/pylint/test_domain_constant.py
+++ b/tests/pylint/test_domain_constant.py
@@ -238,6 +238,13 @@ async_setup_component(hass, Platform.Something, {})
             ("Platform.Something", "async_setup_component"),
             id="attribute_platform",
         ),
+        pytest.param(
+            """
+hass.states.async_entity_ids((Platform.SENSOR, DOMAIN))
+""",
+            ("(Platform.SENSOR, DOMAIN)", "hass.states.async_entity_ids"),
+            id="attribute_platform_tuple",
+        ),
     ],
 )
 def test_domain_argument_flagged(

--- a/tests/pylint/test_domain_constant.py
+++ b/tests/pylint/test_domain_constant.py
@@ -168,49 +168,49 @@ async_setup_component(hass, 5, {})
             """
 async_mock_service(hass, OTHER, "service")
 """,
-            id="async_mock_service",
+            id="async_mock_service_other",
         ),
         pytest.param(
             """
 MockConfigEntry(domain=OTHER)
 """,
-            id="mock_config_entry_kwarg",
+            id="mock_config_entry_kwarg_other_other",
         ),
         pytest.param(
             """
 hass.services.async_call(OTHER, "service")
 """,
-            id="services_async_call",
+            id="services_async_call_other",
         ),
         pytest.param(
             """
 hass.services.call(OTHER, "service")
 """,
-            id="services_call",
+            id="services_call_other",
         ),
         pytest.param(
             """
 hass.config_entries.flow.async_init(OTHER)
 """,
-            id="flow_async_init_positional",
+            id="flow_async_init_positional_other",
         ),
         pytest.param(
             """
 hass.config_entries.flow.async_init(handler=OTHER)
 """,
-            id="flow_async_init_kwarg",
+            id="flow_async_init_kwarg_other",
         ),
         pytest.param(
             """
 hass.states.async_entity_ids(OTHER)
 """,
-            id="async_entity_ids",
+            id="async_entity_ids_other",
         ),
         pytest.param(
             """
 hass.states.async_entity_ids((DOMAIN, OTHER))
 """,
-            id="async_entity_ids_tuple",
+            id="async_entity_ids_tuple_other",
         ),
     ],
 )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
It seems that sadly #173004 is not wanted.

This inverts the logic, so that we check for specific invalid patterns (using `Platform.X` enum) instead of checking for a "preferred" pattern which would make the test code much more consistent.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
