### PR TITLE
Bump uv to 0.11.21

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -70,7 +70,7 @@ standard-telnetlib==3.13.0
 typing-extensions>=4.15.0,<5.0
 ulid-transform==2.2.9
 urllib3>=2.0
-uv==0.11.19
+uv==0.11.21
 voluptuous-openapi==0.3.0
 voluptuous-serialize==2.7.0
 voluptuous==0.15.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ dependencies = [
   "typing-extensions>=4.15.0,<5.0",
   "ulid-transform==2.2.9",
   "urllib3>=2.0",
-  "uv==0.11.19",
+  "uv==0.11.21",
   "voluptuous==0.15.2",
   "voluptuous-serialize==2.7.0",
   "voluptuous-openapi==0.3.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ standard-telnetlib==3.13.0
 typing-extensions>=4.15.0,<5.0
 ulid-transform==2.2.9
 urllib3>=2.0
-uv==0.11.19
+uv==0.11.21
 voluptuous-openapi==0.3.0
 voluptuous-serialize==2.7.0
 voluptuous==0.15.2


### PR DESCRIPTION
## Proposed change

Bump uv from 0.11.19 to 0.11.21.

**Upstream links:**
- Release 0.11.21: https://github.com/astral-sh/uv/releases/tag/0.11.21
- Release 0.11.20: https://github.com/astral-sh/uv/releases/tag/0.11.20
- Diff: https://github.com/astral-sh/uv/compare/0.11.19...0.11.21

**Notable changes across 0.11.20 and 0.11.21:**
- Add CPython 3.13.14 and 3.14.6
- Cache robustness improvements (pruning, malformed entries, overflow handling)
- Fix Python discovery edge cases and stop-discovery-at regression
- Harden parsing/validation for package metadata, requirements, markers, URLs
- Various bug fixes for lock, publish, and workspace commands

These are bug fixes and improvements in the uv package manager. No changes needed on the Home Assistant side.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr