### PR TITLE
Stop validating # of slots in zwave_js.set_credential action

### DIFF
--- a/homeassistant/components/zwave_js/lock_helpers.py
+++ b/homeassistant/components/zwave_js/lock_helpers.py
@@ -432,15 +432,6 @@ async def async_set_credential(
                 translation_key="no_available_credential_slots",
                 translation_placeholders={"credential_type": cred_type_str},
             )
-    elif not 1 <= credential_slot <= type_cap.number_of_credential_slots:
-        raise ServiceValidationError(
-            translation_domain=DOMAIN,
-            translation_key="credential_slot_out_of_range",
-            translation_placeholders={
-                "credential_type": cred_type_str,
-                "max_slot": str(type_cap.number_of_credential_slots),
-            },
-        )
 
     status = await node.access_control.set_credential(
         user_id, credential_type, credential_slot, credential_data

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -322,9 +322,6 @@
     "credential_rejected_wrong_uuid": {
       "message": "The device rejected the credential because the user unique identifier does not match."
     },
-    "credential_slot_out_of_range": {
-      "message": "Credential slot for {credential_type} must be between 1 and {max_slot}."
-    },
     "credential_type_not_supported": {
       "message": "Credential type {credential_type} is not supported on this device"
     },

--- a/tests/components/zwave_js/test_credential_services.py
+++ b/tests/components/zwave_js/test_credential_services.py
@@ -877,48 +877,6 @@ async def test_set_credential_length_validation(
     api.set_credential.assert_not_called()
 
 
-async def test_set_credential_slot_out_of_range(
-    hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
-    device_registry: dr.DeviceRegistry,
-    client: MagicMock,
-    lock_schlage_be469: Node,
-    integration: MockConfigEntry,
-) -> None:
-    """Explicit credential_slot above device capacity fails fast."""
-    api = _mock_access_control(lock_schlage_be469)
-    cred_caps = api.get_credential_capabilities_cached.return_value
-    cred_caps.supported_credential_types[
-        UserCredentialType.PIN_CODE
-    ].number_of_credential_slots = 5
-
-    with pytest.raises(HomeAssistantError) as exc:
-        await hass.services.async_call(
-            DOMAIN,
-            "set_credential",
-            {
-                ATTR_ENTITY_ID: _lock_entity_id(
-                    entity_registry, device_registry, client, lock_schlage_be469
-                ),
-                "user_id": 1,
-                "credential_type": "pin_code",
-                "credential_data": "1234",
-                "credential_slot": 6,
-            },
-            blocking=True,
-            return_response=True,
-        )
-
-    # The explicit slot exceeds the device-reported capacity, so the helper
-    # rejects the call with the rendered upper bound and never writes.
-    assert exc.value.translation_key == "credential_slot_out_of_range"
-    assert exc.value.translation_placeholders == {
-        "credential_type": "pin_code",
-        "max_slot": "5",
-    }
-    api.set_credential.assert_not_called()
-
-
 async def test_delete_credential(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,


### PR DESCRIPTION
## Proposed change
Some Schlage locks don't respond to interview requests correctly (see here for more info: https://github.com/raman325/lock_code_manager/issues/1251) and in some cases the max number of slots is undefined which defaults to 0. The validation prevented users with these locks from using the new action. `zwave-js` does its own validation upstream - by removing the validation here, we fallback to the native validation which should allow these commands to proceed since they are valid.

Conclusion reached in discussion with @AlCalzone 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
