### PR TITLE
Use age-based filter for Matter BLE advertisement history replay

### DIFF
--- a/homeassistant/components/matter/ble_proxy.py
+++ b/homeassistant/components/matter/ble_proxy.py
@@ -33,6 +33,10 @@ from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 
 _LOGGER = logging.getLogger(__name__)
 
+# Replayed history entries older than this are dropped to avoid stale rotating
+# MACs from previous commissioning cycles becoming spurious connect candidates.
+_MAX_STALE_ADVERTISEMENT_SECONDS = 30
+
 
 class HaBluetoothScanSource(BleScanSource):
     """`BleScanSource` backed by Home Assistant's bluetooth component.
@@ -54,9 +58,6 @@ class HaBluetoothScanSource(BleScanSource):
         if self._cancel is not None:
             return
 
-        # Drop HA's synchronous replay of stale history on register; otherwise a
-        # rotating peripheral's old addresses each become a parallel connect candidate.
-        # `MONOTONIC_TIME` is the clock that stamps `service_info.time`.
         scan_start = MONOTONIC_TIME()
 
         @callback
@@ -64,7 +65,7 @@ class HaBluetoothScanSource(BleScanSource):
             service_info: BluetoothServiceInfoBleak,
             _change: object,
         ) -> None:
-            if service_info.time < scan_start:
+            if scan_start - service_info.time > _MAX_STALE_ADVERTISEMENT_SECONDS:
                 return
             try:
                 callback_fn(_to_advertisement_data(service_info))

--- a/tests/components/matter/test_ble_proxy.py
+++ b/tests/components/matter/test_ble_proxy.py
@@ -155,15 +155,16 @@ async def test_scan_source_callback_forwards_advertisement(
 @pytest.mark.parametrize(
     ("advert_time", "expected_count"),
     [
-        pytest.param(999.0, 0, id="stale-before-scan-start-dropped"),
-        pytest.param(1000.0, 1, id="equal-scan-start-forwarded"),
-        pytest.param(1001.0, 1, id="fresh-after-scan-start-forwarded"),
+        pytest.param(969.0, 0, id="stale-31s-old-dropped"),
+        pytest.param(970.0, 1, id="boundary-30s-old-forwarded"),
+        pytest.param(990.0, 1, id="recent-10s-old-forwarded"),
+        pytest.param(1001.0, 1, id="live-after-scan-start-forwarded"),
     ],
 )
 async def test_scan_source_drops_replayed_history(
     hass: HomeAssistant, advert_time: float, expected_count: int
 ) -> None:
-    """Adverts older than the registration instant (HA history replay) are dropped."""
+    """History older than _MAX_STALE_ADVERTISEMENT_SECONDS is dropped; fresher entries pass."""
     forwarded: list[AdvertisementData] = []
     captured: dict[str, object] = {}
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The previous filter dropped all history replayed by habluetooth on callback registration (service_info.time < scan_start). This caused already-advertising Matter devices to be invisible for the entire scan window, because habluetooth's dedup suppresses re-dispatch for unchanged advertisements and history replay is the only way to surface them.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #173400

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been modified to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
