### PR TITLE
Add on demand template framework to template entities

### DIFF
--- a/homeassistant/components/template/entity.py
+++ b/homeassistant/components/template/entity.py
@@ -7,10 +7,16 @@ from typing import Any
 
 from homeassistant.const import CONF_DEVICE_ID, CONF_OPTIMISTIC
 from homeassistant.core import Context, HomeAssistant, callback
+from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import Entity, async_generate_entity_id
 from homeassistant.helpers.script import Script, _VarsType
-from homeassistant.helpers.template import Template, TemplateStateFromEntityId
+from homeassistant.helpers.template import (
+    Template,
+    TemplateStateFromEntityId,
+    render_complex as template_render_complex,
+)
+from homeassistant.helpers.trigger_template_entity import log_triggered_template_error
 from homeassistant.helpers.typing import ConfigType
 
 from .const import CONF_DEFAULT_ENTITY_ID
@@ -25,6 +31,15 @@ class EntityTemplate:
     validator: Callable[[Any], Any] | None
     on_update: Callable[[Any], None] | None
     none_on_template_error: bool
+
+
+@dataclass
+class OnDemandTemplate:
+    """Information class for properly handling on-demand template results."""
+
+    template: Template
+    validator: Callable[[Any], Any] | None
+    render_complex: bool
 
 
 class AbstractTemplateEntity(Entity):
@@ -45,6 +60,7 @@ class AbstractTemplateEntity(Entity):
         self.hass = hass
         self._config = config
         self._templates: dict[str, EntityTemplate] = {}
+        self._on_demand_templates: dict[str, OnDemandTemplate] = {}
         self._action_scripts: dict[str, Script] = {}
 
         if self._optimistic_entity:
@@ -79,8 +95,12 @@ class AbstractTemplateEntity(Entity):
 
     @callback
     @abstractmethod
-    def _render_script_variables(self) -> dict:
+    def _render_script_variables(self) -> dict[str, Any]:
         """Render configured variables."""
+
+    @abstractmethod
+    def _render_entity_variables(self) -> dict[str, Any]:
+        """Render entity variables."""
 
     @abstractmethod
     def setup_state_template(
@@ -130,6 +150,62 @@ class AbstractTemplateEntity(Entity):
             If set to false, template errors will be supplied in the result to
             on_update.
         """
+
+    def setup_on_demand_template(
+        self,
+        option: str,
+        validator: Callable[[Any], Any] | None = None,
+        render_complex: bool = False,
+    ) -> None:
+        """Set up a template that renders and validates the result on demand.
+
+        Add a template that will only render when render_on_demand_template is called.
+
+        Parameters
+        ----------
+        option
+            The configuration key provided by ConfigFlow or the yaml option
+        validator:
+            Optional function that validates the rendered result.
+        on_update:
+            Callback to handle the template validated template result.
+            Passed the result of the validator.
+        render_complex (default=False):
+            This signals trigger based template entities to render the template
+            as a complex result. State based template entities always render
+            complex results.
+        none_on_template_error (default=True)
+            If set to false, template errors will be supplied in the result to
+            on_update.
+        """
+        if (template := self._config.get(option)) and isinstance(template, Template):
+            self._on_demand_templates[option] = OnDemandTemplate(
+                template, validator, render_complex
+            )
+
+    def render_on_demand_template(self, option: str) -> Any | None:
+        """Render an on demand template and return the validated result."""
+        if (on_demand_template := self._on_demand_templates.get(option)) is not None:
+            variables = self._render_entity_variables()
+
+            rendered = None
+            try:
+                if on_demand_template.render_complex:
+                    rendered = template_render_complex(
+                        on_demand_template.template, variables
+                    )
+                else:
+                    rendered = on_demand_template.template.async_render(variables)
+            except TemplateError as err:
+                log_triggered_template_error(self.entity_id, err, option)
+
+            return (
+                on_demand_template.validator(rendered)
+                if on_demand_template.validator
+                else rendered
+            )
+
+        return None
 
     def add_template(
         self,

--- a/homeassistant/components/template/entity.py
+++ b/homeassistant/components/template/entity.py
@@ -167,16 +167,10 @@ class AbstractTemplateEntity(Entity):
             The configuration key provided by ConfigFlow or the yaml option
         validator:
             Optional function that validates the rendered result.
-        on_update:
-            Callback to handle the template validated template result.
-            Passed the result of the validator.
         render_complex (default=False):
             This signals trigger based template entities to render the template
             as a complex result. State based template entities always render
             complex results.
-        none_on_template_error (default=True)
-            If set to false, template errors will be supplied in the result to
-            on_update.
         """
         if (template := self._config.get(option)) and isinstance(template, Template):
             self._on_demand_templates[option] = OnDemandTemplate(

--- a/homeassistant/components/template/template_entity.py
+++ b/homeassistant/components/template/template_entity.py
@@ -292,6 +292,10 @@ class TemplateEntity(AbstractTemplateEntity):
             self.hass, {"this": self._get_this_variable()}
         )
 
+    def _render_entity_variables(self) -> dict[str, Any]:
+        """Render entity variables."""
+        return self._render_script_variables()
+
     def setup_state_template(
         self,
         attribute: str,

--- a/homeassistant/components/template/trigger_entity.py
+++ b/homeassistant/components/template/trigger_entity.py
@@ -146,11 +146,11 @@ class TriggerEntity(  # pylint: disable=home-assistant-enforce-class-module
         return super().available
 
     @callback
-    def _render_script_variables(self) -> dict:
+    def _render_script_variables(self) -> dict[str, Any]:
         """Render configured variables."""
         return self._rendered_entity_variables or {}
 
-    def _render_entity_variables(self):
+    def _render_entity_variables(self) -> dict[str, Any]:
         """Render entity variables."""
 
         # Attach this variable to coordinator variables

--- a/homeassistant/components/template/trigger_entity.py
+++ b/homeassistant/components/template/trigger_entity.py
@@ -150,6 +150,24 @@ class TriggerEntity(  # pylint: disable=home-assistant-enforce-class-module
         """Render configured variables."""
         return self._rendered_entity_variables or {}
 
+    def _render_entity_variables(self):
+        """Render entity variables."""
+
+        # Attach this variable to coordinator variables
+        coordinator_variables = self._template_variables(
+            self.coordinator.data["run_variables"]
+        )
+        if self._entity_variables:
+            entity_variables = self._entity_variables.async_simple_render(
+                coordinator_variables
+            )
+            return {
+                **coordinator_variables,
+                **entity_variables,
+            }
+
+        return coordinator_variables
+
     def _render_single_template(
         self,
         key: str,
@@ -240,19 +258,7 @@ class TriggerEntity(  # pylint: disable=home-assistant-enforce-class-module
     @callback
     def _process_data(self) -> None:
         """Process new data."""
-
-        coordinator_variables = self.coordinator.data["run_variables"]
-        if self._entity_variables:
-            entity_variables = self._entity_variables.async_simple_render(
-                coordinator_variables
-            )
-            self._rendered_entity_variables = {
-                **coordinator_variables,
-                **entity_variables,
-            }
-        else:
-            self._rendered_entity_variables = coordinator_variables
-        variables = self._template_variables(self._rendered_entity_variables)
+        self._rendered_entity_variables = variables = self._render_entity_variables()
 
         self.async_set_context(self.coordinator.data["context"])
         if self._render_availability_template(variables):

--- a/homeassistant/components/template/weather.py
+++ b/homeassistant/components/template/weather.py
@@ -466,28 +466,22 @@ class AbstractTemplateWeather(AbstractTemplateEntity, WeatherEntity):
 
         # Forecasts
 
-        self._forecast_daily: list[Forecast] | None = []
-        self.setup_template(
+        self.setup_on_demand_template(
             CONF_FORECAST_DAILY,
-            "_forecast_daily",
             validate_forecast(self, CONF_FORECAST_DAILY, "daily"),
-            self._update_forecast("daily"),
+            render_complex=True,
         )
 
-        self._forecast_hourly: list[Forecast] | None = []
-        self.setup_template(
+        self.setup_on_demand_template(
             CONF_FORECAST_HOURLY,
-            "_forecast_hourly",
             validate_forecast(self, CONF_FORECAST_HOURLY, "hourly"),
-            self._update_forecast("hourly"),
+            render_complex=True,
         )
 
-        self._forecast_twice_daily: list[Forecast] | None = []
-        self.setup_template(
+        self.setup_on_demand_template(
             CONF_FORECAST_TWICE_DAILY,
-            "_forecast_twice_daily",
             validate_forecast(self, CONF_FORECAST_TWICE_DAILY, "twice_daily"),
-            self._update_forecast("twice_daily"),
+            render_complex=True,
         )
 
         # Legacy support
@@ -502,11 +496,11 @@ class AbstractTemplateWeather(AbstractTemplateEntity, WeatherEntity):
 
         # Supported Features
         self._attr_supported_features = 0
-        if CONF_FORECAST_DAILY in self._templates:
+        if CONF_FORECAST_DAILY in self._on_demand_templates:
             self._attr_supported_features |= WeatherEntityFeature.FORECAST_DAILY
-        if CONF_FORECAST_HOURLY in self._templates:
+        if CONF_FORECAST_HOURLY in self._on_demand_templates:
             self._attr_supported_features |= WeatherEntityFeature.FORECAST_HOURLY
-        if CONF_FORECAST_TWICE_DAILY in self._templates:
+        if CONF_FORECAST_TWICE_DAILY in self._on_demand_templates:
             self._attr_supported_features |= WeatherEntityFeature.FORECAST_TWICE_DAILY
 
     @property
@@ -523,32 +517,29 @@ class AbstractTemplateWeather(AbstractTemplateEntity, WeatherEntity):
         except vol.Invalid:
             self._attr_wind_bearing = vol.Coerce(str)(result)
 
-    @callback
-    def _update_forecast(
+    def _get_forecast(
         self,
+        option: str,
         forecast_type: Literal["daily", "hourly", "twice_daily"],
-    ) -> Callable[[list[Forecast] | None], None]:
-        """Save template result and trigger forecast listener."""
-
-        def update(result: list[Forecast] | None) -> None:
-            setattr(self, f"_forecast_{forecast_type}", result)
-            self.hass.async_create_task(
-                self.async_update_listeners([forecast_type]), eager_start=True
-            )
-
-        return update
+    ) -> list[Forecast]:
+        """Get template forecast result and trigger forecast listener."""
+        result = self.render_on_demand_template(option)
+        self.hass.async_create_task(
+            self.async_update_listeners([forecast_type]), eager_start=True
+        )
+        return result or []
 
     async def async_forecast_daily(self) -> list[Forecast]:
         """Return the daily forecast in native units."""
-        return self._forecast_daily or []
+        return self._get_forecast(CONF_FORECAST_DAILY, "daily")
 
     async def async_forecast_hourly(self) -> list[Forecast]:
         """Return the daily forecast in native units."""
-        return self._forecast_hourly or []
+        return self._get_forecast(CONF_FORECAST_HOURLY, "hourly")
 
     async def async_forecast_twice_daily(self) -> list[Forecast]:
         """Return the daily forecast in native units."""
-        return self._forecast_twice_daily or []
+        return self._get_forecast(CONF_FORECAST_TWICE_DAILY, "twice_daily")
 
 
 class StateWeatherEntity(TemplateEntity, AbstractTemplateWeather):

--- a/homeassistant/components/template/weather.py
+++ b/homeassistant/components/template/weather.py
@@ -466,22 +466,28 @@ class AbstractTemplateWeather(AbstractTemplateEntity, WeatherEntity):
 
         # Forecasts
 
-        self.setup_on_demand_template(
+        self._forecast_daily: list[Forecast] | None = []
+        self.setup_template(
             CONF_FORECAST_DAILY,
+            "_forecast_daily",
             validate_forecast(self, CONF_FORECAST_DAILY, "daily"),
-            render_complex=True,
+            self._update_forecast("daily"),
         )
 
-        self.setup_on_demand_template(
+        self._forecast_hourly: list[Forecast] | None = []
+        self.setup_template(
             CONF_FORECAST_HOURLY,
+            "_forecast_hourly",
             validate_forecast(self, CONF_FORECAST_HOURLY, "hourly"),
-            render_complex=True,
+            self._update_forecast("hourly"),
         )
 
-        self.setup_on_demand_template(
+        self._forecast_twice_daily: list[Forecast] | None = []
+        self.setup_template(
             CONF_FORECAST_TWICE_DAILY,
+            "_forecast_twice_daily",
             validate_forecast(self, CONF_FORECAST_TWICE_DAILY, "twice_daily"),
-            render_complex=True,
+            self._update_forecast("twice_daily"),
         )
 
         # Legacy support
@@ -496,11 +502,11 @@ class AbstractTemplateWeather(AbstractTemplateEntity, WeatherEntity):
 
         # Supported Features
         self._attr_supported_features = 0
-        if CONF_FORECAST_DAILY in self._on_demand_templates:
+        if CONF_FORECAST_DAILY in self._templates:
             self._attr_supported_features |= WeatherEntityFeature.FORECAST_DAILY
-        if CONF_FORECAST_HOURLY in self._on_demand_templates:
+        if CONF_FORECAST_HOURLY in self._templates:
             self._attr_supported_features |= WeatherEntityFeature.FORECAST_HOURLY
-        if CONF_FORECAST_TWICE_DAILY in self._on_demand_templates:
+        if CONF_FORECAST_TWICE_DAILY in self._templates:
             self._attr_supported_features |= WeatherEntityFeature.FORECAST_TWICE_DAILY
 
     @property
@@ -517,29 +523,32 @@ class AbstractTemplateWeather(AbstractTemplateEntity, WeatherEntity):
         except vol.Invalid:
             self._attr_wind_bearing = vol.Coerce(str)(result)
 
-    def _get_forecast(
+    @callback
+    def _update_forecast(
         self,
-        option: str,
         forecast_type: Literal["daily", "hourly", "twice_daily"],
-    ) -> list[Forecast]:
-        """Get template forecast result and trigger forecast listener."""
-        result = self.render_on_demand_template(option)
-        self.hass.async_create_task(
-            self.async_update_listeners([forecast_type]), eager_start=True
-        )
-        return result or []
+    ) -> Callable[[list[Forecast] | None], None]:
+        """Save template result and trigger forecast listener."""
+
+        def update(result: list[Forecast] | None) -> None:
+            setattr(self, f"_forecast_{forecast_type}", result)
+            self.hass.async_create_task(
+                self.async_update_listeners([forecast_type]), eager_start=True
+            )
+
+        return update
 
     async def async_forecast_daily(self) -> list[Forecast]:
         """Return the daily forecast in native units."""
-        return self._get_forecast(CONF_FORECAST_DAILY, "daily")
+        return self._forecast_daily or []
 
     async def async_forecast_hourly(self) -> list[Forecast]:
         """Return the daily forecast in native units."""
-        return self._get_forecast(CONF_FORECAST_HOURLY, "hourly")
+        return self._forecast_hourly or []
 
     async def async_forecast_twice_daily(self) -> list[Forecast]:
         """Return the daily forecast in native units."""
-        return self._get_forecast(CONF_FORECAST_TWICE_DAILY, "twice_daily")
+        return self._forecast_twice_daily or []
 
 
 class StateWeatherEntity(TemplateEntity, AbstractTemplateWeather):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a framework to template entities that renders templates when `render_on_demand_template` is called.  This is useful for templates that only need to update when a service is called, or a property is accessed.  E.g.  Update Release Notes.

Adds 2 new methods:

setup_on_demand_template - a method that can be called in a construtor to add an on-demand template to the entity

render_on_demand_template - a method that renders, validates, and returns the validated on-demand template result.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
