### PR TITLE
Improve Rainbird config flow test coverage

### DIFF
--- a/homeassistant/components/rainbird/quality_scale.yaml
+++ b/homeassistant/components/rainbird/quality_scale.yaml
@@ -34,11 +34,7 @@ rules:
   docs-removal-instructions: todo
   test-before-setup: done
   docs-high-level-description: done
-  config-flow-test-coverage:
-    status: todo
-    comment: |
-      All config flow tests should finish with CREATE_ENTRY and ABORT to
-      test they are able to recover from errors
+  config-flow-test-coverage: done
   docs-actions: done
   runtime-data: done
 

--- a/tests/components/rainbird/test_config_flow.py
+++ b/tests/components/rainbird/test_config_flow.py
@@ -277,10 +277,17 @@ async def test_controller_cannot_connect(
 ) -> None:
     """Test an error talking to the controller."""
 
-    # Controller response with a failure
+    # Controller response with a failure, followed by successful responses
     responses.clear()
-    responses.append(
-        AiohttpClientMockResponse("POST", URL, status=HTTPStatus.SERVICE_UNAVAILABLE)
+    responses.extend(
+        [
+            AiohttpClientMockResponse(
+                "POST", URL, status=HTTPStatus.SERVICE_UNAVAILABLE
+            ),
+            mock_response(MODEL_AND_VERSION_RESPONSE),
+            mock_response(SERIAL_RESPONSE),
+            mock_json_response(WIFI_PARAMS_RESPONSE),
+        ]
     )
 
     result = await complete_flow(hass)
@@ -289,6 +296,19 @@ async def test_controller_cannot_connect(
     assert result.get("errors") == {"base": "cannot_connect"}
 
     assert not mock_setup.mock_calls
+
+    # Correct the form and enter the password again and setup completes
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: HOST, CONF_PASSWORD: PASSWORD},
+    )
+    assert result.get("type") is FlowResultType.CREATE_ENTRY
+    assert result.get("title") == HOST
+    assert "result" in result
+    assert dict(result["result"].data) == CONFIG_ENTRY_DATA
+    assert result["result"].unique_id == MAC_ADDRESS_UNIQUE_ID
+
+    assert len(mock_setup.mock_calls) == 1
 
 
 async def test_controller_invalid_auth(
@@ -347,19 +367,44 @@ async def test_controller_invalid_auth(
 async def test_controller_timeout(
     hass: HomeAssistant,
     mock_setup: Mock,
+    responses: list[AiohttpClientMockResponse],
 ) -> None:
     """Test an error talking to the controller."""
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result.get("type") is FlowResultType.FORM
+    assert result.get("step_id") == "user"
+    assert not result.get("errors")
+    assert "flow_id" in result
 
     with patch(
         "homeassistant.components.rainbird.config_flow.asyncio.timeout",
         side_effect=TimeoutError,
     ):
-        result = await complete_flow(hass)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_HOST: HOST, CONF_PASSWORD: PASSWORD},
+        )
         assert result.get("type") is FlowResultType.FORM
         assert result.get("step_id") == "user"
         assert result.get("errors") == {"base": "timeout_connect"}
 
     assert not mock_setup.mock_calls
+
+    # Enter the password again and setup completes
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: HOST, CONF_PASSWORD: PASSWORD},
+    )
+    assert result.get("type") is FlowResultType.CREATE_ENTRY
+    assert result.get("title") == HOST
+    assert "result" in result
+    assert dict(result["result"].data) == CONFIG_ENTRY_DATA
+    assert result["result"].unique_id == MAC_ADDRESS_UNIQUE_ID
+
+    assert len(mock_setup.mock_calls) == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Modernize the Rain Bird integration by improving config flow test coverage.

Specifically, this PR updates config flow error-handling tests (`test_controller_cannot_connect` and `test_controller_timeout`) to verify that the flow successfully recovers from connection errors/timeouts on subsequent attempts and finishes with a successful `CREATE_ENTRY`.

Additionally, the Integration Quality Scale compliance checklist (`quality_scale.yaml`) is updated to mark `config-flow-test-coverage` as `done`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
