### PR TITLE
Fix UniFi Protect ufp_set debug log printing UndefinedType for translation-key entities

### DIFF
--- a/homeassistant/components/unifiprotect/entity.py
+++ b/homeassistant/components/unifiprotect/entity.py
@@ -440,7 +440,7 @@ class ProtectSettableKeysMixin(ProtectEntityDescription[T]):
 
     async def ufp_set(self, obj: T, value: Any) -> None:
         """Set value for UniFi Protect device."""
-        _LOGGER.debug("Setting %s to %s for %s", self.name, value, obj.display_name)
+        _LOGGER.debug("Setting %s to %s for %s", self.key, value, obj.display_name)
         if self.ufp_set_method is not None:
             await getattr(obj, self.ufp_set_method)(value)
         elif self.ufp_set_method_fn is not None:


### PR DESCRIPTION
## Proposed change

`ProtectSettableKeysMixin.ufp_set` logs the entity description's static `name` field, which is the `UNDEFINED` sentinel for every entity that uses `translation_key` — i.e. nearly all settable UniFi Protect entities. The debug log reads:

```
Setting UndefinedType._singleton to 0 for Entryway Chime
```

which looks like a broken field mapping and sends people debugging in the wrong direction. Log the always-present `key` instead:

```
Setting volume to 0 for Entryway Chime
```

One-line change in `entity.py`:

```diff
-        _LOGGER.debug("Setting %s to %s for %s", self.name, value, obj.display_name)
+        _LOGGER.debug("Setting %s to %s for %s", self.key, value, obj.display_name)
```

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue: #173459
- Link to documentation pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the development checklist
- [x] I have followed the perfect PR recommendations
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
