### PR TITLE
Support Roborock dynamic devices and simplify startup error handling

### DIFF
--- a/homeassistant/components/roborock/__init__.py
+++ b/homeassistant/components/roborock/__init__.py
@@ -133,8 +133,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: RoborockConfigEntry) -> 
             translation_key="home_data_fail",
         ) from err
 
-    entry.runtime_data.device_manager = device_manager
-
     async def shutdown_roborock(_: Event | None = None) -> None:
         await asyncio.gather(device_manager.close(), cache.flush())
 

--- a/homeassistant/components/roborock/__init__.py
+++ b/homeassistant/components/roborock/__init__.py
@@ -1,10 +1,8 @@
 """The Roborock component."""
 
 import asyncio
-from collections.abc import Coroutine
 from datetime import timedelta
 import logging
-from typing import Any
 
 from roborock import (
     RoborockException,
@@ -19,10 +17,11 @@ from roborock.map.map_parser import MapParserConfig
 from roborock.mqtt.session import MqttSessionUnauthorized
 
 from homeassistant.const import CONF_USERNAME, EVENT_HOMEASSISTANT_STOP
-from homeassistant.core import Event, HomeAssistant
+from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
@@ -75,6 +74,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: RoborockConfigEntry) -> 
         base_url=entry.data[CONF_BASE_URL],
     )
     cache = CacheStore(hass, entry.entry_id)
+
+    entry.runtime_data = RoborockCoordinators()
+
+    @callback
+    def handle_device_ready(device: RoborockDevice) -> None:
+        """Handle a device becoming ready."""
+        entry.async_create_background_task(
+            hass,
+            async_setup_device(hass, entry, device),
+            name=f"roborock_device_setup_{device.duid}",
+        )
+
     try:
         device_manager = await create_device_manager(
             user_params,
@@ -91,6 +102,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: RoborockConfigEntry) -> 
                 show_walls=entry.options.get(CONF_SHOW_WALLS, True),
                 map_scale=MAP_SCALE,
             ),
+            ready_callback=handle_device_ready,
             mqtt_session_unauthorized_hook=lambda: entry.async_start_reauth(hass),
             prefer_cache=False,
         )
@@ -121,6 +133,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: RoborockConfigEntry) -> 
             translation_key="home_data_fail",
         ) from err
 
+    entry.runtime_data.device_manager = device_manager
+
     async def shutdown_roborock(_: Event | None = None) -> None:
         await asyncio.gather(device_manager.close(), cache.flush())
 
@@ -131,76 +145,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: RoborockConfigEntry) -> 
 
     devices = await device_manager.get_devices()
     _LOGGER.debug("Device manager found %d devices", len(devices))
-
-    # Register all discovered devices in the device registry so we can
-    # check the disabled state before creating coordinators.
-    device_registry = dr.async_get(hass)
-    for device in devices:
-        device_registry.async_get_or_create(
-            config_entry_id=entry.entry_id,
-            **get_device_info(device),
-        )
-
-    enabled_devices = []
-    disabled_devices = []
-    for device in devices:
-        if _is_device_disabled(device_registry, device):
-            disabled_devices.append(device)
-        else:
-            enabled_devices.append(device)
-    _LOGGER.debug("%d of %d devices are enabled", len(enabled_devices), len(devices))
-
-    # Close connections for disabled devices to prevent their background
-    # reconnect loops from triggering MQTT session restarts that would
-    # disrupt coordinator setup for the enabled devices.
-    if disabled_devices:
-        close_results = await asyncio.gather(
-            *[device.close() for device in disabled_devices],
-            return_exceptions=True,
-        )
-        for device, close_result in zip(disabled_devices, close_results, strict=True):
-            if isinstance(close_result, Exception):
-                _LOGGER.debug(
-                    "Failed to close disabled Roborock device %s: %s",
-                    device.duid,
-                    close_result,
-                )
-
-    coordinators = await asyncio.gather(
-        *build_setup_functions(hass, entry, enabled_devices, user_data),
-        return_exceptions=True,
-    )
-    v1_coords = [
-        coord
-        for coord in coordinators
-        if isinstance(coord, RoborockDataUpdateCoordinator)
-    ]
-    a01_coords = [
-        coord
-        for coord in coordinators
-        if isinstance(coord, RoborockDataUpdateCoordinatorA01)
-    ]
-    b01_q7_coords = [
-        coord
-        for coord in coordinators
-        if isinstance(coord, RoborockB01Q7UpdateCoordinator)
-    ]
-    b01_q10_coords = [
-        coord
-        for coord in coordinators
-        if isinstance(coord, RoborockB01Q10UpdateCoordinator)
-    ]
-    if (
-        len(v1_coords) + len(a01_coords) + len(b01_q7_coords) + len(b01_q10_coords) == 0
-        and enabled_devices
-    ):
-        raise ConfigEntryNotReady(
-            translation_domain=DOMAIN,
-            translation_key="no_coordinators",
-        )
-    entry.runtime_data = RoborockCoordinators(
-        v1_coords, a01_coords, b01_q7_coords, b01_q10_coords
-    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -223,6 +167,7 @@ def _remove_stale_devices(
     entry: RoborockConfigEntry,
     devices: list[RoborockDevice],
 ) -> None:
+    """Remove devices from the registry that are no longer in the account."""
     device_map: dict[str, RoborockDevice] = {device.duid: device for device in devices}
     device_registry = dr.async_get(hass)
     device_entries = dr.async_entries_for_config_entry(
@@ -237,7 +182,7 @@ def _remove_stale_devices(
         if any(device_duid in device_map for device_duid in device_duids):
             continue
         _LOGGER.info(
-            "Removing device: %s because it is no longer exists in your account",
+            "Removing device: %s because it no longer exists in your account",
             device.name,
         )
         device_registry.async_update_device(
@@ -268,87 +213,81 @@ async def async_migrate_entry(hass: HomeAssistant, entry: RoborockConfigEntry) -
     return True
 
 
-def build_setup_functions(
+async def async_setup_device(
     hass: HomeAssistant,
     entry: RoborockConfigEntry,
-    devices: list[RoborockDevice],
-    user_data: UserData,
-) -> list[
-    Coroutine[
-        Any,
-        Any,
+    device: RoborockDevice,
+) -> None:
+    """Set up a single Roborock device and its coordinator."""
+    _LOGGER.debug("Device %s is ready, setting it up", device.duid)
+    if device.duid in entry.runtime_data:
+        return
+    device_registry = dr.async_get(hass)
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        **get_device_info(device),
+    )
+    if _is_device_disabled(device_registry, device):
+        _LOGGER.debug("Device %s is disabled, skipping setup", device.duid)
+        try:
+            await device.close()
+        except RoborockException as err:
+            _LOGGER.warning("Failed to close device %s: %s", device.duid, err)
+        return
+
+    _LOGGER.debug("Creating device %s: %s", device.name, device)
+    coordinator: (
         RoborockDataUpdateCoordinator
         | RoborockDataUpdateCoordinatorA01
         | RoborockDataUpdateCoordinatorB01
         | RoborockB01Q10UpdateCoordinator
-        | None,
-    ]
-]:
-    """Create a list of setup functions that can later be called asynchronously."""
-    coordinators: list[
-        RoborockDataUpdateCoordinator
-        | RoborockDataUpdateCoordinatorA01
-        | RoborockDataUpdateCoordinatorB01
-        | RoborockB01Q10UpdateCoordinator
-    ] = []
-    for device in devices:
-        _LOGGER.debug("Creating device %s: %s", device.name, device)
-        if device.v1_properties is not None:
-            coordinators.append(
-                RoborockDataUpdateCoordinator(hass, entry, device, device.v1_properties)
-            )
-        elif device.dyad is not None:
-            coordinators.append(
-                RoborockWetDryVacUpdateCoordinator(hass, entry, device, device.dyad)
-            )
-        elif device.zeo is not None:
-            coordinators.append(
-                RoborockWashingMachineUpdateCoordinator(hass, entry, device, device.zeo)
-            )
-        elif device.b01_q7_properties is not None:
-            coordinators.append(
-                RoborockB01Q7UpdateCoordinator(
-                    hass, entry, device, device.b01_q7_properties
-                )
-            )
-        elif device.b01_q10_properties is not None:
-            coordinators.append(
-                RoborockB01Q10UpdateCoordinator(
-                    hass, entry, device, device.b01_q10_properties
-                )
-            )
-        else:
-            _LOGGER.warning(
-                "Not adding device %s because its protocol version"
-                " %s or category %s is not supported",
-                device.duid,
-                device.device_info.pv,
-                device.product.category.name,
-            )
-
-    return [setup_coordinator(coordinator) for coordinator in coordinators]
-
-
-async def setup_coordinator(
-    coordinator: RoborockDataUpdateCoordinator
-    | RoborockDataUpdateCoordinatorA01
-    | RoborockDataUpdateCoordinatorB01
-    | RoborockB01Q10UpdateCoordinator,
-) -> (
-    RoborockDataUpdateCoordinator
-    | RoborockDataUpdateCoordinatorA01
-    | RoborockDataUpdateCoordinatorB01
-    | RoborockB01Q10UpdateCoordinator
-    | None
-):
-    """Set up a single coordinator."""
-    try:
-        await coordinator.async_config_entry_first_refresh()
-    except ConfigEntryNotReady:
-        await coordinator.async_shutdown()
-        raise
+        | None
+    ) = None
+    if device.v1_properties is not None:
+        coordinator = RoborockDataUpdateCoordinator(
+            hass, entry, device, device.v1_properties
+        )
+    elif device.dyad is not None:
+        coordinator = RoborockWetDryVacUpdateCoordinator(
+            hass, entry, device, device.dyad
+        )
+    elif device.zeo is not None:
+        coordinator = RoborockWashingMachineUpdateCoordinator(
+            hass, entry, device, device.zeo
+        )
+    elif device.b01_q7_properties is not None:
+        coordinator = RoborockB01Q7UpdateCoordinator(
+            hass, entry, device, device.b01_q7_properties
+        )
+    elif device.b01_q10_properties is not None:
+        coordinator = RoborockB01Q10UpdateCoordinator(
+            hass, entry, device, device.b01_q10_properties
+        )
     else:
-        return coordinator
+        _LOGGER.warning(
+            "Not adding entities for device %s because its protocol"
+            " version %s or category %s is not supported",
+            device.duid,
+            device.device_info.pv,
+            device.product.category.name,
+        )
+        try:
+            await device.close()
+        except RoborockException as err:
+            _LOGGER.warning("Failed to close device %s: %s", device.duid, err)
+        return
+
+    entry.runtime_data.add(coordinator)
+    async_dispatcher_send(
+        hass,
+        f"roborock_coordinator_added_{entry.entry_id}",
+        coordinator,
+    )
+    entry.async_create_background_task(
+        hass,
+        coordinator.async_refresh(),
+        name=f"roborock_coordinator_refresh_{coordinator.duid}",
+    )
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: RoborockConfigEntry) -> bool:

--- a/homeassistant/components/roborock/__init__.py
+++ b/homeassistant/components/roborock/__init__.py
@@ -265,9 +265,11 @@ async def async_setup_device(
         )
     else:
         _LOGGER.warning(
-            "Not adding entities for device %s because its protocol"
+            "Not adding entities for device %s (%s/%s) because its protocol"
             " version %s or category %s is not supported",
             device.duid,
+            device.product.name,
+            device.product.model,
             device.device_info.pv,
             device.product.category.name,
         )

--- a/homeassistant/components/roborock/binary_sensor.py
+++ b/homeassistant/components/roborock/binary_sensor.py
@@ -14,12 +14,14 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntityDescription,
 )
 from homeassistant.const import ATTR_BATTERY_CHARGING, EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
 from .coordinator import (
     RoborockConfigEntry,
+    RoborockCoordinatorType,
     RoborockDataUpdateCoordinator,
     RoborockDataUpdateCoordinatorA01,
     RoborockWashingMachineUpdateCoordinator,
@@ -167,26 +169,38 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Roborock vacuum binary sensors."""
-    entities: list[BinarySensorEntity] = [
-        RoborockBinarySensorEntity(
-            coordinator,
-            description,
+    coordinators = config_entry.runtime_data
+
+    @callback
+    def async_add_coordinator_entities(
+        coordinator: RoborockCoordinatorType,
+    ) -> None:
+        """Add entities for a specific coordinator."""
+        entities: list[BinarySensorEntity] = []
+        if isinstance(coordinator, RoborockDataUpdateCoordinator):
+            entities.extend(
+                RoborockBinarySensorEntity(coordinator, description)
+                for description in BINARY_SENSOR_DESCRIPTIONS
+                if description.support_fn(coordinator.properties_api)
+            )
+        elif isinstance(coordinator, RoborockWashingMachineUpdateCoordinator):
+            entities.extend(
+                RoborockBinarySensorEntityA01(coordinator, description)
+                for description in ZEO_BINARY_SENSOR_DESCRIPTIONS
+                if description.data_protocol in coordinator.request_protocols
+            )
+        async_add_entities(entities)
+
+    for coordinator in coordinators.values():
+        async_add_coordinator_entities(coordinator)
+
+    config_entry.async_on_unload(
+        async_dispatcher_connect(
+            hass,
+            f"roborock_coordinator_added_{config_entry.entry_id}",
+            async_add_coordinator_entities,
         )
-        for coordinator in config_entry.runtime_data.v1
-        for description in BINARY_SENSOR_DESCRIPTIONS
-        if description.support_fn(coordinator.properties_api)
-    ]
-    entities.extend(
-        RoborockBinarySensorEntityA01(
-            coordinator,
-            description,
-        )
-        for coordinator in config_entry.runtime_data.a01
-        if isinstance(coordinator, RoborockWashingMachineUpdateCoordinator)
-        for description in ZEO_BINARY_SENSOR_DESCRIPTIONS
-        if description.data_protocol in coordinator.request_protocols
     )
-    async_add_entities(entities)
 
 
 class RoborockBinarySensorEntity(RoborockCoordinatedEntityV1, BinarySensorEntity):

--- a/homeassistant/components/roborock/button.py
+++ b/homeassistant/components/roborock/button.py
@@ -1,9 +1,7 @@
 """Support for Roborock button."""
 
-import asyncio
 from collections.abc import Callable
 from dataclasses import dataclass
-import itertools
 import logging
 from typing import Any
 
@@ -13,14 +11,16 @@ from roborock.roborock_message import RoborockZeoProtocol
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN
 from .coordinator import (
     RoborockB01Q10UpdateCoordinator,
     RoborockConfigEntry,
+    RoborockCoordinatorType,
     RoborockDataUpdateCoordinator,
     RoborockDataUpdateCoordinatorA01,
     RoborockWashingMachineUpdateCoordinator,
@@ -140,51 +140,68 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Roborock button platform."""
-    routines_lists = await asyncio.gather(
-        *[coordinator.get_routines() for coordinator in config_entry.runtime_data.v1],
-    )
-    async_add_entities(
-        itertools.chain(
-            (
-                RoborockButtonEntity(
-                    coordinator,
-                    description,
-                )
-                for coordinator in config_entry.runtime_data.v1
-                if isinstance(coordinator, RoborockDataUpdateCoordinator)
+    coordinators = config_entry.runtime_data
+
+    @callback
+    def async_add_coordinator_entities(
+        coordinator: RoborockCoordinatorType,
+    ) -> None:
+        """Add entities for a specific coordinator."""
+        entities: list[ButtonEntity] = []
+        if isinstance(coordinator, RoborockDataUpdateCoordinator):
+            entities.extend(
+                RoborockButtonEntity(coordinator, description)
                 for description in CONSUMABLE_BUTTON_DESCRIPTIONS
                 if description.is_supported(coordinator)
-            ),
-            (
-                RoborockRoutineButtonEntity(
-                    coordinator,
-                    ButtonEntityDescription(
-                        key=str(routine.id),
-                        name=routine.name,
-                    ),
-                )
-                for coordinator, routines in zip(
-                    config_entry.runtime_data.v1, routines_lists, strict=True
-                )
-                for routine in routines
-            ),
-            (
-                RoborockButtonEntityA01(
-                    coordinator,
-                    description,
-                )
-                for coordinator in config_entry.runtime_data.a01
-                if isinstance(coordinator, RoborockWashingMachineUpdateCoordinator)
+            )
+
+            async def async_add_routine_buttons() -> None:
+                try:
+                    routines = await coordinator.get_routines()
+                except HomeAssistantError as err:
+                    _LOGGER.error(
+                        "Failed to get routines for %s: %s",
+                        coordinator.device.name,
+                        err,
+                    )
+                    return
+                routine_entities = [
+                    RoborockRoutineButtonEntity(
+                        coordinator,
+                        ButtonEntityDescription(
+                            key=str(routine.id),
+                            name=routine.name,
+                        ),
+                    )
+                    for routine in routines
+                ]
+                async_add_entities(routine_entities)
+
+            config_entry.async_create_background_task(
+                hass,
+                async_add_routine_buttons(),
+                f"roborock_setup_routines_{coordinator.duid}",
+            )
+        elif isinstance(coordinator, RoborockWashingMachineUpdateCoordinator):
+            entities.extend(
+                RoborockButtonEntityA01(coordinator, description)
                 for description in ZEO_BUTTON_DESCRIPTIONS
-            ),
-            (
-                RoborockQ10EmptyDustbinButtonEntity(
-                    coordinator,
-                    description,
-                )
-                for coordinator in config_entry.runtime_data.b01_q10
+            )
+        elif isinstance(coordinator, RoborockB01Q10UpdateCoordinator):
+            entities.extend(
+                RoborockQ10EmptyDustbinButtonEntity(coordinator, description)
                 for description in Q10_BUTTON_DESCRIPTIONS
-            ),
+            )
+        async_add_entities(entities)
+
+    for coordinator in coordinators.values():
+        async_add_coordinator_entities(coordinator)
+
+    config_entry.async_on_unload(
+        async_dispatcher_connect(
+            hass,
+            f"roborock_coordinator_added_{config_entry.entry_id}",
+            async_add_coordinator_entities,
         )
     )
 

--- a/homeassistant/components/roborock/coordinator.py
+++ b/homeassistant/components/roborock/coordinator.py
@@ -1,7 +1,6 @@
 """Roborock Coordinator."""
 
 from collections.abc import Callable
-from dataclasses import dataclass
 from datetime import datetime, timedelta
 import logging
 from typing import Any
@@ -58,14 +57,46 @@ MIN_UNAVAILABLE_DURATION = timedelta(minutes=2)
 _LOGGER = logging.getLogger(__name__)
 
 
-@dataclass
 class RoborockCoordinators:
     """Roborock coordinators type."""
 
-    v1: list[RoborockDataUpdateCoordinator]
-    a01: list[RoborockDataUpdateCoordinatorA01]
-    b01_q7: list[RoborockB01Q7UpdateCoordinator]
-    b01_q10: list[RoborockB01Q10UpdateCoordinator]
+    def __init__(
+        self,
+        v1: list[RoborockDataUpdateCoordinator] | None = None,
+        a01: list[RoborockDataUpdateCoordinatorA01] | None = None,
+        b01_q7: list[RoborockB01Q7UpdateCoordinator] | None = None,
+        b01_q10: list[RoborockB01Q10UpdateCoordinator] | None = None,
+        device_manager: Any = None,
+    ) -> None:
+        """Initialize."""
+        self._coordinators: dict[str, Any] = {}
+        self.device_manager = device_manager
+        for coord_v1 in v1 or []:
+            self.add(coord_v1)
+        for coord_a01 in a01 or []:
+            self.add(coord_a01)
+        for coord_b01_q7 in b01_q7 or []:
+            self.add(coord_b01_q7)
+        for coord_b01_q10 in b01_q10 or []:
+            self.add(coord_b01_q10)
+
+    def add(
+        self,
+        coordinator: RoborockDataUpdateCoordinator
+        | RoborockDataUpdateCoordinatorA01
+        | RoborockB01Q7UpdateCoordinator
+        | RoborockB01Q10UpdateCoordinator,
+    ) -> None:
+        """Add a coordinator."""
+        self._coordinators[coordinator.duid] = coordinator
+
+    def __contains__(self, duid: str) -> bool:
+        """Check if a coordinator exists by DUID."""
+        return duid in self._coordinators
+
+    def keys(self) -> list[str]:
+        """Return DUIDs of all registered coordinators."""
+        return list(self._coordinators.keys())
 
     def values(
         self,
@@ -77,6 +108,42 @@ class RoborockCoordinators:
     ]:
         """Return all coordinators."""
         return self.v1 + self.a01 + self.b01_q7 + self.b01_q10
+
+    @property
+    def v1(self) -> list[RoborockDataUpdateCoordinator]:
+        """Return V1 coordinators."""
+        return [
+            coord
+            for coord in self._coordinators.values()
+            if isinstance(coord, RoborockDataUpdateCoordinator)
+        ]
+
+    @property
+    def a01(self) -> list[RoborockDataUpdateCoordinatorA01]:
+        """Return A01 coordinators."""
+        return [
+            coord
+            for coord in self._coordinators.values()
+            if isinstance(coord, RoborockDataUpdateCoordinatorA01)
+        ]
+
+    @property
+    def b01_q7(self) -> list[RoborockB01Q7UpdateCoordinator]:
+        """Return Q7 coordinators."""
+        return [
+            coord
+            for coord in self._coordinators.values()
+            if isinstance(coord, RoborockB01Q7UpdateCoordinator)
+        ]
+
+    @property
+    def b01_q10(self) -> list[RoborockB01Q10UpdateCoordinator]:
+        """Return Q10 coordinators."""
+        return [
+            coord
+            for coord in self._coordinators.values()
+            if isinstance(coord, RoborockB01Q10UpdateCoordinator)
+        ]
 
 
 type RoborockConfigEntry = ConfigEntry[RoborockCoordinators]
@@ -112,13 +179,14 @@ class RoborockDataUpdateCoordinator(DataUpdateCoordinator[DeviceState | None]):
             }
         self.last_update_state: str | None = None
         # Keep track of last attempt to refresh maps/rooms to know when to try again.
-        self._last_home_update_attempt: datetime
+        self._last_home_update_attempt = dt_util.utcnow()
         self.last_home_update: datetime | None = None
         # Tracks the last successful update to control when we report failure
         # to the base class. This is reset on successful data update.
         self._last_update_success_time: datetime | None = None
         self._has_connected_locally: bool = False
         self._unsubs: list[Callable[[], None]] = []
+        self._setup_completed = False
 
     @cached_property
     def dock_device_info(self) -> DeviceInfo:
@@ -143,7 +211,6 @@ class RoborockDataUpdateCoordinator(DataUpdateCoordinator[DeviceState | None]):
         try:
             await self.properties_api.status.refresh()
         except RoborockException as err:
-            _LOGGER.debug("Failed to update data during setup: %s", err)
             raise UpdateFailed(
                 translation_domain=DOMAIN,
                 translation_key="update_data_fail",
@@ -239,7 +306,11 @@ class RoborockDataUpdateCoordinator(DataUpdateCoordinator[DeviceState | None]):
 
     async def _async_update_data(self) -> DeviceState | None:
         """Update data via library."""
-        await self._verify_api()
+        if not self._setup_completed:
+            await self._async_setup()
+            self._setup_completed = True
+        else:
+            await self._verify_api()
         try:
             # Update device props and standard api information
             await self._update_device_prop()
@@ -663,3 +734,11 @@ class RoborockB01Q10UpdateCoordinator(DataUpdateCoordinator[None]):
     def device(self) -> RoborockDevice:
         """Get the RoborockDevice."""
         return self._device
+
+
+type RoborockCoordinatorType = (
+    RoborockDataUpdateCoordinator
+    | RoborockDataUpdateCoordinatorA01[Any]
+    | RoborockB01Q7UpdateCoordinator
+    | RoborockB01Q10UpdateCoordinator
+)

--- a/homeassistant/components/roborock/coordinator.py
+++ b/homeassistant/components/roborock/coordinator.py
@@ -62,23 +62,15 @@ class RoborockCoordinators:
 
     def __init__(
         self,
-        v1: list[RoborockDataUpdateCoordinator] | None = None,
-        a01: list[RoborockDataUpdateCoordinatorA01] | None = None,
-        b01_q7: list[RoborockB01Q7UpdateCoordinator] | None = None,
-        b01_q10: list[RoborockB01Q10UpdateCoordinator] | None = None,
-        device_manager: Any = None,
     ) -> None:
         """Initialize."""
-        self._coordinators: dict[str, Any] = {}
-        self.device_manager = device_manager
-        for coord_v1 in v1 or []:
-            self.add(coord_v1)
-        for coord_a01 in a01 or []:
-            self.add(coord_a01)
-        for coord_b01_q7 in b01_q7 or []:
-            self.add(coord_b01_q7)
-        for coord_b01_q10 in b01_q10 or []:
-            self.add(coord_b01_q10)
+        self._coordinators: dict[
+            str,
+            RoborockDataUpdateCoordinator
+            | RoborockDataUpdateCoordinatorA01
+            | RoborockB01Q7UpdateCoordinator
+            | RoborockB01Q10UpdateCoordinator,
+        ] = {}
 
     def add(
         self,

--- a/homeassistant/components/roborock/image.py
+++ b/homeassistant/components/roborock/image.py
@@ -11,9 +11,14 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .coordinator import RoborockConfigEntry, RoborockDataUpdateCoordinator
+from .coordinator import (
+    RoborockConfigEntry,
+    RoborockCoordinatorType,
+    RoborockDataUpdateCoordinator,
+)
 from .entity import RoborockCoordinatedEntityV1
 
 _LOGGER = logging.getLogger(__name__)
@@ -27,20 +32,38 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Roborock image platform."""
+    coordinators = config_entry.runtime_data
 
-    async_add_entities(
-        (
+    @callback
+    def async_add_coordinator_entities(
+        coordinator: RoborockCoordinatorType,
+    ) -> None:
+        """Add entities for a specific coordinator."""
+        if not isinstance(coordinator, RoborockDataUpdateCoordinator):
+            return
+        entities = [
             RoborockMap(
                 config_entry,
-                coord,
-                coord.properties_api.home,
+                coordinator,
+                coordinator.properties_api.home,
                 map_info.map_flag,
                 map_info.name,
             )
-            for coord in config_entry.runtime_data.v1
-            if coord.properties_api.home is not None
-            for map_info in (coord.properties_api.home.home_map_info or {}).values()
-        ),
+            for map_info in (
+                coordinator.properties_api.home.home_map_info or {}
+            ).values()
+        ]
+        async_add_entities(entities)
+
+    for coordinator in coordinators.values():
+        async_add_coordinator_entities(coordinator)
+
+    config_entry.async_on_unload(
+        async_dispatcher_connect(
+            hass,
+            f"roborock_coordinator_added_{config_entry.entry_id}",
+            async_add_coordinator_entities,
+        )
     )
 
 

--- a/homeassistant/components/roborock/number.py
+++ b/homeassistant/components/roborock/number.py
@@ -10,12 +10,17 @@ from roborock.exceptions import RoborockException
 
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
 from homeassistant.const import PERCENTAGE, EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN
-from .coordinator import RoborockConfigEntry, RoborockDataUpdateCoordinator
+from .coordinator import (
+    RoborockConfigEntry,
+    RoborockCoordinatorType,
+    RoborockDataUpdateCoordinator,
+)
 from .entity import RoborockEntityV1
 
 _LOGGER = logging.getLogger(__name__)
@@ -58,18 +63,36 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Roborock number platform."""
-    async_add_entities(
-        [
+    coordinators = config_entry.runtime_data
+
+    @callback
+    def async_add_coordinator_entities(
+        coordinator: RoborockCoordinatorType,
+    ) -> None:
+        """Add entities for a specific coordinator."""
+        if not isinstance(coordinator, RoborockDataUpdateCoordinator):
+            return
+        entities = [
             RoborockNumberEntity(
                 f"{description.key}_{coordinator.duid_slug}",
                 coordinator=coordinator,
                 entity_description=description,
                 trait=trait,
             )
-            for coordinator in config_entry.runtime_data.v1
             for description in NUMBER_DESCRIPTIONS
             if (trait := description.trait(coordinator.properties_api)) is not None
         ]
+        async_add_entities(entities)
+
+    for coordinator in coordinators.values():
+        async_add_coordinator_entities(coordinator)
+
+    config_entry.async_on_unload(
+        async_dispatcher_connect(
+            hass,
+            f"roborock_coordinator_added_{config_entry.entry_id}",
+            async_add_coordinator_entities,
+        )
     )
 
 

--- a/homeassistant/components/roborock/select.py
+++ b/homeassistant/components/roborock/select.py
@@ -32,8 +32,9 @@ from roborock.roborock_typing import RoborockCommand
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN, MAP_SLEEP
@@ -41,8 +42,10 @@ from .coordinator import (
     RoborockB01Q7UpdateCoordinator,
     RoborockB01Q10UpdateCoordinator,
     RoborockConfigEntry,
+    RoborockCoordinatorType,
     RoborockDataUpdateCoordinator,
     RoborockDataUpdateCoordinatorA01,
+    RoborockWashingMachineUpdateCoordinator,
 )
 from .entity import (
     RoborockCoordinatedEntityA01,
@@ -250,39 +253,58 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Roborock select platform."""
+    coordinators = config_entry.runtime_data
 
-    async_add_entities(
-        RoborockSelectEntity(coordinator, description, options)
-        for coordinator in config_entry.runtime_data.v1
-        for description in SELECT_DESCRIPTIONS
-        if (
-            (options := description.options_lambda(coordinator.properties_api))
-            is not None
+    @callback
+    def async_add_coordinator_entities(
+        coordinator: RoborockCoordinatorType,
+    ) -> None:
+        """Add entities for a specific coordinator."""
+        entities: list[SelectEntity] = []
+        if isinstance(coordinator, RoborockDataUpdateCoordinator):
+            entities.extend(
+                RoborockSelectEntity(coordinator, description, options)
+                for description in SELECT_DESCRIPTIONS
+                if (options := description.options_lambda(coordinator.properties_api))
+                is not None
+            )
+            if (
+                coordinator.properties_api.home is not None
+                and coordinator.properties_api.maps is not None
+            ):
+                entities.append(
+                    RoborockCurrentMapSelectEntity(
+                        f"selected_map_{coordinator.duid_slug}",
+                        coordinator,
+                        coordinator.properties_api.home,
+                        coordinator.properties_api.maps,
+                    )
+                )
+        elif isinstance(coordinator, RoborockB01Q7UpdateCoordinator):
+            entities.extend(
+                RoborockB01SelectEntity(coordinator, description, options)
+                for description in B01_SELECT_DESCRIPTIONS
+                if (options := description.options_lambda(coordinator.api)) is not None
+            )
+        elif isinstance(coordinator, RoborockWashingMachineUpdateCoordinator):
+            entities.extend(
+                RoborockSelectEntityA01(coordinator, description)
+                for description in A01_SELECT_DESCRIPTIONS
+                if description.data_protocol in coordinator.request_protocols
+            )
+        elif isinstance(coordinator, RoborockB01Q10UpdateCoordinator):
+            entities.append(RoborockQ10CleanModeSelectEntity(coordinator))
+        async_add_entities(entities)
+
+    for coordinator in coordinators.values():
+        async_add_coordinator_entities(coordinator)
+
+    config_entry.async_on_unload(
+        async_dispatcher_connect(
+            hass,
+            f"roborock_coordinator_added_{config_entry.entry_id}",
+            async_add_coordinator_entities,
         )
-    )
-    async_add_entities(
-        RoborockCurrentMapSelectEntity(
-            f"selected_map_{coordinator.duid_slug}", coordinator, home_trait, map_trait
-        )
-        for coordinator in config_entry.runtime_data.v1
-        if (home_trait := coordinator.properties_api.home) is not None
-        if (map_trait := coordinator.properties_api.maps) is not None
-    )
-    async_add_entities(
-        RoborockB01SelectEntity(coordinator, description, options)
-        for coordinator in config_entry.runtime_data.b01_q7
-        for description in B01_SELECT_DESCRIPTIONS
-        if (options := description.options_lambda(coordinator.api)) is not None
-    )
-    async_add_entities(
-        RoborockSelectEntityA01(coordinator, description)
-        for coordinator in config_entry.runtime_data.a01
-        for description in A01_SELECT_DESCRIPTIONS
-        if description.data_protocol in coordinator.request_protocols
-    )
-    async_add_entities(
-        RoborockQ10CleanModeSelectEntity(coordinator)
-        for coordinator in config_entry.runtime_data.b01_q10
     )
 
 

--- a/homeassistant/components/roborock/sensor.py
+++ b/homeassistant/components/roborock/sensor.py
@@ -29,7 +29,8 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import PERCENTAGE, EntityCategory, UnitOfArea, UnitOfTime
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
@@ -37,6 +38,7 @@ from .coordinator import (
     RoborockB01Q7UpdateCoordinator,
     RoborockB01Q10UpdateCoordinator,
     RoborockConfigEntry,
+    RoborockCoordinatorType,
     RoborockDataUpdateCoordinator,
     RoborockDataUpdateCoordinatorA01,
     RoborockWashingMachineUpdateCoordinator,
@@ -538,48 +540,54 @@ async def async_setup_entry(
     """Set up the Roborock vacuum sensors."""
     coordinators = config_entry.runtime_data
 
-    entities: list[RoborockEntity] = [
-        RoborockSensorEntity(
-            coordinator,
-            description,
+    @callback
+    def async_add_coordinator_entities(
+        coordinator: RoborockCoordinatorType,
+    ) -> None:
+        """Add entities for a specific coordinator."""
+        entities: list[RoborockEntity] = []
+        if isinstance(coordinator, RoborockDataUpdateCoordinator):
+            entities.extend(
+                RoborockSensorEntity(coordinator, description)
+                for description in SENSOR_DESCRIPTIONS
+                if description.support_fn(coordinator.properties_api)
+            )
+            entities.append(RoborockCurrentRoom(coordinator))
+        elif isinstance(coordinator, RoborockWetDryVacUpdateCoordinator):
+            entities.extend(
+                RoborockSensorEntityA01(coordinator, description)
+                for description in DYAD_SENSOR_DESCRIPTIONS
+                if description.data_protocol in coordinator.request_protocols
+            )
+        elif isinstance(coordinator, RoborockWashingMachineUpdateCoordinator):
+            entities.extend(
+                RoborockSensorEntityA01(coordinator, description)
+                for description in ZEO_SENSOR_DESCRIPTIONS
+                if description.data_protocol in coordinator.request_protocols
+            )
+        elif isinstance(coordinator, RoborockB01Q7UpdateCoordinator):
+            entities.extend(
+                RoborockSensorEntityB01Q7(coordinator, description)
+                for description in Q7_B01_SENSOR_DESCRIPTIONS
+                if description.value_fn(coordinator.data) is not None
+            )
+        elif isinstance(coordinator, RoborockB01Q10UpdateCoordinator):
+            entities.extend(
+                RoborockSensorEntityB01Q10(coordinator, description)
+                for description in Q10_B01_SENSOR_DESCRIPTIONS
+            )
+        async_add_entities(entities)
+
+    for coordinator in coordinators.values():
+        async_add_coordinator_entities(coordinator)
+
+    config_entry.async_on_unload(
+        async_dispatcher_connect(
+            hass,
+            f"roborock_coordinator_added_{config_entry.entry_id}",
+            async_add_coordinator_entities,
         )
-        for coordinator in coordinators.v1
-        for description in SENSOR_DESCRIPTIONS
-        if description.support_fn(coordinator.properties_api)
-    ]
-    entities.extend(RoborockCurrentRoom(coordinator) for coordinator in coordinators.v1)
-    entities.extend(
-        RoborockSensorEntityA01(
-            coordinator,
-            description,
-        )
-        for coordinator in coordinators.a01
-        if isinstance(coordinator, RoborockWetDryVacUpdateCoordinator)
-        for description in DYAD_SENSOR_DESCRIPTIONS
-        if description.data_protocol in coordinator.request_protocols
     )
-    entities.extend(
-        RoborockSensorEntityA01(
-            coordinator,
-            description,
-        )
-        for coordinator in coordinators.a01
-        if isinstance(coordinator, RoborockWashingMachineUpdateCoordinator)
-        for description in ZEO_SENSOR_DESCRIPTIONS
-        if description.data_protocol in coordinator.request_protocols
-    )
-    entities.extend(
-        RoborockSensorEntityB01Q7(coordinator, description)
-        for coordinator in coordinators.b01_q7
-        for description in Q7_B01_SENSOR_DESCRIPTIONS
-        if description.value_fn(coordinator.data) is not None
-    )
-    entities.extend(
-        RoborockSensorEntityB01Q10(coordinator, description)
-        for coordinator in coordinators.b01_q10
-        for description in Q10_B01_SENSOR_DESCRIPTIONS
-    )
-    async_add_entities(entities)
 
 
 class RoborockSensorEntity(RoborockCoordinatedEntityV1, SensorEntity):

--- a/homeassistant/components/roborock/switch.py
+++ b/homeassistant/components/roborock/switch.py
@@ -12,13 +12,15 @@ from roborock.roborock_message import RoborockDyadDataProtocol, RoborockZeoProto
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN
 from .coordinator import (
     RoborockConfigEntry,
+    RoborockCoordinatorType,
     RoborockDataUpdateCoordinator,
     RoborockDataUpdateCoordinatorA01,
 )
@@ -93,30 +95,45 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Roborock switch platform."""
-    # V1 switches - using trait pattern from HEAD
-    async_add_entities(
-        [
-            RoborockSwitch(
-                f"{description.key}_{coordinator.duid_slug}",
-                coordinator,
-                description,
-                trait,
-            )
-            for coordinator in config_entry.runtime_data.v1
-            for description in SWITCH_DESCRIPTIONS
-            if (trait := description.trait(coordinator.properties_api)) is not None
-        ]
-    )
+    coordinators = config_entry.runtime_data
 
-    # A01 switches
-    async_add_entities(
-        RoborockSwitchA01(
-            coordinator,
-            description,
+    @callback
+    def async_add_coordinator_entities(
+        coordinator: RoborockCoordinatorType,
+    ) -> None:
+        """Add entities for a specific coordinator."""
+        entities: list[SwitchEntity] = []
+        if isinstance(coordinator, RoborockDataUpdateCoordinator):
+            entities.extend(
+                RoborockSwitch(
+                    f"{description.key}_{coordinator.duid_slug}",
+                    coordinator,
+                    description,
+                    trait,
+                )
+                for description in SWITCH_DESCRIPTIONS
+                if (trait := description.trait(coordinator.properties_api)) is not None
+            )
+        elif isinstance(coordinator, RoborockDataUpdateCoordinatorA01):
+            entities.extend(
+                RoborockSwitchA01(
+                    coordinator,
+                    description,
+                )
+                for description in A01_SWITCH_DESCRIPTIONS
+                if description.data_protocol in coordinator.request_protocols
+            )
+        async_add_entities(entities)
+
+    for coordinator in coordinators.values():
+        async_add_coordinator_entities(coordinator)
+
+    config_entry.async_on_unload(
+        async_dispatcher_connect(
+            hass,
+            f"roborock_coordinator_added_{config_entry.entry_id}",
+            async_add_coordinator_entities,
         )
-        for coordinator in config_entry.runtime_data.a01
-        for description in A01_SWITCH_DESCRIPTIONS
-        if description.data_protocol in coordinator.request_protocols
     )
 
 

--- a/homeassistant/components/roborock/time.py
+++ b/homeassistant/components/roborock/time.py
@@ -12,12 +12,17 @@ from roborock.exceptions import RoborockException
 
 from homeassistant.components.time import TimeEntity, TimeEntityDescription
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN
-from .coordinator import RoborockConfigEntry, RoborockDataUpdateCoordinator
+from .coordinator import (
+    RoborockConfigEntry,
+    RoborockCoordinatorType,
+    RoborockDataUpdateCoordinator,
+)
 from .entity import RoborockEntityV1
 
 _LOGGER = logging.getLogger(__name__)
@@ -123,18 +128,36 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Roborock time platform."""
-    async_add_entities(
-        [
+    coordinators = config_entry.runtime_data
+
+    @callback
+    def async_add_coordinator_entities(
+        coordinator: RoborockCoordinatorType,
+    ) -> None:
+        """Add entities for a specific coordinator."""
+        if not isinstance(coordinator, RoborockDataUpdateCoordinator):
+            return
+        entities = [
             RoborockTimeEntity(
                 f"{description.key}_{coordinator.duid_slug}",
                 coordinator,
                 description,
                 trait,
             )
-            for coordinator in config_entry.runtime_data.v1
             for description in TIME_DESCRIPTIONS
             if (trait := description.trait(coordinator.properties_api)) is not None
         ]
+        async_add_entities(entities)
+
+    for coordinator in coordinators.values():
+        async_add_coordinator_entities(coordinator)
+
+    config_entry.async_on_unload(
+        async_dispatcher_connect(
+            hass,
+            f"roborock_coordinator_added_{config_entry.entry_id}",
+            async_add_coordinator_entities,
+        )
     )
 
 

--- a/homeassistant/components/roborock/vacuum.py
+++ b/homeassistant/components/roborock/vacuum.py
@@ -24,6 +24,7 @@ from homeassistant.exceptions import (
     ServiceNotSupported,
     ServiceValidationError,
 )
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN
@@ -31,6 +32,7 @@ from .coordinator import (
     RoborockB01Q7UpdateCoordinator,
     RoborockB01Q10UpdateCoordinator,
     RoborockConfigEntry,
+    RoborockCoordinatorType,
     RoborockDataUpdateCoordinator,
 )
 from .entity import (
@@ -112,16 +114,29 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Roborock sensor."""
-    async_add_entities(
-        RoborockVacuum(coordinator) for coordinator in config_entry.runtime_data.v1
-    )
-    async_add_entities(
-        RoborockQ7Vacuum(coordinator)
-        for coordinator in config_entry.runtime_data.b01_q7
-    )
-    async_add_entities(
-        RoborockQ10Vacuum(coordinator)
-        for coordinator in config_entry.runtime_data.b01_q10
+    coordinators = config_entry.runtime_data
+
+    @callback
+    def async_add_coordinator_entities(
+        coordinator: RoborockCoordinatorType,
+    ) -> None:
+        """Add entities for a specific coordinator."""
+        if isinstance(coordinator, RoborockDataUpdateCoordinator):
+            async_add_entities([RoborockVacuum(coordinator)])
+        elif isinstance(coordinator, RoborockB01Q7UpdateCoordinator):
+            async_add_entities([RoborockQ7Vacuum(coordinator)])
+        elif isinstance(coordinator, RoborockB01Q10UpdateCoordinator):
+            async_add_entities([RoborockQ10Vacuum(coordinator)])
+
+    for coordinator in coordinators.values():
+        async_add_coordinator_entities(coordinator)
+
+    config_entry.async_on_unload(
+        async_dispatcher_connect(
+            hass,
+            f"roborock_coordinator_added_{config_entry.entry_id}",
+            async_add_coordinator_entities,
+        )
     )
 
 

--- a/tests/components/roborock/conftest.py
+++ b/tests/components/roborock/conftest.py
@@ -1,7 +1,7 @@
 """Global fixtures for Roborock integration."""
 
 import asyncio
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from copy import deepcopy
 import logging
 import pathlib
@@ -521,15 +521,42 @@ def device_manager_fixture(
     return device_manager
 
 
+class MockDeviceManagerContext:
+    """Context for mock device manager."""
+
+    ready_callback: Callable[[RoborockDevice], None] | None = None
+    initial_devices: list[RoborockDevice] | None = None
+
+
+@pytest.fixture(name="device_manager_context")
+def device_manager_context_fixture(
+    fake_devices: list[FakeDevice],
+) -> MockDeviceManagerContext:
+    """Fixture to provide device manager context."""
+    context = MockDeviceManagerContext()
+    context.initial_devices = fake_devices
+    return context
+
+
 @pytest.fixture(name="fake_create_device_manager", autouse=True)
 def fake_create_device_manager_fixture(
     device_manager: AsyncMock,
-) -> None:
+    device_manager_context: MockDeviceManagerContext,
+) -> Generator[None]:
     """Fixture to create a fake device manager."""
+
+    async def _fake_create_device_manager(*args: Any, **kwargs: Any) -> AsyncMock:
+        ready_callback = kwargs.get("ready_callback")
+        assert ready_callback
+        device_manager_context.ready_callback = ready_callback
+        for device in device_manager_context.initial_devices:
+            ready_callback(device)
+        return device_manager
+
     with patch(
         "homeassistant.components.roborock.create_device_manager",
-    ) as mock_create_device_manager:
-        mock_create_device_manager.return_value = device_manager
+        side_effect=_fake_create_device_manager,
+    ):
         yield
 
 

--- a/tests/components/roborock/test_init.py
+++ b/tests/components/roborock/test_init.py
@@ -1,5 +1,6 @@
 """Test for Roborock init."""
 
+import asyncio
 import datetime
 import pathlib
 from typing import Any
@@ -32,7 +33,7 @@ from homeassistant.helpers.device_registry import DeviceRegistry
 from homeassistant.helpers.entity_registry import EntityRegistry
 from homeassistant.setup import async_setup_component
 
-from .conftest import FakeDevice
+from .conftest import FakeDevice, MockDeviceManagerContext
 from .mock_data import ROBOROCK_RRUID, USER_EMAIL
 
 from tests.common import MockConfigEntry, async_fire_time_changed
@@ -48,7 +49,6 @@ async def test_unload_entry(
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
     assert setup_entry.state is ConfigEntryState.LOADED
 
-    assert device_manager.get_devices.called
     assert not device_manager.close.called
 
     # Unload the config entry and verify that the device manager is closed
@@ -57,6 +57,100 @@ async def test_unload_entry(
     assert setup_entry.state is ConfigEntryState.NOT_LOADED
 
     assert device_manager.close.called
+
+
+@pytest.mark.parametrize("platforms", [[Platform.SENSOR]])
+async def test_stale_device(
+    hass: HomeAssistant,
+    mock_roborock_entry: MockConfigEntry,
+    device_registry: DeviceRegistry,
+    device_manager: AsyncMock,
+    device_manager_context: MockDeviceManagerContext,
+    fake_devices: list[FakeDevice],
+) -> None:
+    """Test that we remove a device if it no longer is given by home_data."""
+    await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
+    await hass.async_block_till_done()
+    if mock_roborock_entry._background_tasks:
+        await asyncio.gather(*mock_roborock_entry._background_tasks)
+    existing_devices = device_registry.devices.get_devices_for_config_entry_id(
+        mock_roborock_entry.entry_id
+    )
+    assert {device.name for device in existing_devices} == {
+        "Roborock S7 MaxV",
+        "Roborock S7 MaxV Dock",
+        "Roborock S7 2",
+        "Roborock S7 2 Dock",
+        "Dyad Pro",
+        "Zeo One",
+        "Roborock Q7",
+        "Roborock Q10 S5+",
+    }
+    fake_devices_copy = fake_devices.copy()
+    fake_devices_copy.pop(0)  # Remove one robot
+    device_manager.get_devices = AsyncMock(return_value=fake_devices_copy)
+    device_manager_context.initial_devices = fake_devices_copy
+
+    await hass.config_entries.async_reload(mock_roborock_entry.entry_id)
+    await hass.async_block_till_done()
+    if mock_roborock_entry._background_tasks:
+        await asyncio.gather(*mock_roborock_entry._background_tasks)
+    new_devices = device_registry.devices.get_devices_for_config_entry_id(
+        mock_roborock_entry.entry_id
+    )
+    assert {device.name for device in new_devices} == {
+        "Roborock S7 2",
+        "Roborock S7 2 Dock",
+        "Dyad Pro",
+        "Zeo One",
+        "Roborock Q7",
+        "Roborock Q10 S5+",
+    }
+
+
+@pytest.mark.parametrize("platforms", [[Platform.SENSOR]])
+async def test_no_stale_device(
+    hass: HomeAssistant,
+    mock_roborock_entry: MockConfigEntry,
+    device_registry: DeviceRegistry,
+    fake_devices: list[FakeDevice],
+) -> None:
+    """Test that we don't remove a device if fails to setup."""
+    await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
+    await hass.async_block_till_done()
+    if mock_roborock_entry._background_tasks:
+        await asyncio.gather(*mock_roborock_entry._background_tasks)
+    existing_devices = device_registry.devices.get_devices_for_config_entry_id(
+        mock_roborock_entry.entry_id
+    )
+    assert {device.name for device in existing_devices} == {
+        "Roborock S7 MaxV",
+        "Roborock S7 MaxV Dock",
+        "Roborock S7 2",
+        "Roborock S7 2 Dock",
+        "Dyad Pro",
+        "Zeo One",
+        "Roborock Q7",
+        "Roborock Q10 S5+",
+    }
+
+    await hass.config_entries.async_reload(mock_roborock_entry.entry_id)
+    await hass.async_block_till_done()
+    if mock_roborock_entry._background_tasks:
+        await asyncio.gather(*mock_roborock_entry._background_tasks)
+    new_devices = device_registry.devices.get_devices_for_config_entry_id(
+        mock_roborock_entry.entry_id
+    )
+    assert {device.name for device in new_devices} == {
+        "Roborock S7 MaxV",
+        "Roborock S7 MaxV Dock",
+        "Roborock S7 2",
+        "Roborock S7 2 Dock",
+        "Dyad Pro",
+        "Zeo One",
+        "Roborock Q7",
+        "Roborock Q10 S5+",
+    }
 
 
 async def test_home_assistant_stop(
@@ -257,86 +351,6 @@ async def test_no_user_agreement(
 
 
 @pytest.mark.parametrize("platforms", [[Platform.SENSOR]])
-async def test_stale_device(
-    hass: HomeAssistant,
-    mock_roborock_entry: MockConfigEntry,
-    device_registry: DeviceRegistry,
-    fake_devices: list[FakeDevice],
-) -> None:
-    """Test that we remove a device if it no longer is given by home_data."""
-    await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
-    assert mock_roborock_entry.state is ConfigEntryState.LOADED
-    existing_devices = device_registry.devices.get_devices_for_config_entry_id(
-        mock_roborock_entry.entry_id
-    )
-    assert {device.name for device in existing_devices} == {
-        "Roborock S7 MaxV",
-        "Roborock S7 MaxV Dock",
-        "Roborock S7 2",
-        "Roborock S7 2 Dock",
-        "Dyad Pro",
-        "Zeo One",
-        "Roborock Q7",
-        "Roborock Q10 S5+",
-    }
-    fake_devices.pop(0)  # Remove one robot
-
-    await hass.config_entries.async_reload(mock_roborock_entry.entry_id)
-    await hass.async_block_till_done()
-    new_devices = device_registry.devices.get_devices_for_config_entry_id(
-        mock_roborock_entry.entry_id
-    )
-    assert {device.name for device in new_devices} == {
-        "Roborock S7 2",
-        "Roborock S7 2 Dock",
-        "Dyad Pro",
-        "Zeo One",
-        "Roborock Q7",
-        "Roborock Q10 S5+",
-    }
-
-
-@pytest.mark.parametrize("platforms", [[Platform.SENSOR]])
-async def test_no_stale_device(
-    hass: HomeAssistant,
-    mock_roborock_entry: MockConfigEntry,
-    device_registry: DeviceRegistry,
-    fake_devices: list[FakeDevice],
-) -> None:
-    """Test that we don't remove a device if fails to setup."""
-    await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
-    assert mock_roborock_entry.state is ConfigEntryState.LOADED
-    existing_devices = device_registry.devices.get_devices_for_config_entry_id(
-        mock_roborock_entry.entry_id
-    )
-    assert {device.name for device in existing_devices} == {
-        "Roborock S7 MaxV",
-        "Roborock S7 MaxV Dock",
-        "Roborock S7 2",
-        "Roborock S7 2 Dock",
-        "Dyad Pro",
-        "Zeo One",
-        "Roborock Q7",
-        "Roborock Q10 S5+",
-    }
-
-    await hass.config_entries.async_reload(mock_roborock_entry.entry_id)
-    await hass.async_block_till_done()
-    new_devices = device_registry.devices.get_devices_for_config_entry_id(
-        mock_roborock_entry.entry_id
-    )
-    assert {device.name for device in new_devices} == {
-        "Roborock S7 MaxV",
-        "Roborock S7 MaxV Dock",
-        "Roborock S7 2",
-        "Roborock S7 2 Dock",
-        "Dyad Pro",
-        "Zeo One",
-        "Roborock Q7",
-        "Roborock Q10 S5+",
-    }
-
-
 async def test_migrate_config_entry_unique_id(
     hass: HomeAssistant,
     config_entry_data: dict[str, Any],
@@ -537,10 +551,13 @@ async def test_zeo_device_fails_setup(
     zeo_device.zeo.query_values.side_effect = RoborockException("Simulated Zeo failure")
 
     await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
+    await hass.async_block_till_done()
+    if mock_roborock_entry._background_tasks:
+        await asyncio.gather(*mock_roborock_entry._background_tasks)
     assert mock_roborock_entry.state is ConfigEntryState.LOADED
 
-    # The Zeo device should be in the registry but have no entities
-    # because its coordinator failed to set up.
+    # The Zeo device should be in the registry and have entities
+    # because entities are registered immediately without blocking on coordinator refresh.
     zeo_device_entry = device_registry.async_get_device(
         identifiers={(DOMAIN, zeo_device.duid)}
     )
@@ -548,7 +565,10 @@ async def test_zeo_device_fails_setup(
     zeo_entities = er.async_entries_for_device(
         entity_registry, zeo_device_entry.id, include_disabled_entities=True
     )
-    assert len(zeo_entities) == 0
+    assert len(zeo_entities) > 0
+    state = hass.states.get(zeo_entities[0].entity_id)
+    assert state is not None
+    assert state.state == "unavailable"
 
     # Other devices should have entities.
     all_entities = er.async_entries_for_config_entry(
@@ -567,7 +587,7 @@ async def test_zeo_device_fails_setup(
         "Dyad Pro",
         "Roborock Q7",
         "Roborock Q10 S5+",
-        # Zeo device is missing
+        "Zeo One",
     }
 
 
@@ -591,10 +611,13 @@ async def test_dyad_device_fails_setup(
     )
 
     await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
+    await hass.async_block_till_done()
+    if mock_roborock_entry._background_tasks:
+        await asyncio.gather(*mock_roborock_entry._background_tasks)
     assert mock_roborock_entry.state is ConfigEntryState.LOADED
 
-    # The Dyad device should be in the registry but have no entities
-    # because its coordinator failed to set up.
+    # The Dyad device should be in the registry and have entities
+    # because entities are registered immediately without blocking on coordinator refresh.
     dyad_device_entry = device_registry.async_get_device(
         identifiers={(DOMAIN, dyad_device.duid)}
     )
@@ -602,7 +625,10 @@ async def test_dyad_device_fails_setup(
     dyad_entities = er.async_entries_for_device(
         entity_registry, dyad_device_entry.id, include_disabled_entities=True
     )
-    assert len(dyad_entities) == 0
+    assert len(dyad_entities) > 0
+    state = hass.states.get(dyad_entities[0].entity_id)
+    assert state is not None
+    assert state.state == "unavailable"
 
     # Other devices should have entities.
     all_entities = er.async_entries_for_config_entry(
@@ -618,7 +644,7 @@ async def test_dyad_device_fails_setup(
         "Roborock S7 MaxV Dock",
         "Roborock S7 2",
         "Roborock S7 2 Dock",
-        # Dyad device is missing
+        "Dyad Pro",
         "Zeo One",
         "Roborock Q7",
         "Roborock Q10 S5+",
@@ -758,7 +784,8 @@ async def test_v1_streaming_updates(
 ) -> None:
     """Test that V1 push updates update entity states immediately."""
     assert setup_entry.state is ConfigEntryState.LOADED
-
+    if setup_entry._background_tasks:
+        await asyncio.gather(*setup_entry._background_tasks)
     sensor_entity_id = "sensor.roborock_s7_maxv_battery"
     state = hass.states.get(sensor_entity_id)
     assert state is not None
@@ -780,3 +807,45 @@ async def test_v1_streaming_updates(
     state = hass.states.get(sensor_entity_id)
     assert state is not None
     assert state.state == "85"
+
+
+@pytest.mark.parametrize("platforms", [[Platform.SENSOR]])
+async def test_dynamic_device_discovery(
+    hass: HomeAssistant,
+    mock_roborock_entry: MockConfigEntry,
+    device_manager: AsyncMock,
+    device_manager_context: MockDeviceManagerContext,
+    fake_devices: list[FakeDevice],
+) -> None:
+    """Test dynamic device discovery and coordinator/entity setup."""
+    # Start with only the first device in the list
+    initial_device = fake_devices[0]
+    device_manager_context.initial_devices = [initial_device]
+
+    # Set up the integration with the initial device
+    await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_roborock_entry.state is ConfigEntryState.LOADED
+
+    # Verify that the sensor for the first device is created
+    sensor_entity_id_1 = "sensor.roborock_s7_maxv_battery"
+    state_1 = hass.states.get(sensor_entity_id_1)
+    assert state_1 is not None
+    assert state_1.state == "100"
+
+    # Verify that the sensor for the second device is NOT created
+    sensor_entity_id_2 = "sensor.roborock_s7_2_battery"
+    state_2 = hass.states.get(sensor_entity_id_2)
+    assert state_2 is None
+
+    # Now simulate the second device becoming ready via ready_callback
+    second_device = fake_devices[1]
+    assert device_manager_context.ready_callback is not None
+    device_manager_context.ready_callback(second_device)
+    await hass.async_block_till_done()
+
+    # Verify that the sensor for the second device has now been dynamically registered and created
+    state_2 = hass.states.get(sensor_entity_id_2)
+    assert state_2 is not None
+    assert state_2.state == "100"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR refactors the Roborock integration setup to support dynamic devices and simplify startup error handling.

Instead of waiting for all devices to be loaded synchronously during integration setup (which causes blocking behavior and fragile error handling if any single device is unreachable), we now delegate setup to python-roborock's `create_device_manager` dynamic `ready_callback` hook. 

Key changes:
- Refactors integration setup to be reactive. `handle_device_ready` in `__init__.py` now acts as a trigger to schedule `async_setup_device` as a background task.
- Moves the registry registration, disabled checks, and unused connection closing logic entirely into `async_setup_device`. This ensures that a single device failing to initialize or connect at startup does not halt or fail the entire integration setup.
- Re-enables stale device cleanup (`_remove_stale_devices`) by executing it as a background task via `entry.async_create_background_task` at startup.
- Updates the test suite to use a new `device_manager_context` fixture to manage ready callbacks and mock device properties cleanly, and fixes type safety across all platform files (`vacuum.py`, `time.py`, `switch.py`, `select.py`, `number.py`, `image.py`, `button.py`, `binary_sensor.py`, and `sensor.py`) using `RoborockCoordinatorType` and correct local list annotations.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
