### PR TITLE
Fix template light temperature validation to accept Kelvin values

### DIFF
--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -75,9 +75,6 @@ CONF_SUPPORTS_TRANSITION = "supports_transition"
 CONF_TEMPERATURE_ACTION = "set_temperature"
 CONF_TEMPERATURE = "temperature"
 
-DEFAULT_MIN_MIREDS = 153
-DEFAULT_MAX_MIREDS = 500
-
 DEFAULT_NAME = "Template Light"
 
 SCRIPT_FIELDS = (
@@ -642,28 +639,21 @@ class AbstractTemplateLight(AbstractTemplateEntity, LightEntity):
 
     @callback
     def _validate_temperature(self, result: Any) -> int | None:
-        """Validate the temperature from the template."""
+        """Validate the color temperature in Kelvin from the template."""
         if template_validators.check_result_for_none(result):
             return None
 
-        if (min_kelvin := self._attr_min_color_temp_kelvin) is not None:
-            max_mireds = color_util.color_temperature_kelvin_to_mired(min_kelvin)
-        else:
-            max_mireds = DEFAULT_MAX_MIREDS
+        min_kelvin = self._attr_min_color_temp_kelvin or DEFAULT_MIN_KELVIN
+        max_kelvin = self._attr_max_color_temp_kelvin or DEFAULT_MAX_KELVIN
 
-        if (max_kelvin := self._attr_max_color_temp_kelvin) is not None:
-            min_mireds = color_util.color_temperature_kelvin_to_mired(max_kelvin)
-        else:
-            min_mireds = DEFAULT_MIN_MIREDS
-
-        if isinstance(result, (int, float)) and min_mireds <= result <= max_mireds:
-            return color_util.color_temperature_mired_to_kelvin(result)
+        if isinstance(result, (int, float)) and min_kelvin <= result <= max_kelvin:
+            return int(result)
 
         template_validators.log_validation_result_error(
             self,
             CONF_TEMPERATURE,
             result,
-            f"expected a number between {min_mireds} and {max_mireds}",
+            f"expected a number between {min_kelvin} and {max_kelvin}",
         )
         return None
 

--- a/tests/components/template/test_light.py
+++ b/tests/components/template/test_light.py
@@ -310,7 +310,7 @@ async def setup_light_with_mireds(
         count,
         {
             attribute: attribute_template,
-            "temperature": "{{ 200 }}",
+            "temperature": "{{ 5000 }}",
             **make_test_action("set_temperature", {"color_temp": "{{ color_temp }}"}),
         },
         "{{ 1==1 }}",
@@ -747,8 +747,10 @@ async def test_level_template(
 @pytest.mark.parametrize(
     ("expected_temp", "attribute_template", "expected_color_mode"),
     [
-        (2000, "{{500}}", ColorMode.COLOR_TEMP),
-        (None, "{{501}}", ColorMode.COLOR_TEMP),
+        (2000, "{{2000}}", ColorMode.COLOR_TEMP),
+        (4000, "{{4000}}", ColorMode.COLOR_TEMP),
+        (None, "{{1999}}", ColorMode.COLOR_TEMP),
+        (None, "{{6536}}", ColorMode.COLOR_TEMP),
         (None, "{{x - 12}}", ColorMode.COLOR_TEMP),
         (None, "None", ColorMode.COLOR_TEMP),
         (None, "{{ none }}", ColorMode.COLOR_TEMP),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The `temperature` template for template lights now expects Kelvin values (2000 to 6535) instead of mired values (153 to 500). If you are currently providing mired values in your `temperature` template, you will need to update them to Kelvin. For example, change `{{ 200 }}` (mireds) to `{{ 5000 }}` (Kelvin). You can use `{{ state_attr('light.my_light', 'color_temp_kelvin') }}` to read the Kelvin value from another light entity.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The template light's `_validate_temperature` method still validated the `temperature` template result against the mired range (153 to 500) and converted it from mireds to Kelvin. Since the light platform has migrated to Kelvin as the primary color temperature unit, this caused template lights to reject valid Kelvin values (e.g. 2202) with the error: "expected a number between 153 and 500".

This PR updates the validation to accept Kelvin values directly (default range 2000 to 6535), matching the rest of the light platform. The now unused `DEFAULT_MIN_MIREDS` and `DEFAULT_MAX_MIREDS` constants are also removed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #173516
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
