### PR TITLE
Drop redundant MotionDetectorPushButton dispatch in HmIP Cloud sensor

### DIFF
--- a/homeassistant/components/homematicip_cloud/sensor.py
+++ b/homeassistant/components/homematicip_cloud/sensor.py
@@ -216,10 +216,6 @@ def get_device_handlers(hap: HomematicipHAP) -> dict[type, Callable]:
         MotionDetectorOutdoor: lambda device: [
             HomematicipIlluminanceSensor(hap, device),
         ],
-        # MotionDetectorPushButton is a subclass of MotionDetectorOutdoor, so
-        # the isinstance dispatch above already covers it. A separate entry
-        # would register HomematicipIlluminanceSensor twice and trigger a
-        # unique_id collision.
         PresenceDetectorIndoor: lambda device: [
             HomematicipIlluminanceSensor(hap, device),
         ],

--- a/homeassistant/components/homematicip_cloud/sensor.py
+++ b/homeassistant/components/homematicip_cloud/sensor.py
@@ -23,7 +23,6 @@ from homematicip.device import (
     LightSensor,
     MotionDetectorIndoor,
     MotionDetectorOutdoor,
-    MotionDetectorPushButton,
     PassageDetector,
     PresenceDetectorIndoor,
     RoomControlDeviceAnalog,
@@ -217,9 +216,10 @@ def get_device_handlers(hap: HomematicipHAP) -> dict[type, Callable]:
         MotionDetectorOutdoor: lambda device: [
             HomematicipIlluminanceSensor(hap, device),
         ],
-        MotionDetectorPushButton: lambda device: [
-            HomematicipIlluminanceSensor(hap, device),
-        ],
+        # MotionDetectorPushButton is a subclass of MotionDetectorOutdoor, so
+        # the isinstance dispatch above already covers it. A separate entry
+        # would register HomematicipIlluminanceSensor twice and trigger a
+        # unique_id collision.
         PresenceDetectorIndoor: lambda device: [
             HomematicipIlluminanceSensor(hap, device),
         ],

--- a/tests/components/homematicip_cloud/test_sensor.py
+++ b/tests/components/homematicip_cloud/test_sensor.py
@@ -1,6 +1,7 @@
 """Tests for HomematicIP Cloud sensor."""
 
 from homematicip.base.enums import ValveState, WindowState
+import pytest
 
 from homeassistant.components.homematicip_cloud import DOMAIN
 from homeassistant.components.homematicip_cloud.entity import (
@@ -338,6 +339,33 @@ async def test_hmip_illuminance_sensor2(
     assert ha_state.attributes[ATTR_CURRENT_ILLUMINATION] == 785.2
     assert ha_state.attributes[ATTR_HIGHEST_ILLUMINATION] == 837.1
     assert ha_state.attributes[ATTR_LOWEST_ILLUMINATION] == 785.2
+
+
+async def test_hmip_motion_detector_push_button_single_illuminance(
+    hass: HomeAssistant,
+    default_mock_hap_factory: HomeFactory,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test MotionDetectorPushButton produces exactly one illuminance sensor."""
+    # MotionDetectorPushButton subclasses MotionDetectorOutdoor; an isinstance
+    # dispatch loop would otherwise register HomematicipIlluminanceSensor twice.
+    # HA's entity platform silently drops the second one with an error log, so
+    # the bug is observable only via the duplicate-unique-id error message.
+    await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=["Bewegungsmelder für 55er Rahmen – innen"]
+    )
+    illuminance_states = [
+        state
+        for state in hass.states.async_all("sensor")
+        if state.entity_id.endswith("_illuminance")
+    ]
+    assert len(illuminance_states) == 1
+    assert (
+        illuminance_states[0].entity_id
+        == "sensor.bewegungsmelder_fur_55er_rahmen_innen_illuminance"
+    )
+    assert illuminance_states[0].state == "14.2"
+    assert "does not generate unique IDs" not in caplog.text
 
 
 async def test_hmip_windspeed_sensor(

--- a/tests/components/homematicip_cloud/test_sensor.py
+++ b/tests/components/homematicip_cloud/test_sensor.py
@@ -347,10 +347,6 @@ async def test_hmip_motion_detector_push_button_single_illuminance(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test MotionDetectorPushButton produces exactly one illuminance sensor."""
-    # MotionDetectorPushButton subclasses MotionDetectorOutdoor; an isinstance
-    # dispatch loop would otherwise register HomematicipIlluminanceSensor twice.
-    # HA's entity platform silently drops the second one with an error log, so
-    # the bug is observable only via the duplicate-unique-id error message.
     await default_mock_hap_factory.async_get_mock_hap(
         test_devices=["Bewegungsmelder für 55er Rahmen – innen"]
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`MotionDetectorPushButton` subclasses `MotionDetectorOutdoor` in the `homematicip` library. The isinstance-based dispatch in `async_setup_entry` already matches a `MotionDetectorPushButton` device via the `MotionDetectorOutdoor` entry, so the separate `MotionDetectorPushButton: lambda ...` entry instantiated a second `HomematicipIlluminanceSensor` with the same unique ID per HmIP-SMI55 device.

HA's entity platform silently rejects the second registration with `Platform homematicip_cloud does not generate unique IDs. ID ... is already used by ... - ignoring ...`, so the user-visible behaviour is correct (illuminance entity works). The fix removes the spurious error log line and one wasted entity instance per HmIP-SMI55 motion detector.

Regression test asserts a single illuminance state for the HmIP-SMI55 fixture device and the absence of the duplicate-unique-ID error in the captured log.

Surfaced by Copilot during review of #173441.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #173441 (Copilot review)
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr