### PR TITLE
Skip setting unused legacy columns when recording states and events

### DIFF
--- a/homeassistant/components/recorder/db_schema.py
+++ b/homeassistant/components/recorder/db_schema.py
@@ -308,17 +308,17 @@ class Events(Base):
     def from_event(event: Event) -> Events:
         """Create an event database object from a native event."""
         context = event.context
+        # The unused legacy columns (event_type, event_data, time_fired,
+        # context_id, context_user_id, context_parent_id) are nullable with no
+        # default, so they are intentionally left unset here. Assigning them
+        # None would still insert NULL, but each assignment goes through
+        # SQLAlchemy's instrumented attribute machinery, which is a measurable
+        # cost when run for every recorded event.
         return Events(
-            event_type=None,
-            event_data=None,
             origin_idx=event.origin.idx,
-            time_fired=None,
             time_fired_ts=event.time_fired_timestamp,
-            context_id=None,
             context_id_bin=ulid_to_bytes_or_none(context.id),
-            context_user_id=None,
             context_user_id_bin=uuid_hex_to_bytes_or_none(context.user_id),
-            context_parent_id=None,
             context_parent_id_bin=ulid_to_bytes_or_none(context.parent_id),
         )
 
@@ -491,19 +491,18 @@ class States(Base):
             else:
                 last_reported_ts = state.last_reported_timestamp
         context = event.context
+        # The unused legacy columns (entity_id, attributes, context_id,
+        # context_user_id, context_parent_id, last_updated, last_changed) are
+        # nullable with no default, so they are intentionally left unset here.
+        # Assigning them None would still insert NULL, but each assignment goes
+        # through SQLAlchemy's instrumented attribute machinery, which is a
+        # measurable cost when run for every recorded state change.
         return States(
             state=state_value,
-            entity_id=None,
-            attributes=None,
-            context_id=None,
             context_id_bin=ulid_to_bytes_or_none(context.id),
-            context_user_id=None,
             context_user_id_bin=uuid_hex_to_bytes_or_none(context.user_id),
-            context_parent_id=None,
             context_parent_id_bin=ulid_to_bytes_or_none(context.parent_id),
             origin_idx=event.origin.idx,
-            last_updated=None,
-            last_changed=None,
             last_updated_ts=last_updated_ts,
             last_changed_ts=last_changed_ts,
             last_reported_ts=last_reported_ts,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`States.from_event` and `Events.from_event` run in the recorder for every recorded state change and event. Both explicitly assigned the unused legacy columns to `None`:

- States: `entity_id`, `attributes`, `last_updated`, `last_changed`, `context_id`, `context_user_id`, `context_parent_id`
- Events: `event_type`, `event_data`, `time_fired`, `context_id`, `context_user_id`, `context_parent_id`

These columns are all nullable with no column default, so leaving them unset inserts `NULL` exactly as assigning `None` does. Assigning them, however, runs SQLAlchemy's instrumented attribute machinery (`InstrumentedAttribute.__set__` → `_modified_event` → history tracking) once per column. In the single threaded recorder, which processes every recorded state change and event, that adds up.

This PR simply omits those assignments. The inserted rows are unchanged (the legacy columns remain `NULL`).

While profiling the recorder thread (via an in-thread `cProfile`, since the recorder runs in its own thread), the recorder thread's CPU is dominated by SQLAlchemy ORM flush/commit, but `States.from_event` was a notable HA-side cost, almost entirely SQLAlchemy attribute instrumentation rather than the actual values being set.

Measured:

| | before | after |
| --- | --- | --- |
| `States(...)` construction (microbenchmark) | ~13.4 µs | ~8.1 µs (~1.65x) |
| `States.from_event` (in-thread recorder profile, cumulative) | ~1.52 s | ~1.02 s (~33%) |

No behavior change: 530 recorder, history, logbook and statistics tests pass, all of which record states and events and read them back.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
