### PR TITLE
Add network MAC connection to Renson devices

### DIFF
--- a/homeassistant/components/renson/entity.py
+++ b/homeassistant/components/renson/entity.py
@@ -8,7 +8,11 @@ from renson_endura_delta.field_enum import (
 )
 from renson_endura_delta.renson import RensonVentilation
 
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.device_registry import (
+    CONNECTION_NETWORK_MAC,
+    DeviceInfo,
+    format_mac,
+)
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
@@ -27,6 +31,12 @@ class RensonEntity(CoordinatorEntity[RensonCoordinator]):
         self._attr_device_info = DeviceInfo(
             identifiers={
                 (DOMAIN, api.get_field_value(coordinator.data, MAC_ADDRESS.name))
+            },
+            connections={
+                (
+                    CONNECTION_NETWORK_MAC,
+                    format_mac(api.get_field_value(coordinator.data, MAC_ADDRESS.name)),
+                )
             },
             manufacturer="Renson",
             model=api.get_field_value(coordinator.data, DEVICE_NAME_FIELD.name),

--- a/homeassistant/components/renson/entity.py
+++ b/homeassistant/components/renson/entity.py
@@ -28,16 +28,11 @@ class RensonEntity(CoordinatorEntity[RensonCoordinator]):
         """Initialize the Renson entity."""
         super().__init__(coordinator)
 
+        mac = api.get_field_value(coordinator.data, MAC_ADDRESS.name)
+
         self._attr_device_info = DeviceInfo(
-            identifiers={
-                (DOMAIN, api.get_field_value(coordinator.data, MAC_ADDRESS.name))
-            },
-            connections={
-                (
-                    CONNECTION_NETWORK_MAC,
-                    format_mac(api.get_field_value(coordinator.data, MAC_ADDRESS.name)),
-                )
-            },
+            identifiers={(DOMAIN, mac)},
+            connections={(CONNECTION_NETWORK_MAC, format_mac(mac))},
             manufacturer="Renson",
             model=api.get_field_value(coordinator.data, DEVICE_NAME_FIELD.name),
             name="Ventilation",
@@ -51,6 +46,4 @@ class RensonEntity(CoordinatorEntity[RensonCoordinator]):
 
         self.api = api
 
-        self._attr_unique_id = (
-            api.get_field_value(coordinator.data, MAC_ADDRESS.name) + f"{name}"
-        )
+        self._attr_unique_id = f"{mac}{name}"

--- a/homeassistant/components/renson/entity.py
+++ b/homeassistant/components/renson/entity.py
@@ -8,11 +8,7 @@ from renson_endura_delta.field_enum import (
 )
 from renson_endura_delta.renson import RensonVentilation
 
-from homeassistant.helpers.device_registry import (
-    CONNECTION_NETWORK_MAC,
-    DeviceInfo,
-    format_mac,
-)
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
@@ -32,7 +28,7 @@ class RensonEntity(CoordinatorEntity[RensonCoordinator]):
 
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, mac)},
-            connections={(CONNECTION_NETWORK_MAC, format_mac(mac))},
+            connections={(CONNECTION_NETWORK_MAC, mac)},
             manufacturer="Renson",
             model=api.get_field_value(coordinator.data, DEVICE_NAME_FIELD.name),
             name="Ventilation",

--- a/tests/components/renson/snapshots/test_init.ambr
+++ b/tests/components/renson/snapshots/test_init.ambr
@@ -1,0 +1,36 @@
+# serializer version: 1
+# name: test_device_registry
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'config_entries_subentries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+      tuple(
+        'mac',
+        '80:7d:3a:bd:1e:32',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': '8.0',
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'renson',
+        '80:7d:3a:bd:1e:32',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'Renson',
+    'model': 'Endura Delta',
+    'model_id': None,
+    'name': 'Ventilation',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'sw_version': 'Firmware version 4.9.1',
+    'via_device_id': None,
+  })
+# ---

--- a/tests/components/renson/test_init.py
+++ b/tests/components/renson/test_init.py
@@ -1,0 +1,64 @@
+"""Tests for the Renson integration setup."""
+
+from unittest.mock import MagicMock, patch
+
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.renson.const import DOMAIN
+from homeassistant.const import CONF_HOST, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from tests.common import MockConfigEntry
+
+
+async def test_device_registry(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the device registry entry, including the network MAC connection."""
+    all_data = {
+        "ModifiedItems": [
+            {"Name": "MAC", "Value": "80:7d:3a:bd:1e:32"},
+            {"Name": "Device name", "Value": "Endura Delta"},
+            {"Name": "Firmware version", "Value": "Firmware version 4.9.1"},
+            {"Name": "Hardware version", "Value": "8.0"},
+        ]
+    }
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "1.1.1.1"},
+    )
+    entry.add_to_hass(hass)
+
+    mock_api = MagicMock()
+    mock_api.connect.return_value = True
+    mock_api.get_all_data.return_value = all_data
+
+    def _get_field_value(data: dict, fieldname: str) -> str:
+        for item in data["ModifiedItems"]:
+            if item["Name"] == fieldname:
+                return item["Value"]
+        return ""
+
+    mock_api.get_field_value.side_effect = _get_field_value
+
+    with (
+        patch(
+            "homeassistant.components.renson.RensonVentilation",
+            return_value=mock_api,
+        ),
+        patch(
+            "homeassistant.components.renson.PLATFORMS",
+            [Platform.SENSOR],
+        ),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, "80:7d:3a:bd:1e:32")}
+    )
+    assert device_entry == snapshot


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Register Renson ventilation units with its network MAC address as a connection so the MAC is
shown on the device page and other integrations can attach to the same device.

The device was registered without any device `connections`, so Home Assistant did
not display the MAC on the device page, and integrations that key off the network
MAC (for example, the UniFi Network integration) created a separate device for the
same physical unit. Adding the `CONNECTION_NETWORK_MAC` connection fixes both: the
MAC now shows on the device page, and integrations referencing the same network
device link to it instead of producing a duplicate.

This is the same change applied to Aranet in #173066 and to AirVisual Pro in
#173071.

Please re-classify it as a Bugfix if deemed appropriate (as one could argue a
network device should always carry its network MAC connection).

The change is covered by a new device-registry snapshot test that asserts the
network MAC connection is registered.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
