### PR TITLE
Strict port matching for network URL helpers

### DIFF
--- a/homeassistant/helpers/http.py
+++ b/homeassistant/helpers/http.py
@@ -60,12 +60,9 @@ def request_handler_factory(
             from .network import NoURLAvailableError, get_url  # noqa: PLC0415
 
             # Get the current request header to include as resource metadata
-            # endpoint for RFC9728. We currently prefer external since this
-            # is likely most used by remote OAuth clients
+            # endpoint for RFC9728.
             try:
-                url_prefix = get_url(
-                    hass, require_current_request=True, prefer_external=True
-                )
+                url_prefix = get_url(hass, require_current_request=True)
             except NoURLAvailableError:
                 # Omit header to avoid leaking configured URLs
                 raise HTTPUnauthorized from None

--- a/homeassistant/helpers/network.py
+++ b/homeassistant/helpers/network.py
@@ -168,8 +168,10 @@ def get_url(
                 raise NoURLAvailableError
 
     # For current request, we accept loopback interfaces (e.g., 127.0.0.1),
-    # the Supervisor hostname and localhost transparently
-    request_host, request_port = _get_request_host_port()
+    # the Supervisor hostname and localhost transparently. We ignore the port
+    # in the request since we didn't match above and only use the configured
+    # scheme/port.
+    request_host, _ = _get_request_host_port()
     if (
         require_current_request
         and request_host is not None
@@ -177,7 +179,7 @@ def get_url(
     ):
         scheme = "https" if hass.config.api.use_ssl else "http"
         current_url = yarl.URL.build(
-            scheme=scheme, host=request_host, port=request_port
+            scheme=scheme, host=request_host, port=hass.config.api.port
         )
 
         known_hostnames = ["localhost"]

--- a/homeassistant/helpers/network.py
+++ b/homeassistant/helpers/network.py
@@ -167,9 +167,7 @@ def get_url(
             if require_cloud:
                 raise NoURLAvailableError
 
-    # For current request, we accept loopback interfaces (e.g., 127.0.0.1),
-    # the Supervisor hostname and localhost transparently
-    request_host, _ = _get_request_host_port()
+    request_host, request_port = _get_request_host_port()
     if (
         require_current_request
         and request_host is not None
@@ -177,7 +175,7 @@ def get_url(
     ):
         scheme = "https" if hass.config.api.use_ssl else "http"
         current_url = yarl.URL.build(
-            scheme=scheme, host=request_host, port=hass.config.api.port
+            scheme=scheme, host=request_host, port=request_port
         )
 
         known_hostnames = ["localhost"]
@@ -237,15 +235,26 @@ def _get_request_host_port() -> tuple[str | None, int | None]:
     if "[" in host:
         host_part, _, port_part = host.partition("[")[2].partition("]")
         port_str = port_part[1:] if port_part.startswith(":") else ""
+        has_port = port_part.startswith(":")
     # partition the host to remove the port
     # because the raw host header can contain the port
     elif ":" in host:
         host_part, _, port_str = host.partition(":")
+        has_port = True
     else:
         host_part, port_str = host, ""
+        has_port = False
 
-    port = int(port_str) if port_str.isdigit() else None
-    if port is None:
+    port = None
+    if has_port:
+        if port_str.isdigit():
+            with suppress(ValueError):
+                val = int(port_str)
+                if 1 <= val <= 65535:
+                    port = val
+        if port is None:
+            return None, None
+    else:
         port = 443 if request.url.scheme == "https" else 80
 
     return host_part, port

--- a/homeassistant/helpers/network.py
+++ b/homeassistant/helpers/network.py
@@ -167,6 +167,8 @@ def get_url(
             if require_cloud:
                 raise NoURLAvailableError
 
+    # For current request, we accept loopback interfaces (e.g., 127.0.0.1),
+    # the Supervisor hostname and localhost transparently
     request_host, request_port = _get_request_host_port()
     if (
         require_current_request

--- a/homeassistant/helpers/network.py
+++ b/homeassistant/helpers/network.py
@@ -169,7 +169,7 @@ def get_url(
 
     # For current request, we accept loopback interfaces (e.g., 127.0.0.1),
     # the Supervisor hostname and localhost transparently
-    request_host = _get_request_host()
+    request_host, _ = _get_request_host_port()
     if (
         require_current_request
         and request_host is not None
@@ -217,22 +217,48 @@ def get_url(
     raise NoURLAvailableError
 
 
-def _get_request_host() -> str | None:
-    """Get the host address of the current request."""
+def _get_url_port(url: yarl.URL) -> int:
+    """Get resolved port of a yarl.URL."""
+    if url.port is not None:
+        return url.port
+    return 443 if url.scheme == "https" else 80
+
+
+def _get_request_host_port() -> tuple[str | None, int | None]:
+    """Get the host address and resolved port of the current request."""
     if (request := http.current_request.get()) is None:
         raise NoURLAvailableError
-    # partition the host to remove the port
-    # because the raw host header can contain the port
     host = request.headers.get(hdrs.HOST)
     if host is None:
-        return None
+        return None, None
+
     # IPv6 addresses are enclosed in brackets
     # use same logic as yarl and urllib to extract the host
     if "[" in host:
-        return (host.partition("[")[2]).partition("]")[0]
-    if ":" in host:
-        host = host.partition(":")[0]
-    return host
+        host_part, _, port_part = host.partition("[")[2].partition("]")
+        port_str = port_part[1:] if port_part.startswith(":") else ""
+    # partition the host to remove the port
+    # because the raw host header can contain the port
+    elif ":" in host:
+        host_part, _, port_str = host.partition(":")
+    else:
+        host_part, port_str = host, ""
+
+    port = int(port_str) if port_str.isdigit() else None
+    if port is None:
+        port = 443 if request.url.scheme == "https" else 80
+
+    return host_part, port
+
+
+def _match_request_host_port(url: yarl.URL) -> bool:
+    """Match request host and resolved port."""
+    try:
+        req_host, req_port = _get_request_host_port()
+    except NoURLAvailableError:
+        return False
+
+    return url.host == req_host and _get_url_port(url) == req_port
 
 
 def _get_internal_url(
@@ -247,7 +273,7 @@ def _get_internal_url(
     if hass.config.internal_url:
         internal_url = yarl.URL(hass.config.internal_url)
         if (
-            (not require_current_request or internal_url.host == _get_request_host())
+            (not require_current_request or _match_request_host_port(internal_url))
             and (not require_ssl or internal_url.scheme == "https")
             and (not require_standard_port or internal_url.is_default_port())
             and (allow_ip or not is_ip_address(str(internal_url.host)))
@@ -264,7 +290,7 @@ def _get_internal_url(
         if (
             ip_url.host
             and not is_loopback(ip_address(ip_url.host))
-            and (not require_current_request or ip_url.host == _get_request_host())
+            and (not require_current_request or _match_request_host_port(ip_url))
             and (not require_standard_port or ip_url.is_default_port())
         ):
             return normalize_url(str(ip_url))
@@ -295,9 +321,7 @@ def _get_external_url(
         external_url = yarl.URL(hass.config.external_url)
         if (
             (allow_ip or not is_ip_address(str(external_url.host)))
-            and (
-                not require_current_request or external_url.host == _get_request_host()
-            )
+            and (not require_current_request or _match_request_host_port(external_url))
             and (not require_standard_port or external_url.is_default_port())
             and (
                 not require_ssl
@@ -330,7 +354,7 @@ def _get_cloud_url(hass: HomeAssistant, require_current_request: bool = False) -
         except CloudNotAvailable as err:
             raise NoURLAvailableError from err
 
-        if not require_current_request or cloud_url.host == _get_request_host():
+        if not require_current_request or _match_request_host_port(cloud_url):
             return normalize_url(str(cloud_url))
 
     raise NoURLAvailableError

--- a/homeassistant/helpers/network.py
+++ b/homeassistant/helpers/network.py
@@ -236,25 +236,18 @@ def _get_request_host_port() -> tuple[str | None, int | None]:
     # use same logic as yarl and urllib to extract the host
     if "[" in host:
         host_part, _, port_part = host.partition("[")[2].partition("]")
-        port_str = port_part[1:] if port_part.startswith(":") else ""
-        has_port = port_part.startswith(":")
+        port_str = port_part.lstrip(":")
     # partition the host to remove the port
     # because the raw host header can contain the port
     elif ":" in host:
         host_part, _, port_str = host.partition(":")
-        has_port = True
     else:
         host_part, port_str = host, ""
-        has_port = False
 
-    port = None
-    if has_port:
-        if port_str.isdigit():
-            with suppress(ValueError):
-                val = int(port_str)
-                if 1 <= val <= 65535:
-                    port = val
-        if port is None:
+    if port_str:
+        try:
+            port = int(port_str)
+        except ValueError:
             return None, None
     else:
         port = 443 if request.url.scheme == "https" else 80

--- a/homeassistant/helpers/network.py
+++ b/homeassistant/helpers/network.py
@@ -179,7 +179,9 @@ def get_url(
     ):
         scheme = "https" if hass.config.api.use_ssl else "http"
         current_url = yarl.URL.build(
-            scheme=scheme, host=request_host, port=hass.config.api.port,
+            scheme=scheme,
+            host=request_host,
+            port=hass.config.api.port,
         )
 
         known_hostnames = ["localhost"]

--- a/homeassistant/helpers/network.py
+++ b/homeassistant/helpers/network.py
@@ -238,25 +238,18 @@ def _get_request_host_port() -> tuple[str | None, int | None]:
     # use same logic as yarl and urllib to extract the host
     if "[" in host:
         host_part, _, port_part = host.partition("[")[2].partition("]")
-        port_str = port_part[1:] if port_part.startswith(":") else ""
-        has_port = port_part.startswith(":")
+        port_str = port_part.lstrip(":")
     # partition the host to remove the port
     # because the raw host header can contain the port
     elif ":" in host:
         host_part, _, port_str = host.partition(":")
-        has_port = True
     else:
         host_part, port_str = host, ""
-        has_port = False
 
-    port = None
-    if has_port:
-        if port_str.isdigit():
-            with suppress(ValueError):
-                val = int(port_str)
-                if 1 <= val <= 65535:
-                    port = val
-        if port is None:
+    if port_str:
+        try:
+            port = int(port_str)
+        except ValueError:
             return None, None
     else:
         port = 443 if request.url.scheme == "https" else 80

--- a/homeassistant/helpers/network.py
+++ b/homeassistant/helpers/network.py
@@ -179,7 +179,7 @@ def get_url(
     ):
         scheme = "https" if hass.config.api.use_ssl else "http"
         current_url = yarl.URL.build(
-            scheme=scheme, host=request_host, port=hass.config.api.port
+            scheme=scheme, host=request_host, port=hass.config.api.port,
         )
 
         known_hostnames = ["localhost"]
@@ -239,15 +239,26 @@ def _get_request_host_port() -> tuple[str | None, int | None]:
     if "[" in host:
         host_part, _, port_part = host.partition("[")[2].partition("]")
         port_str = port_part[1:] if port_part.startswith(":") else ""
+        has_port = port_part.startswith(":")
     # partition the host to remove the port
     # because the raw host header can contain the port
     elif ":" in host:
         host_part, _, port_str = host.partition(":")
+        has_port = True
     else:
         host_part, port_str = host, ""
+        has_port = False
 
-    port = int(port_str) if port_str.isdigit() else None
-    if port is None:
+    port = None
+    if has_port:
+        if port_str.isdigit():
+            with suppress(ValueError):
+                val = int(port_str)
+                if 1 <= val <= 65535:
+                    port = val
+        if port is None:
+            return None, None
+    else:
         port = 443 if request.url.scheme == "https" else 80
 
     return host_part, port

--- a/homeassistant/helpers/network.py
+++ b/homeassistant/helpers/network.py
@@ -238,7 +238,7 @@ def _get_request_host_port() -> tuple[str | None, int | None]:
     # use same logic as yarl and urllib to extract the host
     if "[" in host:
         host_part, _, port_part = host.partition("[")[2].partition("]")
-        port_str = port_part.lstrip(":")
+        port_str = port_part[1:] if port_part.startswith(":") else ""
     # partition the host to remove the port
     # because the raw host header can contain the port
     elif ":" in host:
@@ -246,12 +246,8 @@ def _get_request_host_port() -> tuple[str | None, int | None]:
     else:
         host_part, port_str = host, ""
 
-    if port_str:
-        try:
-            port = int(port_str)
-        except ValueError:
-            return None, None
-    else:
+    port = int(port_str) if port_str.isdigit() else None
+    if port is None:
         port = 443 if request.url.scheme == "https" else 80
 
     return host_part, port

--- a/tests/components/http/test_view.py
+++ b/tests/components/http/test_view.py
@@ -163,8 +163,7 @@ def mock_current_request(
     mock_request.get = Mock(return_value=False)
     mock_request.headers = {hdrs.HOST: request_host}
     mock_request.app = {KEY_HASS: hass}
-    mock_request.url = Mock(return_value=False)
-    mock_request.url.scheme = request_scheme or "http"
+    mock_request.url = Mock(scheme=request_scheme or "http")
 
     token = current_request.set(mock_request)
     yield mock_request

--- a/tests/components/http/test_view.py
+++ b/tests/components/http/test_view.py
@@ -149,14 +149,22 @@ async def test_requires_auth_omits_www_authenticate_without_url(
     assert "WWW-Authenticate" not in exc_info.value.headers
 
 
+@pytest.fixture(name="request_scheme")
+def mock_request_scheme() -> str:
+    """Fixture for the mock current request scheme."""
+    return "http"
+
+
 @pytest.fixture
 def mock_current_request(
-    mock_request: Mock, request_host: str, hass: HomeAssistant
+    mock_request: Mock, request_host: str, request_scheme: str, hass: HomeAssistant
 ) -> Generator[Mock]:
     """Set the current request context."""
     mock_request.get = Mock(return_value=False)
     mock_request.headers = {hdrs.HOST: request_host}
     mock_request.app = {KEY_HASS: hass}
+    mock_request.url = Mock(return_value=False)
+    mock_request.url.scheme = request_scheme or "http"
 
     token = current_request.set(mock_request)
     yield mock_request
@@ -164,36 +172,82 @@ def mock_current_request(
 
 
 @pytest.mark.parametrize(
-    ("internal_url", "external_url", "request_host", "expected_url"),
+    ("internal_url", "external_url", "request_host", "request_scheme", "expected_url"),
     [
         # Match either internal or external
-        ("https://foo.com", "https://example.com", "foo.com:18123", "https://foo.com"),
-        ("https://example.com", "https://foo.com", "foo.com:18123", "https://foo.com"),
-        # Requests have a port and match external url
-        # Note: We currently do not fully properly handle port matching for
-        # internal urls. The tests here work because of prefer_external=True. We
-        # can improve get_url so that additional cases where the internal url
-        # have the same hostname work in future:
-        # - Match request to internal url when external url has a port
-        # - Match request to external url when internal url has a port
+        (
+            "https://foo.com",
+            "https://example.com",
+            "foo.com",
+            "https",
+            "https://foo.com",
+        ),
+        (
+            "https://foo.com:18123",
+            "https://example.com",
+            "foo.com:18123",
+            "https",
+            "https://foo.com:18123",
+        ),
+        (
+            "https://example.com",
+            "https://foo.com",
+            "foo.com",
+            "https",
+            "https://foo.com",
+        ),
+        (
+            "https://example.com",
+            "https://foo.com:18123",
+            "foo.com:18123",
+            "https",
+            "https://foo.com:18123",
+        ),
+        # Tests for internal and external url with the same hostname but different port
         (
             "https://foo.com",
             "https://foo.com:18123",
             "foo.com:18123",
+            "https",
             "https://foo.com:18123",
         ),
-        ("https://foo.com:18123", "https://foo.com", "foo.com", "https://foo.com"),
+        (
+            "https://foo.com",
+            "https://foo.com:18123",
+            "foo.com",
+            "https",
+            "https://foo.com",
+        ),
+        (
+            "https://foo.com:18123",
+            "https://foo.com",
+            "foo.com:18123",
+            "https",
+            "https://foo.com:18123",
+        ),
+        (
+            "https://foo.com:18123",
+            "https://foo.com",
+            "foo.com",
+            "https",
+            "https://foo.com",
+        ),
         (
             "http://192.168.1.2:8123",
             "https://foo.com:18123",
             "192.168.1.2:8123",
+            "http",
             "http://192.168.1.2:8123",
         ),
     ],
     ids=[
         "request_host_matches_internal",
+        "request_host_matches_internal_with_port",
         "request_host_matches_external",
+        "request_host_matches_external_with_port",
         "internal_no_port_request_external",
+        "internal_no_port_request_internal",
+        "internal_port_request_internal",
         "internal_port_request_external",
         "request_internal_distinct_host",
     ],

--- a/tests/components/roku/test_media_player.py
+++ b/tests/components/roku/test_media_player.py
@@ -810,7 +810,8 @@ async def test_media_browse_internal(
     client = await hass_ws_client(hass)
 
     with patch(
-        "homeassistant.helpers.network._get_request_host", return_value="example.local"
+        "homeassistant.helpers.network._get_request_host_port",
+        return_value=("example.local", 8123),
     ):
         await client.send_json(
             {

--- a/tests/helpers/test_network.py
+++ b/tests/helpers/test_network.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.network import (
     _get_cloud_url,
     _get_external_url,
     _get_internal_url,
-    _get_request_host,
+    _get_request_host_port,
     get_supervisor_network_url,
     get_url,
     is_hass_url,
@@ -63,7 +63,8 @@ async def test_get_url_internal(hass: HomeAssistant) -> None:
         _get_internal_url(hass, require_current_request=True)
 
     with patch(
-        "homeassistant.helpers.network._get_request_host", return_value="example.local"
+        "homeassistant.helpers.network._get_request_host_port",
+        return_value=("example.local", 8123),
     ):
         assert (
             _get_internal_url(hass, require_current_request=True)
@@ -80,8 +81,8 @@ async def test_get_url_internal(hass: HomeAssistant) -> None:
 
     with (
         patch(
-            "homeassistant.helpers.network._get_request_host",
-            return_value="no_match.example.local",
+            "homeassistant.helpers.network._get_request_host_port",
+            return_value=("no_match.example.local", 8123),
         ),
         pytest.raises(NoURLAvailableError),
     ):
@@ -162,7 +163,8 @@ async def test_get_url_internal(hass: HomeAssistant) -> None:
         _get_internal_url(hass, allow_ip=False)
 
     with patch(
-        "homeassistant.helpers.network._get_request_host", return_value="192.168.0.1"
+        "homeassistant.helpers.network._get_request_host_port",
+        return_value=("192.168.0.1", 8123),
     ):
         assert (
             _get_internal_url(hass, require_current_request=True)
@@ -266,7 +268,8 @@ async def test_get_url_external(hass: HomeAssistant) -> None:
         _get_external_url(hass, require_current_request=True)
 
     with patch(
-        "homeassistant.helpers.network._get_request_host", return_value="example.com"
+        "homeassistant.helpers.network._get_request_host_port",
+        return_value=("example.com", 8123),
     ):
         assert (
             _get_external_url(hass, require_current_request=True)
@@ -283,8 +286,8 @@ async def test_get_url_external(hass: HomeAssistant) -> None:
 
     with (
         patch(
-            "homeassistant.helpers.network._get_request_host",
-            return_value="no_match.example.com",
+            "homeassistant.helpers.network._get_request_host_port",
+            return_value=("no_match.example.com", 8123),
         ),
         pytest.raises(NoURLAvailableError),
     ):
@@ -352,7 +355,8 @@ async def test_get_url_external(hass: HomeAssistant) -> None:
         _get_external_url(hass, require_ssl=True)
 
     with patch(
-        "homeassistant.helpers.network._get_request_host", return_value="192.168.0.1"
+        "homeassistant.helpers.network._get_request_host_port",
+        return_value=("192.168.0.1", 443),
     ):
         assert (
             _get_external_url(hass, require_current_request=True)
@@ -393,8 +397,8 @@ async def test_get_cloud_url(hass: HomeAssistant) -> None:
             _get_cloud_url(hass, require_current_request=True)
 
         with patch(
-            "homeassistant.helpers.network._get_request_host",
-            return_value="example.nabu.casa",
+            "homeassistant.helpers.network._get_request_host_port",
+            return_value=("example.nabu.casa", 443),
         ):
             assert (
                 _get_cloud_url(hass, require_current_request=True)
@@ -403,8 +407,8 @@ async def test_get_cloud_url(hass: HomeAssistant) -> None:
 
         with (
             patch(
-                "homeassistant.helpers.network._get_request_host",
-                return_value="no_match.nabu.casa",
+                "homeassistant.helpers.network._get_request_host_port",
+                return_value=("no_match.nabu.casa", 443),
             ),
             pytest.raises(NoURLAvailableError),
         ):
@@ -535,8 +539,8 @@ async def test_get_url(hass: HomeAssistant) -> None:
 
     with (
         patch(
-            "homeassistant.helpers.network._get_request_host",
-            return_value="example.com",
+            "homeassistant.helpers.network._get_request_host_port",
+            return_value=("example.com", 443),
         ),
         patch("homeassistant.helpers.http.current_request"),
     ):
@@ -551,8 +555,8 @@ async def test_get_url(hass: HomeAssistant) -> None:
 
     with (
         patch(
-            "homeassistant.helpers.network._get_request_host",
-            return_value="example.local",
+            "homeassistant.helpers.network._get_request_host_port",
+            return_value=("example.local", 80),
         ),
         patch("homeassistant.helpers.http.current_request"),
     ):
@@ -566,8 +570,8 @@ async def test_get_url(hass: HomeAssistant) -> None:
 
     with (
         patch(
-            "homeassistant.helpers.network._get_request_host",
-            return_value="no_match.example.com",
+            "homeassistant.helpers.network._get_request_host_port",
+            return_value=("no_match.example.com", 80),
         ),
         pytest.raises(NoURLAvailableError),
     ):
@@ -587,10 +591,68 @@ async def test_get_url(hass: HomeAssistant) -> None:
         assert get_url(hass, allow_internal=False)
 
 
-async def test_get_request_host_with_port(hass: HomeAssistant) -> None:
-    """Test getting the host of the current web request from the request context."""
+@pytest.mark.parametrize(
+    ("scheme", "default_port"),
+    [
+        ("http", "80"),
+        ("https", "443"),
+    ],
+)
+@pytest.mark.parametrize("prefer_external", [False, True])
+@pytest.mark.parametrize(
+    ("internal_url", "external_url"),
+    [
+        ("{scheme}://example.com", "{scheme}://example.com:18123"),
+        ("{scheme}://example.com:18123", "{scheme}://example.com"),
+    ],
+)
+@pytest.mark.parametrize(
+    ("host_header", "expected_url"),
+    [
+        ("example.com", "{scheme}://example.com"),
+        ("example.com:DEFAULT_PORT", "{scheme}://example.com"),
+        ("example.com:18123", "{scheme}://example.com:18123"),
+    ],
+)
+async def test_get_url_host_matching_respects_port(
+    hass: HomeAssistant,
+    scheme: str,
+    default_port: str,
+    internal_url: str,
+    external_url: str,
+    host_header: str,
+    expected_url: str,
+    prefer_external: bool,
+) -> None:
+    """Test that get_url respects the port when matching the request host."""
+    host_header_formatted = host_header.replace("DEFAULT_PORT", default_port)
+    int_url = internal_url.format(scheme=scheme)
+    ext_url = external_url.format(scheme=scheme)
+    exp_url = expected_url.format(scheme=scheme)
+
+    await async_process_ha_core_config(
+        hass,
+        {
+            "internal_url": int_url,
+            "external_url": ext_url,
+        },
+    )
+    with patch("homeassistant.helpers.http.current_request") as mock_request_context:
+        mock_request = Mock()
+        mock_request.headers = {hdrs.HOST: host_header_formatted}
+        mock_request.url = URL(f"{scheme}://{host_header_formatted}/test/request")
+        mock_request_context.get.return_value = mock_request
+
+        assert (
+            get_url(hass, require_current_request=True, prefer_external=prefer_external)
+            == exp_url
+        )
+
+
+async def test_get_request_host_port_with_port(hass: HomeAssistant) -> None:
+    """Test getting the host and port of the current web request from the request context."""
     with pytest.raises(NoURLAvailableError):
-        _get_request_host()
+        _get_request_host_port()
 
     with patch("homeassistant.helpers.http.current_request") as mock_request_context:
         mock_request = Mock()
@@ -601,13 +663,13 @@ async def test_get_request_host_with_port(hass: HomeAssistant) -> None:
         mock_request.host = "example.com:8123"
         mock_request_context.get = Mock(return_value=mock_request)
 
-        assert _get_request_host() == "example.com"
+        assert _get_request_host_port() == ("example.com", 8123)
 
 
-async def test_get_request_host_without_port(hass: HomeAssistant) -> None:
-    """Test getting the host of the current web request from the request context."""
+async def test_get_request_host_port_without_port(hass: HomeAssistant) -> None:
+    """Test getting the host and port of the current web request from the request context."""
     with pytest.raises(NoURLAvailableError):
-        _get_request_host()
+        _get_request_host_port()
 
     with patch("homeassistant.helpers.http.current_request") as mock_request_context:
         mock_request = Mock()
@@ -616,13 +678,13 @@ async def test_get_request_host_without_port(hass: HomeAssistant) -> None:
         mock_request.host = "example.com"
         mock_request_context.get = Mock(return_value=mock_request)
 
-        assert _get_request_host() == "example.com"
+        assert _get_request_host_port() == ("example.com", 80)
 
 
 async def test_get_request_ipv6_address(hass: HomeAssistant) -> None:
-    """Test getting the ipv6 host of the current web request."""
+    """Test getting the ipv6 host and port of the current web request."""
     with pytest.raises(NoURLAvailableError):
-        _get_request_host()
+        _get_request_host_port()
 
     with patch("homeassistant.helpers.http.current_request") as mock_request_context:
         mock_request = Mock()
@@ -631,13 +693,13 @@ async def test_get_request_ipv6_address(hass: HomeAssistant) -> None:
         mock_request.host = "[::1]:8123"
         mock_request_context.get = Mock(return_value=mock_request)
 
-        assert _get_request_host() == "::1"
+        assert _get_request_host_port() == ("::1", 8123)
 
 
 async def test_get_request_ipv6_address_without_port(hass: HomeAssistant) -> None:
-    """Test getting the ipv6 host of the current web request."""
+    """Test getting the ipv6 host and port of the current web request."""
     with pytest.raises(NoURLAvailableError):
-        _get_request_host()
+        _get_request_host_port()
 
     with patch("homeassistant.helpers.http.current_request") as mock_request_context:
         mock_request = Mock()
@@ -646,13 +708,13 @@ async def test_get_request_ipv6_address_without_port(hass: HomeAssistant) -> Non
         mock_request.host = "[::1]"
         mock_request_context.get = Mock(return_value=mock_request)
 
-        assert _get_request_host() == "::1"
+        assert _get_request_host_port() == ("::1", 80)
 
 
-async def test_get_request_host_no_host_header(hass: HomeAssistant) -> None:
-    """Test getting the host of the current web request from the request context."""
+async def test_get_request_host_port_no_host_header(hass: HomeAssistant) -> None:
+    """Test getting the host and port of the current web request from the request context."""
     with pytest.raises(NoURLAvailableError):
-        _get_request_host()
+        _get_request_host_port()
 
     with patch("homeassistant.helpers.http.current_request") as mock_request_context:
         mock_request = Mock()
@@ -660,7 +722,7 @@ async def test_get_request_host_no_host_header(hass: HomeAssistant) -> None:
         mock_request.url = URL("/test/request")
         mock_request_context.get = Mock(return_value=mock_request)
 
-        assert _get_request_host() is None
+        assert _get_request_host_port() == (None, None)
 
 
 @patch("homeassistant.helpers.hassio.is_hassio", Mock(return_value=True))
@@ -680,7 +742,8 @@ async def test_get_current_request_url_with_known_host(
 
     # Ensure we accept localhost
     with patch(
-        "homeassistant.helpers.network._get_request_host", return_value="localhost"
+        "homeassistant.helpers.network._get_request_host_port",
+        return_value=("localhost", 8123),
     ):
         assert get_url(hass, require_current_request=True) == "http://localhost:8123"
         with pytest.raises(NoURLAvailableError):
@@ -690,7 +753,8 @@ async def test_get_current_request_url_with_known_host(
 
     # Ensure we accept local loopback ip (e.g., 127.0.0.1)
     with patch(
-        "homeassistant.helpers.network._get_request_host", return_value="127.0.0.8"
+        "homeassistant.helpers.network._get_request_host_port",
+        return_value=("127.0.0.8", 8123),
     ):
         assert get_url(hass, require_current_request=True) == "http://127.0.0.8:8123"
         with pytest.raises(NoURLAvailableError):
@@ -700,8 +764,8 @@ async def test_get_current_request_url_with_known_host(
     mock_component(hass, "hassio")
 
     with patch(
-        "homeassistant.helpers.network._get_request_host",
-        return_value="homeassistant.local",
+        "homeassistant.helpers.network._get_request_host_port",
+        return_value=("homeassistant.local", 8123),
     ):
         assert (
             get_url(hass, require_current_request=True)
@@ -709,8 +773,8 @@ async def test_get_current_request_url_with_known_host(
         )
 
     with patch(
-        "homeassistant.helpers.network._get_request_host",
-        return_value="homeassistant",
+        "homeassistant.helpers.network._get_request_host_port",
+        return_value=("homeassistant", 8123),
     ):
         assert (
             get_url(hass, require_current_request=True) == "http://homeassistant:8123"
@@ -718,8 +782,8 @@ async def test_get_current_request_url_with_known_host(
 
     with (
         patch(
-            "homeassistant.helpers.network._get_request_host",
-            return_value="unknown.local",
+            "homeassistant.helpers.network._get_request_host_port",
+            return_value=("unknown.local", 8123),
         ),
         pytest.raises(NoURLAvailableError),
     ):

--- a/tests/helpers/test_network.py
+++ b/tests/helpers/test_network.py
@@ -591,192 +591,265 @@ async def test_get_url(hass: HomeAssistant) -> None:
         assert get_url(hass, allow_internal=False)
 
 
-async def test_get_url_http_internal_standard_external_custom(
+@pytest.mark.parametrize(
+    (
+        "internal_url",
+        "external_url",
+        "host_header",
+        "request_url",
+        "expected_url",
+        "prefer_external",
+    ),
+    [
+        # Scenario 1: HTTP, internal is standard port (http://example.com), external is custom port (http://example.com:18123)
+        pytest.param(
+            "http://example.com",
+            "http://example.com:18123",
+            "example.com",
+            "http://example.com/test/request",
+            "http://example.com",
+            False,
+            id="http_internal_std_request_std_prefer_internal",
+        ),
+        pytest.param(
+            "http://example.com",
+            "http://example.com:18123",
+            "example.com",
+            "http://example.com/test/request",
+            "http://example.com",
+            True,
+            id="http_internal_std_request_std_prefer_external",
+        ),
+        pytest.param(
+            "http://example.com",
+            "http://example.com:18123",
+            "example.com:80",
+            "http://example.com:80/test/request",
+            "http://example.com",
+            False,
+            id="http_internal_std_request_80_prefer_internal",
+        ),
+        pytest.param(
+            "http://example.com",
+            "http://example.com:18123",
+            "example.com:80",
+            "http://example.com:80/test/request",
+            "http://example.com",
+            True,
+            id="http_internal_std_request_80_prefer_external",
+        ),
+        pytest.param(
+            "http://example.com",
+            "http://example.com:18123",
+            "example.com:18123",
+            "http://example.com:18123/test/request",
+            "http://example.com:18123",
+            False,
+            id="http_internal_std_request_custom_prefer_internal",
+        ),
+        pytest.param(
+            "http://example.com",
+            "http://example.com:18123",
+            "example.com:18123",
+            "http://example.com:18123/test/request",
+            "http://example.com:18123",
+            True,
+            id="http_internal_std_request_custom_prefer_external",
+        ),
+        # Scenario 2: HTTP, internal is custom port (http://example.com:18123), external is standard port (http://example.com)
+        pytest.param(
+            "http://example.com:18123",
+            "http://example.com",
+            "example.com",
+            "http://example.com/test/request",
+            "http://example.com",
+            False,
+            id="http_internal_custom_request_std_prefer_internal",
+        ),
+        pytest.param(
+            "http://example.com:18123",
+            "http://example.com",
+            "example.com",
+            "http://example.com/test/request",
+            "http://example.com",
+            True,
+            id="http_internal_custom_request_std_prefer_external",
+        ),
+        pytest.param(
+            "http://example.com:18123",
+            "http://example.com",
+            "example.com:80",
+            "http://example.com:80/test/request",
+            "http://example.com",
+            False,
+            id="http_internal_custom_request_80_prefer_internal",
+        ),
+        pytest.param(
+            "http://example.com:18123",
+            "http://example.com",
+            "example.com:80",
+            "http://example.com:80/test/request",
+            "http://example.com",
+            True,
+            id="http_internal_custom_request_80_prefer_external",
+        ),
+        pytest.param(
+            "http://example.com:18123",
+            "http://example.com",
+            "example.com:18123",
+            "http://example.com:18123/test/request",
+            "http://example.com:18123",
+            False,
+            id="http_internal_custom_request_custom_prefer_internal",
+        ),
+        pytest.param(
+            "http://example.com:18123",
+            "http://example.com",
+            "example.com:18123",
+            "http://example.com:18123/test/request",
+            "http://example.com:18123",
+            True,
+            id="http_internal_custom_request_custom_prefer_external",
+        ),
+        # Scenario 3: HTTPS, internal is standard port (https://example.com), external is custom port (https://example.com:18123)
+        pytest.param(
+            "https://example.com",
+            "https://example.com:18123",
+            "example.com",
+            "https://example.com/test/request",
+            "https://example.com",
+            False,
+            id="https_internal_std_request_std_prefer_internal",
+        ),
+        pytest.param(
+            "https://example.com",
+            "https://example.com:18123",
+            "example.com",
+            "https://example.com/test/request",
+            "https://example.com",
+            True,
+            id="https_internal_std_request_std_prefer_external",
+        ),
+        pytest.param(
+            "https://example.com",
+            "https://example.com:18123",
+            "example.com:443",
+            "https://example.com:443/test/request",
+            "https://example.com",
+            False,
+            id="https_internal_std_request_443_prefer_internal",
+        ),
+        pytest.param(
+            "https://example.com",
+            "https://example.com:18123",
+            "example.com:443",
+            "https://example.com:443/test/request",
+            "https://example.com",
+            True,
+            id="https_internal_std_request_443_prefer_external",
+        ),
+        pytest.param(
+            "https://example.com",
+            "https://example.com:18123",
+            "example.com:18123",
+            "https://example.com:18123/test/request",
+            "https://example.com:18123",
+            False,
+            id="https_internal_std_request_custom_prefer_internal",
+        ),
+        pytest.param(
+            "https://example.com",
+            "https://example.com:18123",
+            "example.com:18123",
+            "https://example.com:18123/test/request",
+            "https://example.com:18123",
+            True,
+            id="https_internal_std_request_custom_prefer_external",
+        ),
+        # Scenario 4: HTTPS, internal is custom port (https://example.com:18123), external is standard port (https://example.com)
+        pytest.param(
+            "https://example.com:18123",
+            "https://example.com",
+            "example.com",
+            "https://example.com/test/request",
+            "https://example.com",
+            False,
+            id="https_internal_custom_request_std_prefer_internal",
+        ),
+        pytest.param(
+            "https://example.com:18123",
+            "https://example.com",
+            "example.com",
+            "https://example.com/test/request",
+            "https://example.com",
+            True,
+            id="https_internal_custom_request_std_prefer_external",
+        ),
+        pytest.param(
+            "https://example.com:18123",
+            "https://example.com",
+            "example.com:443",
+            "https://example.com:443/test/request",
+            "https://example.com",
+            False,
+            id="https_internal_custom_request_443_prefer_internal",
+        ),
+        pytest.param(
+            "https://example.com:18123",
+            "https://example.com",
+            "example.com:443",
+            "https://example.com:443/test/request",
+            "https://example.com",
+            True,
+            id="https_internal_custom_request_443_prefer_external",
+        ),
+        pytest.param(
+            "https://example.com:18123",
+            "https://example.com",
+            "example.com:18123",
+            "https://example.com:18123/test/request",
+            "https://example.com:18123",
+            False,
+            id="https_internal_custom_request_custom_prefer_internal",
+        ),
+        pytest.param(
+            "https://example.com:18123",
+            "https://example.com",
+            "example.com:18123",
+            "https://example.com:18123/test/request",
+            "https://example.com:18123",
+            True,
+            id="https_internal_custom_request_custom_prefer_external",
+        ),
+    ],
+)
+async def test_get_url_host_matching_respects_port(
     hass: HomeAssistant,
+    internal_url: str,
+    external_url: str,
+    host_header: str,
+    request_url: str,
+    expected_url: str,
+    prefer_external: bool,
 ) -> None:
-    """Test get_url matches custom/standard port over HTTP when internal is standard port."""
+    """Test that get_url respects the port when matching the request host."""
     await async_process_ha_core_config(
         hass,
         {
-            "internal_url": "http://example.com",
-            "external_url": "http://example.com:18123",
+            "internal_url": internal_url,
+            "external_url": external_url,
         },
     )
     with patch("homeassistant.helpers.http.current_request") as mock_request_context:
         mock_request = Mock()
+        mock_request.headers = {hdrs.HOST: host_header}
+        mock_request.url = URL(request_url)
         mock_request_context.get.return_value = mock_request
 
-        for prefer_external in (False, True):
-            # Incoming request with no explicit port (default 80) should match internal
-            mock_request.headers = {hdrs.HOST: "example.com"}
-            mock_request.url = URL("http://example.com/test/request")
-            assert (
-                get_url(
-                    hass, require_current_request=True, prefer_external=prefer_external
-                )
-                == "http://example.com"
-            )
-
-            # Incoming request with standard port 80 should match internal
-            mock_request.headers = {hdrs.HOST: "example.com:80"}
-            mock_request.url = URL("http://example.com:80/test/request")
-            assert (
-                get_url(
-                    hass, require_current_request=True, prefer_external=prefer_external
-                )
-                == "http://example.com"
-            )
-
-            # Incoming request with custom port 18123 should match external
-            mock_request.headers = {hdrs.HOST: "example.com:18123"}
-            mock_request.url = URL("http://example.com:18123/test/request")
-            assert (
-                get_url(
-                    hass, require_current_request=True, prefer_external=prefer_external
-                )
-                == "http://example.com:18123"
-            )
-
-
-async def test_get_url_http_internal_custom_external_standard(
-    hass: HomeAssistant,
-) -> None:
-    """Test get_url matches custom/standard port over HTTP when external is standard port."""
-    await async_process_ha_core_config(
-        hass,
-        {
-            "internal_url": "http://example.com:18123",
-            "external_url": "http://example.com",
-        },
-    )
-    with patch("homeassistant.helpers.http.current_request") as mock_request_context:
-        mock_request = Mock()
-        mock_request_context.get.return_value = mock_request
-
-        for prefer_external in (False, True):
-            # Incoming request with no explicit port (default 80) should match external
-            mock_request.headers = {hdrs.HOST: "example.com"}
-            mock_request.url = URL("http://example.com/test/request")
-            assert (
-                get_url(
-                    hass, require_current_request=True, prefer_external=prefer_external
-                )
-                == "http://example.com"
-            )
-
-            # Incoming request with standard port 80 should match external
-            mock_request.headers = {hdrs.HOST: "example.com:80"}
-            mock_request.url = URL("http://example.com:80/test/request")
-            assert (
-                get_url(
-                    hass, require_current_request=True, prefer_external=prefer_external
-                )
-                == "http://example.com"
-            )
-
-            # Incoming request with custom port 18123 should match internal
-            mock_request.headers = {hdrs.HOST: "example.com:18123"}
-            mock_request.url = URL("http://example.com:18123/test/request")
-            assert (
-                get_url(
-                    hass, require_current_request=True, prefer_external=prefer_external
-                )
-                == "http://example.com:18123"
-            )
-
-
-async def test_get_url_https_internal_standard_external_custom(
-    hass: HomeAssistant,
-) -> None:
-    """Test get_url matches custom/standard port over HTTPS when internal is standard port."""
-    await async_process_ha_core_config(
-        hass,
-        {
-            "internal_url": "https://example.com",
-            "external_url": "https://example.com:18123",
-        },
-    )
-    with patch("homeassistant.helpers.http.current_request") as mock_request_context:
-        mock_request = Mock()
-        mock_request_context.get.return_value = mock_request
-
-        for prefer_external in (False, True):
-            # Incoming request with no explicit port (default 443) should match internal
-            mock_request.headers = {hdrs.HOST: "example.com"}
-            mock_request.url = URL("https://example.com/test/request")
-            assert (
-                get_url(
-                    hass, require_current_request=True, prefer_external=prefer_external
-                )
-                == "https://example.com"
-            )
-
-            # Incoming request with standard port 443 should match internal
-            mock_request.headers = {hdrs.HOST: "example.com:443"}
-            mock_request.url = URL("https://example.com:443/test/request")
-            assert (
-                get_url(
-                    hass, require_current_request=True, prefer_external=prefer_external
-                )
-                == "https://example.com"
-            )
-
-            # Incoming request with custom port 18123 should match external
-            mock_request.headers = {hdrs.HOST: "example.com:18123"}
-            mock_request.url = URL("https://example.com:18123/test/request")
-            assert (
-                get_url(
-                    hass, require_current_request=True, prefer_external=prefer_external
-                )
-                == "https://example.com:18123"
-            )
-
-
-async def test_get_url_https_internal_custom_external_standard(
-    hass: HomeAssistant,
-) -> None:
-    """Test get_url matches custom/standard port over HTTPS when external is standard port."""
-    await async_process_ha_core_config(
-        hass,
-        {
-            "internal_url": "https://example.com:18123",
-            "external_url": "https://example.com",
-        },
-    )
-    with patch("homeassistant.helpers.http.current_request") as mock_request_context:
-        mock_request = Mock()
-        mock_request_context.get.return_value = mock_request
-
-        for prefer_external in (False, True):
-            # Incoming request with no explicit port (default 443) should match external
-            mock_request.headers = {hdrs.HOST: "example.com"}
-            mock_request.url = URL("https://example.com/test/request")
-            assert (
-                get_url(
-                    hass, require_current_request=True, prefer_external=prefer_external
-                )
-                == "https://example.com"
-            )
-
-            # Incoming request with standard port 443 should match external
-            mock_request.headers = {hdrs.HOST: "example.com:443"}
-            mock_request.url = URL("https://example.com:443/test/request")
-            assert (
-                get_url(
-                    hass, require_current_request=True, prefer_external=prefer_external
-                )
-                == "https://example.com"
-            )
-
-            # Incoming request with custom port 18123 should match internal
-            mock_request.headers = {hdrs.HOST: "example.com:18123"}
-            mock_request.url = URL("https://example.com:18123/test/request")
-            assert (
-                get_url(
-                    hass, require_current_request=True, prefer_external=prefer_external
-                )
-                == "https://example.com:18123"
-            )
+        assert (
+            get_url(hass, require_current_request=True, prefer_external=prefer_external)
+            == expected_url
+        )
 
 
 async def test_get_request_host_port_with_port(hass: HomeAssistant) -> None:

--- a/tests/helpers/test_network.py
+++ b/tests/helpers/test_network.py
@@ -1,6 +1,6 @@
 """Test network helper."""
 
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 from aiohttp import hdrs
 from multidict import CIMultiDict, CIMultiDictProxy
@@ -591,62 +591,192 @@ async def test_get_url(hass: HomeAssistant) -> None:
         assert get_url(hass, allow_internal=False)
 
 
-@pytest.mark.parametrize(
-    ("scheme", "default_port"),
-    [
-        ("http", "80"),
-        ("https", "443"),
-    ],
-)
-@pytest.mark.parametrize("prefer_external", [False, True])
-@pytest.mark.parametrize(
-    ("internal_url", "external_url"),
-    [
-        ("{scheme}://example.com", "{scheme}://example.com:18123"),
-        ("{scheme}://example.com:18123", "{scheme}://example.com"),
-    ],
-)
-@pytest.mark.parametrize(
-    ("host_header", "expected_url"),
-    [
-        ("example.com", "{scheme}://example.com"),
-        ("example.com:DEFAULT_PORT", "{scheme}://example.com"),
-        ("example.com:18123", "{scheme}://example.com:18123"),
-    ],
-)
-async def test_get_url_host_matching_respects_port(
+async def test_get_url_http_internal_standard_external_custom(
     hass: HomeAssistant,
-    scheme: str,
-    default_port: str,
-    internal_url: str,
-    external_url: str,
-    host_header: str,
-    expected_url: str,
-    prefer_external: bool,
 ) -> None:
-    """Test that get_url respects the port when matching the request host."""
-    host_header_formatted = host_header.replace("DEFAULT_PORT", default_port)
-    int_url = internal_url.format(scheme=scheme)
-    ext_url = external_url.format(scheme=scheme)
-    exp_url = expected_url.format(scheme=scheme)
-
+    """Test get_url matches custom/standard port over HTTP when internal is standard port."""
     await async_process_ha_core_config(
         hass,
         {
-            "internal_url": int_url,
-            "external_url": ext_url,
+            "internal_url": "http://example.com",
+            "external_url": "http://example.com:18123",
         },
     )
     with patch("homeassistant.helpers.http.current_request") as mock_request_context:
         mock_request = Mock()
-        mock_request.headers = {hdrs.HOST: host_header_formatted}
-        mock_request.url = URL(f"{scheme}://{host_header_formatted}/test/request")
         mock_request_context.get.return_value = mock_request
 
-        assert (
-            get_url(hass, require_current_request=True, prefer_external=prefer_external)
-            == exp_url
-        )
+        for prefer_external in (False, True):
+            # Incoming request with no explicit port (default 80) should match internal
+            mock_request.headers = {hdrs.HOST: "example.com"}
+            mock_request.url = URL("http://example.com/test/request")
+            assert (
+                get_url(
+                    hass, require_current_request=True, prefer_external=prefer_external
+                )
+                == "http://example.com"
+            )
+
+            # Incoming request with standard port 80 should match internal
+            mock_request.headers = {hdrs.HOST: "example.com:80"}
+            mock_request.url = URL("http://example.com:80/test/request")
+            assert (
+                get_url(
+                    hass, require_current_request=True, prefer_external=prefer_external
+                )
+                == "http://example.com"
+            )
+
+            # Incoming request with custom port 18123 should match external
+            mock_request.headers = {hdrs.HOST: "example.com:18123"}
+            mock_request.url = URL("http://example.com:18123/test/request")
+            assert (
+                get_url(
+                    hass, require_current_request=True, prefer_external=prefer_external
+                )
+                == "http://example.com:18123"
+            )
+
+
+async def test_get_url_http_internal_custom_external_standard(
+    hass: HomeAssistant,
+) -> None:
+    """Test get_url matches custom/standard port over HTTP when external is standard port."""
+    await async_process_ha_core_config(
+        hass,
+        {
+            "internal_url": "http://example.com:18123",
+            "external_url": "http://example.com",
+        },
+    )
+    with patch("homeassistant.helpers.http.current_request") as mock_request_context:
+        mock_request = Mock()
+        mock_request_context.get.return_value = mock_request
+
+        for prefer_external in (False, True):
+            # Incoming request with no explicit port (default 80) should match external
+            mock_request.headers = {hdrs.HOST: "example.com"}
+            mock_request.url = URL("http://example.com/test/request")
+            assert (
+                get_url(
+                    hass, require_current_request=True, prefer_external=prefer_external
+                )
+                == "http://example.com"
+            )
+
+            # Incoming request with standard port 80 should match external
+            mock_request.headers = {hdrs.HOST: "example.com:80"}
+            mock_request.url = URL("http://example.com:80/test/request")
+            assert (
+                get_url(
+                    hass, require_current_request=True, prefer_external=prefer_external
+                )
+                == "http://example.com"
+            )
+
+            # Incoming request with custom port 18123 should match internal
+            mock_request.headers = {hdrs.HOST: "example.com:18123"}
+            mock_request.url = URL("http://example.com:18123/test/request")
+            assert (
+                get_url(
+                    hass, require_current_request=True, prefer_external=prefer_external
+                )
+                == "http://example.com:18123"
+            )
+
+
+async def test_get_url_https_internal_standard_external_custom(
+    hass: HomeAssistant,
+) -> None:
+    """Test get_url matches custom/standard port over HTTPS when internal is standard port."""
+    await async_process_ha_core_config(
+        hass,
+        {
+            "internal_url": "https://example.com",
+            "external_url": "https://example.com:18123",
+        },
+    )
+    with patch("homeassistant.helpers.http.current_request") as mock_request_context:
+        mock_request = Mock()
+        mock_request_context.get.return_value = mock_request
+
+        for prefer_external in (False, True):
+            # Incoming request with no explicit port (default 443) should match internal
+            mock_request.headers = {hdrs.HOST: "example.com"}
+            mock_request.url = URL("https://example.com/test/request")
+            assert (
+                get_url(
+                    hass, require_current_request=True, prefer_external=prefer_external
+                )
+                == "https://example.com"
+            )
+
+            # Incoming request with standard port 443 should match internal
+            mock_request.headers = {hdrs.HOST: "example.com:443"}
+            mock_request.url = URL("https://example.com:443/test/request")
+            assert (
+                get_url(
+                    hass, require_current_request=True, prefer_external=prefer_external
+                )
+                == "https://example.com"
+            )
+
+            # Incoming request with custom port 18123 should match external
+            mock_request.headers = {hdrs.HOST: "example.com:18123"}
+            mock_request.url = URL("https://example.com:18123/test/request")
+            assert (
+                get_url(
+                    hass, require_current_request=True, prefer_external=prefer_external
+                )
+                == "https://example.com:18123"
+            )
+
+
+async def test_get_url_https_internal_custom_external_standard(
+    hass: HomeAssistant,
+) -> None:
+    """Test get_url matches custom/standard port over HTTPS when external is standard port."""
+    await async_process_ha_core_config(
+        hass,
+        {
+            "internal_url": "https://example.com:18123",
+            "external_url": "https://example.com",
+        },
+    )
+    with patch("homeassistant.helpers.http.current_request") as mock_request_context:
+        mock_request = Mock()
+        mock_request_context.get.return_value = mock_request
+
+        for prefer_external in (False, True):
+            # Incoming request with no explicit port (default 443) should match external
+            mock_request.headers = {hdrs.HOST: "example.com"}
+            mock_request.url = URL("https://example.com/test/request")
+            assert (
+                get_url(
+                    hass, require_current_request=True, prefer_external=prefer_external
+                )
+                == "https://example.com"
+            )
+
+            # Incoming request with standard port 443 should match external
+            mock_request.headers = {hdrs.HOST: "example.com:443"}
+            mock_request.url = URL("https://example.com:443/test/request")
+            assert (
+                get_url(
+                    hass, require_current_request=True, prefer_external=prefer_external
+                )
+                == "https://example.com"
+            )
+
+            # Incoming request with custom port 18123 should match internal
+            mock_request.headers = {hdrs.HOST: "example.com:18123"}
+            mock_request.url = URL("https://example.com:18123/test/request")
+            assert (
+                get_url(
+                    hass, require_current_request=True, prefer_external=prefer_external
+                )
+                == "https://example.com:18123"
+            )
 
 
 async def test_get_request_host_port_with_port(hass: HomeAssistant) -> None:
@@ -731,7 +861,7 @@ async def test_get_request_host_port_no_host_header(hass: HomeAssistant) -> None
     Mock(return_value={"hostname": "homeassistant"}),
 )
 async def test_get_current_request_url_with_known_host(
-    hass: HomeAssistant, current_request
+    hass: HomeAssistant, current_request: MagicMock
 ) -> None:
     """Test getting current request URL with known hosts addresses."""
     hass.config.api = Mock(use_ssl=False, port=8123, local_ip="127.0.0.1")
@@ -798,7 +928,9 @@ async def test_get_current_request_url_with_known_host(
     "homeassistant.components.hassio.get_host_info",
     Mock(return_value={"hostname": "hellohost"}),
 )
-async def test_is_internal_request(hass: HomeAssistant, mock_current_request) -> None:
+async def test_is_internal_request(
+    hass: HomeAssistant, mock_current_request: MagicMock
+) -> None:
     """Test if accessing an instance on its internal URL."""
     # Test with internal URL: http://example.local:8123
     await async_process_ha_core_config(

--- a/tests/helpers/test_network.py
+++ b/tests/helpers/test_network.py
@@ -592,263 +592,60 @@ async def test_get_url(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    (
-        "internal_url",
-        "external_url",
-        "host_header",
-        "request_url",
-        "expected_url",
-        "prefer_external",
-    ),
+    ("scheme", "default_port"),
     [
-        # Scenario 1: HTTP, internal is standard port (http://example.com), external is custom port (http://example.com:18123)
-        pytest.param(
-            "http://example.com",
-            "http://example.com:18123",
-            "example.com",
-            "http://example.com/test/request",
-            "http://example.com",
-            False,
-            id="http_internal_std_request_std_prefer_internal",
-        ),
-        pytest.param(
-            "http://example.com",
-            "http://example.com:18123",
-            "example.com",
-            "http://example.com/test/request",
-            "http://example.com",
-            True,
-            id="http_internal_std_request_std_prefer_external",
-        ),
-        pytest.param(
-            "http://example.com",
-            "http://example.com:18123",
-            "example.com:80",
-            "http://example.com:80/test/request",
-            "http://example.com",
-            False,
-            id="http_internal_std_request_80_prefer_internal",
-        ),
-        pytest.param(
-            "http://example.com",
-            "http://example.com:18123",
-            "example.com:80",
-            "http://example.com:80/test/request",
-            "http://example.com",
-            True,
-            id="http_internal_std_request_80_prefer_external",
-        ),
-        pytest.param(
-            "http://example.com",
-            "http://example.com:18123",
-            "example.com:18123",
-            "http://example.com:18123/test/request",
-            "http://example.com:18123",
-            False,
-            id="http_internal_std_request_custom_prefer_internal",
-        ),
-        pytest.param(
-            "http://example.com",
-            "http://example.com:18123",
-            "example.com:18123",
-            "http://example.com:18123/test/request",
-            "http://example.com:18123",
-            True,
-            id="http_internal_std_request_custom_prefer_external",
-        ),
-        # Scenario 2: HTTP, internal is custom port (http://example.com:18123), external is standard port (http://example.com)
-        pytest.param(
-            "http://example.com:18123",
-            "http://example.com",
-            "example.com",
-            "http://example.com/test/request",
-            "http://example.com",
-            False,
-            id="http_internal_custom_request_std_prefer_internal",
-        ),
-        pytest.param(
-            "http://example.com:18123",
-            "http://example.com",
-            "example.com",
-            "http://example.com/test/request",
-            "http://example.com",
-            True,
-            id="http_internal_custom_request_std_prefer_external",
-        ),
-        pytest.param(
-            "http://example.com:18123",
-            "http://example.com",
-            "example.com:80",
-            "http://example.com:80/test/request",
-            "http://example.com",
-            False,
-            id="http_internal_custom_request_80_prefer_internal",
-        ),
-        pytest.param(
-            "http://example.com:18123",
-            "http://example.com",
-            "example.com:80",
-            "http://example.com:80/test/request",
-            "http://example.com",
-            True,
-            id="http_internal_custom_request_80_prefer_external",
-        ),
-        pytest.param(
-            "http://example.com:18123",
-            "http://example.com",
-            "example.com:18123",
-            "http://example.com:18123/test/request",
-            "http://example.com:18123",
-            False,
-            id="http_internal_custom_request_custom_prefer_internal",
-        ),
-        pytest.param(
-            "http://example.com:18123",
-            "http://example.com",
-            "example.com:18123",
-            "http://example.com:18123/test/request",
-            "http://example.com:18123",
-            True,
-            id="http_internal_custom_request_custom_prefer_external",
-        ),
-        # Scenario 3: HTTPS, internal is standard port (https://example.com), external is custom port (https://example.com:18123)
-        pytest.param(
-            "https://example.com",
-            "https://example.com:18123",
-            "example.com",
-            "https://example.com/test/request",
-            "https://example.com",
-            False,
-            id="https_internal_std_request_std_prefer_internal",
-        ),
-        pytest.param(
-            "https://example.com",
-            "https://example.com:18123",
-            "example.com",
-            "https://example.com/test/request",
-            "https://example.com",
-            True,
-            id="https_internal_std_request_std_prefer_external",
-        ),
-        pytest.param(
-            "https://example.com",
-            "https://example.com:18123",
-            "example.com:443",
-            "https://example.com:443/test/request",
-            "https://example.com",
-            False,
-            id="https_internal_std_request_443_prefer_internal",
-        ),
-        pytest.param(
-            "https://example.com",
-            "https://example.com:18123",
-            "example.com:443",
-            "https://example.com:443/test/request",
-            "https://example.com",
-            True,
-            id="https_internal_std_request_443_prefer_external",
-        ),
-        pytest.param(
-            "https://example.com",
-            "https://example.com:18123",
-            "example.com:18123",
-            "https://example.com:18123/test/request",
-            "https://example.com:18123",
-            False,
-            id="https_internal_std_request_custom_prefer_internal",
-        ),
-        pytest.param(
-            "https://example.com",
-            "https://example.com:18123",
-            "example.com:18123",
-            "https://example.com:18123/test/request",
-            "https://example.com:18123",
-            True,
-            id="https_internal_std_request_custom_prefer_external",
-        ),
-        # Scenario 4: HTTPS, internal is custom port (https://example.com:18123), external is standard port (https://example.com)
-        pytest.param(
-            "https://example.com:18123",
-            "https://example.com",
-            "example.com",
-            "https://example.com/test/request",
-            "https://example.com",
-            False,
-            id="https_internal_custom_request_std_prefer_internal",
-        ),
-        pytest.param(
-            "https://example.com:18123",
-            "https://example.com",
-            "example.com",
-            "https://example.com/test/request",
-            "https://example.com",
-            True,
-            id="https_internal_custom_request_std_prefer_external",
-        ),
-        pytest.param(
-            "https://example.com:18123",
-            "https://example.com",
-            "example.com:443",
-            "https://example.com:443/test/request",
-            "https://example.com",
-            False,
-            id="https_internal_custom_request_443_prefer_internal",
-        ),
-        pytest.param(
-            "https://example.com:18123",
-            "https://example.com",
-            "example.com:443",
-            "https://example.com:443/test/request",
-            "https://example.com",
-            True,
-            id="https_internal_custom_request_443_prefer_external",
-        ),
-        pytest.param(
-            "https://example.com:18123",
-            "https://example.com",
-            "example.com:18123",
-            "https://example.com:18123/test/request",
-            "https://example.com:18123",
-            False,
-            id="https_internal_custom_request_custom_prefer_internal",
-        ),
-        pytest.param(
-            "https://example.com:18123",
-            "https://example.com",
-            "example.com:18123",
-            "https://example.com:18123/test/request",
-            "https://example.com:18123",
-            True,
-            id="https_internal_custom_request_custom_prefer_external",
-        ),
+        ("http", "80"),
+        ("https", "443"),
+    ],
+)
+@pytest.mark.parametrize("prefer_external", [False, True])
+@pytest.mark.parametrize(
+    ("internal_url", "external_url"),
+    [
+        ("{scheme}://example.com", "{scheme}://example.com:18123"),
+        ("{scheme}://example.com:18123", "{scheme}://example.com"),
+    ],
+)
+@pytest.mark.parametrize(
+    ("host_header", "expected_url"),
+    [
+        ("example.com", "{scheme}://example.com"),
+        ("example.com:DEFAULT_PORT", "{scheme}://example.com"),
+        ("example.com:18123", "{scheme}://example.com:18123"),
     ],
 )
 async def test_get_url_host_matching_respects_port(
     hass: HomeAssistant,
+    scheme: str,
+    default_port: str,
     internal_url: str,
     external_url: str,
     host_header: str,
-    request_url: str,
     expected_url: str,
     prefer_external: bool,
 ) -> None:
     """Test that get_url respects the port when matching the request host."""
+    host_header_formatted = host_header.replace("DEFAULT_PORT", default_port)
+    int_url = internal_url.format(scheme=scheme)
+    ext_url = external_url.format(scheme=scheme)
+    exp_url = expected_url.format(scheme=scheme)
+
     await async_process_ha_core_config(
         hass,
         {
-            "internal_url": internal_url,
-            "external_url": external_url,
+            "internal_url": int_url,
+            "external_url": ext_url,
         },
     )
     with patch("homeassistant.helpers.http.current_request") as mock_request_context:
         mock_request = Mock()
-        mock_request.headers = {hdrs.HOST: host_header}
-        mock_request.url = URL(request_url)
+        mock_request.headers = {hdrs.HOST: host_header_formatted}
+        mock_request.url = URL(f"{scheme}://{host_header_formatted}/test/request")
         mock_request_context.get.return_value = mock_request
 
         assert (
             get_url(hass, require_current_request=True, prefer_external=prefer_external)
-            == expected_url
+            == exp_url
         )
 
 

--- a/tests/helpers/test_network.py
+++ b/tests/helpers/test_network.py
@@ -1002,7 +1002,8 @@ async def test_get_current_request_url_with_known_host(
     Mock(return_value={"hostname": "hellohost"}),
 )
 async def test_is_internal_request(
-    hass: HomeAssistant, mock_current_request: MagicMock
+    hass: HomeAssistant,
+    mock_current_request: Mock,
 ) -> None:
     """Test if accessing an instance on its internal URL."""
     # Test with internal URL: http://example.local:8123

--- a/tests/helpers/test_network.py
+++ b/tests/helpers/test_network.py
@@ -591,62 +591,192 @@ async def test_get_url(hass: HomeAssistant) -> None:
         assert get_url(hass, allow_internal=False)
 
 
-@pytest.mark.parametrize(
-    ("scheme", "default_port"),
-    [
-        ("http", "80"),
-        ("https", "443"),
-    ],
-)
-@pytest.mark.parametrize("prefer_external", [False, True])
-@pytest.mark.parametrize(
-    ("internal_url", "external_url"),
-    [
-        ("{scheme}://example.com", "{scheme}://example.com:18123"),
-        ("{scheme}://example.com:18123", "{scheme}://example.com"),
-    ],
-)
-@pytest.mark.parametrize(
-    ("host_header", "expected_url"),
-    [
-        ("example.com", "{scheme}://example.com"),
-        ("example.com:DEFAULT_PORT", "{scheme}://example.com"),
-        ("example.com:18123", "{scheme}://example.com:18123"),
-    ],
-)
-async def test_get_url_host_matching_respects_port(
+async def test_get_url_http_internal_standard_external_custom(
     hass: HomeAssistant,
-    scheme: str,
-    default_port: str,
-    internal_url: str,
-    external_url: str,
-    host_header: str,
-    expected_url: str,
-    prefer_external: bool,
 ) -> None:
-    """Test that get_url respects the port when matching the request host."""
-    host_header_formatted = host_header.replace("DEFAULT_PORT", default_port)
-    int_url = internal_url.format(scheme=scheme)
-    ext_url = external_url.format(scheme=scheme)
-    exp_url = expected_url.format(scheme=scheme)
-
+    """Test get_url matches custom/standard port over HTTP when internal is standard port."""
     await async_process_ha_core_config(
         hass,
         {
-            "internal_url": int_url,
-            "external_url": ext_url,
+            "internal_url": "http://example.com",
+            "external_url": "http://example.com:18123",
         },
     )
     with patch("homeassistant.helpers.http.current_request") as mock_request_context:
         mock_request = Mock()
-        mock_request.headers = {hdrs.HOST: host_header_formatted}
-        mock_request.url = URL(f"{scheme}://{host_header_formatted}/test/request")
         mock_request_context.get.return_value = mock_request
 
-        assert (
-            get_url(hass, require_current_request=True, prefer_external=prefer_external)
-            == exp_url
-        )
+        for prefer_external in (False, True):
+            # Incoming request with no explicit port (default 80) should match internal
+            mock_request.headers = {hdrs.HOST: "example.com"}
+            mock_request.url = URL("http://example.com/test/request")
+            assert (
+                get_url(
+                    hass, require_current_request=True, prefer_external=prefer_external
+                )
+                == "http://example.com"
+            )
+
+            # Incoming request with standard port 80 should match internal
+            mock_request.headers = {hdrs.HOST: "example.com:80"}
+            mock_request.url = URL("http://example.com:80/test/request")
+            assert (
+                get_url(
+                    hass, require_current_request=True, prefer_external=prefer_external
+                )
+                == "http://example.com"
+            )
+
+            # Incoming request with custom port 18123 should match external
+            mock_request.headers = {hdrs.HOST: "example.com:18123"}
+            mock_request.url = URL("http://example.com:18123/test/request")
+            assert (
+                get_url(
+                    hass, require_current_request=True, prefer_external=prefer_external
+                )
+                == "http://example.com:18123"
+            )
+
+
+async def test_get_url_http_internal_custom_external_standard(
+    hass: HomeAssistant,
+) -> None:
+    """Test get_url matches custom/standard port over HTTP when external is standard port."""
+    await async_process_ha_core_config(
+        hass,
+        {
+            "internal_url": "http://example.com:18123",
+            "external_url": "http://example.com",
+        },
+    )
+    with patch("homeassistant.helpers.http.current_request") as mock_request_context:
+        mock_request = Mock()
+        mock_request_context.get.return_value = mock_request
+
+        for prefer_external in (False, True):
+            # Incoming request with no explicit port (default 80) should match external
+            mock_request.headers = {hdrs.HOST: "example.com"}
+            mock_request.url = URL("http://example.com/test/request")
+            assert (
+                get_url(
+                    hass, require_current_request=True, prefer_external=prefer_external
+                )
+                == "http://example.com"
+            )
+
+            # Incoming request with standard port 80 should match external
+            mock_request.headers = {hdrs.HOST: "example.com:80"}
+            mock_request.url = URL("http://example.com:80/test/request")
+            assert (
+                get_url(
+                    hass, require_current_request=True, prefer_external=prefer_external
+                )
+                == "http://example.com"
+            )
+
+            # Incoming request with custom port 18123 should match internal
+            mock_request.headers = {hdrs.HOST: "example.com:18123"}
+            mock_request.url = URL("http://example.com:18123/test/request")
+            assert (
+                get_url(
+                    hass, require_current_request=True, prefer_external=prefer_external
+                )
+                == "http://example.com:18123"
+            )
+
+
+async def test_get_url_https_internal_standard_external_custom(
+    hass: HomeAssistant,
+) -> None:
+    """Test get_url matches custom/standard port over HTTPS when internal is standard port."""
+    await async_process_ha_core_config(
+        hass,
+        {
+            "internal_url": "https://example.com",
+            "external_url": "https://example.com:18123",
+        },
+    )
+    with patch("homeassistant.helpers.http.current_request") as mock_request_context:
+        mock_request = Mock()
+        mock_request_context.get.return_value = mock_request
+
+        for prefer_external in (False, True):
+            # Incoming request with no explicit port (default 443) should match internal
+            mock_request.headers = {hdrs.HOST: "example.com"}
+            mock_request.url = URL("https://example.com/test/request")
+            assert (
+                get_url(
+                    hass, require_current_request=True, prefer_external=prefer_external
+                )
+                == "https://example.com"
+            )
+
+            # Incoming request with standard port 443 should match internal
+            mock_request.headers = {hdrs.HOST: "example.com:443"}
+            mock_request.url = URL("https://example.com:443/test/request")
+            assert (
+                get_url(
+                    hass, require_current_request=True, prefer_external=prefer_external
+                )
+                == "https://example.com"
+            )
+
+            # Incoming request with custom port 18123 should match external
+            mock_request.headers = {hdrs.HOST: "example.com:18123"}
+            mock_request.url = URL("https://example.com:18123/test/request")
+            assert (
+                get_url(
+                    hass, require_current_request=True, prefer_external=prefer_external
+                )
+                == "https://example.com:18123"
+            )
+
+
+async def test_get_url_https_internal_custom_external_standard(
+    hass: HomeAssistant,
+) -> None:
+    """Test get_url matches custom/standard port over HTTPS when external is standard port."""
+    await async_process_ha_core_config(
+        hass,
+        {
+            "internal_url": "https://example.com:18123",
+            "external_url": "https://example.com",
+        },
+    )
+    with patch("homeassistant.helpers.http.current_request") as mock_request_context:
+        mock_request = Mock()
+        mock_request_context.get.return_value = mock_request
+
+        for prefer_external in (False, True):
+            # Incoming request with no explicit port (default 443) should match external
+            mock_request.headers = {hdrs.HOST: "example.com"}
+            mock_request.url = URL("https://example.com/test/request")
+            assert (
+                get_url(
+                    hass, require_current_request=True, prefer_external=prefer_external
+                )
+                == "https://example.com"
+            )
+
+            # Incoming request with standard port 443 should match external
+            mock_request.headers = {hdrs.HOST: "example.com:443"}
+            mock_request.url = URL("https://example.com:443/test/request")
+            assert (
+                get_url(
+                    hass, require_current_request=True, prefer_external=prefer_external
+                )
+                == "https://example.com"
+            )
+
+            # Incoming request with custom port 18123 should match internal
+            mock_request.headers = {hdrs.HOST: "example.com:18123"}
+            mock_request.url = URL("https://example.com:18123/test/request")
+            assert (
+                get_url(
+                    hass, require_current_request=True, prefer_external=prefer_external
+                )
+                == "https://example.com:18123"
+            )
 
 
 async def test_get_request_host_port_with_port(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


This PR introduces "Strict Port Matching" within the network helper module's URL resolution logic (`get_url`). 

Currently, if an instance has internal and external URLs sharing the same hostname but using different ports (e.g. `example.com:80` vs `example.com:8123`), the matcher `url.host == _get_request_host()` would match any incoming request with the matching host, ignoring the port entirely. This leads to Home Assistant returning the wrong URL for requests (for instance, returning the internal URL when accessing from external, or vice-versa).

This PR:
1. Implements strict port matching by introducing `_get_request_host_port()` to parse both host and port from the `Host` header of a web request.
2. Simplifies the parsing to be highly performant, utilizing direct string manipulation and avoiding heavy object parsing.
3. Updates `_get_internal_url`, `_get_external_url`, and `_get_cloud_url` to match the resolved port.
4. Preserves full mock compatibility with existing unit tests where request context or certain headers may not be fully populated.
5. Reverts a "prefer_external" in OAuth code which is no longer needed (http view tests pass with or without it)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
