### PR TITLE
Disambiguate duplicate channel names in LG Netcast source list

### DIFF
--- a/homeassistant/components/lg_netcast/media_player.py
+++ b/homeassistant/components/lg_netcast/media_player.py
@@ -133,13 +133,24 @@ class LgTVDevice(MediaPlayerEntity):
 
                 channel_list = client.query_data("channel_list")
                 if channel_list:
-                    channel_names = []
+                    channel_pairs = []
                     for channel in channel_list:
                         channel_name = channel.find("chname")
                         if channel_name is not None:
-                            channel_names.append(str(channel_name.text))
-                    self._sources = dict(zip(channel_names, channel_list, strict=False))
-                    # sort source names by the major channel number
+                            channel_pairs.append((str(channel_name.text), channel))
+
+                    name_count: dict[str, int] = {}
+                    for name, _ in channel_pairs:
+                        name_count[name] = name_count.get(name, 0) + 1
+
+                    self._sources = {}
+                    for name, channel in channel_pairs:
+                        if name_count[name] > 1:
+                            major = channel.find("major")
+                            if major is not None:
+                                name = f"{name} ({major.text})"
+                        self._sources[name] = channel
+
                     source_tuples = [
                         (k, source.find("major").text)
                         for k, source in self._sources.items()

--- a/homeassistant/components/lg_netcast/media_player.py
+++ b/homeassistant/components/lg_netcast/media_player.py
@@ -1,5 +1,6 @@
 """Support for LG TV running on NetCast 3 or 4."""
 
+from collections import Counter
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
@@ -139,9 +140,7 @@ class LgTVDevice(MediaPlayerEntity):
                         if channel_name is not None:
                             channel_pairs.append((str(channel_name.text), channel))
 
-                    name_count: dict[str, int] = {}
-                    for name, _ in channel_pairs:
-                        name_count[name] = name_count.get(name, 0) + 1
+                    name_count = Counter(name for name, _ in channel_pairs)
 
                     self._sources = {}
                     for name, channel in channel_pairs:

--- a/tests/components/lg_netcast/test_media_player.py
+++ b/tests/components/lg_netcast/test_media_player.py
@@ -1,0 +1,70 @@
+"""Tests for LG Netcast media player platform."""
+
+from collections.abc import Generator
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
+
+from . import MODEL_NAME, setup_lgnetcast
+
+from tests.common import async_fire_time_changed
+
+ENTITY_ID = f"{MP_DOMAIN}.{MODEL_NAME.lower()}"
+
+
+def _make_channel(name: str, major: str) -> ET.Element:
+    """Create a fake channel XML element."""
+    channel = ET.Element("data")
+    chname = ET.SubElement(channel, "chname")
+    chname.text = name
+    major_el = ET.SubElement(channel, "major")
+    major_el.text = major
+    return channel
+
+
+@pytest.fixture(autouse=True)
+def mock_lg_netcast() -> Generator[MagicMock]:
+    """Mock LG Netcast library."""
+    with patch(
+        "homeassistant.components.lg_netcast.LgNetCastClient"
+    ) as mock_client_class:
+        yield mock_client_class
+
+
+async def test_source_list_duplicate_channel_names(
+    hass: HomeAssistant,
+    mock_lg_netcast: MagicMock,
+) -> None:
+    """Test that duplicate channel names are disambiguated in source list."""
+    client = mock_lg_netcast.return_value
+    client.get_volume.return_value = (20, False)
+    context_client = client.__enter__.return_value
+    channel_data = {
+        "cur_channel": None,
+        "channel_list": [
+            _make_channel("BBC One", "1"),
+            _make_channel("ITV", "3"),
+            _make_channel("BBC One", "101"),
+        ],
+    }
+    context_client.query_data.side_effect = channel_data.get
+
+    await setup_lgnetcast(hass)
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=60))
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    entity = hass.states.get(ENTITY_ID)
+    assert entity is not None
+    source_list = entity.attributes.get("source_list")
+    assert source_list is not None
+    assert len(source_list) == 3
+    assert "ITV" in source_list
+    assert "BBC One (1)" in source_list
+    assert "BBC One (101)" in source_list


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When a TV's channel list contains two or more channels with the same name (e.g., a TV station and a radio station both called "BBC One"), only the last one appears in the source list. This happens because the channel names are used as dict keys via `dict(zip(channel_names, channel_list))`, and duplicate keys overwrite earlier entries.

This change builds name/channel pairs together, counts occurrences of each name, and appends the channel number in parentheses to any duplicates (e.g., "BBC One (1)" and "BBC One (101)"). Channels with unique names remain unchanged.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #173542
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr