### PR TITLE
Add RGBIC Neon Rope Light support to switchbot

### DIFF
--- a/homeassistant/components/switchbot/__init__.py
+++ b/homeassistant/components/switchbot/__init__.py
@@ -197,7 +197,12 @@ PLATFORMS_BY_TYPE = {
         Platform.SENSOR,
     ],
     SupportedModels.WEATHER_STATION.value: [Platform.SENSOR],
-SupportedModels.CANDLE_WARMER_LAMP.value: [Platform.LIGHT, Platform.SENSOR],    SupportedModels.RGBIC_NEON_ROPE_LIGHT.value: [Platform.LIGHT, Platform.SENSOR],    SupportedModels.RGBIC_NEON_WIRE_ROPE_LIGHT.value: [        Platform.LIGHT,        Platform.SENSOR,    ],
+    SupportedModels.CANDLE_WARMER_LAMP.value: [Platform.LIGHT, Platform.SENSOR],
+    SupportedModels.RGBIC_NEON_ROPE_LIGHT.value: [Platform.LIGHT, Platform.SENSOR],
+    SupportedModels.RGBIC_NEON_WIRE_ROPE_LIGHT.value: [
+        Platform.LIGHT,
+        Platform.SENSOR,
+    ],
 }
 CLASS_BY_DEVICE = {
     SupportedModels.CEILING_LIGHT.value: switchbot.SwitchbotCeilingLight,
@@ -251,10 +256,17 @@ CLASS_BY_DEVICE = {
     SupportedModels.LOCK_VISION_PRO.value: switchbot.SwitchbotLock,
     SupportedModels.LOCK_VISION.value: switchbot.SwitchbotLock,
     SupportedModels.LOCK_PRO_WIFI.value: switchbot.SwitchbotLock,
-SupportedModels.CANDLE_WARMER_LAMP.value: switchbot.SwitchbotCandleWarmerLamp,    SupportedModels.RGBIC_NEON_ROPE_LIGHT.value: switchbot.SwitchbotRgbicNeonLight,    SupportedModels.RGBIC_NEON_WIRE_ROPE_LIGHT.value: switchbot.SwitchbotRgbicNeonLight,
+    SupportedModels.CANDLE_WARMER_LAMP.value: switchbot.SwitchbotCandleWarmerLamp,
+    SupportedModels.RGBIC_NEON_ROPE_LIGHT.value: switchbot.SwitchbotRgbicNeonLight,
+    SupportedModels.RGBIC_NEON_WIRE_ROPE_LIGHT.value: switchbot.SwitchbotRgbicNeonLight,
 }
 
-SupportedModels.CANDLE_WARMER_LAMP.value: switchbot.SwitchbotCandleWarmerLamp,    SupportedModels.RGBIC_NEON_ROPE_LIGHT.value: switchbot.SwitchbotRgbicNeonLight,    SupportedModels.RGBIC_NEON_WIRE_ROPE_LIGHT.value: switchbot.SwitchbotRgbicNeonLight,
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _migrate_deprecated_air_purifier_type(
+    hass: HomeAssistant, entry: SwitchbotConfigEntry
 ) -> bool:
     """Migrate deprecated air purifier sensor types introduced before pySwitchbot 2.0.0.
 

--- a/homeassistant/components/switchbot/__init__.py
+++ b/homeassistant/components/switchbot/__init__.py
@@ -197,7 +197,7 @@ PLATFORMS_BY_TYPE = {
         Platform.SENSOR,
     ],
     SupportedModels.WEATHER_STATION.value: [Platform.SENSOR],
-    SupportedModels.CANDLE_WARMER_LAMP.value: [Platform.LIGHT, Platform.SENSOR],
+SupportedModels.CANDLE_WARMER_LAMP.value: [Platform.LIGHT, Platform.SENSOR],    SupportedModels.RGBIC_NEON_ROPE_LIGHT.value: [Platform.LIGHT, Platform.SENSOR],    SupportedModels.RGBIC_NEON_WIRE_ROPE_LIGHT.value: [        Platform.LIGHT,        Platform.SENSOR,    ],
 }
 CLASS_BY_DEVICE = {
     SupportedModels.CEILING_LIGHT.value: switchbot.SwitchbotCeilingLight,
@@ -251,15 +251,10 @@ CLASS_BY_DEVICE = {
     SupportedModels.LOCK_VISION_PRO.value: switchbot.SwitchbotLock,
     SupportedModels.LOCK_VISION.value: switchbot.SwitchbotLock,
     SupportedModels.LOCK_PRO_WIFI.value: switchbot.SwitchbotLock,
-    SupportedModels.CANDLE_WARMER_LAMP.value: switchbot.SwitchbotCandleWarmerLamp,
+SupportedModels.CANDLE_WARMER_LAMP.value: switchbot.SwitchbotCandleWarmerLamp,    SupportedModels.RGBIC_NEON_ROPE_LIGHT.value: switchbot.SwitchbotRgbicNeonLight,    SupportedModels.RGBIC_NEON_WIRE_ROPE_LIGHT.value: switchbot.SwitchbotRgbicNeonLight,
 }
 
-
-_LOGGER = logging.getLogger(__name__)
-
-
-def _migrate_deprecated_air_purifier_type(
-    hass: HomeAssistant, entry: SwitchbotConfigEntry
+SupportedModels.CANDLE_WARMER_LAMP.value: switchbot.SwitchbotCandleWarmerLamp,    SupportedModels.RGBIC_NEON_ROPE_LIGHT.value: switchbot.SwitchbotRgbicNeonLight,    SupportedModels.RGBIC_NEON_WIRE_ROPE_LIGHT.value: switchbot.SwitchbotRgbicNeonLight,
 ) -> bool:
     """Migrate deprecated air purifier sensor types introduced before pySwitchbot 2.0.0.
 

--- a/homeassistant/components/switchbot/const.py
+++ b/homeassistant/components/switchbot/const.py
@@ -71,8 +71,7 @@ class SupportedModels(StrEnum):
     LOCK_VISION = "lock_vision"
     LOCK_PRO_WIFI = "lock_pro_wifi"
     WEATHER_STATION = "weather_station"
-    STANDING_FAN = "standing_fan"
-    CANDLE_WARMER_LAMP = "candle_warmer_lamp"
+CANDLE_WARMER_LAMP = "candle_warmer_lamp"    RGBIC_NEON_ROPE_LIGHT = "rgbic_neon_rope_light"    RGBIC_NEON_WIRE_ROPE_LIGHT = "rgbic_neon_wire_rope_light"
 
 
 CONNECTABLE_SUPPORTED_MODEL_TYPES = {
@@ -123,13 +122,9 @@ CONNECTABLE_SUPPORTED_MODEL_TYPES = {
     SwitchbotModel.LOCK_VISION: SupportedModels.LOCK_VISION,
     SwitchbotModel.LOCK_PRO_WIFI: SupportedModels.LOCK_PRO_WIFI,
     SwitchbotModel.STANDING_FAN: SupportedModels.STANDING_FAN,
-    SwitchbotModel.CANDLE_WARMER_LAMP: SupportedModels.CANDLE_WARMER_LAMP,
-}
-
-NON_CONNECTABLE_SUPPORTED_MODEL_TYPES = {
-    SwitchbotModel.METER: SupportedModels.HYGROMETER,
-    SwitchbotModel.IO_METER: SupportedModels.HYGROMETER,
-    SwitchbotModel.METER_PRO: SupportedModels.HYGROMETER,
+    SwitchbotModel.CANDLE_WARMER_LAMP: SupportedModels.CANDLE_WARMER_LAMP,    SwitchbotModel.RGBIC_NEON_ROPE_LIGHT: SupportedModels.RGBIC_NEON_ROPE_LIGHT,
+    SwitchbotModel.RGBIC_NEON_WIRE_ROPE_LIGHT: (
+SwitchbotModel.CANDLE_WARMER_LAMP: SupportedModels.CANDLE_WARMER_LAMP,    SwitchbotModel.RGBIC_NEON_ROPE_LIGHT: SupportedModels.RGBIC_NEON_ROPE_LIGHT,    SwitchbotModel.RGBIC_NEON_WIRE_ROPE_LIGHT: (        SupportedModels.RGBIC_NEON_WIRE_ROPE_LIGHT    ),
     SwitchbotModel.METER_PRO_C: SupportedModels.HYGROMETER_CO2,
     SwitchbotModel.CONTACT_SENSOR: SupportedModels.CONTACT,
     SwitchbotModel.MOTION_SENSOR: SupportedModels.MOTION,
@@ -173,8 +168,7 @@ ENCRYPTED_MODELS = {
     SwitchbotModel.LOCK_VISION_PRO,
     SwitchbotModel.LOCK_VISION,
     SwitchbotModel.LOCK_PRO_WIFI,
-    SwitchbotModel.CANDLE_WARMER_LAMP,
-}
+SwitchbotModel.CANDLE_WARMER_LAMP,    SwitchbotModel.RGBIC_NEON_ROPE_LIGHT,    SwitchbotModel.RGBIC_NEON_WIRE_ROPE_LIGHT,
 
 ENCRYPTED_SWITCHBOT_MODEL_TO_CLASS: dict[
     SwitchbotModel, switchbot.SwitchbotEncryptedDevice
@@ -207,7 +201,8 @@ ENCRYPTED_SWITCHBOT_MODEL_TO_CLASS: dict[
     SwitchbotModel.LOCK_VISION_PRO: switchbot.SwitchbotLock,
     SwitchbotModel.LOCK_VISION: switchbot.SwitchbotLock,
     SwitchbotModel.LOCK_PRO_WIFI: switchbot.SwitchbotLock,
-    SwitchbotModel.CANDLE_WARMER_LAMP: switchbot.SwitchbotCandleWarmerLamp,
+    SwitchbotModel.CANDLE_WARMER_LAMP: switchbot.SwitchbotCandleWarmerLamp,    SwitchbotModel.RGBIC_NEON_ROPE_LIGHT: switchbot.SwitchbotRgbicNeonLight,
+    SwitchbotModel.RGBIC_NEON_WIRE_ROPE_LIGHT: switchbot.SwitchbotRgbicNeonLight,
 }
 
 HASS_SENSOR_TYPE_TO_SWITCHBOT_MODEL = {

--- a/homeassistant/components/switchbot/const.py
+++ b/homeassistant/components/switchbot/const.py
@@ -71,7 +71,10 @@ class SupportedModels(StrEnum):
     LOCK_VISION = "lock_vision"
     LOCK_PRO_WIFI = "lock_pro_wifi"
     WEATHER_STATION = "weather_station"
-CANDLE_WARMER_LAMP = "candle_warmer_lamp"    RGBIC_NEON_ROPE_LIGHT = "rgbic_neon_rope_light"    RGBIC_NEON_WIRE_ROPE_LIGHT = "rgbic_neon_wire_rope_light"
+    STANDING_FAN = "standing_fan"
+    CANDLE_WARMER_LAMP = "candle_warmer_lamp"
+    RGBIC_NEON_ROPE_LIGHT = "rgbic_neon_rope_light"
+    RGBIC_NEON_WIRE_ROPE_LIGHT = "rgbic_neon_wire_rope_light"
 
 
 CONNECTABLE_SUPPORTED_MODEL_TYPES = {
@@ -122,9 +125,17 @@ CONNECTABLE_SUPPORTED_MODEL_TYPES = {
     SwitchbotModel.LOCK_VISION: SupportedModels.LOCK_VISION,
     SwitchbotModel.LOCK_PRO_WIFI: SupportedModels.LOCK_PRO_WIFI,
     SwitchbotModel.STANDING_FAN: SupportedModels.STANDING_FAN,
-    SwitchbotModel.CANDLE_WARMER_LAMP: SupportedModels.CANDLE_WARMER_LAMP,    SwitchbotModel.RGBIC_NEON_ROPE_LIGHT: SupportedModels.RGBIC_NEON_ROPE_LIGHT,
+    SwitchbotModel.CANDLE_WARMER_LAMP: SupportedModels.CANDLE_WARMER_LAMP,
+    SwitchbotModel.RGBIC_NEON_ROPE_LIGHT: SupportedModels.RGBIC_NEON_ROPE_LIGHT,
     SwitchbotModel.RGBIC_NEON_WIRE_ROPE_LIGHT: (
-SwitchbotModel.CANDLE_WARMER_LAMP: SupportedModels.CANDLE_WARMER_LAMP,    SwitchbotModel.RGBIC_NEON_ROPE_LIGHT: SupportedModels.RGBIC_NEON_ROPE_LIGHT,    SwitchbotModel.RGBIC_NEON_WIRE_ROPE_LIGHT: (        SupportedModels.RGBIC_NEON_WIRE_ROPE_LIGHT    ),
+        SupportedModels.RGBIC_NEON_WIRE_ROPE_LIGHT
+    ),
+}
+
+NON_CONNECTABLE_SUPPORTED_MODEL_TYPES = {
+    SwitchbotModel.METER: SupportedModels.HYGROMETER,
+    SwitchbotModel.IO_METER: SupportedModels.HYGROMETER,
+    SwitchbotModel.METER_PRO: SupportedModels.HYGROMETER,
     SwitchbotModel.METER_PRO_C: SupportedModels.HYGROMETER_CO2,
     SwitchbotModel.CONTACT_SENSOR: SupportedModels.CONTACT,
     SwitchbotModel.MOTION_SENSOR: SupportedModels.MOTION,
@@ -168,7 +179,10 @@ ENCRYPTED_MODELS = {
     SwitchbotModel.LOCK_VISION_PRO,
     SwitchbotModel.LOCK_VISION,
     SwitchbotModel.LOCK_PRO_WIFI,
-SwitchbotModel.CANDLE_WARMER_LAMP,    SwitchbotModel.RGBIC_NEON_ROPE_LIGHT,    SwitchbotModel.RGBIC_NEON_WIRE_ROPE_LIGHT,
+    SwitchbotModel.CANDLE_WARMER_LAMP,
+    SwitchbotModel.RGBIC_NEON_ROPE_LIGHT,
+    SwitchbotModel.RGBIC_NEON_WIRE_ROPE_LIGHT,
+}
 
 ENCRYPTED_SWITCHBOT_MODEL_TO_CLASS: dict[
     SwitchbotModel, switchbot.SwitchbotEncryptedDevice
@@ -201,7 +215,8 @@ ENCRYPTED_SWITCHBOT_MODEL_TO_CLASS: dict[
     SwitchbotModel.LOCK_VISION_PRO: switchbot.SwitchbotLock,
     SwitchbotModel.LOCK_VISION: switchbot.SwitchbotLock,
     SwitchbotModel.LOCK_PRO_WIFI: switchbot.SwitchbotLock,
-    SwitchbotModel.CANDLE_WARMER_LAMP: switchbot.SwitchbotCandleWarmerLamp,    SwitchbotModel.RGBIC_NEON_ROPE_LIGHT: switchbot.SwitchbotRgbicNeonLight,
+    SwitchbotModel.CANDLE_WARMER_LAMP: switchbot.SwitchbotCandleWarmerLamp,
+    SwitchbotModel.RGBIC_NEON_ROPE_LIGHT: switchbot.SwitchbotRgbicNeonLight,
     SwitchbotModel.RGBIC_NEON_WIRE_ROPE_LIGHT: switchbot.SwitchbotRgbicNeonLight,
 }
 

--- a/tests/components/switchbot/__init__.py
+++ b/tests/components/switchbot/__init__.py
@@ -1104,7 +1104,14 @@ CANDLE_WARMER_LAMP_SERVICE_INFO = BluetoothServiceInfoBleak(
     manufacturer_data={
         2409: b"\x90\xe5\xb1h\xda\xaa\n\xb0 \x00",
     },
-    service_data={"0000fd3d-0000-1000-8000-00805f9b34fb": b'\x00\x00\x00\x00\x11"\xb8'},
+    service_data={"0000fd3d-0000-1000-8000-00805f9b34fb": b'\x00\x00\x00\x00\x11"\xb8'},RGBIC_NEON_LIGHT_SERVICE_INFO = BluetoothServiceInfoBleak(
+    name="RGBIC Neon Rope Light",
+    manufacturer_data={
+        2409: b'\xdc\x06u\xa6\xfb\xb2y\x9e"\x00\x11\xb8\x00',
+    },
+    service_data={
+        "0000fd3d-0000-1000-8000-00805f9b34fb": b"\x00\x00\x00\x00\x10\xd0\xb6"
+    },
     service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
     address="AA:BB:CC:DD:EE:FF",
     rssi=-60,
@@ -1119,7 +1126,16 @@ CANDLE_WARMER_LAMP_SERVICE_INFO = BluetoothServiceInfoBleak(
         },
         service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
     ),
-    device=generate_ble_device("AA:BB:CC:DD:EE:FF", "Candle Warmer Lamp"),
+    device=generate_ble_device("AA:BB:CC:DD:EE:FF", "Candle Warmer Lamp"),        local_name="RGBIC Neon Rope Light",
+        manufacturer_data={
+            2409: b'\xdc\x06u\xa6\xfb\xb2y\x9e"\x00\x11\xb8\x00',
+        },
+        service_data={
+            "0000fd3d-0000-1000-8000-00805f9b34fb": b"\x00\x00\x00\x00\x10\xd0\xb6"
+        },
+        service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
+    ),
+    device=generate_ble_device("AA:BB:CC:DD:EE:FF", "RGBIC Neon Rope Light"),
     time=0,
     connectable=True,
     tx_power=-127,

--- a/tests/components/switchbot/__init__.py
+++ b/tests/components/switchbot/__init__.py
@@ -1104,14 +1104,7 @@ CANDLE_WARMER_LAMP_SERVICE_INFO = BluetoothServiceInfoBleak(
     manufacturer_data={
         2409: b"\x90\xe5\xb1h\xda\xaa\n\xb0 \x00",
     },
-    service_data={"0000fd3d-0000-1000-8000-00805f9b34fb": b'\x00\x00\x00\x00\x11"\xb8'},RGBIC_NEON_LIGHT_SERVICE_INFO = BluetoothServiceInfoBleak(
-    name="RGBIC Neon Rope Light",
-    manufacturer_data={
-        2409: b'\xdc\x06u\xa6\xfb\xb2y\x9e"\x00\x11\xb8\x00',
-    },
-    service_data={
-        "0000fd3d-0000-1000-8000-00805f9b34fb": b"\x00\x00\x00\x00\x10\xd0\xb6"
-    },
+    service_data={"0000fd3d-0000-1000-8000-00805f9b34fb": b'\x00\x00\x00\x00\x11"\xb8'},
     service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
     address="AA:BB:CC:DD:EE:FF",
     rssi=-60,
@@ -1126,7 +1119,26 @@ CANDLE_WARMER_LAMP_SERVICE_INFO = BluetoothServiceInfoBleak(
         },
         service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
     ),
-    device=generate_ble_device("AA:BB:CC:DD:EE:FF", "Candle Warmer Lamp"),        local_name="RGBIC Neon Rope Light",
+    device=generate_ble_device("AA:BB:CC:DD:EE:FF", "Candle Warmer Lamp"),
+    time=0,
+    connectable=True,
+    tx_power=-127,
+)
+
+RGBIC_NEON_LIGHT_SERVICE_INFO = BluetoothServiceInfoBleak(
+    name="RGBIC Neon Rope Light",
+    manufacturer_data={
+        2409: b'\xdc\x06u\xa6\xfb\xb2y\x9e"\x00\x11\xb8\x00',
+    },
+    service_data={
+        "0000fd3d-0000-1000-8000-00805f9b34fb": b"\x00\x00\x00\x00\x10\xd0\xb6"
+    },
+    service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
+    address="AA:BB:CC:DD:EE:FF",
+    rssi=-60,
+    source="local",
+    advertisement=generate_advertisement_data(
+        local_name="RGBIC Neon Rope Light",
         manufacturer_data={
             2409: b'\xdc\x06u\xa6\xfb\xb2y\x9e"\x00\x11\xb8\x00',
         },

--- a/tests/components/switchbot/test_light.py
+++ b/tests/components/switchbot/test_light.py
@@ -31,6 +31,7 @@ from . import (
     CEILING_LIGHT_SERVICE_INFO,
     FLOOR_LAMP_SERVICE_INFO,
     PERMANENT_OUTDOOR_LIGHT_SERVICE_INFO,
+    RGBIC_NEON_LIGHT_SERVICE_INFO,
     RGBICWW_FLOOR_LAMP_SERVICE_INFO,
     RGBICWW_STRIP_LIGHT_SERVICE_INFO,
     STRIP_LIGHT_3_SERVICE_INFO,
@@ -133,12 +134,13 @@ FLOOR_LAMP_PARAMETERS = (
     ],
 )
 
-CANDLE_WARMER_LAMP_PARAMETERS = (
+CANDLE_WARMER_LAMP_PARAMETERS = (RGBIC_NEON_LIGHT_PARAMETERS = (
     COMMON_PARAMETERS,
     [
         TURN_ON_PARAMETERS,
         TURN_OFF_PARAMETERS,
         SET_BRIGHTNESS_PARAMETERS,
+SET_RGB_PARAMETERS,        (            SERVICE_TURN_ON,            {ATTR_EFFECT: "party"},            "set_effect",            ("party",),        ),
     ],
 )
 
@@ -534,6 +536,81 @@ async def test_candle_warmer_lamp_services_exception(
     error_message = "An error occurred while performing the action: Operation failed"
     with patch.multiple(
         "homeassistant.components.switchbot.light.switchbot.SwitchbotCandleWarmerLamp",
+        **{mock_method: AsyncMock(side_effect=exception)},
+        update=AsyncMock(return_value=None),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        with pytest.raises(HomeAssistantError, match=error_message):
+            await hass.services.async_call(
+                LIGHT_DOMAIN,
+                service,
+                {**service_data, ATTR_ENTITY_ID: entity_id},
+                blocking=True,
+            )
+
+
+@pytest.mark.parametrize(
+    "sensor_type",
+    ["rgbic_neon_rope_light", "rgbic_neon_wire_rope_light"],
+)
+@pytest.mark.parametrize(*RGBIC_NEON_LIGHT_PARAMETERS)
+async def test_rgbic_neon_light_services(
+    hass: HomeAssistant,
+    mock_entry_encrypted_factory: Callable[[str], MockConfigEntry],
+    sensor_type: str,
+    service: str,
+    service_data: dict,
+    mock_method: str,
+    expected_args: Any,
+) -> None:
+    """Test all SwitchBot RGBIC neon light services."""
+    inject_bluetooth_service_info(hass, RGBIC_NEON_LIGHT_SERVICE_INFO)
+
+    entry = mock_entry_encrypted_factory(sensor_type=sensor_type)
+    entry.add_to_hass(hass)
+    entity_id = "light.test_name"
+
+    mocked_instance = AsyncMock(return_value=True)
+
+    with patch.multiple(
+        "homeassistant.components.switchbot.light.switchbot.SwitchbotRgbicNeonLight",
+        **{mock_method: mocked_instance},
+        update=AsyncMock(return_value=None),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            service,
+            {**service_data, ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
+
+        mocked_instance.assert_awaited_once_with(*expected_args)
+
+
+@pytest.mark.parametrize(*RGBIC_NEON_LIGHT_PARAMETERS)
+async def test_rgbic_neon_light_services_exception(
+    hass: HomeAssistant,
+    mock_entry_encrypted_factory: Callable[[str], MockConfigEntry],
+    service: str,
+    service_data: dict,
+    mock_method: str,
+    expected_args: Any,
+) -> None:
+    """Test all SwitchBot RGBIC neon light services with exception."""
+    inject_bluetooth_service_info(hass, RGBIC_NEON_LIGHT_SERVICE_INFO)
+
+    entry = mock_entry_encrypted_factory(sensor_type="rgbic_neon_rope_light")
+    entry.add_to_hass(hass)
+    entity_id = "light.test_name"
+    exception = SwitchbotOperationError("Operation failed")
+    error_message = "An error occurred while performing the action: Operation failed"
+    with patch.multiple(
+        "homeassistant.components.switchbot.light.switchbot.SwitchbotRgbicNeonLight",
         **{mock_method: AsyncMock(side_effect=exception)},
         update=AsyncMock(return_value=None),
     ):

--- a/tests/components/switchbot/test_light.py
+++ b/tests/components/switchbot/test_light.py
@@ -134,13 +134,28 @@ FLOOR_LAMP_PARAMETERS = (
     ],
 )
 
-CANDLE_WARMER_LAMP_PARAMETERS = (RGBIC_NEON_LIGHT_PARAMETERS = (
+CANDLE_WARMER_LAMP_PARAMETERS = (
     COMMON_PARAMETERS,
     [
         TURN_ON_PARAMETERS,
         TURN_OFF_PARAMETERS,
         SET_BRIGHTNESS_PARAMETERS,
-SET_RGB_PARAMETERS,        (            SERVICE_TURN_ON,            {ATTR_EFFECT: "party"},            "set_effect",            ("party",),        ),
+    ],
+)
+
+RGBIC_NEON_LIGHT_PARAMETERS = (
+    COMMON_PARAMETERS,
+    [
+        TURN_ON_PARAMETERS,
+        TURN_OFF_PARAMETERS,
+        SET_BRIGHTNESS_PARAMETERS,
+        SET_RGB_PARAMETERS,
+        (
+            SERVICE_TURN_ON,
+            {ATTR_EFFECT: "party"},
+            "set_effect",
+            ("party",),
+        ),
     ],
 )
 


### PR DESCRIPTION
## Proposed change

This PR adds support for the **SwitchBot RGBIC Neon Rope Light** and **RGBIC Neon Wire Rope Light** to the SwitchBot integration. Both models are driven by the same `switchbot.SwitchbotRgbicNeonLight` device class:

- `SwitchbotModel.RGBIC_NEON_ROPE_LIGHT`
- `SwitchbotModel.RGBIC_NEON_WIRE_ROPE_LIGHT`

These are RGB encrypted lights with effect support (no color temperature). Like the existing RGBIC strip/floor lights, they are wired up via the generic `SwitchbotLightEntity`, which already drives RGB, brightness and effects from the device properties — so no new entity class is required:

- `const.py`: register both models in `SupportedModels`, `CONNECTABLE_SUPPORTED_MODEL_TYPES`, `ENCRYPTED_MODELS` and `ENCRYPTED_SWITCHBOT_MODEL_TO_CLASS`.
- `__init__.py`: register `[Platform.LIGHT, Platform.SENSOR]` and the device class for both models.

Support for these devices was added to the underlying `PySwitchbot` library in aronsho/pySwitchbot#452, which is already part of the pinned `PySwitchbot==2.2.0`; no dependency bump is required.


## Note from SwitchBot team

This change is developed by the **official SwitchBot team**. The implementation has been verified with real hardware testing on physical devices.

If you have any questions or need clarification, please reach out:
- Discord: @7eaves
- GitHub: @fankai777
## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)


