### PR TITLE
Add tests for itach integration

### DIFF
--- a/tests/components/itach/__init__.py
+++ b/tests/components/itach/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the iTach integration."""

--- a/tests/components/itach/test_remote.py
+++ b/tests/components/itach/test_remote.py
@@ -1,0 +1,299 @@
+"""Tests for the iTach remote platform."""
+
+from collections.abc import Iterable
+import logging
+from typing import Any
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from homeassistant.components.itach import remote
+from homeassistant.const import (
+    CONF_DEVICES,
+    CONF_HOST,
+    CONF_MAC,
+    CONF_NAME,
+    CONF_PORT,
+    DEVICE_DEFAULT_NAME,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+# Test helpers: _default_config(), _capture_added_entities()
+
+
+def _default_config(**overrides: Any) -> dict[str, Any]:
+    """Return a default iTach YAML platform config."""
+    config: dict[str, Any] = {
+        CONF_HOST: "192.168.1.50",
+        CONF_PORT: 4998,
+        CONF_DEVICES: [
+            {
+                CONF_NAME: "TV",
+                "connaddr": 1,
+                "commands": [
+                    {
+                        CONF_NAME: "ON",
+                        "data": "sendir-on",
+                    },
+                ],
+            }
+        ],
+    }
+    config.update(overrides)
+    return config
+
+
+def _capture_added_entities() -> tuple[list[Entity], AddEntitiesCallback]:
+    """Return an entity list and add_entities callback."""
+    added_entities: list[Entity] = []
+
+    def add_entities(
+        new_entities: Iterable[Entity], update_before_add: bool = False
+    ) -> None:
+        added_entities.extend(new_entities)
+
+    return added_entities, add_entities
+
+
+def test_setup_platform_creates_entity(hass: HomeAssistant) -> None:
+    """Test setup creates one remote entity from YAML config."""
+    mock_itach = MagicMock()
+    mock_itach.ready.return_value = True
+    added_entities, add_entities = _capture_added_entities()
+
+    with patch(
+        "homeassistant.components.itach.remote.pyitachip2ir.ITachIP2IR",
+        return_value=mock_itach,
+    ):
+        remote.setup_platform(hass, _default_config(), add_entities)
+
+    assert len(added_entities) == 1
+    assert added_entities[0].name == "TV"
+
+
+def test_setup_platform_initializes_library(hass: HomeAssistant) -> None:
+    """Test setup initializes the pyitachip2ir client with YAML values."""
+    mock_itach = MagicMock()
+    mock_itach.ready.return_value = True
+    _added_entities, add_entities = _capture_added_entities()
+
+    with patch(
+        "homeassistant.components.itach.remote.pyitachip2ir.ITachIP2IR",
+        return_value=mock_itach,
+    ) as mock_itach_class:
+        remote.setup_platform(
+            hass,
+            _default_config(**{CONF_MAC: "AA:BB:CC:DD:EE:FF"}),
+            add_entities,
+        )
+
+    mock_itach_class.assert_called_once_with("AA:BB:CC:DD:EE:FF", "192.168.1.50", 4998)
+
+
+def test_setup_platform_ready_failure(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test setup does not add entities when iTach is not ready."""
+    mock_itach = MagicMock()
+    mock_itach.ready.return_value = False
+    added_entities, add_entities = _capture_added_entities()
+
+    caplog.set_level(logging.ERROR)
+
+    with patch(
+        "homeassistant.components.itach.remote.pyitachip2ir.ITachIP2IR",
+        return_value=mock_itach,
+    ):
+        remote.setup_platform(hass, _default_config(), add_entities)
+
+    assert not added_entities
+    mock_itach.ready.assert_called_once_with(remote.CONNECT_TIMEOUT)
+    mock_itach.addDevice.assert_not_called()
+    assert "Unable to find iTach" in caplog.text
+
+
+def test_setup_platform_adds_device_with_command_table(
+    hass: HomeAssistant,
+) -> None:
+    """Test setup adds a device with the expected command table."""
+    mock_itach = MagicMock()
+    mock_itach.ready.return_value = True
+    _added_entities, add_entities = _capture_added_entities()
+
+    config = _default_config(
+        **{
+            CONF_DEVICES: [
+                {
+                    CONF_NAME: "TV",
+                    "modaddr": 1,
+                    "connaddr": 2,
+                    "commands": [
+                        {
+                            CONF_NAME: "ON",
+                            "data": "sendir-on",
+                        },
+                        {
+                            CONF_NAME: "OFF",
+                            "data": "sendir-off",
+                        },
+                    ],
+                }
+            ]
+        }
+    )
+
+    with patch(
+        "homeassistant.components.itach.remote.pyitachip2ir.ITachIP2IR",
+        return_value=mock_itach,
+    ):
+        remote.setup_platform(hass, config, add_entities)
+
+    mock_itach.addDevice.assert_called_once_with(
+        "TV",
+        1,
+        2,
+        "ON\nsendir-on\nOFF\nsendir-off\n",
+    )
+
+
+def test_turn_on_sends_on_command() -> None:
+    """Test turn_on sends the ON command."""
+    mock_itach = MagicMock()
+    entity = remote.ITachIP2IRRemote(mock_itach, "TV", 2)
+
+    with patch.object(entity, "schedule_update_ha_state") as mock_schedule_update:
+        entity.turn_on()
+
+    assert entity.is_on is True
+    mock_itach.send.assert_called_once_with("TV", "ON", 2)
+    mock_schedule_update.assert_called_once_with()
+
+
+def test_turn_off_sends_off_command() -> None:
+    """Test turn_off sends the OFF command."""
+    mock_itach = MagicMock()
+    entity = remote.ITachIP2IRRemote(mock_itach, "TV", 2)
+
+    with patch.object(entity, "schedule_update_ha_state") as mock_schedule_update:
+        entity.turn_off()
+
+    assert entity.is_on is False
+    mock_itach.send.assert_called_once_with("TV", "OFF", 2)
+    mock_schedule_update.assert_called_once_with()
+
+
+def test_send_command_sends_each_command() -> None:
+    """Test send_command sends each command."""
+    mock_itach = MagicMock()
+    entity = remote.ITachIP2IRRemote(mock_itach, "TV", 2)
+
+    entity.send_command(["VOLUME_UP", "VOLUME_DOWN"])
+
+    assert mock_itach.send.call_args_list == [
+        call("TV", "VOLUME_UP", 2),
+        call("TV", "VOLUME_DOWN", 2),
+    ]
+
+
+def test_send_command_applies_num_repeats_to_ir_count() -> None:
+    """Test send_command multiplies ir_count by num_repeats."""
+    mock_itach = MagicMock()
+    entity = remote.ITachIP2IRRemote(mock_itach, "TV", 2)
+
+    entity.send_command(["VOLUME_UP"], num_repeats=3)
+
+    mock_itach.send.assert_called_once_with("TV", "VOLUME_UP", 6)
+
+
+def test_update_calls_library_update() -> None:
+    """Test update calls the pyitachip2ir update method."""
+    mock_itach = MagicMock()
+    entity = remote.ITachIP2IRRemote(mock_itach, "TV", 2)
+
+    entity.update()
+
+    mock_itach.update.assert_called_once_with()
+
+
+def test_setup_platform_uses_default_values(hass: HomeAssistant) -> None:
+    """Test setup uses default values for optional YAML fields."""
+    mock_itach = MagicMock()
+    mock_itach.ready.return_value = True
+    added_entities, add_entities = _capture_added_entities()
+
+    config = _default_config(
+        **{
+            CONF_DEVICES: [
+                {
+                    "connaddr": 2,
+                    "commands": [
+                        {
+                            CONF_NAME: "ON",
+                            "data": "sendir-on",
+                        },
+                    ],
+                }
+            ]
+        }
+    )
+
+    with patch(
+        "homeassistant.components.itach.remote.pyitachip2ir.ITachIP2IR",
+        return_value=mock_itach,
+    ) as mock_itach_class:
+        remote.setup_platform(hass, config, add_entities)
+
+    mock_itach_class.assert_called_once_with(None, "192.168.1.50", 4998)
+    mock_itach.addDevice.assert_called_once_with(
+        None,
+        1,
+        2,
+        "ON\nsendir-on\n",
+    )
+    assert len(added_entities) == 1
+    assert added_entities[0].name == DEVICE_DEFAULT_NAME
+
+
+def test_setup_platform_uses_empty_string_placeholders_for_empty_commands(
+    hass: HomeAssistant,
+) -> None:
+    """Test setup converts empty command names and data to placeholders."""
+    mock_itach = MagicMock()
+    mock_itach.ready.return_value = True
+    _added_entities, add_entities = _capture_added_entities()
+
+    config = _default_config(
+        **{
+            CONF_DEVICES: [
+                {
+                    CONF_NAME: "TV",
+                    "connaddr": 1,
+                    "commands": [
+                        {
+                            CONF_NAME: "",
+                            "data": "",
+                        },
+                        {
+                            CONF_NAME: "   ",
+                            "data": "   ",
+                        },
+                    ],
+                }
+            ]
+        }
+    )
+
+    with patch(
+        "homeassistant.components.itach.remote.pyitachip2ir.ITachIP2IR",
+        return_value=mock_itach,
+    ):
+        remote.setup_platform(hass, config, add_entities)
+
+    mock_itach.addDevice.assert_called_once_with(
+        "TV",
+        1,
+        1,
+        '""\n""\n""\n""\n',
+    )

--- a/tests/components/itach/test_remote.py
+++ b/tests/components/itach/test_remote.py
@@ -1,6 +1,5 @@
 """Tests for the iTach remote platform."""
 
-from collections.abc import Iterable
 import logging
 from typing import Any
 from unittest.mock import MagicMock, call, patch
@@ -8,6 +7,7 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 
 from homeassistant.components.itach import remote
+from homeassistant.components.remote import DOMAIN as REMOTE_DOMAIN
 from homeassistant.const import (
     CONF_DEVICES,
     CONF_HOST,
@@ -17,10 +17,9 @@ from homeassistant.const import (
     DEVICE_DEFAULT_NAME,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.setup import async_setup_component
 
-# Test helpers: _default_config(), _capture_added_entities()
+# Test helpers.
 
 
 def _default_config(**overrides: Any) -> dict[str, Any]:
@@ -45,60 +44,75 @@ def _default_config(**overrides: Any) -> dict[str, Any]:
     return config
 
 
-def _capture_added_entities() -> tuple[list[Entity], AddEntitiesCallback]:
-    """Return an entity list and add_entities callback."""
-    added_entities: list[Entity] = []
+def _remote_config(**overrides: Any) -> dict[str, Any]:
+    """Return a Home Assistant remote config for the iTach platform."""
+    return {
+        REMOTE_DOMAIN: [
+            {
+                "platform": "itach",
+                **_default_config(**overrides),
+            }
+        ]
+    }
 
-    def add_entities(
-        new_entities: Iterable[Entity], update_before_add: bool = False
-    ) -> None:
-        added_entities.extend(new_entities)
 
-    return added_entities, add_entities
+async def _async_setup_itach_remote(
+    hass: HomeAssistant,
+    **overrides: Any,
+) -> None:
+    """Set up the iTach remote platform through Home Assistant."""
+    assert await async_setup_component(
+        hass,
+        REMOTE_DOMAIN,
+        _remote_config(**overrides),
+    )
+    await hass.async_block_till_done()
 
 
-def test_setup_platform_creates_entity(hass: HomeAssistant) -> None:
+async def test_setup_platform_creates_entity(hass: HomeAssistant) -> None:
     """Test setup creates one remote entity from YAML config."""
     mock_itach = MagicMock()
     mock_itach.ready.return_value = True
-    added_entities, add_entities = _capture_added_entities()
 
     with patch(
         "homeassistant.components.itach.remote.pyitachip2ir.ITachIP2IR",
         return_value=mock_itach,
     ):
-        remote.setup_platform(hass, _default_config(), add_entities)
+        await _async_setup_itach_remote(hass)
 
-    assert len(added_entities) == 1
-    assert added_entities[0].name == "TV"
+    state = hass.states.get("remote.tv")
+
+    assert state is not None
+    assert state.state == "off"
 
 
-def test_setup_platform_initializes_library(hass: HomeAssistant) -> None:
+async def test_setup_platform_initializes_library(hass: HomeAssistant) -> None:
     """Test setup initializes the pyitachip2ir client with YAML values."""
     mock_itach = MagicMock()
     mock_itach.ready.return_value = True
-    _added_entities, add_entities = _capture_added_entities()
 
     with patch(
         "homeassistant.components.itach.remote.pyitachip2ir.ITachIP2IR",
         return_value=mock_itach,
     ) as mock_itach_class:
-        remote.setup_platform(
+        await _async_setup_itach_remote(
             hass,
-            _default_config(**{CONF_MAC: "AA:BB:CC:DD:EE:FF"}),
-            add_entities,
+            **{CONF_MAC: "AA:BB:CC:DD:EE:FF"},
         )
 
-    mock_itach_class.assert_called_once_with("AA:BB:CC:DD:EE:FF", "192.168.1.50", 4998)
+    mock_itach_class.assert_called_once_with(
+        "AA:BB:CC:DD:EE:FF",
+        "192.168.1.50",
+        4998,
+    )
 
 
-def test_setup_platform_ready_failure(
+async def test_setup_platform_ready_failure(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Test setup does not add entities when iTach is not ready."""
+    """Test setup does not create an entity when iTach is not ready."""
     mock_itach = MagicMock()
     mock_itach.ready.return_value = False
-    added_entities, add_entities = _capture_added_entities()
 
     caplog.set_level(logging.ERROR)
 
@@ -106,49 +120,43 @@ def test_setup_platform_ready_failure(
         "homeassistant.components.itach.remote.pyitachip2ir.ITachIP2IR",
         return_value=mock_itach,
     ):
-        remote.setup_platform(hass, _default_config(), add_entities)
+        await _async_setup_itach_remote(hass)
 
-    assert not added_entities
+    assert hass.states.get("remote.tv") is None
     mock_itach.ready.assert_called_once_with(remote.CONNECT_TIMEOUT)
     mock_itach.addDevice.assert_not_called()
     assert "Unable to find iTach" in caplog.text
 
 
-def test_setup_platform_adds_device_with_command_table(
+async def test_setup_platform_adds_device_with_command_table(
     hass: HomeAssistant,
 ) -> None:
     """Test setup adds a device with the expected command table."""
     mock_itach = MagicMock()
     mock_itach.ready.return_value = True
-    _added_entities, add_entities = _capture_added_entities()
-
-    config = _default_config(
-        **{
-            CONF_DEVICES: [
+    devices = [
+        {
+            CONF_NAME: "TV",
+            "modaddr": 1,
+            "connaddr": 2,
+            "commands": [
                 {
-                    CONF_NAME: "TV",
-                    "modaddr": 1,
-                    "connaddr": 2,
-                    "commands": [
-                        {
-                            CONF_NAME: "ON",
-                            "data": "sendir-on",
-                        },
-                        {
-                            CONF_NAME: "OFF",
-                            "data": "sendir-off",
-                        },
-                    ],
-                }
-            ]
+                    CONF_NAME: "ON",
+                    "data": "sendir-on",
+                },
+                {
+                    CONF_NAME: "OFF",
+                    "data": "sendir-off",
+                },
+            ],
         }
-    )
+    ]
 
     with patch(
         "homeassistant.components.itach.remote.pyitachip2ir.ITachIP2IR",
         return_value=mock_itach,
     ):
-        remote.setup_platform(hass, config, add_entities)
+        await _async_setup_itach_remote(hass, **{CONF_DEVICES: devices})
 
     mock_itach.addDevice.assert_called_once_with(
         "TV",
@@ -217,33 +225,29 @@ def test_update_calls_library_update() -> None:
     mock_itach.update.assert_called_once_with()
 
 
-def test_setup_platform_uses_default_values(hass: HomeAssistant) -> None:
+async def test_setup_platform_uses_default_values(hass: HomeAssistant) -> None:
     """Test setup uses default values for optional YAML fields."""
     mock_itach = MagicMock()
     mock_itach.ready.return_value = True
-    added_entities, add_entities = _capture_added_entities()
-
-    config = _default_config(
-        **{
-            CONF_DEVICES: [
+    devices = [
+        {
+            "connaddr": 2,
+            "commands": [
                 {
-                    "connaddr": 2,
-                    "commands": [
-                        {
-                            CONF_NAME: "ON",
-                            "data": "sendir-on",
-                        },
-                    ],
-                }
-            ]
+                    CONF_NAME: "ON",
+                    "data": "sendir-on",
+                },
+            ],
         }
-    )
+    ]
 
     with patch(
         "homeassistant.components.itach.remote.pyitachip2ir.ITachIP2IR",
         return_value=mock_itach,
     ) as mock_itach_class:
-        remote.setup_platform(hass, config, add_entities)
+        await _async_setup_itach_remote(hass, **{CONF_DEVICES: devices})
+
+    states = hass.states.async_all(REMOTE_DOMAIN)
 
     mock_itach_class.assert_called_once_with(None, "192.168.1.50", 4998)
     mock_itach.addDevice.assert_called_once_with(
@@ -252,44 +256,38 @@ def test_setup_platform_uses_default_values(hass: HomeAssistant) -> None:
         2,
         "ON\nsendir-on\n",
     )
-    assert len(added_entities) == 1
-    assert added_entities[0].name == DEVICE_DEFAULT_NAME
+    assert len(states) == 1
+    assert states[0].name == DEVICE_DEFAULT_NAME
 
 
-def test_setup_platform_uses_empty_string_placeholders_for_empty_commands(
+async def test_setup_platform_uses_empty_string_placeholders_for_empty_commands(
     hass: HomeAssistant,
 ) -> None:
     """Test setup converts empty command names and data to placeholders."""
     mock_itach = MagicMock()
     mock_itach.ready.return_value = True
-    _added_entities, add_entities = _capture_added_entities()
-
-    config = _default_config(
-        **{
-            CONF_DEVICES: [
+    devices = [
+        {
+            CONF_NAME: "TV",
+            "connaddr": 1,
+            "commands": [
                 {
-                    CONF_NAME: "TV",
-                    "connaddr": 1,
-                    "commands": [
-                        {
-                            CONF_NAME: "",
-                            "data": "",
-                        },
-                        {
-                            CONF_NAME: "   ",
-                            "data": "   ",
-                        },
-                    ],
-                }
-            ]
+                    CONF_NAME: "",
+                    "data": "",
+                },
+                {
+                    CONF_NAME: "   ",
+                    "data": "   ",
+                },
+            ],
         }
-    )
+    ]
 
     with patch(
         "homeassistant.components.itach.remote.pyitachip2ir.ITachIP2IR",
         return_value=mock_itach,
     ):
-        remote.setup_platform(hass, config, add_entities)
+        await _async_setup_itach_remote(hass, **{CONF_DEVICES: devices})
 
     mock_itach.addDevice.assert_called_once_with(
         "TV",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add regression coverage for the existing YAML-based iTach remote platform. The tests cover setup behavior, pyitachip2ir client initialization, ready() failure handling, command table formatting, default values, empty command placeholders, turn_on/turn_off behavior, send_command repeat handling, and update delegation. No production behavior is changed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
