### PR TITLE
Fix workday entity triggering updates while disabled

### DIFF
--- a/homeassistant/components/workday/entity.py
+++ b/homeassistant/components/workday/entity.py
@@ -86,6 +86,13 @@ class BaseWorkdayEntity(Entity):
         """Set up first update."""
         self._update_state_and_setup_listener()
 
+    async def async_will_remove_from_hass(self) -> None:
+        """Cancel pending listener when entity is removed."""
+        await super().async_will_remove_from_hass()
+        if self.unsub:
+            self.unsub()
+            self.unsub = None
+
     @abstractmethod
     def update_data(self, now: datetime) -> None:
         """Update data."""

--- a/tests/components/workday/test_calendar.py
+++ b/tests/components/workday/test_calendar.py
@@ -1,6 +1,7 @@
 """Tests for calendar platform of Workday integration."""
 
 from datetime import datetime, timedelta
+import logging
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
@@ -14,6 +15,7 @@ from homeassistant.components.calendar import (
 )
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
 
 from . import TEST_CONFIG_WITH_PROVINCE, init_integration
@@ -90,3 +92,34 @@ async def test_holiday_calendar_entity(
     state = hass.states.get("calendar.workday_sensor_de_bw_calendar")
     assert state is not None
     assert state.state == "off"
+
+
+async def test_no_update_when_disabled(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    entity_registry: er.EntityRegistry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that a disabled calendar entity does not trigger updates."""
+    zone = await dt_util.async_get_time_zone("US/Hawaii")
+    freezer.move_to(datetime(2023, 1, 1, 0, 1, 1, tzinfo=zone))
+    await init_integration(hass, TEST_CONFIG_WITH_PROVINCE)
+
+    entity_id = "calendar.workday_sensor_de_bw_calendar"
+    state = hass.states.get(entity_id)
+    assert state is not None
+
+    entity_registry.async_update_entity(
+        entity_id, disabled_by=er.RegistryEntryDisabler.USER
+    )
+    await hass.async_block_till_done()
+
+    with caplog.at_level(logging.WARNING, logger="homeassistant.helpers.entity"):
+        freezer.move_to(datetime(2023, 1, 2, 0, 1, 1, tzinfo=zone))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+    assert (
+        "incorrectly being triggered for updates while it is disabled"
+        not in caplog.text
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The workday integration's `BaseWorkdayEntity` sets up a recurring `point_in_time_listener` that fires daily at midnight, calling `async_write_ha_state()`. When a workday entity (such as the calendar) is disabled by the user, it gets removed from the platform, but the timer listener is never cancelled. This causes the listener to keep firing and calling `async_write_ha_state()` on the removed entity, which logs a warning: "Entity ... is incorrectly being triggered for updates while it is disabled."

This PR adds `async_will_remove_from_hass` to `BaseWorkdayEntity` to cancel the pending listener when the entity is removed. It also calls `super()` to ensure the `CalendarEntity` base class performs its own cleanup of calendar alarm subscriptions.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #173592
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr