### PR TITLE
Add oven stop button to Whirlpool

### DIFF
--- a/homeassistant/components/whirlpool/__init__.py
+++ b/homeassistant/components/whirlpool/__init__.py
@@ -17,7 +17,13 @@ from .const import BRANDS_CONF_MAP, CONF_BRAND, DOMAIN, REGIONS_CONF_MAP
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.CLIMATE, Platform.SELECT, Platform.SENSOR]
+PLATFORMS = [
+    Platform.BINARY_SENSOR,
+    Platform.BUTTON,
+    Platform.CLIMATE,
+    Platform.SELECT,
+    Platform.SENSOR,
+]
 
 type WhirlpoolConfigEntry = ConfigEntry[AppliancesManager]
 

--- a/homeassistant/components/whirlpool/button.py
+++ b/homeassistant/components/whirlpool/button.py
@@ -1,0 +1,43 @@
+"""Button platform for the Whirlpool Appliances integration."""
+
+from whirlpool.oven import Cavity as OvenCavity, Oven
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import WhirlpoolConfigEntry
+from .entity import WhirlpoolOvenEntity
+
+PARALLEL_UPDATES = 1
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: WhirlpoolConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the button platform."""
+    appliances_manager = config_entry.runtime_data
+    async_add_entities(
+        WhirlpoolOvenStopButton(oven, cavity)
+        for oven in appliances_manager.ovens
+        for cavity in (OvenCavity.Upper, OvenCavity.Lower)
+        if oven.get_oven_cavity_exists(cavity)
+    )
+
+
+class WhirlpoolOvenStopButton(WhirlpoolOvenEntity, ButtonEntity):
+    """Button to stop the current cook in an oven cavity."""
+
+    _appliance: Oven
+
+    def __init__(self, appliance: Oven, cavity: OvenCavity) -> None:
+        """Initialize the oven stop button."""
+        super().__init__(appliance, cavity, "oven_stop", "-stop")
+
+    async def async_press(self) -> None:
+        """Stop cooking."""
+        WhirlpoolOvenStopButton._check_service_request(
+            await self._appliance.stop_cook(self.cavity)
+        )

--- a/homeassistant/components/whirlpool/strings.json
+++ b/homeassistant/components/whirlpool/strings.json
@@ -46,6 +46,17 @@
     }
   },
   "entity": {
+    "button": {
+      "oven_stop": {
+        "name": "Stop"
+      },
+      "oven_stop_lower": {
+        "name": "Lower oven stop"
+      },
+      "oven_stop_upper": {
+        "name": "Upper oven stop"
+      }
+    },
     "select": {
       "refrigerator_temperature_level": {
         "name": "Temperature level"

--- a/tests/components/whirlpool/snapshots/test_button.ambr
+++ b/tests/components/whirlpool/snapshots/test_button.ambr
@@ -1,0 +1,151 @@
+# serializer version: 1
+# name: test_all_entities[button.dual_cavity_oven_lower_oven_stop-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.dual_cavity_oven_lower_oven_stop',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Lower oven stop',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Lower oven stop',
+    'platform': 'whirlpool',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'oven_stop_lower',
+    'unique_id': 'said_oven_dual-stop_lower',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[button.dual_cavity_oven_lower_oven_stop-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Dual cavity oven Lower oven stop',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.dual_cavity_oven_lower_oven_stop',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_all_entities[button.dual_cavity_oven_upper_oven_stop-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.dual_cavity_oven_upper_oven_stop',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Upper oven stop',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Upper oven stop',
+    'platform': 'whirlpool',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'oven_stop_upper',
+    'unique_id': 'said_oven_dual-stop_upper',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[button.dual_cavity_oven_upper_oven_stop-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Dual cavity oven Upper oven stop',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.dual_cavity_oven_upper_oven_stop',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_all_entities[button.single_cavity_oven_stop-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.single_cavity_oven_stop',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Stop',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Stop',
+    'platform': 'whirlpool',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'oven_stop',
+    'unique_id': 'said_oven_single-stop',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[button.single_cavity_oven_stop-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Single cavity oven Stop',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.single_cavity_oven_stop',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/whirlpool/test_button.py
+++ b/tests/components/whirlpool/test_button.py
@@ -1,0 +1,75 @@
+"""Test the Whirlpool button platform."""
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+import whirlpool
+
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from . import init_integration, snapshot_whirlpool_entities
+
+
+@pytest.fixture(
+    params=[
+        ("button.single_cavity_oven_stop", "mock_oven_single_cavity_api", whirlpool.oven.Cavity.Upper),
+        ("button.dual_cavity_oven_upper_oven_stop", "mock_oven_dual_cavity_api", whirlpool.oven.Cavity.Upper),
+        ("button.dual_cavity_oven_lower_oven_stop", "mock_oven_dual_cavity_api", whirlpool.oven.Cavity.Lower),
+    ]
+)
+def oven_button_entity(
+    request: pytest.FixtureRequest,
+) -> tuple[str, str, whirlpool.oven.Cavity]:
+    """Parametrize the oven stop button entities."""
+    return request.param
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_all_entities(
+    hass: HomeAssistant, snapshot: SnapshotAssertion, entity_registry: er.EntityRegistry
+) -> None:
+    """Test all entities."""
+    await init_integration(hass)
+    snapshot_whirlpool_entities(hass, entity_registry, snapshot, Platform.BUTTON)
+
+
+async def test_stop_button_press(
+    hass: HomeAssistant,
+    oven_button_entity: tuple[str, str, whirlpool.oven.Cavity],
+    request: pytest.FixtureRequest,
+) -> None:
+    """Test pressing the stop button cancels the cook."""
+    entity_id, mock_fixture, cavity = oven_button_entity
+    mock = request.getfixturevalue(mock_fixture)
+    await init_integration(hass)
+
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    mock.stop_cook.assert_called_once_with(cavity)
+
+
+async def test_stop_button_failure(
+    hass: HomeAssistant,
+    oven_button_entity: tuple[str, str, whirlpool.oven.Cavity],
+    request: pytest.FixtureRequest,
+) -> None:
+    """Test a failed stop request raises HomeAssistantError."""
+    entity_id, mock_fixture, _ = oven_button_entity
+    mock = request.getfixturevalue(mock_fixture)
+    mock.stop_cook.return_value = False
+    await init_integration(hass)
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )

--- a/tests/components/whirlpool/test_button.py
+++ b/tests/components/whirlpool/test_button.py
@@ -15,9 +15,21 @@ from . import init_integration, snapshot_whirlpool_entities
 
 @pytest.fixture(
     params=[
-        ("button.single_cavity_oven_stop", "mock_oven_single_cavity_api", whirlpool.oven.Cavity.Upper),
-        ("button.dual_cavity_oven_upper_oven_stop", "mock_oven_dual_cavity_api", whirlpool.oven.Cavity.Upper),
-        ("button.dual_cavity_oven_lower_oven_stop", "mock_oven_dual_cavity_api", whirlpool.oven.Cavity.Lower),
+        (
+            "button.single_cavity_oven_stop",
+            "mock_oven_single_cavity_api",
+            whirlpool.oven.Cavity.Upper,
+        ),
+        (
+            "button.dual_cavity_oven_upper_oven_stop",
+            "mock_oven_dual_cavity_api",
+            whirlpool.oven.Cavity.Upper,
+        ),
+        (
+            "button.dual_cavity_oven_lower_oven_stop",
+            "mock_oven_dual_cavity_api",
+            whirlpool.oven.Cavity.Lower,
+        ),
     ]
 )
 def oven_button_entity(


### PR DESCRIPTION
## Proposed change

Adds a utton platform to the Whirlpool integration with a **Stop** button per oven cavity, allowing users to cancel an active cook via stop_cook. Split from #173326 per review (one platform per PR). Sibling PRs: #173411 (number), #173412 (select).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: N/A
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45837

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. Your PR cannot be merged unless tests pass
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist](https://developers.home-assistant.io/docs/development_checklist/)
- [x] I have followed the [documentation checklist](https://developers.home-assistant.io/docs/documenting/checklist/)
- [x] Tests have been added to verify that the new code works.