### PR TITLE
Add network MAC connection to Rain Bird controller

### DIFF
--- a/homeassistant/components/rainbird/coordinator.py
+++ b/homeassistant/components/rainbird/coordinator.py
@@ -16,11 +16,7 @@ from pyrainbird.data import ModelAndVersion, Schedule
 from homeassistant.const import CONF_MAC
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.debounce import Debouncer
-from homeassistant.helpers.device_registry import (
-    CONNECTION_NETWORK_MAC,
-    DeviceInfo,
-    format_mac,
-)
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN, MANUFACTURER, TIMEOUT_SECONDS
@@ -119,9 +115,7 @@ class RainbirdUpdateCoordinator(DataUpdateCoordinator[RainbirdDeviceState]):
         # The unique id is the formatted MAC for current config entries, but was
         # historically the serial number, so derive the connection from the MAC.
         if mac_address := self.config_entry.data.get(CONF_MAC):
-            device_info["connections"] = {
-                (CONNECTION_NETWORK_MAC, format_mac(mac_address))
-            }
+            device_info["connections"] = {(CONNECTION_NETWORK_MAC, mac_address)}
         return device_info
 
     async def _async_update_data(self) -> RainbirdDeviceState:

--- a/homeassistant/components/rainbird/coordinator.py
+++ b/homeassistant/components/rainbird/coordinator.py
@@ -13,9 +13,14 @@ from pyrainbird.async_client import (
 )
 from pyrainbird.data import ModelAndVersion, Schedule
 
+from homeassistant.const import CONF_MAC
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.debounce import Debouncer
-from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
+from homeassistant.helpers.device_registry import (
+    CONNECTION_NETWORK_MAC,
+    DeviceInfo,
+    format_mac,
+)
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN, MANUFACTURER, TIMEOUT_SECONDS
@@ -104,14 +109,20 @@ class RainbirdUpdateCoordinator(DataUpdateCoordinator[RainbirdDeviceState]):
         """Return information about the device."""
         if self._unique_id is None:
             return None
-        return DeviceInfo(
+        device_info = DeviceInfo(
             name=self.device_name,
             identifiers={(DOMAIN, self._unique_id)},
-            connections={(CONNECTION_NETWORK_MAC, self._unique_id)},
             manufacturer=MANUFACTURER,
             model=self._model_info.model_name,
             sw_version=f"{self._model_info.major}.{self._model_info.minor}",
         )
+        # The unique id is the formatted MAC for current config entries, but was
+        # historically the serial number, so derive the connection from the MAC.
+        if mac_address := self.config_entry.data.get(CONF_MAC):
+            device_info["connections"] = {
+                (CONNECTION_NETWORK_MAC, format_mac(mac_address))
+            }
+        return device_info
 
     async def _async_update_data(self) -> RainbirdDeviceState:
         """Fetch data from Rain Bird device."""

--- a/homeassistant/components/rainbird/coordinator.py
+++ b/homeassistant/components/rainbird/coordinator.py
@@ -15,7 +15,7 @@ from pyrainbird.data import ModelAndVersion, Schedule
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.debounce import Debouncer
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN, MANUFACTURER, TIMEOUT_SECONDS
@@ -107,6 +107,7 @@ class RainbirdUpdateCoordinator(DataUpdateCoordinator[RainbirdDeviceState]):
         return DeviceInfo(
             name=self.device_name,
             identifiers={(DOMAIN, self._unique_id)},
+            connections={(CONNECTION_NETWORK_MAC, self._unique_id)},
             manufacturer=MANUFACTURER,
             model=self._model_info.model_name,
             sw_version=f"{self._model_info.major}.{self._model_info.minor}",

--- a/tests/components/rainbird/snapshots/test_init.ambr
+++ b/tests/components/rainbird/snapshots/test_init.ambr
@@ -1,0 +1,36 @@
+# serializer version: 1
+# name: test_device_registry
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'config_entries_subentries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+      tuple(
+        'mac',
+        '4c:a1:61:00:11:22',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'rainbird',
+        '4c:a1:61:00:11:22',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'Rain Bird',
+    'model': 'ESP-TM2',
+    'model_id': None,
+    'name': 'Rain Bird Controller',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'sw_version': '9.12',
+    'via_device_id': None,
+  })
+# ---

--- a/tests/components/rainbird/test_init.py
+++ b/tests/components/rainbird/test_init.py
@@ -2,12 +2,14 @@
 
 from http import HTTPStatus
 from typing import Any
+from unittest.mock import patch
 
 import pytest
+from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.rainbird.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import CONF_MAC
+from homeassistant.const import CONF_MAC, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
@@ -40,6 +42,24 @@ async def test_init_success(
     await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
     assert config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+async def test_device_registry(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the controller device registry entry, including the network MAC connection."""
+    # Load a platform so the controller device is registered.
+    with patch("homeassistant.components.rainbird.PLATFORMS", [Platform.SENSOR]):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, MAC_ADDRESS_UNIQUE_ID)}
+    )
+    assert device_entry == snapshot
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Register the Rain Bird controller with its network MAC address as a connection so
the MAC is shown on the device page and other integrations can attach to the same
device.

The controller's config entry unique id is already the formatted MAC (derived
from the device's Wi-Fi MAC during setup) and is used as the device identifier,
but the device was registered without any `connections`. As a result, Home
Assistant did not display the MAC on the device page, and integrations that key
off the network MAC (for example, the UniFi Network integration) created a
separate device for the same physical unit. Adding the `CONNECTION_NETWORK_MAC`
connection fixes both.

The connection is added to the controller device only. The per-zone switch
devices remain linked to the controller via `via_device`, so no connection tuple
is duplicated across devices.

This is the same change applied to Aranet in #173066 and to AirVisual Pro in
#173071.

Please re-classify it as a Bugfix if deemed appropriate (as one could argue a
network device should always carry its network MAC connection).

Tested on real hardware (a Rain Bird ESP-ME3 controller). With the change
applied, the controller's device page shows its MAC address, and the UniFi
Network integration's client device merges onto the same device via the new
connection instead of remaining a separate entry. The change is also covered by
a new device-registry snapshot test that asserts the network MAC connection is
registered on the controller device.

Below, the controller device page before and after the change. Before: no MAC,
Rain Bird only. After: the MAC is shown and the UniFi Network integration has
merged onto the same device.

Before:
<img width="332" height="267" alt="RainBird Before" src="https://github.com/user-attachments/assets/0a4bf201-a016-4ed7-ba17-d0dda8041230" />

After:
<img width="339" height="397" alt="RainBird After" src="https://github.com/user-attachments/assets/d1f6fd3d-7dda-42ed-8426-731bd3be26f0" />

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
