### PR TITLE
Refresh preferred Thread border agent address on OTBR reconnect

### DIFF
--- a/homeassistant/components/thread/dataset_store.py
+++ b/homeassistant/components/thread/dataset_store.py
@@ -393,12 +393,7 @@ class DatasetStore:
         """
         if not preferred_extended_address:
             return
-        if entry.preferred_extended_address is None:
-            self.async_set_preferred_border_agent(
-                entry.id, preferred_border_agent_id, preferred_extended_address
-            )
-            return
-        if (
+        if entry.preferred_extended_address is None or (
             preferred_border_agent_id is not None
             and preferred_border_agent_id == entry.preferred_border_agent_id
             and preferred_extended_address != entry.preferred_extended_address

--- a/homeassistant/components/thread/dataset_store.py
+++ b/homeassistant/components/thread/dataset_store.py
@@ -287,13 +287,9 @@ class DatasetStore:
         entry: DatasetEntry | None
         for entry in self.datasets.values():
             if entry.dataset == dataset:
-                if (
-                    preferred_extended_address
-                    and entry.preferred_extended_address is None
-                ):
-                    self.async_set_preferred_border_agent(
-                        entry.id, preferred_border_agent_id, preferred_extended_address
-                    )
+                self._async_maybe_update_preferred_border_agent(
+                    entry, preferred_border_agent_id, preferred_extended_address
+                )
                 return
 
         # Update if dataset with same extended pan id exists and the timestamp
@@ -341,10 +337,9 @@ class DatasetStore:
                 self.datasets[entry.id], tlv=tlv
             )
             self.async_schedule_save()
-            if preferred_extended_address and entry.preferred_extended_address is None:
-                self.async_set_preferred_border_agent(
-                    entry.id, preferred_border_agent_id, preferred_extended_address
-                )
+            self._async_maybe_update_preferred_border_agent(
+                entry, preferred_border_agent_id, preferred_extended_address
+            )
             return
 
         entry = DatasetEntry(
@@ -381,6 +376,42 @@ class DatasetStore:
     def async_get(self, dataset_id: str) -> DatasetEntry | None:
         """Get dataset by id."""
         return self.datasets.get(dataset_id)
+
+    @callback
+    def _async_maybe_update_preferred_border_agent(
+        self,
+        entry: DatasetEntry,
+        preferred_border_agent_id: str | None,
+        preferred_extended_address: str | None,
+    ) -> None:
+        """Update the preferred border agent of an existing dataset if appropriate.
+
+        Sets the preferred border agent if it was not set yet, or refreshes the
+        stored extended address when the border agent ID still matches but the
+        extended address changed. The latter happens e.g. after an OTBR upgrade
+        regenerates the extended address while keeping the same border agent ID.
+        """
+        if not preferred_extended_address:
+            return
+        if entry.preferred_extended_address is None:
+            self.async_set_preferred_border_agent(
+                entry.id, preferred_border_agent_id, preferred_extended_address
+            )
+            return
+        if (
+            preferred_border_agent_id is not None
+            and preferred_border_agent_id == entry.preferred_border_agent_id
+            and preferred_extended_address != entry.preferred_extended_address
+        ):
+            _LOGGER.info(
+                "Updating extended address of preferred border agent %s from %s to %s",
+                preferred_border_agent_id,
+                entry.preferred_extended_address,
+                preferred_extended_address,
+            )
+            self.async_set_preferred_border_agent(
+                entry.id, preferred_border_agent_id, preferred_extended_address
+            )
 
     @callback
     def async_set_preferred_border_agent(

--- a/tests/components/thread/test_dataset_store.py
+++ b/tests/components/thread/test_dataset_store.py
@@ -782,6 +782,64 @@ async def test_set_preferred_extended_address(hass: HomeAssistant) -> None:
     assert list(store.datasets.values())[2].preferred_extended_address == "blah"
 
 
+async def test_refresh_preferred_extended_address(hass: HomeAssistant) -> None:
+    """Test the preferred extended address is refreshed when the border agent ID matches.
+
+    An OTBR upgrade can regenerate the extended address while keeping the same
+    border agent ID. In that case the stored extended address should be updated
+    so the preferred border agent keeps being recognized.
+    """
+    await dataset_store.async_add_dataset(
+        hass,
+        "source",
+        DATASET_1,
+        preferred_border_agent_id="baid",
+        preferred_extended_address="old_address",
+    )
+
+    store = await dataset_store.async_get_store(hass)
+    assert len(store.datasets) == 1
+    entry = list(store.datasets.values())[0]
+    assert entry.preferred_border_agent_id == "baid"
+    assert entry.preferred_extended_address == "old_address"
+
+    # Same dataset and border agent ID, new extended address: refresh the address
+    await dataset_store.async_add_dataset(
+        hass,
+        "source",
+        DATASET_1,
+        preferred_border_agent_id="baid",
+        preferred_extended_address="new_address",
+    )
+    entry = list(store.datasets.values())[0]
+    assert entry.preferred_border_agent_id == "baid"
+    assert entry.preferred_extended_address == "new_address"
+
+    # Different border agent ID: leave the preferred border agent untouched
+    await dataset_store.async_add_dataset(
+        hass,
+        "source",
+        DATASET_1,
+        preferred_border_agent_id="other_baid",
+        preferred_extended_address="other_address",
+    )
+    entry = list(store.datasets.values())[0]
+    assert entry.preferred_border_agent_id == "baid"
+    assert entry.preferred_extended_address == "new_address"
+
+    # Newer dataset (same extended PAN ID) with matching border agent ID: refresh
+    await dataset_store.async_add_dataset(
+        hass,
+        "source",
+        DATASET_1_LARGER_TIMESTAMP,
+        preferred_border_agent_id="baid",
+        preferred_extended_address="newest_address",
+    )
+    entry = list(store.datasets.values())[0]
+    assert entry.preferred_border_agent_id == "baid"
+    assert entry.preferred_extended_address == "newest_address"
+
+
 async def test_automatically_set_preferred_dataset(
     hass: HomeAssistant, mock_async_zeroconf: MagicMock
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The preferred Thread border agent is identified by its border agent ID and extended address. The latter is used by Apple/iOS to identify the border router. A border router can regenerate this extended address across an OTBR upgrade while keeping the same border agent ID. When that happens, the stored `preferred_extended_address` no longer matches the router, so the preferred border agent's extended address is effectively lost. This surfaces in the companion apps as:

> Failed to save thread network credential, error: Thread network credentials does not match with any of the active thread networks around

This was observed upgrading the OTBR add-on from 2.16.8 to 3.0, where it went from Thread 1.3 to Thread 1.4. We deliberately decided against migrating the Thread network information across that add-on upgrade (home-assistant/addons#4344), so the regenerated extended address has to be reconciled on the Core side instead.

This PR refreshes the stored extended address when a dataset is re-added with the same border agent ID but a changed extended address. As a result, the preferred border agent self-heals on the next OTBR setup (i.e. a Core restart). The border agent ID is treated as the stable identifier; if it also changes, the preferred border agent is left untouched and the user re-selects it, as before.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes home-assistant/addons#4644
- This PR is related to issue: home-assistant/addons#4344
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
