### PR TITLE
Fix Fibaro FGD212 dimmers not detected as dimmable lights

### DIFF
--- a/homeassistant/components/fibaro/light.py
+++ b/homeassistant/components/fibaro/light.py
@@ -79,10 +79,13 @@ class FibaroLight(FibaroEntity, LightEntity):
             or "RGBW" in fibaro_device.type
             or "rgbw" in fibaro_device.type
         )
-        supports_dimming = (
-            fibaro_device.has_interface("levelChange")
-            or fibaro_device.type == "com.fibaro.multilevelSwitch"
-        ) and "setValue" in fibaro_device.actions
+        supports_dimming = fibaro_device.has_interface("levelChange") or (
+            (
+                fibaro_device.base_type == "com.fibaro.multilevelSwitch"
+                or fibaro_device.type == "com.fibaro.multilevelSwitch"
+            )
+            and "setValue" in fibaro_device.actions
+        )
 
         if supports_color and supports_white_v:
             self._attr_supported_color_modes = {ColorMode.RGBW}

--- a/tests/components/fibaro/conftest.py
+++ b/tests/components/fibaro/conftest.py
@@ -173,6 +173,40 @@ def mock_light() -> Mock:
 
 
 @pytest.fixture
+def mock_fgd212_light() -> Mock:
+    """Fixture for an FGD212 dimmer without setValue in actions."""
+    light = Mock()
+    light.fibaro_id = 116
+    light.parent_fibaro_id = 113
+    light.name = "8 Spots"
+    light.room_id = 1
+    light.dead = False
+    light.visible = True
+    light.enabled = True
+    light.type = "com.fibaro.FGD212"
+    light.base_type = "com.fibaro.multilevelSwitch"
+    light.properties = {"manufacturer": "", "isLight": True}
+    light.actions = {
+        "configureFavoritePositions": 1,
+        "setAutoOff": 0,
+        "setFavoritePosition": 1,
+    }
+    light.supported_features = {}
+    light.has_interface.side_effect = lambda name: name == "levelChange"
+    light.raw_data = {
+        "fibaro_id": 116,
+        "name": "8 Spots",
+        "interfaces": ["levelChange", "light"],
+        "properties": {"value": 50},
+    }
+    value_mock = Mock()
+    value_mock.has_value = True
+    value_mock.int_value.return_value = 50
+    light.value = value_mock
+    return light
+
+
+@pytest.fixture
 def mock_zigbee_light() -> Mock:
     """Fixture for a dimmmable zigbee light."""
     light = Mock()

--- a/tests/components/fibaro/test_light.py
+++ b/tests/components/fibaro/test_light.py
@@ -2,7 +2,11 @@
 
 from unittest.mock import Mock, patch
 
-from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    DOMAIN as LIGHT_DOMAIN,
+    ColorMode,
+)
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -55,6 +59,29 @@ async def test_light_brightness(
         # Assert
         state = hass.states.get("light.room_1_test_light_3")
         assert state.attributes["brightness"] == 51
+        assert state.state == "on"
+
+
+async def test_fgd212_light_brightness_without_setvalue_action(
+    hass: HomeAssistant,
+    mock_fibaro_client: Mock,
+    mock_config_entry: MockConfigEntry,
+    mock_fgd212_light: Mock,
+    mock_room: Mock,
+) -> None:
+    """Test FGD212 dimmers with levelChange but no setValue action."""
+
+    # Arrange
+    mock_fibaro_client.read_rooms.return_value = [mock_room]
+    mock_fibaro_client.read_devices.return_value = [mock_fgd212_light]
+
+    with patch("homeassistant.components.fibaro.PLATFORMS", [Platform.LIGHT]):
+        # Act
+        await init_integration(hass, mock_config_entry)
+        # Assert
+        state = hass.states.get("light.room_1_8_spots_116")
+        assert state.attributes[ATTR_BRIGHTNESS] == 128
+        assert state.attributes["color_mode"] == ColorMode.BRIGHTNESS
         assert state.state == "on"
 
 


### PR DESCRIPTION
## Summary

Fixes Fibaro FGD212 dimmers (and similar multilevel switches) being imported as on/off lights instead of dimmable lights.

Modern Fibaro Home Center devices expose FGD212 dimmers with `base_type` `com.fibaro.multilevelSwitch` and a `levelChange` interface, but often omit `setValue` from the device actions dict. The previous logic required both `levelChange`/`multilevelSwitch` type **and** `setValue` in actions, causing dimmers to fall back to `ColorMode.ONOFF`.

## Changes

- Trust the `levelChange` interface alone for dimming support
- Also check `base_type` for `com.fibaro.multilevelSwitch` (not just `type`)
- Keep legacy fallback requiring `setValue` in actions for older devices
- Add test for FGD212 device without `setValue` in actions

## Test plan

- [x] Added unit test `test_fgd212_light_brightness_without_setvalue_action`
- [x] Verified on real Fibaro HC with FGD212 dimmers (FGD212 node 23 / device 116)

Fixes issue where entities like `light.keuken_8_spots_116` reported `supported_color_modes: ["onoff"]` instead of `["brightness"]`.
