### PR TITLE
Sort aliases in LLM prompts for stable prefix caching

### DIFF
--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -700,7 +700,7 @@ def _get_exposed_entities(
             ):
                 # Entity is in area
                 area_names.append(area_entry.name)
-                area_names.extend(area_entry.aliases)
+                area_names.extend(sorted(area_entry.aliases))
             elif device_entry is not None:
                 # Check device area
                 if (
@@ -711,7 +711,7 @@ def _get_exposed_entities(
                     is not None
                 ):
                     area_names.append(area_entry.name)
-                    area_names.extend(area_entry.aliases)
+                    area_names.extend(sorted(area_entry.aliases))
 
         info: dict[str, Any] = {
             "names": ", ".join(names),
@@ -962,9 +962,9 @@ def _get_cached_action_parameters(
                 aliases = er.async_get_entity_aliases(hass, entity_entry)
                 if aliases:
                     if description:
-                        description = description + ". Aliases: " + str(list(aliases))
+                        description = description + ". Aliases: " + str(sorted(aliases))
                     else:
-                        description = "Aliases: " + str(list(aliases))
+                        description = "Aliases: " + str(sorted(aliases))
 
         parameters_cache.setdefault(domain, {})[action] = (description, parameters)
 

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -1234,7 +1234,7 @@ async def test_script_tool(
     assert tool.name == "test_script"
     assert (
         tool.description
-        == "This is a test script. Aliases: ['script name', 'script alias']"
+        == "This is a test script. Aliases: ['script alias', 'script name']"
     )
     schema = {
         vol.Required("beer", description="Number of beers"): cv.string,
@@ -1249,7 +1249,7 @@ async def test_script_tool(
 
     assert hass.data[llm.ACTION_PARAMETERS_CACHE]["script"] == {
         "test_script": (
-            "This is a test script. Aliases: ['script name', 'script alias']",
+            "This is a test script. Aliases: ['script alias', 'script name']",
             vol.Schema(schema),
         ),
         "script_with_no_fields": (
@@ -1358,14 +1358,14 @@ async def test_script_tool(
     assert tool.name == "test_script"
     assert (
         tool.description
-        == "This is a new test script. Aliases: ['script name', 'script alias']"
+        == "This is a new test script. Aliases: ['script alias', 'script name']"
     )
     schema = {vol.Required("beer", description="Number of beers"): cv.string}
     assert tool.parameters.schema == schema
 
     assert hass.data[llm.ACTION_PARAMETERS_CACHE]["script"] == {
         "test_script": (
-            "This is a new test script. Aliases: ['script name', 'script alias']",
+            "This is a new test script. Aliases: ['script alias', 'script name']",
             vol.Schema(schema),
         ),
         "script_with_no_fields": (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Sort area aliases and script entity aliases before serializing them into LLM system prompts.

`area_entry.aliases` is a `set[str]`, whose iteration order is randomized per Python process. Every HA restart shuffles the alias order in the static context section of the LLM prompt, even when nothing changed. This invalidates the prefix KV cache on LLM backends that support it (Ollama, vLLM, llama.cpp), slowing down every voice assist conversation after a restart.

This is a follow-up to #165136 which fixed entity name sorting but missed area aliases and script aliases.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #173350
- This PR is related to issue: #165136
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr