### PR TITLE
Add network MAC connection to Vilfo router

### DIFF
--- a/homeassistant/components/vilfo/sensor.py
+++ b/homeassistant/components/vilfo/sensor.py
@@ -76,12 +76,16 @@ class VilfoRouterSensor(SensorEntity):
         self.entity_description = description
         self.api = api
         self._attr_device_info = DeviceInfo(
+            # This identifier is a non-standard 3-tuple kept as-is to avoid
+            # migrating existing devices; only the connection is added here.
             identifiers={(DOMAIN, api.host, api.mac_address)},  # type: ignore[arg-type]
             name=ROUTER_DEFAULT_NAME,
             manufacturer=ROUTER_MANUFACTURER,
             model=ROUTER_DEFAULT_MODEL,
             sw_version=api.firmware_version,
         )
+        # The router does not always report a MAC address (e.g. when set up by
+        # host), so only attach the connection when one is available.
         if api.mac_address:
             self._attr_device_info["connections"] = {
                 (CONNECTION_NETWORK_MAC, format_mac(api.mac_address))

--- a/homeassistant/components/vilfo/sensor.py
+++ b/homeassistant/components/vilfo/sensor.py
@@ -9,7 +9,11 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import PERCENTAGE
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.device_registry import (
+    CONNECTION_NETWORK_MAC,
+    DeviceInfo,
+    format_mac,
+)
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import VilfoConfigEntry
@@ -78,6 +82,10 @@ class VilfoRouterSensor(SensorEntity):
             model=ROUTER_DEFAULT_MODEL,
             sw_version=api.firmware_version,
         )
+        if api.mac_address:
+            self._attr_device_info["connections"] = {
+                (CONNECTION_NETWORK_MAC, format_mac(api.mac_address))
+            }
         self._attr_unique_id = f"{api.unique_id}_{description.key}"
 
     @property

--- a/homeassistant/components/vilfo/sensor.py
+++ b/homeassistant/components/vilfo/sensor.py
@@ -9,11 +9,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import PERCENTAGE
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import (
-    CONNECTION_NETWORK_MAC,
-    DeviceInfo,
-    format_mac,
-)
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import VilfoConfigEntry
@@ -88,7 +84,7 @@ class VilfoRouterSensor(SensorEntity):
         # host), so only attach the connection when one is available.
         if api.mac_address:
             self._attr_device_info["connections"] = {
-                (CONNECTION_NETWORK_MAC, format_mac(api.mac_address))
+                (CONNECTION_NETWORK_MAC, api.mac_address)
             }
         self._attr_unique_id = f"{api.unique_id}_{description.key}"
 

--- a/tests/components/vilfo/snapshots/test_init.ambr
+++ b/tests/components/vilfo/snapshots/test_init.ambr
@@ -1,0 +1,37 @@
+# serializer version: 1
+# name: test_device_registry
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'config_entries_subentries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+      tuple(
+        'mac',
+        'ff:00:00:00:00:00',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'vilfo',
+        'testadmin.vilfo.com',
+        'FF-00-00-00-00-00',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'Vilfo AB',
+    'model': 'Vilfo Router',
+    'model_id': None,
+    'name': 'Vilfo Router',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'sw_version': '1.1.0',
+    'via_device_id': None,
+  })
+# ---

--- a/tests/components/vilfo/snapshots/test_init.ambr
+++ b/tests/components/vilfo/snapshots/test_init.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_device_registry
+# name: test_device_registry[with_mac]
   DeviceRegistryEntrySnapshot({
     'area_id': None,
     'config_entries': <ANY>,
@@ -20,6 +20,38 @@
         'vilfo',
         'testadmin.vilfo.com',
         'FF-00-00-00-00-00',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'Vilfo AB',
+    'model': 'Vilfo Router',
+    'model_id': None,
+    'name': 'Vilfo Router',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'sw_version': '1.1.0',
+    'via_device_id': None,
+  })
+# ---
+# name: test_device_registry[without_mac]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'config_entries_subentries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'vilfo',
+        'testadmin.vilfo.com',
+        None,
       ),
     }),
     'labels': set({

--- a/tests/components/vilfo/test_init.py
+++ b/tests/components/vilfo/test_init.py
@@ -1,0 +1,39 @@
+"""Tests for the Vilfo Router integration setup."""
+
+from unittest.mock import patch
+
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.vilfo.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from tests.common import MockConfigEntry
+
+
+async def test_device_registry(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the device registry entry, including the network MAC connection."""
+    mock_config_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.vilfo.VilfoClient", autospec=True
+    ) as mock_client:
+        client = mock_client.return_value
+        client.mac = "FF-00-00-00-00-00"
+        client.get_board_information.return_value = {
+            "version": "1.1.0",
+            "bootTime": "2024-01-01T00:00:00+00:00",
+        }
+        client.get_load.return_value = 30
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, "testadmin.vilfo.com", "FF-00-00-00-00-00")}
+    )
+    assert device_entry == snapshot

--- a/tests/components/vilfo/test_init.py
+++ b/tests/components/vilfo/test_init.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import patch
 
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.vilfo.const import DOMAIN
@@ -11,20 +12,41 @@ from homeassistant.helpers import device_registry as dr
 from tests.common import MockConfigEntry
 
 
+@pytest.mark.parametrize(
+    ("mac", "identifiers"),
+    [
+        pytest.param(
+            "FF-00-00-00-00-00",
+            {(DOMAIN, "testadmin.vilfo.com", "FF-00-00-00-00-00")},
+            id="with_mac",
+        ),
+        pytest.param(
+            None,
+            {(DOMAIN, "testadmin.vilfo.com", None)},
+            id="without_mac",
+        ),
+    ],
+)
 async def test_device_registry(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     device_registry: dr.DeviceRegistry,
     snapshot: SnapshotAssertion,
+    mac: str | None,
+    identifiers: set[tuple[str, str | None]],
 ) -> None:
-    """Test the device registry entry, including the network MAC connection."""
+    """Test the device registry entry.
+
+    The network MAC connection is only attached when the router reports a MAC;
+    a router set up by host may not report one.
+    """
     mock_config_entry.add_to_hass(hass)
 
     with patch(
         "homeassistant.components.vilfo.VilfoClient", autospec=True
     ) as mock_client:
         client = mock_client.return_value
-        client.mac = "FF-00-00-00-00-00"
+        client.mac = mac
         client.get_board_information.return_value = {
             "version": "1.1.0",
             "bootTime": "2024-01-01T00:00:00+00:00",
@@ -33,7 +55,5 @@ async def test_device_registry(
         assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "testadmin.vilfo.com", "FF-00-00-00-00-00")}
-    )
+    device_entry = device_registry.async_get_device(identifiers=identifiers)
     assert device_entry == snapshot


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Register the Vilfo router with its network MAC address as a connection so the MAC is
shown on the device page and other integrations can attach to the same device.

The device was registered without any device `connections`, so Home Assistant did
not display the MAC on the device page, and integrations that key off the network
MAC (for example, the UniFi Network integration) created a separate device for the
same physical unit. Adding the `CONNECTION_NETWORK_MAC` connection fixes both: the
MAC now shows on the device page, and integrations referencing the same network
device link to it instead of producing a duplicate. The connection is only added when the router reports a MAC address. (The existing device identifier is an unusual three-part tuple; that is intentionally left unchanged here to avoid a device-identity migration, and could be addressed separately.)

This is the same change applied to Aranet in #173066 and to AirVisual Pro in
#173071.

Please re-classify it as a Bugfix if deemed appropriate (as one could argue a
network device should always carry its network MAC connection).

The change is covered by a new device-registry snapshot test that asserts the
network MAC connection is registered.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
