### PR TITLE
Add OptionsFlow to SMTP integration

### DIFF
--- a/homeassistant/components/smtp/__init__.py
+++ b/homeassistant/components/smtp/__init__.py
@@ -22,6 +22,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 CONF_RECIPIENT: [
                     subentry.unique_id for subentry in entry.subentries.values()
                 ],
+                **entry.options,
             },
             {},
         )

--- a/homeassistant/components/smtp/config_flow.py
+++ b/homeassistant/components/smtp/config_flow.py
@@ -16,21 +16,29 @@ from homeassistant.config_entries import (
     ConfigSubentryData,
     ConfigSubentryFlow,
     FlowType,
+    OptionsFlow,
     SubentryFlowContext,
     SubentryFlowResult,
 )
 from homeassistant.const import (
+    CONF_DEBUG,
     CONF_NAME,
     CONF_PASSWORD,
     CONF_PORT,
     CONF_RECIPIENT,
     CONF_SENDER,
+    CONF_TIMEOUT,
     CONF_USERNAME,
     CONF_VERIFY_SSL,
+    UnitOfTime,
 )
 from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.selector import (
+    BooleanSelector,
+    NumberSelector,
+    NumberSelectorConfig,
+    NumberSelectorMode,
     SelectSelector,
     SelectSelectorConfig,
     SelectSelectorMode,
@@ -44,6 +52,7 @@ from .const import (
     CONF_ENCRYPTION,
     CONF_SENDER_NAME,
     CONF_SERVER,
+    DEFAULT_DEBUG,
     DEFAULT_ENCRYPTION,
     DEFAULT_HOST,
     DEFAULT_PORT,
@@ -90,6 +99,19 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
     }
 )
 
+OPTIONS_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): NumberSelector(
+            NumberSelectorConfig(
+                min=1,
+                unit_of_measurement=UnitOfTime.SECONDS,
+                mode=NumberSelectorMode.BOX,
+            )
+        ),
+        vol.Optional(CONF_DEBUG, default=DEFAULT_DEBUG): BooleanSelector(),
+    }
+)
+
 
 class MailConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for SMTP."""
@@ -101,6 +123,12 @@ class MailConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> dict[str, type[ConfigSubentryFlow]]:
         """Return subentries supported by this integration."""
         return {SUBENTRY_TYPE_RECIPIENT: RecipientSubentryFlowHandler}
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlowHandler:
+        """Get the options flow for this handler."""
+        return OptionsFlowHandler()
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -144,6 +172,10 @@ class MailConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_import(self, import_info: dict[str, Any]) -> ConfigFlowResult:
         """Import config from yaml."""
 
+        options = {
+            CONF_DEBUG: import_info.pop(CONF_DEBUG, DEFAULT_DEBUG),
+            CONF_TIMEOUT: import_info.pop(CONF_TIMEOUT, DEFAULT_TIMEOUT),
+        }
         self._async_abort_entries_match(import_info)
 
         errors = await self.hass.async_add_executor_job(validate_input, import_info)
@@ -156,6 +188,7 @@ class MailConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_create_entry(
                 title=title,
                 data=import_info,
+                options=options,
                 subentries=[
                     ConfigSubentryData(
                         subentry_type=SUBENTRY_TYPE_RECIPIENT,
@@ -236,5 +269,23 @@ class RecipientSubentryFlowHandler(ConfigSubentryFlow):
                         ),
                     ),
                 }
+            ),
+        )
+
+
+class OptionsFlowHandler(OptionsFlow):
+    """Handle options flow."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=self.add_suggested_values_to_schema(
+                OPTIONS_SCHEMA, self.config_entry.options
             ),
         )

--- a/homeassistant/components/smtp/config_flow.py
+++ b/homeassistant/components/smtp/config_flow.py
@@ -102,6 +102,7 @@ OPTIONS_SCHEMA = vol.Schema(
             NumberSelector(
                 NumberSelectorConfig(
                     min=1,
+                    max=1800,
                     step=1,
                     unit_of_measurement=UnitOfTime.SECONDS,
                     mode=NumberSelectorMode.BOX,

--- a/homeassistant/components/smtp/config_flow.py
+++ b/homeassistant/components/smtp/config_flow.py
@@ -104,6 +104,7 @@ OPTIONS_SCHEMA = vol.Schema(
         vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): NumberSelector(
             NumberSelectorConfig(
                 min=1,
+                step=1,
                 unit_of_measurement=UnitOfTime.SECONDS,
                 mode=NumberSelectorMode.BOX,
             )

--- a/homeassistant/components/smtp/config_flow.py
+++ b/homeassistant/components/smtp/config_flow.py
@@ -21,7 +21,6 @@ from homeassistant.config_entries import (
     SubentryFlowResult,
 )
 from homeassistant.const import (
-    CONF_DEBUG,
     CONF_NAME,
     CONF_PASSWORD,
     CONF_PORT,
@@ -35,7 +34,6 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.selector import (
-    BooleanSelector,
     NumberSelector,
     NumberSelectorConfig,
     NumberSelectorMode,
@@ -52,7 +50,6 @@ from .const import (
     CONF_ENCRYPTION,
     CONF_SENDER_NAME,
     CONF_SERVER,
-    DEFAULT_DEBUG,
     DEFAULT_ENCRYPTION,
     DEFAULT_HOST,
     DEFAULT_PORT,
@@ -111,8 +108,7 @@ OPTIONS_SCHEMA = vol.Schema(
                 )
             ),
             vol.Coerce(int),
-        ),
-        vol.Optional(CONF_DEBUG, default=DEFAULT_DEBUG): BooleanSelector(),
+        )
     }
 )
 
@@ -176,10 +172,7 @@ class MailConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_import(self, import_info: dict[str, Any]) -> ConfigFlowResult:
         """Import config from yaml."""
 
-        options = {
-            CONF_DEBUG: import_info.pop(CONF_DEBUG, DEFAULT_DEBUG),
-            CONF_TIMEOUT: import_info.pop(CONF_TIMEOUT, DEFAULT_TIMEOUT),
-        }
+        options = {CONF_TIMEOUT: import_info.pop(CONF_TIMEOUT, DEFAULT_TIMEOUT)}
         self._async_abort_entries_match(import_info)
 
         errors = await self.hass.async_add_executor_job(validate_input, import_info)

--- a/homeassistant/components/smtp/config_flow.py
+++ b/homeassistant/components/smtp/config_flow.py
@@ -101,13 +101,16 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
 
 OPTIONS_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): NumberSelector(
-            NumberSelectorConfig(
-                min=1,
-                step=1,
-                unit_of_measurement=UnitOfTime.SECONDS,
-                mode=NumberSelectorMode.BOX,
-            )
+        vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): vol.All(
+            NumberSelector(
+                NumberSelectorConfig(
+                    min=1,
+                    step=1,
+                    unit_of_measurement=UnitOfTime.SECONDS,
+                    mode=NumberSelectorMode.BOX,
+                )
+            ),
+            vol.Coerce(int),
         ),
         vol.Optional(CONF_DEBUG, default=DEFAULT_DEBUG): BooleanSelector(),
     }

--- a/homeassistant/components/smtp/notify.py
+++ b/homeassistant/components/smtp/notify.py
@@ -119,7 +119,7 @@ async def async_get_service(
         discovery_info.get(CONF_PASSWORD),
         discovery_info[CONF_RECIPIENT],
         discovery_info.get(CONF_SENDER_NAME),
-        DEFAULT_DEBUG,
+        discovery_info.get(CONF_DEBUG, DEFAULT_DEBUG),
         discovery_info[CONF_VERIFY_SSL],
         ssl_context,
     )

--- a/homeassistant/components/smtp/notify.py
+++ b/homeassistant/components/smtp/notify.py
@@ -119,7 +119,7 @@ async def async_get_service(
         discovery_info.get(CONF_PASSWORD),
         discovery_info[CONF_RECIPIENT],
         discovery_info.get(CONF_SENDER_NAME),
-        discovery_info.get(CONF_DEBUG, DEFAULT_DEBUG),
+        DEFAULT_DEBUG,
         discovery_info[CONF_VERIFY_SSL],
         ssl_context,
     )

--- a/homeassistant/components/smtp/strings.json
+++ b/homeassistant/components/smtp/strings.json
@@ -70,6 +70,20 @@
       "title": "Failed to import SMTP YAML configuration"
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "debug": "Enable debug mode",
+          "timeout": "Connection timeout"
+        },
+        "data_description": {
+          "debug": "Enables debug logging for the connection and for all messages sent to and received from the server.",
+          "timeout": "Maximum time to wait for SMTP server responses before terminating the request."
+        }
+      }
+    }
+  },
   "selector": {
     "encryption": {
       "options": {

--- a/homeassistant/components/smtp/strings.json
+++ b/homeassistant/components/smtp/strings.json
@@ -77,7 +77,7 @@
           "timeout": "Connection timeout"
         },
         "data_description": {
-          "timeout": "Maximum time to wait for SMTP server responses before terminating the request."
+          "timeout": "Maximum time to wait for a response from the SMTP server before the connection attempt is aborted."
         }
       }
     }

--- a/homeassistant/components/smtp/strings.json
+++ b/homeassistant/components/smtp/strings.json
@@ -74,11 +74,9 @@
     "step": {
       "init": {
         "data": {
-          "debug": "Enable debug mode",
           "timeout": "Connection timeout"
         },
         "data_description": {
-          "debug": "Enables debug logging for the connection and for all messages sent to and received from the server.",
           "timeout": "Maximum time to wait for SMTP server responses before terminating the request."
         }
       }

--- a/tests/components/smtp/conftest.py
+++ b/tests/components/smtp/conftest.py
@@ -14,9 +14,11 @@ from homeassistant.components.smtp.const import (
 )
 from homeassistant.config_entries import ConfigSubentryData
 from homeassistant.const import (
+    CONF_DEBUG,
     CONF_PASSWORD,
     CONF_PORT,
     CONF_SENDER,
+    CONF_TIMEOUT,
     CONF_USERNAME,
     CONF_VERIFY_SSL,
 )
@@ -73,6 +75,10 @@ def mock_config_entry() -> MockConfigEntry:
             CONF_USERNAME: "test-username",
             CONF_PASSWORD: "test-password",
             CONF_VERIFY_SSL: True,
+        },
+        options={
+            CONF_DEBUG: False,
+            CONF_TIMEOUT: 5,
         },
         entry_id="123456789",
         subentries_data=[

--- a/tests/components/smtp/conftest.py
+++ b/tests/components/smtp/conftest.py
@@ -14,7 +14,6 @@ from homeassistant.components.smtp.const import (
 )
 from homeassistant.config_entries import ConfigSubentryData
 from homeassistant.const import (
-    CONF_DEBUG,
     CONF_PASSWORD,
     CONF_PORT,
     CONF_SENDER,
@@ -77,7 +76,6 @@ def mock_config_entry() -> MockConfigEntry:
             CONF_VERIFY_SSL: True,
         },
         options={
-            CONF_DEBUG: False,
             CONF_TIMEOUT: 5,
         },
         entry_id="123456789",

--- a/tests/components/smtp/test_config_flow.py
+++ b/tests/components/smtp/test_config_flow.py
@@ -14,13 +14,15 @@ from homeassistant.components.smtp.const import (
     DOMAIN,
     SUBENTRY_TYPE_RECIPIENT,
 )
-from homeassistant.config_entries import SOURCE_USER, FlowType
+from homeassistant.config_entries import SOURCE_USER, ConfigEntryState, FlowType
 from homeassistant.const import (
+    CONF_DEBUG,
     CONF_NAME,
     CONF_PASSWORD,
     CONF_PORT,
     CONF_RECIPIENT,
     CONF_SENDER,
+    CONF_TIMEOUT,
     CONF_USERNAME,
     CONF_VERIFY_SSL,
 )
@@ -221,3 +223,35 @@ async def test_form_recipient_already_configured(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+
+
+async def test_options_flow(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test options flow."""
+
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_DEBUG: True,
+            CONF_TIMEOUT: 10,
+        },
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert config_entry.options == {
+        CONF_DEBUG: True,
+        CONF_TIMEOUT: 10,
+    }

--- a/tests/components/smtp/test_config_flow.py
+++ b/tests/components/smtp/test_config_flow.py
@@ -16,7 +16,6 @@ from homeassistant.components.smtp.const import (
 )
 from homeassistant.config_entries import SOURCE_USER, ConfigEntryState, FlowType
 from homeassistant.const import (
-    CONF_DEBUG,
     CONF_NAME,
     CONF_PASSWORD,
     CONF_PORT,
@@ -245,13 +244,11 @@ async def test_options_flow(
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            CONF_DEBUG: True,
             CONF_TIMEOUT: 10,
         },
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert config_entry.options == {
-        CONF_DEBUG: True,
         CONF_TIMEOUT: 10,
     }

--- a/tests/components/smtp/test_init.py
+++ b/tests/components/smtp/test_init.py
@@ -73,6 +73,8 @@ async def test_import(
                     CONF_PASSWORD: "test-password",
                     CONF_VERIFY_SSL: True,
                     CONF_RECIPIENT: "recipient@example.com",
+                    CONF_DEBUG: True,
+                    CONF_TIMEOUT: 10,
                 }
             ]
         },
@@ -98,8 +100,10 @@ async def test_import(
         CONF_PASSWORD: "test-password",
         CONF_VERIFY_SSL: True,
         CONF_RECIPIENT: ["recipient@example.com"],
-        CONF_TIMEOUT: 5,
-        CONF_DEBUG: False,
+    }
+    assert entries[0].options == {
+        CONF_TIMEOUT: 10,
+        CONF_DEBUG: True,
     }
 
     assert list(entries[0].subentries.values())[0].unique_id == "recipient@example.com"
@@ -132,8 +136,6 @@ async def test_import_already_configured(
             CONF_PASSWORD: "test-password",
             CONF_VERIFY_SSL: True,
             CONF_RECIPIENT: ["recipient@example.com"],
-            CONF_DEBUG: False,
-            CONF_TIMEOUT: 5,
         },
         entry_id="123456789",
     )

--- a/tests/components/smtp/test_init.py
+++ b/tests/components/smtp/test_init.py
@@ -73,7 +73,6 @@ async def test_import(
                     CONF_PASSWORD: "test-password",
                     CONF_VERIFY_SSL: True,
                     CONF_RECIPIENT: "recipient@example.com",
-                    CONF_DEBUG: True,
                     CONF_TIMEOUT: 10,
                 }
             ]
@@ -100,11 +99,9 @@ async def test_import(
         CONF_PASSWORD: "test-password",
         CONF_VERIFY_SSL: True,
         CONF_RECIPIENT: ["recipient@example.com"],
+        CONF_DEBUG: False,
     }
-    assert entries[0].options == {
-        CONF_TIMEOUT: 10,
-        CONF_DEBUG: True,
-    }
+    assert entries[0].options == {CONF_TIMEOUT: 10}
 
     assert list(entries[0].subentries.values())[0].unique_id == "recipient@example.com"
 
@@ -136,6 +133,7 @@ async def test_import_already_configured(
             CONF_PASSWORD: "test-password",
             CONF_VERIFY_SSL: True,
             CONF_RECIPIENT: ["recipient@example.com"],
+            CONF_DEBUG: False,
         },
         entry_id="123456789",
     )


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


Adds an options flow to the SMTP integration that reintroduces the ~debug and~ timeout parameters that were previously available in YAML configuration but omitted in the transition to UI config. The Import flow has been adjusted to import the parameters to options.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45841
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
