### PR TITLE
Raise HomeAssistantError in Modern Forms action handlers

### DIFF
--- a/homeassistant/components/modern_forms/__init__.py
+++ b/homeassistant/components/modern_forms/__init__.py
@@ -1,14 +1,15 @@
 """The Modern Forms integration."""
 
 from collections.abc import Callable, Coroutine
-import logging
 from typing import Any, Concatenate
 
 from aiomodernforms import ModernFormsConnectionError, ModernFormsError
 
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 
+from .const import DOMAIN
 from .coordinator import ModernFormsConfigEntry, ModernFormsDataUpdateCoordinator
 from .entity import ModernFormsDeviceEntity
 
@@ -19,7 +20,6 @@ PLATFORMS = [
     Platform.SENSOR,
     Platform.SWITCH,
 ]
-_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ModernFormsConfigEntry) -> bool:
@@ -53,7 +53,7 @@ def modernforms_exception_handler[
     """Decorate Modern Forms calls to handle Modern Forms exceptions.
 
     A decorator that wraps the passed in function, catches Modern Forms errors,
-    and handles the availability of the device in the data coordinator.
+    and raises translated HomeAssistantError exceptions.
     """
 
     async def handler(
@@ -64,11 +64,17 @@ def modernforms_exception_handler[
             self.coordinator.async_update_listeners()
 
         except ModernFormsConnectionError as error:
-            _LOGGER.error("Error communicating with API: %s", error)
             self.coordinator.last_update_success = False
             self.coordinator.async_update_listeners()
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="communication_error",
+            ) from error
 
         except ModernFormsError as error:
-            _LOGGER.error("Invalid response from API: %s", error)
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_response",
+            ) from error
 
     return handler

--- a/homeassistant/components/modern_forms/fan.py
+++ b/homeassistant/components/modern_forms/fan.py
@@ -108,13 +108,11 @@ class ModernFormsFanEntity(FanEntity, ModernFormsDeviceEntity):
         """Return the state of the fan."""
         return bool(self.coordinator.data.state.fan_on)
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
     @modernforms_exception_handler
     async def async_set_direction(self, direction: str) -> None:
         """Set the direction of the fan."""
         await self.coordinator.modern_forms.fan(direction=direction)
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
     @modernforms_exception_handler
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed percentage of the fan."""
@@ -123,7 +121,6 @@ class ModernFormsFanEntity(FanEntity, ModernFormsDeviceEntity):
         else:
             await self.async_turn_off()
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
     @modernforms_exception_handler
     async def async_turn_on(
         self,
@@ -140,13 +137,11 @@ class ModernFormsFanEntity(FanEntity, ModernFormsDeviceEntity):
             )
         await self.coordinator.modern_forms.fan(**data)
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
     @modernforms_exception_handler
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the fan off."""
         await self.coordinator.modern_forms.fan(on=FAN_POWER_OFF)
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
     @modernforms_exception_handler
     async def async_set_fan_sleep_timer(
         self,
@@ -155,7 +150,6 @@ class ModernFormsFanEntity(FanEntity, ModernFormsDeviceEntity):
         """Set a Modern Forms light sleep timer."""
         await self.coordinator.modern_forms.fan(sleep=sleep_time * 60)
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
     @modernforms_exception_handler
     async def async_clear_fan_sleep_timer(
         self,

--- a/homeassistant/components/modern_forms/light.py
+++ b/homeassistant/components/modern_forms/light.py
@@ -100,13 +100,11 @@ class ModernFormsLightEntity(ModernFormsDeviceEntity, LightEntity):
         """Return the state of the light."""
         return bool(self.coordinator.data.state.light_on)
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
     @modernforms_exception_handler
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the light."""
         await self.coordinator.modern_forms.light(on=LIGHT_POWER_OFF)
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
     @modernforms_exception_handler
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the light."""
@@ -119,7 +117,6 @@ class ModernFormsLightEntity(ModernFormsDeviceEntity, LightEntity):
 
         await self.coordinator.modern_forms.light(**data)
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
     @modernforms_exception_handler
     async def async_set_light_sleep_timer(
         self,
@@ -128,7 +125,6 @@ class ModernFormsLightEntity(ModernFormsDeviceEntity, LightEntity):
         """Set a Modern Forms light sleep timer."""
         await self.coordinator.modern_forms.light(sleep=sleep_time * 60)
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
     @modernforms_exception_handler
     async def async_clear_light_sleep_timer(
         self,

--- a/homeassistant/components/modern_forms/strings.json
+++ b/homeassistant/components/modern_forms/strings.json
@@ -60,6 +60,14 @@
       }
     }
   },
+  "exceptions": {
+    "communication_error": {
+      "message": "Error communicating with the Modern Forms device"
+    },
+    "invalid_response": {
+      "message": "Invalid response from the Modern Forms device"
+    }
+  },
   "services": {
     "clear_fan_sleep_timer": {
       "description": "Clears the sleep timer on a Modern Forms fan.",

--- a/homeassistant/components/modern_forms/switch.py
+++ b/homeassistant/components/modern_forms/switch.py
@@ -62,13 +62,11 @@ class ModernFormsAwaySwitch(ModernFormsSwitch):
         """Return the state of the switch."""
         return bool(self.coordinator.data.state.away_mode_enabled)
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
     @modernforms_exception_handler
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the Modern Forms Away mode switch."""
         await self.coordinator.modern_forms.away(away=False)
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
     @modernforms_exception_handler
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the Modern Forms Away mode switch."""
@@ -95,13 +93,11 @@ class ModernFormsAdaptiveLearningSwitch(ModernFormsSwitch):
         """Return the state of the switch."""
         return bool(self.coordinator.data.state.adaptive_learning_enabled)
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
     @modernforms_exception_handler
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the Modern Forms Adaptive Learning switch."""
         await self.coordinator.modern_forms.adaptive_learning(adaptive_learning=False)
 
-    # pylint: disable-next=home-assistant-action-swallowed-exception
     @modernforms_exception_handler
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the Modern Forms Adaptive Learning switch."""

--- a/tests/components/modern_forms/test_fan.py
+++ b/tests/components/modern_forms/test_fan.py
@@ -28,6 +28,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
 from . import init_integration
@@ -182,7 +183,6 @@ async def test_set_percentage(
 async def test_fan_error(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test error handling of the Modern Forms fans."""
 
@@ -191,8 +191,11 @@ async def test_fan_error(
 
     aioclient_mock.post("http://192.168.1.123:80/mf", text="", status=400)
 
-    with patch(
-        "homeassistant.components.modern_forms.coordinator.ModernFormsDevice.update"
+    with (
+        patch(
+            "homeassistant.components.modern_forms.coordinator.ModernFormsDevice.update"
+        ),
+        pytest.raises(HomeAssistantError) as exc_info,
     ):
         await hass.services.async_call(
             FAN_DOMAIN,
@@ -200,16 +203,15 @@ async def test_fan_error(
             {ATTR_ENTITY_ID: "fan.modernformsfan_fan"},
             blocking=True,
         )
-        await hass.async_block_till_done()
-        state = hass.states.get("fan.modernformsfan_fan")
-        assert state.state == STATE_ON
-        assert "Invalid response from API" in caplog.text
+
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == "invalid_response"
 
 
 async def test_fan_connection_error(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
-    """Test error handling of the Moder Forms fans."""
+    """Test error handling of the Modern Forms fans."""
     await init_integration(hass, aioclient_mock)
 
     with (
@@ -220,6 +222,7 @@ async def test_fan_connection_error(
             "homeassistant.components.modern_forms.coordinator.ModernFormsDevice.fan",
             side_effect=ModernFormsConnectionError,
         ),
+        pytest.raises(HomeAssistantError) as exc_info,
     ):
         await hass.services.async_call(
             FAN_DOMAIN,
@@ -227,7 +230,9 @@ async def test_fan_connection_error(
             {ATTR_ENTITY_ID: "fan.modernformsfan_fan"},
             blocking=True,
         )
-        await hass.async_block_till_done()
 
-        state = hass.states.get("fan.modernformsfan_fan")
-        assert state.state == STATE_UNAVAILABLE
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == "communication_error"
+
+    state = hass.states.get("fan.modernformsfan_fan")
+    assert state.state == STATE_UNAVAILABLE

--- a/tests/components/modern_forms/test_light.py
+++ b/tests/components/modern_forms/test_light.py
@@ -21,6 +21,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
 from . import init_integration
@@ -110,7 +111,6 @@ async def test_sleep_timer_services(
 async def test_light_error(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test error handling of the Modern Forms lights."""
 
@@ -119,8 +119,11 @@ async def test_light_error(
 
     aioclient_mock.post("http://192.168.1.123:80/mf", text="", status=400)
 
-    with patch(
-        "homeassistant.components.modern_forms.coordinator.ModernFormsDevice.update"
+    with (
+        patch(
+            "homeassistant.components.modern_forms.coordinator.ModernFormsDevice.update"
+        ),
+        pytest.raises(HomeAssistantError) as exc_info,
     ):
         await hass.services.async_call(
             LIGHT_DOMAIN,
@@ -128,16 +131,15 @@ async def test_light_error(
             {ATTR_ENTITY_ID: "light.modernformsfan_light"},
             blocking=True,
         )
-        await hass.async_block_till_done()
-        state = hass.states.get("light.modernformsfan_light")
-        assert state.state == STATE_ON
-        assert "Invalid response from API" in caplog.text
+
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == "invalid_response"
 
 
 async def test_light_connection_error(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
-    """Test error handling of the Moder Forms lights."""
+    """Test error handling of the Modern Forms lights."""
     await init_integration(hass, aioclient_mock)
 
     with (
@@ -148,6 +150,7 @@ async def test_light_connection_error(
             "homeassistant.components.modern_forms.coordinator.ModernFormsDevice.light",
             side_effect=ModernFormsConnectionError,
         ),
+        pytest.raises(HomeAssistantError) as exc_info,
     ):
         await hass.services.async_call(
             LIGHT_DOMAIN,
@@ -155,7 +158,9 @@ async def test_light_connection_error(
             {ATTR_ENTITY_ID: "light.modernformsfan_light"},
             blocking=True,
         )
-        await hass.async_block_till_done()
 
-        state = hass.states.get("light.modernformsfan_light")
-        assert state.state == STATE_UNAVAILABLE
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == "communication_error"
+
+    state = hass.states.get("light.modernformsfan_light")
+    assert state.state == STATE_UNAVAILABLE

--- a/tests/components/modern_forms/test_switch.py
+++ b/tests/components/modern_forms/test_switch.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from aiomodernforms import ModernFormsConnectionError
 import pytest
 
+from homeassistant.components.modern_forms.const import DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -14,6 +15,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
 from . import init_integration
@@ -102,7 +104,6 @@ async def test_switch_change_state(
 async def test_switch_error(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test error handling of the Modern Forms switches."""
     await init_integration(hass, aioclient_mock)
@@ -110,8 +111,11 @@ async def test_switch_error(
     aioclient_mock.clear_requests()
     aioclient_mock.post("http://192.168.1.123:80/mf", text="", status=400)
 
-    with patch(
-        "homeassistant.components.modern_forms.coordinator.ModernFormsDevice.update"
+    with (
+        patch(
+            "homeassistant.components.modern_forms.coordinator.ModernFormsDevice.update"
+        ),
+        pytest.raises(HomeAssistantError) as exc_info,
     ):
         await hass.services.async_call(
             SWITCH_DOMAIN,
@@ -119,11 +123,9 @@ async def test_switch_error(
             {ATTR_ENTITY_ID: "switch.modernformsfan_away_mode"},
             blocking=True,
         )
-        await hass.async_block_till_done()
 
-        state = hass.states.get("switch.modernformsfan_away_mode")
-        assert state.state == STATE_OFF
-        assert "Invalid response from API" in caplog.text
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == "invalid_response"
 
 
 async def test_switch_connection_error(
@@ -140,6 +142,7 @@ async def test_switch_connection_error(
             "homeassistant.components.modern_forms.coordinator.ModernFormsDevice.away",
             side_effect=ModernFormsConnectionError,
         ),
+        pytest.raises(HomeAssistantError) as exc_info,
     ):
         await hass.services.async_call(
             SWITCH_DOMAIN,
@@ -147,7 +150,9 @@ async def test_switch_connection_error(
             {ATTR_ENTITY_ID: "switch.modernformsfan_away_mode"},
             blocking=True,
         )
-        await hass.async_block_till_done()
 
-        state = hass.states.get("switch.modernformsfan_away_mode")
-        assert state.state == STATE_UNAVAILABLE
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == "communication_error"
+
+    state = hass.states.get("switch.modernformsfan_away_mode")
+    assert state.state == STATE_UNAVAILABLE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The Modern Forms integration's `modernforms_exception_handler` decorator catches `ModernFormsConnectionError` and `ModernFormsError` exceptions in all action handlers but only logs them instead of re-raising. This means the user gets no feedback in the UI when an action fails, and automations continue executing as if the action succeeded.

This PR updates the decorator to raise `HomeAssistantError` with translated messages for both exception types, giving users proper error feedback. With the exceptions no longer swallowed, all 14 `pylint: disable-next=home-assistant-action-swallowed-exception` suppressions across the fan, light, and switch platforms are removed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170626
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr