### PR TITLE
Remove listener from holiday calendar when entity is disabled

### DIFF
--- a/homeassistant/components/holiday/calendar.py
+++ b/homeassistant/components/holiday/calendar.py
@@ -151,6 +151,13 @@ class HolidayCalendarEntity(CalendarEntity):
         """Set up first update."""
         self._update_state_and_setup_listener()
 
+    async def async_will_remove_from_hass(self) -> None:
+        """Cancel listener when removing."""
+        await super().async_will_remove_from_hass()
+        if self.unsub:
+            self.unsub()
+            self.unsub = None
+
     def update_event(self, now: datetime) -> CalendarEvent | None:
         """Return the next upcoming event."""
         next_holiday = None

--- a/tests/components/holiday/test_calendar.py
+++ b/tests/components/holiday/test_calendar.py
@@ -1,6 +1,7 @@
 """Tests for calendar platform of Holiday integration."""
 
 from datetime import datetime, timedelta
+import logging
 
 from freezegun.api import FrozenDateTimeFactory
 from holidays import CATHOLIC
@@ -17,6 +18,7 @@ from homeassistant.components.holiday.const import (
 )
 from homeassistant.const import CONF_COUNTRY
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -431,3 +433,45 @@ async def test_categories(
             ]
         }
     }
+
+
+async def test_no_update_when_disabled(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    entity_registry: er.EntityRegistry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that a disabled calendar entity does not trigger updates."""
+    zone = await dt_util.async_get_time_zone("US/Hawaii")
+    freezer.move_to(datetime(2023, 1, 1, 0, 1, 1, tzinfo=zone))
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_COUNTRY: "US", CONF_PROVINCE: "AK"},
+        title="United States, AK",
+    )
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    await async_setup_component(hass, "calendar", {})
+    await hass.async_block_till_done()
+
+    entity_id = "calendar.united_states_ak"
+    state = hass.states.get(entity_id)
+    assert state is not None
+
+    entity_registry.async_update_entity(
+        entity_id, disabled_by=er.RegistryEntryDisabler.USER
+    )
+    await hass.async_block_till_done()
+
+    with caplog.at_level(logging.WARNING, logger="homeassistant.helpers.entity"):
+        freezer.move_to(datetime(2023, 1, 2, 0, 1, 1, tzinfo=zone))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+    assert (
+        "incorrectly being triggered for updates while it is disabled"
+        not in caplog.text
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change


## Proposed change
Add `async_will_remove_from_hass` to unsubscribe the listener when the entity is disabled.
"copy" of https://github.com/home-assistant/core/pull/173626

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository. 