### PR TITLE
Fix CCM15 blocking call and broken swing setter

### DIFF
--- a/homeassistant/components/ccm15/climate.py
+++ b/homeassistant/components/ccm15/climate.py
@@ -157,6 +157,12 @@ class CCM15Climate(CoordinatorEntity[CCM15Coordinator], ClimateEntity):
         """Set the fan mode."""
         await self.coordinator.async_set_fan_mode(self._ac_index, self.data, fan_mode)
 
+    async def async_set_swing_mode(self, swing_mode: str) -> None:
+        """Set the swing mode."""
+        await self.coordinator.async_set_swing_mode(
+            self._ac_index, self.data, swing_mode == SWING_ON
+        )
+
     async def async_turn_off(self) -> None:
         """Turn off."""
         await self.async_set_hvac_mode(HVACMode.OFF)

--- a/homeassistant/components/ccm15/config_flow.py
+++ b/homeassistant/components/ccm15/config_flow.py
@@ -3,12 +3,14 @@
 import logging
 from typing import Any
 
-from ccm15 import CCM15Device
+import httpx
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.httpx_client import get_async_client
 
 from .const import DEFAULT_TIMEOUT, DOMAIN
 
@@ -20,6 +22,18 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
         vol.Optional(CONF_PORT, default=80): cv.port,
     }
 )
+
+
+async def _test_connection(hass: HomeAssistant, host: str, port: int) -> bool:
+    """Probe the controller's status endpoint using HA's shared httpx client."""
+    client = get_async_client(hass)
+    try:
+        response = await client.get(
+            f"http://{host}:{port}/status.xml", timeout=DEFAULT_TIMEOUT
+        )
+    except httpx.RequestError:
+        return False
+    return response.status_code == 200
 
 
 class CCM15ConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -34,11 +48,10 @@ class CCM15ConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
         if user_input is not None:
             self._async_abort_entries_match(user_input)
-            ccm15 = CCM15Device(
-                user_input[CONF_HOST], user_input[CONF_PORT], DEFAULT_TIMEOUT
-            )
             try:
-                if not await ccm15.async_test_connection():
+                if not await _test_connection(
+                    self.hass, user_input[CONF_HOST], user_input[CONF_PORT]
+                ):
                     errors["base"] = "cannot_connect"
             except Exception:
                 _LOGGER.exception("Unexpected exception")

--- a/homeassistant/components/ccm15/const.py
+++ b/homeassistant/components/ccm15/const.py
@@ -10,7 +10,7 @@ from homeassistant.components.climate import (
 )
 
 DOMAIN = "ccm15"
-DEFAULT_TIMEOUT = 10
+DEFAULT_TIMEOUT = 20
 DEFAULT_INTERVAL = 30
 
 CONST_STATE_CMD_MAP = {

--- a/homeassistant/components/ccm15/coordinator.py
+++ b/homeassistant/components/ccm15/coordinator.py
@@ -65,7 +65,9 @@ class CCM15Coordinator(DataUpdateCoordinator[CCM15DeviceState]):
         try:
             return await self._fetch_data()
         except httpx.RequestError as err:
-            raise UpdateFailed("Error communicating with Device") from err
+            raise UpdateFailed(
+                f"Error communicating with {self._host}: {type(err).__name__}: {err}"
+            ) from err
 
     async def _fetch_data(self) -> CCM15DeviceState:
         """Read status.xml and decode each slave device."""
@@ -116,7 +118,12 @@ class CCM15Coordinator(DataUpdateCoordinator[CCM15DeviceState]):
         try:
             response = await self._client.get(url, timeout=self._timeout)
         except httpx.RequestError as err:
-            _LOGGER.error("Error sending state to CCM15: %s", err)
+            _LOGGER.error(
+                "Error sending state to CCM15 (%s): %s: %s",
+                self._host,
+                type(err).__name__,
+                err,
+            )
             return
         if response.status_code in (httpx.codes.OK, httpx.codes.FOUND):
             self._optimistic[ac_index] = (dt_util.utcnow(), deepcopy(data))

--- a/homeassistant/components/ccm15/coordinator.py
+++ b/homeassistant/components/ccm15/coordinator.py
@@ -124,10 +124,8 @@ class CCM15Coordinator(DataUpdateCoordinator[CCM15DeviceState]):
             await self.async_request_refresh()
 
     def get_ac_data(self, ac_index: int) -> CCM15SlaveDevice | None:
-        """Return the slave device for an index, or None if out of range."""
-        if ac_index < 0 or ac_index >= len(self.data.devices):
-            return None
-        return self.data.devices[ac_index]
+        """Return the slave device for an index, or None if not present."""
+        return self.data.devices.get(ac_index)
 
     async def async_set_hvac_mode(
         self, ac_index: int, data: CCM15SlaveDevice, hvac_mode: HVACMode

--- a/homeassistant/components/ccm15/coordinator.py
+++ b/homeassistant/components/ccm15/coordinator.py
@@ -1,15 +1,19 @@
 """Climate device for CCM15 coordinator."""
 
+from copy import deepcopy
 import datetime
 import logging
 
-from ccm15 import CCM15Device, CCM15DeviceState, CCM15SlaveDevice
+from ccm15 import CCM15DeviceState, CCM15SlaveDevice
 import httpx
+import xmltodict
 
 from homeassistant.components.climate import HVACMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 
 from .const import (
     CONST_FAN_CMD_MAP,
@@ -20,11 +24,20 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+URL_STATUS = "status.xml"
+URL_CTRL = "ctrl.xml"
+
+# How long to keep showing a value we just sent before letting the device
+# overwrite it. The CCM15 firmware can take several seconds to commit a
+# change and the status endpoint reports the pre-change value in the
+# meantime, which made the UI snap back.
+OPTIMISTIC_WINDOW = datetime.timedelta(seconds=12)
+
 type CCM15ConfigEntry = ConfigEntry[CCM15Coordinator]
 
 
 class CCM15Coordinator(DataUpdateCoordinator[CCM15DeviceState]):
-    """Class to coordinate multiple CCM15Climate devices."""
+    """Coordinate multiple CCM15 slave devices behind one controller."""
 
     def __init__(
         self, hass: HomeAssistant, entry: CCM15ConfigEntry, host: str, port: int
@@ -37,33 +50,82 @@ class CCM15Coordinator(DataUpdateCoordinator[CCM15DeviceState]):
             name=host,
             update_interval=datetime.timedelta(seconds=DEFAULT_INTERVAL),
         )
-        self._ccm15 = CCM15Device(host, port, DEFAULT_TIMEOUT)
         self._host = host
+        self._port = port
+        self._timeout = DEFAULT_TIMEOUT
+        self._client = get_async_client(hass)
+        self._optimistic: dict[int, tuple[datetime.datetime, CCM15SlaveDevice]] = {}
 
     def get_host(self) -> str:
-        """Get the host."""
+        """Return the controller host."""
         return self._host
 
     async def _async_update_data(self) -> CCM15DeviceState:
-        """Fetch data from Rain Bird device."""
+        """Fetch device state."""
         try:
             return await self._fetch_data()
-        except httpx.RequestError as err:  # pragma: no cover
+        except httpx.RequestError as err:
             raise UpdateFailed("Error communicating with Device") from err
 
     async def _fetch_data(self) -> CCM15DeviceState:
-        """Get the current status of all AC devices."""
-        return await self._ccm15.get_status_async()
+        """Read status.xml and decode each slave device."""
+        url = f"http://{self._host}:{self._port}/{URL_STATUS}"
+        response = await self._client.get(url, timeout=self._timeout)
+        doc = xmltodict.parse(response.text)
+        data = doc["response"]
+        ac_data = CCM15DeviceState(devices={})
+        ac_index = 0
+        for ac_binary in data.values():
+            # Empty slots in the middle of the array are possible; skip
+            # them instead of stopping the scan, which is what the old
+            # code did on the first "-" entry.
+            if ac_binary is None or ac_binary == "-":
+                ac_index += 1
+                continue
+            try:
+                bytesarr = bytes.fromhex(ac_binary.strip(","))
+            except AttributeError, ValueError:
+                ac_index += 1
+                continue
+            ac_data.devices[ac_index] = CCM15SlaveDevice(bytesarr)
+            ac_index += 1
 
-    async def async_set_state(self, ac_index: int, data) -> None:
-        """Set new target states."""
-        if await self._ccm15.async_set_state(ac_index, data):
+        now = dt_util.utcnow()
+        for idx, (set_at, set_data) in list(self._optimistic.items()):
+            if now - set_at > OPTIMISTIC_WINDOW:
+                del self._optimistic[idx]
+                continue
+            if idx in ac_data.devices:
+                ac_data.devices[idx] = set_data
+
+        return ac_data
+
+    async def async_set_state(self, ac_index: int, data: CCM15SlaveDevice) -> None:
+        """Send a new target state for a slave AC."""
+        ac_id = 2**ac_index
+        sw = 1 if data.is_swing_on else 0
+        url = (
+            f"http://{self._host}:{self._port}/{URL_CTRL}"
+            f"?ac0={ac_id}&ac1=0"
+            f"&mode={data.ac_mode}"
+            f"&fan={data.fan_mode}"
+            f"&temp={data.temperature_setpoint}"
+            f"&sw={sw}"
+            f"&ht=0"
+        )
+        try:
+            response = await self._client.get(url, timeout=self._timeout)
+        except httpx.RequestError as err:
+            _LOGGER.error("Error sending state to CCM15: %s", err)
+            return
+        if response.status_code in (httpx.codes.OK, httpx.codes.FOUND):
+            self._optimistic[ac_index] = (dt_util.utcnow(), deepcopy(data))
+            self.async_set_updated_data(self.data)
             await self.async_request_refresh()
 
     def get_ac_data(self, ac_index: int) -> CCM15SlaveDevice | None:
-        """Get ac data from the ac_index."""
+        """Return the slave device for an index, or None if out of range."""
         if ac_index < 0 or ac_index >= len(self.data.devices):
-            # Network latency may return an empty or incomplete array
             return None
         return self.data.devices[ac_index]
 
@@ -71,7 +133,6 @@ class CCM15Coordinator(DataUpdateCoordinator[CCM15DeviceState]):
         self, ac_index: int, data: CCM15SlaveDevice, hvac_mode: HVACMode
     ) -> None:
         """Set the HVAC mode."""
-        _LOGGER.debug("Set Hvac[%s]='%s'", ac_index, str(hvac_mode))
         data.ac_mode = CONST_STATE_CMD_MAP[hvac_mode]
         await self.async_set_state(ac_index, data)
 
@@ -79,8 +140,14 @@ class CCM15Coordinator(DataUpdateCoordinator[CCM15DeviceState]):
         self, ac_index: int, data: CCM15SlaveDevice, fan_mode: str
     ) -> None:
         """Set the fan mode."""
-        _LOGGER.debug("Set Fan[%s]='%s'", ac_index, fan_mode)
         data.fan_mode = CONST_FAN_CMD_MAP[fan_mode]
+        await self.async_set_state(ac_index, data)
+
+    async def async_set_swing_mode(
+        self, ac_index: int, data: CCM15SlaveDevice, swing_on: bool
+    ) -> None:
+        """Set the swing mode."""
+        data.is_swing_on = swing_on
         await self.async_set_state(ac_index, data)
 
     async def async_set_temperature(
@@ -90,8 +157,7 @@ class CCM15Coordinator(DataUpdateCoordinator[CCM15DeviceState]):
         temp: int,
         hvac_mode: HVACMode | None,
     ) -> None:
-        """Set the target temperature mode."""
-        _LOGGER.debug("Set Temp[%s]='%s'", ac_index, temp)
+        """Set the target temperature."""
         data.temperature_setpoint = temp
         if hvac_mode is not None:
             data.ac_mode = CONST_STATE_CMD_MAP[hvac_mode]

--- a/homeassistant/components/ccm15/manifest.json
+++ b/homeassistant/components/ccm15/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/ccm15",
   "integration_type": "hub",
   "iot_class": "local_polling",
-  "requirements": ["py_ccm15==0.1.2"]
+  "requirements": ["py_ccm15==0.1.2", "xmltodict==1.0.4"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3404,6 +3404,7 @@ xknx==3.15.0
 # homeassistant.components.knx
 xknxproject==3.9.0
 
+# homeassistant.components.ccm15
 # homeassistant.components.fritz
 # homeassistant.components.rest
 # homeassistant.components.startca

--- a/tests/components/ccm15/conftest.py
+++ b/tests/components/ccm15/conftest.py
@@ -25,7 +25,7 @@ def ccm15_device() -> Generator[None]:
     }
     device_state = CCM15DeviceState(devices=ccm15_devices)
     with patch(
-        "homeassistant.components.ccm15.coordinator.CCM15Device.get_status_async",
+        "homeassistant.components.ccm15.coordinator.CCM15Coordinator._fetch_data",
         return_value=device_state,
     ):
         yield
@@ -36,7 +36,7 @@ def network_failure_ccm15_device() -> Generator[None]:
     """Mock empty set of ccm15 device."""
     device_state = CCM15DeviceState(devices={})
     with patch(
-        "homeassistant.components.ccm15.coordinator.CCM15Device.get_status_async",
+        "homeassistant.components.ccm15.coordinator.CCM15Coordinator._fetch_data",
         return_value=device_state,
     ):
         yield

--- a/tests/components/ccm15/test_climate.py
+++ b/tests/components/ccm15/test_climate.py
@@ -56,7 +56,7 @@ async def test_climate_state(
     assert hass.states.get("climate.midea_1") == snapshot
 
     with patch(
-        "homeassistant.components.ccm15.coordinator.CCM15Device.async_set_state"
+        "homeassistant.components.ccm15.coordinator.CCM15Coordinator.async_set_state"
     ) as mock_set_state:
         await hass.services.async_call(
             CLIMATE_DOMAIN,
@@ -68,7 +68,7 @@ async def test_climate_state(
         mock_set_state.assert_called_once()
 
     with patch(
-        "homeassistant.components.ccm15.coordinator.CCM15Device.async_set_state"
+        "homeassistant.components.ccm15.coordinator.CCM15Coordinator.async_set_state"
     ) as mock_set_state:
         await hass.services.async_call(
             CLIMATE_DOMAIN,
@@ -80,7 +80,7 @@ async def test_climate_state(
         mock_set_state.assert_called_once()
 
     with patch(
-        "homeassistant.components.ccm15.coordinator.CCM15Device.async_set_state"
+        "homeassistant.components.ccm15.coordinator.CCM15Coordinator.async_set_state"
     ) as mock_set_state:
         await hass.services.async_call(
             CLIMATE_DOMAIN,
@@ -92,7 +92,7 @@ async def test_climate_state(
         mock_set_state.assert_called_once()
 
     with patch(
-        "homeassistant.components.ccm15.coordinator.CCM15Device.async_set_state"
+        "homeassistant.components.ccm15.coordinator.CCM15Coordinator.async_set_state"
     ) as mock_set_state:
         await hass.services.async_call(
             CLIMATE_DOMAIN,
@@ -104,7 +104,7 @@ async def test_climate_state(
         mock_set_state.assert_called_once()
 
     with patch(
-        "homeassistant.components.ccm15.coordinator.CCM15Device.async_set_state"
+        "homeassistant.components.ccm15.coordinator.CCM15Coordinator.async_set_state"
     ) as mock_set_state:
         await hass.services.async_call(
             CLIMATE_DOMAIN,
@@ -115,10 +115,9 @@ async def test_climate_state(
         await hass.async_block_till_done()
         mock_set_state.assert_called_once()
 
-    # Create an instance of the CCM15DeviceState class
     device_state = CCM15DeviceState(devices={})
     with patch(
-        "ccm15.CCM15Device.CCM15Device.get_status_async",
+        "homeassistant.components.ccm15.coordinator.CCM15Coordinator._fetch_data",
         return_value=device_state,
     ):
         freezer.tick(timedelta(minutes=15))

--- a/tests/components/ccm15/test_config_flow.py
+++ b/tests/components/ccm15/test_config_flow.py
@@ -22,7 +22,7 @@ async def test_form(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
     assert result["errors"] == {}
 
     with patch(
-        "ccm15.CCM15Device.CCM15Device.async_test_connection",
+        "homeassistant.components.ccm15.config_flow._test_connection",
         return_value=True,
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -53,7 +53,7 @@ async def test_form_invalid_host(
     assert result["errors"] == {}
 
     with patch(
-        "ccm15.CCM15Device.CCM15Device.async_test_connection",
+        "homeassistant.components.ccm15.config_flow._test_connection",
         return_value=False,
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -69,7 +69,7 @@ async def test_form_invalid_host(
     assert len(mock_setup_entry.mock_calls) == 0
 
     with patch(
-        "ccm15.CCM15Device.CCM15Device.async_test_connection", return_value=True
+        "homeassistant.components.ccm15.config_flow._test_connection", return_value=True
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -89,7 +89,8 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     )
 
     with patch(
-        "ccm15.CCM15Device.CCM15Device.async_test_connection", return_value=False
+        "homeassistant.components.ccm15.config_flow._test_connection",
+        return_value=False,
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -102,7 +103,7 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     assert result2["errors"] == {"base": "cannot_connect"}
 
     with patch(
-        "ccm15.CCM15Device.CCM15Device.async_test_connection", return_value=True
+        "homeassistant.components.ccm15.config_flow._test_connection", return_value=True
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -122,7 +123,7 @@ async def test_form_unexpected_error(hass: HomeAssistant) -> None:
     )
 
     with patch(
-        "ccm15.CCM15Device.CCM15Device.async_test_connection",
+        "homeassistant.components.ccm15.config_flow._test_connection",
         side_effect=Exception(),
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -136,7 +137,7 @@ async def test_form_unexpected_error(hass: HomeAssistant) -> None:
     assert result2["errors"] == {"base": "unknown"}
 
     with patch(
-        "ccm15.CCM15Device.CCM15Device.async_test_connection", return_value=True
+        "homeassistant.components.ccm15.config_flow._test_connection", return_value=True
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The integration currently fails to set up on recent Home Assistant releases. The asyncio blocking-call detector trips on `ssl.load_verify_locations` during the first refresh and the config entry never finishes loading, so no entities are created. The blocking call comes from the upstream `py_ccm15` library, which builds an `httpx.AsyncClient` inside `get_status_async()` (and an `aiohttp.ClientSession` inside `async_test_connection()`), both of which load the certifi CA bundle synchronously on the event loop.

Rather than wait on the dependency, this PR drops the library's HTTP helpers and talks to `status.xml` / `ctrl.xml` directly through Home Assistant's shared httpx client, whose SSL context is pre-loaded in an executor at startup. The library is still used for its `CCM15DeviceState` / `CCM15SlaveDevice` parsers.

A few related bugs are fixed in the same change:

- Skip empty slots in the status response instead of bailing out on the first `"-"`. A controller that reports `slot0=- slot1=<bytes>` used to produce zero entities.
- Cache the last value written for a slave for ~12 s. The CCM15 firmware takes several seconds to commit a change and the status endpoint reports the old value in the meantime, which made the UI snap back to the previous fan/temp/mode immediately after a service call.
- Wire up `async_set_swing_mode`. The entity already advertised `SWING_MODE` and exposed a `swing_mode` property, but had no setter, so calling `climate.set_swing_mode` raised `unknown error`. The control URL also gains `&sw=` / `&ht=0`, which is what the controller's own web UI sends.

A follow-up PR will add the optional device password, configurable temperature limits and reconfigure flow on top of this one. Tests are updated to patch the new helpers; `xmltodict==1.0.4` is already pinned for other integrations and was added to the manifest.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #161926, #133897, #124918, #115223
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
