### PR TITLE
Add window state sensor for HomematicIP rotary handle (HmIP-SRH)

### DIFF
--- a/homeassistant/components/homematicip_cloud/sensor.py
+++ b/homeassistant/components/homematicip_cloud/sensor.py
@@ -27,6 +27,7 @@ from homematicip.device import (
     PassageDetector,
     PresenceDetectorIndoor,
     RoomControlDeviceAnalog,
+    RotaryHandleSensor,
     SmokeDetector,
     SoilMoistureSensorInterface,
     SwitchMeasuring,
@@ -166,6 +167,7 @@ ILLUMINATION_DEVICE_ATTRIBUTES = {
 }
 
 TILT_STATE_VALUES = ["neutral", "tilted", "non_neutral"]
+WINDOW_STATE_VALUES = ["open", "closed", "tilted"]
 
 
 def get_device_handlers(hap: HomematicipHAP) -> dict[type, Callable]:
@@ -203,6 +205,9 @@ def get_device_handlers(hap: HomematicipHAP) -> dict[type, Callable]:
         ],
         RoomControlDeviceAnalog: lambda device: [
             HomematicipTemperatureSensor(hap, device),
+        ],
+        RotaryHandleSensor: lambda device: [
+            HomematicipWindowStateSensor(hap, device),
         ],
         LightSensor: lambda device: [
             HomematicipIlluminanceSensor(hap, device),
@@ -496,6 +501,24 @@ class HomematicipTiltStateSensor(HomematicipGenericEntity, SensorEntity):
         )
 
         return state_attr
+
+
+class HomematicipWindowStateSensor(HomematicipGenericEntity, SensorEntity):
+    """Representation of the HomematicIP rotary handle window state sensor."""
+
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_options = WINDOW_STATE_VALUES
+    _attr_translation_key = "window_state"
+
+    def __init__(self, hap: HomematicipHAP, device: RotaryHandleSensor) -> None:
+        """Initialize the window state sensor."""
+        super().__init__(hap, device, feature_id="window_state")
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the state."""
+        window_state = getattr(self._device, "windowState", None)
+        return window_state.lower() if window_state is not None else None
 
 
 class HomematicipFloorTerminalBlockMechanicChannelValve(

--- a/homeassistant/components/homematicip_cloud/strings.json
+++ b/homeassistant/components/homematicip_cloud/strings.json
@@ -98,6 +98,14 @@
           "non_neutral": "Non-neutral",
           "tilted": "Tilted"
         }
+      },
+      "window_state": {
+        "name": "Window state",
+        "state": {
+          "closed": "[%key:common::state::closed%]",
+          "open": "[%key:common::state::open%]",
+          "tilted": "Tilted"
+        }
       }
     }
   },

--- a/tests/components/homematicip_cloud/test_device.py
+++ b/tests/components/homematicip_cloud/test_device.py
@@ -22,7 +22,7 @@ async def test_hmip_load_all_supported_devices(
         test_devices=None, test_groups=None
     )
 
-    assert len(mock_hap.hmip_device_by_entity_id) == 384
+    assert len(mock_hap.hmip_device_by_entity_id) == 385
 
 
 async def test_hmip_remove_device(

--- a/tests/components/homematicip_cloud/test_sensor.py
+++ b/tests/components/homematicip_cloud/test_sensor.py
@@ -1,6 +1,6 @@
 """Tests for HomematicIP Cloud sensor."""
 
-from homematicip.base.enums import ValveState
+from homematicip.base.enums import ValveState, WindowState
 
 from homeassistant.components.homematicip_cloud import DOMAIN
 from homeassistant.components.homematicip_cloud.entity import (
@@ -743,6 +743,38 @@ async def test_hmip_tilt_vibration_sensor_tilt_state(
     assert ha_state.attributes[ATTR_ACCELERATION_SENSOR_NEUTRAL_POSITION] == "VERTICAL"
     assert ha_state.attributes[ATTR_ACCELERATION_SENSOR_TRIGGER_ANGLE] == 20
     assert ha_state.attributes[ATTR_ACCELERATION_SENSOR_SECOND_TRIGGER_ANGLE] == 75
+
+
+async def test_hmip_rotary_handle_window_state_sensor(
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
+) -> None:
+    """Test HomematicipWindowStateSensor exposes the three-way state of HmIP-SRH."""
+    entity_id = "sensor.fenstergriffsensor_window_state"
+    entity_name = "Fenstergriffsensor Window state"
+    device_model = "HmIP-SRH"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=["Fenstergriffsensor"]
+    )
+
+    ha_state, hmip_device = get_and_check_entity_basics(
+        hass, mock_hap, entity_id, entity_name, device_model
+    )
+
+    assert ha_state.state == "tilted"
+
+    await async_manipulate_test_data(hass, hmip_device, "windowState", WindowState.OPEN)
+    ha_state = hass.states.get(entity_id)
+    assert ha_state.state == "open"
+
+    await async_manipulate_test_data(
+        hass, hmip_device, "windowState", WindowState.CLOSED
+    )
+    ha_state = hass.states.get(entity_id)
+    assert ha_state.state == "closed"
+
+    await async_manipulate_test_data(hass, hmip_device, "windowState", None)
+    ha_state = hass.states.get(entity_id)
+    assert ha_state.state == STATE_UNKNOWN
 
 
 async def test_hmip_tilt_vibration_sensor_tilt_angle(


### PR DESCRIPTION
## Proposed change

The HomematicIP rotary handle sensor (HmIP-SRH) reports three positions: `OPEN`, `CLOSED`, and `TILTED`. The existing `binary_sensor` entity can only expose two states, so `OPEN` and `TILTED` collapse into "on". The `TILTED` value is available today only as the `window_state` attribute on the binary sensor, which makes it awkward to use in automations or dashboards.

This PR adds a `sensor` entity with `SensorDeviceClass.ENUM` (options: `open`, `closed`, `tilted`) for `RotaryHandleSensor` devices, exposing the full window state directly. Typical use case: a blind that should close when the handle is `closed` or `tilted`, but stay open when the handle is `open`.

The existing `binary_sensor` is unchanged: `is_on = True` for both `OPEN` and `TILTED`, so heating/AC automations that just need "window not sealed" keep working without modification.

Only `RotaryHandleSensor` devices get the new entity. Other devices that share `windowState` via inheritance (magnetic shutter contacts, contact interfaces) are physically incapable of detecting `TILTED`, so adding the sensor there would create a permanently-frozen entity.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: hahn-th/homematicip-rest-api#670
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr