### PR TITLE
Fix ccm15 setup abort (blocking httpx client) and non-contiguous AC slots

### DIFF
--- a/homeassistant/components/ccm15/config_flow.py
+++ b/homeassistant/components/ccm15/config_flow.py
@@ -9,6 +9,7 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.httpx_client import get_async_client
 
 from .const import DEFAULT_TIMEOUT, DOMAIN
 
@@ -35,7 +36,10 @@ class CCM15ConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             self._async_abort_entries_match(user_input)
             ccm15 = CCM15Device(
-                user_input[CONF_HOST], user_input[CONF_PORT], DEFAULT_TIMEOUT
+                user_input[CONF_HOST],
+                user_input[CONF_PORT],
+                DEFAULT_TIMEOUT,
+                client=get_async_client(self.hass),
             )
             try:
                 if not await ccm15.async_test_connection():

--- a/homeassistant/components/ccm15/coordinator.py
+++ b/homeassistant/components/ccm15/coordinator.py
@@ -9,6 +9,7 @@ import httpx
 from homeassistant.components.climate import HVACMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
@@ -37,7 +38,9 @@ class CCM15Coordinator(DataUpdateCoordinator[CCM15DeviceState]):
             name=host,
             update_interval=datetime.timedelta(seconds=DEFAULT_INTERVAL),
         )
-        self._ccm15 = CCM15Device(host, port, DEFAULT_TIMEOUT)
+        self._ccm15 = CCM15Device(
+            host, port, DEFAULT_TIMEOUT, client=get_async_client(hass)
+        )
         self._host = host
 
     def get_host(self) -> str:
@@ -62,10 +65,8 @@ class CCM15Coordinator(DataUpdateCoordinator[CCM15DeviceState]):
 
     def get_ac_data(self, ac_index: int) -> CCM15SlaveDevice | None:
         """Get ac data from the ac_index."""
-        if ac_index < 0 or ac_index >= len(self.data.devices):
-            # Network latency may return an empty or incomplete array
-            return None
-        return self.data.devices[ac_index]
+        # Slot indices can be sparse and reach >= 32, so look up by key.
+        return self.data.devices.get(ac_index)
 
     async def async_set_hvac_mode(
         self, ac_index: int, data: CCM15SlaveDevice, hvac_mode: HVACMode

--- a/tests/components/ccm15/test_config_flow.py
+++ b/tests/components/ccm15/test_config_flow.py
@@ -9,6 +9,7 @@ from homeassistant.components.ccm15.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.httpx_client import get_async_client
 
 from tests.common import MockConfigEntry
 
@@ -175,3 +176,29 @@ async def test_duplicate_host(hass: HomeAssistant) -> None:
 
     assert result2["type"] is FlowResultType.ABORT
     assert result2["reason"] == "already_configured"
+
+
+async def test_form_uses_shared_httpx_client(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
+    """The config flow passes HA's shared httpx client to the library.
+
+    Letting the library build its own client runs blocking certifi/SSL setup on
+    the event loop, which aborts the flow; the shared client avoids that.
+    """
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.ccm15.config_flow.CCM15Device", autospec=True
+    ) as mock_device:
+        mock_device.return_value.async_test_connection.return_value = True
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_HOST: "1.1.1.1"},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert mock_device.call_args.kwargs["client"] is get_async_client(hass)

--- a/tests/components/ccm15/test_init.py
+++ b/tests/components/ccm15/test_init.py
@@ -1,5 +1,8 @@
 """Tests for the ccm15 component."""
 
+from unittest.mock import patch
+
+from ccm15 import CCM15DeviceState, CCM15SlaveDevice
 import pytest
 
 from homeassistant.components.ccm15.const import DOMAIN
@@ -32,3 +35,38 @@ async def test_load_unload(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     assert entry.state is ConfigEntryState.NOT_LOADED
+
+
+async def test_non_contiguous_slots(hass: HomeAssistant) -> None:
+    """Entities for sparse slot indices, including >= 32, are available.
+
+    ``devices`` is keyed by the true slot index, which can be sparse and reach
+    >= 32. The coordinator must look devices up by key, not assume a contiguous
+    0..N-1 range, or any entity past a gap stays permanently unavailable.
+    """
+    device_state = CCM15DeviceState(
+        devices={
+            4: CCM15SlaveDevice(bytes.fromhex("000000b0b8001b")),
+            33: CCM15SlaveDevice(bytes.fromhex("00000041c0001a")),
+        }
+    )
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="1.1.1.1",
+        data={CONF_HOST: "1.1.1.1", CONF_PORT: 80},
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.ccm15.coordinator.CCM15Device.get_status_async",
+        return_value=device_state,
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+
+    for entity_id in ("climate.midea_4", "climate.midea_33"):
+        state = hass.states.get(entity_id)
+        assert state is not None
+        assert state.state != "unavailable"


### PR DESCRIPTION
## Proposed change

Fix the `ccm15` integration's setup abort and make the non-contiguous-slot
handling actually reach entities. The `py_ccm15` bump that delivers the
injectable client already landed on `dev` via #174099 (`py_ccm15==0.6.0`), so
this PR is fixes-only.

1. **Pass HA''s shared httpx client into every `CCM15Device`** — both the
   coordinator and the config flow''s connection test —
   `CCM15Device(..., client=get_async_client(hass))`. Previously the library
   built its own `httpx.AsyncClient` lazily on the event loop; its synchronous
   certifi/SSL setup trips the blocking-call detector and aborts setup. HA owns
   the shared client''s lifecycle, and the library only closes clients it built
   itself, so this is safe. (This also satisfies the Platinum `inject-websession`
   rule for the integration.)
2. **Fix `get_ac_data`** to look devices up by their true slot key
   (`self.data.devices.get(ac_index)`) instead of the old
   `ac_index >= len(...)` bound. `devices` is keyed by the real slot index,
   which can be sparse and reach `>= 32`; the old check left any entity past a
   gap permanently `None`/unavailable.

Tests: the config flow injects HA''s shared client, and sparse / `>= 32` slot
indices stay available end-to-end.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- The `py_ccm15` dependency bump (0.6.0) landed separately in #174099.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      _(The dependency bump landed in #174099; this PR changes no dependencies.)_

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr