### PR TITLE
Fix template switch state restore calling super twice in optimistic mode

### DIFF
--- a/homeassistant/components/template/switch.py
+++ b/homeassistant/components/template/switch.py
@@ -181,11 +181,12 @@ class StateSwitchEntity(TemplateEntity, AbstractTemplateSwitch):
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
-        if CONF_STATE not in self._templates:
-            # restore state after startup
-            await super().async_added_to_hass()
-            if state := await self.async_get_last_state():
-                self._attr_is_on = state.state == STATE_ON
+        if (
+            CONF_STATE not in self._templates
+            and (state := await self.async_get_last_state()) is not None
+            and state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE)
+        ):
+            self._attr_is_on = state.state == STATE_ON
         await super().async_added_to_hass()
 
 

--- a/tests/components/template/test_switch.py
+++ b/tests/components/template/test_switch.py
@@ -9,6 +9,7 @@ from homeassistant.components import switch, template
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
+    EVENT_HOMEASSISTANT_START,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
     STATE_OFF,
@@ -581,7 +582,7 @@ async def test_off_action_optimistic(
 async def test_restore_state(
     hass: HomeAssistant, style: ConfigurationStyle, test_state: str
 ) -> None:
-    """Test state restoration."""
+    """Test state restoration persists through startup for optimistic switches."""
     mock_restore_cache(
         hass,
         (State(TEST_SWITCH.entity_id, test_state),),
@@ -591,6 +592,13 @@ async def test_restore_state(
     mock_component(hass, "recorder")
 
     await setup_entity(hass, TEST_SWITCH, style, 1, SWITCH_ACTIONS)
+
+    state = hass.states.get(TEST_SWITCH.entity_id)
+    assert state
+    assert state.state == test_state
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
 
     state = hass.states.get(TEST_SWITCH.entity_id)
     assert state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`StateSwitchEntity.async_added_to_hass()` called `super().async_added_to_hass()` twice when in optimistic mode (no state template configured). This registered duplicate template listeners and duplicate `async_at_start` callbacks.

This PR restructures the method to follow the same pattern used by the template binary sensor, alarm control panel, and other template entities: restore the cached state before the single `super().async_added_to_hass()` call, and skip restoration when the cached state is `unknown` or `unavailable`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #173706
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr