### PR TITLE
Fix MQTT config flow not loading data flow schema when reconfig fails

### DIFF
--- a/homeassistant/components/mqtt/config_flow.py
+++ b/homeassistant/components/mqtt/config_flow.py
@@ -5409,7 +5409,7 @@ async def async_get_broker_settings(
             or user_input_basic[ADVANCED_OPTIONS]
         )
         if user_input_basic.get(ADVANCED_OPTIONS):
-            # Treat the previous post as an update of the current settings/
+            # Treat the previous post as an update of the current settings
             # (if there was a basic broker setup step)
             current_config.update(user_input_basic)
             complete_settings = False
@@ -5418,7 +5418,7 @@ async def async_get_broker_settings(
         ):
             current_config.update(validated_user_input)
         else:
-            # Treat the previous post as an update of the current settings/
+            # Treat the previous post as an update of the current settings
             # (if there was a basic broker setup step)
             current_config.update(user_input_basic)
             complete_settings = False

--- a/homeassistant/components/mqtt/config_flow.py
+++ b/homeassistant/components/mqtt/config_flow.py
@@ -5273,6 +5273,7 @@ async def async_get_broker_settings(
     Returns True when settings are collected successfully.
     """
     hass = flow.hass
+    complete_settings: bool = True
     advanced_broker_options: bool = False
     user_input_basic: dict[str, Any] = {}
     current_config: dict[str, Any] = (
@@ -5403,32 +5404,34 @@ async def async_get_broker_settings(
 
     if user_input:
         user_input_basic = user_input.copy()
-        advanced_broker_options = user_input_basic.get(ADVANCED_OPTIONS, False)
-        if ADVANCED_OPTIONS not in user_input or advanced_broker_options is False:
-            if await _async_validate_broker_settings(
-                current_config,
-                user_input_basic,
-                validated_user_input,
-                errors,
-            ):
-                return True
-        # Get defaults settings from previous post
-        current_broker = user_input_basic.get(CONF_BROKER)
-        current_port = user_input_basic.get(CONF_PORT, DEFAULT_PORT)
-        current_user = user_input_basic.get(CONF_USERNAME)
-        current_pass = user_input_basic.get(CONF_PASSWORD)
+        advanced_broker_options = (
+            ADVANCED_OPTIONS not in user_input_basic
+            or user_input_basic[ADVANCED_OPTIONS]
+        )
+        if user_input_basic.get(ADVANCED_OPTIONS):
+            # Treat the previous post as an update of the current settings/
+            # (if there was a basic broker setup step)
+            current_config.update(user_input_basic)
+            complete_settings = False
+        elif complete_settings := await _async_validate_broker_settings(
+            current_config, user_input_basic, validated_user_input, errors
+        ):
+            current_config.update(validated_user_input)
+        else:
+            # Treat the previous post as an update of the current settings/
+            # (if there was a basic broker setup step)
+            current_config.update(user_input_basic)
+            complete_settings = False
     else:
-        # Get default settings from entry (if any)
-        current_broker = current_config.get(CONF_BROKER)
-        current_port = current_config.get(CONF_PORT, DEFAULT_PORT)
-        current_user = current_config.get(CONF_USERNAME)
-        # Return the sentinel password to avoid exposure
-        current_entry_pass = current_config.get(CONF_PASSWORD)
-        current_pass = PWD_NOT_CHANGED if current_entry_pass else None
+        complete_settings = False
 
-    # Treat the previous post as an update of the current settings
-    # (if there was a basic broker setup step)
-    current_config.update(user_input_basic)
+    # Get default settings from entry (if any)
+    current_broker = current_config.get(CONF_BROKER)
+    current_port = current_config.get(CONF_PORT, DEFAULT_PORT)
+    current_user = current_config.get(CONF_USERNAME)
+    # Return the sentinel password to avoid exposure
+    current_entry_pass = current_config.get(CONF_PASSWORD)
+    current_pass = PWD_NOT_CHANGED if current_entry_pass else None
 
     # Get default settings for advanced broker options
     current_client_id = current_config.get(CONF_CLIENT_ID)
@@ -5480,13 +5483,23 @@ async def async_get_broker_settings(
     ] = PASSWORD_SELECTOR
     # show advanced options checkbox if no defaults
     # of the advanced options are overridden
-    if not advanced_broker_options:
+    if (
+        not user_input_basic
+        or (
+            user_input_basic
+            and ADVANCED_OPTIONS in user_input_basic
+            and not user_input_basic[ADVANCED_OPTIONS]
+        )
+    ) and not advanced_broker_options:
         fields[
             vol.Optional(
                 ADVANCED_OPTIONS,
+                description={
+                    "suggested_value": user_input_basic.get(ADVANCED_OPTIONS, False)
+                },
             )
         ] = BOOLEAN_SELECTOR
-        return False
+        return complete_settings
     fields[
         vol.Optional(
             CONF_CLIENT_ID,
@@ -5506,30 +5519,16 @@ async def async_get_broker_settings(
             or current_config.get(SET_CLIENT_CERT) is True,
         )
     ] = BOOLEAN_SELECTOR
-    if (
-        current_client_certificate is not None
-        or current_config.get(SET_CLIENT_CERT) is True
-    ):
-        fields[
-            vol.Optional(
-                CONF_CLIENT_CERT,
-                description={"suggested_value": user_input_basic.get(CONF_CLIENT_CERT)},
-            )
-        ] = CERT_UPLOAD_SELECTOR
-        fields[
-            vol.Optional(
-                CONF_CLIENT_KEY,
-                description={"suggested_value": user_input_basic.get(CONF_CLIENT_KEY)},
-            )
-        ] = CERT_KEY_UPLOAD_SELECTOR
-        fields[
-            vol.Optional(
-                CONF_CLIENT_KEY_PASSWORD,
-                description={
-                    "suggested_value": user_input_basic.get(CONF_CLIENT_KEY_PASSWORD)
-                },
-            )
-        ] = PASSWORD_SELECTOR
+    fields[vol.Optional(CONF_CLIENT_CERT)] = CERT_UPLOAD_SELECTOR
+    fields[vol.Optional(CONF_CLIENT_KEY)] = CERT_KEY_UPLOAD_SELECTOR
+    fields[
+        vol.Optional(
+            CONF_CLIENT_KEY_PASSWORD,
+            description={
+                "suggested_value": user_input_basic.get(CONF_CLIENT_KEY_PASSWORD)
+            },
+        )
+    ] = PASSWORD_SELECTOR
     verification_mode = current_config.get(SET_CA_CERT) or (
         "off"
         if current_ca_certificate is None
@@ -5537,30 +5536,17 @@ async def async_get_broker_settings(
         if current_ca_certificate == "auto"
         else "custom"
     )
+    fields[vol.Optional(SET_CA_CERT, default=verification_mode)] = (
+        BROKER_VERIFICATION_SELECTOR
+    )
+    fields[vol.Optional(CONF_CERTIFICATE)] = CA_CERT_UPLOAD_SELECTOR
     fields[
         vol.Optional(
-            SET_CA_CERT,
-            default=verification_mode,
-        )
-    ] = BROKER_VERIFICATION_SELECTOR
-    if current_ca_certificate is not None or verification_mode == "custom":
-        fields[
-            vol.Optional(
-                CONF_CERTIFICATE,
-                user_input_basic.get(CONF_CERTIFICATE),
-            )
-        ] = CA_CERT_UPLOAD_SELECTOR
-    fields[
-        vol.Optional(
-            CONF_TLS_INSECURE,
-            description={"suggested_value": current_tls_insecure},
+            CONF_TLS_INSECURE, description={"suggested_value": current_tls_insecure}
         )
     ] = BOOLEAN_SELECTOR
     fields[
-        vol.Optional(
-            CONF_TRANSPORT,
-            description={"suggested_value": current_transport},
-        )
+        vol.Optional(CONF_TRANSPORT, description={"suggested_value": current_transport})
     ] = TRANSPORT_SELECTOR
     if current_transport == TRANSPORT_WEBSOCKETS:
         fields[
@@ -5572,8 +5558,7 @@ async def async_get_broker_settings(
             )
         ] = WS_HEADERS_SELECTOR
 
-    # Show form
-    return False
+    return complete_settings
 
 
 def check_certicate_chain() -> str | None:

--- a/tests/components/mqtt/test_config_flow.py
+++ b/tests/components/mqtt/test_config_flow.py
@@ -2154,8 +2154,8 @@ async def test_setup_with_advanced_settings(
     assert result["data_schema"].schema[mqtt.CONF_TLS_INSECURE]
     assert result["data_schema"].schema[CONF_PROTOCOL]
     assert result["data_schema"].schema[mqtt.CONF_TRANSPORT]
-    assert mqtt.CONF_CLIENT_CERT not in result["data_schema"].schema
-    assert mqtt.CONF_CLIENT_KEY not in result["data_schema"].schema
+    assert result["data_schema"].schema[mqtt.CONF_CLIENT_CERT]
+    assert result["data_schema"].schema[mqtt.CONF_CLIENT_KEY]
 
     # second iteration, advanced settings with request for client cert
     result = await hass.config_entries.flow.async_configure(
@@ -2188,7 +2188,7 @@ async def test_setup_with_advanced_settings(
     assert result["data_schema"].schema[mqtt.CONF_WS_PATH]
     assert result["data_schema"].schema[mqtt.CONF_WS_HEADERS]
 
-    # third iteration, advanced settings with client cert and key
+    # second iteration, advanced settings with client cert and key
     # set and bad json payload
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -2340,41 +2340,10 @@ async def test_setup_with_certificates(
     assert result["data_schema"].schema[mqtt.CONF_TLS_INSECURE]
     assert result["data_schema"].schema[CONF_PROTOCOL]
     assert result["data_schema"].schema[mqtt.CONF_TRANSPORT]
-    assert mqtt.CONF_CLIENT_CERT not in result["data_schema"].schema
-    assert mqtt.CONF_CLIENT_KEY not in result["data_schema"].schema
-
-    # second iteration, advanced settings with request for client cert
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        user_input={
-            mqtt.CONF_BROKER: "test-broker",
-            CONF_PORT: 2345,
-            CONF_USERNAME: "user",
-            CONF_PASSWORD: "secret",
-            mqtt.CONF_KEEPALIVE: 30,
-            "set_ca_cert": "custom",
-            "set_client_cert": True,
-            mqtt.CONF_TLS_INSECURE: False,
-            CONF_PROTOCOL: "5",
-            mqtt.CONF_TRANSPORT: "tcp",
-        },
-    )
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "broker"
-    assert "advanced_options" not in result["data_schema"].schema
-    assert result["data_schema"].schema[CONF_CLIENT_ID]
-    assert result["data_schema"].schema[mqtt.CONF_KEEPALIVE]
-    assert result["data_schema"].schema["set_client_cert"]
-    assert result["data_schema"].schema["set_ca_cert"]
-    assert result["data_schema"].schema["client_key_password"]
-    assert result["data_schema"].schema[mqtt.CONF_TLS_INSECURE]
-    assert result["data_schema"].schema[CONF_PROTOCOL]
-    assert result["data_schema"].schema[mqtt.CONF_CERTIFICATE]
     assert result["data_schema"].schema[mqtt.CONF_CLIENT_CERT]
     assert result["data_schema"].schema[mqtt.CONF_CLIENT_KEY]
-    assert result["data_schema"].schema[mqtt.CONF_TRANSPORT]
 
-    # third iteration, advanced settings with client cert and key and CA certificate
+    # second iteration, advanced settings with client cert and key and CA certificate
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={

--- a/tests/components/mqtt/test_config_flow.py
+++ b/tests/components/mqtt/test_config_flow.py
@@ -2188,7 +2188,7 @@ async def test_setup_with_advanced_settings(
     assert result["data_schema"].schema[mqtt.CONF_WS_PATH]
     assert result["data_schema"].schema[mqtt.CONF_WS_HEADERS]
 
-    # second iteration, advanced settings with client cert and key
+    # third iteration, advanced settings with client cert and key
     # set and bad json payload
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When validation in the MQTT config flow fails, the data flow schema is not populated, and the user loses all changes. This PR ensures the schema is loaded after a validation error. No extra step is needed to set client certificates or the broker CA certificate.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
