### PR TITLE
Add diagnostics platform to Daikin integration

### DIFF
--- a/homeassistant/components/daikin/diagnostics.py
+++ b/homeassistant/components/daikin/diagnostics.py
@@ -1,0 +1,38 @@
+"""Diagnostics support for Daikin."""
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.const import (
+    CONF_API_KEY,
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_UUID,
+)
+from homeassistant.core import HomeAssistant
+
+from .coordinator import DaikinConfigEntry
+
+TO_REDACT_ENTRY = {CONF_API_KEY, CONF_HOST, CONF_PASSWORD, CONF_UUID}
+TO_REDACT_DEVICE = {"mac"}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: DaikinConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    device = entry.runtime_data.device
+    return {
+        "entry_data": async_redact_data(dict(entry.data), TO_REDACT_ENTRY),
+        "device": {
+            "values": async_redact_data(dict(device.values), TO_REDACT_DEVICE),
+            "support_away_mode": device.support_away_mode,
+            "support_advanced_modes": device.support_advanced_modes,
+            "support_fan_rate": device.support_fan_rate,
+            "support_swing_mode": device.support_swing_mode,
+            "support_outside_temperature": device.support_outside_temperature,
+            "support_humidity": device.support_humidity,
+            "support_energy_consumption": device.support_energy_consumption,
+            "support_compressor_frequency": device.support_compressor_frequency,
+        },
+    }

--- a/homeassistant/components/daikin/diagnostics.py
+++ b/homeassistant/components/daikin/diagnostics.py
@@ -6,9 +6,10 @@ from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_PASSWORD, CONF_UUID
 from homeassistant.core import HomeAssistant
 
+from .const import KEY_MAC
 from .coordinator import DaikinConfigEntry
 
-TO_REDACT_ENTRY = {CONF_API_KEY, CONF_HOST, CONF_PASSWORD, CONF_UUID}
+TO_REDACT_ENTRY = {CONF_API_KEY, CONF_HOST, CONF_PASSWORD, CONF_UUID, KEY_MAC}
 TO_REDACT_DEVICE = {"mac"}
 
 

--- a/homeassistant/components/daikin/diagnostics.py
+++ b/homeassistant/components/daikin/diagnostics.py
@@ -3,12 +3,7 @@
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
-from homeassistant.const import (
-    CONF_API_KEY,
-    CONF_HOST,
-    CONF_PASSWORD,
-    CONF_UUID,
-)
+from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_PASSWORD, CONF_UUID
 from homeassistant.core import HomeAssistant
 
 from .coordinator import DaikinConfigEntry

--- a/tests/components/daikin/snapshots/test_diagnostics.ambr
+++ b/tests/components/daikin/snapshots/test_diagnostics.ambr
@@ -1,0 +1,28 @@
+# serializer version: 1
+# name: test_diagnostics
+  dict({
+    'device': dict({
+      'support_advanced_modes': False,
+      'support_away_mode': False,
+      'support_compressor_frequency': False,
+      'support_energy_consumption': False,
+      'support_fan_rate': False,
+      'support_humidity': False,
+      'support_outside_temperature': False,
+      'support_swing_mode': False,
+      'values': dict({
+        'lztemp_c': '22',
+        'lztemp_h': '22',
+        'model': 'TESTMODEL',
+        'name': 'Daikin Test',
+        'ver': '1_0_0',
+        'zone_name': 'Living',
+        'zone_onoff': '1',
+      }),
+    }),
+    'entry_data': dict({
+      'host': '**REDACTED**',
+      'mac': '**REDACTED**',
+    }),
+  })
+# ---

--- a/tests/components/daikin/test_diagnostics.py
+++ b/tests/components/daikin/test_diagnostics.py
@@ -29,6 +29,4 @@ async def test_diagnostics(
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert (
-        await get_diagnostics_for_config_entry(hass, hass_client, entry) == snapshot
-    )
+    assert await get_diagnostics_for_config_entry(hass, hass_client, entry) == snapshot

--- a/tests/components/daikin/test_diagnostics.py
+++ b/tests/components/daikin/test_diagnostics.py
@@ -1,0 +1,34 @@
+"""Tests for the diagnostics data provided by the Daikin integration."""
+
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.daikin.const import KEY_MAC
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+
+from .test_config_flow import HOST, MAC
+
+from tests.common import MockConfigEntry
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
+
+
+async def test_diagnostics(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    zone_device,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test diagnostics."""
+    entry = MockConfigEntry(
+        domain="daikin",
+        unique_id=MAC,
+        data={CONF_HOST: HOST, KEY_MAC: MAC},
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        await get_diagnostics_for_config_entry(hass, hass_client, entry) == snapshot
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Adds a `diagnostics.py` platform to the Daikin integration so users can download a redacted JSON snapshot of their config entry + device state from the device page in the UI.

This is intended to make triage easier for the existing reliability reports against this integration (#129707, #158913, #168471, #164712 and similar) — maintainers can ask reporters to attach a diagnostic file instead of asking for ad‑hoc debug logs and screenshots.

The diagnostic exposes:

- `entry_data` — the config entry data, with `host`, `api_key`, `password`, and `uuid` redacted.
- `device.values` — the raw key/value dict pydaikin reads from the BRP HTTP endpoints, with `mac` redacted. This is what most "weird behaviour" reports actually need to inspect.
- `device.support_*` — the capability flags the integration uses to decide which entities to expose.

Sensitive fields are redacted via `async_redact_data` per the diagnostics quality‑scale rule.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- The Daikin integration currently has no `quality_scale.yaml`. Diagnostics is a pre-requisite for Silver tier and a common ask in user reports, so this lands the lowest‑risk piece first.
- No new dependencies, no breaking changes, no config flow changes.
- Test follows the `elgato`/`wled` snapshot pattern.

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io