### PR TITLE
Add network MAC connection to AsusWRT router

### DIFF
--- a/homeassistant/components/asuswrt/router.py
+++ b/homeassistant/components/asuswrt/router.py
@@ -16,7 +16,11 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.device_registry import DeviceInfo, format_mac
+from homeassistant.helpers.device_registry import (
+    CONNECTION_NETWORK_MAC,
+    DeviceInfo,
+    format_mac,
+)
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
@@ -392,6 +396,10 @@ class AsusWrtRouter:
             serial_number=self._api.serial_number,
             manufacturer="Asus",
         )
+        if self._entry.unique_id:
+            info["connections"] = {
+                (CONNECTION_NETWORK_MAC, format_mac(self._entry.unique_id))
+            }
         if self._api.firmware:
             info["sw_version"] = self._api.firmware
 

--- a/homeassistant/components/asuswrt/router.py
+++ b/homeassistant/components/asuswrt/router.py
@@ -396,6 +396,8 @@ class AsusWrtRouter:
             serial_number=self._api.serial_number,
             manufacturer="Asus",
         )
+        # The config entry unique id is the router's label MAC (the only MAC the
+        # integration persists); a single configured router may have none.
         if self._entry.unique_id:
             info["connections"] = {
                 (CONNECTION_NETWORK_MAC, format_mac(self._entry.unique_id))

--- a/homeassistant/components/asuswrt/router.py
+++ b/homeassistant/components/asuswrt/router.py
@@ -396,8 +396,6 @@ class AsusWrtRouter:
             serial_number=self._api.serial_number,
             manufacturer="Asus",
         )
-        # Source the MAC from the bridge identity (already normalized via
-        # format_mac); a router queried purely by host may not report one.
         if label_mac := self._api.label_mac:
             info["connections"] = {(CONNECTION_NETWORK_MAC, label_mac)}
         if self._api.firmware:

--- a/homeassistant/components/asuswrt/router.py
+++ b/homeassistant/components/asuswrt/router.py
@@ -396,12 +396,10 @@ class AsusWrtRouter:
             serial_number=self._api.serial_number,
             manufacturer="Asus",
         )
-        # The config entry unique id is the router's label MAC (the only MAC the
-        # integration persists); a single configured router may have none.
-        if self._entry.unique_id:
-            info["connections"] = {
-                (CONNECTION_NETWORK_MAC, format_mac(self._entry.unique_id))
-            }
+        # Source the MAC from the bridge identity (already normalized via
+        # format_mac); a router queried purely by host may not report one.
+        if label_mac := self._api.label_mac:
+            info["connections"] = {(CONNECTION_NETWORK_MAC, label_mac)}
         if self._api.firmware:
             info["sw_version"] = self._api.firmware
 

--- a/tests/components/asuswrt/snapshots/test_init.ambr
+++ b/tests/components/asuswrt/snapshots/test_init.ambr
@@ -1,0 +1,36 @@
+# serializer version: 1
+# name: test_device_registry
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'config_entries_subentries': <ANY>,
+    'configuration_url': 'http://myrouter.asuswrt.com:80',
+    'connections': set({
+      tuple(
+        'mac',
+        'a1:b2:c3:d4:e5:f6',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'asuswrt',
+        'a1:b2:c3:d4:e5:f6',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'Asus',
+    'model': 'FAKE_MODEL',
+    'model_id': None,
+    'name': 'myrouter.asuswrt.com',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'sw_version': 'FAKE_FIRMWARE',
+    'via_device_id': None,
+  })
+# ---

--- a/tests/components/asuswrt/test_init.py
+++ b/tests/components/asuswrt/test_init.py
@@ -40,6 +40,7 @@ async def test_disconnect_on_stop(hass: HomeAssistant, connect_legacy) -> None:
 async def test_device_registry(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test the router device registry entry, including the network MAC connection."""
@@ -52,7 +53,6 @@ async def test_device_registry(
 
     # Router sensors are disabled by default; pre-enable one so the router
     # device is registered in the device registry.
-    entity_registry = er.async_get(hass)
     unique_id_prefix = slugify(ROUTER_MAC_ADDR)
     sensor_id = slugify("sensor_rx_bytes")
     entity_registry.async_get_or_create(

--- a/tests/components/asuswrt/test_init.py
+++ b/tests/components/asuswrt/test_init.py
@@ -1,11 +1,17 @@
 """Tests for the AsusWrt integration."""
 
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components import sensor
 from homeassistant.components.asuswrt.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.util import slugify
 
-from .common import CONFIG_DATA_TELNET, ROUTER_MAC_ADDR
+from .common import CONFIG_DATA_HTTP, CONFIG_DATA_TELNET, HOST, ROUTER_MAC_ADDR
 
 from tests.common import MockConfigEntry
 
@@ -28,3 +34,40 @@ async def test_disconnect_on_stop(hass: HomeAssistant, connect_legacy) -> None:
 
     assert connect_legacy.return_value.async_disconnect.await_count == 1
     assert config_entry.state is ConfigEntryState.LOADED
+
+
+@pytest.mark.usefixtures("connect_http", "connect_http_sens_detect")
+async def test_device_registry(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the router device registry entry, including the network MAC connection."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=CONFIG_DATA_HTTP,
+        unique_id=ROUTER_MAC_ADDR,
+    )
+    config_entry.add_to_hass(hass)
+
+    # Router sensors are disabled by default; pre-enable one so the router
+    # device is registered in the device registry.
+    entity_registry = er.async_get(hass)
+    unique_id_prefix = slugify(ROUTER_MAC_ADDR)
+    sensor_id = slugify("sensor_rx_bytes")
+    entity_registry.async_get_or_create(
+        sensor.DOMAIN,
+        DOMAIN,
+        f"{unique_id_prefix}_{sensor_id}",
+        suggested_object_id=f"{slugify(HOST)}_{sensor_id}",
+        config_entry=config_entry,
+        disabled_by=None,
+    )
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, ROUTER_MAC_ADDR)}
+    )
+    assert device_entry == snapshot


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Register the AsusWRT router with its network MAC address as a connection so the MAC is
shown on the device page and other integrations can attach to the same device.

The device was registered without any device `connections`, so Home Assistant did
not display the MAC on the device page, and integrations that key off the network
MAC (for example, the UniFi Network integration) created a separate device for the
same physical unit. Adding the `CONNECTION_NETWORK_MAC` connection fixes both: the
MAC now shows on the device page, and integrations referencing the same network
device link to it instead of producing a duplicate. The connection is only added when the config entry has a unique id (the router's label MAC), so single-instance setups without one are unaffected.

This is the same change applied to Aranet in #173066 and to AirVisual Pro in
#173071.

Please re-classify it as a Bugfix if deemed appropriate (as one could argue a
network device should always carry its network MAC connection).

The change is covered by a new device-registry snapshot test that asserts the
network MAC connection is registered.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
