### PR TITLE
Fix Yale Smart Living panic button unique_id for multiple hubs

### DIFF
--- a/homeassistant/components/yale_smart_alarm/__init__.py
+++ b/homeassistant/components/yale_smart_alarm/__init__.py
@@ -55,6 +55,17 @@ async def async_migrate_entry(hass: HomeAssistant, entry: YaleConfigEntry) -> bo
         del new_data[CONF_NAME]
         hass.config_entries.async_update_entry(entry, data=new_data, minor_version=2)
 
+    if entry.version == 2 and entry.minor_version == 2:
+        entity_reg = er.async_get(hass)
+        entries = er.async_entries_for_config_entry(entity_reg, entry.entry_id)
+        for entity in entries:
+            if entity.unique_id == "yale_smart_alarm-panic":
+                entity_reg.async_update_entity(
+                    entity.entity_id,
+                    new_unique_id=f"{entry.entry_id}-panic",
+                )
+        hass.config_entries.async_update_entry(entry, minor_version=3)
+
     LOGGER.debug("Migration to version %s successful", entry.version)
 
     return True

--- a/homeassistant/components/yale_smart_alarm/__init__.py
+++ b/homeassistant/components/yale_smart_alarm/__init__.py
@@ -31,7 +31,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: YaleConfigEntry) -> boo
 
 async def async_migrate_entry(hass: HomeAssistant, entry: YaleConfigEntry) -> bool:
     """Migrate old entry."""
-    LOGGER.debug("Migrating from version %s", entry.version)
+    LOGGER.debug("Migrating from version %s.%s", entry.version, entry.minor_version)
 
     if entry.version == 1:
         new_options = entry.options.copy()
@@ -66,6 +66,8 @@ async def async_migrate_entry(hass: HomeAssistant, entry: YaleConfigEntry) -> bo
                 )
         hass.config_entries.async_update_entry(entry, minor_version=3)
 
-    LOGGER.debug("Migration to version %s successful", entry.version)
+    LOGGER.debug(
+        "Migration to version %s.%s successful", entry.version, entry.minor_version
+    )
 
     return True

--- a/homeassistant/components/yale_smart_alarm/button.py
+++ b/homeassistant/components/yale_smart_alarm/button.py
@@ -47,7 +47,7 @@ class YalePanicButton(YaleAlarmEntity, ButtonEntity):
         """Initialize the plug switch."""
         super().__init__(coordinator)
         self.entity_description = description
-        self._attr_unique_id = f"yale_smart_alarm-{description.key}"
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}-{description.key}"
 
     async def async_press(self) -> None:
         """Press the button."""

--- a/homeassistant/components/yale_smart_alarm/config_flow.py
+++ b/homeassistant/components/yale_smart_alarm/config_flow.py
@@ -64,7 +64,7 @@ class YaleConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Yale integration."""
 
     VERSION = 2
-    MINOR_VERSION = 2
+    MINOR_VERSION = 3
 
     @staticmethod
     @callback

--- a/tests/components/yale_smart_alarm/conftest.py
+++ b/tests/components/yale_smart_alarm/conftest.py
@@ -46,7 +46,7 @@ async def load_config_entry(
             entry_id="1",
             unique_id="username",
             version=2,
-            minor_version=2,
+            minor_version=3,
         )
 
         config_entry.add_to_hass(hass)

--- a/tests/components/yale_smart_alarm/snapshots/test_button.ambr
+++ b/tests/components/yale_smart_alarm/snapshots/test_button.ambr
@@ -32,7 +32,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'panic',
-    'unique_id': 'yale_smart_alarm-panic',
+    'unique_id': '1-panic',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/yale_smart_alarm/test_init.py
+++ b/tests/components/yale_smart_alarm/test_init.py
@@ -27,7 +27,7 @@ async def test_setup_entry(
         entry_id="1",
         unique_id="username",
         version=2,
-        minor_version=2,
+        minor_version=3,
     )
     entry.add_to_hass(hass)
 
@@ -87,7 +87,7 @@ async def test_migrate_entry(
 
     assert entry.state is ConfigEntryState.LOADED
     assert entry.version == 2
-    assert entry.minor_version == 2
+    assert entry.minor_version == 3
     assert entry.data == ENTRY_CONFIG
     assert entry.options == OPTIONS_CONFIG
 
@@ -95,3 +95,47 @@ async def test_migrate_entry(
     lock = entity_registry.async_get(lock_entity_id)
 
     assert lock.options == {"lock": {"default_code": "123456"}}
+
+
+async def test_migrate_panic_button_unique_id(
+    hass: HomeAssistant,
+    get_client: Mock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test migration of panic button unique_id from v2.2 to v2.3."""
+    entry = MockConfigEntry(
+        title=ENTRY_CONFIG["username"],
+        domain=DOMAIN,
+        source=SOURCE_USER,
+        data=ENTRY_CONFIG,
+        options=OPTIONS_CONFIG,
+        entry_id="1",
+        unique_id="username",
+        version=2,
+        minor_version=2,
+    )
+    entry.add_to_hass(hass)
+    entity_registry.async_get_or_create(
+        "button",
+        DOMAIN,
+        "yale_smart_alarm-panic",
+        config_entry=entry,
+    )
+
+    with patch(
+        "homeassistant.components.yale_smart_alarm.coordinator.YaleSmartAlarmClient",
+        return_value=get_client,
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert entry.version == 2
+    assert entry.minor_version == 3
+
+    migrated = entity_registry.async_get_entity_id("button", DOMAIN, "1-panic")
+    assert migrated is not None
+    old = entity_registry.async_get_entity_id(
+        "button", DOMAIN, "yale_smart_alarm-panic"
+    )
+    assert old is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The Yale Smart Living panic button uses a hardcoded unique_id (`yale_smart_alarm-panic`) that doesn't include any per-hub identifier. When multiple Yale hubs are configured, only the first hub gets a panic button entity since subsequent hubs collide on the same unique_id.

Changes the unique_id to include the config entry ID (`{entry_id}-panic`), matching the pattern used by the alarm control panel entity. Includes a v2.2 to v2.3 migration to update existing entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #173346
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr