### PR TITLE
Convert JPEG-incompatible image modes to RGB in image upload thumbnail generation

### DIFF
--- a/homeassistant/components/image_upload/__init__.py
+++ b/homeassistant/components/image_upload/__init__.py
@@ -248,7 +248,10 @@ def _generate_thumbnail_if_file_does_not_exist(
     if not target_file.is_file():
         image = ImageOps.exif_transpose(Image.open(original_path))
         image.thumbnail(target_size)
-        image.save(target_path, format=content_type.partition("/")[-1])
+        save_format = content_type.partition("/")[-1]
+        if save_format == "jpeg" and image.mode not in ("RGB", "L", "CMYK"):
+            image = image.convert("RGB")
+        image.save(target_path, format=save_format)
 
 
 def _validate_size_from_filename(filename: str) -> tuple[int, int]:

--- a/tests/components/image_upload/test_init.py
+++ b/tests/components/image_upload/test_init.py
@@ -110,7 +110,6 @@ async def test_upload_image_thumbnail_rgba_as_jpeg(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
     hass_client: ClientSessionGenerator,
-    hass_ws_client: WebSocketGenerator,
     image_mode: str,
     content_type: str,
 ) -> None:

--- a/tests/components/image_upload/test_init.py
+++ b/tests/components/image_upload/test_init.py
@@ -6,6 +6,8 @@ from unittest.mock import patch
 
 from aiohttp import ClientSession, ClientWebSocketResponse
 from freezegun.api import FrozenDateTimeFactory
+from PIL import Image
+import pytest
 
 from homeassistant.components.image_upload import DOMAIN
 from homeassistant.components.websocket_api import TYPE_RESULT
@@ -94,3 +96,58 @@ async def test_upload_image(
 
         # Ensure removed from disk
         assert not item_folder.is_dir()
+
+
+@pytest.mark.parametrize(
+    ("image_mode", "content_type"),
+    [
+        ("RGBA", "image/jpeg"),
+        ("LA", "image/jpeg"),
+        ("P", "image/jpeg"),
+    ],
+)
+async def test_upload_image_thumbnail_rgba_as_jpeg(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    hass_client: ClientSessionGenerator,
+    hass_ws_client: WebSocketGenerator,
+    image_mode: str,
+    content_type: str,
+) -> None:
+    """Test thumbnail generation when image mode is incompatible with JPEG."""
+    now = dt_util.utcnow()
+    freezer.move_to(now)
+
+    with (
+        tempfile.TemporaryDirectory() as tempdir,
+        patch.object(hass.config, "path", return_value=tempdir),
+    ):
+        assert await async_setup_component(hass, DOMAIN, {})
+        client: ClientSession = await hass_client()
+
+        with TEST_IMAGE.open("rb") as fp:
+            res = await client.post("/api/image/upload", data={"file": fp})
+
+        assert res.status == 200
+        item = await res.json()
+        image_id = item["id"]
+
+        tempdir = pathlib.Path(tempdir)
+        item_folder = tempdir / image_id
+
+        # Create an image file with the given mode to simulate the mismatch
+        original_path = item_folder / "original"
+        img = Image.new(image_mode, (300, 300))
+        img.save(original_path, format="png")
+
+        # Change the stored content_type to simulate the mismatch
+        hass.data[DOMAIN].data[image_id]["content_type"] = content_type
+
+        # Fetch the thumbnail; this should not raise an OSError
+        res = await client.get(f"/api/image/serve/{image_id}/256x256")
+        assert res.status == 200
+        assert (item_folder / "256x256").is_file()
+
+        # Verify the generated thumbnail is a valid JPEG
+        thumbnail = Image.open(item_folder / "256x256")
+        assert thumbnail.mode == "RGB"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
 ## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Convert JPEG-incompatible image modes (RGBA, LA, P, etc.) to RGB before saving thumbnails in the image upload component. JPEG does not support alpha channels, so when an image with transparency is stored with a `image/jpeg` content type, the thumbnail generator crashes with `OSError: cannot write mode RGBA as JPEG`. The conversion only applies when saving as JPEG and the image mode is not already compatible.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #173180
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr