### PR TITLE
Avoid leaking Immich API key in error logs

### DIFF
--- a/homeassistant/components/immich/coordinator.py
+++ b/homeassistant/components/immich/coordinator.py
@@ -119,7 +119,7 @@ class ImmichDataUpdateCoordinator(DataUpdateCoordinator[ImmichData]):
             raise UpdateFailed(
                 translation_domain=DOMAIN,
                 translation_key="update_error",
-                translation_placeholders={"error": repr(err)},
+                translation_placeholders={"error": str(err)},
             ) from err
 
         return ImmichData(

--- a/tests/components/immich/test_sensor.py
+++ b/tests/components/immich/test_sensor.py
@@ -1,6 +1,6 @@
 """Test the Immich sensor platform."""
 
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import Mock, patch
 
 from aiohttp import ContentTypeError, RequestInfo
 from multidict import CIMultiDict, CIMultiDictProxy
@@ -50,7 +50,7 @@ async def test_admin_sensors(
 
 async def test_update_error_does_not_leak_api_key(
     hass: HomeAssistant,
-    mock_immich: AsyncMock,
+    mock_immich: Mock,
     mock_config_entry: MockConfigEntry,
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/components/immich/test_sensor.py
+++ b/tests/components/immich/test_sensor.py
@@ -1,9 +1,12 @@
 """Test the Immich sensor platform."""
 
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
+from aiohttp import ContentTypeError, RequestInfo
+from multidict import CIMultiDict, CIMultiDictProxy
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from yarl import URL
 
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -43,3 +46,32 @@ async def test_admin_sensors(
     assert hass.states.get("sensor.mock_title_videos_count") is None
     assert hass.states.get("sensor.mock_title_disk_used_by_photos") is None
     assert hass.states.get("sensor.mock_title_disk_used_by_videos") is None
+
+
+async def test_update_error_does_not_leak_api_key(
+    hass: HomeAssistant,
+    mock_immich: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that API key is not leaked in error logs on connection failure."""
+    await setup_integration(hass, mock_config_entry)
+
+    api_key = "SECRET_API_KEY_12345"
+    headers = CIMultiDictProxy(
+        CIMultiDict({"x-api-key": api_key, "Host": "example.com"})
+    )
+    request_info = RequestInfo(
+        url=URL("https://example.com/api/server/about"),
+        method="GET",
+        headers=headers,
+        real_url=URL("https://example.com/api/server/about"),
+    )
+    mock_immich.server.async_get_about_info.side_effect = ContentTypeError(
+        request_info, (), status=503, message="Service Unavailable"
+    )
+
+    await hass.config_entries.async_reload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert api_key not in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Replace `repr(err)` with `str(err)` in the Immich coordinator's `UpdateFailed` error placeholder. The `repr()` of aiohttp exceptions includes the full `RequestInfo` with headers, which leaks the `x-api-key` into Home Assistant logs. The `str()` representation provides the HTTP status, message, and URL without exposing sensitive headers.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #173052
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr