### PR TITLE
Bump homematicip to 2.13.0

### DIFF
--- a/homeassistant/components/homematicip_cloud/manifest.json
+++ b/homeassistant/components/homematicip_cloud/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_push",
   "loggers": ["homematicip"],
-  "requirements": ["homematicip==2.12.0"]
+  "requirements": ["homematicip==2.13.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1281,7 +1281,7 @@ homekit-audio-proxy==1.2.1
 homelink-integration-api==0.0.5
 
 # homeassistant.components.homematicip_cloud
-homematicip==2.12.0
+homematicip==2.13.0
 
 # homeassistant.components.homevolt
 homevolt==0.5.0


### PR DESCRIPTION
## Proposed change

Bump `homematicip` from 2.12.0 to 2.13.0. Changelog: https://github.com/hahn-th/homematicip-rest-api/blob/master/CHANGELOG.md#2130

This release adds:

- Register `DEVICE_CODE_STATE_EVENT` and forward it as a typed `CodeStateEvent` to the originating device. The HmIP-WKP keypad emits this event whenever a code is entered; previously every keypress logged an `Unknown EventType` warning. Fixes hahn-th/homematicip-rest-api#668.
- Add support for **HmIP-WRCR** (Wall-mount Remote Control - Rotary): new device class `WallMountedRemoteControlRotaryButton` with a `SINGLE_KEY_CHANNEL` for the centre push button and a new `RotaryWheelChannel` carrying `rotationDirection`. Addresses #173014.
- Add support for **HmIP-KRC-K** (Key Ring Remote Control for KeyMatic): new device class `KeyRemoteControlKeyMatic` with four `SINGLE_KEY_CHANNEL` buttons under `KEY_GROUP_FOR_DOOR_LOCK`.

Once this bump lands, the WRCR push button and all four KRC-K buttons are exposed as `event` entities automatically via the per-button event framework added in #171065. Modelling rotation events for the WRCR is deferred to a follow-up.

Diff: https://github.com/hahn-th/homematicip-rest-api/compare/2.12.0..2.13.0

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #173014
- This PR is related to issue: hahn-th/homematicip-rest-api#668
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr