### PR TITLE
Add WS API to get compatible groups and add entities for group integration

### DIFF
--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -52,6 +52,7 @@ from .const import (  # noqa: F401
 )
 from .entity import Group, async_get_component
 from .registry import async_setup as async_setup_registry
+from .websocket_api import async_setup as async_setup_websocket_api
 
 CONF_ALL = "all"
 
@@ -171,6 +172,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     component = async_get_component(hass)
 
     await async_setup_registry(hass)
+
+    async_setup_websocket_api(hass)
 
     await _async_process_config(hass, config)
 

--- a/homeassistant/components/group/config_flow.py
+++ b/homeassistant/components/group/config_flow.py
@@ -22,7 +22,7 @@ from homeassistant.helpers.schema_config_entry_flow import (
 
 from .binary_sensor import CONF_ALL, async_create_preview_binary_sensor
 from .button import async_create_preview_button
-from .const import CONF_HIDE_MEMBERS, CONF_IGNORE_NON_NUMERIC, DOMAIN
+from .const import CONF_HIDE_MEMBERS, CONF_IGNORE_NON_NUMERIC, DOMAIN, GROUP_TYPES
 from .cover import async_create_preview_cover
 from .entity import GroupEntity
 from .event import async_create_preview_event
@@ -33,6 +33,7 @@ from .media_player import MediaPlayerGroup, async_create_preview_media_player
 from .notify import async_create_preview_notify
 from .sensor import async_create_preview_sensor
 from .switch import async_create_preview_switch
+from .util import async_hide_members
 from .valve import async_create_preview_valve
 
 _STATISTIC_MEASURES = [
@@ -158,22 +159,6 @@ SWITCH_CONFIG_SCHEMA = basic_group_config_schema("switch").extend(
         vol.Required(CONF_ALL, default=False): selector.BooleanSelector(),
     }
 )
-
-
-GROUP_TYPES = [
-    "binary_sensor",
-    "button",
-    "cover",
-    "event",
-    "fan",
-    "light",
-    "lock",
-    "media_player",
-    "notify",
-    "sensor",
-    "switch",
-    "valve",
-]
 
 
 async def choose_options_step(options: dict[str, Any]) -> str:
@@ -355,7 +340,7 @@ class GroupConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
     def async_config_flow_finished(self, options: Mapping[str, Any]) -> None:
         """Hide the group members if requested."""
         if options[CONF_HIDE_MEMBERS]:
-            _async_hide_members(
+            async_hide_members(
                 self.hass, options[CONF_ENTITIES], er.RegistryEntryHider.INTEGRATION
             )
 
@@ -368,7 +353,7 @@ class GroupConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
         hidden_by = (
             er.RegistryEntryHider.INTEGRATION if options[CONF_HIDE_MEMBERS] else None
         )
-        _async_hide_members(hass, options[CONF_ENTITIES], hidden_by)
+        async_hide_members(hass, options[CONF_ENTITIES], hidden_by)
 
     @staticmethod
     async def async_setup_preview(hass: HomeAssistant) -> None:
@@ -384,19 +369,6 @@ class GroupConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
             )
             PREVIEW_OPTIONS_SCHEMA[group_type] = await schema(None)
         websocket_api.async_register_command(hass, ws_start_preview)
-
-
-def _async_hide_members(
-    hass: HomeAssistant, members: list[str], hidden_by: er.RegistryEntryHider | None
-) -> None:
-    """Hide or unhide group members."""
-    registry = er.async_get(hass)
-    for member in members:
-        if not (entity_id := er.async_resolve_entity_id(registry, member)):
-            continue
-        if entity_id not in registry.entities:
-            continue
-        registry.async_update_entity(entity_id, hidden_by=hidden_by)
 
 
 @websocket_api.websocket_command(

--- a/homeassistant/components/group/const.py
+++ b/homeassistant/components/group/const.py
@@ -25,3 +25,18 @@ ATTR_ENTITIES = "entities"
 ATTR_OBJECT_ID = "object_id"
 ATTR_ORDER = "order"
 ATTR_ALL = "all"
+
+GROUP_TYPES = [
+    "binary_sensor",
+    "button",
+    "cover",
+    "event",
+    "fan",
+    "light",
+    "lock",
+    "media_player",
+    "notify",
+    "sensor",
+    "switch",
+    "valve",
+]

--- a/homeassistant/components/group/util.py
+++ b/homeassistant/components/group/util.py
@@ -1,11 +1,12 @@
-"""Utility functions to combine state attributes from multiple entities."""
+"""Utility functions for Group integration."""
 
 from collections.abc import Callable, Iterator
 from itertools import groupby
 from math import atan2, cos, degrees, radians, sin
 from typing import Any
 
-from homeassistant.core import State
+from homeassistant.core import HomeAssistant, State
+from homeassistant.helpers import entity_registry as er
 
 
 def find_state_attributes(states: list[State], key: str) -> Iterator[Any]:
@@ -99,3 +100,16 @@ def reduce_attribute(
         return attrs[0]
 
     return reduce(*attrs)
+
+
+def async_hide_members(
+    hass: HomeAssistant, members: list[str], hidden_by: er.RegistryEntryHider | None
+) -> None:
+    """Hide or unhide group members."""
+    registry = er.async_get(hass)
+    for member in members:
+        if not (entity_id := er.async_resolve_entity_id(registry, member)):
+            continue
+        if entity_id not in registry.entities:
+            continue
+        registry.async_update_entity(entity_id, hidden_by=hidden_by)

--- a/homeassistant/components/group/websocket_api.py
+++ b/homeassistant/components/group/websocket_api.py
@@ -1,0 +1,129 @@
+"""Websocket API for Group integration."""
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.components import websocket_api
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_ENTITY_ID, CONF_ENTITIES
+from homeassistant.core import HomeAssistant, callback, split_entity_id
+from homeassistant.helpers import config_validation as cv, entity_registry as er
+
+from .const import CONF_HIDE_MEMBERS, DOMAIN, GROUP_TYPES
+from .util import async_hide_members
+
+
+def async_setup(hass: HomeAssistant) -> None:
+    """Set up the Group websocket API."""
+    websocket_api.async_register_command(hass, websocket_groups_for_entity)
+    websocket_api.async_register_command(hass, websocket_add_entity_to_group)
+
+
+def _group_type_for_entity_id(entity_id: str) -> str | None:
+    """Return the compatible group type for an entity."""
+    domain = split_entity_id(entity_id)[0]
+    if domain in GROUP_TYPES:
+        return domain
+    return None
+
+
+def _group_entity_id_for_config_entry(
+    registry: er.EntityRegistry, entry: ConfigEntry
+) -> str | None:
+    """Return the entity ID for a group config entry."""
+    entries = er.async_entries_for_config_entry(registry, entry.entry_id)
+    return entries[0].entity_id if entries else None
+
+
+def _compatible_group_entries(
+    hass: HomeAssistant, entity_id: str
+) -> tuple[str | None, list[ConfigEntry]]:
+    """Return compatible group config entries for an entity."""
+    group_type = _group_type_for_entity_id(entity_id)
+    if group_type is None:
+        return None, []
+
+    entries = [
+        entry
+        for entry in hass.config_entries.async_entries(DOMAIN)
+        if entry.options.get("group_type") == group_type
+    ]
+    return group_type, entries
+
+
+@callback
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "group/groups_for_entity",
+        vol.Required(ATTR_ENTITY_ID): cv.entity_id,
+    }
+)
+def websocket_groups_for_entity(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """List compatible groups for an entity."""
+    entity_id = msg[ATTR_ENTITY_ID]
+    group_type, entries = _compatible_group_entries(hass, entity_id)
+    registry = er.async_get(hass)
+
+    connection.send_result(
+        msg["id"],
+        {
+            "group_type": group_type,
+            "groups": [
+                {
+                    "entry_id": entry.entry_id,
+                    "entity_id": _group_entity_id_for_config_entry(registry, entry),
+                    "name": entry.title,
+                }
+                for entry in entries
+                if entity_id not in entry.options[CONF_ENTITIES]
+            ],
+        },
+    )
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "group/add_entity",
+        vol.Required("entry_id"): str,
+        vol.Required(ATTR_ENTITY_ID): cv.entity_id,
+    }
+)
+@websocket_api.async_response
+async def websocket_add_entity_to_group(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Add an entity to a group config entry."""
+    entity_id = msg[ATTR_ENTITY_ID]
+    entry = hass.config_entries.async_get_entry(msg["entry_id"])
+
+    if entry is None or entry.domain != DOMAIN:
+        connection.send_error(msg["id"], websocket_api.ERR_NOT_FOUND, "Group not found")
+        return
+
+    group_type = _group_type_for_entity_id(entity_id)
+    if group_type is None or entry.options.get("group_type") != group_type:
+        connection.send_error(
+            msg["id"], "invalid_entity", "Entity cannot be added to this group"
+        )
+        return
+
+    entities = list(entry.options[CONF_ENTITIES])
+    if entity_id not in entities:
+        entities.append(entity_id)
+        hass.config_entries.async_update_entry(
+            entry, options={**entry.options, CONF_ENTITIES: entities}
+        )
+        if entry.options[CONF_HIDE_MEMBERS]:
+            async_hide_members(hass, [entity_id], er.RegistryEntryHider.INTEGRATION)
+        await hass.config_entries.async_reload(entry.entry_id)
+
+    connection.send_result(msg["id"], {"entities": entities})

--- a/homeassistant/components/group/websocket_api.py
+++ b/homeassistant/components/group/websocket_api.py
@@ -14,6 +14,7 @@ from .const import CONF_HIDE_MEMBERS, DOMAIN, GROUP_TYPES
 from .util import async_hide_members
 
 
+@callback
 def async_setup(hass: HomeAssistant) -> None:
     """Set up the Group websocket API."""
     websocket_api.async_register_command(hass, websocket_groups_for_entity)

--- a/homeassistant/components/group/websocket_api.py
+++ b/homeassistant/components/group/websocket_api.py
@@ -70,20 +70,26 @@ def websocket_groups_for_entity(
     entity_id = msg[ATTR_ENTITY_ID]
     group_type, entries = _compatible_group_entries(hass, entity_id)
     registry = er.async_get(hass)
+    groups = []
+
+    for entry in entries:
+        group_entity_id = _group_entity_id_for_config_entry(registry, entry)
+        if group_entity_id == entity_id or entity_id in entry.options[CONF_ENTITIES]:
+            continue
+
+        groups.append(
+            {
+                "entry_id": entry.entry_id,
+                "entity_id": group_entity_id,
+                "name": entry.title,
+            }
+        )
 
     connection.send_result(
         msg["id"],
         {
             "group_type": group_type,
-            "groups": [
-                {
-                    "entry_id": entry.entry_id,
-                    "entity_id": _group_entity_id_for_config_entry(registry, entry),
-                    "name": entry.title,
-                }
-                for entry in entries
-                if entity_id not in entry.options[CONF_ENTITIES]
-            ],
+            "groups": groups,
         },
     )
 
@@ -112,6 +118,13 @@ async def websocket_add_entity_to_group(
 
     group_type = _group_type_for_entity_id(entity_id)
     if group_type is None or entry.options.get("group_type") != group_type:
+        connection.send_error(
+            msg["id"], "invalid_entity", "Entity cannot be added to this group"
+        )
+        return
+
+    registry = er.async_get(hass)
+    if _group_entity_id_for_config_entry(registry, entry) == entity_id:
         connection.send_error(
             msg["id"], "invalid_entity", "Entity cannot be added to this group"
         )

--- a/tests/components/group/test_websocket_api.py
+++ b/tests/components/group/test_websocket_api.py
@@ -2,6 +2,7 @@
 
 from homeassistant.components import group
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
@@ -124,6 +125,51 @@ async def test_add_entity_to_group(
         "light.one",
         "light.two",
     ]
+
+
+async def test_add_entity_to_group_hides_member(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test adding an entity to a group hides the entity if requested."""
+    hass.states.async_set("light.one", "on")
+    entity_entry = entity_registry.async_get_or_create(
+        "light", "test", "two", suggested_object_id="two"
+    )
+    hass.states.async_set(entity_entry.entity_id, "off")
+
+    light_group = MockConfigEntry(
+        domain=group.DOMAIN,
+        options={
+            "all": False,
+            "entities": ["light.one"],
+            "group_type": "light",
+            "hide_members": True,
+            "name": "Kitchen lights",
+        },
+        title="Kitchen lights",
+    )
+    light_group.add_to_hass(hass)
+
+    assert await async_setup_component(hass, group.DOMAIN, {})
+    await hass.async_block_till_done()
+
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id(
+        {
+            "type": "group/add_entity",
+            "entry_id": light_group.entry_id,
+            "entity_id": entity_entry.entity_id,
+        }
+    )
+    response = await client.receive_json()
+
+    assert response["success"]
+    assert response["result"] == {"entities": ["light.one", "light.two"]}
+    assert entity_registry.async_get(entity_entry.entity_id).hidden_by is (
+        er.RegistryEntryHider.INTEGRATION
+    )
 
 
 async def test_add_incompatible_entity_to_group(

--- a/tests/components/group/test_websocket_api.py
+++ b/tests/components/group/test_websocket_api.py
@@ -1,0 +1,165 @@
+"""Tests for the Group websocket API."""
+
+from homeassistant.components import group
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
+from tests.typing import WebSocketGenerator
+
+
+async def test_groups_for_entity(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test listing compatible groups for an entity."""
+    hass.states.async_set("light.one", "on")
+    hass.states.async_set("light.two", "on")
+    hass.states.async_set("switch.one", "on")
+
+    light_group = MockConfigEntry(
+        domain=group.DOMAIN,
+        options={
+            "all": False,
+            "entities": ["light.one"],
+            "group_type": "light",
+            "hide_members": False,
+            "name": "Kitchen lights",
+        },
+        title="Kitchen lights",
+    )
+    light_group.add_to_hass(hass)
+
+    switch_group = MockConfigEntry(
+        domain=group.DOMAIN,
+        options={
+            "all": False,
+            "entities": ["switch.one"],
+            "group_type": "switch",
+            "hide_members": False,
+            "name": "Kitchen switches",
+        },
+        title="Kitchen switches",
+    )
+    switch_group.add_to_hass(hass)
+
+    assert await async_setup_component(hass, group.DOMAIN, {})
+    await hass.async_block_till_done()
+
+    unloaded_light_group = MockConfigEntry(
+        domain=group.DOMAIN,
+        options={
+            "all": False,
+            "entities": ["light.one"],
+            "group_type": "light",
+            "hide_members": False,
+            "name": "Unloaded lights",
+        },
+        title="Unloaded lights",
+    )
+    unloaded_light_group.add_to_hass(hass)
+
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id(
+        {"type": "group/groups_for_entity", "entity_id": "light.two"}
+    )
+    response = await client.receive_json()
+
+    assert response["success"]
+    assert response["result"] == {
+        "group_type": "light",
+        "groups": [
+            {
+                "entry_id": light_group.entry_id,
+                "entity_id": "light.kitchen_lights",
+                "name": "Kitchen lights",
+            },
+            {
+                "entry_id": unloaded_light_group.entry_id,
+                "entity_id": None,
+                "name": "Unloaded lights",
+            },
+        ],
+    }
+
+
+async def test_add_entity_to_group(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test adding an entity to a group."""
+    hass.states.async_set("light.one", "on")
+    hass.states.async_set("light.two", "off")
+
+    light_group = MockConfigEntry(
+        domain=group.DOMAIN,
+        options={
+            "all": False,
+            "entities": ["light.one"],
+            "group_type": "light",
+            "hide_members": False,
+            "name": "Kitchen lights",
+        },
+        title="Kitchen lights",
+    )
+    light_group.add_to_hass(hass)
+
+    assert await async_setup_component(hass, group.DOMAIN, {})
+    await hass.async_block_till_done()
+
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id(
+        {
+            "type": "group/add_entity",
+            "entry_id": light_group.entry_id,
+            "entity_id": "light.two",
+        }
+    )
+    response = await client.receive_json()
+
+    assert response["success"]
+    assert response["result"] == {"entities": ["light.one", "light.two"]}
+    assert light_group.options["entities"] == ["light.one", "light.two"]
+    assert hass.states.get("light.kitchen_lights").attributes["entity_id"] == [
+        "light.one",
+        "light.two",
+    ]
+
+
+async def test_add_incompatible_entity_to_group(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test adding an incompatible entity to a group."""
+    hass.states.async_set("light.one", "on")
+    hass.states.async_set("switch.one", "on")
+
+    light_group = MockConfigEntry(
+        domain=group.DOMAIN,
+        options={
+            "all": False,
+            "entities": ["light.one"],
+            "group_type": "light",
+            "hide_members": False,
+            "name": "Kitchen lights",
+        },
+        title="Kitchen lights",
+    )
+    light_group.add_to_hass(hass)
+
+    assert await async_setup_component(hass, group.DOMAIN, {})
+    await hass.async_block_till_done()
+
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id(
+        {
+            "type": "group/add_entity",
+            "entry_id": light_group.entry_id,
+            "entity_id": "switch.one",
+        }
+    )
+    response = await client.receive_json()
+
+    assert not response["success"]
+    assert response["error"]["code"] == "invalid_entity"
+    assert light_group.options["entities"] == ["light.one"]

--- a/tests/components/group/test_websocket_api.py
+++ b/tests/components/group/test_websocket_api.py
@@ -84,6 +84,62 @@ async def test_groups_for_entity(
     }
 
 
+async def test_groups_for_entity_excludes_own_group(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test listing compatible groups excludes the entity's own group."""
+    hass.states.async_set("light.one", "on")
+    hass.states.async_set("light.two", "on")
+
+    kitchen_group = MockConfigEntry(
+        domain=group.DOMAIN,
+        options={
+            "all": False,
+            "entities": ["light.one"],
+            "group_type": "light",
+            "hide_members": False,
+            "name": "Kitchen lights",
+        },
+        title="Kitchen lights",
+    )
+    kitchen_group.add_to_hass(hass)
+
+    bedroom_group = MockConfigEntry(
+        domain=group.DOMAIN,
+        options={
+            "all": False,
+            "entities": ["light.two"],
+            "group_type": "light",
+            "hide_members": False,
+            "name": "Bedroom lights",
+        },
+        title="Bedroom lights",
+    )
+    bedroom_group.add_to_hass(hass)
+
+    assert await async_setup_component(hass, group.DOMAIN, {})
+    await hass.async_block_till_done()
+
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id(
+        {"type": "group/groups_for_entity", "entity_id": "light.kitchen_lights"}
+    )
+    response = await client.receive_json()
+
+    assert response["success"]
+    assert response["result"] == {
+        "group_type": "light",
+        "groups": [
+            {
+                "entry_id": bedroom_group.entry_id,
+                "entity_id": "light.bedroom_lights",
+                "name": "Bedroom lights",
+            },
+        ],
+    }
+
+
 async def test_add_entity_to_group(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
@@ -170,6 +226,44 @@ async def test_add_entity_to_group_hides_member(
     assert entity_registry.async_get(entity_entry.entity_id).hidden_by is (
         er.RegistryEntryHider.INTEGRATION
     )
+
+
+async def test_add_entity_to_group_rejects_own_group(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test adding a group entity to itself is rejected."""
+    hass.states.async_set("light.one", "on")
+
+    light_group = MockConfigEntry(
+        domain=group.DOMAIN,
+        options={
+            "all": False,
+            "entities": ["light.one"],
+            "group_type": "light",
+            "hide_members": False,
+            "name": "Kitchen lights",
+        },
+        title="Kitchen lights",
+    )
+    light_group.add_to_hass(hass)
+
+    assert await async_setup_component(hass, group.DOMAIN, {})
+    await hass.async_block_till_done()
+
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id(
+        {
+            "type": "group/add_entity",
+            "entry_id": light_group.entry_id,
+            "entity_id": "light.kitchen_lights",
+        }
+    )
+    response = await client.receive_json()
+
+    assert not response["success"]
+    assert response["error"]["code"] == "invalid_entity"
+    assert light_group.options["entities"] == ["light.one"]
 
 
 async def test_add_incompatible_entity_to_group(


### PR DESCRIPTION
## Proposed change

Add two admin-only websocket commands for the Group integration:

- `group/groups_for_entity` lists existing groups that are compatible with a given entity and excludes groups that already contain it.
- `group/add_entity` adds a compatible entity to an existing group config entry, updates the entry options, preserves member hiding behavior, and reloads the group.

This also moves shared group type and member hiding helpers into common modules so the config flow and websocket API use the same logic.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/52521

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
