### PR TITLE
Fix pause before Assist starts talking on ESPHome Assist Satelites

### DIFF
--- a/homeassistant/components/esphome/assist_satellite.py
+++ b/homeassistant/components/esphome/assist_satellite.py
@@ -10,6 +10,7 @@ import json
 import logging
 from pathlib import Path
 import socket
+import struct
 from typing import Any, cast
 
 
@@ -715,6 +716,10 @@ class EsphomeAssistSatellite(
 
             bytes_buffer = bytearray()
             found_data_chunk = False
+            fmt_validated = False
+            riff_checked = False
+            parsing_headers = True
+
             bytes_per_chunk_payload = samples_per_chunk * sample_width * sample_channels
             seconds_in_chunk = samples_per_chunk / sample_rate
 
@@ -724,14 +729,63 @@ class EsphomeAssistSatellite(
 
                 bytes_buffer.extend(chunk)
 
-                if not found_data_chunk:
-                    # Look for 'data' + 4 bytes size
-                    data_idx = bytes_buffer.find(b"data")
-                    if data_idx != -1 and len(bytes_buffer) >= data_idx + 8:
+                while parsing_headers:
+                    if not riff_checked:
+                        if len(bytes_buffer) < 12:
+                            break  # wait for more data
+                        riff, _, wave_fmt = struct.unpack("<4sI4s", bytes_buffer[:12])
+                        if riff != b"RIFF" or wave_fmt != b"WAVE":
+                            _LOGGER.error("Invalid WAV format: missing RIFF/WAVE header")
+                            return
+                        riff_checked = True
+                        del bytes_buffer[:12]
+
+                    if len(bytes_buffer) < 8:
+                        break  # wait for more data
+
+                    chunk_id, chunk_size = struct.unpack("<4sI", bytes_buffer[:8])
+
+                    if chunk_id == b"fmt ":
+                        if len(bytes_buffer) < 8 + chunk_size:
+                            break  # wait for full fmt chunk
+
+                        # Parse fmt chunk (we only need the first 16 bytes of it)
+                        audio_format, num_channels, chunk_sample_rate, _, _, bits_per_sample = struct.unpack(
+                            "<HHIIHH", bytes_buffer[8:24]
+                        )
+
+                        if audio_format != 1:
+                            _LOGGER.error("Can only stream PCM WAV, got format %s", audio_format)
+                            return
+                        if num_channels != sample_channels:
+                            _LOGGER.error("Expected %s channels, got %s", sample_channels, num_channels)
+                            return
+                        if chunk_sample_rate != sample_rate:
+                            _LOGGER.error("Expected %s Hz, got %s Hz", sample_rate, chunk_sample_rate)
+                            return
+                        if bits_per_sample // 8 != sample_width:
+                            _LOGGER.error("Expected %s bytes per sample, got %s", sample_width, bits_per_sample // 8)
+                            return
+
+                        fmt_validated = True
+                        del bytes_buffer[:8 + chunk_size]
+
+                    elif chunk_id == b"data":
+                        # Found data chunk!
+                        if not fmt_validated:
+                            _LOGGER.error("WAV missing fmt chunk before data chunk")
+                            return
+
                         found_data_chunk = True
-                        # Remove everything up to and including the data chunk header
-                        bytes_buffer = bytes_buffer[data_idx + 8:]
-                        _LOGGER.debug("Found WAV data chunk, starting streaming")
+                        parsing_headers = False
+                        del bytes_buffer[:8]
+                        _LOGGER.debug("Validated WAV header and found data chunk, starting streaming")
+                        break
+                    else:
+                        # Skip other chunks
+                        if len(bytes_buffer) < 8 + chunk_size:
+                            break  # wait for full chunk to skip
+                        del bytes_buffer[:8 + chunk_size]
 
                 if found_data_chunk:
                     while len(bytes_buffer) >= bytes_per_chunk_payload:

--- a/homeassistant/components/esphome/assist_satellite.py
+++ b/homeassistant/components/esphome/assist_satellite.py
@@ -11,7 +11,7 @@ import logging
 from pathlib import Path
 import socket
 from typing import Any, cast
-import wave
+
 
 from aioesphomeapi import (
     MediaPlayerFormatPurpose,
@@ -713,36 +713,49 @@ class EsphomeAssistSatellite(
                 )
                 return
 
-            data = b"".join([chunk async for chunk in tts_result.async_stream_result()])
+            bytes_buffer = bytearray()
+            found_data_chunk = False
+            bytes_per_chunk_payload = samples_per_chunk * sample_width * sample_channels
+            seconds_in_chunk = samples_per_chunk / sample_rate
 
-            with io.BytesIO(data) as wav_io, wave.open(wav_io, "rb") as wav_file:
-                if (
-                    (wav_file.getframerate() != sample_rate)
-                    or (wav_file.getsampwidth() != sample_width)
-                    or (wav_file.getnchannels() != sample_channels)
-                ):
-                    _LOGGER.error("Can only stream 16Khz 16-bit mono WAV")
-                    return
+            async for chunk in tts_result.async_stream_result():
+                if not self._is_running:
+                    break
 
-                _LOGGER.debug("Streaming %s audio samples", wav_file.getnframes())
+                bytes_buffer.extend(chunk)
 
-                while self._is_running:
-                    chunk = wav_file.readframes(samples_per_chunk)
-                    if not chunk:
-                        break
+                if not found_data_chunk:
+                    # Look for 'data' + 4 bytes size
+                    data_idx = bytes_buffer.find(b"data")
+                    if data_idx != -1 and len(bytes_buffer) >= data_idx + 8:
+                        found_data_chunk = True
+                        # Remove everything up to and including the data chunk header
+                        bytes_buffer = bytes_buffer[data_idx + 8:]
+                        _LOGGER.debug("Found WAV data chunk, starting streaming")
 
-                    if self._udp_server is not None:
-                        self._udp_server.send_audio_bytes(chunk)
-                    else:
-                        self.cli.send_voice_assistant_audio(chunk)
+                if found_data_chunk:
+                    while len(bytes_buffer) >= bytes_per_chunk_payload:
+                        payload = bytes(bytes_buffer[:bytes_per_chunk_payload])
+                        del bytes_buffer[:bytes_per_chunk_payload]
 
-                    # Wait for 90% of the duration of the audio that was
-                    # sent for it to be played.  This will overrun the
-                    # device's buffer for very long audio, so using a media
-                    # player is preferred.
-                    samples_in_chunk = len(chunk) // (sample_width * sample_channels)
-                    seconds_in_chunk = samples_in_chunk / sample_rate
-                    await asyncio.sleep(seconds_in_chunk * 0.9)
+                        if self._udp_server is not None:
+                            self._udp_server.send_audio_bytes(payload)
+                        else:
+                            self.cli.send_voice_assistant_audio(payload)
+
+                        # Wait for 90% of the duration of the audio that was
+                        # sent for it to be played.  This will overrun the
+                        # device's buffer for very long audio, so using a media
+                        # player is preferred.
+                        await asyncio.sleep(seconds_in_chunk * 0.9)
+
+            if found_data_chunk and len(bytes_buffer) > 0 and self._is_running:
+                payload = bytes(bytes_buffer)
+                if self._udp_server is not None:
+                    self._udp_server.send_audio_bytes(payload)
+                else:
+                    self.cli.send_voice_assistant_audio(payload)
+
         except asyncio.CancelledError:
             return  # Don't trigger state change
         finally:


### PR DESCRIPTION
## Proposed change


### Overview 

This is to fix the delay between the user speaking and the response from Home Assistant on the ESPHome Assist satelites.

This change is to reduce latency in the audio path.  I specifically wrote it for my [ha-gemini-live](https://github.com/matt123p/ha-gemini-live) custom component, which allows you to use the Gemini Live models (that is ones that take in and send out audio, skipping the Speech-to-text and Text-to-speech).


### Change

Currently, when Home Assistant sends a TTS audio stream to an ESPHome satellite (`assist_satellite`), the `_stream_tts_audio` method buffers the entire stream into memory:
```python
data = b"".join([chunk async for chunk in tts_result.async_stream_result()])
```
This is done to utilize Python's standard library `wave` module to validate the WAV format.

This PR implements an on-the-fly WAV header parser using the `struct` module, replacing the blocking `wave` module. 

Instead of waiting for the `async_stream_result()` generator to finish, the new logic accumulates incoming bytes and processes the WAV structure sequentially:
1. Validates the `RIFF` and `WAVE` headers.
2. Unpacks the `fmt ` chunk to strictly enforce the required audio format (PCM, 16kHz, 16-bit, Mono).
3. Safely skips over any metadata chunks (like `JUNK` or `INFO`).
4. Identifies the `data` chunk and immediately begins forwarding the raw payload frames to the UDP/API socket.

In this way we validate the format "on-the-fly", removing the need to wait for the stream to complete but also 
retain data safety. The moment a TTS engine yields its first audio chunk, it plays on the ESPHome speaker.


## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
