### PR TITLE
Switch existing YAML remote platform from pyitachip2ir2 to async pyitach

### DIFF
--- a/homeassistant/components/itach/client.py
+++ b/homeassistant/components/itach/client.py
@@ -1,0 +1,47 @@
+"""Client helpers for the legacy iTach remote platform."""
+
+from pyitach import ItachClient, ItachError
+
+from .command import ParsedItachCommand
+
+
+def raw_timing_to_gc_cycles(duration_us: int, carrier_frequency: int) -> int:
+    """Convert a raw microsecond timing to Global Caché carrier cycles."""
+    return max(1, round(duration_us * carrier_frequency / 1_000_000))
+
+
+def command_to_gc_timings(command: ParsedItachCommand) -> list[int]:
+    """Convert parsed raw timings to Global Caché carrier-cycle timings."""
+    return [
+        raw_timing_to_gc_cycles(timing, command.modulation)
+        for pair in command.get_raw_timings()
+        for timing in (pair.high_us, pair.low_us)
+    ]
+
+
+async def async_create_client(host: str, port: int, timeout: float) -> ItachClient:
+    """Create and connect a pyitach client."""
+    client = ItachClient(host, port, timeout=timeout)
+    try:
+        await client.async_connect()
+    except ItachError:
+        await client.close()
+        raise
+    return client
+
+
+async def async_send_command(
+    client: ItachClient,
+    module: int,
+    connector: int,
+    command: ParsedItachCommand,
+    repeat: int,
+) -> None:
+    """Send a parsed legacy iTach command through pyitach."""
+    await client.async_send_ir(
+        module,
+        connector,
+        command.modulation,
+        command_to_gc_timings(command),
+        repeat=repeat,
+    )

--- a/homeassistant/components/itach/command.py
+++ b/homeassistant/components/itach/command.py
@@ -1,0 +1,143 @@
+"""Command parsing helpers for the legacy iTach remote platform."""
+
+from dataclasses import dataclass
+
+# Pronto learned-code timing unit in microseconds.
+PRONTO_FREQUENCY_REFERENCE_US = 0.241246
+
+
+@dataclass(frozen=True, slots=True)
+class RawTiming:
+    """One raw IR mark/space timing pair in microseconds."""
+
+    high_us: int
+    low_us: int
+
+
+class CommandParseError(ValueError):
+    """Raised when a legacy iTach IR command cannot be parsed."""
+
+
+class ParsedItachCommand:
+    """Parsed legacy iTach command data.
+
+    The legacy YAML remote platform stores command data as learned Pronto hex.
+    Keep this command-like object close to the virtual_remote command parser so
+    the same parsed representation can be used when sending through pyitach or a
+    future Home Assistant infrared entity.
+    """
+
+    def __init__(self, *, modulation: int, timings: list[int]) -> None:
+        """Initialize parsed command."""
+        self.modulation = modulation
+        self._timings = timings
+
+    def get_raw_timings(self) -> list[RawTiming]:
+        """Return raw timings as mark/space pairs."""
+        return [
+            RawTiming(high_us=high_us, low_us=low_us)
+            for high_us, low_us in zip(
+                self._timings[::2],
+                self._timings[1::2],
+                strict=True,
+            )
+        ]
+
+
+def parse_pronto_command(command: str) -> ParsedItachCommand:
+    """Parse learned raw Pronto hex into an iTach command.
+
+    This supports raw learned Pronto codes beginning with 0000. Once and repeat
+    sections are flattened into one raw timing sequence.
+    """
+    modulation, timings = _parse_pronto_command(command.strip())
+    _validate_raw_command(modulation, timings)
+    return ParsedItachCommand(modulation=modulation, timings=timings)
+
+
+def _parse_pronto_command(command: str) -> tuple[int, list[int]]:
+    """Parse learned raw Pronto hex into carrier frequency and timings."""
+    if not command:
+        raise _command_error("Command cannot be empty")
+
+    words = command.split()
+    if not _looks_like_pronto(words):
+        raise _command_error(
+            "Only learned raw Pronto commands beginning with 0000 are supported"
+        )
+
+    values = [int(word, 16) for word in words]
+    if len(values) < 6:
+        raise _command_error("Pronto command is too short")
+
+    pronto_type = values[0]
+    frequency_word = values[1]
+    once_pairs = values[2]
+    repeat_pairs = values[3]
+    timing_words = values[4:]
+    pair_count = once_pairs + repeat_pairs
+    expected_timing_words = pair_count * 2
+
+    if pronto_type != 0x0000:
+        raise _command_error(
+            "Only learned raw Pronto commands beginning with 0000 are supported"
+        )
+
+    if frequency_word <= 0:
+        raise _command_error("Pronto frequency word must be greater than zero")
+
+    if pair_count <= 0:
+        raise _command_error("Pronto command must declare at least one timing pair")
+
+    if len(timing_words) != expected_timing_words:
+        raise _command_error(
+            "Pronto command timing word count does not match the declared lengths"
+        )
+
+    if any(word <= 0 for word in timing_words):
+        raise _command_error("Pronto timing words must be greater than zero")
+
+    modulation = round(1_000_000 / (frequency_word * PRONTO_FREQUENCY_REFERENCE_US))
+    timings = [
+        round(word * frequency_word * PRONTO_FREQUENCY_REFERENCE_US)
+        for word in timing_words
+    ]
+    return modulation, timings
+
+
+def _looks_like_pronto(words: list[str]) -> bool:
+    """Return whether words look like raw Pronto hex."""
+    if len(words) < 4:
+        return False
+    return all(_is_hex_word(word) for word in words) and words[0].lower() == "0000"
+
+
+def _is_hex_word(word: str) -> bool:
+    """Return whether a string is a 16-bit Pronto-style hex word."""
+    if len(word) != 4:
+        return False
+    try:
+        int(word, 16)
+    except ValueError:
+        return False
+    return True
+
+
+def _validate_raw_command(modulation: int, timings: list[int]) -> None:
+    """Validate raw remote command fields."""
+    if modulation <= 0:
+        raise _command_error("modulation must be greater than zero")
+
+    if not timings:
+        raise _command_error("timings cannot be empty")
+
+    if len(timings) % 2 != 0:
+        raise _command_error("timings must contain mark/space pairs")
+
+    if any(timing <= 0 for timing in timings):
+        raise _command_error("timings must be greater than zero")
+
+
+def _command_error(error: str) -> CommandParseError:
+    """Build a command parser error."""
+    return CommandParseError(error)

--- a/homeassistant/components/itach/manifest.json
+++ b/homeassistant/components/itach/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/itach",
   "iot_class": "assumed_state",
   "quality_scale": "legacy",
-  "requirements": ["pyitachip2ir2==0.0.8"]
+  "requirements": ["pyitach==0.1.0"]
 }

--- a/homeassistant/components/itach/remote.py
+++ b/homeassistant/components/itach/remote.py
@@ -164,14 +164,14 @@ class ITachIP2IRRemote(remote.RemoteEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
-        self._attr_is_on = True
         await self._async_send_named_command("ON", self._ir_count)
+        self._attr_is_on = True
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
-        self._attr_is_on = False
         await self._async_send_named_command("OFF", self._ir_count)
+        self._attr_is_on = False
         self.async_write_ha_state()
 
     async def async_send_command(self, command: Iterable[str], **kwargs: Any) -> None:

--- a/homeassistant/components/itach/remote.py
+++ b/homeassistant/components/itach/remote.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable
 import logging
 from typing import Any
 
-import pyitachip2ir
+from pyitach import ItachClient, ItachError
 import voluptuous as vol
 
 from homeassistant.components import remote
@@ -22,9 +22,13 @@ from homeassistant.const import (
     DEVICE_DEFAULT_NAME,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+
+from .client import async_create_client, async_send_command as async_send_itach_command
+from .command import CommandParseError, ParsedItachCommand, parse_pronto_command
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -71,87 +75,115 @@ PLATFORM_SCHEMA = REMOTE_PLATFORM_SCHEMA.extend(
 )
 
 
-def _format_command_value(value: str) -> str:
-    """Format a command name or command data value."""
+def _format_command_name(value: str) -> str:
+    """Format a legacy command name."""
     value = value.strip()
     return value or EMPTY_COMMAND_PLACEHOLDER
 
 
-def _format_command_table(commands: Iterable[dict[str, str]]) -> str:
-    """Format YAML commands for pyitachip2ir."""
-    return "".join(
-        f"{_format_command_value(command[CONF_NAME])}\n"
-        f"{_format_command_value(command[CONF_DATA])}\n"
+def _commands_from_config(
+    commands: Iterable[dict[str, str]],
+) -> dict[str, ParsedItachCommand]:
+    """Parse legacy YAML commands keyed by command name."""
+    return {
+        _format_command_name(command[CONF_NAME]): parse_pronto_command(
+            command[CONF_DATA]
+        )
         for command in commands
-    )
+    }
 
 
 def _setup_remote_entity(
-    itachip2ir: Any, device_config: dict[str, Any]
+    client: ItachClient, device_config: dict[str, Any]
 ) -> ITachIP2IRRemote:
     """Create an iTach remote entity from YAML device config."""
     name = device_config.get(CONF_NAME)
     modaddr = int(device_config.get(CONF_MODADDR, DEFAULT_MODADDR))
     connaddr = int(device_config.get(CONF_CONNADDR, DEFAULT_CONNADDR))
     ir_count = int(device_config.get(CONF_IR_COUNT, DEFAULT_IR_COUNT))
-    command_table = _format_command_table(device_config[CONF_COMMANDS])
+    commands = _commands_from_config(device_config[CONF_COMMANDS])
 
-    itachip2ir.addDevice(name, modaddr, connaddr, command_table)
-    return ITachIP2IRRemote(itachip2ir, name, ir_count)
+    return ITachIP2IRRemote(client, name, modaddr, connaddr, ir_count, commands)
 
 
-def setup_platform(
+async def async_setup_platform(
     hass: HomeAssistant,
     config: ConfigType,
     add_entities: AddEntitiesCallback,
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the ITach connection and devices."""
-    itachip2ir = pyitachip2ir.ITachIP2IR(
-        config.get(CONF_MAC), config[CONF_HOST], int(config[CONF_PORT])
-    )
-
-    if not itachip2ir.ready(CONNECT_TIMEOUT):
+    try:
+        client = await async_create_client(
+            config[CONF_HOST], int(config[CONF_PORT]), CONNECT_TIMEOUT / 1000
+        )
+    except ItachError:
         _LOGGER.error("Unable to find iTach")
         return
 
-    devices = [
-        _setup_remote_entity(itachip2ir, device_config)
-        for device_config in config[CONF_DEVICES]
-    ]
+    try:
+        devices = [
+            _setup_remote_entity(client, device_config)
+            for device_config in config[CONF_DEVICES]
+        ]
+    except CommandParseError as err:
+        _LOGGER.error("Invalid iTach command data: %s", err)
+        await client.close()
+        return
+
     add_entities(devices, True)
 
 
 class ITachIP2IRRemote(remote.RemoteEntity):
     """Device that sends commands to an ITachIP2IR device."""
 
-    def __init__(self, itachip2ir: Any, name: str | None, ir_count: int) -> None:
+    def __init__(
+        self,
+        client: ItachClient,
+        name: str | None,
+        modaddr: int,
+        connaddr: int,
+        ir_count: int,
+        commands: dict[str, ParsedItachCommand],
+    ) -> None:
         """Initialize device."""
-        self.itachip2ir = itachip2ir
+        self._client = client
         self._attr_is_on = False
         self._attr_name = name or DEVICE_DEFAULT_NAME
+        self._modaddr = modaddr
+        self._connaddr = connaddr
         self._ir_count = ir_count or DEFAULT_IR_COUNT
+        self._commands = commands
 
-    def turn_on(self, **kwargs: Any) -> None:
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
         self._attr_is_on = True
-        self.itachip2ir.send(self.name, "ON", self._ir_count)
-        self.schedule_update_ha_state()
+        await self._async_send_named_command("ON", self._ir_count)
+        self.async_write_ha_state()
 
-    def turn_off(self, **kwargs: Any) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
         self._attr_is_on = False
-        self.itachip2ir.send(self.name, "OFF", self._ir_count)
-        self.schedule_update_ha_state()
+        await self._async_send_named_command("OFF", self._ir_count)
+        self.async_write_ha_state()
 
-    def send_command(self, command: Iterable[str], **kwargs: Any) -> None:
+    async def async_send_command(self, command: Iterable[str], **kwargs: Any) -> None:
         """Send a command to one device."""
         num_repeats = kwargs.get(ATTR_NUM_REPEATS, DEFAULT_NUM_REPEATS)
         for single_command in command:
-            self.itachip2ir.send(
-                self.name, single_command, self._ir_count * num_repeats
+            await self._async_send_named_command(
+                single_command, self._ir_count * num_repeats
             )
 
-    def update(self) -> None:
-        """Update the device."""
-        self.itachip2ir.update()
+    async def _async_send_named_command(self, command_name: str, repeat: int) -> None:
+        """Send one named legacy command."""
+        if (command := self._commands.get(command_name)) is None:
+            raise HomeAssistantError(f"Command {command_name} is not configured")
+
+        await async_send_itach_command(
+            self._client,
+            self._modaddr,
+            self._connaddr,
+            command,
+            repeat,
+        )

--- a/homeassistant/components/itach/remote.py
+++ b/homeassistant/components/itach/remote.py
@@ -20,8 +20,9 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_PORT,
     DEVICE_DEFAULT_NAME,
+    EVENT_HOMEASSISTANT_STOP,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Event, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -130,6 +131,12 @@ async def async_setup_platform(
         _LOGGER.error("Invalid iTach command data: %s", err)
         await client.close()
         return
+
+    async def async_close_client(_event: Event[Any]) -> None:
+        """Close the iTach client on Home Assistant stop."""
+        await client.close()
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, async_close_client)
 
     add_entities(devices, True)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2268,7 +2268,7 @@ pyiss==1.0.1
 pyisy==3.6.1
 
 # homeassistant.components.itach
-pyitachip2ir2==0.0.8
+pyitach==0.1.0
 
 # homeassistant.components.ituran
 pyituran==0.1.5

--- a/tests/components/itach/test_client.py
+++ b/tests/components/itach/test_client.py
@@ -1,0 +1,84 @@
+"""Tests for iTach client helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, Mock, patch
+
+from pyitach import ItachClient, ItachConnectionError
+import pytest
+
+from homeassistant.components.itach.client import (
+    async_create_client,
+    async_send_command,
+    command_to_gc_timings,
+    raw_timing_to_gc_cycles,
+)
+from homeassistant.components.itach.command import ParsedItachCommand
+
+
+def test_raw_timing_to_gc_cycles() -> None:
+    """Test converting raw microsecond timings to Global Caché cycles."""
+    assert raw_timing_to_gc_cycles(1000, 38000) == 38
+    assert raw_timing_to_gc_cycles(500, 38000) == 19
+
+
+def test_raw_timing_to_gc_cycles_has_minimum_of_one() -> None:
+    """Test conversion never returns less than one cycle."""
+    assert raw_timing_to_gc_cycles(1, 38000) == 1
+
+
+def test_command_to_gc_timings() -> None:
+    """Test converting a parsed command to Global Caché timings."""
+    command = ParsedItachCommand(modulation=38000, timings=[1000, 500, 1, 20])
+
+    assert command_to_gc_timings(command) == [38, 19, 1, 1]
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_async_create_client() -> None:
+    """Test creating and connecting a pyitach client."""
+    with patch("homeassistant.components.itach.client.ItachClient") as mock_client_cls:
+        mock_client = mock_client_cls.return_value
+        mock_client.async_connect = AsyncMock()
+        mock_client.close = AsyncMock()
+
+        client = await async_create_client("192.168.1.50", 4998, 5.0)
+
+    assert client is mock_client
+    mock_client_cls.assert_called_once_with("192.168.1.50", 4998, timeout=5.0)
+    mock_client.async_connect.assert_awaited_once_with()
+    mock_client.close.assert_not_awaited()
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_async_create_client_closes_on_itach_error() -> None:
+    """Test client is closed when connecting raises an iTach error."""
+    with patch("homeassistant.components.itach.client.ItachClient") as mock_client_cls:
+        mock_client = mock_client_cls.return_value
+        mock_client.async_connect = AsyncMock(
+            side_effect=ItachConnectionError("cannot connect")
+        )
+        mock_client.close = AsyncMock()
+
+        with pytest.raises(ItachConnectionError):
+            await async_create_client("192.168.1.50", 4998, 5.0)
+
+    mock_client.close.assert_awaited_once_with()
+
+
+async def test_async_send_command() -> None:
+    """Test sending a parsed command through pyitach."""
+    mock_client: Any = Mock(spec=ItachClient)
+    mock_client.async_send_ir = AsyncMock()
+    command = ParsedItachCommand(modulation=38000, timings=[1000, 500])
+
+    await async_send_command(mock_client, 1, 2, command, 3)
+
+    mock_client.async_send_ir.assert_awaited_once_with(
+        1,
+        2,
+        38000,
+        [38, 19],
+        repeat=3,
+    )

--- a/tests/components/itach/test_command.py
+++ b/tests/components/itach/test_command.py
@@ -1,0 +1,162 @@
+"""Tests for legacy iTach command parsing."""
+
+from __future__ import annotations
+
+import pytest
+
+from homeassistant.components.itach import command as command_module
+from homeassistant.components.itach.command import (
+    PRONTO_FREQUENCY_REFERENCE_US,
+    CommandParseError,
+    RawTiming,
+    _is_hex_word,
+    _looks_like_pronto,
+    _parse_pronto_command,
+    _validate_raw_command,
+    parse_pronto_command,
+)
+
+VALID_PRONTO = "0000 006D 0002 0001 0156 00AB 0015 0041 0015 0016"
+
+
+def _expected_modulation(frequency_word: int) -> int:
+    """Return expected Pronto carrier frequency."""
+    return round(1_000_000 / (frequency_word * PRONTO_FREQUENCY_REFERENCE_US))
+
+
+def _expected_timing(word: int, frequency_word: int) -> int:
+    """Return expected Pronto timing in microseconds."""
+    return round(word * frequency_word * PRONTO_FREQUENCY_REFERENCE_US)
+
+
+def test_parse_pronto_command_returns_modulation_and_raw_timing_pairs() -> None:
+    """Test parsing learned raw Pronto hex into raw timing pairs."""
+    parsed = parse_pronto_command(VALID_PRONTO)
+
+    assert parsed.modulation == _expected_modulation(0x006D)
+    assert parsed.get_raw_timings() == [
+        RawTiming(
+            high_us=_expected_timing(0x0156, 0x006D),
+            low_us=_expected_timing(0x00AB, 0x006D),
+        ),
+        RawTiming(
+            high_us=_expected_timing(0x0015, 0x006D),
+            low_us=_expected_timing(0x0041, 0x006D),
+        ),
+        RawTiming(
+            high_us=_expected_timing(0x0015, 0x006D),
+            low_us=_expected_timing(0x0016, 0x006D),
+        ),
+    ]
+
+
+def test_parse_pronto_command_strips_input_and_accepts_lowercase_hex() -> None:
+    """Test parsing ignores surrounding whitespace and accepts lowercase hex."""
+    parsed = parse_pronto_command("  0000 006d 0001 0000 0015 0016  ")
+
+    assert parsed.modulation == _expected_modulation(0x006D)
+    assert parsed.get_raw_timings() == [
+        RawTiming(
+            high_us=_expected_timing(0x0015, 0x006D),
+            low_us=_expected_timing(0x0016, 0x006D),
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    ("pronto", "match"),
+    [
+        ("", "Command cannot be empty"),
+        (
+            "sendir-on",
+            "Only learned raw Pronto commands beginning with 0000 are supported",
+        ),
+        (
+            "0000 006D 0000 0001",
+            "Pronto command is too short",
+        ),
+        (
+            "0000 0000 0001 0000 0015 0016",
+            "Pronto frequency word must be greater than zero",
+        ),
+        (
+            "0000 006D 0000 0000 0015 0016",
+            "Pronto command must declare at least one timing pair",
+        ),
+        (
+            "0000 006D 0002 0000 0015 0016",
+            "Pronto command timing word count does not match the declared lengths",
+        ),
+        (
+            "0000 006D 0001 0000 0000 0016",
+            "Pronto timing words must be greater than zero",
+        ),
+    ],
+)
+def test_parse_pronto_command_rejects_invalid_commands(pronto: str, match: str) -> None:
+    """Test invalid Pronto command data raises parser errors."""
+    with pytest.raises(CommandParseError, match=match):
+        parse_pronto_command(pronto)
+
+
+def test_parse_pronto_command_rejects_unsupported_pronto_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test unsupported Pronto command types are rejected defensively."""
+    monkeypatch.setattr(command_module, "_looks_like_pronto", lambda words: True)
+
+    with pytest.raises(
+        CommandParseError,
+        match="Only learned raw Pronto commands beginning with 0000 are supported",
+    ):
+        _parse_pronto_command("0100 006D 0001 0000 0015 0016")
+
+
+@pytest.mark.parametrize(
+    ("modulation", "timings", "match"),
+    [
+        (0, [1, 2], "modulation must be greater than zero"),
+        (38_000, [], "timings cannot be empty"),
+        (38_000, [1], "timings must contain mark/space pairs"),
+        (38_000, [1, 0], "timings must be greater than zero"),
+    ],
+)
+def test_validate_raw_command_rejects_invalid_fields(
+    modulation: int, timings: list[int], match: str
+) -> None:
+    """Test raw command validation errors."""
+    with pytest.raises(CommandParseError, match=match):
+        _validate_raw_command(modulation, timings)
+
+
+def test_validate_raw_command_accepts_valid_fields() -> None:
+    """Test raw command validation accepts valid fields."""
+    _validate_raw_command(38_000, [1, 2])
+
+
+@pytest.mark.parametrize(
+    ("word", "expected"),
+    [
+        ("0000", True),
+        ("abcd", True),
+        ("000", False),
+        ("zzzz", False),
+    ],
+)
+def test_is_hex_word(word: str, expected: bool) -> None:
+    """Test Pronto hex-word detection."""
+    assert _is_hex_word(word) is expected
+
+
+@pytest.mark.parametrize(
+    ("words", "expected"),
+    [
+        (["0000", "006D", "0001"], False),
+        (["0100", "006D", "0001", "0000"], False),
+        (["0000", "zzzz", "0001", "0000"], False),
+        (["0000", "006D", "0001", "0000"], True),
+    ],
+)
+def test_looks_like_pronto(words: list[str], expected: bool) -> None:
+    """Test raw learned Pronto command detection."""
+    assert _looks_like_pronto(words) is expected

--- a/tests/components/itach/test_remote.py
+++ b/tests/components/itach/test_remote.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_PORT,
     DEVICE_DEFAULT_NAME,
+    EVENT_HOMEASSISTANT_STOP,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -144,6 +145,24 @@ async def test_setup_platform_initializes_client(hass: HomeAssistant) -> None:
     mock_client.async_connect.assert_awaited_once_with()
 
 
+async def test_setup_platform_closes_client_on_home_assistant_stop(
+    hass: HomeAssistant,
+) -> None:
+    """Test setup closes the iTach client on Home Assistant stop."""
+    mock_client = _mock_itach_client()
+
+    with patch(
+        "homeassistant.components.itach.client.ItachClient",
+        return_value=mock_client,
+    ):
+        await _async_setup_itach_remote(hass)
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+    await hass.async_block_till_done()
+
+    mock_client.close.assert_awaited_once_with()
+
+
 async def test_setup_platform_connect_failure(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
@@ -207,9 +226,8 @@ async def test_turn_on_sends_on_command() -> None:
         await entity.async_turn_on()
 
     assert entity.is_on is True
-    mock_client.async_send_ir.assert_awaited_once_with(
-        *_expected_send_ir_call(1, 2, VALID_PRONTO, 2).args,
-        **_expected_send_ir_call(1, 2, VALID_PRONTO, 2).kwargs,
+    assert mock_client.async_send_ir.await_args == _expected_send_ir_call(
+        1, 2, VALID_PRONTO, 2
     )
     mock_write_state.assert_called_once_with()
 
@@ -225,9 +243,8 @@ async def test_turn_off_sends_off_command() -> None:
         await entity.async_turn_off()
 
     assert entity.is_on is False
-    mock_client.async_send_ir.assert_awaited_once_with(
-        *_expected_send_ir_call(1, 2, VALID_PRONTO_OFF, 2).args,
-        **_expected_send_ir_call(1, 2, VALID_PRONTO_OFF, 2).kwargs,
+    assert mock_client.async_send_ir.await_args == _expected_send_ir_call(
+        1, 2, VALID_PRONTO_OFF, 2
     )
     mock_write_state.assert_called_once_with()
 
@@ -264,9 +281,8 @@ async def test_send_command_applies_num_repeats_to_ir_count() -> None:
 
     await entity.async_send_command(["VOLUME_UP"], num_repeats=3)
 
-    mock_client.async_send_ir.assert_awaited_once_with(
-        *_expected_send_ir_call(1, 2, VALID_PRONTO, 6).args,
-        **_expected_send_ir_call(1, 2, VALID_PRONTO, 6).kwargs,
+    assert mock_client.async_send_ir.await_args == _expected_send_ir_call(
+        1, 2, VALID_PRONTO, 6
     )
 
 

--- a/tests/components/itach/test_remote.py
+++ b/tests/components/itach/test_remote.py
@@ -2,11 +2,14 @@
 
 import logging
 from typing import Any
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
+from pyitach import ItachClient, ItachConnectionError
 import pytest
 
 from homeassistant.components.itach import remote
+from homeassistant.components.itach.client import command_to_gc_timings
+from homeassistant.components.itach.command import parse_pronto_command
 from homeassistant.components.remote import DOMAIN as REMOTE_DOMAIN
 from homeassistant.const import (
     CONF_DEVICES,
@@ -17,7 +20,11 @@ from homeassistant.const import (
     DEVICE_DEFAULT_NAME,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
+
+VALID_PRONTO = "0000 006D 0001 0000 0015 0016"
+VALID_PRONTO_OFF = "0000 006D 0001 0000 0016 0017"
 
 # Test helpers.
 
@@ -34,7 +41,7 @@ def _default_config(**overrides: Any) -> dict[str, Any]:
                 "commands": [
                     {
                         CONF_NAME: "ON",
-                        "data": "sendir-on",
+                        "data": VALID_PRONTO,
                     },
                 ],
             }
@@ -69,14 +76,44 @@ async def _async_setup_itach_remote(
     await hass.async_block_till_done()
 
 
+def _mock_itach_client() -> MagicMock:
+    """Return a mocked pyitach client."""
+    mock_client = MagicMock(spec=ItachClient)
+    mock_client.async_connect = AsyncMock()
+    mock_client.async_send_ir = AsyncMock()
+    mock_client.close = AsyncMock()
+    return mock_client
+
+
+def _parsed_command(data: str = VALID_PRONTO) -> Any:
+    """Return parsed test command data."""
+    return parse_pronto_command(data)
+
+
+def _expected_send_ir_call(
+    module: int,
+    connector: int,
+    command_data: str,
+    repeat: int,
+) -> Any:
+    """Return expected async_send_ir call."""
+    command = parse_pronto_command(command_data)
+    return call(
+        module,
+        connector,
+        command.modulation,
+        command_to_gc_timings(command),
+        repeat=repeat,
+    )
+
+
 async def test_setup_platform_creates_entity(hass: HomeAssistant) -> None:
     """Test setup creates one remote entity from YAML config."""
-    mock_itach = MagicMock()
-    mock_itach.ready.return_value = True
+    mock_client = _mock_itach_client()
 
     with patch(
-        "homeassistant.components.itach.remote.pyitachip2ir.ITachIP2IR",
-        return_value=mock_itach,
+        "homeassistant.components.itach.client.ItachClient",
+        return_value=mock_client,
     ):
         await _async_setup_itach_remote(hass)
 
@@ -86,212 +123,211 @@ async def test_setup_platform_creates_entity(hass: HomeAssistant) -> None:
     assert state.state == "off"
 
 
-async def test_setup_platform_initializes_library(hass: HomeAssistant) -> None:
-    """Test setup initializes the pyitachip2ir client with YAML values."""
-    mock_itach = MagicMock()
-    mock_itach.ready.return_value = True
+async def test_setup_platform_initializes_client(hass: HomeAssistant) -> None:
+    """Test setup initializes the pyitach client with YAML values."""
+    mock_client = _mock_itach_client()
 
     with patch(
-        "homeassistant.components.itach.remote.pyitachip2ir.ITachIP2IR",
-        return_value=mock_itach,
-    ) as mock_itach_class:
+        "homeassistant.components.itach.client.ItachClient",
+        return_value=mock_client,
+    ) as mock_client_class:
         await _async_setup_itach_remote(
             hass,
             **{CONF_MAC: "AA:BB:CC:DD:EE:FF"},
         )
 
-    mock_itach_class.assert_called_once_with(
-        "AA:BB:CC:DD:EE:FF",
+    mock_client_class.assert_called_once_with(
         "192.168.1.50",
         4998,
+        timeout=remote.CONNECT_TIMEOUT / 1000,
     )
+    mock_client.async_connect.assert_awaited_once_with()
 
 
-async def test_setup_platform_ready_failure(
+async def test_setup_platform_connect_failure(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Test setup does not create an entity when iTach is not ready."""
-    mock_itach = MagicMock()
-    mock_itach.ready.return_value = False
+    """Test setup does not create an entity when iTach cannot connect."""
+    mock_client = _mock_itach_client()
+    mock_client.async_connect.side_effect = ItachConnectionError("cannot connect")
 
     caplog.set_level(logging.ERROR)
 
     with patch(
-        "homeassistant.components.itach.remote.pyitachip2ir.ITachIP2IR",
-        return_value=mock_itach,
+        "homeassistant.components.itach.client.ItachClient",
+        return_value=mock_client,
     ):
         await _async_setup_itach_remote(hass)
 
     assert hass.states.get("remote.tv") is None
-    mock_itach.ready.assert_called_once_with(remote.CONNECT_TIMEOUT)
-    mock_itach.addDevice.assert_not_called()
+    mock_client.async_connect.assert_awaited_once_with()
+    mock_client.close.assert_awaited_once_with()
     assert "Unable to find iTach" in caplog.text
 
 
-async def test_setup_platform_adds_device_with_command_table(
-    hass: HomeAssistant,
+async def test_setup_platform_rejects_invalid_command_data(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Test setup adds a device with the expected command table."""
-    mock_itach = MagicMock()
-    mock_itach.ready.return_value = True
-    devices = [
-        {
-            CONF_NAME: "TV",
-            "modaddr": 1,
-            "connaddr": 2,
-            "commands": [
-                {
-                    CONF_NAME: "ON",
-                    "data": "sendir-on",
-                },
-                {
-                    CONF_NAME: "OFF",
-                    "data": "sendir-off",
-                },
-            ],
-        }
-    ]
-
-    with patch(
-        "homeassistant.components.itach.remote.pyitachip2ir.ITachIP2IR",
-        return_value=mock_itach,
-    ):
-        await _async_setup_itach_remote(hass, **{CONF_DEVICES: devices})
-
-    mock_itach.addDevice.assert_called_once_with(
-        "TV",
-        1,
-        2,
-        "ON\nsendir-on\nOFF\nsendir-off\n",
-    )
-
-
-def test_turn_on_sends_on_command() -> None:
-    """Test turn_on sends the ON command."""
-    mock_itach = MagicMock()
-    entity = remote.ITachIP2IRRemote(mock_itach, "TV", 2)
-
-    with patch.object(entity, "schedule_update_ha_state") as mock_schedule_update:
-        entity.turn_on()
-
-    assert entity.is_on is True
-    mock_itach.send.assert_called_once_with("TV", "ON", 2)
-    mock_schedule_update.assert_called_once_with()
-
-
-def test_turn_off_sends_off_command() -> None:
-    """Test turn_off sends the OFF command."""
-    mock_itach = MagicMock()
-    entity = remote.ITachIP2IRRemote(mock_itach, "TV", 2)
-
-    with patch.object(entity, "schedule_update_ha_state") as mock_schedule_update:
-        entity.turn_off()
-
-    assert entity.is_on is False
-    mock_itach.send.assert_called_once_with("TV", "OFF", 2)
-    mock_schedule_update.assert_called_once_with()
-
-
-def test_send_command_sends_each_command() -> None:
-    """Test send_command sends each command."""
-    mock_itach = MagicMock()
-    entity = remote.ITachIP2IRRemote(mock_itach, "TV", 2)
-
-    entity.send_command(["VOLUME_UP", "VOLUME_DOWN"])
-
-    assert mock_itach.send.call_args_list == [
-        call("TV", "VOLUME_UP", 2),
-        call("TV", "VOLUME_DOWN", 2),
-    ]
-
-
-def test_send_command_applies_num_repeats_to_ir_count() -> None:
-    """Test send_command multiplies ir_count by num_repeats."""
-    mock_itach = MagicMock()
-    entity = remote.ITachIP2IRRemote(mock_itach, "TV", 2)
-
-    entity.send_command(["VOLUME_UP"], num_repeats=3)
-
-    mock_itach.send.assert_called_once_with("TV", "VOLUME_UP", 6)
-
-
-def test_update_calls_library_update() -> None:
-    """Test update calls the pyitachip2ir update method."""
-    mock_itach = MagicMock()
-    entity = remote.ITachIP2IRRemote(mock_itach, "TV", 2)
-
-    entity.update()
-
-    mock_itach.update.assert_called_once_with()
-
-
-async def test_setup_platform_uses_default_values(hass: HomeAssistant) -> None:
-    """Test setup uses default values for optional YAML fields."""
-    mock_itach = MagicMock()
-    mock_itach.ready.return_value = True
-    devices = [
-        {
-            "connaddr": 2,
-            "commands": [
-                {
-                    CONF_NAME: "ON",
-                    "data": "sendir-on",
-                },
-            ],
-        }
-    ]
-
-    with patch(
-        "homeassistant.components.itach.remote.pyitachip2ir.ITachIP2IR",
-        return_value=mock_itach,
-    ) as mock_itach_class:
-        await _async_setup_itach_remote(hass, **{CONF_DEVICES: devices})
-
-    states = hass.states.async_all(REMOTE_DOMAIN)
-
-    mock_itach_class.assert_called_once_with(None, "192.168.1.50", 4998)
-    mock_itach.addDevice.assert_called_once_with(
-        None,
-        1,
-        2,
-        "ON\nsendir-on\n",
-    )
-    assert len(states) == 1
-    assert states[0].name == DEVICE_DEFAULT_NAME
-
-
-async def test_setup_platform_uses_empty_string_placeholders_for_empty_commands(
-    hass: HomeAssistant,
-) -> None:
-    """Test setup converts empty command names and data to placeholders."""
-    mock_itach = MagicMock()
-    mock_itach.ready.return_value = True
+    """Test setup does not create an entity with invalid command data."""
+    mock_client = _mock_itach_client()
     devices = [
         {
             CONF_NAME: "TV",
             "connaddr": 1,
             "commands": [
                 {
-                    CONF_NAME: "",
-                    "data": "",
+                    CONF_NAME: "ON",
+                    "data": "sendir-on",
                 },
+            ],
+        }
+    ]
+
+    caplog.set_level(logging.ERROR)
+
+    with patch(
+        "homeassistant.components.itach.client.ItachClient",
+        return_value=mock_client,
+    ):
+        await _async_setup_itach_remote(hass, **{CONF_DEVICES: devices})
+
+    assert hass.states.get("remote.tv") is None
+    mock_client.close.assert_awaited_once_with()
+    assert "Invalid iTach command data" in caplog.text
+
+
+async def test_turn_on_sends_on_command() -> None:
+    """Test turn_on sends the ON command."""
+    mock_client = _mock_itach_client()
+    entity = remote.ITachIP2IRRemote(
+        mock_client, "TV", 1, 2, 2, {"ON": _parsed_command()}
+    )
+
+    with patch.object(entity, "async_write_ha_state") as mock_write_state:
+        await entity.async_turn_on()
+
+    assert entity.is_on is True
+    mock_client.async_send_ir.assert_awaited_once_with(
+        *_expected_send_ir_call(1, 2, VALID_PRONTO, 2).args,
+        **_expected_send_ir_call(1, 2, VALID_PRONTO, 2).kwargs,
+    )
+    mock_write_state.assert_called_once_with()
+
+
+async def test_turn_off_sends_off_command() -> None:
+    """Test turn_off sends the OFF command."""
+    mock_client = _mock_itach_client()
+    entity = remote.ITachIP2IRRemote(
+        mock_client, "TV", 1, 2, 2, {"OFF": _parsed_command(VALID_PRONTO_OFF)}
+    )
+
+    with patch.object(entity, "async_write_ha_state") as mock_write_state:
+        await entity.async_turn_off()
+
+    assert entity.is_on is False
+    mock_client.async_send_ir.assert_awaited_once_with(
+        *_expected_send_ir_call(1, 2, VALID_PRONTO_OFF, 2).args,
+        **_expected_send_ir_call(1, 2, VALID_PRONTO_OFF, 2).kwargs,
+    )
+    mock_write_state.assert_called_once_with()
+
+
+async def test_send_command_sends_each_command() -> None:
+    """Test send_command sends each command."""
+    mock_client = _mock_itach_client()
+    entity = remote.ITachIP2IRRemote(
+        mock_client,
+        "TV",
+        1,
+        2,
+        2,
+        {
+            "VOLUME_UP": _parsed_command(),
+            "VOLUME_DOWN": _parsed_command(VALID_PRONTO_OFF),
+        },
+    )
+
+    await entity.async_send_command(["VOLUME_UP", "VOLUME_DOWN"])
+
+    assert mock_client.async_send_ir.await_args_list == [
+        _expected_send_ir_call(1, 2, VALID_PRONTO, 2),
+        _expected_send_ir_call(1, 2, VALID_PRONTO_OFF, 2),
+    ]
+
+
+async def test_send_command_applies_num_repeats_to_ir_count() -> None:
+    """Test send_command multiplies ir_count by num_repeats."""
+    mock_client = _mock_itach_client()
+    entity = remote.ITachIP2IRRemote(
+        mock_client, "TV", 1, 2, 2, {"VOLUME_UP": _parsed_command()}
+    )
+
+    await entity.async_send_command(["VOLUME_UP"], num_repeats=3)
+
+    mock_client.async_send_ir.assert_awaited_once_with(
+        *_expected_send_ir_call(1, 2, VALID_PRONTO, 6).args,
+        **_expected_send_ir_call(1, 2, VALID_PRONTO, 6).kwargs,
+    )
+
+
+async def test_send_command_raises_for_unknown_command() -> None:
+    """Test send_command raises for an unknown command."""
+    mock_client = _mock_itach_client()
+    entity = remote.ITachIP2IRRemote(
+        mock_client, "TV", 1, 2, 2, {"VOLUME_UP": _parsed_command()}
+    )
+
+    with pytest.raises(
+        HomeAssistantError, match="Command VOLUME_DOWN is not configured"
+    ):
+        await entity.async_send_command(["VOLUME_DOWN"])
+
+    mock_client.async_send_ir.assert_not_awaited()
+
+
+async def test_setup_platform_uses_default_values(hass: HomeAssistant) -> None:
+    """Test setup uses default values for optional YAML fields."""
+    mock_client = _mock_itach_client()
+    devices = [
+        {
+            "connaddr": 2,
+            "commands": [
                 {
-                    CONF_NAME: "   ",
-                    "data": "   ",
+                    CONF_NAME: "ON",
+                    "data": VALID_PRONTO,
                 },
             ],
         }
     ]
 
     with patch(
-        "homeassistant.components.itach.remote.pyitachip2ir.ITachIP2IR",
-        return_value=mock_itach,
-    ):
+        "homeassistant.components.itach.client.ItachClient",
+        return_value=mock_client,
+    ) as mock_client_class:
         await _async_setup_itach_remote(hass, **{CONF_DEVICES: devices})
 
-    mock_itach.addDevice.assert_called_once_with(
-        "TV",
-        1,
-        1,
-        '""\n""\n""\n""\n',
+    states = hass.states.async_all(REMOTE_DOMAIN)
+
+    mock_client_class.assert_called_once_with(
+        "192.168.1.50",
+        4998,
+        timeout=remote.CONNECT_TIMEOUT / 1000,
     )
+    assert len(states) == 1
+    assert states[0].name == DEVICE_DEFAULT_NAME
+
+
+def test_commands_from_config_uses_empty_string_placeholder_for_empty_command_name() -> (
+    None
+):
+    """Test empty command names are stored as placeholders."""
+    commands = remote._commands_from_config(
+        [
+            {
+                CONF_NAME: "",
+                "data": VALID_PRONTO,
+            }
+        ]
+    )
+
+    assert list(commands) == [remote.EMPTY_COMMAND_PLACEHOLDER]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Replace the legacy `pyitachip2ir2` dependency with `pyitach` for the existing YAML-based iTach remote platform.

The legacy remote platform remains for backward compatibility. Home Assistant now owns the legacy command-name mapping and Pronto HEX command parsing, while `pyitach` is used for device communication.

This preserves the existing YAML schema, remote entity behavior, `turn_on` / `turn_off` command names, `send_command` behavior, and `ir_count * num_repeats` repeat handling.

This does not add config entries, config flow, discovery, repairs, diagnostics, or the modern `infrared` platform. The modern infrared platform will be added separately.

Dependency change:

- Replaces `pyitachip2ir2==0.0.8` with `pyitach==0.1.0`.
- `pyitach` is an async, device-focused iTach client used for TCP communication and IR sending.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
