### PR TITLE
Add Bluetooth connection to Melnor devices

### DIFF
--- a/homeassistant/components/melnor/entity.py
+++ b/homeassistant/components/melnor/entity.py
@@ -6,7 +6,7 @@ from melnor_bluetooth.device import Device, Valve
 
 from homeassistant.components.number import EntityDescription
 from homeassistant.core import callback
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
@@ -30,6 +30,7 @@ class MelnorBluetoothEntity(CoordinatorEntity[MelnorDataUpdateCoordinator]):
 
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._device.mac)},
+            connections={(CONNECTION_BLUETOOTH, self._device.mac)},
             manufacturer="Melnor",
             model=self._device.model,
             name=self._device.name,

--- a/tests/components/melnor/snapshots/test_init.ambr
+++ b/tests/components/melnor/snapshots/test_init.ambr
@@ -1,0 +1,36 @@
+# serializer version: 1
+# name: test_device_registry
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'config_entries_subentries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+      tuple(
+        'bluetooth',
+        'FAKE-ADDRESS-1',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'melnor',
+        'FAKE-ADDRESS-1',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'Melnor',
+    'model': 'test_model',
+    'model_id': None,
+    'name': 'test_melnor',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---

--- a/tests/components/melnor/test_init.py
+++ b/tests/components/melnor/test_init.py
@@ -1,0 +1,37 @@
+"""Test the Melnor integration setup."""
+
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.melnor.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from .conftest import (
+    FAKE_ADDRESS_1,
+    mock_config_entry,
+    patch_async_ble_device_from_address,
+    patch_async_register_callback,
+    patch_melnor_device,
+)
+
+
+async def test_device_registry(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the device registry entry, including the Bluetooth connection."""
+    entry = mock_config_entry(hass)
+
+    with (
+        patch_async_ble_device_from_address(),
+        patch_melnor_device(),
+        patch_async_register_callback(),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, FAKE_ADDRESS_1)}
+    )
+    assert device_entry == snapshot


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Register the Melnor Bluetooth device with its Bluetooth address as a connection
so the address is shown on the device page and other integrations can attach to
the same device.

Melnor devices were registered with only a domain identifier and no device
`connections`, so Home Assistant did not display the device's Bluetooth address,
and other integrations that key off the Bluetooth connection (for example,
Bermuda BLE trilateration) ended up creating a separate device for the same
physical unit. Adding the `CONNECTION_BLUETOOTH` connection fixes both: the
address now shows on the device page, and integrations referencing the same
Bluetooth device link to it instead of producing a duplicate.

The connection is added only to the base device (the physical Bluetooth unit).
The per-zone child devices keep their identifier-only `DeviceInfo` and continue
to link to the base device through `via_device`, so no connection tuple is
duplicated across devices.

This is the same change applied to Aranet in #173066 and to AirVisual Pro in
#173071.

Please re-classify it as a Bugfix if deemed appropriate (as one could argue a
Bluetooth device should always carry its Bluetooth connection).

The change is covered by a new device-registry snapshot test that asserts the
Bluetooth connection is registered on the base device.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
