### PR TITLE
Bump reolink_aio to 0.21.0

### DIFF
--- a/homeassistant/components/reolink/manifest.json
+++ b/homeassistant/components/reolink/manifest.json
@@ -20,5 +20,5 @@
   "iot_class": "local_push",
   "loggers": ["reolink_aio"],
   "quality_scale": "platinum",
-  "requirements": ["reolink-aio==0.20.1"]
+  "requirements": ["reolink-aio==0.21.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2896,7 +2896,7 @@ renault-api==0.5.12
 renson-endura-delta==1.7.2
 
 # homeassistant.components.reolink
-reolink-aio==0.20.1
+reolink-aio==0.21.0
 
 # homeassistant.components.radio_frequency
 rf-protocols==4.1.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump reolink_aio to 0.21.0:
**Battery camera push updates:**
- [Add aiohttp WebhookServer](https://github.com/starkillerOG/reolink_aio/commit/88ada11556e00516045922487c107849dfad2ef3)
  - [Add subscribe/unsubscribe webhook functions for battery cameras](https://github.com/starkillerOG/reolink_aio/commit/5cb8edb363857aa22badc9c98b1d60430099e4d8)
  - [Automatically start internall WebhookServer when calling subscribe_events for battery cams](https://github.com/starkillerOG/reolink_aio/commit/594f81e830c13fb2d9b77b664022452daa08c240)
  - [Implement webhook_push_callback and parsing](https://github.com/starkillerOG/reolink_aio/commit/36e04042ea23aef4835e595f14532265d18d7021)
  - [Use self._subscribed, events_active and add webhook_subscribed for battery cams](https://github.com/starkillerOG/reolink_aio/commit/ab8573cd9435bfb31d719cbdafef739ab0ca6ab9)
  - [Also send cmd_id=31 when subscribing using webhook](https://github.com/starkillerOG/reolink_aio/commit/d52f6fe605a61f83f2da9936d6e8c3431a8c328a)
  - [Do not reset events_active when logout when webhook subscribed](https://github.com/starkillerOG/reolink_aio/commit/af67f139f254a53ec8b4679ce3f90f9f21651fbf)
  - [Protect agains raising errors in subscribe_events during webhook subscription](https://github.com/starkillerOG/reolink_aio/commit/eefd6c448c31fbd766c6ee4083d1f5cc1cf7b95c)
  - [Check if Baichuan webhook is supported](https://github.com/starkillerOG/reolink_aio/commit/edd84636e6617772bbc9e20ff6c244906d89e79d)

**Additions:**
- [Add UID as argument to HOST for faster UDP connections](https://github.com/starkillerOG/reolink_aio/commit/6075cb464a927c4008feceb0b49c86d3149fccdc)

**Bug fixes:**
- [Drop the connection when getting a UDP timeout to start with a fresh connection and wake the camera](https://github.com/starkillerOG/reolink_aio/commit/e70c045d0fac7226f2a4ec03f46c0f728d610471)
- [Fix Baichuan PIR supported detection](https://github.com/starkillerOG/reolink_aio/commit/66cbb59e1fcc7bb6ff519726e1a11fb47c3c0bb1)
- [Base snapshot capability also on "osdCfg" flag](https://github.com/starkillerOG/reolink_aio/commit/f6b441c961f34bc3aefd7975ac60de07c9ac7309)
- [Fix baichuan is_doorbell detection](https://github.com/starkillerOG/reolink_aio/commit/59184227f5da0725e684f772a1bfb5ca0c5fe908)
- [Fix protocol is None error when dropping connection](https://github.com/starkillerOG/reolink_aio/commit/1b0178ed96b35729a4235b878706d04670728cf0)

**Optimizations:**
- [Re-use connection class and remember UID to prevent UDP discovery step](https://github.com/starkillerOG/reolink_aio/commit/fed5e59ef82c116f7b48c43c27655060e2c1da24)
- [Accept UDP D2C_S_R message even if message_id does not match](https://github.com/starkillerOG/reolink_aio/commit/9a1b6cdf591b554483e385385b2cfef5abe1365b)
- [Add loop typing](https://github.com/starkillerOG/reolink_aio/commit/4f646fba4409fd2c94f9380f521f9e41c05805b7)
- [Prevent drop_coroutine.close on a running coroutine](https://github.com/starkillerOG/reolink_aio/commit/b186f639f61862d58d46928017b0dc8c22eb6d76)

**Full Changelog**: https://github.com/starkillerOG/reolink_aio/compare/0.20.1...0.21.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
