### PR TITLE
anova: auto-reconnect websocket on connection drop

### DIFF
--- a/homeassistant/components/anova/__init__.py
+++ b/homeassistant/components/anova/__init__.py
@@ -1,5 +1,6 @@
 """The Anova integration."""
 
+import asyncio
 import logging
 from typing import TYPE_CHECKING
 
@@ -11,8 +12,9 @@ from anova_wifi import (
     WebsocketFailure,
 )
 
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_DEVICES, CONF_PASSWORD, CONF_USERNAME, Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client
 
@@ -21,6 +23,58 @@ from .coordinator import AnovaConfigEntry, AnovaCoordinator, AnovaData
 PLATFORMS = [Platform.SENSOR]
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@callback
+def _async_setup_disconnect_listener(
+    hass: HomeAssistant,
+    entry: AnovaConfigEntry,
+) -> None:
+    """Register a done callback on the websocket listener task to reconnect on drop."""
+    ws_handler = entry.runtime_data.api.websocket_handler
+    if ws_handler is None or ws_handler._message_listener is None:  # noqa: SLF001
+        return
+
+    @callback
+    def _async_on_message_listener_done(task: asyncio.Future[None]) -> None:
+        if task.cancelled():
+            return
+        if entry.state is not ConfigEntryState.LOADED:
+            return
+        entry.async_create_background_task(
+            hass,
+            _async_reconnect_websocket(hass, entry),
+            "anova_websocket_reconnect",
+        )
+
+    ws_handler._message_listener.add_done_callback(  # noqa: SLF001
+        _async_on_message_listener_done
+    )
+
+
+async def _async_reconnect_websocket(
+    hass: HomeAssistant,
+    entry: AnovaConfigEntry,
+) -> None:
+    """Reconnect the Anova websocket and re-wire device coordinators."""
+    _LOGGER.warning("Anova websocket connection lost, attempting to reconnect")
+    try:
+        await entry.runtime_data.api.create_websocket()
+    except (NoDevicesFound, WebsocketFailure) as err:
+        _LOGGER.warning("Failed to reconnect to Anova websocket: %s", err)
+        return
+
+    ws_handler = entry.runtime_data.api.websocket_handler
+    if ws_handler is None:
+        return
+
+    for coordinator in entry.runtime_data.coordinators:
+        device = ws_handler.devices.get(coordinator.device_unique_id)
+        if device is not None:
+            coordinator.anova_device = device
+            device.set_update_listener(coordinator.async_set_updated_data)
+
+    _async_setup_disconnect_listener(hass, entry)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: AnovaConfigEntry) -> bool:
@@ -60,13 +114,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: AnovaConfigEntry) -> boo
     coordinators = [AnovaCoordinator(hass, entry, device) for device in devices]
     entry.runtime_data = AnovaData(api_jwt=api.jwt, coordinators=coordinators, api=api)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    _async_setup_disconnect_listener(hass, entry)
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: AnovaConfigEntry) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        # Disconnect from WS
+        ws_handler = entry.runtime_data.api.websocket_handler
+        if ws_handler is not None and ws_handler._message_listener is not None:  # noqa: SLF001
+            ws_handler._message_listener.cancel()  # noqa: SLF001
         await entry.runtime_data.api.disconnect_websocket()
     return unload_ok
 

--- a/homeassistant/components/anova/__init__.py
+++ b/homeassistant/components/anova/__init__.py
@@ -11,6 +11,7 @@ from anova_wifi import (
     NoDevicesFound,
     WebsocketFailure,
 )
+from anova_wifi.exceptions import LoginUnreachable
 
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_DEVICES, CONF_PASSWORD, CONF_USERNAME, Platform
@@ -60,7 +61,18 @@ async def _async_reconnect_websocket(
     _LOGGER.warning("Anova websocket connection lost, attempting to reconnect")
     try:
         await entry.runtime_data.api.create_websocket()
-    except (NoDevicesFound, WebsocketFailure) as err:
+    except WebsocketFailure:
+        try:
+            await entry.runtime_data.api.authenticate()
+        except (InvalidLogin, LoginUnreachable) as err:
+            _LOGGER.warning("Failed to re-authenticate with Anova: %s", err)
+            return
+        try:
+            await entry.runtime_data.api.create_websocket()
+        except (NoDevicesFound, WebsocketFailure) as err:
+            _LOGGER.warning("Failed to reconnect to Anova websocket: %s", err)
+            return
+    except NoDevicesFound as err:
         _LOGGER.warning("Failed to reconnect to Anova websocket: %s", err)
         return
 

--- a/homeassistant/components/anova/__init__.py
+++ b/homeassistant/components/anova/__init__.py
@@ -18,10 +18,12 @@ from homeassistant.const import CONF_DEVICES, CONF_PASSWORD, CONF_USERNAME, Plat
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client
+from homeassistant.helpers.event import async_call_later
 
 from .coordinator import AnovaConfigEntry, AnovaCoordinator, AnovaData
 
 PLATFORMS = [Platform.SENSOR]
+RECONNECT_RETRY_DELAY = 30
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -53,6 +55,27 @@ def _async_setup_disconnect_listener(
     )
 
 
+@callback
+def _async_schedule_reconnect_retry(
+    hass: HomeAssistant,
+    entry: AnovaConfigEntry,
+) -> None:
+    """Schedule a reconnect attempt after a delay."""
+
+    @callback
+    def _retry(_now: object) -> None:
+        if entry.state is not ConfigEntryState.LOADED:
+            return
+        entry.async_create_background_task(
+            hass,
+            _async_reconnect_websocket(hass, entry),
+            "anova_websocket_reconnect",
+        )
+
+    cancel = async_call_later(hass, RECONNECT_RETRY_DELAY, _retry)
+    entry.async_on_unload(cancel)
+
+
 async def _async_reconnect_websocket(
     hass: HomeAssistant,
     entry: AnovaConfigEntry,
@@ -64,16 +87,22 @@ async def _async_reconnect_websocket(
     except WebsocketFailure:
         try:
             await entry.runtime_data.api.authenticate()
-        except (InvalidLogin, LoginUnreachable) as err:
+        except InvalidLogin as err:
+            _LOGGER.error("Anova re-authentication failed: %s", err)
+            return
+        except LoginUnreachable as err:
             _LOGGER.warning("Failed to re-authenticate with Anova: %s", err)
+            _async_schedule_reconnect_retry(hass, entry)
             return
         try:
             await entry.runtime_data.api.create_websocket()
         except (NoDevicesFound, WebsocketFailure) as err:
             _LOGGER.warning("Failed to reconnect to Anova websocket: %s", err)
+            _async_schedule_reconnect_retry(hass, entry)
             return
     except NoDevicesFound as err:
         _LOGGER.warning("Failed to reconnect to Anova websocket: %s", err)
+        _async_schedule_reconnect_retry(hass, entry)
         return
 
     ws_handler = entry.runtime_data.api.websocket_handler

--- a/homeassistant/components/anova/__init__.py
+++ b/homeassistant/components/anova/__init__.py
@@ -1,6 +1,5 @@
 """The Anova integration."""
 
-import asyncio
 import logging
 from typing import TYPE_CHECKING
 
@@ -11,111 +10,17 @@ from anova_wifi import (
     NoDevicesFound,
     WebsocketFailure,
 )
-from anova_wifi.exceptions import LoginUnreachable
 
-from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_DEVICES, CONF_PASSWORD, CONF_USERNAME, Platform
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client
-from homeassistant.helpers.event import async_call_later
 
 from .coordinator import AnovaConfigEntry, AnovaCoordinator, AnovaData
 
 PLATFORMS = [Platform.SENSOR]
-RECONNECT_RETRY_DELAY = 30
 
 _LOGGER = logging.getLogger(__name__)
-
-
-@callback
-def _async_setup_disconnect_listener(
-    hass: HomeAssistant,
-    entry: AnovaConfigEntry,
-) -> None:
-    """Register a done callback on the websocket listener task to reconnect on drop."""
-    ws_handler = entry.runtime_data.api.websocket_handler
-    if ws_handler is None or ws_handler._message_listener is None:  # noqa: SLF001
-        return
-
-    @callback
-    def _async_on_message_listener_done(task: asyncio.Future[None]) -> None:
-        if task.cancelled():
-            return
-        if entry.state is not ConfigEntryState.LOADED:
-            return
-        entry.async_create_background_task(
-            hass,
-            _async_reconnect_websocket(hass, entry),
-            "anova_websocket_reconnect",
-        )
-
-    ws_handler._message_listener.add_done_callback(  # noqa: SLF001
-        _async_on_message_listener_done
-    )
-
-
-@callback
-def _async_schedule_reconnect_retry(
-    hass: HomeAssistant,
-    entry: AnovaConfigEntry,
-) -> None:
-    """Schedule a reconnect attempt after a delay."""
-
-    @callback
-    def _retry(_now: object) -> None:
-        if entry.state is not ConfigEntryState.LOADED:
-            return
-        entry.async_create_background_task(
-            hass,
-            _async_reconnect_websocket(hass, entry),
-            "anova_websocket_reconnect",
-        )
-
-    cancel = async_call_later(hass, RECONNECT_RETRY_DELAY, _retry)
-    entry.async_on_unload(cancel)
-
-
-async def _async_reconnect_websocket(
-    hass: HomeAssistant,
-    entry: AnovaConfigEntry,
-) -> None:
-    """Reconnect the Anova websocket and re-wire device coordinators."""
-    _LOGGER.warning("Anova websocket connection lost, attempting to reconnect")
-    try:
-        await entry.runtime_data.api.create_websocket()
-    except WebsocketFailure:
-        try:
-            await entry.runtime_data.api.authenticate()
-        except InvalidLogin as err:
-            _LOGGER.error("Anova re-authentication failed: %s", err)
-            return
-        except LoginUnreachable as err:
-            _LOGGER.warning("Failed to re-authenticate with Anova: %s", err)
-            _async_schedule_reconnect_retry(hass, entry)
-            return
-        try:
-            await entry.runtime_data.api.create_websocket()
-        except (NoDevicesFound, WebsocketFailure) as err:
-            _LOGGER.warning("Failed to reconnect to Anova websocket: %s", err)
-            _async_schedule_reconnect_retry(hass, entry)
-            return
-    except NoDevicesFound as err:
-        _LOGGER.warning("Failed to reconnect to Anova websocket: %s", err)
-        _async_schedule_reconnect_retry(hass, entry)
-        return
-
-    ws_handler = entry.runtime_data.api.websocket_handler
-    if ws_handler is None:
-        return
-
-    for coordinator in entry.runtime_data.coordinators:
-        device = ws_handler.devices.get(coordinator.device_unique_id)
-        if device is not None:
-            coordinator.anova_device = device
-            device.set_update_listener(coordinator.async_set_updated_data)
-
-    _async_setup_disconnect_listener(hass, entry)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: AnovaConfigEntry) -> bool:
@@ -155,7 +60,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: AnovaConfigEntry) -> boo
     coordinators = [AnovaCoordinator(hass, entry, device) for device in devices]
     entry.runtime_data = AnovaData(api_jwt=api.jwt, coordinators=coordinators, api=api)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    _async_setup_disconnect_listener(hass, entry)
+    coordinators[0].async_start_disconnect_listener()
     return True
 
 

--- a/homeassistant/components/anova/coordinator.py
+++ b/homeassistant/components/anova/coordinator.py
@@ -1,18 +1,30 @@
 """Support for Anova Coordinators."""
 
-from dataclasses import dataclass
+import asyncio
+from dataclasses import dataclass, field
+from datetime import timedelta
 import logging
 
-from anova_wifi import AnovaApi, APCUpdate, APCWifiDevice
+from anova_wifi import (
+    AnovaApi,
+    APCUpdate,
+    APCWifiDevice,
+    InvalidLogin,
+    NoDevicesFound,
+    WebsocketFailure,
+)
+from anova_wifi.exceptions import LoginUnreachable
 
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+RECONNECT_RETRY_DELAY = 60
 
 
 @dataclass
@@ -22,12 +34,13 @@ class AnovaData:
     api_jwt: str
     coordinators: list[AnovaCoordinator]
     api: AnovaApi
+    reconnect_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
 
 type AnovaConfigEntry = ConfigEntry[AnovaData]
 
 
-class AnovaCoordinator(DataUpdateCoordinator[APCUpdate]):
+class AnovaCoordinator(DataUpdateCoordinator[APCUpdate | None]):
     """Anova custom coordinator."""
 
     config_entry: AnovaConfigEntry
@@ -44,6 +57,7 @@ class AnovaCoordinator(DataUpdateCoordinator[APCUpdate]):
             config_entry=config_entry,
             name="Anova Precision Cooker",
             logger=_LOGGER,
+            update_interval=timedelta(seconds=RECONNECT_RETRY_DELAY),
         )
         self.device_unique_id = anova_device.cooker_id
         self.anova_device = anova_device
@@ -57,3 +71,78 @@ class AnovaCoordinator(DataUpdateCoordinator[APCUpdate]):
             model="Precision Cooker",
         )
         self.sensor_data_set: bool = False
+
+    @callback
+    def async_start_disconnect_listener(self) -> None:
+        """Register a done callback on the websocket listener to detect connection drops."""
+        ws_handler = self.config_entry.runtime_data.api.websocket_handler
+        if ws_handler is None or ws_handler._message_listener is None:  # noqa: SLF001
+            return
+
+        @callback
+        def _on_done(task: asyncio.Future[None]) -> None:
+            if task.cancelled():
+                return
+            if self.config_entry.state is not ConfigEntryState.LOADED:
+                return
+            self.config_entry.async_create_background_task(
+                self.hass,
+                self.async_request_refresh(),
+                "anova_websocket_reconnect",
+            )
+
+        ws_handler._message_listener.add_done_callback(_on_done)  # noqa: SLF001
+
+    async def _async_update_data(self) -> APCUpdate | None:
+        """Reconnect the websocket if it has dropped; return current push data."""
+        ws_handler = self.config_entry.runtime_data.api.websocket_handler
+        if ws_handler is not None:
+            listener = ws_handler._message_listener  # noqa: SLF001
+            if listener is not None and not listener.done():
+                return self.data
+
+        async with self.config_entry.runtime_data.reconnect_lock:
+            ws_handler = self.config_entry.runtime_data.api.websocket_handler
+            if ws_handler is not None:
+                listener = ws_handler._message_listener  # noqa: SLF001
+                if listener is not None and not listener.done():
+                    return self.data
+            await self._async_reconnect()
+
+        return self.data
+
+    async def _async_reconnect(self) -> None:
+        """Reconnect the Anova websocket and re-wire all device coordinators."""
+        api = self.config_entry.runtime_data.api
+        _LOGGER.warning("Anova websocket connection lost, attempting to reconnect")
+        try:
+            await api.create_websocket()
+        except WebsocketFailure:
+            try:
+                await api.authenticate()
+            except InvalidLogin as err:
+                _LOGGER.error("Anova re-authentication failed: %s", err)
+                raise UpdateFailed(str(err)) from err
+            except LoginUnreachable as err:
+                _LOGGER.warning("Failed to re-authenticate with Anova: %s", err)
+                raise UpdateFailed(str(err)) from err
+            try:
+                await api.create_websocket()
+            except (NoDevicesFound, WebsocketFailure) as err:
+                _LOGGER.warning("Failed to reconnect to Anova websocket: %s", err)
+                raise UpdateFailed(str(err)) from err
+        except NoDevicesFound as err:
+            _LOGGER.warning("Failed to reconnect to Anova websocket: %s", err)
+            raise UpdateFailed(str(err)) from err
+
+        ws_handler = api.websocket_handler
+        if ws_handler is None:
+            return
+
+        for coordinator in self.config_entry.runtime_data.coordinators:
+            device = ws_handler.devices.get(coordinator.device_unique_id)
+            if device is not None:
+                coordinator.anova_device = device
+                device.set_update_listener(coordinator.async_set_updated_data)
+
+        self.async_start_disconnect_listener()

--- a/homeassistant/components/anova/sensor.py
+++ b/homeassistant/components/anova/sensor.py
@@ -113,6 +113,8 @@ def setup_coordinator(
     def _async_sensor_listener() -> None:
         """Listen for new sensor data and add sensors if they did not exist."""
         if not coordinator.sensor_data_set:
+            if coordinator.data is None:
+                return
             valid_entities: set[AnovaSensor] = set()
             for description in SENSOR_DESCRIPTIONS:
                 if description.value_fn(coordinator.data.sensor) is not None:
@@ -137,4 +139,6 @@ class AnovaSensor(AnovaDescriptionEntity, SensorEntity):
     @property
     def native_value(self) -> StateType:
         """Return the state."""
+        if self.coordinator.data is None:
+            return None
         return self.entity_description.value_fn(self.coordinator.data.sensor)

--- a/tests/components/anova/conftest.py
+++ b/tests/components/anova/conftest.py
@@ -70,6 +70,7 @@ class MockedAnovaWebsocketHandler(AnovaWebsocketHandler):
         super().__init__(firebase_jwt, jwt, session)
         self.connect_messages = connect_messages
         self.post_connect_messages = post_connect_messages
+        self._disconnect_event: asyncio.Event = asyncio.Event()
 
     async def connect(self) -> None:
         """Create a future for the message listener."""
@@ -79,6 +80,16 @@ class MockedAnovaWebsocketHandler(AnovaWebsocketHandler):
         # RUF006 ignored as it replicates the parent library
         # https://github.com/Lash-L/anova_wifi/issues/35
         asyncio.ensure_future(self.message_listener())  # noqa: RUF006
+        if self.devices:
+            self._message_listener = asyncio.ensure_future(self._wait_for_disconnect())
+
+    async def _wait_for_disconnect(self) -> None:
+        """Block until simulate_disconnect() is called."""
+        await self._disconnect_event.wait()
+
+    def simulate_disconnect(self) -> None:
+        """Simulate the websocket connection dropping."""
+        self._disconnect_event.set()
 
 
 def anova_api_mock(

--- a/tests/components/anova/test_init.py
+++ b/tests/components/anova/test_init.py
@@ -1,8 +1,8 @@
 """Test init for Anova."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
-from anova_wifi import AnovaApi
+from anova_wifi import AnovaApi, WebsocketFailure
 
 from homeassistant.components.anova.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
@@ -87,6 +87,40 @@ async def test_websocket_reconnects_on_disconnect(
         device = new_ws_handler.devices.get(coordinator.device_unique_id)
         assert device is not None
         assert device.update_listener == coordinator.async_set_updated_data
+
+
+async def test_websocket_reconnects_after_auth_expiry(
+    hass: HomeAssistant,
+    anova_api: AnovaApi,
+) -> None:
+    """Test that the integration re-authenticates and reconnects when auth has expired."""
+    entry = await async_init_integration(hass)
+
+    ws_handler = entry.runtime_data.api.websocket_handler
+    assert isinstance(ws_handler, MockedAnovaWebsocketHandler)
+
+    # Simulate: first create_websocket call fails (stale JWT), then succeeds after re-auth.
+    original_side_effect = entry.runtime_data.api.create_websocket.side_effect
+    call_count = 0
+
+    async def create_websocket_after_reauth():
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise WebsocketFailure("Token expired")
+        await original_side_effect()
+
+    entry.runtime_data.api.create_websocket.side_effect = create_websocket_after_reauth
+    entry.runtime_data.api.authenticate = AsyncMock()
+
+    ws_handler.simulate_disconnect()
+    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    entry.runtime_data.api.authenticate.assert_called_once()
+    assert call_count == 2
+    new_ws_handler = entry.runtime_data.api.websocket_handler
+    assert new_ws_handler is not ws_handler
 
 
 async def test_migration_removing_devices_in_config_entry(

--- a/tests/components/anova/test_init.py
+++ b/tests/components/anova/test_init.py
@@ -10,6 +10,7 @@ from homeassistant.const import CONF_DEVICES, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 
 from . import async_init_integration, create_entry
+from .conftest import MockedAnovaWebsocketHandler
 
 from tests.common import MockConfigEntry
 
@@ -60,6 +61,32 @@ async def test_websocket_failure(
     """Test that we successfully handle a websocket failure on setup."""
     entry = await async_init_integration(hass)
     assert entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_websocket_reconnects_on_disconnect(
+    hass: HomeAssistant,
+    anova_api: AnovaApi,
+) -> None:
+    """Test that the integration automatically reconnects when the websocket drops."""
+    entry = await async_init_integration(hass)
+
+    initial_call_count = entry.runtime_data.api.create_websocket.call_count
+    ws_handler = entry.runtime_data.api.websocket_handler
+    assert isinstance(ws_handler, MockedAnovaWebsocketHandler)
+
+    ws_handler.simulate_disconnect()
+    # First call lets _wait_for_disconnect complete and schedules the done callback.
+    # Second call processes the done callback, creates the reconnect task, and waits for it.
+    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert entry.runtime_data.api.create_websocket.call_count == initial_call_count + 1
+    new_ws_handler = entry.runtime_data.api.websocket_handler
+    assert new_ws_handler is not ws_handler
+    for coordinator in entry.runtime_data.coordinators:
+        device = new_ws_handler.devices.get(coordinator.device_unique_id)
+        assert device is not None
+        assert device.update_listener == coordinator.async_set_updated_data
 
 
 async def test_migration_removing_devices_in_config_entry(

--- a/tests/components/anova/test_init.py
+++ b/tests/components/anova/test_init.py
@@ -1,18 +1,24 @@
 """Test init for Anova."""
 
+from datetime import timedelta
+import logging
 from unittest.mock import AsyncMock, patch
 
-from anova_wifi import AnovaApi, WebsocketFailure
+from anova_wifi import AnovaApi, InvalidLogin, NoDevicesFound, WebsocketFailure
+from anova_wifi.exceptions import LoginUnreachable
+import pytest
 
+from homeassistant.components.anova import RECONNECT_RETRY_DELAY
 from homeassistant.components.anova.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_DEVICES, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 
 from . import async_init_integration, create_entry
 from .conftest import MockedAnovaWebsocketHandler
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 async def test_async_setup_entry(hass: HomeAssistant, anova_api: AnovaApi) -> None:
@@ -121,6 +127,94 @@ async def test_websocket_reconnects_after_auth_expiry(
     assert call_count == 2
     new_ws_handler = entry.runtime_data.api.websocket_handler
     assert new_ws_handler is not ws_handler
+
+
+@pytest.mark.parametrize(
+    ("ws_side_effect", "auth_side_effect", "expected_log"),
+    [
+        pytest.param(
+            NoDevicesFound("offline"),
+            None,
+            "Failed to reconnect to Anova websocket",
+            id="no_devices_found",
+        ),
+        pytest.param(
+            WebsocketFailure("expired"),
+            InvalidLogin("bad creds"),
+            "Anova re-authentication failed",
+            id="invalid_login_on_reauth",
+        ),
+        pytest.param(
+            WebsocketFailure("expired"),
+            LoginUnreachable("server down"),
+            "Failed to re-authenticate with Anova",
+            id="login_unreachable_on_reauth",
+        ),
+        pytest.param(
+            WebsocketFailure("expired"),
+            None,
+            "Failed to reconnect to Anova websocket",
+            id="websocket_failure_after_reauth",
+        ),
+    ],
+)
+async def test_websocket_reconnect_failure_paths(
+    hass: HomeAssistant,
+    anova_api: AnovaApi,
+    caplog: pytest.LogCaptureFixture,
+    ws_side_effect: Exception,
+    auth_side_effect: Exception | None,
+    expected_log: str,
+) -> None:
+    """Test that reconnect failures are logged and the entry stays loaded."""
+    entry = await async_init_integration(hass)
+    ws_handler = entry.runtime_data.api.websocket_handler
+    assert isinstance(ws_handler, MockedAnovaWebsocketHandler)
+
+    entry.runtime_data.api.create_websocket.side_effect = ws_side_effect
+    entry.runtime_data.api.authenticate = AsyncMock(side_effect=auth_side_effect)
+
+    with caplog.at_level(logging.WARNING, logger="homeassistant.components.anova"):
+        ws_handler.simulate_disconnect()
+        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert expected_log in caplog.text
+    assert entry.state is ConfigEntryState.LOADED
+
+
+async def test_websocket_reconnect_retries_after_transient_failure(
+    hass: HomeAssistant,
+    anova_api: AnovaApi,
+) -> None:
+    """Test that a transient reconnect failure is retried after a delay."""
+    entry = await async_init_integration(hass)
+    ws_handler = entry.runtime_data.api.websocket_handler
+    assert isinstance(ws_handler, MockedAnovaWebsocketHandler)
+
+    original_side_effect = entry.runtime_data.api.create_websocket.side_effect
+    attempts: list[int] = []
+
+    async def create_websocket_fails_once() -> None:
+        attempts.append(1)
+        if len(attempts) == 1:
+            raise NoDevicesFound("Device temporarily offline")
+        await original_side_effect()
+
+    entry.runtime_data.api.create_websocket.side_effect = create_websocket_fails_once
+
+    ws_handler.simulate_disconnect()
+    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert len(attempts) == 1
+
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + timedelta(seconds=RECONNECT_RETRY_DELAY + 1)
+    )
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert len(attempts) == 2
+    assert entry.runtime_data.api.websocket_handler is not ws_handler
 
 
 async def test_migration_removing_devices_in_config_entry(

--- a/tests/components/anova/test_init.py
+++ b/tests/components/anova/test_init.py
@@ -81,8 +81,10 @@ async def test_websocket_reconnects_on_disconnect(
     assert isinstance(ws_handler, MockedAnovaWebsocketHandler)
 
     ws_handler.simulate_disconnect()
-    # First call lets _wait_for_disconnect complete and schedules the done callback.
-    # Second call processes the done callback, creates the reconnect task, and waits for it.
+    # First call: _wait_for_disconnect completes and the done callback schedules
+    # async_request_refresh as a background task.
+    # Second call: the background task runs async_request_refresh -> _async_update_data
+    # -> _async_reconnect.
     await hass.async_block_till_done()
     await hass.async_block_till_done(wait_background_tasks=True)
 
@@ -181,6 +183,22 @@ async def test_websocket_reconnect_failure_paths(
 
     assert expected_log in caplog.text
     assert entry.state is ConfigEntryState.LOADED
+
+
+async def test_coordinator_poll_does_not_reconnect_when_connected(
+    hass: HomeAssistant,
+    anova_api: AnovaApi,
+) -> None:
+    """Test that the periodic coordinator poll is a no-op when the websocket is alive."""
+    entry = await async_init_integration(hass)
+    initial_call_count = entry.runtime_data.api.create_websocket.call_count
+
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + timedelta(seconds=RECONNECT_RETRY_DELAY + 1)
+    )
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert entry.runtime_data.api.create_websocket.call_count == initial_call_count
 
 
 async def test_websocket_reconnect_retries_after_transient_failure(

--- a/tests/components/anova/test_init.py
+++ b/tests/components/anova/test_init.py
@@ -8,8 +8,8 @@ from anova_wifi import AnovaApi, InvalidLogin, NoDevicesFound, WebsocketFailure
 from anova_wifi.exceptions import LoginUnreachable
 import pytest
 
-from homeassistant.components.anova import RECONNECT_RETRY_DELAY
 from homeassistant.components.anova.const import DOMAIN
+from homeassistant.components.anova.coordinator import RECONNECT_RETRY_DELAY
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_DEVICES, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant


### PR DESCRIPTION
## Proposed change

The Anova integration loses device updates when the websocket connection drops (e.g. network blip, Firebase token expiry) and never recovers — the user has to manually reload the integration.

This PR adds automatic reconnection:

1. After `async_setup_entry` establishes the websocket, an asyncio `done` callback is registered on the library's `_message_listener` task. When the listener task ends unexpectedly, it schedules `async_request_refresh()` via a background task to trigger an immediate reconnect attempt.

2. Reconnect logic lives in `AnovaCoordinator._async_update_data`. The coordinator's `update_interval` (60 s) acts as the retry clock: if reconnect fails with `UpdateFailed`, the `DataUpdateCoordinator` machinery reschedules automatically — matching the pattern used by Shelly and other Gold/Platinum integrations.

3. An `asyncio.Lock` on `AnovaData` prevents multiple coordinators (one per device) from racing to reconnect the shared websocket simultaneously (double-checked locking pattern).

4. On reconnect, each device coordinator is re-wired to the new `APCWifiDevice` object and its update listener re-registered. The done callback is then re-registered on the new listener for the next cycle.

5. If `create_websocket()` raises `WebsocketFailure` (e.g. the Firebase ID token has expired — it has a ~1 hour TTL), the reconnect attempts `authenticate()` first to refresh both JWTs and then retries the connection.

6. On unload, `_message_listener` is cancelled before `disconnect_websocket()` is called so the done callback exits cleanly rather than racing teardown with a reconnect attempt.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Dependency upgrade
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr