### PR TITLE
Add binary sensors to Yoto

### DIFF
--- a/homeassistant/components/yoto/__init__.py
+++ b/homeassistant/components/yoto/__init__.py
@@ -20,6 +20,7 @@ from .const import DOMAIN
 from .coordinator import YotoConfigEntry, YotoDataUpdateCoordinator
 
 PLATFORMS: list[Platform] = [
+    Platform.BINARY_SENSOR,
     Platform.MEDIA_PLAYER,
     Platform.SENSOR,
     Platform.TIME,

--- a/homeassistant/components/yoto/binary_sensor.py
+++ b/homeassistant/components/yoto/binary_sensor.py
@@ -1,0 +1,87 @@
+"""Binary sensor platform for the Yoto integration."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from yoto_api import YotoPlayer
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import YotoConfigEntry, YotoDataUpdateCoordinator
+from .entity import YotoPlayerEntity
+
+PARALLEL_UPDATES = 0
+
+
+@dataclass(frozen=True, kw_only=True)
+class YotoBinarySensorEntityDescription(BinarySensorEntityDescription):
+    """Describes a Yoto binary sensor entity."""
+
+    is_on_fn: Callable[[YotoPlayer], bool | None]
+
+
+BINARY_SENSORS: tuple[YotoBinarySensorEntityDescription, ...] = (
+    YotoBinarySensorEntityDescription(
+        key="charging",
+        device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        is_on_fn=lambda player: player.status.is_charging,
+    ),
+    YotoBinarySensorEntityDescription(
+        key="headphones",
+        translation_key="headphones",
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        is_on_fn=lambda player: player.status.is_audio_device_connected,
+    ),
+    YotoBinarySensorEntityDescription(
+        key="bluetooth_audio",
+        translation_key="bluetooth_audio",
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        is_on_fn=lambda player: player.status.is_bluetooth_audio_connected,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: YotoConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the Yoto binary sensor platform."""
+    coordinator = entry.runtime_data
+    async_add_entities(
+        YotoBinarySensor(coordinator, player, description)
+        for player in coordinator.client.players.values()
+        for description in BINARY_SENSORS
+    )
+
+
+class YotoBinarySensor(YotoPlayerEntity, BinarySensorEntity):
+    """Representation of a Yoto player binary sensor."""
+
+    entity_description: YotoBinarySensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: YotoDataUpdateCoordinator,
+        player: YotoPlayer,
+        description: YotoBinarySensorEntityDescription,
+    ) -> None:
+        """Initialize the binary sensor."""
+        super().__init__(coordinator, player)
+        self.entity_description = description
+        self._attr_unique_id = f"{player.id}_{description.key}"
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return the binary sensor state."""
+        return self.entity_description.is_on_fn(self.player)

--- a/homeassistant/components/yoto/icons.json
+++ b/homeassistant/components/yoto/icons.json
@@ -1,5 +1,13 @@
 {
   "entity": {
+    "binary_sensor": {
+      "bluetooth_audio": {
+        "default": "mdi:bluetooth-audio"
+      },
+      "headphones": {
+        "default": "mdi:headphones"
+      }
+    },
     "sensor": {
       "card_insertion_state": {
         "default": "mdi:card-bulleted-outline",

--- a/homeassistant/components/yoto/strings.json
+++ b/homeassistant/components/yoto/strings.json
@@ -37,6 +37,14 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "bluetooth_audio": {
+        "name": "Bluetooth audio"
+      },
+      "headphones": {
+        "name": "Headphones"
+      }
+    },
     "sensor": {
       "card_insertion_state": {
         "name": "Card slot",

--- a/tests/components/yoto/conftest.py
+++ b/tests/components/yoto/conftest.py
@@ -100,6 +100,9 @@ def _build_player() -> YotoPlayer:
         battery_level_percentage=75,
         card_insertion_state=CardInsertionState.PHYSICAL,
         day_mode=DayMode.DAY,
+        is_charging=True,
+        is_audio_device_connected=False,
+        is_bluetooth_audio_connected=False,
     )
     player.last_event = PlaybackEvent(
         player_id=PLAYER_ID,

--- a/tests/components/yoto/snapshots/test_binary_sensor.ambr
+++ b/tests/components/yoto/snapshots/test_binary_sensor.ambr
@@ -1,0 +1,154 @@
+# serializer version: 1
+# name: test_all_entities[binary_sensor.nursery_yoto_bluetooth_audio-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.nursery_yoto_bluetooth_audio',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Bluetooth audio',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.CONNECTIVITY: 'connectivity'>,
+    'original_icon': None,
+    'original_name': 'Bluetooth audio',
+    'platform': 'yoto',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'bluetooth_audio',
+    'unique_id': 'player-test_bluetooth_audio',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[binary_sensor.nursery_yoto_bluetooth_audio-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'connectivity',
+      'friendly_name': 'Nursery Yoto Bluetooth audio',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.nursery_yoto_bluetooth_audio',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_entities[binary_sensor.nursery_yoto_charging-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.nursery_yoto_charging',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Charging',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.BATTERY_CHARGING: 'battery_charging'>,
+    'original_icon': None,
+    'original_name': 'Charging',
+    'platform': 'yoto',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'player-test_charging',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[binary_sensor.nursery_yoto_charging-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery_charging',
+      'friendly_name': 'Nursery Yoto Charging',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.nursery_yoto_charging',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_all_entities[binary_sensor.nursery_yoto_headphones-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.nursery_yoto_headphones',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Headphones',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.CONNECTIVITY: 'connectivity'>,
+    'original_icon': None,
+    'original_name': 'Headphones',
+    'platform': 'yoto',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'headphones',
+    'unique_id': 'player-test_headphones',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[binary_sensor.nursery_yoto_headphones-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'connectivity',
+      'friendly_name': 'Nursery Yoto Headphones',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.nursery_yoto_headphones',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/yoto/test_binary_sensor.py
+++ b/tests/components/yoto/test_binary_sensor.py
@@ -1,0 +1,49 @@
+"""Tests for the Yoto binary sensor platform."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.const import STATE_UNAVAILABLE, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+pytestmark = pytest.mark.usefixtures("setup_credentials")
+
+ENTITY_ID = "binary_sensor.nursery_yoto_charging"
+
+
+@pytest.mark.usefixtures("mock_yoto_client", "entity_registry_enabled_by_default")
+async def test_all_entities(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Snapshot every Yoto binary sensor entity."""
+    with patch("homeassistant.components.yoto.PLATFORMS", [Platform.BINARY_SENSOR]):
+        await setup_integration(hass, mock_config_entry)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_binary_sensor_unavailable_when_offline(
+    hass: HomeAssistant,
+    mock_yoto_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Binary sensors are unavailable while the player is offline."""
+    player = next(iter(mock_yoto_client.players.values()))
+    player.is_online = False
+
+    with patch("homeassistant.components.yoto.PLATFORMS", [Platform.BINARY_SENSOR]):
+        await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE


### PR DESCRIPTION
## Proposed change

Add a binary sensor platform to the Yoto integration, with three entities read from the player status over MQTT:

- Charging (battery charging state)
- Headphones (wired audio device connected)
- Bluetooth audio (Bluetooth headphones connected)

All three are diagnostic, consistent with the battery sensor.

This also moves the online check into the base entity, so every Yoto entity (the binary sensors and the media player) reports unavailable when the player is offline.

I will need to be rebased if https://github.com/home-assistant/core/pull/173292 is merged before.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45907
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
