### PR TITLE
Simplify DSMR config flow to a single serial port selector

### DIFF
--- a/homeassistant/components/dsmr/config_flow.py
+++ b/homeassistant/components/dsmr/config_flow.py
@@ -155,7 +155,7 @@ class DSMRFlowHandler(ConfigFlow, domain=DOMAIN):
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Step when user initializes a integration.
+        """Step when user initializes an integration.
 
         A single serial port selector handles both local serial devices and
         network connections; a network meter can be reached by entering a URL

--- a/homeassistant/components/dsmr/config_flow.py
+++ b/homeassistant/components/dsmr/config_flow.py
@@ -5,11 +5,8 @@ from functools import partial
 from typing import Any, override
 
 from dsmr_parser import obis_references as obis_ref
-from dsmr_parser.clients.protocol import create_dsmr_reader, create_tcp_dsmr_reader
-from dsmr_parser.clients.rfxtrx_protocol import (
-    create_rfxtrx_dsmr_reader,
-    create_rfxtrx_tcp_dsmr_reader,
-)
+from dsmr_parser.clients.protocol import create_dsmr_reader
+from dsmr_parser.clients.rfxtrx_protocol import create_rfxtrx_dsmr_reader
 from dsmr_parser.objects import DSMRObject
 import voluptuous as vol
 
@@ -19,7 +16,7 @@ from homeassistant.config_entries import (
     ConfigFlowResult,
     OptionsFlow,
 )
-from homeassistant.const import CONF_HOST, CONF_PORT, CONF_PROTOCOL, CONF_TYPE
+from homeassistant.const import CONF_PORT, CONF_PROTOCOL
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.selector import SerialPortSelector
@@ -41,11 +38,8 @@ from .const import (
 class DSMRConnection:
     """Test the connection to DSMR and receive telegram to read serial ids."""
 
-    def __init__(
-        self, host: str | None, port: int, dsmr_version: str, protocol: str
-    ) -> None:
+    def __init__(self, port: str, dsmr_version: str, protocol: str) -> None:
         """Initialize."""
-        self._host = host
         self._port = port
         self._dsmr_version = dsmr_version
         self._protocol = protocol
@@ -86,34 +80,20 @@ class DSMRConnection:
                 self._telegram = telegram
                 transport.close()
 
-        if self._host is None:
-            if self._protocol == DSMR_PROTOCOL:
-                create_reader = create_dsmr_reader
-            else:
-                create_reader = create_rfxtrx_dsmr_reader
-            reader_factory = partial(
-                create_reader,
-                self._port,
-                self._dsmr_version,
-                update_telegram,
-                loop=hass.loop,
-            )
+        if self._protocol == DSMR_PROTOCOL:
+            create_reader = create_dsmr_reader
         else:
-            if self._protocol == DSMR_PROTOCOL:
-                create_reader = create_tcp_dsmr_reader
-            else:
-                create_reader = create_rfxtrx_tcp_dsmr_reader
-            reader_factory = partial(
-                create_reader,
-                self._host,
-                self._port,
-                self._dsmr_version,
-                update_telegram,
-                loop=hass.loop,
-            )
+            create_reader = create_rfxtrx_dsmr_reader
+        reader_factory = partial(
+            create_reader,
+            self._port,
+            self._dsmr_version,
+            update_telegram,
+            loop=hass.loop,
+        )
 
         try:
-            transport, protocol = await asyncio.create_task(reader_factory())
+            transport, protocol = await reader_factory()
         except OSError:
             LOGGER.exception("Error connecting to DSMR")
             return False
@@ -136,7 +116,6 @@ async def _validate_dsmr_connection(
 ) -> dict[str, str | None]:
     """Validate the user input allows us to connect."""
     conn = DSMRConnection(
-        data.get(CONF_HOST),
         data[CONF_PORT],
         data[CONF_DSMR_VERSION],
         protocol,
@@ -176,48 +155,12 @@ class DSMRFlowHandler(ConfigFlow, domain=DOMAIN):
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Step when user initializes a integration."""
-        if user_input is not None:
-            user_selection = user_input[CONF_TYPE]
-            if user_selection == "Serial":
-                return await self.async_step_setup_serial()
+        """Step when user initializes a integration.
 
-            return await self.async_step_setup_network()
-
-        list_of_types = ["Serial", "Network"]
-
-        schema = vol.Schema({vol.Required(CONF_TYPE): vol.In(list_of_types)})
-        return self.async_show_form(step_id="user", data_schema=schema)
-
-    async def async_step_setup_network(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Step when setting up network configuration."""
-        errors: dict[str, str] = {}
-        if user_input is not None:
-            data = await self.async_validate_dsmr(user_input, errors)
-            if not errors:
-                return self.async_create_entry(
-                    title=f"{data[CONF_HOST]}:{data[CONF_PORT]}", data=data
-                )
-
-        schema = vol.Schema(
-            {
-                vol.Required(CONF_HOST): str,
-                vol.Required(CONF_PORT): int,
-                vol.Required(CONF_DSMR_VERSION): vol.In(DSMR_VERSIONS),
-            }
-        )
-        return self.async_show_form(
-            step_id="setup_network",
-            data_schema=schema,
-            errors=errors,
-        )
-
-    async def async_step_setup_serial(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Step when setting up serial configuration."""
+        A single serial port selector handles both local serial devices and
+        network connections; a network meter can be reached by entering a URL
+        such as ``socket://host:port``.
+        """
         errors: dict[str, str] = {}
         if user_input is not None:
             data = await self.async_validate_dsmr(user_input, errors)
@@ -231,7 +174,7 @@ class DSMRFlowHandler(ConfigFlow, domain=DOMAIN):
             }
         )
         return self.async_show_form(
-            step_id="setup_serial",
+            step_id="user",
             data_schema=schema,
             errors=errors,
         )

--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -62,6 +62,7 @@ from .const import (
     DOMAIN,
     DSMR_PROTOCOL,
     LOGGER,
+    RFXTRX_DSMR_PROTOCOL,
 )
 
 EVENT_FIRST_TELEGRAM = "dsmr_first_telegram_{}"
@@ -781,46 +782,44 @@ async def async_setup_entry(
 
     # Creates an asyncio.Protocol factory for reading DSMR telegrams and calls
     # update_entities_telegram to update entities on arrival. A port starting
-    # with "/" is a local serial device, which doesn't need a liveness check.
-    # Anything else is a special URL for a network connection that can drop
-    # silently, so we enable a keep-alive watchdog that closes the connection
-    # (triggering a reconnect) when no telegram arrives in time.
+    # with "/" is a local serial device, which doesn't need a liveness check;
+    # anything else is a network connection that can drop silently, so it gets a
+    # keep-alive watchdog that closes the connection (triggering a reconnect)
+    # when no telegram arrives in time.
     protocol = entry.data.get(CONF_PROTOCOL, DSMR_PROTOCOL)
-    if port.startswith("/"):
-        if protocol == DSMR_PROTOCOL:
-            create_reader = create_dsmr_reader
+    if protocol == RFXTRX_DSMR_PROTOCOL:
+        if port.startswith("/"):
+            reader_factory = partial(
+                create_rfxtrx_dsmr_reader,
+                port,
+                dsmr_version,
+                update_entities_telegram,
+                loop=hass.loop,
+            )
         else:
-            create_reader = create_rfxtrx_dsmr_reader
-        reader_factory = partial(
-            create_reader,
-            port,
-            dsmr_version,
-            update_entities_telegram,
-            loop=hass.loop,
-        )
-    elif protocol == DSMR_PROTOCOL:
-        # create_dsmr_reader opens any URL (socket://, esphome://, ...) and
-        # supports the keep-alive watchdog directly.
+            # The RFXtrx serial reader has no keep-alive support, so the network
+            # host and port are fed to the dedicated TCP reader instead.
+            address = urlparse(port)
+            reader_factory = partial(
+                create_rfxtrx_tcp_dsmr_reader,
+                address.hostname,
+                address.port,
+                dsmr_version,
+                update_entities_telegram,
+                loop=hass.loop,
+                keep_alive_interval=60,
+            )
+    else:
+        # create_dsmr_reader opens both local devices and any URL (socket://,
+        # esphome://, ...); the only difference is the keep-alive watchdog.
+        keep_alive = {} if port.startswith("/") else {"keep_alive_interval": 60}
         reader_factory = partial(
             create_dsmr_reader,
             port,
             dsmr_version,
             update_entities_telegram,
             loop=hass.loop,
-            keep_alive_interval=60,
-        )
-    else:
-        # The RFXtrx serial reader has no keep-alive support, so the network host
-        # and port are fed to the dedicated TCP reader instead.
-        address = urlparse(port)
-        reader_factory = partial(
-            create_rfxtrx_tcp_dsmr_reader,
-            address.hostname,
-            address.port,
-            dsmr_version,
-            update_entities_telegram,
-            loop=hass.loop,
-            keep_alive_interval=60,
+            **keep_alive,
         )
 
     async def connect_and_reconnect() -> None:

--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -9,9 +9,13 @@ from datetime import timedelta
 from enum import IntEnum
 from functools import partial
 from typing import override
+from urllib.parse import urlparse
 
 from dsmr_parser.clients.protocol import create_dsmr_reader
-from dsmr_parser.clients.rfxtrx_protocol import create_rfxtrx_dsmr_reader
+from dsmr_parser.clients.rfxtrx_protocol import (
+    create_rfxtrx_dsmr_reader,
+    create_rfxtrx_tcp_dsmr_reader,
+)
 from dsmr_parser.objects import DSMRObject, MbusDevice, Telegram
 
 from homeassistant.components.sensor import (
@@ -767,26 +771,57 @@ async def async_setup_entry(
                 hass, EVENT_FIRST_TELEGRAM.format(entry.entry_id), telegram
             )
 
-    # Creates an asyncio.Protocol factory for reading DSMR telegrams from
-    # serial and calls update_entities_telegram to update entities on arrival
-    protocol = entry.data.get(CONF_PROTOCOL, DSMR_PROTOCOL)
-    if protocol == DSMR_PROTOCOL:
-        create_reader = create_dsmr_reader
-    else:
-        create_reader = create_rfxtrx_dsmr_reader
     # Legacy network entries stored host and port separately; combine them into
-    # a single socket:// URL in memory so the entry stays untouched and rolling
-    # back to an older Home Assistant version keeps working.
+    # the single socket://host:port form newer entries already use, in memory
+    # only, so the stored entry stays untouched and rolling back to an older
+    # Home Assistant version keeps working.
     port = entry.data[CONF_PORT]
     if CONF_HOST in entry.data:
         port = f"socket://{entry.data[CONF_HOST]}:{port}"
-    reader_factory = partial(
-        create_reader,
-        port,
-        dsmr_version,
-        update_entities_telegram,
-        loop=hass.loop,
-    )
+
+    # Creates an asyncio.Protocol factory for reading DSMR telegrams and calls
+    # update_entities_telegram to update entities on arrival. A port starting
+    # with "/" is a local serial device, which doesn't need a liveness check.
+    # Anything else is a special URL for a network connection that can drop
+    # silently, so we enable a keep-alive watchdog that closes the connection
+    # (triggering a reconnect) when no telegram arrives in time.
+    protocol = entry.data.get(CONF_PROTOCOL, DSMR_PROTOCOL)
+    if port.startswith("/"):
+        if protocol == DSMR_PROTOCOL:
+            create_reader = create_dsmr_reader
+        else:
+            create_reader = create_rfxtrx_dsmr_reader
+        reader_factory = partial(
+            create_reader,
+            port,
+            dsmr_version,
+            update_entities_telegram,
+            loop=hass.loop,
+        )
+    elif protocol == DSMR_PROTOCOL:
+        # create_dsmr_reader opens any URL (socket://, esphome://, ...) and
+        # supports the keep-alive watchdog directly.
+        reader_factory = partial(
+            create_dsmr_reader,
+            port,
+            dsmr_version,
+            update_entities_telegram,
+            loop=hass.loop,
+            keep_alive_interval=60,
+        )
+    else:
+        # The RFXtrx serial reader has no keep-alive support, so the network host
+        # and port are fed to the dedicated TCP reader instead.
+        address = urlparse(port)
+        reader_factory = partial(
+            create_rfxtrx_tcp_dsmr_reader,
+            address.hostname,
+            address.port,
+            dsmr_version,
+            update_entities_telegram,
+            loop=hass.loop,
+            keep_alive_interval=60,
+        )
 
     async def connect_and_reconnect() -> None:
         """Connect to DSMR and keep reconnecting until Home Assistant stops."""

--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -10,11 +10,8 @@ from enum import IntEnum
 from functools import partial
 from typing import override
 
-from dsmr_parser.clients.protocol import create_dsmr_reader, create_tcp_dsmr_reader
-from dsmr_parser.clients.rfxtrx_protocol import (
-    create_rfxtrx_dsmr_reader,
-    create_rfxtrx_tcp_dsmr_reader,
-)
+from dsmr_parser.clients.protocol import create_dsmr_reader
+from dsmr_parser.clients.rfxtrx_protocol import create_rfxtrx_dsmr_reader
 from dsmr_parser.objects import DSMRObject, MbusDevice, Telegram
 
 from homeassistant.components.sensor import (
@@ -773,32 +770,23 @@ async def async_setup_entry(
     # Creates an asyncio.Protocol factory for reading DSMR telegrams from
     # serial and calls update_entities_telegram to update entities on arrival
     protocol = entry.data.get(CONF_PROTOCOL, DSMR_PROTOCOL)
-    if CONF_HOST in entry.data:
-        if protocol == DSMR_PROTOCOL:
-            create_reader = create_tcp_dsmr_reader
-        else:
-            create_reader = create_rfxtrx_tcp_dsmr_reader
-        reader_factory = partial(
-            create_reader,
-            entry.data[CONF_HOST],
-            entry.data[CONF_PORT],
-            dsmr_version,
-            update_entities_telegram,
-            loop=hass.loop,
-            keep_alive_interval=60,
-        )
+    if protocol == DSMR_PROTOCOL:
+        create_reader = create_dsmr_reader
     else:
-        if protocol == DSMR_PROTOCOL:
-            create_reader = create_dsmr_reader
-        else:
-            create_reader = create_rfxtrx_dsmr_reader
-        reader_factory = partial(
-            create_reader,
-            entry.data[CONF_PORT],
-            dsmr_version,
-            update_entities_telegram,
-            loop=hass.loop,
-        )
+        create_reader = create_rfxtrx_dsmr_reader
+    # Legacy network entries stored host and port separately; combine them into
+    # a single socket:// URL in memory so the entry stays untouched and rolling
+    # back to an older Home Assistant version keeps working.
+    port = entry.data[CONF_PORT]
+    if CONF_HOST in entry.data:
+        port = f"socket://{entry.data[CONF_HOST]}:{port}"
+    reader_factory = partial(
+        create_reader,
+        port,
+        dsmr_version,
+        update_entities_telegram,
+        loop=hass.loop,
+    )
 
     async def connect_and_reconnect() -> None:
         """Connect to DSMR and keep reconnecting until Home Assistant stops."""
@@ -814,7 +802,7 @@ async def async_setup_entry(
             update_entities_telegram({})
 
             try:
-                transport, protocol = await hass.loop.create_task(reader_factory())
+                transport, protocol = await reader_factory()
 
                 if transport:
                     # Register listener to close transport on HA shutdown

--- a/homeassistant/components/dsmr/strings.json
+++ b/homeassistant/components/dsmr/strings.json
@@ -11,26 +11,15 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     },
     "step": {
-      "setup_network": {
-        "data": {
-          "dsmr_version": "Select DSMR version",
-          "host": "[%key:common::config_flow::data::host%]",
-          "port": "[%key:common::config_flow::data::port%]"
-        },
-        "title": "Select connection address"
-      },
-      "setup_serial": {
-        "data": {
-          "dsmr_version": "[%key:component::dsmr::config::step::setup_network::data::dsmr_version%]",
-          "port": "Select device"
-        },
-        "title": "[%key:common::config_flow::data::device%]"
-      },
       "user": {
         "data": {
-          "type": "Connection type"
+          "dsmr_version": "Select DSMR version",
+          "port": "Select device"
         },
-        "title": "Select connection type"
+        "data_description": {
+          "port": "Select a serial device, or enter a network address such as socket://host:port"
+        },
+        "title": "[%key:common::config_flow::data::device%]"
       }
     }
   },

--- a/tests/components/dsmr/conftest.py
+++ b/tests/components/dsmr/conftest.py
@@ -34,15 +34,9 @@ def dsmr_connection_fixture() -> Generator[tuple[MagicMock, MagicMock, MagicMock
 
     connection_factory = MagicMock(wraps=connection_factory)
 
-    with (
-        patch(
-            "homeassistant.components.dsmr.sensor.create_dsmr_reader",
-            connection_factory,
-        ),
-        patch(
-            "homeassistant.components.dsmr.sensor.create_tcp_dsmr_reader",
-            connection_factory,
-        ),
+    with patch(
+        "homeassistant.components.dsmr.sensor.create_dsmr_reader",
+        connection_factory,
     ):
         yield (connection_factory, transport, protocol)
         closed.set()
@@ -66,15 +60,9 @@ def rfxtrx_dsmr_connection_fixture() -> Generator[
 
     connection_factory = MagicMock(wraps=connection_factory)
 
-    with (
-        patch(
-            "homeassistant.components.dsmr.sensor.create_rfxtrx_dsmr_reader",
-            connection_factory,
-        ),
-        patch(
-            "homeassistant.components.dsmr.sensor.create_rfxtrx_tcp_dsmr_reader",
-            connection_factory,
-        ),
+    with patch(
+        "homeassistant.components.dsmr.sensor.create_rfxtrx_dsmr_reader",
+        connection_factory,
     ):
         yield (connection_factory, transport, protocol)
         closed.set()
@@ -156,15 +144,9 @@ def dsmr_connection_send_validate_fixture() -> Generator[
 
     protocol.wait_closed = wait_closed
 
-    with (
-        patch(
-            "homeassistant.components.dsmr.config_flow.create_dsmr_reader",
-            connection_factory,
-        ),
-        patch(
-            "homeassistant.components.dsmr.config_flow.create_tcp_dsmr_reader",
-            connection_factory,
-        ),
+    with patch(
+        "homeassistant.components.dsmr.config_flow.create_dsmr_reader",
+        connection_factory,
     ):
         yield (connection_factory, transport, protocol)
 
@@ -207,14 +189,8 @@ def rfxtrx_dsmr_connection_send_validate_fixture() -> Generator[
 
     protocol.wait_closed = wait_closed
 
-    with (
-        patch(
-            "homeassistant.components.dsmr.config_flow.create_rfxtrx_dsmr_reader",
-            connection_factory,
-        ),
-        patch(
-            "homeassistant.components.dsmr.config_flow.create_rfxtrx_tcp_dsmr_reader",
-            connection_factory,
-        ),
+    with patch(
+        "homeassistant.components.dsmr.config_flow.create_rfxtrx_dsmr_reader",
+        connection_factory,
     ):
         yield (connection_factory, transport, protocol)

--- a/tests/components/dsmr/conftest.py
+++ b/tests/components/dsmr/conftest.py
@@ -60,9 +60,15 @@ def rfxtrx_dsmr_connection_fixture() -> Generator[
 
     connection_factory = MagicMock(wraps=connection_factory)
 
-    with patch(
-        "homeassistant.components.dsmr.sensor.create_rfxtrx_dsmr_reader",
-        connection_factory,
+    with (
+        patch(
+            "homeassistant.components.dsmr.sensor.create_rfxtrx_dsmr_reader",
+            connection_factory,
+        ),
+        patch(
+            "homeassistant.components.dsmr.sensor.create_rfxtrx_tcp_dsmr_reader",
+            connection_factory,
+        ),
     ):
         yield (connection_factory, transport, protocol)
         closed.set()

--- a/tests/components/dsmr/test_config_flow.py
+++ b/tests/components/dsmr/test_config_flow.py
@@ -32,44 +32,33 @@ async def test_setup_network(
     hass: HomeAssistant,
     dsmr_connection_send_validate_fixture: tuple[MagicMock, MagicMock, MagicMock],
 ) -> None:
-    """Test we can setup network."""
+    """Test we can setup a network connection via a socket URL."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
-    assert result["errors"] is None
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {"type": "Network"},
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "setup_network"
     assert result["errors"] == {}
 
     with patch("homeassistant.components.dsmr.async_setup_entry", return_value=True):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                "host": "10.10.0.1",
-                "port": 1234,
+                "port": "socket://10.10.0.1:1234",
                 "dsmr_version": "2.2",
             },
         )
         await hass.async_block_till_done()
 
     entry_data = {
-        "host": "10.10.0.1",
-        "port": 1234,
+        "port": "socket://10.10.0.1:1234",
         "dsmr_version": "2.2",
         "protocol": "dsmr_protocol",
     }
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == "10.10.0.1:1234"
+    assert result["title"] == "socket://10.10.0.1:1234"
     assert result["data"] == {**entry_data, **SERIAL_DATA}
 
 
@@ -80,7 +69,7 @@ async def test_setup_network_rfxtrx(
         MagicMock, MagicMock, MagicMock
     ],
 ) -> None:
-    """Test we can setup network."""
+    """Test we can setup a network connection via a socket URL for rfxtrx."""
     (_connection_factory, _transport, protocol) = dsmr_connection_send_validate_fixture
 
     result = await hass.config_entries.flow.async_init(
@@ -89,15 +78,6 @@ async def test_setup_network_rfxtrx(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
-    assert result["errors"] is None
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {"type": "Network"},
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "setup_network"
     assert result["errors"] == {}
 
     # set-up DSMRProtocol to yield no valid telegram,
@@ -108,22 +88,20 @@ async def test_setup_network_rfxtrx(
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                "host": "10.10.0.1",
-                "port": 1234,
+                "port": "socket://10.10.0.1:1234",
                 "dsmr_version": "2.2",
             },
         )
         await hass.async_block_till_done()
 
     entry_data = {
-        "host": "10.10.0.1",
-        "port": 1234,
+        "port": "socket://10.10.0.1:1234",
         "dsmr_version": "2.2",
         "protocol": "rfxtrx_dsmr_protocol",
     }
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == "10.10.0.1:1234"
+    assert result["title"] == "socket://10.10.0.1:1234"
     assert result["data"] == {**entry_data, **SERIAL_DATA}
 
 
@@ -207,15 +185,6 @@ async def test_setup_serial(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
-    assert result["errors"] is None
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {"type": "Serial"},
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "setup_serial"
     assert result["errors"] == {}
 
     with patch("homeassistant.components.dsmr.async_setup_entry", return_value=True):
@@ -248,15 +217,6 @@ async def test_setup_serial_rfxtrx(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
-    assert result["errors"] is None
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {"type": "Serial"},
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "setup_serial"
     assert result["errors"] == {}
 
     # set-up DSMRProtocol to yield no valid telegram,
@@ -302,15 +262,6 @@ async def test_setup_serial_fail(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
-    assert result["errors"] is None
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {"type": "Serial"},
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "setup_serial"
     assert result["errors"] == {}
 
     with patch(
@@ -323,7 +274,7 @@ async def test_setup_serial_fail(
         )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "setup_serial"
+    assert result["step_id"] == "user"
     assert result["errors"] == {"base": "cannot_connect"}
 
 
@@ -362,15 +313,6 @@ async def test_setup_serial_timeout(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
-    assert result["errors"] is None
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {"type": "Serial"},
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "setup_serial"
     assert result["errors"] == {}
 
     with patch("homeassistant.components.dsmr.async_setup_entry", return_value=True):
@@ -379,7 +321,7 @@ async def test_setup_serial_timeout(
         )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "setup_serial"
+    assert result["step_id"] == "user"
     assert result["errors"] == {"base": "cannot_communicate"}
 
 
@@ -406,15 +348,6 @@ async def test_setup_serial_wrong_telegram(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
-    assert result["errors"] is None
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {"type": "Serial"},
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "setup_serial"
     assert result["errors"] == {}
 
     protocol.telegram = {}
@@ -426,7 +359,7 @@ async def test_setup_serial_wrong_telegram(
     )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "setup_serial"
+    assert result["step_id"] == "user"
     assert result["errors"] == {"base": "cannot_communicate"}
 
 

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -1380,8 +1380,9 @@ async def test_tcp(
     await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert connection_factory.call_args_list[0][0][0] == "localhost"
-    assert connection_factory.call_args_list[0][0][1] == "1234"
+    # Legacy host/port is combined into a socket URL in memory; entry untouched
+    assert mock_entry.data["host"] == "localhost"
+    assert connection_factory.call_args_list[0][0][0] == "socket://localhost:1234"
 
 
 async def test_rfxtrx_tcp(
@@ -1409,8 +1410,9 @@ async def test_rfxtrx_tcp(
     await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert connection_factory.call_args_list[0][0][0] == "localhost"
-    assert connection_factory.call_args_list[0][0][1] == "1234"
+    # Legacy host/port is combined into a socket URL in memory; entry untouched
+    assert mock_entry.data["host"] == "localhost"
+    assert connection_factory.call_args_list[0][0][0] == "socket://localhost:1234"
 
 
 @patch("homeassistant.components.dsmr.sensor.DEFAULT_RECONNECT_INTERVAL", 0)

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -1380,9 +1380,12 @@ async def test_tcp(
     await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
-    # Legacy host/port is combined into a socket URL in memory; entry untouched
+    # Legacy host/port entries are combined into a socket URL in memory and
+    # opened with the keep-alive watchdog; the stored entry is left untouched so
+    # a downgrade keeps working.
     assert mock_entry.data["host"] == "localhost"
     assert connection_factory.call_args_list[0][0][0] == "socket://localhost:1234"
+    assert connection_factory.call_args_list[0][1]["keep_alive_interval"] == 60
 
 
 async def test_rfxtrx_tcp(
@@ -1410,9 +1413,66 @@ async def test_rfxtrx_tcp(
     await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
-    # Legacy host/port is combined into a socket URL in memory; entry untouched
+    # Legacy host/port entries keep using the TCP reader (with keep-alive); the
+    # stored entry is left untouched so a downgrade keeps working.
     assert mock_entry.data["host"] == "localhost"
+    assert connection_factory.call_args_list[0][0][0] == "localhost"
+    assert connection_factory.call_args_list[0][0][1] == 1234
+    assert connection_factory.call_args_list[0][1]["keep_alive_interval"] == 60
+
+
+async def test_tcp_socket_url(
+    hass: HomeAssistant, dsmr_connection_fixture: tuple[MagicMock, MagicMock, MagicMock]
+) -> None:
+    """A socket:// port should be opened with the keep-alive watchdog."""
+    (connection_factory, _transport, _protocol) = dsmr_connection_fixture
+
+    entry_data = {
+        "port": "socket://localhost:1234",
+        "dsmr_version": "2.2",
+        "protocol": "dsmr_protocol",
+        "serial_id": "1234",
+        "serial_id_gas": "5678",
+    }
+
+    mock_entry = MockConfigEntry(
+        domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data
+    )
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
+
     assert connection_factory.call_args_list[0][0][0] == "socket://localhost:1234"
+    assert connection_factory.call_args_list[0][1]["keep_alive_interval"] == 60
+
+
+async def test_serial_no_keep_alive(
+    hass: HomeAssistant, dsmr_connection_fixture: tuple[MagicMock, MagicMock, MagicMock]
+) -> None:
+    """A local serial device should use the plain reader without keep-alive."""
+    (connection_factory, _transport, _protocol) = dsmr_connection_fixture
+
+    entry_data = {
+        "port": "/dev/ttyUSB0",
+        "dsmr_version": "2.2",
+        "protocol": "dsmr_protocol",
+        "serial_id": "1234",
+        "serial_id_gas": "5678",
+    }
+
+    mock_entry = MockConfigEntry(
+        domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data
+    )
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert connection_factory.call_args_list[0][0][0] == "/dev/ttyUSB0"
+    assert "keep_alive_interval" not in connection_factory.call_args_list[0][1]
 
 
 @patch("homeassistant.components.dsmr.sensor.DEFAULT_RECONNECT_INTERVAL", 0)


### PR DESCRIPTION
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Not a breaking change. Existing network config entries (which stored host and
port separately) keep working: they are combined into a single
`socket://host:port` value in memory at startup, without modifying the stored
entry, so downgrading Home Assistant continues to work.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follow-up to #171103, which switched the DSMR serial step to a
`SerialPortSelector`. That PR forgot to remove the initial "Serial or Network"
choice and the separate network step — the serial port selector already works
for both, since a network meter can be reached by entering a URL such as
`socket://host:port`, which the underlying serial library (`serialx`, via
`create_dsmr_reader`) resolves and opens directly.

This PR:
- Removes the connection-type question and the dedicated network step; a single
  serial port selector now covers both local serial devices and network meters.
- Passes the selector value straight into `create_dsmr_reader`, dropping the
  separate `create_tcp_dsmr_reader` path.
- Combines legacy network entries (`host` + `port`) into a single
  `socket://host:port` value in memory only, leaving the stored entry untouched
  so a rollback keeps working.

Verified against a real meter by @adonno.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: follow-up to #171103
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

https://claude.ai/code/session_01PriY1TC3P2d3fE5ynAkQ9t

---
_Generated by [Claude Code](https://claude.ai/code/session_01PriY1TC3P2d3fE5ynAkQ9t)_