### PR TITLE
Fix HomeKit Controller doorbell event entity to use ring event type

### DIFF
--- a/homeassistant/components/homekit_controller/event.py
+++ b/homeassistant/components/homekit_controller/event.py
@@ -26,6 +26,12 @@ INPUT_EVENT_VALUES = {
     InputEventValues.LONG_PRESS: "long_press",
 }
 
+DOORBELL_EVENT_VALUES = {
+    InputEventValues.SINGLE_PRESS: "ring",
+    InputEventValues.DOUBLE_PRESS: "double_press",
+    InputEventValues.LONG_PRESS: "long_press",
+}
+
 
 class HomeKitEventEntity(BaseCharacteristicEntity, EventEntity):
     """Representation of a Homekit event entity."""
@@ -50,11 +56,17 @@ class HomeKitEventEntity(BaseCharacteristicEntity, EventEntity):
 
         self.entity_description = entity_description
 
+        self._event_values = (
+            DOORBELL_EVENT_VALUES
+            if entity_description.device_class == EventDeviceClass.DOORBELL
+            else INPUT_EVENT_VALUES
+        )
+
         # An INPUT_EVENT may support single_press, long_press and
         # double_press. All are optional. So we have to clamp
         # InputEventValues for this exact device
         self._attr_event_types = [
-            INPUT_EVENT_VALUES[v]
+            self._event_values[v]
             for v in clamp_enum_to_char(InputEventValues, self._char)
         ]
 
@@ -82,7 +94,7 @@ class HomeKitEventEntity(BaseCharacteristicEntity, EventEntity):
             # pollable, but always returns None when polled
             # Make sure we don't explode if we see that edge case.
             return
-        self._trigger_event(INPUT_EVENT_VALUES[self._char.value])
+        self._trigger_event(self._event_values[self._char.value])
         self.async_write_ha_state()
 
 

--- a/tests/components/homekit_controller/snapshots/test_init.ambr
+++ b/tests/components/homekit_controller/snapshots/test_init.ambr
@@ -19848,7 +19848,7 @@
             'area_id': None,
             'capabilities': dict({
               <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
-                'single_press',
+                'ring',
                 'double_press',
                 'long_press',
               ]),
@@ -19887,7 +19887,7 @@
               <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'doorbell',
               <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
               <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
-                'single_press',
+                'ring',
                 'double_press',
                 'long_press',
               ]),

--- a/tests/components/homekit_controller/test_event.py
+++ b/tests/components/homekit_controller/test_event.py
@@ -168,7 +168,7 @@ async def test_doorbell(
 
     assert doorbell.original_device_class == EventDeviceClass.DOORBELL
     assert doorbell.capabilities["event_types"] == [
-        "single_press",
+        "ring",
         "double_press",
         "long_press",
     ]
@@ -178,7 +178,7 @@ async def test_doorbell(
     )
     await hass.async_block_till_done()
     state = hass.states.get(entity_id)
-    assert state.attributes["event_type"] == "single_press"
+    assert state.attributes["event_type"] == "ring"
 
     helper.pairing.testing.update_named_service(
         "Doorbell", {CharacteristicsTypes.INPUT_EVENT: 1}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

HomeKit Controller doorbell event entities incorrectly report `single_press` instead of `ring` for doorbell press events. The `EventDeviceClass.DOORBELL` requires `DoorbellEventType.RING` in its event types, but the entity was sharing the same `INPUT_EVENT_VALUES` mapping as button entities.

This adds a separate `DOORBELL_EVENT_VALUES` mapping for doorbell entities that translates `InputEventValues.SINGLE_PRESS` to `ring`. The entity selects the correct mapping based on its device class, fixing both the advertised event types and actual event triggering.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #173143
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr