### PR TITLE
Add pylint checker for redundant translation_key with device_class

### DIFF
--- a/pylint/plugins/README.md
+++ b/pylint/plugins/README.md
@@ -127,6 +127,7 @@ Every check has a code following the
 | `W7413` | [`home-assistant-missing-config-entry-unloading`](#w7413-home-assistant-missing-config-entry-unloading) | Integration should implement `async_unload_entry` |
 | `W7415` | [`home-assistant-sequential-executor-jobs`](#w7415-home-assistant-sequential-executor-jobs) | Sequential `async_add_executor_job` calls should be grouped |
 | `W7416` | [`home-assistant-missing-has-entity-name`](#w7416-home-assistant-missing-has-entity-name) | Entity class should set `_attr_has_entity_name = True` |
+| `W7428` | [`home-assistant-redundant-translation-key`](#w7428-home-assistant-redundant-translation-key) | `translation_key` is redundant when `device_class` provides the same translation |
 | `W7429` | [`home-assistant-unnecessary-format-mac`](#w7429-home-assistant-unnecessary-format-mac) | `format_mac()` is unnecessary with `CONNECTION_NETWORK_MAC` |
 
 
@@ -723,6 +724,25 @@ Entity class should statically guarantee `_attr_has_entity_name = True`:
 either set at class level, set unconditionally at the top of a method, or
 supplied by an `entity_description` whose class sets `has_entity_name = True`.
 Conditional patterns are rejected.
+
+
+## `home_assistant_redundant_translation_key` checker
+
+Detects `EntityDescription` instances where `translation_key` resolves
+to the same translated name that the `device_class` already provides.
+Only fires on platforms that have device class translations: `sensor`,
+`binary_sensor`, `number`, `cover`, `switch`, `button`, `event`,
+`humidifier`, and `media_player`.
+
+### `W7428`: `home-assistant-redundant-translation-key`
+
+`translation_key` is redundant because `device_class` already provides
+the same translation. When an entity has a `device_class`, Home Assistant
+automatically supplies a translated name from the platform's device
+class translations (`entity_component.<device_class>.name` in the
+platform's `strings.json`). Setting a `translation_key` that resolves
+to the same name adds unnecessary indirection; remove the
+`translation_key` and let the device class translation apply directly.
 
 
 ## `home_assistant_unnecessary_format_mac` checker

--- a/pylint/plugins/pylint_home_assistant/checkers/redundant_translation_key.py
+++ b/pylint/plugins/pylint_home_assistant/checkers/redundant_translation_key.py
@@ -89,13 +89,15 @@ def _load_device_class_translations(
 
 def _resolve_const_string(node: nodes.NodeNG) -> str | None:
     """Resolve a node to a constant string value."""
-    if isinstance(node, nodes.Const) and isinstance(node.value, str):
-        return node.value
+    match node:
+        case nodes.Const(value=str() as value):
+            return value
 
     try:
         for inferred in node.infer():
-            if isinstance(inferred, nodes.Const) and isinstance(inferred.value, str):
-                return str(inferred.value)
+            match inferred:
+                case nodes.Const(value=str() as value):
+                    return value
     except _InferenceError:
         pass
 
@@ -108,17 +110,20 @@ def _resolve_device_class_value(node: nodes.NodeNG) -> str | None:
     Handles ``SensorDeviceClass.POWER`` style enum references by
     accessing the ``.value`` attribute on the inferred enum instance.
     """
-    if isinstance(node, nodes.Const) and isinstance(node.value, str):
-        return node.value
+    match node:
+        case nodes.Const(value=str() as value):
+            return value
 
     try:
         for inferred in node.infer():
-            if isinstance(inferred, nodes.Const) and isinstance(inferred.value, str):
-                return str(inferred.value)
-            if isinstance(inferred, astroid.Instance):
-                for val in inferred.igetattr("value"):
-                    if isinstance(val, nodes.Const) and isinstance(val.value, str):
-                        return str(val.value)
+            match inferred:
+                case nodes.Const(value=str() as value):
+                    return value
+                case astroid.Instance():
+                    for val in inferred.igetattr("value"):
+                        match val:
+                            case nodes.Const(value=str() as value):
+                                return value
     except _InferenceError, StopIteration:
         pass
 
@@ -142,10 +147,9 @@ def _resolve_description_class(call: nodes.Call) -> nodes.ClassDef | None:
     """Resolve the EntityDescription subclass from a constructor call."""
     try:
         for inferred in call.func.infer():
-            if isinstance(inferred, nodes.ClassDef) and _is_entity_description(
-                inferred
-            ):
-                return inferred
+            match inferred:
+                case nodes.ClassDef() if _is_entity_description(inferred):
+                    return inferred
     except _InferenceError:
         pass
     return None

--- a/pylint/plugins/pylint_home_assistant/checkers/redundant_translation_key.py
+++ b/pylint/plugins/pylint_home_assistant/checkers/redundant_translation_key.py
@@ -1,0 +1,281 @@
+"""Checker for redundant ``translation_key`` when ``device_class`` is set.
+
+When an entity has a ``device_class``, Home Assistant automatically
+provides a translated name from the platform's device class translations
+(``entity_component.<device_class>.name`` in the platform's
+``strings.json``).
+
+Setting ``translation_key`` to a value that resolves to the same
+translated name is redundant and should be removed.
+
+``W7428`` (``home-assistant-redundant-translation-key``)
+"""
+
+import contextlib
+from pathlib import Path
+
+import astroid
+from astroid import nodes
+import orjson
+from pylint.checkers import BaseChecker
+from pylint.lint import PyLinter
+
+from pylint_home_assistant.helpers.integration import get_integration_dir
+from pylint_home_assistant.helpers.module_info import (
+    is_integration_module,
+    parse_module,
+)
+from pylint_home_assistant.helpers.translations import (
+    load_translations,
+    resolve_translation_reference,
+)
+
+_InferenceError = astroid.exceptions.InferenceError
+
+_ENTITY_DESCRIPTION_QNAME = "homeassistant.helpers.entity.EntityDescription"
+
+_PLATFORMS_WITH_DEVICE_CLASS_TRANSLATIONS = frozenset(
+    {
+        "sensor",
+        "binary_sensor",
+        "number",
+        "cover",
+        "switch",
+        "button",
+        "event",
+        "humidifier",
+        "media_player",
+    }
+)
+
+_device_class_translations_cache: dict[str, dict[str, str]] = {}
+
+
+def clear_device_class_cache() -> None:
+    """Clear the device class translations cache (used by tests)."""
+    _device_class_translations_cache.clear()
+
+
+def _load_device_class_translations(
+    module: nodes.Module, platform: str
+) -> dict[str, str]:
+    """Load device class translations for a platform.
+
+    Returns a dict mapping device class value to its translated name.
+    """
+    if platform in _device_class_translations_cache:
+        return _device_class_translations_cache[platform]
+
+    result: dict[str, str] = {}
+    integration_dir = get_integration_dir(module)
+    if integration_dir is not None:
+        components_dir = integration_dir.parent
+        platform_strings = components_dir / platform / "strings.json"
+        if platform_strings.exists():
+            with contextlib.suppress(orjson.JSONDecodeError, OSError):
+                parsed = orjson.loads(platform_strings.read_bytes())
+                if isinstance(parsed, dict):
+                    entity_component = parsed.get("entity_component", {})
+                    for dc_key, dc_data in entity_component.items():
+                        if dc_key == "_" or not isinstance(dc_data, dict):
+                            continue
+                        name = dc_data.get("name")
+                        if isinstance(name, str):
+                            result[dc_key] = name
+
+    _device_class_translations_cache[platform] = result
+    return result
+
+
+def _resolve_const_string(node: nodes.NodeNG) -> str | None:
+    """Resolve a node to a constant string value."""
+    if isinstance(node, nodes.Const) and isinstance(node.value, str):
+        return node.value
+
+    try:
+        for inferred in node.infer():
+            if isinstance(inferred, nodes.Const) and isinstance(inferred.value, str):
+                return str(inferred.value)
+    except _InferenceError:
+        pass
+
+    return None
+
+
+def _resolve_device_class_value(node: nodes.NodeNG) -> str | None:
+    """Resolve a device_class keyword value to its string form.
+
+    Handles ``SensorDeviceClass.POWER`` style enum references by
+    accessing the ``.value`` attribute on the inferred enum instance.
+    """
+    if isinstance(node, nodes.Const) and isinstance(node.value, str):
+        return node.value
+
+    try:
+        for inferred in node.infer():
+            if isinstance(inferred, nodes.Const) and isinstance(inferred.value, str):
+                return str(inferred.value)
+            if isinstance(inferred, astroid.Instance):
+                for val in inferred.igetattr("value"):
+                    if isinstance(val, nodes.Const) and isinstance(val.value, str):
+                        return str(val.value)
+    except _InferenceError, StopIteration:
+        pass
+
+    return None
+
+
+def _is_entity_description(class_node: nodes.ClassDef) -> bool:
+    """Check if a class is or inherits from EntityDescription."""
+    if class_node.qname() == _ENTITY_DESCRIPTION_QNAME:
+        return True
+    try:
+        return any(
+            ancestor.qname() == _ENTITY_DESCRIPTION_QNAME
+            for ancestor in class_node.ancestors()
+        )
+    except _InferenceError:
+        return False
+
+
+def _resolve_description_class(call: nodes.Call) -> nodes.ClassDef | None:
+    """Resolve the EntityDescription subclass from a constructor call."""
+    try:
+        for inferred in call.func.infer():
+            if isinstance(inferred, nodes.ClassDef) and _is_entity_description(
+                inferred
+            ):
+                return inferred
+    except _InferenceError:
+        pass
+    return None
+
+
+class RedundantTranslationKeyChecker(BaseChecker):
+    """Checker for redundant translation_key when device_class is set."""
+
+    name = "home_assistant_redundant_translation_key"
+    priority = -1
+    msgs = {
+        "W7428": (
+            "translation_key '%s' is redundant because device_class '%s' "
+            "already provides the same translation '%s'",
+            "home-assistant-redundant-translation-key",
+            "Used when an entity sets a translation_key that resolves to "
+            "the same name the device_class already provides. Remove the "
+            "translation_key to use the device class translation directly.",
+        ),
+    }
+    options = ()
+
+    _is_platform: bool
+    _platform: str | None
+    _translations: dict | None
+    _components_dir: Path | None
+    _module_node: nodes.Module | None
+
+    def visit_module(self, node: nodes.Module) -> None:
+        """Load translations for platform modules."""
+        self._is_platform = False
+        self._platform = None
+        self._translations = None
+        self._components_dir = None
+        self._module_node = None
+
+        if not is_integration_module(node.name):
+            return
+
+        parsed = parse_module(node.name)
+        if parsed is None or parsed.module is None:
+            return
+
+        if parsed.module not in _PLATFORMS_WITH_DEVICE_CLASS_TRANSLATIONS:
+            return
+
+        self._is_platform = True
+        self._platform = parsed.module
+        self._module_node = node
+        self._translations = load_translations(node)
+        integration_dir = get_integration_dir(node)
+        if integration_dir is not None:
+            self._components_dir = integration_dir.parent
+
+    def visit_call(self, node: nodes.Call) -> None:
+        """Check EntityDescription calls for redundant translation_key."""
+        if not self._is_platform or self._translations is None:
+            return
+
+        if not node.keywords:
+            return
+
+        if (
+            isinstance(node.func, nodes.Attribute)
+            and "Description" not in node.func.attrname
+        ):
+            return
+
+        translation_key: str | None = None
+        device_class: str | None = None
+        tk_keyword: nodes.Keyword | None = None
+
+        for kw in node.keywords:
+            if kw.arg == "translation_key":
+                translation_key = _resolve_const_string(kw.value)
+                tk_keyword = kw
+            elif kw.arg == "device_class":
+                device_class = _resolve_device_class_value(kw.value)
+
+        if translation_key is None or device_class is None or tk_keyword is None:
+            return
+
+        if _resolve_description_class(node) is None:
+            return
+
+        self._check_redundant(node, tk_keyword, translation_key, device_class)
+
+    def _check_redundant(
+        self,
+        node: nodes.Call,
+        tk_keyword: nodes.Keyword,
+        translation_key: str,
+        device_class: str,
+    ) -> None:
+        """Compare entity translation against device class translation."""
+        assert self._platform is not None
+        assert self._translations is not None
+
+        entity_trans = (
+            self._translations.get("entity", {})
+            .get(self._platform, {})
+            .get(translation_key, {})
+        )
+        if not isinstance(entity_trans, dict):
+            return
+
+        entity_name = entity_trans.get("name")
+        if not isinstance(entity_name, str):
+            return
+
+        entity_name = resolve_translation_reference(entity_name, self._components_dir)
+
+        assert self._module_node is not None
+        dc_translations = _load_device_class_translations(
+            self._module_node, self._platform
+        )
+        dc_name = dc_translations.get(device_class)
+        if dc_name is None:
+            return
+
+        dc_name = resolve_translation_reference(dc_name, self._components_dir)
+
+        if entity_name == dc_name:
+            self.add_message(
+                "home-assistant-redundant-translation-key",
+                node=tk_keyword,
+                args=(translation_key, device_class, entity_name),
+            )
+
+
+def register(linter: PyLinter) -> None:
+    """Register the checker."""
+    linter.register_checker(RedundantTranslationKeyChecker(linter))

--- a/tests/pylint/test_redundant_translation_key.py
+++ b/tests/pylint/test_redundant_translation_key.py
@@ -1,0 +1,331 @@
+"""Tests for the redundant translation_key checker."""
+
+import json
+from pathlib import Path
+
+import astroid
+from pylint.testutils import UnittestLinter
+from pylint.utils.ast_walker import ASTWalker
+from pylint_home_assistant.checkers.redundant_translation_key import (
+    RedundantTranslationKeyChecker,
+    clear_device_class_cache,
+)
+from pylint_home_assistant.helpers.translations import clear_translations_cache
+import pytest
+
+from . import assert_no_messages
+
+_SENSOR_MODULE = astroid.MANAGER.ast_from_module_name("homeassistant.components.sensor")
+
+
+@pytest.fixture(name="redundant_tk_checker")
+def redundant_tk_checker_fixture(
+    linter: UnittestLinter,
+) -> RedundantTranslationKeyChecker:
+    """Fixture to provide a redundant translation_key checker."""
+    clear_translations_cache()
+    clear_device_class_cache()
+    return RedundantTranslationKeyChecker(linter)
+
+
+def _make_integration(
+    tmp_path: Path,
+    strings: dict | None = None,
+    platform_strings: dict[str, dict] | None = None,
+) -> Path:
+    """Create a fake integration with strings.json and platform translations."""
+    components_dir = tmp_path / "homeassistant" / "components"
+    integration_dir = components_dir / "test_int"
+    integration_dir.mkdir(parents=True)
+    if strings is not None:
+        (integration_dir / "strings.json").write_text(json.dumps(strings))
+
+    if platform_strings is not None:
+        for platform, data in platform_strings.items():
+            platform_dir = components_dir / platform
+            platform_dir.mkdir(parents=True, exist_ok=True)
+            (platform_dir / "strings.json").write_text(json.dumps(data))
+
+    return integration_dir
+
+
+_PLATFORM_SENSOR_STRINGS = {
+    "entity_component": {
+        "power": {"name": "Power"},
+        "temperature": {"name": "Temperature"},
+        "battery": {"name": "Battery"},
+    }
+}
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        pytest.param(
+            """
+from homeassistant.components.sensor import SensorEntityDescription, SensorDeviceClass
+
+SensorEntityDescription(
+    key="power",
+    device_class=SensorDeviceClass.POWER,
+)
+""",
+            id="no_translation_key",
+        ),
+        pytest.param(
+            """
+from homeassistant.components.sensor import SensorEntityDescription, SensorDeviceClass
+
+SensorEntityDescription(
+    key="device_temp",
+    translation_key="device_temperature",
+    device_class=SensorDeviceClass.TEMPERATURE,
+)
+""",
+            id="different_translation",
+        ),
+        pytest.param(
+            """
+from homeassistant.components.sensor import SensorEntityDescription, SensorDeviceClass
+
+SensorEntityDescription(
+    key="watt_hours",
+    translation_key="energy_consumption",
+    device_class=SensorDeviceClass.POWER,
+)
+""",
+            id="translation_key_not_in_strings",
+        ),
+        pytest.param(
+            """
+from homeassistant.components.sensor import SensorEntityDescription
+
+SensorEntityDescription(
+    key="custom",
+    translation_key="power",
+)
+""",
+            id="no_device_class",
+        ),
+    ],
+)
+def test_no_warning(
+    linter: UnittestLinter,
+    redundant_tk_checker: RedundantTranslationKeyChecker,
+    tmp_path: Path,
+    code: str,
+) -> None:
+    """Test cases that should not trigger a warning."""
+    integration_dir = _make_integration(
+        tmp_path,
+        strings={
+            "entity": {
+                "sensor": {
+                    "device_temperature": {"name": "Device temperature"},
+                }
+            }
+        },
+        platform_strings={"sensor": _PLATFORM_SENSOR_STRINGS},
+    )
+
+    root_node = astroid.parse(code, "homeassistant.components.test_int.sensor")
+    root_node.file = str(integration_dir / "sensor.py")
+
+    walker = ASTWalker(linter)
+    walker.add_checker(redundant_tk_checker)
+
+    with assert_no_messages(linter):
+        walker.walk(root_node)
+
+
+def test_redundant_translation_key_flagged(
+    linter: UnittestLinter,
+    redundant_tk_checker: RedundantTranslationKeyChecker,
+    tmp_path: Path,
+) -> None:
+    """Warning when translation_key provides the same name as device_class."""
+    integration_dir = _make_integration(
+        tmp_path,
+        strings={
+            "entity": {
+                "sensor": {
+                    "power": {"name": "Power"},
+                }
+            }
+        },
+        platform_strings={"sensor": _PLATFORM_SENSOR_STRINGS},
+    )
+
+    code = """
+from homeassistant.components.sensor import SensorEntityDescription, SensorDeviceClass
+
+SensorEntityDescription(
+    key="power",
+    translation_key="power",
+    device_class=SensorDeviceClass.POWER,
+)
+"""
+    root_node = astroid.parse(code, "homeassistant.components.test_int.sensor")
+    root_node.file = str(integration_dir / "sensor.py")
+
+    walker = ASTWalker(linter)
+    walker.add_checker(redundant_tk_checker)
+    walker.walk(root_node)
+
+    messages = linter.release_messages()
+    assert len(messages) == 1
+    assert messages[0].msg_id == "home-assistant-redundant-translation-key"
+    assert messages[0].args == ("power", "power", "Power")
+
+
+def test_redundant_different_key_same_translation(
+    linter: UnittestLinter,
+    redundant_tk_checker: RedundantTranslationKeyChecker,
+    tmp_path: Path,
+) -> None:
+    """Warning when translation_key differs from device_class but resolves to same name."""
+    integration_dir = _make_integration(
+        tmp_path,
+        strings={
+            "entity": {
+                "sensor": {
+                    "cell_temp": {"name": "Temperature"},
+                }
+            }
+        },
+        platform_strings={"sensor": _PLATFORM_SENSOR_STRINGS},
+    )
+
+    code = """
+from homeassistant.components.sensor import SensorEntityDescription, SensorDeviceClass
+
+SensorEntityDescription(
+    key="cell_temp",
+    translation_key="cell_temp",
+    device_class=SensorDeviceClass.TEMPERATURE,
+)
+"""
+    root_node = astroid.parse(code, "homeassistant.components.test_int.sensor")
+    root_node.file = str(integration_dir / "sensor.py")
+
+    walker = ASTWalker(linter)
+    walker.add_checker(redundant_tk_checker)
+    walker.walk(root_node)
+
+    messages = linter.release_messages()
+    assert len(messages) == 1
+    assert messages[0].args == ("cell_temp", "temperature", "Temperature")
+
+
+def test_non_integration_module_ignored(
+    linter: UnittestLinter,
+    redundant_tk_checker: RedundantTranslationKeyChecker,
+) -> None:
+    """No warning for code outside integration modules."""
+    code = """
+from homeassistant.components.sensor import SensorEntityDescription, SensorDeviceClass
+
+SensorEntityDescription(
+    key="power",
+    translation_key="power",
+    device_class=SensorDeviceClass.POWER,
+)
+"""
+    root_node = astroid.parse(code, "some_other.module")
+
+    walker = ASTWalker(linter)
+    walker.add_checker(redundant_tk_checker)
+
+    with assert_no_messages(linter):
+        walker.walk(root_node)
+
+
+def test_non_platform_module_ignored(
+    linter: UnittestLinter,
+    redundant_tk_checker: RedundantTranslationKeyChecker,
+    tmp_path: Path,
+) -> None:
+    """No warning for non-platform modules like __init__.py."""
+    integration_dir = _make_integration(
+        tmp_path,
+        strings={
+            "entity": {
+                "sensor": {
+                    "power": {"name": "Power"},
+                }
+            }
+        },
+        platform_strings={"sensor": _PLATFORM_SENSOR_STRINGS},
+    )
+
+    code = """
+from homeassistant.components.sensor import SensorEntityDescription, SensorDeviceClass
+
+SensorEntityDescription(
+    key="power",
+    translation_key="power",
+    device_class=SensorDeviceClass.POWER,
+)
+"""
+    root_node = astroid.parse(code, "homeassistant.components.test_int")
+    root_node.file = str(integration_dir / "__init__.py")
+
+    walker = ASTWalker(linter)
+    walker.add_checker(redundant_tk_checker)
+
+    with assert_no_messages(linter):
+        walker.walk(root_node)
+
+
+def test_multiple_descriptions_mixed(
+    linter: UnittestLinter,
+    redundant_tk_checker: RedundantTranslationKeyChecker,
+    tmp_path: Path,
+) -> None:
+    """Only flag redundant ones in a list of descriptions."""
+    integration_dir = _make_integration(
+        tmp_path,
+        strings={
+            "entity": {
+                "sensor": {
+                    "power": {"name": "Power"},
+                    "device_temp": {"name": "Device temperature"},
+                    "battery": {"name": "Battery"},
+                }
+            }
+        },
+        platform_strings={"sensor": _PLATFORM_SENSOR_STRINGS},
+    )
+
+    code = """
+from homeassistant.components.sensor import SensorEntityDescription, SensorDeviceClass
+
+SENSORS = [
+    SensorEntityDescription(
+        key="power",
+        translation_key="power",
+        device_class=SensorDeviceClass.POWER,
+    ),
+    SensorEntityDescription(
+        key="device_temp",
+        translation_key="device_temp",
+        device_class=SensorDeviceClass.TEMPERATURE,
+    ),
+    SensorEntityDescription(
+        key="bat",
+        translation_key="battery",
+        device_class=SensorDeviceClass.BATTERY,
+    ),
+]
+"""
+    root_node = astroid.parse(code, "homeassistant.components.test_int.sensor")
+    root_node.file = str(integration_dir / "sensor.py")
+
+    walker = ASTWalker(linter)
+    walker.add_checker(redundant_tk_checker)
+    walker.walk(root_node)
+
+    messages = linter.release_messages()
+    assert len(messages) == 2
+    flagged_keys = {msg.args[0] for msg in messages}
+    assert flagged_keys == {"power", "battery"}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds a new pylint checker (`W7428` / `home-assistant-redundant-translation-key`) that flags `EntityDescription` constructor calls where a `translation_key` resolves to the same translated name that the `device_class` already provides from the platform's `entity_component` translations.

When an entity has a `device_class`, Home Assistant automatically provides a translated name (e.g., `SensorDeviceClass.POWER` provides "Power"). Contributors frequently set a `translation_key` that produces the exact same string, which is redundant. This is one of the most common review comments (~14 occurrences in recent reviews).

The checker:
- Only runs on platform modules (`sensor`, `binary_sensor`, `number`, `cover`, `switch`, `button`, `event`, `humidifier`, `media_player`)
- Resolves enum values (e.g., `SensorDeviceClass.POWER` → `"power"`) via astroid's `igetattr("value")`
- Loads the integration's `strings.json` to get the entity translation at `entity.<platform>.<translation_key>.name`
- Loads the platform's `strings.json` to get the device class translation at `entity_component.<device_class>.name`
- Resolves `[%key:...]` references in both translations before comparing
- Only flags when the resolved translation strings are identical

Currently detects 160 existing violations across the codebase with zero false positives.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr