### PR TITLE
Include spoken language in Google Generative AI STT prompt

### DIFF
--- a/homeassistant/components/google_generative_ai_conversation/stt.py
+++ b/homeassistant/components/google_generative_ai_conversation/stt.py
@@ -230,11 +230,19 @@ class GoogleGenerativeAISttEntity(
                 f"audio/L{metadata.bit_rate.value};rate={metadata.sample_rate.value}",
             )
 
+        prompt = self.subentry.data.get(CONF_PROMPT, DEFAULT_STT_PROMPT)
+        if metadata.language:
+            prompt = (
+                f"{prompt}\n"
+                f"The spoken language is {metadata.language}. "
+                f"Transcribe in that language."
+            )
+
         try:
             response = await self._genai_client.aio.models.generate_content(
                 model=self.subentry.data.get(CONF_CHAT_MODEL, RECOMMENDED_STT_MODEL),
                 contents=[
-                    self.subentry.data.get(CONF_PROMPT, DEFAULT_STT_PROMPT),
+                    prompt,
                     Part.from_bytes(
                         data=audio_data,
                         mime_type=f"audio/{metadata.format.value}",

--- a/tests/components/google_generative_ai_conversation/test_stt.py
+++ b/tests/components/google_generative_ai_conversation/test_stt.py
@@ -147,7 +147,8 @@ async def test_stt_process_audio_stream_success(
     assert call_args.kwargs["model"] == TEST_CHAT_MODEL
 
     contents = call_args.kwargs["contents"]
-    assert contents[0] == TEST_PROMPT
+    assert TEST_PROMPT in contents[0]
+    assert "en-US" in contents[0]
     assert isinstance(contents[1], types.Part)
     assert contents[1].inline_data.mime_type == f"audio/{audio_format.value}"
     if call_convert_to_wav:
@@ -256,7 +257,34 @@ async def test_stt_uses_default_prompt(
 
     call_args = mock_genai_client.aio.models.generate_content.call_args
     contents = call_args.kwargs["contents"]
-    assert contents[0] == DEFAULT_STT_PROMPT
+    assert DEFAULT_STT_PROMPT in contents[0]
+    assert "en-US" in contents[0]
+
+
+@pytest.mark.usefixtures("setup_integration")
+async def test_stt_includes_language_in_prompt(
+    hass: HomeAssistant,
+    mock_genai_client: AsyncMock,
+) -> None:
+    """Test that metadata language is included in the prompt sent to the model."""
+    entity = hass.data[stt.DOMAIN].get_entity("stt.google_ai_stt")
+
+    metadata = stt.SpeechMetadata(
+        language="he-IL",
+        format=stt.AudioFormats.OGG,
+        codec=stt.AudioCodecs.OPUS,
+        bit_rate=stt.AudioBitRates.BITRATE_16,
+        sample_rate=stt.AudioSampleRates.SAMPLERATE_16000,
+        channel=stt.AudioChannels.CHANNEL_MONO,
+    )
+    audio_stream = _async_get_audio_stream(b"test_audio_bytes")
+
+    await entity.async_process_audio_stream(metadata, audio_stream)
+
+    call_args = mock_genai_client.aio.models.generate_content.call_args
+    contents = call_args.kwargs["contents"]
+    prompt = contents[0]
+    assert "he-IL" in prompt
 
 
 @pytest.mark.usefixtures("mock_genai_client")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The Google Generative AI STT integration advertises support for many languages via `supported_languages`, but never passes the pipeline's configured language to the Gemini model. The prompt sent is just "Transcribe the attached audio" with no language hint, so Gemini auto-detects on every utterance. For short commands in non-English languages, this auto-detection is unreliable, resulting in transcriptions in the wrong language entirely (e.g., Hebrew audio transcribed as English or Finnish).

This change includes `metadata.language` in the prompt when it is set by the Assist pipeline, telling the model which language to transcribe in. This respects user-customized prompts by appending the language hint after the configured prompt text.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #173603
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr