### PR TITLE
Migrate AquaLogic integration to use ConfigFlow

### DIFF
--- a/homeassistant/components/aqualogic/__init__.py
+++ b/homeassistant/components/aqualogic/__init__.py
@@ -1,5 +1,6 @@
 """Support for AquaLogic devices."""
 
+import contextlib
 from datetime import timedelta
 import logging
 import threading
@@ -9,22 +10,19 @@ from typing import override
 from aqualogic.core import AquaLogic
 import voluptuous as vol
 
-from homeassistant.const import (
-    CONF_HOST,
-    CONF_PORT,
-    EVENT_HOMEASSISTANT_START,
-    EVENT_HOMEASSISTANT_STOP,
-)
-from homeassistant.core import Event, HomeAssistant
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.dispatcher import dispatcher_send
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.typing import ConfigType
+
+from .const import DOMAIN, PLATFORMS, UPDATE_TOPIC
 
 _LOGGER = logging.getLogger(__name__)
 
-DOMAIN = "aqualogic"
-UPDATE_TOPIC = f"{DOMAIN}_update"
-CONF_UNIT = "unit"
 RECONNECT_INTERVAL = timedelta(seconds=10)
 
 CONFIG_SCHEMA = vol.Schema(
@@ -36,17 +34,82 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
+type AquaLogicConfigEntry = ConfigEntry[AquaLogicProcessor]
 
-def setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up AquaLogic platform."""
-    host = config[DOMAIN][CONF_HOST]
-    port = config[DOMAIN][CONF_PORT]
-    processor = AquaLogicProcessor(hass, host, port)
-    hass.data[DOMAIN] = processor
-    hass.bus.listen_once(EVENT_HOMEASSISTANT_START, processor.start_listen)
-    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, processor.shutdown)
-    _LOGGER.debug("AquaLogicProcessor %s:%i initialized", host, port)
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the AquaLogic component."""
+    if DOMAIN not in config:
+        return True
+
+    hass.async_create_task(_async_import(hass, config[DOMAIN]))
     return True
+
+
+async def _async_import(hass: HomeAssistant, conf: dict) -> None:
+    """Import AquaLogic configuration from YAML and surface appropriate issues."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_IMPORT},
+        data={CONF_HOST: conf[CONF_HOST], CONF_PORT: conf[CONF_PORT]},
+    )
+
+    if (
+        result.get("type") is FlowResultType.ABORT
+        and result.get("reason") != "already_configured"
+    ):
+        async_create_issue(
+            hass,
+            DOMAIN,
+            "deprecated_yaml_import_issue_cannot_connect",
+            breaks_in_ha_version="2027.2.0",
+            is_fixable=False,
+            issue_domain=DOMAIN,
+            severity=IssueSeverity.WARNING,
+            translation_key="deprecated_yaml_import_issue_cannot_connect",
+            translation_placeholders={
+                "domain": DOMAIN,
+                "integration_title": "AquaLogic",
+            },
+        )
+        return
+
+    async_create_issue(
+        hass,
+        HOMEASSISTANT_DOMAIN,
+        f"deprecated_yaml_{DOMAIN}",
+        breaks_in_ha_version="2027.2.0",
+        is_fixable=False,
+        issue_domain=DOMAIN,
+        severity=IssueSeverity.WARNING,
+        translation_key="deprecated_yaml",
+        translation_placeholders={
+            "domain": DOMAIN,
+            "integration_title": "AquaLogic",
+        },
+    )
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: AquaLogicConfigEntry) -> bool:
+    """Set up AquaLogic from a config entry."""
+    processor = AquaLogicProcessor(hass, entry.data[CONF_HOST], entry.data[CONF_PORT])
+    entry.runtime_data = processor
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    processor.start()
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: AquaLogicConfigEntry) -> bool:
+    """Unload an AquaLogic config entry."""
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+        processor = entry.runtime_data
+        processor.shutdown()
+        await hass.async_add_executor_job(lambda: processor.join(timeout=5))
+        if processor.is_alive():
+            _LOGGER.warning("Processor thread did not stop within timeout")
+    return unload_ok
 
 
 class AquaLogicProcessor(threading.Thread):
@@ -59,17 +122,15 @@ class AquaLogicProcessor(threading.Thread):
         self._host = host
         self._port = port
         self._shutdown = False
-        self._panel = None
+        self._panel: AquaLogic | None = None
 
-    def start_listen(self, event: Event) -> None:
-        """Start event-processing thread."""
-        _LOGGER.debug("Event processing thread started")
-        self.start()
-
-    def shutdown(self, event: Event) -> None:
+    def shutdown(self) -> None:
         """Signal shutdown of processing event."""
         _LOGGER.debug("Event processing signaled exit")
         self._shutdown = True
+        if (panel := self._panel) is not None and panel._socket is not None:  # noqa: SLF001
+            with contextlib.suppress(OSError):
+                panel._socket.close()  # noqa: SLF001
 
     def data_changed(self, panel: AquaLogic) -> None:
         """Aqualogic data changed callback."""
@@ -82,13 +143,26 @@ class AquaLogicProcessor(threading.Thread):
         while True:
             panel = AquaLogic()
             self._panel = panel
-            panel.connect(self._host, self._port)
-            panel.process(self.data_changed)
+            try:
+                panel.connect(self._host, self._port)
+                panel.process(self.data_changed)
+            except OSError:
+                pass
+            except Exception as err:
+                _LOGGER.exception(
+                    "Unexpected error in AquaLogic processor: %s",
+                    type(err).__name__,
+                )
 
             if self._shutdown:
                 return
 
-            _LOGGER.error("Connection to %s:%d lost", self._host, self._port)
+            _LOGGER.warning(
+                "Connection to %s:%d lost, retrying in %d seconds",
+                self._host,
+                self._port,
+                int(RECONNECT_INTERVAL.total_seconds()),
+            )
             time.sleep(RECONNECT_INTERVAL.total_seconds())
 
     @property

--- a/homeassistant/components/aqualogic/config_flow.py
+++ b/homeassistant/components/aqualogic/config_flow.py
@@ -1,0 +1,109 @@
+"""Config flow for AquaLogic."""
+
+import contextlib
+import threading
+from typing import Any, override
+
+from aqualogic.core import AquaLogic
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.helpers import config_validation as cv
+
+from .const import DOMAIN
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): str,
+        vol.Required(CONF_PORT): cv.port,
+    }
+)
+
+# Worst case scenario, this covers both a plain socket timeout (READ_TIMEOUT)
+# and an additional frame-scan timeout (another READ_TIMEOUT), plus one second.
+_PROBE_TIMEOUT = AquaLogic.READ_TIMEOUT * 2 + 1
+
+
+class CannotConnect(Exception):
+    """Error to indicate we cannot connect."""
+
+
+class InvalidDevice(Exception):
+    """Error to indicate the device is not an AquaLogic panel."""
+
+
+def _verify_device(host: str, port: int) -> None:
+    """Connect and verify the device is an AquaLogic panel.
+
+    Raises CannotConnect if the host is unreachable.
+    Raises InvalidDevice if no valid AquaLogic data is received within the timeout.
+    """
+    confirmed = threading.Event()
+
+    def _on_data(_: AquaLogic) -> None:
+        confirmed.set()
+
+    panel = AquaLogic()
+    try:
+        panel.connect(host, port)
+    except OSError as err:
+        raise CannotConnect from err
+
+    probe = threading.Thread(target=panel.process, args=(_on_data,), daemon=True)
+    probe.start()
+    try:
+        confirmed.wait(timeout=_PROBE_TIMEOUT)
+    finally:
+        if (sock := panel._socket) is not None:  # noqa: SLF001
+            with contextlib.suppress(OSError):
+                sock.close()
+
+    if not confirmed.is_set():
+        raise InvalidDevice
+
+
+class AquaLogicConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for AquaLogic."""
+
+    VERSION = 1
+
+    @override
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            self._async_abort_entries_match(user_input)
+
+            try:
+                await self.hass.async_add_executor_job(
+                    _verify_device, user_input[CONF_HOST], user_input[CONF_PORT]
+                )
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidDevice:
+                errors["base"] = "invalid_device"
+            else:
+                return self.async_create_entry(title="AquaLogic", data=user_input)
+
+        return self.async_show_form(
+            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+        )
+
+    async def async_step_import(self, import_data: dict[str, Any]) -> ConfigFlowResult:
+        """Import AquaLogic config from configuration.yaml."""
+        self._async_abort_entries_match(
+            {CONF_HOST: import_data[CONF_HOST], CONF_PORT: import_data[CONF_PORT]}
+        )
+
+        try:
+            await self.hass.async_add_executor_job(
+                _verify_device, import_data[CONF_HOST], import_data[CONF_PORT]
+            )
+        except CannotConnect, InvalidDevice:
+            return self.async_abort(reason="cannot_connect")
+
+        return self.async_create_entry(title="AquaLogic", data=import_data)

--- a/homeassistant/components/aqualogic/const.py
+++ b/homeassistant/components/aqualogic/const.py
@@ -1,0 +1,8 @@
+"""Constants for the AquaLogic integration."""
+
+from homeassistant.const import Platform
+
+DOMAIN = "aqualogic"
+PLATFORMS = [Platform.SENSOR, Platform.SWITCH]
+
+UPDATE_TOPIC = f"{DOMAIN}_update"

--- a/homeassistant/components/aqualogic/manifest.json
+++ b/homeassistant/components/aqualogic/manifest.json
@@ -2,9 +2,10 @@
   "domain": "aqualogic",
   "name": "AquaLogic",
   "codeowners": [],
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/aqualogic",
+  "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["aqualogic"],
-  "quality_scale": "legacy",
   "requirements": ["aqualogic==2.6"]
 }

--- a/homeassistant/components/aqualogic/sensor.py
+++ b/homeassistant/components/aqualogic/sensor.py
@@ -3,27 +3,18 @@
 from dataclasses import dataclass
 from typing import override
 
-import voluptuous as vol
-
 from homeassistant.components.sensor import (
-    PLATFORM_SCHEMA as SENSOR_PLATFORM_SCHEMA,
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
 )
-from homeassistant.const import (
-    CONF_MONITORED_CONDITIONS,
-    PERCENTAGE,
-    UnitOfPower,
-    UnitOfTemperature,
-)
+from homeassistant.const import PERCENTAGE, UnitOfPower, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import DOMAIN, UPDATE_TOPIC, AquaLogicProcessor
+from . import AquaLogicConfigEntry, AquaLogicProcessor
+from .const import UPDATE_TOPIC
 
 
 @dataclass(frozen=True)
@@ -101,34 +92,18 @@ SENSOR_TYPES: tuple[AquaLogicSensorEntityDescription, ...] = (
     ),
 )
 
-SENSOR_KEYS: list[str] = [desc.key for desc in SENSOR_TYPES]
 
-PLATFORM_SCHEMA = SENSOR_PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_MONITORED_CONDITIONS, default=SENSOR_KEYS): vol.All(
-            cv.ensure_list, [vol.In(SENSOR_KEYS)]
-        )
-    }
-)
-
-
-async def async_setup_platform(
+async def async_setup_entry(
     hass: HomeAssistant,
-    config: ConfigType,
-    async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
+    entry: AquaLogicConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up the sensor platform."""
-    processor: AquaLogicProcessor = hass.data[DOMAIN]
-    monitored_conditions = config[CONF_MONITORED_CONDITIONS]
+    """Set up the sensor entities."""
+    processor = entry.runtime_data
 
-    entities = [
-        AquaLogicSensor(processor, description)
-        for description in SENSOR_TYPES
-        if description.key in monitored_conditions
-    ]
-
-    async_add_entities(entities)
+    async_add_entities(
+        AquaLogicSensor(processor, description) for description in SENSOR_TYPES
+    )
 
 
 class AquaLogicSensor(SensorEntity):
@@ -172,4 +147,5 @@ class AquaLogicSensor(SensorEntity):
             self._attr_native_value = getattr(panel, self.entity_description.key)
             self.async_write_ha_state()
         else:
-            self._attr_native_unit_of_measurement = None
+            self._attr_native_value = None
+            self.async_write_ha_state()

--- a/homeassistant/components/aqualogic/strings.json
+++ b/homeassistant/components/aqualogic/strings.json
@@ -1,0 +1,30 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_device": "The device at the given address is not an AquaLogic panel"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "port": "[%key:common::config_flow::data::port%]"
+        },
+        "data_description": {
+          "host": "Hostname or IP address of your AquaLogic controller",
+          "port": "TCP port used to connect to the AquaLogic controller"
+        }
+      }
+    }
+  },
+  "issues": {
+    "deprecated_yaml_import_issue_cannot_connect": {
+      "description": "Configuring {integration_title} via YAML is deprecated and will be removed in a future release. While importing your YAML configuration, the AquaLogic device could not be reached or did not respond as an AquaLogic panel. Please ensure the device is accessible and restart Home Assistant to retry, or remove the {domain} key from your configuration and set up the integration via the UI.",
+      "title": "The {integration_title} YAML configuration is being removed"
+    }
+  }
+}

--- a/homeassistant/components/aqualogic/switch.py
+++ b/homeassistant/components/aqualogic/switch.py
@@ -3,55 +3,39 @@
 from typing import Any, override
 
 from aqualogic.core import States
-import voluptuous as vol
 
-from homeassistant.components.switch import (
-    PLATFORM_SCHEMA as SWITCH_PLATFORM_SCHEMA,
-    SwitchEntity,
-)
-from homeassistant.const import CONF_MONITORED_CONDITIONS
+from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import DOMAIN, UPDATE_TOPIC, AquaLogicProcessor
+from . import AquaLogicConfigEntry, AquaLogicProcessor
+from .const import UPDATE_TOPIC
 
-SWITCH_TYPES = {
-    "lights": "Lights",
-    "filter": "Filter",
-    "filter_low_speed": "Filter Low Speed",
-    "aux_1": "Aux 1",
-    "aux_2": "Aux 2",
-    "aux_3": "Aux 3",
-    "aux_4": "Aux 4",
-    "aux_5": "Aux 5",
-    "aux_6": "Aux 6",
-    "aux_7": "Aux 7",
+_SWITCH_MAP: dict[str, tuple[str, States]] = {
+    "lights": ("Lights", States.LIGHTS),
+    "filter": ("Filter", States.FILTER),
+    "filter_low_speed": ("Filter Low Speed", States.FILTER_LOW_SPEED),
+    "aux_1": ("Aux 1", States.AUX_1),
+    "aux_2": ("Aux 2", States.AUX_2),
+    "aux_3": ("Aux 3", States.AUX_3),
+    "aux_4": ("Aux 4", States.AUX_4),
+    "aux_5": ("Aux 5", States.AUX_5),
+    "aux_6": ("Aux 6", States.AUX_6),
+    "aux_7": ("Aux 7", States.AUX_7),
 }
 
-PLATFORM_SCHEMA = SWITCH_PLATFORM_SCHEMA.extend(
-    {
-        vol.Optional(CONF_MONITORED_CONDITIONS, default=list(SWITCH_TYPES)): vol.All(
-            cv.ensure_list, [vol.In(SWITCH_TYPES)]
-        )
-    }
-)
 
-
-async def async_setup_platform(
+async def async_setup_entry(
     hass: HomeAssistant,
-    config: ConfigType,
-    async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
+    entry: AquaLogicConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up the switch platform."""
-    processor: AquaLogicProcessor = hass.data[DOMAIN]
+    """Set up the switch entities."""
+    processor = entry.runtime_data
 
     async_add_entities(
-        AquaLogicSwitch(processor, switch_type)
-        for switch_type in config[CONF_MONITORED_CONDITIONS]
+        AquaLogicSwitch(processor, switch_type) for switch_type in _SWITCH_MAP
     )
 
 
@@ -62,20 +46,10 @@ class AquaLogicSwitch(SwitchEntity):
 
     def __init__(self, processor: AquaLogicProcessor, switch_type: str) -> None:
         """Initialize switch."""
+        name, state = _SWITCH_MAP[switch_type]
         self._processor = processor
-        self._state_name = {
-            "lights": States.LIGHTS,
-            "filter": States.FILTER,
-            "filter_low_speed": States.FILTER_LOW_SPEED,
-            "aux_1": States.AUX_1,
-            "aux_2": States.AUX_2,
-            "aux_3": States.AUX_3,
-            "aux_4": States.AUX_4,
-            "aux_5": States.AUX_5,
-            "aux_6": States.AUX_6,
-            "aux_7": States.AUX_7,
-        }[switch_type]
-        self._attr_name = f"AquaLogic {SWITCH_TYPES[switch_type]}"
+        self._state_name = state
+        self._attr_name = f"AquaLogic {name}"
 
     @property
     @override

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -74,6 +74,7 @@ FLOWS = {
         "aprilaire",
         "apsystems",
         "aquacell",
+        "aqualogic",
         "aqvify",
         "aranet",
         "arcam_fmj",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -499,7 +499,7 @@
     "aqualogic": {
       "name": "AquaLogic",
       "integration_type": "hub",
-      "config_flow": false,
+      "config_flow": true,
       "iot_class": "local_push"
     },
     "aquostv": {

--- a/tests/components/aqualogic/conftest.py
+++ b/tests/components/aqualogic/conftest.py
@@ -1,14 +1,28 @@
-"""Fixtures for AquaLogic tests."""
+"""Fixtures for the AquaLogic integration tests."""
 
-from collections.abc import Callable
+from collections.abc import AsyncGenerator, Generator
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from homeassistant.components.aqualogic import DOMAIN, AquaLogicProcessor
-from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.components.aqualogic import AquaLogicProcessor
+from homeassistant.components.aqualogic.const import DOMAIN, UPDATE_TOPIC
+from homeassistant.const import CONF_HOST, CONF_PORT, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
+from homeassistant.helpers.dispatcher import dispatcher_send
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return a mock config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "1.2.3.4", CONF_PORT: 8899},
+        entry_id="test_aqualogic_entry",
+    )
 
 
 @pytest.fixture
@@ -30,47 +44,69 @@ def mock_panel() -> MagicMock:
 
 
 @pytest.fixture
-def mock_processor(mock_panel: MagicMock) -> MagicMock:
-    """Return a mock AquaLogicProcessor registered in hass.data."""
-    with patch("homeassistant.components.aqualogic.AquaLogicProcessor") as mock_cls:
-        processor = MagicMock()
+def mock_aqualogic_device() -> Generator[MagicMock]:
+    """Return a mock AquaLogic device that immediately triggers the data callback."""
+    with patch(
+        "homeassistant.components.aqualogic.config_flow.AquaLogic"
+    ) as mock_al_class:
+
+        def _fake_process(callback: object) -> None:
+            callback(mock_al_class.return_value)
+
+        mock_al_class.return_value.process.side_effect = _fake_process
+        yield mock_al_class
+
+
+@pytest.fixture
+def mock_processor(hass: HomeAssistant, mock_panel: MagicMock) -> Generator[MagicMock]:
+    """Mock the AquaLogic processor thread."""
+    with patch(
+        "homeassistant.components.aqualogic.AquaLogicProcessor"
+    ) as mock_processor_class:
+        processor = mock_processor_class.return_value
         processor.panel = mock_panel
-        mock_cls.return_value = processor
+        processor.data_changed.side_effect = lambda _: dispatcher_send(
+            hass, UPDATE_TOPIC
+        )
         yield processor
 
 
 @pytest.fixture
 async def init_integration(
-    hass: HomeAssistant, mock_panel: MagicMock
-) -> AquaLogicProcessor:
-    """Set up the AquaLogic integration and run one pass of run() to register the callback.
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_processor: MagicMock,
+    platforms: list[Platform],
+) -> MockConfigEntry:
+    """Set up the AquaLogic integration for testing."""
+    mock_config_entry.add_to_hass(hass)
 
-    AquaLogic is mocked so mock_panel becomes processor.panel. _shutdown is set before
-    run() so it exits after a single iteration, registering the data_changed callback
-    with panel.process() without starting a real network thread.
-    """
-    with patch("homeassistant.components.aqualogic.AquaLogic") as mock_al:
-        mock_al.return_value = mock_panel
-        assert await async_setup_component(
-            hass,
-            DOMAIN,
-            {DOMAIN: {CONF_HOST: "1.2.3.4", CONF_PORT: 8899}},
-        )
+    with patch("homeassistant.components.aqualogic.PLATFORMS", platforms):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
-        processor: AquaLogicProcessor = hass.data[DOMAIN]
-        processor._shutdown = True
-        processor.run()
-    return processor
+
+    return mock_config_entry
 
 
 @pytest.fixture
-def update_callback(
-    init_integration: AquaLogicProcessor, mock_panel: MagicMock
-) -> Callable[[], None]:
-    """Return a callable that fires a panel data update through the registered callback.
+def platforms() -> list[Platform]:
+    """Fixture to specify platforms to test."""
+    return [Platform.SENSOR, Platform.SWITCH]
 
-    Extracts the data_changed callback from the mock's process() call args so tests
-    trigger updates through the same path as real panel data arriving.
-    """
-    callback = mock_panel.process.call_args[0][0]
-    return lambda: callback(mock_panel)
+
+@pytest.fixture
+async def processor_run(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> AsyncGenerator[tuple[AquaLogicProcessor, MagicMock]]:
+    """Provide a real AquaLogicProcessor for testing run() without starting the thread."""
+    mock_config_entry.add_to_hass(hass)
+    with (
+        patch("homeassistant.components.aqualogic.RECONNECT_INTERVAL", timedelta(0)),
+        patch("homeassistant.components.aqualogic.AquaLogic") as mock_al,
+        patch("homeassistant.components.aqualogic.PLATFORMS", []),
+        patch("homeassistant.components.aqualogic.AquaLogicProcessor.start"),
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+        yield mock_config_entry.runtime_data, mock_al

--- a/tests/components/aqualogic/test_config_flow.py
+++ b/tests/components/aqualogic/test_config_flow.py
@@ -1,0 +1,191 @@
+"""Tests for the AquaLogic config flow."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from homeassistant.components.aqualogic.const import DOMAIN
+from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.aqualogic.async_setup_entry", return_value=True
+    ) as mock:
+        yield mock
+
+
+@pytest.mark.usefixtures("mock_aqualogic_device")
+async def test_user_flow_success(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test we get the form and create an entry."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: "1.2.3.4", CONF_PORT: 8899},
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "AquaLogic"
+    assert result["data"] == {CONF_HOST: "1.2.3.4", CONF_PORT: 8899}
+    mock_setup_entry.assert_called_once()
+
+
+async def test_user_flow_cannot_connect(
+    hass: HomeAssistant,
+    mock_aqualogic_device: MagicMock,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test we handle cannot connect error and allow retry."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    mock_aqualogic_device.return_value.connect.side_effect = OSError
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: "1.2.3.4", CONF_PORT: 8899},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+    mock_aqualogic_device.return_value.connect.side_effect = None
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: "1.2.3.4", CONF_PORT: 8899},
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+
+async def test_user_flow_invalid_device(
+    hass: HomeAssistant,
+    mock_aqualogic_device: MagicMock,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test we handle a device that does not speak the AquaLogic protocol."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    mock_aqualogic_device.return_value.process.side_effect = None
+    with patch("homeassistant.components.aqualogic.config_flow._PROBE_TIMEOUT", 0):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_HOST: "1.2.3.4", CONF_PORT: 8899},
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_device"}
+
+    def _fake_process(callback: object) -> None:
+        callback(mock_aqualogic_device.return_value)
+
+    mock_aqualogic_device.return_value.process.side_effect = _fake_process
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: "1.2.3.4", CONF_PORT: 8899},
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+
+async def test_user_flow_already_configured(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test we abort if the host/port is already configured."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: "1.2.3.4", CONF_PORT: 8899},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+@pytest.mark.usefixtures("mock_aqualogic_device")
+async def test_import_flow_success(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test importing from configuration.yaml creates a config entry."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_IMPORT},
+        data={CONF_HOST: "1.2.3.4", CONF_PORT: 8899},
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "AquaLogic"
+    assert result["data"] == {CONF_HOST: "1.2.3.4", CONF_PORT: 8899}
+    mock_setup_entry.assert_called_once()
+
+
+async def test_import_flow_cannot_connect(hass: HomeAssistant) -> None:
+    """Test we abort the import if we cannot connect."""
+    with patch(
+        "homeassistant.components.aqualogic.config_flow.AquaLogic"
+    ) as mock_al_class:
+        mock_al_class.return_value.connect.side_effect = OSError
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_IMPORT},
+            data={CONF_HOST: "1.2.3.4", CONF_PORT: 8899},
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
+
+
+async def test_import_flow_invalid_device(hass: HomeAssistant) -> None:
+    """Test we abort the import if the device does not speak the AquaLogic protocol."""
+    with (
+        patch("homeassistant.components.aqualogic.config_flow.AquaLogic"),
+        patch("homeassistant.components.aqualogic.config_flow._PROBE_TIMEOUT", 0),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_IMPORT},
+            data={CONF_HOST: "1.2.3.4", CONF_PORT: 8899},
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
+
+
+async def test_import_flow_already_configured(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test we abort the import if already configured."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_IMPORT},
+        data={CONF_HOST: "1.2.3.4", CONF_PORT: 8899},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"

--- a/tests/components/aqualogic/test_init.py
+++ b/tests/components/aqualogic/test_init.py
@@ -1,91 +1,145 @@
 """Tests for the AquaLogic integration setup."""
 
-from datetime import timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
-from homeassistant.components.aqualogic import DOMAIN
-from homeassistant.const import (
-    CONF_HOST,
-    CONF_PORT,
-    EVENT_HOMEASSISTANT_START,
-    EVENT_HOMEASSISTANT_STOP,
-)
-from homeassistant.core import HomeAssistant
+import pytest
+
+from homeassistant.components.aqualogic import AquaLogicProcessor
+from homeassistant.components.aqualogic.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.setup import async_setup_component
 
+from tests.common import MockConfigEntry
 
-async def test_setup_creates_processor(
-    hass: HomeAssistant, mock_processor: MagicMock
+
+async def test_load_unload_entry(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_processor: MagicMock,
 ) -> None:
-    """Test setup registers the processor in hass.data."""
-    assert await async_setup_component(
-        hass,
-        DOMAIN,
-        {DOMAIN: {CONF_HOST: "1.2.3.4", CONF_PORT: 8899}},
-    )
+    """Test loading and unloading the config entry starts and stops the processor."""
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert hass.data[DOMAIN] is mock_processor
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    mock_processor.start.assert_called_once()
 
-
-async def test_processor_starts_on_ha_start(
-    hass: HomeAssistant, mock_processor: MagicMock
-) -> None:
-    """Test the processor thread starts when Home Assistant starts."""
-    assert await async_setup_component(
-        hass,
-        DOMAIN,
-        {DOMAIN: {CONF_HOST: "1.2.3.4", CONF_PORT: 8899}},
-    )
+    mock_processor.is_alive.return_value = False
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
-
-    mock_processor.start_listen.assert_called_once()
-
-
-async def test_processor_shuts_down_on_ha_stop(
-    hass: HomeAssistant, mock_processor: MagicMock
-) -> None:
-    """Test the processor shuts down when Home Assistant stops."""
-    assert await async_setup_component(
-        hass,
-        DOMAIN,
-        {DOMAIN: {CONF_HOST: "1.2.3.4", CONF_PORT: 8899}},
-    )
-    await hass.async_block_till_done()
-
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
-    await hass.async_block_till_done()
-
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
     mock_processor.shutdown.assert_called_once()
+    mock_processor.join.assert_called_once_with(timeout=5)
 
 
-async def test_processor_run_reconnects(hass: HomeAssistant) -> None:
-    """Test the processor reconnects after a dropped connection."""
+@pytest.mark.usefixtures("mock_aqualogic_device")
+async def test_import_from_yaml(
+    hass: HomeAssistant,
+    mock_processor: MagicMock,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test importing from YAML creates a config entry and a deprecation issue."""
     assert await async_setup_component(
         hass,
         DOMAIN,
         {DOMAIN: {CONF_HOST: "1.2.3.4", CONF_PORT: 8899}},
     )
     await hass.async_block_till_done()
-    processor = hass.data[DOMAIN]
 
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].data == {CONF_HOST: "1.2.3.4", CONF_PORT: 8899}
+
+    issue = issue_registry.async_get_issue(
+        HOMEASSISTANT_DOMAIN, f"deprecated_yaml_{DOMAIN}"
+    )
+    assert issue is not None
+    assert issue.issue_domain == DOMAIN
+
+
+async def test_import_from_yaml_cannot_connect(
+    hass: HomeAssistant,
+    mock_processor: MagicMock,
+    mock_aqualogic_device: MagicMock,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a failed YAML import raises a specific issue instead of the migration notice."""
+    mock_aqualogic_device.return_value.connect.side_effect = OSError
+    assert await async_setup_component(
+        hass,
+        DOMAIN,
+        {DOMAIN: {CONF_HOST: "1.2.3.4", CONF_PORT: 8899}},
+    )
+    await hass.async_block_till_done()
+
+    assert hass.config_entries.async_entries(DOMAIN) == []
+
+    assert (
+        issue_registry.async_get_issue(
+            HOMEASSISTANT_DOMAIN, f"deprecated_yaml_{DOMAIN}"
+        )
+        is None
+    )
+
+    issue = issue_registry.async_get_issue(
+        DOMAIN, "deprecated_yaml_import_issue_cannot_connect"
+    )
+    assert issue is not None
+    assert issue.issue_domain == DOMAIN
+
+
+async def test_processor_run_exits_on_shutdown(
+    processor_run: tuple[AquaLogicProcessor, MagicMock],
+) -> None:
+    """Test run() processes once then exits when shutdown is already set."""
+    processor, mock_al = processor_run
+    processor._shutdown = True
+    processor.run()
+    mock_al.return_value.connect.assert_called_once_with("1.2.3.4", 8899)
+
+
+async def test_processor_run_continues_after_unexpected_exception(
+    processor_run: tuple[AquaLogicProcessor, MagicMock],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test the processor retries when process() raises an unexpected non-OSError exception."""
+    processor, mock_al = processor_run
     connect_calls = 0
 
-    def stop_on_second_connect(*args: object, **kwargs: object) -> None:
+    def stop_on_second_connect(*_args: object, **_kwargs: object) -> None:
         nonlocal connect_calls
         connect_calls += 1
         if connect_calls >= 2:
             processor._shutdown = True
 
-    # Patch RECONNECT_INTERVAL to zero so time.sleep(0) returns immediately
-    with (
-        patch("homeassistant.components.aqualogic.RECONNECT_INTERVAL", timedelta(0)),
-        patch("homeassistant.components.aqualogic.AquaLogic") as mock_al,
-    ):
-        mock_al.return_value.connect.side_effect = stop_on_second_connect
-        processor.run()
+    mock_al.return_value.connect.side_effect = stop_on_second_connect
+    mock_al.return_value.process.side_effect = RuntimeError("unexpected error")
+    processor.run()
+
+    assert connect_calls == 2
+    assert "Unexpected error in AquaLogic processor: RuntimeError" in caplog.text
+
+
+async def test_processor_run_reconnects(
+    processor_run: tuple[AquaLogicProcessor, MagicMock],
+) -> None:
+    """Test the processor reconnects after a dropped connection."""
+    processor, mock_al = processor_run
+    connect_calls = 0
+
+    def stop_on_second_connect(*_args: object, **_kwargs: object) -> None:
+        nonlocal connect_calls
+        connect_calls += 1
+        if connect_calls >= 2:
+            processor._shutdown = True
+
+    mock_al.return_value.connect.side_effect = stop_on_second_connect
+    processor.run()
 
     assert connect_calls == 2

--- a/tests/components/aqualogic/test_sensor.py
+++ b/tests/components/aqualogic/test_sensor.py
@@ -1,37 +1,28 @@
 """Tests for the AquaLogic sensor platform."""
 
-from collections.abc import Callable
 from unittest.mock import MagicMock
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.aqualogic import DOMAIN, AquaLogicProcessor
+from homeassistant.const import STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
 
 
 @pytest.fixture
-async def init_sensors(
-    hass: HomeAssistant, init_integration: AquaLogicProcessor
-) -> None:
-    """Set up the AquaLogic sensor platform."""
-    assert await async_setup_component(
-        hass,
-        "sensor",
-        {"sensor": {"platform": DOMAIN}},
-    )
-    await hass.async_block_till_done()
+def platforms() -> list[Platform]:
+    """Fixture to specify platforms to test."""
+    return [Platform.SENSOR]
 
 
-@pytest.mark.usefixtures("init_sensors")
+@pytest.mark.usefixtures("init_integration")
 async def test_sensors(
     hass: HomeAssistant,
+    mock_processor: MagicMock,
     snapshot: SnapshotAssertion,
-    update_callback: Callable[[], None],
 ) -> None:
-    """Test all sensor entities are created and report correct state."""
-    update_callback()
+    """Test sensor entities are created and report correct state."""
+    mock_processor.data_changed(mock_processor.panel)
     await hass.async_block_till_done()
 
     states = {
@@ -41,16 +32,33 @@ async def test_sensors(
     assert states == snapshot
 
 
-@pytest.mark.usefixtures("init_sensors")
+@pytest.mark.usefixtures("init_integration")
 async def test_sensors_imperial_units(
     hass: HomeAssistant,
-    update_callback: Callable[[], None],
-    mock_panel: MagicMock,
+    mock_processor: MagicMock,
 ) -> None:
     """Test sensors report imperial units when the panel is not metric."""
-    mock_panel.is_metric = False
-    update_callback()
+    mock_processor.panel.is_metric = False
+    mock_processor.data_changed(mock_processor.panel)
     await hass.async_block_till_done()
 
+    # Use salt_level (g/L → PPM) to verify imperial branch without HA unit conversion
     state = hass.states.get("sensor.aqualogic_salt_level")
     assert state.attributes["unit_of_measurement"] == "PPM"
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_sensors_no_panel(
+    hass: HomeAssistant,
+    mock_processor: MagicMock,
+) -> None:
+    """Test sensors revert to unknown when the panel becomes unavailable."""
+    mock_processor.data_changed(mock_processor.panel)
+    await hass.async_block_till_done()
+    assert hass.states.get("sensor.aqualogic_air_temperature").state == "25.5"
+
+    mock_processor.panel = None
+    mock_processor.data_changed(None)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("sensor.aqualogic_air_temperature").state == STATE_UNKNOWN

--- a/tests/components/aqualogic/test_switch.py
+++ b/tests/components/aqualogic/test_switch.py
@@ -6,32 +6,34 @@ from aqualogic.core import States
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.aqualogic import DOMAIN, AquaLogicProcessor
+from homeassistant.components.aqualogic.const import UPDATE_TOPIC
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
-from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_OFF,
+    Platform,
+)
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 
 @pytest.fixture
-async def init_switches(
-    hass: HomeAssistant, init_integration: AquaLogicProcessor
-) -> None:
-    """Set up the AquaLogic switch platform."""
-    assert await async_setup_component(
-        hass,
-        "switch",
-        {"switch": {"platform": DOMAIN}},
-    )
-    await hass.async_block_till_done()
+def platforms() -> list[Platform]:
+    """Fixture to specify platforms to test."""
+    return [Platform.SWITCH]
 
 
-@pytest.mark.usefixtures("init_switches")
+@pytest.mark.usefixtures("init_integration")
 async def test_switches(
     hass: HomeAssistant,
     snapshot: SnapshotAssertion,
 ) -> None:
-    """Test all switch entities are created and report correct state."""
+    """Test switch entities are created and report correct state."""
+    async_dispatcher_send(hass, UPDATE_TOPIC)
+    await hass.async_block_till_done()
+
     states = {
         state.entity_id: state
         for state in sorted(hass.states.async_all("switch"), key=lambda s: s.entity_id)
@@ -39,7 +41,7 @@ async def test_switches(
     assert states == snapshot
 
 
-@pytest.mark.usefixtures("init_switches")
+@pytest.mark.usefixtures("init_integration")
 @pytest.mark.parametrize(
     ("service", "expected_state"),
     [
@@ -61,3 +63,41 @@ async def test_turn(
         blocking=True,
     )
     mock_panel.set_state.assert_called_once_with(States.LIGHTS, expected_state)
+
+
+@pytest.mark.usefixtures("init_integration")
+@pytest.mark.parametrize(
+    "service",
+    [
+        pytest.param(SERVICE_TURN_ON, id="turn_on"),
+        pytest.param(SERVICE_TURN_OFF, id="turn_off"),
+    ],
+)
+async def test_turn_no_panel(
+    hass: HomeAssistant,
+    mock_processor: MagicMock,
+    service: str,
+) -> None:
+    """Test that turning a switch does nothing when the panel is unavailable."""
+    panel = mock_processor.panel
+    mock_processor.panel = None
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        service,
+        {ATTR_ENTITY_ID: "switch.aqualogic_lights"},
+        blocking=True,
+    )
+    panel.set_state.assert_not_called()
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_is_on_no_panel(
+    hass: HomeAssistant,
+    mock_processor: MagicMock,
+) -> None:
+    """Test switch reports off when panel is unavailable."""
+    mock_processor.panel = None
+    async_dispatcher_send(hass, UPDATE_TOPIC)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("switch.aqualogic_lights").state == STATE_OFF


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrates the AquaLogic integration from YAML-only configuration to a config flow, allowing it to be set up entirely through the UI.

Ran everything locally and works as expected

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository] : https://github.com/home-assistant/home-assistant.io/pull/45865

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
