### PR TITLE
Add network MAC connection to Ring devices

### DIFF
--- a/homeassistant/components/ring/entity.py
+++ b/homeassistant/components/ring/entity.py
@@ -19,7 +19,11 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.device_registry import (
+    CONNECTION_NETWORK_MAC,
+    DeviceInfo,
+    format_mac,
+)
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.update_coordinator import (
@@ -177,6 +181,7 @@ class RingBaseEntity(
         self._attr_extra_state_attributes = {}
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, device.device_id)},  # device_id is the mac
+            connections={(CONNECTION_NETWORK_MAC, format_mac(device.device_id))},
             manufacturer="Ring",
             model=device.model,
             name=device.name,

--- a/tests/components/ring/snapshots/test_init.ambr
+++ b/tests/components/ring/snapshots/test_init.ambr
@@ -1,0 +1,36 @@
+# serializer version: 1
+# name: test_device_registry
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'config_entries_subentries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+      tuple(
+        'mac',
+        'aa:cd:ef:98:76:54',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'ring',
+        'aacdef987654',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'Ring',
+    'model': 'doorbots',
+    'model_id': None,
+    'name': 'Front Door',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---

--- a/tests/components/ring/test_init.py
+++ b/tests/components/ring/test_init.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from ring_doorbell import AuthenticationError, Ring, RingError, RingTimeout
+from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components import ring
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
@@ -20,7 +21,7 @@ from homeassistant.components.ring.coordinator import RingConfigEntry, RingEvent
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import CONF_DEVICE_ID, CONF_TOKEN, CONF_USERNAME
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from .conftest import MOCK_HARDWARE_ID
@@ -41,6 +42,20 @@ async def test_setup_entry(
 ) -> None:
     """Test setup entry."""
     assert mock_added_config_entry.state is ConfigEntryState.LOADED
+
+
+async def test_device_registry(
+    hass: HomeAssistant,
+    mock_added_config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the device registry entry, including the network MAC connection."""
+    # device_id "aacdef987654" is the Front Door doorbell's MAC.
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, "aacdef987654")}
+    )
+    assert device_entry == snapshot
 
 
 async def test_setup_entry_device_update(


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Register Ring devices with their network MAC address as a connection so the MAC
is shown on the device page and other integrations can attach to the same
device.

Ring devices were registered with only a domain identifier (the device's MAC, in
unformatted form) and no device `connections`, so Home Assistant did not display
the MAC on the device page, and integrations that key off the network MAC (for
example, the UniFi Network integration) created a separate device for the same
physical unit. The integration already documents that `device.device_id` is the
MAC — see the existing `# device_id is the mac` comment, and the `ring_doorbell`
`device_id` docstring ("This is the device_id returned by the api, usually the
MAC"). Adding a `CONNECTION_NETWORK_MAC` connection — `format_mac(device.device_id)`
— fixes both. `format_mac` is a no-op for any id that is not MAC-formatted, so
this is safe for the rare non-MAC case.

This is the same change applied to Aranet in #173066 and to AirVisual Pro in
#173071.

The change is covered by a new device-registry snapshot test that asserts the
network MAC connection is registered.

Verified against real Ring hardware that `device.device_id` equals the device's
Wi-Fi MAC across doorbell, chime, and floodlight camera models.

## Before/After Screenshots

<img width="322" height="241" alt="Chime (Before)" src="https://github.com/user-attachments/assets/688705cb-03f1-4769-805a-64d1c1f707f7" />
<img width="322" height="319" alt="Chime (After)" src="https://github.com/user-attachments/assets/040dfc23-d0d2-44ca-91e1-c38706f191b8" />

<img width="322" height="241" alt="Floodlight Cam Pro (Before)" src="https://github.com/user-attachments/assets/e26fc57a-3ede-42e0-97a0-de85ba61a6f7" />
<img width="322" height="319" alt="Floodlight Cam Pro (After)" src="https://github.com/user-attachments/assets/4284878f-5856-49ad-90a4-06a63f0077b9" />

<img width="322" height="241" alt="Stick Up Cam Wired (Before)" src="https://github.com/user-attachments/assets/09f4b2c0-360b-44ae-806d-26698ffe35a8" />
<img width="322" height="319" alt="Stick Up Cam Wired (After)" src="https://github.com/user-attachments/assets/85f167af-ba6a-429e-a689-1f26606e7b6d" />

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

