### PR TITLE
Migrate AquaLogic integration to use ConfigFlow

### DIFF
--- a/homeassistant/components/aqualogic/__init__.py
+++ b/homeassistant/components/aqualogic/__init__.py
@@ -8,22 +8,18 @@ import time
 from aqualogic.core import AquaLogic
 import voluptuous as vol
 
-from homeassistant.const import (
-    CONF_HOST,
-    CONF_PORT,
-    EVENT_HOMEASSISTANT_START,
-    EVENT_HOMEASSISTANT_STOP,
-)
-from homeassistant.core import Event, HomeAssistant
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_STOP
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, Event, HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.dispatcher import dispatcher_send
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.typing import ConfigType
+
+from .const import DOMAIN, PLATFORMS, UPDATE_TOPIC
 
 _LOGGER = logging.getLogger(__name__)
 
-DOMAIN = "aqualogic"
-UPDATE_TOPIC = f"{DOMAIN}_update"
-CONF_UNIT = "unit"
 RECONNECT_INTERVAL = timedelta(seconds=10)
 
 CONFIG_SCHEMA = vol.Schema(
@@ -35,17 +31,62 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
+type AquaLogicConfigEntry = ConfigEntry[AquaLogicProcessor]
 
-def setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up AquaLogic platform."""
-    host = config[DOMAIN][CONF_HOST]
-    port = config[DOMAIN][CONF_PORT]
-    processor = AquaLogicProcessor(hass, host, port)
-    hass.data[DOMAIN] = processor
-    hass.bus.listen_once(EVENT_HOMEASSISTANT_START, processor.start_listen)
-    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, processor.shutdown)
-    _LOGGER.debug("AquaLogicProcessor %s:%i initialized", host, port)
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the AquaLogic component."""
+    if DOMAIN not in config:
+        return True
+
+    conf = config[DOMAIN]
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_IMPORT},
+            data={CONF_HOST: conf[CONF_HOST], CONF_PORT: conf[CONF_PORT]},
+        )
+    )
+
+    async_create_issue(
+        hass,
+        HOMEASSISTANT_DOMAIN,
+        f"deprecated_yaml_{DOMAIN}",
+        breaks_in_ha_version="2026.12.0",
+        is_fixable=False,
+        issue_domain=DOMAIN,
+        severity=IssueSeverity.WARNING,
+        translation_key="deprecated_yaml",
+        translation_placeholders={
+            "domain": DOMAIN,
+            "integration_title": "AquaLogic",
+        },
+    )
+
     return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: AquaLogicConfigEntry) -> bool:
+    """Set up AquaLogic from a config entry."""
+    processor = AquaLogicProcessor(hass, entry.data[CONF_HOST], entry.data[CONF_PORT])
+    entry.runtime_data = processor
+
+    entry.async_on_unload(
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, processor.shutdown)
+    )
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    processor.start()
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: AquaLogicConfigEntry) -> bool:
+    """Unload an AquaLogic config entry."""
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+        entry.runtime_data.shutdown()
+
+    return unload_ok
 
 
 class AquaLogicProcessor(threading.Thread):
@@ -60,12 +101,7 @@ class AquaLogicProcessor(threading.Thread):
         self._shutdown = False
         self._panel = None
 
-    def start_listen(self, event: Event) -> None:
-        """Start event-processing thread."""
-        _LOGGER.debug("Event processing thread started")
-        self.start()
-
-    def shutdown(self, event: Event) -> None:
+    def shutdown(self, event: Event | None = None) -> None:
         """Signal shutdown of processing event."""
         _LOGGER.debug("Event processing signaled exit")
         self._shutdown = True

--- a/homeassistant/components/aqualogic/config_flow.py
+++ b/homeassistant/components/aqualogic/config_flow.py
@@ -1,0 +1,67 @@
+"""Config flow for AquaLogic."""
+
+import socket
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.helpers import config_validation as cv
+
+from .const import DOMAIN
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): str,
+        vol.Required(CONF_PORT): cv.port,
+    }
+)
+
+
+def _can_connect(host: str, port: int) -> bool:
+    """Test if we can connect to the AquaLogic device."""
+    try:
+        with socket.create_connection((host, port), timeout=5):
+            return True
+    except OSError:
+        return False
+
+
+class AquaLogicConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for AquaLogic."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            self._async_abort_entries_match(user_input)
+
+            if await self.hass.async_add_executor_job(
+                _can_connect, user_input[CONF_HOST], user_input[CONF_PORT]
+            ):
+                return self.async_create_entry(title="AquaLogic", data=user_input)
+
+            errors["base"] = "cannot_connect"
+
+        return self.async_show_form(
+            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+        )
+
+    async def async_step_import(self, import_data: dict[str, Any]) -> ConfigFlowResult:
+        """Import AquaLogic config from configuration.yaml."""
+        self._async_abort_entries_match(
+            {CONF_HOST: import_data[CONF_HOST], CONF_PORT: import_data[CONF_PORT]}
+        )
+
+        if not await self.hass.async_add_executor_job(
+            _can_connect, import_data[CONF_HOST], import_data[CONF_PORT]
+        ):
+            return self.async_abort(reason="cannot_connect")
+
+        return self.async_create_entry(title="AquaLogic", data=import_data)

--- a/homeassistant/components/aqualogic/const.py
+++ b/homeassistant/components/aqualogic/const.py
@@ -1,0 +1,8 @@
+"""Constants for the AquaLogic integration."""
+
+from homeassistant.const import Platform
+
+DOMAIN = "aqualogic"
+PLATFORMS = [Platform.SENSOR, Platform.SWITCH]
+
+UPDATE_TOPIC = f"{DOMAIN}_update"

--- a/homeassistant/components/aqualogic/manifest.json
+++ b/homeassistant/components/aqualogic/manifest.json
@@ -2,9 +2,10 @@
   "domain": "aqualogic",
   "name": "AquaLogic",
   "codeowners": [],
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/aqualogic",
+  "integration_type": "device",
   "iot_class": "local_push",
   "loggers": ["aqualogic"],
-  "quality_scale": "legacy",
   "requirements": ["aqualogic==2.6"]
 }

--- a/homeassistant/components/aqualogic/sensor.py
+++ b/homeassistant/components/aqualogic/sensor.py
@@ -2,27 +2,19 @@
 
 from dataclasses import dataclass
 
-import voluptuous as vol
-
 from homeassistant.components.sensor import (
-    PLATFORM_SCHEMA as SENSOR_PLATFORM_SCHEMA,
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
 )
-from homeassistant.const import (
-    CONF_MONITORED_CONDITIONS,
-    PERCENTAGE,
-    UnitOfPower,
-    UnitOfTemperature,
-)
+from homeassistant.const import PERCENTAGE, UnitOfPower, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import DOMAIN, UPDATE_TOPIC, AquaLogicProcessor
+from . import AquaLogicConfigEntry, AquaLogicProcessor
+from .const import DOMAIN, UPDATE_TOPIC
 
 
 @dataclass(frozen=True)
@@ -100,34 +92,19 @@ SENSOR_TYPES: tuple[AquaLogicSensorEntityDescription, ...] = (
     ),
 )
 
-SENSOR_KEYS: list[str] = [desc.key for desc in SENSOR_TYPES]
 
-PLATFORM_SCHEMA = SENSOR_PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_MONITORED_CONDITIONS, default=SENSOR_KEYS): vol.All(
-            cv.ensure_list, [vol.In(SENSOR_KEYS)]
-        )
-    }
-)
-
-
-async def async_setup_platform(
+async def async_setup_entry(
     hass: HomeAssistant,
-    config: ConfigType,
-    async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
+    entry: AquaLogicConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up the sensor platform."""
-    processor: AquaLogicProcessor = hass.data[DOMAIN]
-    monitored_conditions = config[CONF_MONITORED_CONDITIONS]
+    """Set up the sensor entities."""
+    processor = entry.runtime_data
 
-    entities = [
-        AquaLogicSensor(processor, description)
+    async_add_entities(
+        AquaLogicSensor(entry.entry_id, processor, description)
         for description in SENSOR_TYPES
-        if description.key in monitored_conditions
-    ]
-
-    async_add_entities(entities)
+    )
 
 
 class AquaLogicSensor(SensorEntity):
@@ -138,6 +115,7 @@ class AquaLogicSensor(SensorEntity):
 
     def __init__(
         self,
+        entry_id: str,
         processor: AquaLogicProcessor,
         description: AquaLogicSensorEntityDescription,
     ) -> None:
@@ -145,6 +123,12 @@ class AquaLogicSensor(SensorEntity):
         self.entity_description = description
         self._processor = processor
         self._attr_name = f"AquaLogic {description.name}"
+        self._attr_unique_id = f"{entry_id}_{description.key}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry_id)},
+            name="AquaLogic",
+            manufacturer="Hayward",
+        )
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
@@ -170,4 +154,6 @@ class AquaLogicSensor(SensorEntity):
             self._attr_native_value = getattr(panel, self.entity_description.key)
             self.async_write_ha_state()
         else:
+            self._attr_native_value = None
             self._attr_native_unit_of_measurement = None
+            self.async_write_ha_state()

--- a/homeassistant/components/aqualogic/strings.json
+++ b/homeassistant/components/aqualogic/strings.json
@@ -1,0 +1,23 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "port": "[%key:common::config_flow::data::port%]"
+        },
+        "data_description": {
+          "host": "Hostname or IP address of your AquaLogic controller",
+          "port": "TCP port used to connect to the AquaLogic controller"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/components/aqualogic/switch.py
+++ b/homeassistant/components/aqualogic/switch.py
@@ -3,20 +3,15 @@
 from typing import Any
 
 from aqualogic.core import States
-import voluptuous as vol
 
-from homeassistant.components.switch import (
-    PLATFORM_SCHEMA as SWITCH_PLATFORM_SCHEMA,
-    SwitchEntity,
-)
-from homeassistant.const import CONF_MONITORED_CONDITIONS
+from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import DOMAIN, UPDATE_TOPIC, AquaLogicProcessor
+from . import AquaLogicConfigEntry, AquaLogicProcessor
+from .const import DOMAIN, UPDATE_TOPIC
 
 SWITCH_TYPES = {
     "lights": "Lights",
@@ -31,27 +26,31 @@ SWITCH_TYPES = {
     "aux_7": "Aux 7",
 }
 
-PLATFORM_SCHEMA = SWITCH_PLATFORM_SCHEMA.extend(
-    {
-        vol.Optional(CONF_MONITORED_CONDITIONS, default=list(SWITCH_TYPES)): vol.All(
-            cv.ensure_list, [vol.In(SWITCH_TYPES)]
-        )
-    }
-)
+_STATES_MAP = {
+    "lights": States.LIGHTS,
+    "filter": States.FILTER,
+    "filter_low_speed": States.FILTER_LOW_SPEED,
+    "aux_1": States.AUX_1,
+    "aux_2": States.AUX_2,
+    "aux_3": States.AUX_3,
+    "aux_4": States.AUX_4,
+    "aux_5": States.AUX_5,
+    "aux_6": States.AUX_6,
+    "aux_7": States.AUX_7,
+}
 
 
-async def async_setup_platform(
+async def async_setup_entry(
     hass: HomeAssistant,
-    config: ConfigType,
-    async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
+    entry: AquaLogicConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up the switch platform."""
-    processor: AquaLogicProcessor = hass.data[DOMAIN]
+    """Set up the switch entities."""
+    processor = entry.runtime_data
 
     async_add_entities(
-        AquaLogicSwitch(processor, switch_type)
-        for switch_type in config[CONF_MONITORED_CONDITIONS]
+        AquaLogicSwitch(entry.entry_id, processor, switch_type)
+        for switch_type in SWITCH_TYPES
     )
 
 
@@ -60,22 +59,19 @@ class AquaLogicSwitch(SwitchEntity):
 
     _attr_should_poll = False
 
-    def __init__(self, processor: AquaLogicProcessor, switch_type: str) -> None:
+    def __init__(
+        self, entry_id: str, processor: AquaLogicProcessor, switch_type: str
+    ) -> None:
         """Initialize switch."""
         self._processor = processor
-        self._state_name = {
-            "lights": States.LIGHTS,
-            "filter": States.FILTER,
-            "filter_low_speed": States.FILTER_LOW_SPEED,
-            "aux_1": States.AUX_1,
-            "aux_2": States.AUX_2,
-            "aux_3": States.AUX_3,
-            "aux_4": States.AUX_4,
-            "aux_5": States.AUX_5,
-            "aux_6": States.AUX_6,
-            "aux_7": States.AUX_7,
-        }[switch_type]
+        self._state_name = _STATES_MAP[switch_type]
         self._attr_name = f"AquaLogic {SWITCH_TYPES[switch_type]}"
+        self._attr_unique_id = f"{entry_id}_{switch_type}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry_id)},
+            name="AquaLogic",
+            manufacturer="Hayward",
+        )
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -74,6 +74,7 @@ FLOWS = {
         "aprilaire",
         "apsystems",
         "aquacell",
+        "aqualogic",
         "aqvify",
         "aranet",
         "arcam_fmj",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -510,8 +510,8 @@
     },
     "aqualogic": {
       "name": "AquaLogic",
-      "integration_type": "hub",
-      "config_flow": false,
+      "integration_type": "device",
+      "config_flow": true,
       "iot_class": "local_push"
     },
     "aquostv": {

--- a/tests/components/aqualogic/__init__.py
+++ b/tests/components/aqualogic/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the AquaLogic integration."""

--- a/tests/components/aqualogic/conftest.py
+++ b/tests/components/aqualogic/conftest.py
@@ -1,0 +1,74 @@
+"""Fixtures for the AquaLogic integration tests."""
+
+from collections.abc import Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from homeassistant.components.aqualogic.const import DOMAIN
+from homeassistant.const import CONF_HOST, CONF_PORT, Platform
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return a mock config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "1.2.3.4", CONF_PORT: 8899},
+        entry_id="test_aqualogic_entry",
+    )
+
+
+@pytest.fixture
+def mock_panel() -> MagicMock:
+    """Return a mock AquaLogic panel."""
+    panel = MagicMock()
+    panel.is_metric = True
+    panel.air_temp = 25.5
+    panel.pool_temp = 27.8
+    panel.spa_temp = 38.0
+    panel.pool_chlorinator = 50
+    panel.spa_chlorinator = 0
+    panel.salt_level = 3.3
+    panel.pump_speed = 60
+    panel.pump_power = 850
+    panel.status = "OK"
+    panel.get_state.return_value = True
+    return panel
+
+
+@pytest.fixture
+def mock_processor(mock_panel: MagicMock) -> Generator[MagicMock]:
+    """Mock the AquaLogic processor thread."""
+    with patch(
+        "homeassistant.components.aqualogic.AquaLogicProcessor"
+    ) as mock_processor_class:
+        processor = mock_processor_class.return_value
+        processor.panel = mock_panel
+        yield processor
+
+
+@pytest.fixture
+def platforms() -> list[Platform]:
+    """Fixture to specify platforms to test."""
+    return [Platform.SENSOR, Platform.SWITCH]
+
+
+@pytest.fixture
+async def init_integration(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_processor: MagicMock,
+    platforms: list[Platform],
+) -> MockConfigEntry:
+    """Set up the AquaLogic integration for testing."""
+    mock_config_entry.add_to_hass(hass)
+
+    with patch("homeassistant.components.aqualogic.PLATFORMS", platforms):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    return mock_config_entry

--- a/tests/components/aqualogic/snapshots/test_sensor.ambr
+++ b/tests/components/aqualogic/snapshots/test_sensor.ambr
@@ -1,0 +1,470 @@
+# serializer version: 1
+# name: test_sensors[sensor.aqualogic_air_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.aqualogic_air_temperature',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'AquaLogic Air Temperature',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'AquaLogic Air Temperature',
+    'platform': 'aqualogic',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'test_aqualogic_entry_air_temp',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.aqualogic_air_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'AquaLogic Air Temperature',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.aqualogic_air_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '25.5',
+  })
+# ---
+# name: test_sensors[sensor.aqualogic_pool_chlorinator-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.aqualogic_pool_chlorinator',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'AquaLogic Pool Chlorinator',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:gauge',
+    'original_name': 'AquaLogic Pool Chlorinator',
+    'platform': 'aqualogic',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'test_aqualogic_entry_pool_chlorinator',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.aqualogic_pool_chlorinator-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'AquaLogic Pool Chlorinator',
+      'icon': 'mdi:gauge',
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.aqualogic_pool_chlorinator',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '50',
+  })
+# ---
+# name: test_sensors[sensor.aqualogic_pool_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.aqualogic_pool_temperature',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'AquaLogic Pool Temperature',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': 'mdi:oil-temperature',
+    'original_name': 'AquaLogic Pool Temperature',
+    'platform': 'aqualogic',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'test_aqualogic_entry_pool_temp',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.aqualogic_pool_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'AquaLogic Pool Temperature',
+      'icon': 'mdi:oil-temperature',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.aqualogic_pool_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '27.8',
+  })
+# ---
+# name: test_sensors[sensor.aqualogic_pump_power-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.aqualogic_pump_power',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'AquaLogic Pump Power',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'AquaLogic Pump Power',
+    'platform': 'aqualogic',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'test_aqualogic_entry_pump_power',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.aqualogic_pump_power-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'AquaLogic Pump Power',
+      'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.aqualogic_pump_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '850',
+  })
+# ---
+# name: test_sensors[sensor.aqualogic_pump_speed-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.aqualogic_pump_speed',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'AquaLogic Pump Speed',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:speedometer',
+    'original_name': 'AquaLogic Pump Speed',
+    'platform': 'aqualogic',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'test_aqualogic_entry_pump_speed',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.aqualogic_pump_speed-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'AquaLogic Pump Speed',
+      'icon': 'mdi:speedometer',
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.aqualogic_pump_speed',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '60',
+  })
+# ---
+# name: test_sensors[sensor.aqualogic_salt_level-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.aqualogic_salt_level',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'AquaLogic Salt Level',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:gauge',
+    'original_name': 'AquaLogic Salt Level',
+    'platform': 'aqualogic',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'test_aqualogic_entry_salt_level',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.aqualogic_salt_level-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'AquaLogic Salt Level',
+      'icon': 'mdi:gauge',
+      'unit_of_measurement': 'g/L',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.aqualogic_salt_level',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '3.3',
+  })
+# ---
+# name: test_sensors[sensor.aqualogic_spa_chlorinator-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.aqualogic_spa_chlorinator',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'AquaLogic Spa Chlorinator',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:gauge',
+    'original_name': 'AquaLogic Spa Chlorinator',
+    'platform': 'aqualogic',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'test_aqualogic_entry_spa_chlorinator',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.aqualogic_spa_chlorinator-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'AquaLogic Spa Chlorinator',
+      'icon': 'mdi:gauge',
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.aqualogic_spa_chlorinator',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensors[sensor.aqualogic_spa_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.aqualogic_spa_temperature',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'AquaLogic Spa Temperature',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': 'mdi:oil-temperature',
+    'original_name': 'AquaLogic Spa Temperature',
+    'platform': 'aqualogic',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'test_aqualogic_entry_spa_temp',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.aqualogic_spa_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'AquaLogic Spa Temperature',
+      'icon': 'mdi:oil-temperature',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.aqualogic_spa_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '38.0',
+  })
+# ---
+# name: test_sensors[sensor.aqualogic_status-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.aqualogic_status',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'AquaLogic Status',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:alert',
+    'original_name': 'AquaLogic Status',
+    'platform': 'aqualogic',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'test_aqualogic_entry_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.aqualogic_status-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'AquaLogic Status',
+      'icon': 'mdi:alert',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.aqualogic_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'OK',
+  })
+# ---

--- a/tests/components/aqualogic/snapshots/test_switch.ambr
+++ b/tests/components/aqualogic/snapshots/test_switch.ambr
@@ -1,0 +1,501 @@
+# serializer version: 1
+# name: test_switches[switch.aqualogic_aux_1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.aqualogic_aux_1',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'AquaLogic Aux 1',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'AquaLogic Aux 1',
+    'platform': 'aqualogic',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'test_aqualogic_entry_aux_1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.aqualogic_aux_1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'AquaLogic Aux 1',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.aqualogic_aux_1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switches[switch.aqualogic_aux_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.aqualogic_aux_2',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'AquaLogic Aux 2',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'AquaLogic Aux 2',
+    'platform': 'aqualogic',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'test_aqualogic_entry_aux_2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.aqualogic_aux_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'AquaLogic Aux 2',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.aqualogic_aux_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switches[switch.aqualogic_aux_3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.aqualogic_aux_3',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'AquaLogic Aux 3',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'AquaLogic Aux 3',
+    'platform': 'aqualogic',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'test_aqualogic_entry_aux_3',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.aqualogic_aux_3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'AquaLogic Aux 3',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.aqualogic_aux_3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switches[switch.aqualogic_aux_4-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.aqualogic_aux_4',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'AquaLogic Aux 4',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'AquaLogic Aux 4',
+    'platform': 'aqualogic',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'test_aqualogic_entry_aux_4',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.aqualogic_aux_4-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'AquaLogic Aux 4',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.aqualogic_aux_4',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switches[switch.aqualogic_aux_5-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.aqualogic_aux_5',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'AquaLogic Aux 5',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'AquaLogic Aux 5',
+    'platform': 'aqualogic',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'test_aqualogic_entry_aux_5',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.aqualogic_aux_5-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'AquaLogic Aux 5',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.aqualogic_aux_5',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switches[switch.aqualogic_aux_6-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.aqualogic_aux_6',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'AquaLogic Aux 6',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'AquaLogic Aux 6',
+    'platform': 'aqualogic',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'test_aqualogic_entry_aux_6',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.aqualogic_aux_6-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'AquaLogic Aux 6',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.aqualogic_aux_6',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switches[switch.aqualogic_aux_7-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.aqualogic_aux_7',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'AquaLogic Aux 7',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'AquaLogic Aux 7',
+    'platform': 'aqualogic',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'test_aqualogic_entry_aux_7',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.aqualogic_aux_7-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'AquaLogic Aux 7',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.aqualogic_aux_7',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switches[switch.aqualogic_filter-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.aqualogic_filter',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'AquaLogic Filter',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'AquaLogic Filter',
+    'platform': 'aqualogic',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'test_aqualogic_entry_filter',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.aqualogic_filter-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'AquaLogic Filter',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.aqualogic_filter',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switches[switch.aqualogic_filter_low_speed-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.aqualogic_filter_low_speed',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'AquaLogic Filter Low Speed',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'AquaLogic Filter Low Speed',
+    'platform': 'aqualogic',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'test_aqualogic_entry_filter_low_speed',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.aqualogic_filter_low_speed-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'AquaLogic Filter Low Speed',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.aqualogic_filter_low_speed',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switches[switch.aqualogic_lights-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.aqualogic_lights',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'AquaLogic Lights',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'AquaLogic Lights',
+    'platform': 'aqualogic',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'test_aqualogic_entry_lights',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.aqualogic_lights-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'AquaLogic Lights',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.aqualogic_lights',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---

--- a/tests/components/aqualogic/test_config_flow.py
+++ b/tests/components/aqualogic/test_config_flow.py
@@ -1,0 +1,169 @@
+"""Tests for the AquaLogic config flow."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant.components.aqualogic import config_flow
+from homeassistant.components.aqualogic.const import DOMAIN
+from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.aqualogic.async_setup_entry", return_value=True
+    ) as mock:
+        yield mock
+
+
+async def test_user_flow_success(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
+    """Test we get the form and create an entry."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    with patch(
+        "homeassistant.components.aqualogic.config_flow._can_connect",
+        return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_HOST: "1.2.3.4", CONF_PORT: 8899},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "AquaLogic"
+    assert result["data"] == {CONF_HOST: "1.2.3.4", CONF_PORT: 8899}
+    mock_setup_entry.assert_called_once()
+
+
+async def test_user_flow_cannot_connect(hass: HomeAssistant) -> None:
+    """Test we handle cannot connect error and allow retry."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.aqualogic.config_flow._can_connect",
+        return_value=False,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_HOST: "1.2.3.4", CONF_PORT: 8899},
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+    with (
+        patch(
+            "homeassistant.components.aqualogic.config_flow._can_connect",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.aqualogic.async_setup_entry", return_value=True
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_HOST: "1.2.3.4", CONF_PORT: 8899},
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+
+async def test_user_flow_already_configured(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test we abort if the host/port is already configured."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: "1.2.3.4", CONF_PORT: 8899},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_import_flow_success(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
+    """Test importing from configuration.yaml creates a config entry."""
+    with patch(
+        "homeassistant.components.aqualogic.config_flow._can_connect",
+        return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_IMPORT},
+            data={CONF_HOST: "1.2.3.4", CONF_PORT: 8899},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "AquaLogic"
+    assert result["data"] == {CONF_HOST: "1.2.3.4", CONF_PORT: 8899}
+    mock_setup_entry.assert_called_once()
+
+
+async def test_import_flow_cannot_connect(hass: HomeAssistant) -> None:
+    """Test we abort the import if we cannot connect."""
+    with patch(
+        "homeassistant.components.aqualogic.config_flow._can_connect",
+        return_value=False,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_IMPORT},
+            data={CONF_HOST: "1.2.3.4", CONF_PORT: 8899},
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
+
+
+async def test_import_flow_already_configured(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test we abort the import if already configured."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_IMPORT},
+        data={CONF_HOST: "1.2.3.4", CONF_PORT: 8899},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "expected"),
+    [
+        pytest.param(None, True, id="success"),
+        pytest.param(OSError, False, id="os_error"),
+    ],
+)
+def test_can_connect(side_effect: type[Exception] | None, expected: bool) -> None:
+    """Test _can_connect returns True on success and False on OSError."""
+    with patch("socket.create_connection", side_effect=side_effect):
+        assert config_flow._can_connect("1.2.3.4", 8899) is expected

--- a/tests/components/aqualogic/test_init.py
+++ b/tests/components/aqualogic/test_init.py
@@ -1,0 +1,124 @@
+"""Tests for the AquaLogic integration setup."""
+
+from unittest.mock import MagicMock, patch
+
+from homeassistant.components.aqualogic import RECONNECT_INTERVAL, AquaLogicProcessor
+from homeassistant.components.aqualogic.const import DOMAIN, UPDATE_TOPIC
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_STOP
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
+from homeassistant.helpers import issue_registry as ir
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
+
+
+async def test_load_unload_entry(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_processor: MagicMock,
+) -> None:
+    """Test loading and unloading the config entry starts and stops the processor."""
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    mock_processor.start.assert_called_once()
+
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+    mock_processor.shutdown.assert_called_once()
+
+
+async def test_shutdown_on_homeassistant_stop(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_processor: MagicMock,
+) -> None:
+    """Test the processor shuts down when Home Assistant stops."""
+    mock_config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+    await hass.async_block_till_done()
+
+    mock_processor.shutdown.assert_called_once()
+
+
+async def test_import_from_yaml(
+    hass: HomeAssistant,
+    mock_processor: MagicMock,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test importing from YAML creates a config entry and a deprecation issue."""
+    with patch(
+        "homeassistant.components.aqualogic.config_flow._can_connect",
+        return_value=True,
+    ):
+        assert await async_setup_component(
+            hass,
+            DOMAIN,
+            {DOMAIN: {CONF_HOST: "1.2.3.4", CONF_PORT: 8899}},
+        )
+        await hass.async_block_till_done()
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].data == {CONF_HOST: "1.2.3.4", CONF_PORT: 8899}
+
+    issue = issue_registry.async_get_issue(
+        HOMEASSISTANT_DOMAIN, f"deprecated_yaml_{DOMAIN}"
+    )
+    assert issue is not None
+    assert issue.issue_domain == DOMAIN
+
+
+async def test_processor_panel(hass: HomeAssistant) -> None:
+    """Test panel property returns None initially then the assigned panel."""
+    processor = AquaLogicProcessor(hass, "1.2.3.4", 8899)
+    assert processor.panel is None
+    mock_panel = MagicMock()
+    processor._panel = mock_panel
+    assert processor.panel is mock_panel
+
+
+async def test_processor_shutdown(hass: HomeAssistant) -> None:
+    """Test shutdown sets the internal flag."""
+    processor = AquaLogicProcessor(hass, "1.2.3.4", 8899)
+    processor.shutdown()
+    assert processor._shutdown is True
+
+
+async def test_processor_data_changed(hass: HomeAssistant) -> None:
+    """Test data_changed dispatches the update topic."""
+    processor = AquaLogicProcessor(hass, "1.2.3.4", 8899)
+    with patch("homeassistant.components.aqualogic.dispatcher_send") as mock_send:
+        processor.data_changed(MagicMock())
+    mock_send.assert_called_once_with(hass, UPDATE_TOPIC)
+
+
+async def test_processor_run_exits_on_shutdown(hass: HomeAssistant) -> None:
+    """Test run() processes once then exits when shutdown is already set."""
+    processor = AquaLogicProcessor(hass, "1.2.3.4", 8899)
+    processor._shutdown = True
+    with patch("homeassistant.components.aqualogic.AquaLogic") as mock_aqualogic:
+        processor.run()
+    mock_aqualogic.return_value.connect.assert_called_once_with("1.2.3.4", 8899)
+
+
+async def test_processor_run_reconnects(hass: HomeAssistant) -> None:
+    """Test run() logs an error and reconnects after a dropped connection."""
+    processor = AquaLogicProcessor(hass, "1.2.3.4", 8899)
+    with (
+        patch("homeassistant.components.aqualogic.AquaLogic") as mock_aqualogic,
+        patch("homeassistant.components.aqualogic.time.sleep") as mock_sleep,
+    ):
+        mock_sleep.side_effect = lambda _: setattr(processor, "_shutdown", True)
+        processor.run()
+    assert mock_aqualogic.return_value.connect.call_count == 2
+    mock_sleep.assert_called_once_with(RECONNECT_INTERVAL.total_seconds())

--- a/tests/components/aqualogic/test_sensor.py
+++ b/tests/components/aqualogic/test_sensor.py
@@ -1,0 +1,67 @@
+"""Tests for the AquaLogic sensor platform."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.aqualogic.const import UPDATE_TOPIC
+from homeassistant.const import STATE_UNKNOWN, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.fixture
+def platforms() -> list[Platform]:
+    """Fixture to specify platforms to test."""
+    return [Platform.SENSOR]
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_sensors(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+    init_integration: MockConfigEntry,
+    mock_processor: MagicMock,
+) -> None:
+    """Test sensor entities are created and report correct state."""
+    async_dispatcher_send(hass, UPDATE_TOPIC)
+    await hass.async_block_till_done()
+
+    await snapshot_platform(hass, entity_registry, snapshot, init_integration.entry_id)
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_sensors_imperial_units(
+    hass: HomeAssistant,
+    mock_processor: MagicMock,
+) -> None:
+    """Test sensors report imperial units when the panel is not metric."""
+    mock_processor.panel.is_metric = False
+    async_dispatcher_send(hass, UPDATE_TOPIC)
+    await hass.async_block_till_done()
+
+    # Use salt_level (g/L → PPM) to verify imperial branch without HA unit conversion
+    state = hass.states.get("sensor.aqualogic_salt_level")
+    assert state.attributes["unit_of_measurement"] == "PPM"
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_sensors_no_panel(
+    hass: HomeAssistant,
+    mock_processor: MagicMock,
+) -> None:
+    """Test sensors revert to unknown when the panel becomes unavailable."""
+    async_dispatcher_send(hass, UPDATE_TOPIC)
+    await hass.async_block_till_done()
+    assert hass.states.get("sensor.aqualogic_air_temperature").state == "25.5"
+
+    mock_processor.panel = None
+    async_dispatcher_send(hass, UPDATE_TOPIC)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("sensor.aqualogic_air_temperature").state == STATE_UNKNOWN

--- a/tests/components/aqualogic/test_switch.py
+++ b/tests/components/aqualogic/test_switch.py
@@ -1,0 +1,105 @@
+"""Tests for the AquaLogic switch platform."""
+
+from unittest.mock import MagicMock
+
+from aqualogic.core import States
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.aqualogic.const import UPDATE_TOPIC
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_OFF,
+    Platform,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.fixture
+def platforms() -> list[Platform]:
+    """Fixture to specify platforms to test."""
+    return [Platform.SWITCH]
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_switches(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+    init_integration: MockConfigEntry,
+    mock_processor: MagicMock,
+) -> None:
+    """Test switch entities are created and report correct state."""
+    async_dispatcher_send(hass, UPDATE_TOPIC)
+    await hass.async_block_till_done()
+
+    await snapshot_platform(hass, entity_registry, snapshot, init_integration.entry_id)
+
+
+@pytest.mark.usefixtures("init_integration")
+@pytest.mark.parametrize(
+    ("service", "expected_state"),
+    [
+        pytest.param(SERVICE_TURN_ON, True, id="turn_on"),
+        pytest.param(SERVICE_TURN_OFF, False, id="turn_off"),
+    ],
+)
+async def test_turn(
+    hass: HomeAssistant,
+    mock_processor: MagicMock,
+    service: str,
+    expected_state: bool,
+) -> None:
+    """Test turning a switch on/off calls set_state on the panel."""
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        service,
+        {ATTR_ENTITY_ID: "switch.aqualogic_lights"},
+        blocking=True,
+    )
+    mock_processor.panel.set_state.assert_called_with(States.LIGHTS, expected_state)
+
+
+@pytest.mark.usefixtures("init_integration")
+@pytest.mark.parametrize(
+    "service",
+    [
+        pytest.param(SERVICE_TURN_ON, id="turn_on"),
+        pytest.param(SERVICE_TURN_OFF, id="turn_off"),
+    ],
+)
+async def test_turn_no_panel(
+    hass: HomeAssistant,
+    mock_processor: MagicMock,
+    service: str,
+) -> None:
+    """Test that turning a switch does nothing when the panel is unavailable."""
+    panel = mock_processor.panel
+    mock_processor.panel = None
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        service,
+        {ATTR_ENTITY_ID: "switch.aqualogic_lights"},
+        blocking=True,
+    )
+    panel.set_state.assert_not_called()
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_is_on_no_panel(
+    hass: HomeAssistant,
+    mock_processor: MagicMock,
+) -> None:
+    """Test switch reports off when panel is unavailable."""
+    mock_processor.panel = None
+    async_dispatcher_send(hass, UPDATE_TOPIC)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("switch.aqualogic_lights").state == STATE_OFF


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrates the AquaLogic integration from YAML-only configuration to a config flow, allowing it to be set up entirely through the UI.

Also changes the integration type from `hub` to `device` 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository] : https://github.com/home-assistant/home-assistant.io/pull/45849

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
