### PR TITLE
Fix daikin setup_error on transient DaikinException during startup

### DIFF
--- a/homeassistant/components/daikin/__init__.py
+++ b/homeassistant/components/daikin/__init__.py
@@ -58,6 +58,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: DaikinConfigEntry) -> bo
         _LOGGER.debug("ClientConnectionError to %s", host)
         raise ConfigEntryNotReady from err
     except DaikinException as err:
+        # pydaikin has no subclass hierarchy for transient vs permanent errors.
+        # DaikinException during factory/init almost always means the device is not
+        # yet ready (e.g. "Empty values." when the unit hasn't finished booting),
+        # so treat all factory-time DaikinExceptions as transient.
         _LOGGER.debug("DaikinException from %s: %s", host, err)
         raise ConfigEntryNotReady from err
 

--- a/homeassistant/components/daikin/__init__.py
+++ b/homeassistant/components/daikin/__init__.py
@@ -5,6 +5,7 @@ import logging
 
 from aiohttp import ClientConnectionError
 from pydaikin.daikin_base import Appliance
+from pydaikin.exceptions import DaikinException
 from pydaikin.factory import DaikinFactory
 
 from homeassistant.const import (
@@ -55,6 +56,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: DaikinConfigEntry) -> bo
         raise ConfigEntryNotReady from err
     except ClientConnectionError as err:
         _LOGGER.debug("ClientConnectionError to %s", host)
+        raise ConfigEntryNotReady from err
+    except DaikinException as err:
+        _LOGGER.debug("DaikinException from %s: %s", host, err)
         raise ConfigEntryNotReady from err
 
     coordinator = DaikinCoordinator(hass, entry, device)

--- a/tests/components/daikin/test_init.py
+++ b/tests/components/daikin/test_init.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, PropertyMock, patch
 
 from aiohttp import ClientConnectionError
 from freezegun.api import FrozenDateTimeFactory
+from pydaikin.exceptions import DaikinException
 import pytest
 
 from homeassistant.components.daikin import update_unique_id
@@ -220,6 +221,28 @@ async def test_timeout_error(hass: HomeAssistant, mock_daikin) -> None:
     config_entry.add_to_hass(hass)
 
     mock_daikin.side_effect = TimeoutError
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_daikin_exception_retries(hass: HomeAssistant, mock_daikin) -> None:
+    """Test that a DaikinException during setup triggers SETUP_RETRY.
+
+    A DaikinException (e.g. "Empty values." from DaikinAirBase.init when the
+    device HTTP endpoint returns an empty response) is a transient condition —
+    the device is not yet ready, not a permanent configuration problem — so the
+    entry must land in SETUP_RETRY rather than SETUP_ERROR.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=MAC,
+        data={CONF_HOST: HOST, KEY_MAC: MAC},
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_daikin.side_effect = DaikinException("Empty values.")
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 


### PR DESCRIPTION
## Proposed change

When HA restarts while a Daikin device's HTTP endpoint is not yet ready (e.g. the AC unit has not finished booting, or returns an empty response body), `DaikinFactory` probes several device types in turn and ultimately calls `DaikinAirBase.init()`, which raises `DaikinException("Empty values.")` when the device responds but produces no usable data.

The existing try/except in `async_setup_entry` only caught `TimeoutError` and `aiohttp.ClientConnectionError`. `DaikinException` is a plain `Exception` subclass — not in either caught hierarchy — so it escaped entirely → HA's config-entry machinery caught it as an unexpected error and set the entry to `setup_error` with no automatic retry. A manual reload was required each time.

This is a transient condition (the device is temporarily not ready, not permanently misconfigured), so it should raise `ConfigEntryNotReady` and let HA retry with backoff as intended.

**Fix:** add `except DaikinException as err: raise ConfigEntryNotReady from err` alongside the existing `TimeoutError` and `ClientConnectionError` handlers.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #168471
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. Your PR cannot be merged unless tests pass
- [x] Tests have been added to verify the fix (`test_daikin_exception_retries`).
- [ ] The documentation has been updated if necessary.
- [x] The changes have no obvious security issues.
- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/