### PR TITLE
Solve issue with double slash in url when writing data to InfluxDB

### DIFF
--- a/homeassistant/components/influxdb/__init__.py
+++ b/homeassistant/components/influxdb/__init__.py
@@ -423,7 +423,7 @@ def get_influx_connection(  # noqa: C901
     if CONF_HOST in conf:
         kwargs[CONF_HOST] = conf[CONF_HOST]
 
-    if (path := conf.get(CONF_PATH)) is not None:
+    if (path := conf.get(CONF_PATH)) is not None and path != "/":
         kwargs[CONF_PATH] = path
 
     if (port := conf.get(CONF_PORT)) is not None:

--- a/tests/components/influxdb/test_init.py
+++ b/tests/components/influxdb/test_init.py
@@ -13,7 +13,13 @@ import pytest
 from homeassistant.components import influxdb
 from homeassistant.components.influxdb.const import DEFAULT_BUCKET, DOMAIN
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import PERCENTAGE, STATE_OFF, STATE_ON, STATE_STANDBY
+from homeassistant.const import (
+    CONF_PATH,
+    PERCENTAGE,
+    STATE_OFF,
+    STATE_ON,
+    STATE_STANDBY,
+)
 from homeassistant.core import HomeAssistant, split_entity_id
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.setup import async_setup_component
@@ -319,6 +325,50 @@ async def test_setup_config_ssl(
         await hass.async_block_till_done()
 
         assert expected_client_args.items() <= mock_client.call_args.kwargs.items()
+
+
+@pytest.mark.parametrize(
+    ("mock_client", "config_ext", "path_in_kwargs"),
+    [
+        pytest.param(
+            influxdb.DEFAULT_API_VERSION,
+            {CONF_PATH: "/"},
+            False,
+            id="root_path_excluded",
+        ),
+        pytest.param(
+            influxdb.DEFAULT_API_VERSION,
+            {CONF_PATH: "/custom_path"},
+            True,
+            id="custom_path_included",
+        ),
+        pytest.param(
+            influxdb.DEFAULT_API_VERSION,
+            {},
+            False,
+            id="no_path_excluded",
+        ),
+    ],
+    indirect=["mock_client"],
+)
+async def test_setup_config_path(
+    hass: HomeAssistant, mock_client, config_ext: dict, path_in_kwargs: bool
+) -> None:
+    """Test that path='/' is not passed to InfluxDBClient, but other paths are."""
+    config = BASE_V1_CONFIG.copy()
+    config.update(config_ext)
+
+    mock_entry = MockConfigEntry(domain=DOMAIN, data=config)
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    if path_in_kwargs:
+        assert CONF_PATH in mock_client.call_args.kwargs
+        assert mock_client.call_args.kwargs[CONF_PATH] == config_ext[CONF_PATH]
+    else:
+        assert CONF_PATH not in mock_client.call_args.kwargs
 
 
 @pytest.mark.parametrize(

--- a/tests/components/influxdb/test_init.py
+++ b/tests/components/influxdb/test_init.py
@@ -328,31 +328,31 @@ async def test_setup_config_ssl(
 
 
 @pytest.mark.parametrize(
-    ("mock_client", "config_ext", "path_in_kwargs"),
+    ("mock_client", "config_ext", "expected_path"),
     [
         pytest.param(
             influxdb.DEFAULT_API_VERSION,
             {CONF_PATH: "/"},
-            False,
+            None,
             id="root_path_excluded",
         ),
         pytest.param(
             influxdb.DEFAULT_API_VERSION,
             {CONF_PATH: "/custom_path"},
-            True,
+            "/custom_path",
             id="custom_path_included",
         ),
         pytest.param(
             influxdb.DEFAULT_API_VERSION,
             {},
-            False,
+            None,
             id="no_path_excluded",
         ),
     ],
     indirect=["mock_client"],
 )
 async def test_setup_config_path(
-    hass: HomeAssistant, mock_client, config_ext: dict, path_in_kwargs: bool
+    hass: HomeAssistant, mock_client, config_ext: dict, expected_path: bool
 ) -> None:
     """Test that path='/' is not passed to InfluxDBClient, but other paths are."""
     config = BASE_V1_CONFIG.copy()
@@ -364,11 +364,7 @@ async def test_setup_config_path(
     await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
-    if path_in_kwargs:
-        assert CONF_PATH in mock_client.call_args.kwargs
-        assert mock_client.call_args.kwargs[CONF_PATH] == config_ext[CONF_PATH]
-    else:
-        assert CONF_PATH not in mock_client.call_args.kwargs
+    assert mock_client.call_args.kwargs.get(CONF_PATH) == expected_path
 
 
 @pytest.mark.parametrize(

--- a/tests/components/influxdb/test_init.py
+++ b/tests/components/influxdb/test_init.py
@@ -352,7 +352,7 @@ async def test_setup_config_ssl(
     indirect=["mock_client"],
 )
 async def test_setup_config_path(
-    hass: HomeAssistant, mock_client, config_ext: dict, expected_path: bool
+    hass: HomeAssistant, mock_client, config_ext: dict, expected_path: str | None
 ) -> None:
     """Test that path='/' is not passed to InfluxDBClient, but other paths are."""
     config = BASE_V1_CONFIG.copy()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When for influxdb v1, the config entry contains a "/" for path, this is written to InfluxDB Client. When the client builds a url, it adds another slash ending up with two slashes. Somehow in 2026.6, this does not work anymore. This change ignores only a "/" in path.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #173086
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
