### PR TITLE
Add bulk update action for todo lists

### DIFF
--- a/homeassistant/components/bring/todo.py
+++ b/homeassistant/components/bring/todo.py
@@ -125,7 +125,7 @@ class BringTodoListEntity(BringBaseEntity, TodoListEntity):
         await self.coordinator.async_refresh()
 
     async def async_update_todo_item(self, item: TodoItem) -> None:
-        """Update an item to the To-do list.
+        """Update an item in the To-do list.
 
         Bring has an internal 'recent' list which we want to use instead of a todo list
         status, therefore completed todo list items are matched to the recent list and

--- a/homeassistant/components/local_todo/todo.py
+++ b/homeassistant/components/local_todo/todo.py
@@ -118,6 +118,7 @@ class LocalTodoListEntity(TodoListEntity):
         | TodoListEntityFeature.SET_DUE_DATETIME_ON_ITEM
         | TodoListEntityFeature.SET_DUE_DATE_ON_ITEM
         | TodoListEntityFeature.SET_DESCRIPTION_ON_ITEM
+        | TodoListEntityFeature.UPDATE_TODO_ITEMS
     )
     _attr_should_poll = False
 
@@ -169,7 +170,7 @@ class LocalTodoListEntity(TodoListEntity):
         await self.async_update_ha_state(force_refresh=True)
 
     async def async_update_todo_item(self, item: TodoItem) -> None:
-        """Update an item to the To-do list."""
+        """Update an item in the To-do list."""
         todo = _convert_item(item)
         async with self._calendar_lock:
             todo_store = self._new_todo_store()
@@ -177,12 +178,23 @@ class LocalTodoListEntity(TodoListEntity):
             await self.async_save()
         await self.async_update_ha_state(force_refresh=True)
 
+    async def async_update_todo_items(self, items: list[TodoItem]) -> None:
+        """Update multiple items in the To-do list."""
+        async with self._calendar_lock:
+            todo_store = self._new_todo_store()
+            # Only edit items for which something changes
+            await self.hass.async_add_executor_job(
+                _todo_store_bulk_edit, todo_store, items
+            )
+            await self.async_save()
+        await self.async_update_ha_state(force_refresh=True)
+
     async def async_delete_todo_items(self, uids: list[str]) -> None:
         """Delete an item from the To-do list."""
-        store = self._new_todo_store()
         async with self._calendar_lock:
+            todo_store = self._new_todo_store()
             for uid in uids:
-                store.delete(uid)
+                todo_store.delete(uid)
             await self.async_save()
         await self.async_update_ha_state(force_refresh=True)
 
@@ -216,3 +228,11 @@ class LocalTodoListEntity(TodoListEntity):
         """Persist the todo list to disk."""
         content = IcsCalendarStream.calendar_to_ics(self._calendar)
         await self._store.async_store(content)
+
+
+def _todo_store_bulk_edit(todo_store: TodoStore, items: list[TodoItem]) -> None:
+    # Note that todo_store.edit is O(N), where N is the length of the store.
+    # However, todo.update_list service ensures that only items that are changed should reach here.
+    for item in items:
+        todo = _convert_item(item)
+        todo_store.edit(todo.uid, todo)

--- a/homeassistant/components/local_todo/todo.py
+++ b/homeassistant/components/local_todo/todo.py
@@ -182,7 +182,6 @@ class LocalTodoListEntity(TodoListEntity):
         """Update multiple items in the To-do list."""
         async with self._calendar_lock:
             todo_store = self._new_todo_store()
-            # Only edit items for which something changes
             await self.hass.async_add_executor_job(
                 _todo_store_bulk_edit, todo_store, items
             )

--- a/homeassistant/components/shopping_list/common.py
+++ b/homeassistant/components/shopping_list/common.py
@@ -141,6 +141,57 @@ class ShoppingData:
         )
         return item
 
+    async def async_bulk_update(
+        self,
+        items: list[tuple[str | None, dict[str, JsonValueType]]],
+        context: Context | None = None,
+    ) -> list[dict[str, JsonValueType]]:
+        """Update multiple shopping list items."""
+        # Shortcut empty update
+        if not items:
+            return []
+
+        # Get both a list of valid ids and their locations in one pass.
+        items_index = {
+            uid: idx
+            for idx, itm in enumerate(self.items)
+            if isinstance((uid := itm["id"]), str) and uid
+        }
+
+        # Look for missing or invalid IDs. Only report the first one
+        # and stop before changing anything.
+        first_missing_uid = next(
+            (uid for uid, *_ in items if uid not in items_index), None
+        )
+        if first_missing_uid:
+            raise NoMatchingShoppingListItem(
+                f"Item '{first_missing_uid}' not found in shopping list"
+            )
+
+        # Apply updates and keep track of changes
+        changed: dict[str, dict[str, JsonValueType]] = {}
+        for uid, info in items:
+            assert uid  # reassure the linter
+            info = ITEM_UPDATE_SCHEMA(info)
+            if info:
+                assert isinstance(info, dict)  # reassure the linter
+                item = self.items[items_index[uid]]
+                item.update(info)
+                changed[uid] = item  # only track final state
+
+        await self.hass.async_add_executor_job(self.save)
+        self._async_notify()
+
+        changed_items = list(changed.values())
+        for item in changed_items:
+            self.hass.bus.async_fire(
+                EVENT_SHOPPING_LIST_UPDATED,
+                {"action": "update", "item": item},  # only notify final states
+                context=context,
+            )
+
+        return changed_items
+
     async def async_clear_completed(self, context: Context | None = None) -> None:
         """Clear completed items."""
         self.items = [itm for itm in self.items if not itm["complete"]]

--- a/homeassistant/components/shopping_list/common.py
+++ b/homeassistant/components/shopping_list/common.py
@@ -123,8 +123,8 @@ class ShoppingData:
         self, item_id: str | None, info: dict[str, Any], context: Context | None = None
     ) -> dict[str, JsonValueType]:
         """Update a shopping list item."""
+        # This method is optimised a single update.
         item = next((itm for itm in self.items if itm["id"] == item_id), None)
-
         if item is None:
             raise NoMatchingShoppingListItem(
                 f"Item '{item_id}' not found in shopping list"
@@ -147,19 +147,19 @@ class ShoppingData:
         context: Context | None = None,
     ) -> list[dict[str, JsonValueType]]:
         """Update multiple shopping list items."""
-        # Shortcut empty update
+        # This method is optimised for lots of updates.
         if not items:
-            return []
+            return []  # Shortcut for no updates
 
-        # Get both a list of valid ids and their locations in one pass.
+        # Get both a list of valid existing ids and their locations in one pass.
         items_index = {
             uid: idx
             for idx, itm in enumerate(self.items)
             if isinstance((uid := itm["id"]), str) and uid
         }
 
-        # Look for missing or invalid IDs. Only report the first one
-        # and stop before changing anything.
+        # Only report the first missing/invalid ID and stop before changing
+        # anything.
         first_missing_uid = next(
             (uid for uid, *_ in items if uid not in items_index), None
         )
@@ -168,16 +168,16 @@ class ShoppingData:
                 f"Item '{first_missing_uid}' not found in shopping list"
             )
 
-        # Apply updates and keep track of changes
+        # Only keep track of final state of changed items
         changed: dict[str, dict[str, JsonValueType]] = {}
         for uid, info in items:
             assert uid  # reassure the linter
             info = ITEM_UPDATE_SCHEMA(info)
-            if info:
+            if info:  # skip empty updates
                 assert isinstance(info, dict)  # reassure the linter
                 item = self.items[items_index[uid]]
                 item.update(info)
-                changed[uid] = item  # only track final state
+                changed[uid] = item
 
         await self.hass.async_add_executor_job(self.save)
         self._async_notify()
@@ -186,7 +186,7 @@ class ShoppingData:
         for item in changed_items:
             self.hass.bus.async_fire(
                 EVENT_SHOPPING_LIST_UPDATED,
-                {"action": "update", "item": item},  # only notify final states
+                {"action": "update", "item": item},
                 context=context,
             )
 

--- a/homeassistant/components/shopping_list/todo.py
+++ b/homeassistant/components/shopping_list/todo.py
@@ -11,6 +11,7 @@ from homeassistant.components.todo import (
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.util.json import JsonValueType
 
 from .common import NoMatchingShoppingListItem, ShoppingData, ShoppingListConfigEntry
 
@@ -26,6 +27,20 @@ async def async_setup_entry(
     async_add_entities([entity], True)
 
 
+def _prepare_update(item: TodoItem) -> tuple[str | None, dict[str, JsonValueType]]:
+    """Convert a HomeAssistant TodoItem to an ShoppingList item update."""
+    # Leave checking the validity of the values to the update methods
+    info: dict[str, JsonValueType] = {}
+
+    # These attributes must be set so ignore None values
+    if (summary := item.summary) is not None:
+        info["name"] = summary
+    if (status := item.status) is not None:
+        info["complete"] = status == TodoItemStatus.COMPLETED
+
+    return item.uid, info
+
+
 class ShoppingTodoListEntity(TodoListEntity):
     """A To-do List representation of the Shopping List."""
 
@@ -37,6 +52,7 @@ class ShoppingTodoListEntity(TodoListEntity):
         | TodoListEntityFeature.DELETE_TODO_ITEM
         | TodoListEntityFeature.UPDATE_TODO_ITEM
         | TodoListEntityFeature.MOVE_TODO_ITEM
+        | TodoListEntityFeature.UPDATE_TODO_ITEMS
     )
 
     def __init__(self, data: ShoppingData, unique_id: str) -> None:
@@ -51,20 +67,28 @@ class ShoppingTodoListEntity(TodoListEntity):
         )
 
     async def async_update_todo_item(self, item: TodoItem) -> None:
-        """Update an item to the To-do list."""
-        data = {
-            "name": item.summary,
-            "complete": item.status == TodoItemStatus.COMPLETED,
-        }
+        """Update an item in the To-do list."""
+        uid, data = _prepare_update(item)
         try:
-            await self._data.async_update(item.uid, data)
+            await self._data.async_update(uid, data)
         except NoMatchingShoppingListItem as err:
             raise HomeAssistantError(
-                f"Shopping list item '{item.uid}' was not found"
+                f"Shopping list item '{uid}' was not found"
+            ) from err
+
+    async def async_update_todo_items(self, items: list[TodoItem]) -> None:
+        """Update multiple items in the To-do list."""
+
+        updates = [_prepare_update(item) for item in items]
+        try:
+            await self._data.async_bulk_update(updates)
+        except NoMatchingShoppingListItem as err:
+            raise HomeAssistantError(
+                "One or more Shopping list items were not found"
             ) from err
 
     async def async_delete_todo_items(self, uids: list[str]) -> None:
-        """Add an item to the To-do list."""
+        """Delete items from the To-do list."""
         await self._data.async_remove_items(set(uids))
 
     async def async_move_todo_item(

--- a/homeassistant/components/shopping_list/todo.py
+++ b/homeassistant/components/shopping_list/todo.py
@@ -28,7 +28,7 @@ async def async_setup_entry(
 
 
 def _prepare_update(item: TodoItem) -> tuple[str | None, dict[str, JsonValueType]]:
-    """Convert a HomeAssistant TodoItem to an ShoppingList item update."""
+    """Convert a HomeAssistant TodoItem to a ShoppingList item update."""
     # Leave checking the validity of the values to the update methods
     info: dict[str, JsonValueType] = {}
 

--- a/homeassistant/components/todo/__init__.py
+++ b/homeassistant/components/todo/__init__.py
@@ -191,6 +191,19 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         _async_remove_completed_items,
         required_features=[TodoListEntityFeature.DELETE_TODO_ITEM],
     )
+    component.async_register_entity_service(
+        TodoServices.UPDATE_LIST,
+        cv.make_entity_service_schema(
+            {
+                # Note that future updates might make this Optional
+                vol.Required(ATTR_STATUS): vol.In(
+                    {TodoItemStatus.NEEDS_ACTION, TodoItemStatus.COMPLETED},
+                ),
+            }
+        ),
+        _async_update_todo_list,
+        required_features=[TodoListEntityFeature.UPDATE_TODO_ITEMS],
+    )
 
     await component.async_setup(config)
     return True
@@ -263,6 +276,16 @@ class TodoListEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
 
     async def async_delete_todo_items(self, uids: list[str]) -> None:
         """Delete an item in the To-do list."""
+        raise NotImplementedError
+
+    async def async_update_todo_items(self, items: list[TodoItem]) -> None:
+        """Update multiple items in the To-do list."""
+        # Note that there is no fallback to async_update_todo_item since
+        # integrations need to do bulk updates efficiently, but logically this
+        # should be the same as the following.
+        #
+        # for item in items:
+        #     await self.async_update_todo_item(item)
         raise NotImplementedError
 
     async def async_move_todo_item(
@@ -468,6 +491,31 @@ async def _async_add_todo_item(entity: TodoListEntity, call: ServiceCall) -> Non
     )
 
 
+def _prepare_update(entity: TodoListEntity, data: dict[str, Any]) -> dict[str, Any]:
+    # Note that extra fields in data are ignored.
+
+    _validate_supported_features(entity.supported_features, data)
+
+    # Prepare an update based on the fields present in the service call.
+    # This allows explicitly clearing any of the extended fields present
+    # and set to None.
+    info = {}
+    if summary := data.get(ATTR_RENAME):
+        info["summary"] = summary
+    if status := data.get(ATTR_STATUS):
+        info["status"] = TodoItemStatus(status)
+
+    # This allows explicitly clearing any of the extended fields present and set to None.
+    info.update(
+        {
+            desc.todo_item_field: data[desc.service_field]
+            for desc in TODO_ITEM_FIELDS
+            if desc.service_field in data
+        }
+    )
+    return info
+
+
 async def _async_update_todo_item(entity: TodoListEntity, call: ServiceCall) -> None:
     """Update an item in the To-do list."""
     item = call.data["item"]
@@ -479,24 +527,12 @@ async def _async_update_todo_item(entity: TodoListEntity, call: ServiceCall) -> 
             translation_placeholders={"item": item},
         )
 
-    _validate_supported_features(entity.supported_features, call.data)
-
     # Perform a partial update on the existing entity based on the fields
-    # present in the update. This allows explicitly clearing any of the
-    # extended fields present and set to None.
-    updated_data = dataclasses.asdict(found)
-    if summary := call.data.get("rename"):
-        updated_data["summary"] = summary
-    if status := call.data.get("status"):
-        updated_data["status"] = status
-    updated_data.update(
-        {
-            desc.todo_item_field: call.data[desc.service_field]
-            for desc in TODO_ITEM_FIELDS
-            if desc.service_field in call.data
-        }
-    )
-    await entity.async_update_todo_item(item=TodoItem(**updated_data))
+    # present in the update.
+    updated_data = _prepare_update(entity, call.data)
+    updated_item = dataclasses.replace(found, **updated_data)
+
+    await entity.async_update_todo_item(item=updated_item)
 
 
 async def _async_remove_todo_items(entity: TodoListEntity, call: ServiceCall) -> None:
@@ -536,3 +572,25 @@ async def _async_remove_completed_items(entity: TodoListEntity, _: ServiceCall) 
     ]
     if uids:
         await entity.async_delete_todo_items(uids=uids)
+
+
+async def _async_update_todo_list(entity: TodoListEntity, call: ServiceCall) -> None:
+    """Update all items in the To-do list."""
+    todo_items = entity.todo_items
+    if not todo_items:
+        return  # Shortcut for empty todo list
+
+    updated_data = _prepare_update(entity, call.data)
+    if not updated_data:
+        return  # Shortcut for empty update
+
+    updated_items = [
+        new_item
+        for item in todo_items
+        if (new_item := dataclasses.replace(item, **updated_data)) != item
+    ]
+    if not updated_items:
+        return  # Shortcut for no changes
+
+    # Pass update to integration
+    await entity.async_update_todo_items(items=updated_items)

--- a/homeassistant/components/todo/__init__.py
+++ b/homeassistant/components/todo/__init__.py
@@ -280,9 +280,9 @@ class TodoListEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
 
     async def async_update_todo_items(self, items: list[TodoItem]) -> None:
         """Update multiple items in the To-do list."""
-        # Note that there is no fallback to async_update_todo_item since
-        # integrations need to do bulk updates efficiently, but logically this
-        # should be the same as the following.
+        # Note that there is no automatic fallback to async_update_todo_item
+        # since integrations need to do bulk updates efficiently. However,
+        # logically, this must have the same effect as the following.
         #
         # for item in items:
         #     await self.async_update_todo_item(item)
@@ -492,13 +492,12 @@ async def _async_add_todo_item(entity: TodoListEntity, call: ServiceCall) -> Non
 
 
 def _prepare_update(entity: TodoListEntity, data: dict[str, Any]) -> dict[str, Any]:
-    # Note that extra fields in data are ignored.
+    """Prepare a partial update based on the fields present in the service call.
 
+    Note that extra fields in data are ignored.
+    """
     _validate_supported_features(entity.supported_features, data)
 
-    # Prepare an update based on the fields present in the service call.
-    # This allows explicitly clearing any of the extended fields present
-    # and set to None.
     info = {}
     if summary := data.get(ATTR_RENAME):
         info["summary"] = summary
@@ -527,8 +526,6 @@ async def _async_update_todo_item(entity: TodoListEntity, call: ServiceCall) -> 
             translation_placeholders={"item": item},
         )
 
-    # Perform a partial update on the existing entity based on the fields
-    # present in the update.
     updated_data = _prepare_update(entity, call.data)
     updated_item = dataclasses.replace(found, **updated_data)
 
@@ -584,10 +581,10 @@ async def _async_update_todo_list(entity: TodoListEntity, call: ServiceCall) -> 
     if not updated_data:
         return  # Shortcut for empty update
 
-    updated_items = [
-        new_item
+    updated_items = [  # only store items changed by update
+        updated_item
         for item in todo_items
-        if (new_item := dataclasses.replace(item, **updated_data)) != item
+        if (updated_item := dataclasses.replace(item, **updated_data)) != item
     ]
     if not updated_items:
         return  # Shortcut for no changes

--- a/homeassistant/components/todo/const.py
+++ b/homeassistant/components/todo/const.py
@@ -30,6 +30,7 @@ class TodoServices(StrEnum):
     REMOVE_ITEM = "remove_item"
     GET_ITEMS = "get_items"
     REMOVE_COMPLETED_ITEMS = "remove_completed_items"
+    UPDATE_LIST = "update_list"
 
 
 class TodoListEntityFeature(IntFlag):
@@ -42,6 +43,7 @@ class TodoListEntityFeature(IntFlag):
     SET_DUE_DATE_ON_ITEM = 16
     SET_DUE_DATETIME_ON_ITEM = 32
     SET_DESCRIPTION_ON_ITEM = 64
+    UPDATE_TODO_ITEMS = 128
 
 
 class TodoItemStatus(StrEnum):

--- a/homeassistant/components/todo/icons.json
+++ b/homeassistant/components/todo/icons.json
@@ -27,6 +27,9 @@
     },
     "update_item": {
       "service": "mdi:clipboard-edit"
+    },
+    "update_list": {
+      "service": "mdi:checkbox-multiple-blank-outline"
     }
   },
   "triggers": {

--- a/homeassistant/components/todo/services.yaml
+++ b/homeassistant/components/todo/services.yaml
@@ -103,10 +103,25 @@ remove_item:
       example: "Submit income tax return"
       selector:
         text:
-
 remove_completed_items:
   target:
     entity:
       domain: todo
       supported_features:
         - todo.TodoListEntityFeature.DELETE_TODO_ITEM
+update_list:
+  target:
+    entity:
+      domain: todo
+      supported_features:
+        - todo.TodoListEntityFeature.UPDATE_TODO_ITEMS
+  fields:
+    status:
+      required: true # Note that future updates might make this Optional
+      example: "needs_action"
+      selector:
+        select:
+          translation_key: status
+          options:
+            - needs_action
+            - completed

--- a/homeassistant/components/todo/strings.json
+++ b/homeassistant/components/todo/strings.json
@@ -125,11 +125,21 @@
           "name": "Rename item"
         },
         "status": {
-          "description": "A status or confirmation of the to-do item.",
+          "description": "A status for the to-do item.",
           "name": "Set status"
         }
       },
       "name": "Update to-do list item"
+    },
+    "update_list": {
+      "description": "Updates every item in a to-do list, according to provided attributes.",
+      "fields": {
+        "status": {
+          "description": "A status for each item in the to-do list.",
+          "name": "Set status"
+        }
+      },
+      "name": "Update all items in a to-do list"
     }
   },
   "title": "To-do list",

--- a/tests/components/local_todo/test_todo.py
+++ b/tests/components/local_todo/test_todo.py
@@ -1,6 +1,6 @@
 """Tests for todo platform of local_todo."""
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable, Coroutine
 from datetime import datetime
 import textwrap
 from typing import Any
@@ -11,6 +11,7 @@ from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.todo import (
     ATTR_DESCRIPTION,
+    ATTR_DUE,
     ATTR_DUE_DATE,
     ATTR_DUE_DATETIME,
     ATTR_ITEM,
@@ -27,11 +28,12 @@ from .conftest import TEST_ENTITY
 
 from tests.typing import WebSocketGenerator
 
+type WsGetItemsType = Callable[[], Coroutine[Any, Any, list[dict[str, str]]]]
+type WsMoveItemType = Callable[[str, str | None], Coroutine[Any, Any, dict[str, Any]]]
+
 
 @pytest.fixture
-async def ws_get_items(
-    hass_ws_client: WebSocketGenerator,
-) -> Callable[[], Awaitable[dict[str, str]]]:
+async def ws_get_items(hass_ws_client: WebSocketGenerator) -> WsGetItemsType:
     """Fixture to fetch items from the todo websocket."""
 
     async def get() -> list[dict[str, str]]:
@@ -51,12 +53,10 @@ async def ws_get_items(
 
 
 @pytest.fixture
-async def ws_move_item(
-    hass_ws_client: WebSocketGenerator,
-) -> Callable[[str, str | None], Awaitable[None]]:
+async def ws_move_item(hass_ws_client: WebSocketGenerator) -> WsMoveItemType:
     """Fixture to move an item in the todo list."""
 
-    async def move(uid: str, previous_uid: str | None) -> None:
+    async def move(uid: str, previous_uid: str | None) -> dict[str, Any]:
         # Fetch items using To-do platform
         client = await hass_ws_client()
         data = {
@@ -67,15 +67,14 @@ async def ws_move_item(
         if previous_uid is not None:
             data["previous_uid"] = previous_uid
         await client.send_json_auto_id(data)
-        resp = await client.receive_json()
-        assert resp.get("success")
+        return await client.receive_json()
 
     return move
 
 
 @pytest.fixture(autouse=True)
 async def set_time_zone(hass: HomeAssistant) -> None:
-    """Set the time zone for the tests that keesp UTC-6 all year round."""
+    """Set the time zone for the tests that keeps UTC-6 all year round."""
     await hass.config.async_set_time_zone("America/Regina")
 
 
@@ -106,7 +105,7 @@ async def test_add_item(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     setup_integration: None,
-    ws_get_items: Callable[[], Awaitable[dict[str, str]]],
+    ws_get_items: WsGetItemsType,
     item_data: dict[str, Any],
     expected_item_data: dict[str, Any],
 ) -> None:
@@ -151,7 +150,7 @@ async def test_add_item(
 async def test_remove_item(
     hass: HomeAssistant,
     setup_integration: None,
-    ws_get_items: Callable[[], Awaitable[dict[str, str]]],
+    ws_get_items: WsGetItemsType,
     item_data: dict[str, Any],
     expected_item_data: dict[str, Any],
 ) -> None:
@@ -195,7 +194,7 @@ async def test_remove_item(
 async def test_bulk_remove(
     hass: HomeAssistant,
     setup_integration: None,
-    ws_get_items: Callable[[], Awaitable[dict[str, str]]],
+    ws_get_items: WsGetItemsType,
 ) -> None:
     """Test removing multiple todo items."""
     for i in range(5):
@@ -269,7 +268,7 @@ EXPECTED_UPDATE_ITEM = {
 async def test_update_item(
     hass: HomeAssistant,
     setup_integration: None,
-    ws_get_items: Callable[[], Awaitable[dict[str, str]]],
+    ws_get_items: WsGetItemsType,
     item_data: dict[str, Any],
     expected_item_data: dict[str, Any],
     expected_state: str,
@@ -396,7 +395,7 @@ async def test_update_item(
 async def test_update_existing_field(
     hass: HomeAssistant,
     setup_integration: None,
-    ws_get_items: Callable[[], Awaitable[dict[str, str]]],
+    ws_get_items: WsGetItemsType,
     item_data: dict[str, Any],
     expected_item_data: dict[str, Any],
 ) -> None:
@@ -447,7 +446,7 @@ async def test_update_existing_field(
 async def test_rename(
     hass: HomeAssistant,
     setup_integration: None,
-    ws_get_items: Callable[[], Awaitable[dict[str, str]]],
+    ws_get_items: WsGetItemsType,
 ) -> None:
     """Test renaming a todo item."""
 
@@ -521,8 +520,8 @@ async def test_rename(
 async def test_move_item(
     hass: HomeAssistant,
     setup_integration: None,
-    ws_get_items: Callable[[], Awaitable[dict[str, str]]],
-    ws_move_item: Callable[[str, str | None], Awaitable[None]],
+    ws_get_items: WsGetItemsType,
+    ws_move_item: WsMoveItemType,
     src_idx: int,
     dst_idx: int | None,
     expected_items: list[str],
@@ -547,7 +546,8 @@ async def test_move_item(
     previous_uid = None
     if dst_idx is not None:
         previous_uid = uids[dst_idx]
-    await ws_move_item(uids[src_idx], previous_uid)
+    resp = await ws_move_item(uids[src_idx], previous_uid)
+    assert resp.get("success")
 
     items = await ws_get_items()
     assert len(items) == 4
@@ -583,7 +583,7 @@ async def test_move_item_previous_unknown(
     hass: HomeAssistant,
     setup_integration: None,
     hass_ws_client: WebSocketGenerator,
-    ws_get_items: Callable[[], Awaitable[dict[str, str]]],
+    ws_get_items: WsGetItemsType,
 ) -> None:
     """Test moving a todo item that does not exist."""
 
@@ -739,7 +739,7 @@ async def test_parse_existing_ics(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     setup_integration: None,
-    ws_get_items: Callable[[], Awaitable[dict[str, str]]],
+    ws_get_items: WsGetItemsType,
     snapshot: SnapshotAssertion,
     expected_state: str,
 ) -> None:
@@ -812,3 +812,176 @@ async def test_susbcribe(
     assert items[0]["summary"] == "milk"
     assert items[0]["status"] == "needs_action"
     assert "uid" in items[0]
+
+
+async def test_reset_item_via_update(
+    hass: HomeAssistant,
+    setup_integration: None,
+    ws_get_items: WsGetItemsType,
+) -> None:
+    """Test resetting a todo item via update action."""
+
+    # Create new item
+    await hass.services.async_call(
+        TODO_DOMAIN,
+        TodoServices.ADD_ITEM,
+        {ATTR_ITEM: "soda"},
+        target={ATTR_ENTITY_ID: TEST_ENTITY},
+        blocking=True,
+    )
+
+    # Fetch item
+    items = await ws_get_items()
+    assert len(items) == 1
+
+    item = items[0]
+    assert item["summary"] == "soda"
+    assert item["status"] == "needs_action"
+    item_uid = item.pop("uid")
+
+    state = hass.states.get(TEST_ENTITY)
+    assert state
+    assert state.state == "1"
+
+    # Complete item
+    update_time = datetime(2023, 11, 18, 8, 0, 0, tzinfo=dt_util.UTC)
+    with freeze_time(update_time):
+        await hass.services.async_call(
+            TODO_DOMAIN,
+            TodoServices.UPDATE_ITEM,
+            {ATTR_ITEM: item_uid, ATTR_STATUS: "completed"},
+            target={ATTR_ENTITY_ID: TEST_ENTITY},
+            blocking=True,
+        )
+
+    # Verify item is completed
+    items = await ws_get_items()
+    assert len(items) == 1
+    item = items[0]
+    assert item["summary"] == "soda"
+    assert "uid" in item
+    del item["uid"]
+    assert item == {
+        **EXPECTED_UPDATE_ITEM,
+        "status": "completed",
+        "completed": "2023-11-18T08:00:00+00:00",
+    }
+
+    state = hass.states.get(TEST_ENTITY)
+    assert state
+    assert state.state == "0"
+
+    # Reset item
+    update_time = datetime(2023, 11, 18, 8, 1, 0, tzinfo=dt_util.UTC)
+    with freeze_time(update_time):
+        await hass.services.async_call(
+            TODO_DOMAIN,
+            TodoServices.UPDATE_ITEM,
+            {ATTR_ITEM: item_uid, ATTR_STATUS: "needs_action"},
+            target={ATTR_ENTITY_ID: TEST_ENTITY},
+            blocking=True,
+        )
+
+    # Verify item is not completed
+    items = await ws_get_items()
+    assert len(items) == 1
+    item = items[0]
+    assert item["summary"] == "soda"
+    assert item.get("completed") is None  # automatically unset
+    assert "uid" in item
+    del item["uid"]
+    assert item == {
+        **EXPECTED_UPDATE_ITEM,
+        "status": "needs_action",
+    }
+
+    state = hass.states.get(TEST_ENTITY)
+    assert state
+    assert state.state == "1"
+
+
+@pytest.mark.parametrize(
+    "info",
+    [
+        {ATTR_STATUS: "needs_action"},
+        {ATTR_STATUS: "completed"},
+    ],
+)
+async def test_bulk_update(
+    hass: HomeAssistant,
+    setup_integration: None,
+    ws_get_items: WsGetItemsType,
+    info: dict[str, Any],
+) -> None:
+    """Test bulk update of a todo list."""
+
+    total_items = 5
+    completed_items = [0, 2, 3]
+    expected_state = total_items - len(completed_items)
+
+    # Populate list
+    for _i in range(total_items):
+        await hass.services.async_call(
+            TODO_DOMAIN,
+            TodoServices.ADD_ITEM,
+            {
+                ATTR_ITEM: f"item {_i}",
+                ATTR_DUE_DATE: f"2026-06-{_i + 1:02d}",
+                ATTR_DESCRIPTION: f"Thing {_i + 1}",
+            },
+            target={ATTR_ENTITY_ID: TEST_ENTITY},
+            blocking=True,
+        )
+
+    # Set status for completed items
+    items = await ws_get_items()
+    assert len(items) == total_items
+    uids = [item["uid"] for item in items]
+
+    for _i in completed_items:
+        await hass.services.async_call(
+            TODO_DOMAIN,
+            TodoServices.UPDATE_ITEM,
+            {
+                ATTR_ITEM: uids[_i],
+                ATTR_STATUS: "completed",
+            },
+            target={ATTR_ENTITY_ID: TEST_ENTITY},
+            blocking=True,
+        )
+
+    state = hass.states.get(TEST_ENTITY)
+    assert state
+    assert state.state == str(expected_state)
+
+    # Store original values of attributes that shouldn't change
+    original_items = await ws_get_items()
+    names = [item["summary"] for item in original_items]
+    due_datetimes = [item.get(ATTR_DUE) for item in original_items]
+    descriptions = [item.get(ATTR_DESCRIPTION) for item in original_items]
+
+    # ACT: bulk-update list
+    await hass.services.async_call(
+        TODO_DOMAIN,
+        TodoServices.UPDATE_LIST,
+        info,
+        target={ATTR_ENTITY_ID: TEST_ENTITY},
+        blocking=True,
+    )
+
+    items = await ws_get_items()
+    assert len(items) == total_items
+
+    # Verify status
+    if status := info.get("status"):
+        assert not [item for item in items if item["status"] != status]
+        expected_state = 0 if status == "completed" else total_items
+
+    state = hass.states.get(TEST_ENTITY)
+    assert state
+    assert state.state == str(expected_state)
+
+    # Verify nothing else changed
+    assert [item["summary"] for item in items] == names
+    assert [item.get(ATTR_DUE) for item in items] == due_datetimes
+    assert [item.get(ATTR_DESCRIPTION) for item in items] == descriptions

--- a/tests/components/shopping_list/test_todo.py
+++ b/tests/components/shopping_list/test_todo.py
@@ -516,3 +516,76 @@ async def test_subscribe_item(
     assert items[0]["summary"] == "milk"
     assert items[0]["status"] == "needs_action"
     assert "uid" in items[0]
+
+
+@pytest.mark.parametrize(
+    "info",
+    [
+        {ATTR_STATUS: "needs_action"},
+        {ATTR_STATUS: "completed"},
+    ],
+)
+async def test_bulk_update(
+    hass: HomeAssistant,
+    sl_setup: None,
+    ws_get_items: WsGetItemsType,
+    info: dict[str, Any],
+) -> None:
+    """Test bulk updating a todo list."""
+
+    total_items = 5
+    completed_items = [0, 2, 3]
+    expected_state = total_items - len(completed_items)
+
+    # Populate list
+    for _i in range(total_items):
+        await hass.services.async_call(
+            TODO_DOMAIN,
+            TodoServices.ADD_ITEM,
+            {
+                ATTR_ITEM: f"item {_i}",
+            },
+            target={ATTR_ENTITY_ID: TEST_ENTITY},
+            blocking=True,
+        )
+
+    items = await ws_get_items()
+    assert len(items) == total_items
+    uids = [item["uid"] for item in items]
+
+    for _i in completed_items:
+        await hass.services.async_call(
+            TODO_DOMAIN,
+            TodoServices.UPDATE_ITEM,
+            {
+                ATTR_ITEM: uids[_i],
+                ATTR_STATUS: "completed",
+            },
+            target={ATTR_ENTITY_ID: TEST_ENTITY},
+            blocking=True,
+        )
+
+    state = hass.states.get(TEST_ENTITY)
+    assert state
+    assert state.state == str(expected_state)
+
+    # Bulk-update list
+    await hass.services.async_call(
+        TODO_DOMAIN,
+        TodoServices.UPDATE_LIST,
+        info,
+        target={ATTR_ENTITY_ID: TEST_ENTITY},
+        blocking=True,
+    )
+
+    items = await ws_get_items()
+    assert len(items) == total_items
+
+    # Verify status
+    if status := info.get("status"):
+        assert not [item for item in items if item["status"] != status]
+        expected_state = 0 if status == "completed" else total_items
+
+    state = hass.states.get(TEST_ENTITY)
+    assert state
+    assert state.state == str(expected_state)

--- a/tests/components/todo/__init__.py
+++ b/tests/components/todo/__init__.py
@@ -49,6 +49,15 @@ class MockTodoListEntity(TodoListEntity):
                 self._attr_todo_items[idx] = item
                 break
 
+    async def async_update_todo_items(self, items: list[TodoItem]) -> None:
+        """Update multiple items in the To-do list."""
+        list_index = {todo.uid: idx for idx, todo in enumerate(self.items) if todo.uid}
+        for item in items:
+            assert item.uid  # reassure the linter
+            idx = list_index[item.uid]
+            assert self._attr_todo_items is not None
+            self._attr_todo_items[idx] = item
+
 
 async def create_mock_platform(
     hass: HomeAssistant,

--- a/tests/components/todo/conftest.py
+++ b/tests/components/todo/conftest.py
@@ -1,7 +1,9 @@
 """Fixtures for the todo component tests."""
 
 from collections.abc import Generator
+import datetime
 from unittest.mock import AsyncMock
+import zoneinfo
 
 import pytest
 
@@ -18,6 +20,8 @@ from homeassistant.core import HomeAssistant
 from . import TEST_DOMAIN, MockFlow, MockTodoListEntity
 
 from tests.common import MockModule, mock_config_flow, mock_integration, mock_platform
+
+TEST_TIMEZONE = zoneinfo.ZoneInfo("America/Regina")
 
 
 @pytest.fixture(autouse=True)
@@ -62,7 +66,7 @@ def mock_setup_integration(hass: HomeAssistant) -> None:
 
 @pytest.fixture(autouse=True)
 async def set_time_zone(hass: HomeAssistant) -> None:
-    """Set the time zone for the tests that keesp UTC-6 all year round."""
+    """Set the time zone for the tests that keeps UTC-6 all year round."""
     await hass.config.async_set_time_zone("America/Regina")
 
 
@@ -70,8 +74,17 @@ async def set_time_zone(hass: HomeAssistant) -> None:
 def mock_test_entity_items() -> list[TodoItem]:
     """Fixture that creates the items returned by the test entity."""
     return [
-        TodoItem(summary="Item #1", uid="1", status=TodoItemStatus.NEEDS_ACTION),
-        TodoItem(summary="Item #2", uid="2", status=TodoItemStatus.COMPLETED),
+        TodoItem(
+            summary="Item #1",
+            uid="1",
+            status=TodoItemStatus.NEEDS_ACTION,
+        ),
+        TodoItem(
+            summary="Item #2",
+            uid="2",
+            status=TodoItemStatus.COMPLETED,
+            completed=datetime.datetime(2026, 3, 27, 11, 0, 0, tzinfo=TEST_TIMEZONE),
+        ),
     ]
 
 
@@ -85,9 +98,11 @@ def mock_test_entity(test_entity_items: list[TodoItem]) -> TodoListEntity:
         | TodoListEntityFeature.UPDATE_TODO_ITEM
         | TodoListEntityFeature.DELETE_TODO_ITEM
         | TodoListEntityFeature.MOVE_TODO_ITEM
+        | TodoListEntityFeature.UPDATE_TODO_ITEMS
     )
     entity1.async_create_todo_item = AsyncMock(wraps=entity1.async_create_todo_item)
-    entity1.async_update_todo_item = AsyncMock()
+    entity1.async_update_todo_item = AsyncMock(wraps=entity1.async_update_todo_item)
     entity1.async_delete_todo_items = AsyncMock(wraps=entity1.async_delete_todo_items)
+    entity1.async_update_todo_items = AsyncMock(wraps=entity1.async_update_todo_items)
     entity1.async_move_todo_item = AsyncMock()
     return entity1

--- a/tests/components/todo/test_init.py
+++ b/tests/components/todo/test_init.py
@@ -35,6 +35,9 @@ from . import create_mock_platform
 
 from tests.typing import WebSocketGenerator
 
+TEST_TIMEZONE = zoneinfo.ZoneInfo("America/Regina")
+TEST_OFFSET = "-06:00"
+
 ITEM_1 = {
     "uid": "1",
     "summary": "Item #1",
@@ -44,9 +47,8 @@ ITEM_2 = {
     "uid": "2",
     "summary": "Item #2",
     "status": "completed",
+    "completed": f"2026-03-27T11:00:00{TEST_OFFSET}",
 }
-TEST_TIMEZONE = zoneinfo.ZoneInfo("America/Regina")
-TEST_OFFSET = "-06:00"
 
 
 async def test_unload_entry(
@@ -81,7 +83,7 @@ async def test_list_todo_items(
     state = hass.states.get("todo.entity1")
     assert state
     assert state.state == "1"
-    assert state.attributes == {"supported_features": 15}
+    assert state.attributes == {ATTR_SUPPORTED_FEATURES: 143}
 
     client = await hass_ws_client(hass)
     await client.send_json(
@@ -124,7 +126,7 @@ async def test_get_items_service(
     state = hass.states.get("todo.entity1")
     assert state
     assert state.state == "1"
-    assert state.attributes == {ATTR_SUPPORTED_FEATURES: 15}
+    assert state.attributes == {ATTR_SUPPORTED_FEATURES: 143}
 
     result = await hass.services.async_call(
         DOMAIN,
@@ -555,9 +557,9 @@ async def test_update_item_service_invalid_input(
 @pytest.mark.parametrize(
     ("update_data"),
     [
-        ({"due_datetime": f"2023-11-13T17:00:00{TEST_OFFSET}"}),
-        ({"due_date": "2023-11-13"}),
-        ({"description": "Submit revised draft"}),
+        ({ATTR_DUE_DATETIME: f"2023-11-13T17:00:00{TEST_OFFSET}"}),
+        ({ATTR_DUE_DATE: "2023-11-13"}),
+        ({ATTR_DESCRIPTION: "Submit revised draft"}),
     ],
 )
 async def test_update_todo_item_field_unsupported(
@@ -623,6 +625,7 @@ async def test_update_todo_item_extended_fields(
 ) -> None:
     """Test updating an item in a To-do list."""
 
+    assert test_entity._attr_supported_features is not None
     test_entity._attr_supported_features |= supported_entity_feature
     await create_mock_platform(hass, [test_entity])
 
@@ -645,32 +648,32 @@ async def test_update_todo_item_extended_fields(
     [
         (
             [TodoItem(uid="1", summary="Summary", description="description")],
-            {"description": "Submit revised draft"},
+            {ATTR_DESCRIPTION: "Submit revised draft"},
             TodoItem(uid="1", summary="Summary", description="Submit revised draft"),
         ),
         (
             [TodoItem(uid="1", summary="Summary", description="description")],
-            {"description": ""},
+            {ATTR_DESCRIPTION: ""},
             TodoItem(uid="1", summary="Summary", description=""),
         ),
         (
             [TodoItem(uid="1", summary="Summary", description="description")],
-            {"description": None},
+            {ATTR_DESCRIPTION: None},
             TodoItem(uid="1", summary="Summary"),
         ),
         (
             [TodoItem(uid="1", summary="Summary", due=datetime.date(2024, 1, 1))],
-            {"due_date": datetime.date(2024, 1, 2)},
+            {ATTR_DUE_DATE: datetime.date(2024, 1, 2)},
             TodoItem(uid="1", summary="Summary", due=datetime.date(2024, 1, 2)),
         ),
         (
             [TodoItem(uid="1", summary="Summary", due=datetime.date(2024, 1, 1))],
-            {"due_date": None},
+            {ATTR_DUE_DATE: None},
             TodoItem(uid="1", summary="Summary"),
         ),
         (
             [TodoItem(uid="1", summary="Summary", due=datetime.date(2024, 1, 1))],
-            {"due_datetime": datetime.datetime(2024, 1, 1, 10, 0, 0)},
+            {ATTR_DUE_DATETIME: datetime.datetime(2024, 1, 1, 10, 0, 0)},
             TodoItem(
                 uid="1",
                 summary="Summary",
@@ -687,7 +690,7 @@ async def test_update_todo_item_extended_fields(
                     due=datetime.datetime(2024, 1, 1, 10, 0, 0),
                 )
             ],
-            {"due_datetime": None},
+            {ATTR_DUE_DATETIME: None},
             TodoItem(uid="1", summary="Summary"),
         ),
     ],
@@ -709,6 +712,7 @@ async def test_update_todo_item_extended_fields_overwrite_existing_values(
 ) -> None:
     """Test updating an item in a To-do list."""
 
+    assert test_entity._attr_supported_features is not None
     test_entity._attr_supported_features |= (
         TodoListEntityFeature.SET_DESCRIPTION_ON_ITEM
         | TodoListEntityFeature.SET_DUE_DATE_ON_ITEM
@@ -952,6 +956,12 @@ async def test_move_todo_item_service_invalid_input(
             TodoServices.REMOVE_COMPLETED_ITEMS,
             None,
         ),
+        (
+            TodoServices.UPDATE_LIST,
+            {
+                ATTR_STATUS: "needs_action",
+            },
+        ),
     ],
 )
 async def test_unsupported_service(
@@ -1052,6 +1062,62 @@ async def test_remove_completed_items_service_raises(
         )
 
 
+@pytest.mark.parametrize(
+    "status",
+    [
+        "needs_action",
+        "completed",
+    ],
+)
+async def test_update_todo_list_action(
+    hass: HomeAssistant,
+    test_entity: TodoListEntity,
+    status: str,
+) -> None:
+    """Test update todo list service."""
+    await create_mock_platform(hass, [test_entity])
+
+    affected_uids = {
+        item.uid
+        for item in test_entity._attr_todo_items or []
+        if item.status != TodoItemStatus(status)
+    }
+    assert affected_uids, "Some items must be affected"
+
+    await hass.services.async_call(
+        DOMAIN,
+        TodoServices.UPDATE_LIST,
+        {ATTR_STATUS: status},
+        target={ATTR_ENTITY_ID: "todo.entity1"},
+        blocking=True,
+    )
+
+    args = test_entity.async_update_todo_items.call_args
+    assert args
+    items = args.kwargs.get("items")
+    assert {item.uid for item in items} == affected_uids
+    assert all(item.status == TodoItemStatus(status) for item in items)
+
+
+async def test_update_todo_list_action_raises(
+    hass: HomeAssistant,
+    test_entity: TodoListEntity,
+) -> None:
+    """Test update todo list that raises an error."""
+
+    await create_mock_platform(hass, [test_entity])
+
+    test_entity.async_update_todo_items.side_effect = HomeAssistantError("Ooops")
+    with pytest.raises(HomeAssistantError, match="Ooops"):
+        await hass.services.async_call(
+            DOMAIN,
+            TodoServices.UPDATE_LIST,
+            {ATTR_STATUS: "needs_action"},
+            target={ATTR_ENTITY_ID: "todo.entity1"},
+            blocking=True,
+        )
+
+
 async def test_subscribe(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
@@ -1094,7 +1160,7 @@ async def test_subscribe(
                 "status": "completed",
                 "due": None,
                 "description": None,
-                "completed": None,
+                "completed": f"2026-03-27T11:00:00{TEST_OFFSET}",
             },
         ]
     }
@@ -1122,7 +1188,7 @@ async def test_subscribe(
                 "status": "completed",
                 "due": None,
                 "description": None,
-                "completed": None,
+                "completed": f"2026-03-27T11:00:00{TEST_OFFSET}",
             },
             {
                 "summary": "Item #3",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add "todo.update_list" service to mark all items as completed or not completed. This is only supported on integrations that provide an API for bulk updates.

Architecture discussion: https://github.com/home-assistant/architecture/discussions/1305. Replaces #155922.

This makes todo lists reusable, e.g. for checklists, chores, etc. Compare with: https://play.google.com/store/apps/details?id=name.obrien.dave.lister&hl=en_GB.

This also makes the `shopping_list.complete_all` and `shopping_list.incomplete_all` actions available to any to-do integration. https://www.home-assistant.io/integrations/shopping_list/#action-complete-all

Service allows easy integration with UI and automations. Logically, if there's a service to bulk remove completed items, then there should be a service to bulk reset them to "not completed".

For example, you can have a list of daily chores as a todo list, then reset them all to needed at midnight via an automation.

This is just the core PR. I'll do the docs and frontend when this has been reviewed.

It's up to the individual integrations to determine how to implement the bulk updates, since this needs to be done efficiently and in a way that best suits that integration. However, the service call will determine exactly which items are modified. So far, I've only implemented bulk updates for the two native integrations (shopping_list and local_todo), but I can look at more (e.g. google_tasks) later.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: - TBD
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
