### PR TITLE
Add SwitchBot Standing Fan fan platform

### DIFF
--- a/homeassistant/components/switchbot/__init__.py
+++ b/homeassistant/components/switchbot/__init__.py
@@ -97,6 +97,7 @@ PLATFORMS_BY_TYPE = {
     SupportedModels.HUBMINI_MATTER.value: [Platform.SENSOR],
     SupportedModels.CIRCULATOR_FAN.value: [Platform.FAN, Platform.SENSOR],
     SupportedModels.STANDING_FAN.value: [
+        Platform.FAN,
         Platform.SELECT,
         Platform.NUMBER,
         Platform.SWITCH,

--- a/homeassistant/components/switchbot/fan.py
+++ b/homeassistant/components/switchbot/fan.py
@@ -139,6 +139,7 @@ class SwitchBotStandingFanEntity(SwitchBotFanEntity):
 
     _device: switchbot.SwitchbotStandingFan
     _attr_preset_modes = StandingFanMode.get_modes()
+    _attr_translation_key = "standing_fan"
 
 
 class SwitchBotAirPurifierEntity(SwitchbotEntity, FanEntity):

--- a/homeassistant/components/switchbot/fan.py
+++ b/homeassistant/components/switchbot/fan.py
@@ -1,5 +1,6 @@
 """Support for SwitchBot Fans."""
 
+from collections.abc import Mapping
 import logging
 from typing import Any, override
 
@@ -8,9 +9,11 @@ from switchbot import AirPurifierMode, FanMode, StandingFanMode
 
 from homeassistant.components.fan import FanEntity, FanEntityFeature
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
+from .const import DOMAIN
 from .coordinator import SwitchbotConfigEntry, SwitchbotDataUpdateCoordinator
 from .entity import SwitchbotEntity, exception_handler
 
@@ -140,6 +143,90 @@ class SwitchBotStandingFanEntity(SwitchBotFanEntity):
     _device: switchbot.SwitchbotStandingFan
     _attr_preset_modes = StandingFanMode.get_modes()
     _attr_translation_key = "standing_fan"
+
+    @property
+    @override
+    def extra_state_attributes(self) -> Mapping[str, Any]:
+        """Return the state attributes.
+
+        Failures surface as HomeAssistantError, so last_run_success is not used.
+        """
+        return {}
+
+    @exception_handler
+    @override
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Set the preset mode of the fan."""
+        _LOGGER.debug(
+            "Switchbot standing fan to set preset mode %s %s",
+            preset_mode,
+            self._address,
+        )
+        if not await self._device.set_preset_mode(preset_mode):
+            raise HomeAssistantError(
+                translation_domain=DOMAIN, translation_key="set_fan_state_failed"
+            )
+        self.async_write_ha_state()
+
+    @exception_handler
+    @override
+    async def async_set_percentage(self, percentage: int) -> None:
+        """Set the speed percentage of the fan."""
+        _LOGGER.debug(
+            "Switchbot standing fan to set percentage %d %s", percentage, self._address
+        )
+        if not await self._device.set_percentage(percentage):
+            raise HomeAssistantError(
+                translation_domain=DOMAIN, translation_key="set_fan_state_failed"
+            )
+        self.async_write_ha_state()
+
+    @exception_handler
+    @override
+    async def async_oscillate(self, oscillating: bool) -> None:
+        """Oscillate the fan."""
+        _LOGGER.debug(
+            "Switchbot standing fan to set oscillating %s %s",
+            oscillating,
+            self._address,
+        )
+        if not await self._device.set_oscillation(oscillating):
+            raise HomeAssistantError(
+                translation_domain=DOMAIN, translation_key="set_fan_state_failed"
+            )
+        self.async_write_ha_state()
+
+    @exception_handler
+    @override
+    async def async_turn_on(
+        self,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Turn on the fan."""
+        _LOGGER.debug(
+            "Switchbot standing fan to set turn on %s %s %s",
+            percentage,
+            preset_mode,
+            self._address,
+        )
+        if not await self._device.turn_on():
+            raise HomeAssistantError(
+                translation_domain=DOMAIN, translation_key="set_fan_state_failed"
+            )
+        self.async_write_ha_state()
+
+    @exception_handler
+    @override
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off the fan."""
+        _LOGGER.debug("Switchbot standing fan to set turn off %s", self._address)
+        if not await self._device.turn_off():
+            raise HomeAssistantError(
+                translation_domain=DOMAIN, translation_key="set_fan_state_failed"
+            )
+        self.async_write_ha_state()
 
 
 class SwitchBotAirPurifierEntity(SwitchbotEntity, FanEntity):

--- a/homeassistant/components/switchbot/fan.py
+++ b/homeassistant/components/switchbot/fan.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any, override
 
 import switchbot
-from switchbot import AirPurifierMode, FanMode
+from switchbot import AirPurifierMode, FanMode, StandingFanMode
 
 from homeassistant.components.fan import FanEntity, FanEntityFeature
 from homeassistant.core import HomeAssistant
@@ -27,6 +27,8 @@ async def async_setup_entry(
     coordinator = entry.runtime_data
     if isinstance(coordinator.device, switchbot.SwitchbotAirPurifier):
         async_add_entities([SwitchBotAirPurifierEntity(coordinator)])
+    elif isinstance(coordinator.device, switchbot.SwitchbotStandingFan):
+        async_add_entities([SwitchBotStandingFanEntity(coordinator)])
     else:
         async_add_entities([SwitchBotFanEntity(coordinator)])
 
@@ -130,6 +132,13 @@ class SwitchBotFanEntity(SwitchbotEntity, FanEntity, RestoreEntity):
         _LOGGER.debug("Switchbot fan to set turn off %s", self._address)
         self._last_run_success = bool(await self._device.turn_off())
         self.async_write_ha_state()
+
+
+class SwitchBotStandingFanEntity(SwitchBotFanEntity):
+    """Representation of a Switchbot Standing Fan."""
+
+    _device: switchbot.SwitchbotStandingFan
+    _attr_preset_modes = StandingFanMode.get_modes()
 
 
 class SwitchBotAirPurifierEntity(SwitchbotEntity, FanEntity):

--- a/homeassistant/components/switchbot/strings.json
+++ b/homeassistant/components/switchbot/strings.json
@@ -187,6 +187,25 @@
             }
           }
         }
+      },
+      "standing_fan": {
+        "state_attributes": {
+          "last_run_success": {
+            "state": {
+              "false": "[%key:component::binary_sensor::entity_component::problem::state::on%]",
+              "true": "[%key:component::binary_sensor::entity_component::problem::state::off%]"
+            }
+          },
+          "preset_mode": {
+            "state": {
+              "baby": "Baby",
+              "custom_natural": "Custom Natural",
+              "natural": "Natural",
+              "normal": "[%key:common::state::normal%]",
+              "sleep": "Sleep"
+            }
+          }
+        }
       }
     },
     "humidifier": {

--- a/homeassistant/components/switchbot/strings.json
+++ b/homeassistant/components/switchbot/strings.json
@@ -190,19 +190,13 @@
       },
       "standing_fan": {
         "state_attributes": {
-          "last_run_success": {
-            "state": {
-              "false": "[%key:component::binary_sensor::entity_component::problem::state::on%]",
-              "true": "[%key:component::binary_sensor::entity_component::problem::state::off%]"
-            }
-          },
           "preset_mode": {
             "state": {
-              "baby": "Baby",
-              "custom_natural": "Custom Natural",
-              "natural": "Natural",
+              "baby": "[%key:component::switchbot::entity::fan::fan::state_attributes::preset_mode::state::baby%]",
+              "custom_natural": "Custom natural",
+              "natural": "[%key:component::switchbot::entity::fan::fan::state_attributes::preset_mode::state::natural%]",
               "normal": "[%key:common::state::normal%]",
-              "sleep": "Sleep"
+              "sleep": "[%key:component::switchbot::entity::fan::fan::state_attributes::preset_mode::state::sleep%]"
             }
           }
         }
@@ -436,6 +430,9 @@
     },
     "operation_error": {
       "message": "An error occurred while performing the action: {error}"
+    },
+    "set_fan_state_failed": {
+      "message": "Failed to send the command to the fan."
     },
     "value_error": {
       "message": "Switchbot device initialization failed because of incorrect configuration parameters: {error}"

--- a/tests/components/switchbot/test_fan.py
+++ b/tests/components/switchbot/test_fan.py
@@ -26,6 +26,7 @@ from . import (
     AIR_PURIFIER_TABLE_US_SERVICE_INFO,
     AIR_PURIFIER_US_SERVICE_INFO,
     CIRCULATOR_FAN_SERVICE_INFO,
+    STANDING_FAN_SERVICE_INFO,
 )
 
 from tests.common import MockConfigEntry
@@ -232,3 +233,53 @@ async def test_exception_handling_air_purifier_service(
                 {**service_data, ATTR_ENTITY_ID: entity_id},
                 blocking=True,
             )
+
+
+@pytest.mark.parametrize(
+    ("service", "service_data", "mock_method", "expected_call"),
+    [
+        (
+            SERVICE_SET_PRESET_MODE,
+            {ATTR_PRESET_MODE: "sleep"},
+            "set_preset_mode",
+            ("sleep",),
+        ),
+        (SERVICE_SET_PERCENTAGE, {ATTR_PERCENTAGE: 50}, "set_percentage", (50,)),
+        (SERVICE_OSCILLATE, {ATTR_OSCILLATING: True}, "set_oscillation", (True,)),
+        (SERVICE_TURN_OFF, {}, "turn_off", ()),
+        (SERVICE_TURN_ON, {}, "turn_on", ()),
+    ],
+)
+async def test_standing_fan_controlling(
+    hass: HomeAssistant,
+    mock_entry_factory: Callable[[str], MockConfigEntry],
+    service: str,
+    service_data: dict,
+    mock_method: str,
+    expected_call: tuple,
+) -> None:
+    """Test controlling the standing fan with different services."""
+    inject_bluetooth_service_info(hass, STANDING_FAN_SERVICE_INFO)
+
+    entry = mock_entry_factory(sensor_type="standing_fan")
+    entity_id = "fan.test_name"
+    entry.add_to_hass(hass)
+
+    mocked_instance = AsyncMock(return_value=True)
+    mocked_none = AsyncMock(return_value=None)
+    with patch.multiple(
+        "homeassistant.components.switchbot.fan.switchbot.SwitchbotStandingFan",
+        get_basic_info=mocked_none,
+        **{mock_method: mocked_instance},
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        await hass.services.async_call(
+            FAN_DOMAIN,
+            service,
+            {**service_data, ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
+
+        mocked_instance.assert_awaited_once_with(*expected_call)

--- a/tests/components/switchbot/test_fan.py
+++ b/tests/components/switchbot/test_fan.py
@@ -283,3 +283,96 @@ async def test_standing_fan_controlling(
         )
 
         mocked_instance.assert_awaited_once_with(*expected_call)
+
+
+@pytest.mark.parametrize(
+    ("service", "service_data", "mock_method"),
+    [
+        (SERVICE_SET_PRESET_MODE, {ATTR_PRESET_MODE: "sleep"}, "set_preset_mode"),
+        (SERVICE_SET_PERCENTAGE, {ATTR_PERCENTAGE: 50}, "set_percentage"),
+        (SERVICE_OSCILLATE, {ATTR_OSCILLATING: True}, "set_oscillation"),
+        (SERVICE_TURN_OFF, {}, "turn_off"),
+        (SERVICE_TURN_ON, {}, "turn_on"),
+    ],
+)
+async def test_exception_handling_standing_fan_service(
+    hass: HomeAssistant,
+    mock_entry_factory: Callable[[str], MockConfigEntry],
+    service: str,
+    service_data: dict,
+    mock_method: str,
+) -> None:
+    """Test a communication error raises HomeAssistantError for the standing fan."""
+    inject_bluetooth_service_info(hass, STANDING_FAN_SERVICE_INFO)
+
+    entry = mock_entry_factory(sensor_type="standing_fan")
+    entry.add_to_hass(hass)
+    entity_id = "fan.test_name"
+
+    mocked_none = AsyncMock(return_value=None)
+    with patch.multiple(
+        "homeassistant.components.switchbot.fan.switchbot.SwitchbotStandingFan",
+        get_basic_info=mocked_none,
+        **{
+            mock_method: AsyncMock(
+                side_effect=SwitchbotOperationError("Operation failed")
+            )
+        },
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        with pytest.raises(
+            HomeAssistantError,
+            match="An error occurred while performing the action: Operation failed",
+        ):
+            await hass.services.async_call(
+                FAN_DOMAIN,
+                service,
+                {**service_data, ATTR_ENTITY_ID: entity_id},
+                blocking=True,
+            )
+
+
+@pytest.mark.parametrize(
+    ("service", "service_data", "mock_method"),
+    [
+        (SERVICE_SET_PRESET_MODE, {ATTR_PRESET_MODE: "sleep"}, "set_preset_mode"),
+        (SERVICE_SET_PERCENTAGE, {ATTR_PERCENTAGE: 50}, "set_percentage"),
+        (SERVICE_OSCILLATE, {ATTR_OSCILLATING: True}, "set_oscillation"),
+        (SERVICE_TURN_OFF, {}, "turn_off"),
+        (SERVICE_TURN_ON, {}, "turn_on"),
+    ],
+)
+async def test_standing_fan_command_failure(
+    hass: HomeAssistant,
+    mock_entry_factory: Callable[[str], MockConfigEntry],
+    service: str,
+    service_data: dict,
+    mock_method: str,
+) -> None:
+    """Test an unsuccessful command (device returns False) raises HomeAssistantError."""
+    inject_bluetooth_service_info(hass, STANDING_FAN_SERVICE_INFO)
+
+    entry = mock_entry_factory(sensor_type="standing_fan")
+    entry.add_to_hass(hass)
+    entity_id = "fan.test_name"
+
+    mocked_none = AsyncMock(return_value=None)
+    with patch.multiple(
+        "homeassistant.components.switchbot.fan.switchbot.SwitchbotStandingFan",
+        get_basic_info=mocked_none,
+        **{mock_method: AsyncMock(return_value=False)},
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        with pytest.raises(
+            HomeAssistantError, match="Failed to send the command to the fan"
+        ):
+            await hass.services.async_call(
+                FAN_DOMAIN,
+                service,
+                {**service_data, ATTR_ENTITY_ID: entity_id},
+                blocking=True,
+            )


### PR DESCRIPTION
## Proposed change

This is part of splitting #172109 into per-platform pull requests, as requested in review (one platform per PR, each based on `dev` and independently reviewable/mergeable).

This PR adds the **fan platform** for the SwitchBot Standing Fan (FAN2). The fan entity exposes:

- Five preset modes (Normal, Natural, Sleep, Baby, Custom Natural), via `StandingFanMode.get_modes()`.
- Percentage speed control.
- Oscillation toggle.
- Turn on/off.

To be self-contained and independently mergeable, this PR also registers the Standing Fan device itself (`const.py` / `__init__.py`, mapping it to `switchbot.SwitchbotStandingFan`) and the `STANDING_FAN_SERVICE_INFO` advertisement test fixture. It registers the `[Platform.FAN, Platform.SENSOR]` platforms. The switch and select platforms follow in separate PRs split from #172109.


## Note from SwitchBot team

This change is developed by the **official SwitchBot team**. The implementation has been verified with real hardware testing on physical devices.

If you have any questions or need clarification, please reach out:
- Discord: @7eaves
- GitHub: @fankai777
## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45557
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

