### PR TITLE
Add Hot Water Override select entity to opentherm_gw

### DIFF
--- a/homeassistant/components/opentherm_gw/select.py
+++ b/homeassistant/components/opentherm_gw/select.py
@@ -2,10 +2,11 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from enum import IntEnum, StrEnum
+from enum import Enum, IntEnum, StrEnum
 from functools import partial
 
 from pyotgw.vars import (
+    OTGW_DHW_OVRD,
     OTGW_GPIO_A,
     OTGW_GPIO_B,
     OTGW_LED_A,
@@ -30,6 +31,14 @@ from .const import (
     OpenThermDataSource,
 )
 from .entity import OpenThermEntityDescription, OpenThermStatusEntity
+
+
+class OpenThermSelectDHWOvrdMode(StrEnum):
+    """OpenTherm Gateway Hot Water Override modes."""
+
+    OFF = "force_off"
+    ON = "force_on"
+    DISABLED = "override_disabled"
 
 
 class OpenThermSelectGPIOMode(StrEnum):
@@ -61,6 +70,14 @@ class OpenThermSelectLEDMode(StrEnum):
     TX_ERROR_DETECTED = "transmit_error_detected"
     BOILER_MAINTENANCE_REQUIRED = "boiler_maintenance_required"
     RAISED_POWER_MODE_ACTIVE = "raised_power_mode_active"
+
+
+class PyotgwDHWOvrdMode(Enum):
+    """pyotgw Hot Water Override modes."""
+
+    OFF = 0
+    ON = 1
+    DISABLED = "A"
 
 
 class PyotgwGPIOMode(IntEnum):
@@ -105,6 +122,20 @@ def pyotgw_led_mode_to_ha_led_mode(
     )
 
 
+async def set_dhw_ovrd_mode(
+    gw_hub: OpenThermGatewayHub, mode: str
+) -> OpenThermSelectDHWOvrdMode:
+    """Set hot water override mode, return selected option."""
+    value = await gw_hub.gateway.set_hot_water_ovrd(
+        PyotgwDHWOvrdMode[OpenThermSelectDHWOvrdMode(mode).name].value
+    )
+    return (
+        OpenThermSelectDHWOvrdMode[PyotgwDHWOvrdMode(value).name]
+        if value in PyotgwDHWOvrdMode
+        else OpenThermSelectDHWOvrdMode.DISABLED
+    )
+
+
 async def set_gpio_mode(
     gpio_id: str, gw_hub: OpenThermGatewayHub, mode: str
 ) -> OpenThermSelectGPIOMode | None:
@@ -144,6 +175,18 @@ class OpenThermSelectEntityDescription(
 
 
 SELECT_DESCRIPTIONS: tuple[OpenThermSelectEntityDescription, ...] = (
+    OpenThermSelectEntityDescription(
+        key=OTGW_DHW_OVRD,
+        translation_key="dhw_ovrd_mode",
+        device_description=GATEWAY_DEVICE_DESCRIPTION,
+        options=list(OpenThermSelectDHWOvrdMode),
+        select_action=set_dhw_ovrd_mode,
+        convert_pyotgw_state_to_ha_state=(
+            lambda state: OpenThermSelectDHWOvrdMode[PyotgwDHWOvrdMode(state).name]
+            if state in PyotgwDHWOvrdMode
+            else OpenThermSelectDHWOvrdMode.DISABLED
+        ),
+    ),
     OpenThermSelectEntityDescription(
         key=OTGW_GPIO_A,
         translation_key="gpio_mode_n",

--- a/homeassistant/components/opentherm_gw/select.py
+++ b/homeassistant/components/opentherm_gw/select.py
@@ -124,7 +124,7 @@ def pyotgw_led_mode_to_ha_led_mode(
 
 async def set_dhw_ovrd_mode(
     gw_hub: OpenThermGatewayHub, mode: str
-) -> OpenThermSelectDHWOvrdMode:
+) -> OpenThermSelectDHWOvrdMode | None:
     """Set hot water override mode, return selected option."""
     value = await gw_hub.gateway.set_hot_water_ovrd(
         PyotgwDHWOvrdMode[OpenThermSelectDHWOvrdMode(mode).name].value
@@ -132,7 +132,7 @@ async def set_dhw_ovrd_mode(
     return (
         OpenThermSelectDHWOvrdMode[PyotgwDHWOvrdMode(value).name]
         if value in PyotgwDHWOvrdMode
-        else OpenThermSelectDHWOvrdMode.DISABLED
+        else None
     )
 
 
@@ -185,7 +185,7 @@ SELECT_DESCRIPTIONS: tuple[OpenThermSelectEntityDescription, ...] = (
             lambda state: (
                 OpenThermSelectDHWOvrdMode[PyotgwDHWOvrdMode(state).name]
                 if state in PyotgwDHWOvrdMode
-                else OpenThermSelectDHWOvrdMode.DISABLED
+                else None
             )
         ),
     ),

--- a/homeassistant/components/opentherm_gw/select.py
+++ b/homeassistant/components/opentherm_gw/select.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from enum import Enum, IntEnum, StrEnum
+from enum import IntEnum, StrEnum
 from functools import partial
 
 from pyotgw.vars import (
@@ -32,13 +32,14 @@ from .const import (
 )
 from .entity import OpenThermEntityDescription, OpenThermStatusEntity
 
+MAP_DHW_OVRD_MODES = {
+    "force_off": 0,
+    "force_on": 1,
+    "override_disabled": "A",
+}
 
-class OpenThermSelectDHWOvrdMode(StrEnum):
-    """OpenTherm Gateway Hot Water Override modes."""
 
-    OFF = "force_off"
-    ON = "force_on"
-    DISABLED = "override_disabled"
+INVERSE_MAP_DHW_OVRD_MODES = {v: k for k, v in MAP_DHW_OVRD_MODES.items()}
 
 
 class OpenThermSelectGPIOMode(StrEnum):
@@ -70,14 +71,6 @@ class OpenThermSelectLEDMode(StrEnum):
     TX_ERROR_DETECTED = "transmit_error_detected"
     BOILER_MAINTENANCE_REQUIRED = "boiler_maintenance_required"
     RAISED_POWER_MODE_ACTIVE = "raised_power_mode_active"
-
-
-class PyotgwDHWOvrdMode(Enum):
-    """pyotgw Hot Water Override modes."""
-
-    OFF = 0
-    ON = 1
-    DISABLED = "A"
 
 
 class PyotgwGPIOMode(IntEnum):
@@ -122,18 +115,10 @@ def pyotgw_led_mode_to_ha_led_mode(
     )
 
 
-async def set_dhw_ovrd_mode(
-    gw_hub: OpenThermGatewayHub, mode: str
-) -> OpenThermSelectDHWOvrdMode | None:
+async def set_dhw_ovrd_mode(gw_hub: OpenThermGatewayHub, mode: str) -> str | None:
     """Set hot water override mode, return selected option."""
-    value = await gw_hub.gateway.set_hot_water_ovrd(
-        PyotgwDHWOvrdMode[OpenThermSelectDHWOvrdMode(mode).name].value
-    )
-    return (
-        OpenThermSelectDHWOvrdMode[PyotgwDHWOvrdMode(value).name]
-        if value in PyotgwDHWOvrdMode
-        else None
-    )
+    value = await gw_hub.gateway.set_hot_water_ovrd(MAP_DHW_OVRD_MODES[mode])
+    return INVERSE_MAP_DHW_OVRD_MODES.get(value)
 
 
 async def set_gpio_mode(
@@ -179,15 +164,9 @@ SELECT_DESCRIPTIONS: tuple[OpenThermSelectEntityDescription, ...] = (
         key=OTGW_DHW_OVRD,
         translation_key="dhw_ovrd_mode",
         device_description=GATEWAY_DEVICE_DESCRIPTION,
-        options=list(OpenThermSelectDHWOvrdMode),
+        options=list(MAP_DHW_OVRD_MODES.keys()),
         select_action=set_dhw_ovrd_mode,
-        convert_pyotgw_state_to_ha_state=(
-            lambda state: (
-                OpenThermSelectDHWOvrdMode[PyotgwDHWOvrdMode(state).name]
-                if state in PyotgwDHWOvrdMode
-                else None
-            )
-        ),
+        convert_pyotgw_state_to_ha_state=INVERSE_MAP_DHW_OVRD_MODES.get,
     ),
     OpenThermSelectEntityDescription(
         key=OTGW_GPIO_A,

--- a/homeassistant/components/opentherm_gw/select.py
+++ b/homeassistant/components/opentherm_gw/select.py
@@ -182,9 +182,11 @@ SELECT_DESCRIPTIONS: tuple[OpenThermSelectEntityDescription, ...] = (
         options=list(OpenThermSelectDHWOvrdMode),
         select_action=set_dhw_ovrd_mode,
         convert_pyotgw_state_to_ha_state=(
-            lambda state: OpenThermSelectDHWOvrdMode[PyotgwDHWOvrdMode(state).name]
-            if state in PyotgwDHWOvrdMode
-            else OpenThermSelectDHWOvrdMode.DISABLED
+            lambda state: (
+                OpenThermSelectDHWOvrdMode[PyotgwDHWOvrdMode(state).name]
+                if state in PyotgwDHWOvrdMode
+                else OpenThermSelectDHWOvrdMode.DISABLED
+            )
         ),
     ),
     OpenThermSelectEntityDescription(

--- a/homeassistant/components/opentherm_gw/select.py
+++ b/homeassistant/components/opentherm_gw/select.py
@@ -2,11 +2,12 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from enum import IntEnum, StrEnum
+from enum import Enum, IntEnum, StrEnum
 from functools import partial
 from typing import override
 
 from pyotgw.vars import (
+    OTGW_DHW_OVRD,
     OTGW_GPIO_A,
     OTGW_GPIO_B,
     OTGW_LED_A,
@@ -31,6 +32,14 @@ from .const import (
     OpenThermDataSource,
 )
 from .entity import OpenThermEntityDescription, OpenThermStatusEntity
+
+
+class OpenThermSelectDHWOvrdMode(StrEnum):
+    """OpenTherm Gateway Hot Water Override modes."""
+
+    OFF = "force_off"
+    ON = "force_on"
+    DISABLED = "override_disabled"
 
 
 class OpenThermSelectGPIOMode(StrEnum):
@@ -62,6 +71,14 @@ class OpenThermSelectLEDMode(StrEnum):
     TX_ERROR_DETECTED = "transmit_error_detected"
     BOILER_MAINTENANCE_REQUIRED = "boiler_maintenance_required"
     RAISED_POWER_MODE_ACTIVE = "raised_power_mode_active"
+
+
+class PyotgwDHWOvrdMode(Enum):
+    """pyotgw Hot Water Override modes."""
+
+    OFF = 0
+    ON = 1
+    DISABLED = "A"
 
 
 class PyotgwGPIOMode(IntEnum):
@@ -106,6 +123,20 @@ def pyotgw_led_mode_to_ha_led_mode(
     )
 
 
+async def set_dhw_ovrd_mode(
+    gw_hub: OpenThermGatewayHub, mode: str
+) -> OpenThermSelectDHWOvrdMode:
+    """Set hot water override mode, return selected option."""
+    value = await gw_hub.gateway.set_hot_water_ovrd(
+        PyotgwDHWOvrdMode[OpenThermSelectDHWOvrdMode(mode).name].value
+    )
+    return (
+        OpenThermSelectDHWOvrdMode[PyotgwDHWOvrdMode(value).name]
+        if value in PyotgwDHWOvrdMode
+        else OpenThermSelectDHWOvrdMode.DISABLED
+    )
+
+
 async def set_gpio_mode(
     gpio_id: str, gw_hub: OpenThermGatewayHub, mode: str
 ) -> OpenThermSelectGPIOMode | None:
@@ -145,6 +176,18 @@ class OpenThermSelectEntityDescription(
 
 
 SELECT_DESCRIPTIONS: tuple[OpenThermSelectEntityDescription, ...] = (
+    OpenThermSelectEntityDescription(
+        key=OTGW_DHW_OVRD,
+        translation_key="dhw_ovrd_mode",
+        device_description=GATEWAY_DEVICE_DESCRIPTION,
+        options=list(OpenThermSelectDHWOvrdMode),
+        select_action=set_dhw_ovrd_mode,
+        convert_pyotgw_state_to_ha_state=(
+            lambda state: OpenThermSelectDHWOvrdMode[PyotgwDHWOvrdMode(state).name]
+            if state in PyotgwDHWOvrdMode
+            else OpenThermSelectDHWOvrdMode.DISABLED
+        ),
+    ),
     OpenThermSelectEntityDescription(
         key=OTGW_GPIO_A,
         translation_key="gpio_mode_n",

--- a/homeassistant/components/opentherm_gw/select.py
+++ b/homeassistant/components/opentherm_gw/select.py
@@ -125,7 +125,7 @@ def pyotgw_led_mode_to_ha_led_mode(
 
 async def set_dhw_ovrd_mode(
     gw_hub: OpenThermGatewayHub, mode: str
-) -> OpenThermSelectDHWOvrdMode:
+) -> OpenThermSelectDHWOvrdMode | None:
     """Set hot water override mode, return selected option."""
     value = await gw_hub.gateway.set_hot_water_ovrd(
         PyotgwDHWOvrdMode[OpenThermSelectDHWOvrdMode(mode).name].value
@@ -133,7 +133,7 @@ async def set_dhw_ovrd_mode(
     return (
         OpenThermSelectDHWOvrdMode[PyotgwDHWOvrdMode(value).name]
         if value in PyotgwDHWOvrdMode
-        else OpenThermSelectDHWOvrdMode.DISABLED
+        else None
     )
 
 
@@ -186,7 +186,7 @@ SELECT_DESCRIPTIONS: tuple[OpenThermSelectEntityDescription, ...] = (
             lambda state: (
                 OpenThermSelectDHWOvrdMode[PyotgwDHWOvrdMode(state).name]
                 if state in PyotgwDHWOvrdMode
-                else OpenThermSelectDHWOvrdMode.DISABLED
+                else None
             )
         ),
     ),

--- a/homeassistant/components/opentherm_gw/select.py
+++ b/homeassistant/components/opentherm_gw/select.py
@@ -183,9 +183,11 @@ SELECT_DESCRIPTIONS: tuple[OpenThermSelectEntityDescription, ...] = (
         options=list(OpenThermSelectDHWOvrdMode),
         select_action=set_dhw_ovrd_mode,
         convert_pyotgw_state_to_ha_state=(
-            lambda state: OpenThermSelectDHWOvrdMode[PyotgwDHWOvrdMode(state).name]
-            if state in PyotgwDHWOvrdMode
-            else OpenThermSelectDHWOvrdMode.DISABLED
+            lambda state: (
+                OpenThermSelectDHWOvrdMode[PyotgwDHWOvrdMode(state).name]
+                if state in PyotgwDHWOvrdMode
+                else OpenThermSelectDHWOvrdMode.DISABLED
+            )
         ),
     ),
     OpenThermSelectEntityDescription(

--- a/homeassistant/components/opentherm_gw/select.py
+++ b/homeassistant/components/opentherm_gw/select.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from enum import Enum, IntEnum, StrEnum
+from enum import IntEnum, StrEnum
 from functools import partial
 from typing import override
 
@@ -33,13 +33,14 @@ from .const import (
 )
 from .entity import OpenThermEntityDescription, OpenThermStatusEntity
 
+MAP_DHW_OVRD_MODES = {
+    "force_off": 0,
+    "force_on": 1,
+    "override_disabled": "A",
+}
 
-class OpenThermSelectDHWOvrdMode(StrEnum):
-    """OpenTherm Gateway Hot Water Override modes."""
 
-    OFF = "force_off"
-    ON = "force_on"
-    DISABLED = "override_disabled"
+INVERSE_MAP_DHW_OVRD_MODES = {v: k for k, v in MAP_DHW_OVRD_MODES.items()}
 
 
 class OpenThermSelectGPIOMode(StrEnum):
@@ -71,14 +72,6 @@ class OpenThermSelectLEDMode(StrEnum):
     TX_ERROR_DETECTED = "transmit_error_detected"
     BOILER_MAINTENANCE_REQUIRED = "boiler_maintenance_required"
     RAISED_POWER_MODE_ACTIVE = "raised_power_mode_active"
-
-
-class PyotgwDHWOvrdMode(Enum):
-    """pyotgw Hot Water Override modes."""
-
-    OFF = 0
-    ON = 1
-    DISABLED = "A"
 
 
 class PyotgwGPIOMode(IntEnum):
@@ -123,18 +116,10 @@ def pyotgw_led_mode_to_ha_led_mode(
     )
 
 
-async def set_dhw_ovrd_mode(
-    gw_hub: OpenThermGatewayHub, mode: str
-) -> OpenThermSelectDHWOvrdMode | None:
+async def set_dhw_ovrd_mode(gw_hub: OpenThermGatewayHub, mode: str) -> str | None:
     """Set hot water override mode, return selected option."""
-    value = await gw_hub.gateway.set_hot_water_ovrd(
-        PyotgwDHWOvrdMode[OpenThermSelectDHWOvrdMode(mode).name].value
-    )
-    return (
-        OpenThermSelectDHWOvrdMode[PyotgwDHWOvrdMode(value).name]
-        if value in PyotgwDHWOvrdMode
-        else None
-    )
+    value = await gw_hub.gateway.set_hot_water_ovrd(MAP_DHW_OVRD_MODES[mode])
+    return INVERSE_MAP_DHW_OVRD_MODES.get(value)
 
 
 async def set_gpio_mode(
@@ -180,15 +165,9 @@ SELECT_DESCRIPTIONS: tuple[OpenThermSelectEntityDescription, ...] = (
         key=OTGW_DHW_OVRD,
         translation_key="dhw_ovrd_mode",
         device_description=GATEWAY_DEVICE_DESCRIPTION,
-        options=list(OpenThermSelectDHWOvrdMode),
+        options=list(MAP_DHW_OVRD_MODES.keys()),
         select_action=set_dhw_ovrd_mode,
-        convert_pyotgw_state_to_ha_state=(
-            lambda state: (
-                OpenThermSelectDHWOvrdMode[PyotgwDHWOvrdMode(state).name]
-                if state in PyotgwDHWOvrdMode
-                else None
-            )
-        ),
+        convert_pyotgw_state_to_ha_state=INVERSE_MAP_DHW_OVRD_MODES.get,
     ),
     OpenThermSelectEntityDescription(
         key=OTGW_GPIO_A,

--- a/homeassistant/components/opentherm_gw/strings.json
+++ b/homeassistant/components/opentherm_gw/strings.json
@@ -163,6 +163,14 @@
       }
     },
     "select": {
+      "dhw_ovrd_mode": {
+        "name": "Hot water override",
+        "state": {
+          "force_off": "Force off",
+          "force_on": "Force on",
+          "override_disabled": "[%key:common::state::disabled%]"
+        }
+      },
       "gpio_mode_n": {
         "name": "GPIO {gpio_id} mode",
         "state": {

--- a/tests/components/opentherm_gw/test_select.py
+++ b/tests/components/opentherm_gw/test_select.py
@@ -4,6 +4,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 from pyotgw.vars import (
+    OTGW_DHW_OVRD,
     OTGW_GPIO_A,
     OTGW_GPIO_B,
     OTGW_LED_A,
@@ -22,8 +23,10 @@ from homeassistant.components.opentherm_gw.const import (
     OpenThermDeviceIdentifier,
 )
 from homeassistant.components.opentherm_gw.select import (
+    OpenThermSelectDHWOvrdMode,
     OpenThermSelectGPIOMode,
     OpenThermSelectLEDMode,
+    PyotgwDHWOvrdMode,
     PyotgwGPIOMode,
     PyotgwLEDMode,
 )
@@ -152,8 +155,68 @@ async def test_select_change_value(
 
 
 @pytest.mark.parametrize(
+    ("target_param", "resulting_state"),
+    [
+        (
+            PyotgwDHWOvrdMode.OFF.value,
+            OpenThermSelectDHWOvrdMode.OFF,
+        ),
+        (
+            PyotgwDHWOvrdMode.ON.value,
+            OpenThermSelectDHWOvrdMode.ON,
+        ),
+        (
+            PyotgwDHWOvrdMode.DISABLED.value,
+            OpenThermSelectDHWOvrdMode.DISABLED,
+        ),
+    ],
+)
+async def test_select_dhw_ovrd_change_value(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_pyotgw: MagicMock,
+    target_param: str | int,
+    resulting_state: str,
+) -> None:
+    """Test DHW override mode selector."""
+
+    mock_pyotgw.return_value.set_hot_water_ovrd = AsyncMock(return_value=target_param)
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        select_entity_id := entity_registry.async_get_entity_id(
+            SELECT_DOMAIN,
+            DOMAIN,
+            f"{mock_config_entry.data[CONF_ID]}-{OpenThermDeviceIdentifier.GATEWAY}-{OTGW_DHW_OVRD}",
+        )
+    ) is not None
+    assert hass.states.get(select_entity_id).state == STATE_UNKNOWN
+
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {ATTR_ENTITY_ID: select_entity_id, ATTR_OPTION: resulting_state},
+        blocking=True,
+    )
+    assert hass.states.get(select_entity_id).state == resulting_state
+
+    mock_pyotgw.return_value.set_hot_water_ovrd.assert_awaited_once_with(target_param)
+
+
+@pytest.mark.parametrize(
     ("entity_key", "test_value", "resulting_state"),
     [
+        (
+            OTGW_DHW_OVRD,
+            PyotgwDHWOvrdMode.DISABLED.value,
+            OpenThermSelectDHWOvrdMode.DISABLED,
+        ),
+        (OTGW_DHW_OVRD, PyotgwDHWOvrdMode.OFF.value, OpenThermSelectDHWOvrdMode.OFF),
+        (OTGW_DHW_OVRD, PyotgwDHWOvrdMode.ON.value, OpenThermSelectDHWOvrdMode.ON),
         (OTGW_GPIO_A, PyotgwGPIOMode.AWAY, OpenThermSelectGPIOMode.AWAY),
         (OTGW_GPIO_B, PyotgwGPIOMode.LED_F, OpenThermSelectGPIOMode.LED_F),
         (

--- a/tests/components/opentherm_gw/test_select.py
+++ b/tests/components/opentherm_gw/test_select.py
@@ -155,19 +155,27 @@ async def test_select_change_value(
 
 
 @pytest.mark.parametrize(
-    ("target_param", "resulting_state"),
+    ("target_param", "pyotgw_return", "resulting_state"),
     [
         (
             PyotgwDHWOvrdMode.OFF.value,
+            0,
             OpenThermSelectDHWOvrdMode.OFF,
         ),
         (
             PyotgwDHWOvrdMode.ON.value,
+            1,
             OpenThermSelectDHWOvrdMode.ON,
         ),
         (
             PyotgwDHWOvrdMode.DISABLED.value,
+            "A",
             OpenThermSelectDHWOvrdMode.DISABLED,
+        ),
+        (
+            PyotgwDHWOvrdMode.ON.value,
+            None,
+            OpenThermSelectDHWOvrdMode.ON,
         ),
     ],
 )
@@ -177,11 +185,12 @@ async def test_select_dhw_ovrd_change_value(
     mock_config_entry: MockConfigEntry,
     mock_pyotgw: MagicMock,
     target_param: str | int,
+    pyotgw_return: str | int | None,
     resulting_state: str,
 ) -> None:
     """Test DHW override mode selector."""
 
-    mock_pyotgw.return_value.set_hot_water_ovrd = AsyncMock(return_value=target_param)
+    mock_pyotgw.return_value.set_hot_water_ovrd = AsyncMock(return_value=pyotgw_return)
     mock_config_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
@@ -202,9 +211,16 @@ async def test_select_dhw_ovrd_change_value(
         {ATTR_ENTITY_ID: select_entity_id, ATTR_OPTION: resulting_state},
         blocking=True,
     )
-    assert hass.states.get(select_entity_id).state == resulting_state
-
-    mock_pyotgw.return_value.set_hot_water_ovrd.assert_awaited_once_with(target_param)
+    if pyotgw_return is None:
+        assert hass.states.get(select_entity_id).state == STATE_UNKNOWN
+        mock_pyotgw.return_value.set_hot_water_ovrd.assert_awaited_once_with(
+            target_param
+        )
+    else:
+        assert hass.states.get(select_entity_id).state == resulting_state
+        mock_pyotgw.return_value.set_hot_water_ovrd.assert_awaited_once_with(
+            target_param
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/components/opentherm_gw/test_select.py
+++ b/tests/components/opentherm_gw/test_select.py
@@ -23,10 +23,8 @@ from homeassistant.components.opentherm_gw.const import (
     OpenThermDeviceIdentifier,
 )
 from homeassistant.components.opentherm_gw.select import (
-    OpenThermSelectDHWOvrdMode,
     OpenThermSelectGPIOMode,
     OpenThermSelectLEDMode,
-    PyotgwDHWOvrdMode,
     PyotgwGPIOMode,
     PyotgwLEDMode,
 )
@@ -157,26 +155,10 @@ async def test_select_change_value(
 @pytest.mark.parametrize(
     ("target_param", "pyotgw_return", "resulting_state"),
     [
-        (
-            PyotgwDHWOvrdMode.OFF.value,
-            0,
-            OpenThermSelectDHWOvrdMode.OFF,
-        ),
-        (
-            PyotgwDHWOvrdMode.ON.value,
-            1,
-            OpenThermSelectDHWOvrdMode.ON,
-        ),
-        (
-            PyotgwDHWOvrdMode.DISABLED.value,
-            "A",
-            OpenThermSelectDHWOvrdMode.DISABLED,
-        ),
-        (
-            PyotgwDHWOvrdMode.ON.value,
-            None,
-            OpenThermSelectDHWOvrdMode.ON,
-        ),
+        (0, 0, "force_off"),
+        (1, 1, "force_on"),
+        ("A", "A", "override_disabled"),
+        (1, None, "force_on"),
     ],
 )
 async def test_select_dhw_ovrd_change_value(
@@ -228,11 +210,11 @@ async def test_select_dhw_ovrd_change_value(
     [
         (
             OTGW_DHW_OVRD,
-            PyotgwDHWOvrdMode.DISABLED.value,
-            OpenThermSelectDHWOvrdMode.DISABLED,
+            "A",
+            "override_disabled",
         ),
-        (OTGW_DHW_OVRD, PyotgwDHWOvrdMode.OFF.value, OpenThermSelectDHWOvrdMode.OFF),
-        (OTGW_DHW_OVRD, PyotgwDHWOvrdMode.ON.value, OpenThermSelectDHWOvrdMode.ON),
+        (OTGW_DHW_OVRD, 1, "force_on"),
+        (OTGW_DHW_OVRD, 0, "force_off"),
         (OTGW_GPIO_A, PyotgwGPIOMode.AWAY, OpenThermSelectGPIOMode.AWAY),
         (OTGW_GPIO_B, PyotgwGPIOMode.LED_F, OpenThermSelectGPIOMode.LED_F),
         (

--- a/tests/components/opentherm_gw/test_select.py
+++ b/tests/components/opentherm_gw/test_select.py
@@ -153,12 +153,12 @@ async def test_select_change_value(
 
 
 @pytest.mark.parametrize(
-    ("target_param", "pyotgw_return", "resulting_state"),
+    ("target_param", "pyotgw_return", "selected_option", "resulting_state"),
     [
-        (0, 0, "force_off"),
-        (1, 1, "force_on"),
-        ("A", "A", "override_disabled"),
-        (1, None, "force_on"),
+        (0, 0, "force_off", "force_off"),
+        (1, 1, "force_on", "force_on"),
+        ("A", "A", "override_disabled", "override_disabled"),
+        (1, None, "force_on", STATE_UNKNOWN),
     ],
 )
 async def test_select_dhw_ovrd_change_value(
@@ -168,6 +168,7 @@ async def test_select_dhw_ovrd_change_value(
     mock_pyotgw: MagicMock,
     target_param: str | int,
     pyotgw_return: str | int | None,
+    selected_option: str,
     resulting_state: str,
 ) -> None:
     """Test DHW override mode selector."""
@@ -190,19 +191,11 @@ async def test_select_dhw_ovrd_change_value(
     await hass.services.async_call(
         SELECT_DOMAIN,
         SERVICE_SELECT_OPTION,
-        {ATTR_ENTITY_ID: select_entity_id, ATTR_OPTION: resulting_state},
+        {ATTR_ENTITY_ID: select_entity_id, ATTR_OPTION: selected_option},
         blocking=True,
     )
-    if pyotgw_return is None:
-        assert hass.states.get(select_entity_id).state == STATE_UNKNOWN
-        mock_pyotgw.return_value.set_hot_water_ovrd.assert_awaited_once_with(
-            target_param
-        )
-    else:
-        assert hass.states.get(select_entity_id).state == resulting_state
-        mock_pyotgw.return_value.set_hot_water_ovrd.assert_awaited_once_with(
-            target_param
-        )
+    assert hass.states.get(select_entity_id).state == resulting_state
+    mock_pyotgw.return_value.set_hot_water_ovrd.assert_awaited_once_with(target_param)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Basically another attempt at #162218, where some discussion points were left open.
Add a select entity to the OpenTherm Gateway integration for the Hot Water Override functionality.
This implements part of the functionality of the existing opentherm_gw.set_hot_water_ovrd service action, which will be removed in a different PR once all service actions have corresponding entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
