### PR TITLE
Handle read timeouts in google_wifi sensor update

### DIFF
--- a/homeassistant/components/google_wifi/sensor.py
+++ b/homeassistant/components/google_wifi/sensor.py
@@ -155,7 +155,7 @@ class GoogleWifiSensor(SensorEntity):
 class GoogleWifiAPI:
     """Get the latest data and update the states."""
 
-    def __init__(self, host, conditions):
+    def __init__(self, host, conditions) -> None:
         """Initialize the data object."""
         uri = "http://"
         resource = f"{uri}{host}{ENDPOINT}"
@@ -182,7 +182,7 @@ class GoogleWifiAPI:
             self.raw_data = response.json()
             self.data_format()
             self.available = True
-        except ValueError, requests.exceptions.ConnectionError:
+        except ValueError, requests.exceptions.RequestException:
             _LOGGER.warning("Unable to fetch data from Google Wifi")
             self.available = False
             self.raw_data = None

--- a/tests/components/google_wifi/test_sensor.py
+++ b/tests/components/google_wifi/test_sensor.py
@@ -5,9 +5,12 @@ from http import HTTPStatus
 from typing import Any
 from unittest.mock import Mock, patch
 
+import pytest
+import requests
 import requests_mock
 
 from homeassistant.components.google_wifi import sensor as google_wifi
+from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
@@ -81,6 +84,23 @@ async def test_setup_get(
     )
     await hass.async_block_till_done()
     assert_setup_component(6, "sensor")
+
+
+async def test_setup_when_router_unreachable(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
+    """Test platform setup completes when the router does not respond."""
+    resource = f"http://{google_wifi.DEFAULT_HOST}{google_wifi.ENDPOINT}"
+    requests_mock.get(resource, exc=requests.exceptions.ReadTimeout)
+    assert await async_setup_component(
+        hass,
+        "sensor",
+        {"sensor": {"platform": "google_wifi", "monitored_conditions": ["uptime"]}},
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("sensor.google_wifi_uptime")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
 
 
 def setup_api(
@@ -211,6 +231,53 @@ def test_when_api_data_missing(
             fake_delay(hass, 2)
             sensor.update()
             assert sensor.state is None
+
+
+@pytest.mark.parametrize(
+    "mock_kwargs",
+    [
+        pytest.param({"exc": requests.exceptions.ReadTimeout}, id="read_timeout"),
+        pytest.param({"exc": requests.exceptions.ConnectTimeout}, id="connect_timeout"),
+        pytest.param(
+            {"exc": requests.exceptions.ConnectionError}, id="connection_error"
+        ),
+        pytest.param(
+            {"text": "not json", "status_code": HTTPStatus.OK}, id="invalid_json"
+        ),
+    ],
+)
+def test_update_when_request_fails(
+    hass: HomeAssistant,
+    requests_mock: requests_mock.Mocker,
+    mock_kwargs: dict[str, Any],
+) -> None:
+    """Test sensors become unavailable when the update fails."""
+    api, sensor_dict = setup_api(hass, MOCK_DATA, requests_mock)
+    assert api.available is True
+    requests_mock.get(f"http://localhost{google_wifi.ENDPOINT}", **mock_kwargs)
+    api.update(no_throttle=True)
+    assert api.available is False
+    for value in sensor_dict.values():
+        sensor = value["sensor"]
+        sensor.update()
+        assert sensor.state is None
+
+
+def test_update_recovers_after_failure(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
+    """Test the API recovers once the router responds again."""
+    api, sensor_dict = setup_api(hass, MOCK_DATA, requests_mock)
+    resource = f"http://localhost{google_wifi.ENDPOINT}"
+    requests_mock.get(resource, exc=requests.exceptions.ReadTimeout)
+    api.update(no_throttle=True)
+    assert api.available is False
+    requests_mock.get(resource, text=MOCK_DATA, status_code=HTTPStatus.OK)
+    api.update(no_throttle=True)
+    assert api.available is True
+    sensor = sensor_dict[google_wifi.ATTR_UPTIME]["sensor"]
+    sensor.update()
+    assert sensor.state == 1
 
 
 def test_update_when_unavailable(


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`GoogleWifiAPI.update()` catches only `ValueError` and `requests.exceptions.ConnectionError`. In the `requests` exception hierarchy, `ReadTimeout` derives from `Timeout`, not from `ConnectionError`, so a router that accepts the connection but responds slowly raises an unhandled exception on every poll:

```
ERROR (MainThread) [homeassistant.helpers.entity] Update for sensor.googlewifi_current_version fails
...
requests.exceptions.ReadTimeout: HTTPConnectionPool(host='192.168.5.1', port=80): Read timed out. (read timeout=10)
```

Because `GoogleWifiAPI.__init__` calls `update()`, the same exception also crashes platform setup ("Error while setting up platform google_wifi", as reported in #26647).

This broadens the handler to `requests.exceptions.RequestException`, the common base of `ConnectionError`, `Timeout` (including `ReadTimeout` and `ConnectTimeout`), and `TooManyRedirects`, so any transport failure marks the sensors unavailable instead of raising. `ValueError` remains for the `response.json()` decode path.

Tests added (the integration's error handling previously had no direct coverage — the existing `test_update_when_unavailable` mocks out `update()` entirely):

- `test_update_when_request_fails`, parametrized over read timeout, connect timeout, connection error, and an invalid (non-JSON) response body, asserting the API flips to unavailable and sensor states become unknown.
- `test_setup_when_router_unreachable`: platform setup with the endpoint timing out completes and creates the entity as unavailable (reproduces the #26647 crash; fails without the fix).
- `test_update_recovers_after_failure`: after a timeout, a subsequent successful poll restores availability and data.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #26647
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
