### PR TITLE
Fix Satel Integra arm home mode selection

### DIFF
--- a/homeassistant/components/satel_integra/config_flow.py
+++ b/homeassistant/components/satel_integra/config_flow.py
@@ -69,6 +69,7 @@ PARTITION_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_NAME): cv.string,
         vol.Required(CONF_ARM_HOME_MODE, default=DEFAULT_CONF_ARM_HOME_MODE): vol.All(
+            vol.Any(vol.Coerce(str), int),
             selector.SelectSelector(
                 selector.SelectSelectorConfig(
                     options=ARM_HOME_MODE_OPTIONS,

--- a/homeassistant/components/satel_integra/config_flow.py
+++ b/homeassistant/components/satel_integra/config_flow.py
@@ -63,11 +63,20 @@ CODE_SCHEMA = vol.Schema(
     }
 )
 
+ARM_HOME_MODE_OPTIONS = ["1", "2", "3"]
+
 PARTITION_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_NAME): cv.string,
-        vol.Required(CONF_ARM_HOME_MODE, default=DEFAULT_CONF_ARM_HOME_MODE): vol.In(
-            [1, 2, 3]
+        vol.Required(CONF_ARM_HOME_MODE, default=DEFAULT_CONF_ARM_HOME_MODE): vol.All(
+            selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=ARM_HOME_MODE_OPTIONS,
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                    translation_key="arm_home_mode",
+                )
+            ),
+            vol.Coerce(int),
         ),
     }
 )

--- a/homeassistant/components/satel_integra/config_flow.py
+++ b/homeassistant/components/satel_integra/config_flow.py
@@ -69,7 +69,7 @@ PARTITION_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_NAME): cv.string,
         vol.Required(CONF_ARM_HOME_MODE, default=DEFAULT_CONF_ARM_HOME_MODE): vol.All(
-            vol.Any(vol.Coerce(str), int),
+            vol.Coerce(str),
             selector.SelectSelector(
                 selector.SelectSelectorConfig(
                     options=ARM_HOME_MODE_OPTIONS,

--- a/homeassistant/components/satel_integra/const.py
+++ b/homeassistant/components/satel_integra/const.py
@@ -1,6 +1,6 @@
 """Constants for the Satel Integra integration."""
 
-DEFAULT_CONF_ARM_HOME_MODE = 1
+DEFAULT_CONF_ARM_HOME_MODE = "1"
 DEFAULT_PORT = 7094
 
 DOMAIN = "satel_integra"

--- a/homeassistant/components/satel_integra/strings.json
+++ b/homeassistant/components/satel_integra/strings.json
@@ -113,7 +113,7 @@
             "partition_number": "Partition number"
           },
           "data_description": {
-            "arm_home_mode": "The mode in which the partition is armed when 'arm home' is used. For more information on what the differences are between them, please refer to Satel Integra manual.",
+            "arm_home_mode": "The arming mode to use for 'arm home':\nMode 1 fully arms and bypasses zones configured as bypassed if no exit.\nMode 2 disarms interior zones; exterior zones trigger silent alarms and other alarm zones trigger loud alarms.\nMode 3 is like mode 2, but delayed zones are instant.",
             "name": "The name to give to the alarm panel",
             "partition_number": "Enter partition number to configure"
           },
@@ -223,6 +223,13 @@
     }
   },
   "selector": {
+    "arm_home_mode": {
+      "options": {
+        "1": "1 - Full arming + bypasses",
+        "2": "2 - No interior zones",
+        "3": "3 - No interior zones or entry delay"
+      }
+    },
     "binary_sensor_device_class": {
       "options": {
         "battery": "[%key:component::binary_sensor::entity_component::battery::name%]",

--- a/homeassistant/components/satel_integra/strings.json
+++ b/homeassistant/components/satel_integra/strings.json
@@ -113,7 +113,7 @@
             "partition_number": "Partition number"
           },
           "data_description": {
-            "arm_home_mode": "The arming mode to use for 'arm home':\nMode 1 fully arms and bypasses zones configured as bypassed if no exit.\nMode 2 disarms interior zones; exterior zones trigger silent alarms and other alarm zones trigger loud alarms.\nMode 3 is like mode 2, but delayed zones are instant.",
+            "arm_home_mode": "The arming mode to use for 'arm home':\nMode 1 fully arms and bypasses zones that have the 'Bypassed if no exit' option enabled.\nMode 2 disarms interior zones; exterior zones trigger silent alarms and other alarm zones trigger loud alarms.\nMode 3 is like mode 2, but delayed zones are instant.",
             "name": "The name to give to the alarm panel",
             "partition_number": "Enter partition number to configure"
           },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
While tracing another issue, I noticed the selection for the 'Arm Home Mode' property of the partition subentry flow is broken. We expect an int value to send to the client library, values are also stored as int.
The existing implementation shows the int values, but actually exposes them as string when selected, resulting in a failed validation with the message: `value must be one of [1, 2, 3]`.
Existing values also are not showing the prefilled value when reconfiguring due to this type mismatch.

We now changed the selection values to be string instead, and coerse on the schema validation.
Because coersing to int shows a generic number input box, I've changed this to a dropdown selection, with some additional text to help users. 
I'm happy to remove this additional change if it's too much for a bugfix and put it into another PR for future releases.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/173272
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
