### PR TITLE
Add missing translation_domain to nasweb exception raises

### DIFF
--- a/homeassistant/components/nasweb/__init__.py
+++ b/homeassistant/components/nasweb/__init__.py
@@ -50,16 +50,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: NASwebConfigEntry) -> bo
             )
         if not await webio_api.refresh_device_info():
             _LOGGER.error("[%s] Refresh device info failed", entry.data[CONF_HOST])
-            # pylint: disable-next=home-assistant-exception-translation-key-domain-mismatch
             raise ConfigEntryError(
+                translation_domain=DOMAIN,
                 translation_key="config_entry_error_internal_error",
                 translation_placeholders={"support_email": SUPPORT_EMAIL},
             )
         webio_serial = webio_api.get_serial_number()
         if webio_serial is None:
             _LOGGER.error("[%s] Serial number not available", entry.data[CONF_HOST])
-            # pylint: disable-next=home-assistant-exception-translation-key-domain-mismatch
             raise ConfigEntryError(
+                translation_domain=DOMAIN,
                 translation_key="config_entry_error_internal_error",
                 translation_placeholders={"support_email": SUPPORT_EMAIL},
             )
@@ -67,8 +67,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: NASwebConfigEntry) -> bo
             _LOGGER.error(
                 "[%s] Serial number doesn't match config entry", entry.data[CONF_HOST]
             )
-            # pylint: disable-next=home-assistant-exception-translation-key-domain-mismatch
-            raise ConfigEntryError(translation_key="config_entry_error_serial_mismatch")
+            raise ConfigEntryError(
+                translation_domain=DOMAIN,
+                translation_key="config_entry_error_serial_mismatch",
+            )
 
         coordinator = NASwebCoordinator(
             hass, webio_api, name=f"NASweb[{webio_api.get_name()}]"
@@ -79,15 +81,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: NASwebConfigEntry) -> bo
         webhook_url = nasweb_data.get_webhook_url(hass)
         if not await webio_api.status_subscription(webhook_url, True):
             _LOGGER.error("Failed to subscribe for status updates from webio")
-            # pylint: disable-next=home-assistant-exception-translation-key-domain-mismatch
             raise ConfigEntryError(
+                translation_domain=DOMAIN,
                 translation_key="config_entry_error_internal_error",
                 translation_placeholders={"support_email": SUPPORT_EMAIL},
             )
         if not await nasweb_data.notify_coordinator.check_connection(webio_serial):
             _LOGGER.error("Did not receive status from device")
-            # pylint: disable-next=home-assistant-exception-translation-key-domain-mismatch
             raise ConfigEntryError(
+                translation_domain=DOMAIN,
                 translation_key="config_entry_error_no_status_update",
                 translation_placeholders={"support_email": SUPPORT_EMAIL},
             )
@@ -96,14 +98,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: NASwebConfigEntry) -> bo
             f"[{entry.data[CONF_HOST]}] Check connection reached timeout"
         ) from error
     except AuthError as error:
-        # pylint: disable-next=home-assistant-exception-translation-key-domain-mismatch
         raise ConfigEntryError(
-            translation_key="config_entry_error_invalid_authentication"
+            translation_domain=DOMAIN,
+            translation_key="config_entry_error_invalid_authentication",
         ) from error
     except NoURLAvailableError as error:
-        # pylint: disable-next=home-assistant-exception-translation-key-domain-mismatch
         raise ConfigEntryError(
-            translation_key="config_entry_error_missing_internal_url"
+            translation_domain=DOMAIN,
+            translation_key="config_entry_error_missing_internal_url",
         ) from error
 
     device_registry = dr.async_get(hass)

--- a/homeassistant/components/nasweb/strings.json
+++ b/homeassistant/components/nasweb/strings.json
@@ -65,7 +65,7 @@
     "config_entry_error_no_status_update": {
       "message": "Did not receive any status updates within the expected time window. Make sure the Home Assistant internal URL is reachable from the NASweb device. If the issue persists contact support at {support_email}"
     },
-    "serial_mismatch": {
+    "config_entry_error_serial_mismatch": {
       "message": "Connected to different NASweb device (serial number mismatch)."
     }
   }

--- a/tests/components/nasweb/conftest.py
+++ b/tests/components/nasweb/conftest.py
@@ -5,6 +5,25 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from homeassistant.components.nasweb.const import DOMAIN
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return the default mocked config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "1.1.1.1",
+            CONF_USERNAME: "test-username",
+            CONF_PASSWORD: "test-password",
+        },
+        unique_id=TEST_SERIAL_NUMBER,
+    )
+
 
 @pytest.fixture
 def mock_setup_entry() -> Generator[AsyncMock]:
@@ -59,3 +78,34 @@ def validate_input_all_ok() -> Generator[dict[str, AsyncMock | MagicMock]]:
             BASE_NASWEB_DATA
             + "NotificationCoordinator.check_connection": check_status_confirmation,
         }
+
+
+@pytest.fixture
+def mock_webio_api() -> Generator[MagicMock]:
+    """Return a mocked WebioAPI client."""
+    with (
+        patch(
+            "homeassistant.components.nasweb.WebioAPI",
+            autospec=True,
+        ) as webio_api_mock,
+        patch(
+            BASE_NASWEB_DATA + "NASwebData.get_webhook_url",
+            return_value="http://127.0.0.1:8123/api/webhook/test",
+        ),
+        patch(
+            BASE_NASWEB_DATA + "NotificationCoordinator.check_connection",
+            return_value=True,
+        ),
+    ):
+        webio_api = webio_api_mock.return_value
+        webio_api.check_connection.return_value = True
+        webio_api.refresh_device_info.return_value = True
+        webio_api.get_serial_number.return_value = TEST_SERIAL_NUMBER
+        webio_api.get_name.return_value = "TestNASweb"
+        webio_api.status_subscription.return_value = True
+        webio_api.outputs = {}
+        webio_api.inputs = {}
+        webio_api.temp_sensor = {}
+        webio_api.thermostat = {}
+        webio_api.zones = {}
+        yield webio_api

--- a/tests/components/nasweb/test_init.py
+++ b/tests/components/nasweb/test_init.py
@@ -1,0 +1,121 @@
+"""Tests for the NASweb integration."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from webio_api.api_client import AuthError
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.network import NoURLAvailableError
+
+from .conftest import BASE_NASWEB_DATA
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.parametrize(
+    ("mock_attr", "mock_value", "expected_translation_key"),
+    [
+        (
+            "refresh_device_info",
+            False,
+            "config_entry_error_internal_error",
+        ),
+        (
+            "get_serial_number",
+            None,
+            "config_entry_error_internal_error",
+        ),
+        (
+            "get_serial_number",
+            "different_serial",
+            "config_entry_error_serial_mismatch",
+        ),
+        (
+            "status_subscription",
+            False,
+            "config_entry_error_internal_error",
+        ),
+    ],
+)
+async def test_setup_entry_config_entry_error(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_webio_api: MagicMock,
+    mock_attr: str,
+    mock_value: object,
+    expected_translation_key: str,
+) -> None:
+    """Test setup entry raises ConfigEntryError with correct translation key."""
+    getattr(mock_webio_api, mock_attr).return_value = mock_value
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+    assert mock_config_entry.error_reason_translation_key == expected_translation_key
+
+
+async def test_setup_entry_auth_error(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_webio_api: MagicMock,
+) -> None:
+    """Test setup entry raises ConfigEntryError on authentication failure."""
+    mock_webio_api.check_connection.side_effect = AuthError
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+    assert (
+        mock_config_entry.error_reason_translation_key
+        == "config_entry_error_invalid_authentication"
+    )
+
+
+async def test_setup_entry_no_status_update(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_webio_api: MagicMock,
+) -> None:
+    """Test setup entry raises ConfigEntryError when no status update received."""
+    with patch(
+        BASE_NASWEB_DATA + "NotificationCoordinator.check_connection",
+        return_value=False,
+    ):
+        mock_config_entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+    assert (
+        mock_config_entry.error_reason_translation_key
+        == "config_entry_error_no_status_update"
+    )
+
+
+async def test_setup_entry_missing_internal_url(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_webio_api: MagicMock,
+) -> None:
+    """Test setup entry raises ConfigEntryError when internal URL is missing."""
+    with patch(
+        BASE_NASWEB_DATA + "NASwebData.get_webhook_url",
+        side_effect=NoURLAvailableError,
+    ):
+        mock_config_entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+    assert (
+        mock_config_entry.error_reason_translation_key
+        == "config_entry_error_missing_internal_url"
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add the missing `translation_domain=DOMAIN` to all `ConfigEntryError` raises in the nasweb integration. Without `translation_domain`, the exception translation system cannot resolve the message from `strings.json`, resulting in users seeing "Unknown fatal config entry error" instead of the proper translated error message.

Also fixes a mismatched translation key: the code referenced `config_entry_error_serial_mismatch` but `strings.json` had the key as `serial_mismatch`.

Adds tests covering all error paths in `async_setup_entry`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #171552
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr