### PR TITLE
Fix Withings activity sensors using wrong timezone for date comparison

### DIFF
--- a/homeassistant/components/withings/coordinator.py
+++ b/homeassistant/components/withings/coordinator.py
@@ -1,7 +1,7 @@
 """Withings coordinator."""
 
 from abc import abstractmethod
-from datetime import date, datetime, timedelta
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
 from aiowithings import (
@@ -270,7 +270,7 @@ class WithingsActivityDataUpdateCoordinator(
                 self._last_valid_update
             )
 
-        today = date.today()  # noqa: DTZ011
+        today = dt_util.now().date()
         for activity in activities:
             if activity.date == today:
                 self._previous_data = activity

--- a/tests/components/withings/snapshots/test_sensor.ambr
+++ b/tests/components/withings/snapshots/test_sensor.ambr
@@ -107,7 +107,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'henk Active calories burnt today',
-      'last_reset': '2023-10-20T00:00:00-07:00',
+      'last_reset': '2023-10-21T00:00:00-07:00',
       'state_class': <SensorStateClass.TOTAL: 'total'>,
       'unit_of_measurement': 'calories',
     }),
@@ -169,7 +169,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'duration',
       'friendly_name': 'henk Active time today',
-      'last_reset': '2023-10-20T00:00:00-07:00',
+      'last_reset': '2023-10-21T00:00:00-07:00',
       'state_class': <SensorStateClass.TOTAL: 'total'>,
       'unit_of_measurement': <UnitOfTime.HOURS: 'h'>,
     }),
@@ -733,7 +733,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'distance',
       'friendly_name': 'henk Distance travelled today',
-      'last_reset': '2023-10-20T00:00:00-07:00',
+      'last_reset': '2023-10-21T00:00:00-07:00',
       'state_class': <SensorStateClass.TOTAL: 'total'>,
       'unit_of_measurement': <UnitOfLength.METERS: 'm'>,
     }),
@@ -1000,7 +1000,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'distance',
       'friendly_name': 'henk Elevation change today',
-      'last_reset': '2023-10-20T00:00:00-07:00',
+      'last_reset': '2023-10-21T00:00:00-07:00',
       'state_class': <SensorStateClass.TOTAL: 'total'>,
       'unit_of_measurement': <UnitOfLength.METERS: 'm'>,
     }),
@@ -2043,7 +2043,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'duration',
       'friendly_name': 'henk Intense activity today',
-      'last_reset': '2023-10-20T00:00:00-07:00',
+      'last_reset': '2023-10-21T00:00:00-07:00',
       'state_class': <SensorStateClass.TOTAL: 'total'>,
       'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
     }),
@@ -2702,7 +2702,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'duration',
       'friendly_name': 'henk Moderate activity today',
-      'last_reset': '2023-10-20T00:00:00-07:00',
+      'last_reset': '2023-10-21T00:00:00-07:00',
       'state_class': <SensorStateClass.TOTAL: 'total'>,
       'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
     }),
@@ -3576,7 +3576,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'duration',
       'friendly_name': 'henk Soft activity today',
-      'last_reset': '2023-10-20T00:00:00-07:00',
+      'last_reset': '2023-10-21T00:00:00-07:00',
       'state_class': <SensorStateClass.TOTAL: 'total'>,
       'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
     }),
@@ -3739,7 +3739,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'henk Steps today',
-      'last_reset': '2023-10-20T00:00:00-07:00',
+      'last_reset': '2023-10-21T00:00:00-07:00',
       'state_class': <SensorStateClass.TOTAL: 'total'>,
       'unit_of_measurement': 'steps',
     }),
@@ -4035,7 +4035,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'henk Total calories burnt today',
-      'last_reset': '2023-10-20T00:00:00-07:00',
+      'last_reset': '2023-10-21T00:00:00-07:00',
       'state_class': <SensorStateClass.TOTAL: 'total'>,
       'unit_of_measurement': 'calories',
     }),

--- a/tests/components/withings/test_sensor.py
+++ b/tests/components/withings/test_sensor.py
@@ -26,7 +26,7 @@ from . import (
 from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
 
 
-@pytest.mark.freeze_time("2023-10-21")
+@pytest.mark.freeze_time("2023-10-21 12:00:00")
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_all_entities(
     hass: HomeAssistant,
@@ -160,7 +160,7 @@ async def test_activity_sensors_unknown_next_day(
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test activity sensors will return unknown the next day."""
-    freezer.move_to("2023-10-21")
+    freezer.move_to("2023-10-21 12:00:00")
     await setup_integration(hass, polling_config_entry, False)
 
     assert hass.states.get("sensor.henk_steps_today")
@@ -181,7 +181,7 @@ async def test_activity_sensors_same_result_same_day(
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test activity sensors will return the same result if old data is updated."""
-    freezer.move_to("2023-10-21")
+    freezer.move_to("2023-10-21 12:00:00")
     await setup_integration(hass, polling_config_entry, False)
 
     assert hass.states.get("sensor.henk_steps_today").state == "1155"
@@ -202,7 +202,7 @@ async def test_activity_sensors_created_when_existed(
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test activity sensors will be added if they existed before."""
-    freezer.move_to("2023-10-21")
+    freezer.move_to("2023-10-21 12:00:00")
     await setup_integration(hass, polling_config_entry, False)
 
     assert hass.states.get("sensor.henk_steps_today")
@@ -223,7 +223,7 @@ async def test_activity_sensors_created_when_receive_activity_data(
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test activity sensors will be added if we receive activity data."""
-    freezer.move_to("2023-10-21")
+    freezer.move_to("2023-10-21 12:00:00")
     withings.get_activities_in_period.return_value = []
     await setup_integration(hass, polling_config_entry, False)
 
@@ -242,6 +242,22 @@ async def test_activity_sensors_created_when_receive_activity_data(
     await hass.async_block_till_done()
 
     assert hass.states.get("sensor.henk_steps_today")
+
+
+async def test_activity_sensors_respect_timezone(
+    hass: HomeAssistant,
+    withings: AsyncMock,
+    polling_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test activity sensors use HA timezone instead of system timezone."""
+    await hass.config.async_set_time_zone("Asia/Tokyo")
+    freezer.move_to("2023-10-20T20:00:00+00:00")
+    await setup_integration(hass, polling_config_entry, False)
+
+    state = hass.states.get("sensor.henk_steps_today")
+    assert state is not None
+    assert state.state == "1155"
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The Withings activity coordinator uses `date.today()` to determine the current date when matching activity data. This returns the date in the system's local timezone (often UTC in Docker installations), not the Home Assistant configured timezone. When the user's configured timezone differs from the system timezone, the activity sensors can show data for the wrong day or return unknown when they should have data.

This replaces `date.today()` with `dt_util.now().date()`, which correctly uses the Home Assistant configured timezone.

The existing tests had their freeze times set to midnight UTC, which happened to work with the buggy `date.today()` but mapped to the previous day in the default US/Pacific test timezone. These have been updated to noon UTC so the date is consistent across both timezones. A new test explicitly validates the timezone handling by setting the HA timezone to Asia/Tokyo and freezing time at a UTC timestamp where the UTC date and Tokyo date differ.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170591
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr