### PR TITLE
Do not enable MQTT entities though discovery that were disabled by user

### DIFF
--- a/homeassistant/components/mqtt/entity.py
+++ b/homeassistant/components/mqtt/entity.py
@@ -1432,9 +1432,10 @@ class MqttEntity(
         if (
             self._config[CONF_ENABLED_BY_DEFAULT]
             and deleted_entry
-            and deleted_entry.disabled_by is not None
+            and deleted_entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
         ):
-            # Enable previous deleted entity and enable it
+            # Enable previous deleted entity and enable it,
+            # if it was not disabled by the user
             recreated_entry = entity_registry.async_get_or_create(
                 entity_platform, DOMAIN, self.unique_id
             )

--- a/tests/components/mqtt/test_mixins.py
+++ b/tests/components/mqtt/test_mixins.py
@@ -626,6 +626,27 @@ async def test_registry_enable_not_enabled_by_default_entity(
     assert not entry.disabled
     assert device_registry.async_get(device_id) is not None
 
+    # Mock the the entry is disabled by the user
+    entity_registry.async_update_entity(
+        "sensor.test_new", disabled_by=er.RegistryEntryDisabler.USER
+    )
+    await hass.async_block_till_done(wait_background_tasks=True)
+    state = hass.states.get("sensor.test_new")
+    assert state is None
+    # Remove the disabled entry
+    entity_registry.async_remove(entry.id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    entry = entity_registry.async_get("sensor.test_new")
+    assert entry is not None
+
+    # Repeat the re-discovery, and assert the entity remains disabled
+    async_fire_mqtt_message(hass, discovery_topic, config_enabled_new_entity_name)
+    await hass.async_block_till_done()
+    entry = entity_registry.async_get("sensor.test_new")
+    assert entry is not None
+    assert entry.disabled
+    assert device_registry.async_get(device_id) is not None
+
 
 @pytest.mark.parametrize(
     "mqtt_config_subentries_data",

--- a/tests/components/mqtt/test_mixins.py
+++ b/tests/components/mqtt/test_mixins.py
@@ -626,7 +626,7 @@ async def test_registry_enable_not_enabled_by_default_entity(
     assert not entry.disabled
     assert device_registry.async_get(device_id) is not None
 
-    # Mock the the entry is disabled by the user
+    # Mock the entry is disabled by the user
     entity_registry.async_update_entity(
         "sensor.test_new", disabled_by=er.RegistryEntryDisabler.USER
     )
@@ -634,10 +634,10 @@ async def test_registry_enable_not_enabled_by_default_entity(
     state = hass.states.get("sensor.test_new")
     assert state is None
     # Remove the disabled entry
-    entity_registry.async_remove(entry.id)
+    entity_registry.async_remove("sensor.test_new")
     await hass.async_block_till_done(wait_background_tasks=True)
     entry = entity_registry.async_get("sensor.test_new")
-    assert entry is not None
+    assert entry is None
 
     # Repeat the re-discovery, and assert the entity remains disabled
     async_fire_mqtt_message(hass, discovery_topic, config_enabled_new_entity_name)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When MQTT entities are disabled by the user, a rediscovery should never re-enable the entity.
Entities that are disabled by default are not effected by this change. This allows to remove and rediscovery an entity en configure as enabled by default.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
