### PR TITLE
Bump snapcast to 2.3.8

### DIFF
--- a/homeassistant/components/snapcast/manifest.json
+++ b/homeassistant/components/snapcast/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["construct", "snapcast"],
-  "requirements": ["snapcast==2.3.7"]
+  "requirements": ["snapcast==2.3.8"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3046,7 +3046,7 @@ slixmpp==1.13.2
 smart-meter-texas==0.5.5
 
 # homeassistant.components.snapcast
-snapcast==2.3.7
+snapcast==2.3.8
 
 # homeassistant.components.sonos
 soco==0.31.1


### PR DESCRIPTION
## Proposed change

Bump snapcast from 2.3.7 to 2.3.8.

**Upstream links:**
- Release: https://github.com/happyleavesaoc/python-snapcast/releases/tag/2.3.8
- Diff: https://github.com/happyleavesaoc/python-snapcast/compare/2.3.7...2.3.8

**Changes in 2.3.8:**
- Fix protocol race condition KeyError when responses arrive for unknown request ids ([happyleavesaoc/python-snapcast#84](https://github.com/happyleavesaoc/python-snapcast/pull/84))
- Fix KeyError when stream_status is called on a group ([happyleavesaoc/python-snapcast#83](https://github.com/happyleavesaoc/python-snapcast/pull/83))
- Better callback handling and thread-safe monotonic counter for JSON-RPC request ids
- Expose Snapclient, Snapgroup and Snapstream attributes, add stream attribute to Snapclient ([happyleavesaoc/python-snapcast#82](https://github.com/happyleavesaoc/python-snapcast/pull/82))

These are bug fixes and internal reliability improvements. No changes needed on the Home Assistant side.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
