### PR TITLE
Add network MAC connection to JVC Projector device

### DIFF
--- a/homeassistant/components/jvc_projector/entity.py
+++ b/homeassistant/components/jvc_projector/entity.py
@@ -27,6 +27,9 @@ class JvcProjectorEntity(CoordinatorEntity[JvcProjectorDataUpdateCoordinator]):
         super().__init__(coordinator, command)
 
         self._attr_unique_id = coordinator.unique_id
+        # The config entry unique id is the device's formatted MAC address (set
+        # from the projector's MAC in the config flow), so it doubles as the
+        # network MAC connection.
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._attr_unique_id)},
             connections={(CONNECTION_NETWORK_MAC, self._attr_unique_id)},

--- a/homeassistant/components/jvc_projector/entity.py
+++ b/homeassistant/components/jvc_projector/entity.py
@@ -4,7 +4,7 @@ import logging
 
 from jvcprojector import Command, JvcProjector
 
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, MANUFACTURER, NAME
@@ -29,6 +29,7 @@ class JvcProjectorEntity(CoordinatorEntity[JvcProjectorDataUpdateCoordinator]):
         self._attr_unique_id = coordinator.unique_id
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._attr_unique_id)},
+            connections={(CONNECTION_NETWORK_MAC, self._attr_unique_id)},
             name=NAME,
             model=self.device.model,
             manufacturer=MANUFACTURER,

--- a/tests/components/jvc_projector/snapshots/test_init.ambr
+++ b/tests/components/jvc_projector/snapshots/test_init.ambr
@@ -1,0 +1,36 @@
+# serializer version: 1
+# name: test_device_registry
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'config_entries_subentries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+      tuple(
+        'mac',
+        'e0:da:dc:0a:12:34',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'jvc_projector',
+        'e0:da:dc:0a:12:34',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'JVC',
+    'model': 'B2A2',
+    'model_id': None,
+    'name': 'JVC Projector',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---

--- a/tests/components/jvc_projector/test_init.py
+++ b/tests/components/jvc_projector/test_init.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, patch
 
 from jvcprojector import JvcProjectorAuthError, JvcProjectorTimeoutError
+from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.jvc_projector.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
@@ -28,6 +29,20 @@ async def test_init(
     device = device_registry.async_get_device(identifiers={(DOMAIN, mac)})
     assert device is not None
     assert device.identifiers == {(DOMAIN, mac)}
+
+
+async def test_device_registry(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mock_device: AsyncMock,
+    mock_integration: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the device registry entry, including the network MAC connection."""
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, format_mac(MOCK_MAC))}
+    )
+    assert device_entry == snapshot
 
 
 async def test_unload_config_entry(


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Register the JVC projector with its network MAC address as a connection so the MAC is
shown on the device page and other integrations can attach to the same device.

The device was registered without any device `connections`, so Home Assistant did
not display the MAC on the device page, and integrations that key off the network
MAC (for example, the UniFi Network integration) created a separate device for the
same physical unit. Adding the `CONNECTION_NETWORK_MAC` connection fixes both: the
MAC now shows on the device page, and integrations referencing the same network
device link to it instead of producing a duplicate.

This is the same change applied to Aranet in #173066 and to AirVisual Pro in
#173071.

Please re-classify it as a Bugfix if deemed appropriate (as one could argue a
network device should always carry its network MAC connection).

The change is covered by a new device-registry snapshot test that asserts the
network MAC connection is registered.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
