### PR TITLE
Delete `zigbee.db` when ZHA is removed

### DIFF
--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import logging
+from pathlib import Path
 from zoneinfo import ZoneInfo
 
 import voluptuous as vol
@@ -53,6 +54,7 @@ from .helpers import (
     create_zha_config,
     get_config_entry_unique_id,
     get_zha_data,
+    get_zigpy_database_path,
 )
 from .radio_manager import ZhaRadioManager
 from .repairs.network_settings_inconsistent import warn_on_inconsistent_network_settings
@@ -299,6 +301,20 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
     websocket_api.async_unload_api(hass)
 
     return True
+
+
+async def async_remove_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+    """Remove the ZHA config entry, deleting the zigbee database."""
+    database_path = Path(get_zigpy_database_path(hass))
+
+    # The `-shm` and `-wal` files are SQLite write-ahead log sidecars
+    for path in (
+        database_path,
+        database_path.with_name(f"{database_path.name}-shm"),
+        database_path.with_name(f"{database_path.name}-wal"),
+    ):
+        with contextlib.suppress(OSError):
+            await hass.async_add_executor_job(path.unlink)
 
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -1108,6 +1108,13 @@ def get_zha_data(hass: HomeAssistant) -> HAZHAData:
     return hass.data[DATA_ZHA]
 
 
+def get_zigpy_database_path(hass: HomeAssistant) -> str:
+    """Get the path to the zigpy database (`zigbee.db`)."""
+    return get_zha_data(hass).yaml_config.get(
+        CONF_DATABASE, hass.config.path(DEFAULT_DATABASE_NAME)
+    )
+
+
 def get_zha_gateway(hass: HomeAssistant) -> Gateway:
     """Get the ZHA gateway object."""
     if (gateway_proxy := get_zha_data(hass).gateway_proxy) is None:
@@ -1310,11 +1317,7 @@ def create_zha_config(hass: HomeAssistant, ha_zha_data: HAZHAData) -> ZHAData:
     # deep copy the yaml config to avoid modifying the original and to safely
     # pass it to the ZHA library
     app_config = copy.deepcopy(ha_zha_data.yaml_config.get(CONF_ZIGPY, {}))
-    database = ha_zha_data.yaml_config.get(
-        CONF_DATABASE,
-        hass.config.path(DEFAULT_DATABASE_NAME),
-    )
-    app_config[CONF_DATABASE] = database
+    app_config[CONF_DATABASE] = get_zigpy_database_path(hass)
     app_config[CONF_DEVICE] = ha_zha_data.config_entry.data[CONF_DEVICE]
 
     radio_type = RadioType[ha_zha_data.config_entry.data[CONF_RADIO_TYPE]]

--- a/homeassistant/components/zha/radio_manager.py
+++ b/homeassistant/components/zha/radio_manager.py
@@ -34,13 +34,8 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.service_info.usb import UsbServiceInfo
 
 from . import repairs
-from .const import (
-    CONF_RADIO_TYPE,
-    CONF_ZIGPY,
-    DEFAULT_DATABASE_NAME,
-    EZSP_OVERWRITE_EUI64,
-)
-from .helpers import get_zha_data
+from .const import CONF_RADIO_TYPE, CONF_ZIGPY, EZSP_OVERWRITE_EUI64
+from .helpers import get_zha_data, get_zigpy_database_path
 
 RECOMMENDED_RADIOS = (
     RadioType.ezsp,
@@ -160,12 +155,7 @@ class ZhaRadioManager:
     @property
     def zigpy_database_path(self) -> str:
         """Path to `zigbee.db`."""
-        config = get_zha_data(self.hass).yaml_config
-
-        return config.get(
-            CONF_DATABASE,
-            self.hass.config.path(DEFAULT_DATABASE_NAME),
-        )
+        return get_zigpy_database_path(self.hass)
 
     @contextlib.asynccontextmanager
     async def create_zigpy_app(

--- a/tests/components/zha/test_init.py
+++ b/tests/components/zha/test_init.py
@@ -3,6 +3,7 @@
 import asyncio
 from collections.abc import Callable
 import logging
+from pathlib import Path
 import typing
 from unittest.mock import AsyncMock, patch
 import zoneinfo
@@ -27,6 +28,7 @@ from homeassistant.components.zha.const import (
     CONF_FLOW_CONTROL,
     CONF_RADIO_TYPE,
     CONF_USB_PATH,
+    DEFAULT_DATABASE_NAME,
     DOMAIN,
 )
 from homeassistant.components.zha.helpers import (
@@ -569,3 +571,43 @@ async def test_gateway_created_with_migrated_device_path(
     zha_data = mock_create_config.call_args.args[1]
 
     assert zha_data.config_entry.data[CONF_DEVICE][CONF_DEVICE_PATH] == unique_path
+
+
+async def test_remove_entry_deletes_database(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_zigpy_connect: ControllerApplication,
+) -> None:
+    """Test that removing the ZHA entry deletes the zigbee database and its sidecars."""
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    database_files = [
+        Path(hass.config.path(f"{DEFAULT_DATABASE_NAME}{suffix}"))
+        for suffix in ("", "-shm", "-wal")
+    ]
+    for database_file in database_files:
+        database_file.write_bytes(b"")
+
+    await hass.config_entries.async_remove(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    for database_file in database_files:
+        assert not database_file.exists()
+
+
+async def test_remove_entry_no_database(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_zigpy_connect: ControllerApplication,
+) -> None:
+    """Test that removing the ZHA entry succeeds when no database files exist."""
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert not Path(hass.config.path(DEFAULT_DATABASE_NAME)).exists()
+
+    await hass.config_entries.async_remove(config_entry.entry_id)
+    await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
All old network backups and previously joined device caches will be deleted if you remove the ZHA integration. Users relying on being able to delete ZHA and then set it up again without losing any devices will not be able to do so any longer. The underlying network will not be lost if you do, if you set ZHA up with "keep existing adapter settings" your network will slowly be rebuilt as devices check in.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When the ZHA integration is removed, delete `/config/zigbee.db`. This ensures that no network settings are retained on disk if Zigbee is removed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
