### PR TITLE
Fix tessie setup_error on transient aiohttp.ClientError during startup

### DIFF
--- a/homeassistant/components/tessie/__init__.py
+++ b/homeassistant/components/tessie/__init__.py
@@ -156,7 +156,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: TessieConfigEntry) -> bo
                     live_status = (await api.live_status())["response"]
                 except (InvalidToken, Forbidden, SubscriptionRequired) as e:
                     raise ConfigEntryAuthFailed from e
-                except (TeslaFleetError, ClientError) as e:
+                except TeslaFleetError as e:
+                    raise ConfigEntryNotReady(getattr(e, "message", str(e))) from e
+                except ClientError as e:
                     raise ConfigEntryNotReady from e
 
                 powerwall = (

--- a/homeassistant/components/tessie/__init__.py
+++ b/homeassistant/components/tessie/__init__.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 
+from aiohttp import ClientError
 from tesla_fleet_api.const import Scope
 from tesla_fleet_api.exceptions import (
     Forbidden,
@@ -81,6 +82,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: TessieConfigEntry) -> bo
             translation_domain=DOMAIN,
             translation_key="cannot_connect",
         ) from e
+    except ClientError as e:
+        raise ConfigEntryNotReady from e
 
     vehicles: list[TessieVehicleData] = []
     for vehicle in state_of_all_vehicles["results"]:
@@ -124,13 +127,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: TessieConfigEntry) -> bo
 
     try:
         scopes = await tessie.scopes()
-    except TeslaFleetError as e:
+    except (TeslaFleetError, ClientError) as e:
         raise ConfigEntryNotReady from e
 
     if Scope.ENERGY_DEVICE_DATA in scopes:
         try:
             products = (await tessie.products())["response"]
-        except TeslaFleetError as e:
+        except (TeslaFleetError, ClientError) as e:
             raise ConfigEntryNotReady from e
 
         for product in products:
@@ -153,8 +156,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: TessieConfigEntry) -> bo
                     live_status = (await api.live_status())["response"]
                 except (InvalidToken, Forbidden, SubscriptionRequired) as e:
                     raise ConfigEntryAuthFailed from e
-                except TeslaFleetError as e:
-                    raise ConfigEntryNotReady(e.message) from e
+                except (TeslaFleetError, ClientError) as e:
+                    raise ConfigEntryNotReady from e
 
                 powerwall = (
                     product["components"]["battery"] or product["components"]["solar"]

--- a/tests/components/tessie/test_init.py
+++ b/tests/components/tessie/test_init.py
@@ -79,28 +79,75 @@ async def test_scopes_error(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
+    ("patch_target", "exception"),
+    [
+        pytest.param(
+            None,
+            ClientConnectionError(),
+            id="list_vehicles-connection_error",
+        ),
+        pytest.param(
+            None,
+            ClientError(),
+            id="list_vehicles-client_error",
+        ),
+        pytest.param(
+            "homeassistant.components.tessie.Tessie.scopes",
+            ClientConnectionError(),
+            id="scopes-connection_error",
+        ),
+        pytest.param(
+            "homeassistant.components.tessie.Tessie.scopes",
+            ClientError(),
+            id="scopes-client_error",
+        ),
+        pytest.param(
+            "homeassistant.components.tessie.Tessie.products",
+            ClientConnectionError(),
+            id="products-connection_error",
+        ),
+        pytest.param(
+            "homeassistant.components.tessie.Tessie.products",
+            ClientError(),
+            id="products-client_error",
+        ),
+    ],
+)
+async def test_aiohttp_client_error_retries(
+    hass: HomeAssistant,
+    mock_get_state_of_all_vehicles: AsyncMock,
+    patch_target: str | None,
+    exception: ClientError,
+) -> None:
+    """Test that aiohttp.ClientError on any setup call triggers SETUP_RETRY.
+
+    Covers list_vehicles(), scopes(), and products() — all network calls that
+    tesla_fleet_api does not wrap in TeslaFleetError.
+    """
+    if patch_target is None:
+        mock_get_state_of_all_vehicles.side_effect = exception
+        entry = await setup_platform(hass)
+    else:
+        with patch(patch_target, side_effect=exception):
+            entry = await setup_platform(hass)
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+
+
+@pytest.mark.parametrize(
     "exception",
     [
         pytest.param(ClientConnectionError(), id="connection_error"),
         pytest.param(ClientError(), id="client_error"),
     ],
 )
-async def test_aiohttp_client_error_retries(
+async def test_aiohttp_client_error_on_live_status_retries(
     hass: HomeAssistant,
-    mock_get_state_of_all_vehicles: AsyncMock,
     exception: ClientError,
 ) -> None:
-    """Test that aiohttp.ClientError during list_vehicles triggers SETUP_RETRY."""
-    mock_get_state_of_all_vehicles.side_effect = exception
-    entry = await setup_platform(hass)
-    assert entry.state is ConfigEntryState.SETUP_RETRY
-
-
-async def test_aiohttp_client_error_on_scopes_retries(hass: HomeAssistant) -> None:
-    """Test that aiohttp.ClientError during scopes() triggers SETUP_RETRY."""
+    """Test that aiohttp.ClientError during live_status() triggers SETUP_RETRY."""
     with patch(
-        "homeassistant.components.tessie.Tessie.scopes",
-        side_effect=ClientConnectionError(),
+        "tesla_fleet_api.tessie.EnergySite.live_status",
+        side_effect=exception,
     ):
         entry = await setup_platform(hass)
-        assert entry.state is ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/tessie/test_init.py
+++ b/tests/components/tessie/test_init.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import AsyncMock, patch
 
+from aiohttp import ClientConnectionError, ClientError
+import pytest
 from tesla_fleet_api.exceptions import (
     InvalidRequest,
     InvalidToken,
@@ -71,6 +73,34 @@ async def test_scopes_error(hass: HomeAssistant) -> None:
 
     with patch(
         "homeassistant.components.tessie.Tessie.scopes", side_effect=TeslaFleetError
+    ):
+        entry = await setup_platform(hass)
+        assert entry.state is ConfigEntryState.SETUP_RETRY
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        pytest.param(ClientConnectionError(), id="connection_error"),
+        pytest.param(ClientError(), id="client_error"),
+    ],
+)
+async def test_aiohttp_client_error_retries(
+    hass: HomeAssistant,
+    mock_get_state_of_all_vehicles: AsyncMock,
+    exception: ClientError,
+) -> None:
+    """Test that aiohttp.ClientError during list_vehicles triggers SETUP_RETRY."""
+    mock_get_state_of_all_vehicles.side_effect = exception
+    entry = await setup_platform(hass)
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_aiohttp_client_error_on_scopes_retries(hass: HomeAssistant) -> None:
+    """Test that aiohttp.ClientError during scopes() triggers SETUP_RETRY."""
+    with patch(
+        "homeassistant.components.tessie.Tessie.scopes",
+        side_effect=ClientConnectionError(),
     ):
         entry = await setup_platform(hass)
         assert entry.state is ConfigEntryState.SETUP_RETRY


### PR DESCRIPTION
## Proposed change

`tesla_fleet_api._request()` makes HTTP calls via `aiohttp.ClientSession.request()` directly, with no internal try/except around network errors. When the Tessie API is unreachable at HA startup (host network not yet routed, DNS resolution failure, connection timeout), `aiohttp.ClientError` (and its subclasses — `ConnectionTimeoutError`, `ClientConnectionError`, etc.) propagates from `list_vehicles()`, `scopes()`, `products()`, or `live_status()` into `async_setup_entry`.

The existing exception chain only handled `TeslaFleetError` subclasses, and `aiohttp.ClientError` is not in that hierarchy, so the exception escaped entirely → HA's config-entry machinery caught it as an unexpected error and set the entry to `setup_error` with no automatic retry. A manual reload was required to recover.

These are transient failures (the API is temporarily unreachable, not permanently broken), so they should raise `ConfigEntryNotReady` and let HA retry with backoff.

**Fix:** add `except ClientError as e: raise ConfigEntryNotReady from e` after each `TeslaFleetError` handler on all four network call sites in `async_setup_entry`. As a cleanup, the `live_status` site previously used `raise ConfigEntryNotReady(e.message)` which is incorrect when the caught exception is a `ClientError` (no `.message` attribute); changed to plain `raise ConfigEntryNotReady from e`, consistent with the rest of the file.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. Your PR cannot be merged unless tests pass
- [x] Tests have been added to verify the fix (`test_aiohttp_client_error_retries`, `test_aiohttp_client_error_on_scopes_retries`).
- [ ] The documentation has been updated if necessary.
- [x] The changes have no obvious security issues.
- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/