### PR TITLE
Bump roborock dependencies

### DIFF
--- a/homeassistant/components/roborock/manifest.json
+++ b/homeassistant/components/roborock/manifest.json
@@ -20,7 +20,7 @@
   "loggers": ["roborock"],
   "quality_scale": "silver",
   "requirements": [
-    "python-roborock==5.14.1",
-    "vacuum-map-parser-roborock==0.1.4"
+    "python-roborock==5.14.2",
+    "vacuum-map-parser-roborock==0.1.5"
   ]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2733,7 +2733,7 @@ python-rabbitair==0.0.8
 python-ripple-api==0.0.3
 
 # homeassistant.components.roborock
-python-roborock==5.14.1
+python-roborock==5.14.2
 
 # homeassistant.components.smarttub
 python-smarttub==0.0.47
@@ -3287,7 +3287,7 @@ url-normalize==3.0.0
 uvcclient==0.12.1
 
 # homeassistant.components.roborock
-vacuum-map-parser-roborock==0.1.4
+vacuum-map-parser-roborock==0.1.5
 
 # homeassistant.components.vallox
 vallox-websocket-api==6.0.0

--- a/tests/components/roborock/test_select.py
+++ b/tests/components/roborock/test_select.py
@@ -457,7 +457,7 @@ async def test_q10_cleaning_mode_select_current_option(
     assert state.state == STATE_UNKNOWN
     options = state.attributes.get("options")
     assert options is not None
-    assert set(options) == {"vac_and_mop", "vacuum", "mop"}
+    assert set(options) == {"vac_and_mop", "vacuum", "mop", "customized"}
 
     assert fake_q10_vacuum.b01_q10_properties
     fake_q10_vacuum.b01_q10_properties.status.update_from_dps(


### PR DESCRIPTION
## Proposed change

Bump roborock dependencies:
- python-roborock from 5.14.1 to 5.14.2
- vacuum-map-parser-roborock from 0.1.4 to 0.1.5

**python-roborock upstream links:**
- Release: https://github.com/Python-roborock/python-roborock/releases/tag/v5.14.2
- Diff: https://github.com/Python-roborock/python-roborock/compare/v5.14.1...v5.14.2

**Changes in python-roborock 5.14.2:**
- Fix Q10 customized clean mode code 4 ([Python-roborock/python-roborock#838](https://github.com/Python-roborock/python-roborock/pull/838))

**vacuum-map-parser-roborock upstream links:**
- Release: https://github.com/PiotrMachowski/Python-package-vacuum-map-parser-roborock/releases/tag/v0.1.5
- Diff: https://github.com/PiotrMachowski/Python-package-vacuum-map-parser-roborock/compare/v0.1.4...v0.1.5

**Changes in vacuum-map-parser-roborock 0.1.5:**
- Added support for removed submaps ([PiotrMachowski/Python-package-vacuum-map-parser-roborock#15](https://github.com/PiotrMachowski/Python-package-vacuum-map-parser-roborock/pull/15))

Both are bug fixes in the libraries. No changes needed on the Home Assistant side.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
