### PR TITLE
Bump python-linkplay to 0.2.14

### DIFF
--- a/homeassistant/components/linkplay/manifest.json
+++ b/homeassistant/components/linkplay/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["linkplay"],
-  "requirements": ["python-linkplay==0.2.12"],
+  "requirements": ["python-linkplay==0.2.14"],
   "zeroconf": ["_linkplay._tcp.local."]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2684,7 +2684,7 @@ python-join-api==0.1.1
 python-kasa[speedups]==0.10.2
 
 # homeassistant.components.linkplay
-python-linkplay==0.2.12
+python-linkplay==0.2.14
 
 # homeassistant.components.melcloud
 python-melcloud==0.1.3


### PR DESCRIPTION
## Proposed change

Bump python-linkplay from 0.2.12 to 0.2.14.

**Upstream links:**
- Release 0.2.14: https://github.com/Velleman/python-linkplay/releases/tag/v0.2.14
- Release 0.2.13: https://github.com/Velleman/python-linkplay/releases/tag/v0.2.13
- Diff: https://github.com/Velleman/python-linkplay/compare/v0.2.12...v0.2.14

**Changes across 0.2.13 and 0.2.14:**
- Expanded manufacturer and device lists ([Velleman/python-linkplay#112](https://github.com/Velleman/python-linkplay/pull/112), [Velleman/python-linkplay#116](https://github.com/Velleman/python-linkplay/pull/116), [Velleman/python-linkplay#118](https://github.com/Velleman/python-linkplay/pull/118))
- Increased request timeout ([Velleman/python-linkplay#117](https://github.com/Velleman/python-linkplay/pull/117))
- Improved request handling ([Velleman/python-linkplay#119](https://github.com/Velleman/python-linkplay/pull/119))

These are device support expansions and reliability improvements. No changes needed on the Home Assistant side.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr