### PR TITLE
Fix OpenRGB recreating HID devices on reconnect

### DIFF
--- a/homeassistant/components/openrgb/__init__.py
+++ b/homeassistant/components/openrgb/__init__.py
@@ -1,7 +1,6 @@
 """The OpenRGB integration."""
 
 from collections import defaultdict
-import logging
 
 from homeassistant.const import CONF_NAME, Platform
 from homeassistant.core import HomeAssistant
@@ -10,8 +9,6 @@ from homeassistant.helpers.device_registry import DeviceEntry
 
 from .const import DOMAIN, UID_SEPARATOR
 from .coordinator import OpenRGBConfigEntry, OpenRGBCoordinator
-
-_LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [Platform.LIGHT, Platform.SELECT]
 
@@ -52,26 +49,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: OpenRGBConfigEntry) -> b
     return True
 
 
-def _build_hid_index_map(old_uids: list[str]) -> dict[str, str]:
-    """Map old HID unique IDs to new indexed ones.
+def _build_hid_index_map(uids: list[str]) -> dict[str, str]:
+    """Map old HID unique IDs to new indexed format.
 
-    Groups UIDs that share the same base key (first 5 parts), sorts each group
-    by old location for deterministic ordering, and assigns indices 0, 1, 2, …
-
-    Only UIDs with a 6-part format whose location starts with ``HID:`` are
-    considered; all others are ignored.
+    Groups UIDs sharing the same base key (first 5 parts), sorts each group
+    by the old location for deterministic ordering, and assigns ``hid_0``,
+    ``hid_1``, … suffixes.  UIDs that are not 6-part HID entries are ignored.
     """
     groups: dict[str, list[str]] = defaultdict(list)
-    for uid in old_uids:
+    for uid in uids:
         parts = uid.split(UID_SEPARATOR)
         if len(parts) == 6 and parts[5].startswith("HID:"):
-            base_key = UID_SEPARATOR.join(parts[:5])
-            groups[base_key].append(uid)
+            groups[UID_SEPARATOR.join(parts[:5])].append(uid)
 
     mapping: dict[str, str] = {}
-    for base_key, uids in groups.items():
-        uids.sort(key=lambda u: u.split(UID_SEPARATOR)[5])
-        for idx, uid in enumerate(uids):
+    for base_key, group in groups.items():
+        group.sort(key=lambda u: u.split(UID_SEPARATOR)[5])
+        for idx, uid in enumerate(group):
             new_uid = f"{base_key}{UID_SEPARATOR}hid_{idx}"
             if uid != new_uid:
                 mapping[uid] = new_uid
@@ -79,47 +73,30 @@ def _build_hid_index_map(old_uids: list[str]) -> dict[str, str]:
 
 
 def _async_migrate_unique_ids(hass: HomeAssistant, entry: OpenRGBConfigEntry) -> None:
-    """Migrate entity and device unique IDs to the new indexed HID format.
+    """Migrate entity and device unique IDs from raw HID locations to indexed format.
 
-    Old format: ...||HID: DevSrvsID:xxx  (raw location)
-    New format: ...||hid_N              (indexed)
+    Old format: ``…||HID: DevSrvsID:xxx``  New format: ``…||hid_N``
     """
     ent_reg = er.async_get(hass)
     dev_reg = dr.async_get(hass)
 
-    # --- Entity migration ---
     entities = ent_reg.entities.get_entries_for_config_entry_id(entry.entry_id)
     ent_map = _build_hid_index_map([e.unique_id for e in entities])
     for entity in entities:
         if new_uid := ent_map.get(entity.unique_id):
-            _LOGGER.debug(
-                "Migrating entity unique ID from %s to %s",
-                entity.unique_id,
-                new_uid,
-            )
             ent_reg.async_update_entity(entity.entity_id, new_unique_id=new_uid)
 
-    # --- Device migration ---
     devices = dr.async_entries_for_config_entry(dev_reg, entry.entry_id)
-    dev_ids = [
-        identifier
-        for device in devices
-        for domain, identifier in device.identifiers
-        if domain == DOMAIN
-    ]
-    dev_map = _build_hid_index_map(dev_ids)
+    dev_map = _build_hid_index_map(
+        [i for d in devices for dom, i in d.identifiers if dom == DOMAIN]
+    )
     for device in devices:
-        new_identifiers = {
-            (d, dev_map.get(i, i)) if d == DOMAIN else (d, i)
-            for d, i in device.identifiers
+        new_ids = {
+            (dom, dev_map.get(i, i)) if dom == DOMAIN else (dom, i)
+            for dom, i in device.identifiers
         }
-        if new_identifiers != device.identifiers:
-            _LOGGER.debug(
-                "Migrating device identifiers from %s to %s",
-                device.identifiers,
-                new_identifiers,
-            )
-            dev_reg.async_update_device(device.id, new_identifiers=new_identifiers)
+        if new_ids != device.identifiers:
+            dev_reg.async_update_device(device.id, new_identifiers=new_ids)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: OpenRGBConfigEntry) -> bool:

--- a/homeassistant/components/openrgb/__init__.py
+++ b/homeassistant/components/openrgb/__init__.py
@@ -1,5 +1,6 @@
 """The OpenRGB integration."""
 
+from collections import defaultdict
 import logging
 
 from homeassistant.const import CONF_NAME, Platform
@@ -51,33 +52,46 @@ async def async_setup_entry(hass: HomeAssistant, entry: OpenRGBConfigEntry) -> b
     return True
 
 
-def _migrate_uid(unique_id: str) -> str | None:
-    """Migrate an old-format unique ID to the new format.
+def _build_hid_index_map(old_uids: list[str]) -> dict[str, str]:
+    """Map old HID unique IDs to new indexed ones.
 
-    Old format included raw location for all devices. New format drops location
-    for HID devices.
+    Groups UIDs that share the same base key (first 5 parts), sorts each group
+    by old location for deterministic ordering, and assigns indices 0, 1, 2, …
 
-    Returns the new unique ID, or None if no migration is needed.
+    Only UIDs with a 6-part format whose location starts with ``HID:`` are
+    considered; all others are ignored.
     """
-    parts = unique_id.split(UID_SEPARATOR)
-    if len(parts) != 6:
-        return None
+    groups: dict[str, list[str]] = defaultdict(list)
+    for uid in old_uids:
+        parts = uid.split(UID_SEPARATOR)
+        if len(parts) == 6 and parts[5].startswith("HID:"):
+            base_key = UID_SEPARATOR.join(parts[:5])
+            groups[base_key].append(uid)
 
-    location = parts[5]
-
-    if location.startswith("HID:"):
-        parts[5] = "hid"
-        return UID_SEPARATOR.join(parts)
-
-    return None
+    mapping: dict[str, str] = {}
+    for base_key, uids in groups.items():
+        uids.sort(key=lambda u: u.split(UID_SEPARATOR)[5])
+        for idx, uid in enumerate(uids):
+            new_uid = f"{base_key}{UID_SEPARATOR}hid_{idx}"
+            if uid != new_uid:
+                mapping[uid] = new_uid
+    return mapping
 
 
 def _async_migrate_unique_ids(hass: HomeAssistant, entry: OpenRGBConfigEntry) -> None:
-    """Migrate entity and device unique IDs to the new format."""
-    # Migrate entity unique IDs
+    """Migrate entity and device unique IDs to the new indexed HID format.
+
+    Old format: ...||HID: DevSrvsID:xxx  (raw location)
+    New format: ...||hid_N              (indexed)
+    """
     ent_reg = er.async_get(hass)
-    for entity in ent_reg.entities.get_entries_for_config_entry_id(entry.entry_id):
-        if new_uid := _migrate_uid(entity.unique_id):
+    dev_reg = dr.async_get(hass)
+
+    # --- Entity migration ---
+    entities = ent_reg.entities.get_entries_for_config_entry_id(entry.entry_id)
+    ent_map = _build_hid_index_map([e.unique_id for e in entities])
+    for entity in entities:
+        if new_uid := ent_map.get(entity.unique_id):
             _LOGGER.debug(
                 "Migrating entity unique ID from %s to %s",
                 entity.unique_id,
@@ -85,18 +99,21 @@ def _async_migrate_unique_ids(hass: HomeAssistant, entry: OpenRGBConfigEntry) ->
             )
             ent_reg.async_update_entity(entity.entity_id, new_unique_id=new_uid)
 
-    # Migrate device identifiers
-    dev_reg = dr.async_get(hass)
-    for device in dr.async_entries_for_config_entry(dev_reg, entry.entry_id):
-        new_identifiers: set[tuple[str, str]] = set()
-        changed = False
-        for domain, identifier in device.identifiers:
-            if domain == DOMAIN and (new_uid := _migrate_uid(identifier)):
-                new_identifiers.add((domain, new_uid))
-                changed = True
-            else:
-                new_identifiers.add((domain, identifier))
-        if changed:
+    # --- Device migration ---
+    devices = dr.async_entries_for_config_entry(dev_reg, entry.entry_id)
+    dev_ids = [
+        identifier
+        for device in devices
+        for domain, identifier in device.identifiers
+        if domain == DOMAIN
+    ]
+    dev_map = _build_hid_index_map(dev_ids)
+    for device in devices:
+        new_identifiers = {
+            (d, dev_map.get(i, i)) if d == DOMAIN else (d, i)
+            for d, i in device.identifiers
+        }
+        if new_identifiers != device.identifiers:
             _LOGGER.debug(
                 "Migrating device identifiers from %s to %s",
                 device.identifiers,

--- a/homeassistant/components/openrgb/__init__.py
+++ b/homeassistant/components/openrgb/__init__.py
@@ -55,7 +55,7 @@ def _migrate_uid(unique_id: str) -> str | None:
     """Migrate an old-format unique ID to the new format.
 
     Old format included raw location for all devices. New format drops location
-    for HID devices and for devices that have a serial number.
+    for HID devices.
 
     Returns the new unique ID, or None if no migration is needed.
     """
@@ -63,13 +63,12 @@ def _migrate_uid(unique_id: str) -> str | None:
     if len(parts) != 6:
         return None
 
-    serial = parts[4]
     location = parts[5]
 
     if location == "none":
         return None
 
-    if location.startswith("HID:") or serial != "none":
+    if location.startswith("HID:"):
         parts[5] = "none"
         return UID_SEPARATOR.join(parts)
 

--- a/homeassistant/components/openrgb/__init__.py
+++ b/homeassistant/components/openrgb/__init__.py
@@ -1,12 +1,16 @@
 """The OpenRGB integration."""
 
+import logging
+
 from homeassistant.const import CONF_NAME, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.device_registry import DeviceEntry
 
-from .const import DOMAIN
+from .const import DOMAIN, UID_SEPARATOR
 from .coordinator import OpenRGBConfigEntry, OpenRGBCoordinator
+
+_LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [Platform.LIGHT, Platform.SELECT]
 
@@ -31,6 +35,8 @@ def _setup_server_device_registry(
 
 async def async_setup_entry(hass: HomeAssistant, entry: OpenRGBConfigEntry) -> bool:
     """Set up OpenRGB from a config entry."""
+    _async_migrate_unique_ids(hass, entry)
+
     coordinator = OpenRGBCoordinator(hass, entry)
 
     await coordinator.async_config_entry_first_refresh()
@@ -43,6 +49,64 @@ async def async_setup_entry(hass: HomeAssistant, entry: OpenRGBConfigEntry) -> b
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
+
+
+def _migrate_uid(unique_id: str) -> str | None:
+    """Migrate an old-format unique ID to the new format.
+
+    Old format included raw location for all devices. New format drops location
+    for HID devices and for devices that have a serial number.
+
+    Returns the new unique ID, or None if no migration is needed.
+    """
+    parts = unique_id.split(UID_SEPARATOR)
+    if len(parts) != 6:
+        return None
+
+    serial = parts[4]
+    location = parts[5]
+
+    if location == "none":
+        return None
+
+    if location.startswith("HID:") or serial != "none":
+        parts[5] = "none"
+        return UID_SEPARATOR.join(parts)
+
+    return None
+
+
+def _async_migrate_unique_ids(hass: HomeAssistant, entry: OpenRGBConfigEntry) -> None:
+    """Migrate entity and device unique IDs to the new format."""
+    # Migrate entity unique IDs
+    ent_reg = er.async_get(hass)
+    for entity in ent_reg.entities.get_entries_for_config_entry_id(entry.entry_id):
+        if new_uid := _migrate_uid(entity.unique_id):
+            _LOGGER.debug(
+                "Migrating entity unique ID from %s to %s",
+                entity.unique_id,
+                new_uid,
+            )
+            ent_reg.async_update_entity(entity.entity_id, new_unique_id=new_uid)
+
+    # Migrate device identifiers
+    dev_reg = dr.async_get(hass)
+    for device in dr.async_entries_for_config_entry(dev_reg, entry.entry_id):
+        new_identifiers: set[tuple[str, str]] = set()
+        changed = False
+        for domain, identifier in device.identifiers:
+            if domain == DOMAIN and (new_uid := _migrate_uid(identifier)):
+                new_identifiers.add((domain, new_uid))
+                changed = True
+            else:
+                new_identifiers.add((domain, identifier))
+        if changed:
+            _LOGGER.debug(
+                "Migrating device identifiers from %s to %s",
+                device.identifiers,
+                new_identifiers,
+            )
+            dev_reg.async_update_device(device.id, new_identifiers=new_identifiers)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: OpenRGBConfigEntry) -> bool:

--- a/homeassistant/components/openrgb/__init__.py
+++ b/homeassistant/components/openrgb/__init__.py
@@ -65,11 +65,8 @@ def _migrate_uid(unique_id: str) -> str | None:
 
     location = parts[5]
 
-    if location == "none":
-        return None
-
     if location.startswith("HID:"):
-        parts[5] = "none"
+        parts[5] = "hid"
         return UID_SEPARATOR.join(parts)
 
     return None

--- a/homeassistant/components/openrgb/coordinator.py
+++ b/homeassistant/components/openrgb/coordinator.py
@@ -106,14 +106,28 @@ class OpenRGBCoordinator(DataUpdateCoordinator[dict[str, Device]]):
 
         Note: the OpenRGB device.id is intentionally not used because it is just
         a positional index that can change when devices are added or removed.
+
+        For HID devices without a serial number, the location string is excluded
+        because it contains a platform-specific path (e.g. DevSrvsID on macOS)
+        that changes every time the device is reconnected. For devices with a
+        serial number, location is not needed since serial is already unique.
+        For non-HID devices (e.g. I2C), location is more stable and is included.
         """
+        location = device.metadata.location or "none"
+        serial = device.metadata.serial or "none"
+
+        # HID location paths change on reconnect, so only include location
+        # for non-HID devices without a serial number
+        if location.startswith("HID:") or serial != "none":
+            location = "none"
+
         parts = (
             self.entry_id,
             device.type.name,
             device.metadata.vendor or "none",
             device.metadata.description or "none",
-            device.metadata.serial or "none",
-            device.metadata.location or "none",
+            serial,
+            location,
         )
         # Double pipe is readable and is unlikely to appear in metadata
         return UID_SEPARATOR.join(parts)

--- a/homeassistant/components/openrgb/coordinator.py
+++ b/homeassistant/components/openrgb/coordinator.py
@@ -93,13 +93,7 @@ class OpenRGBCoordinator(DataUpdateCoordinator[dict[str, Device]]):
         return self._index_devices(self.client.devices)
 
     def _index_devices(self, devices: list[Device]) -> dict[str, Device]:
-        """Build a dict of devices keyed by their stable unique key.
-
-        HID devices that share the same base key (identical model, no serial)
-        are sorted by their raw location string and then assigned incrementing
-        suffixes (hid_0, hid_1, …).  This matches the ordering used by the
-        unique-ID migration so indices stay consistent.
-        """
+        """Index devices by stable key, appending ``_N`` for duplicate HID keys."""
         result: dict[str, Device] = {}
         hid_groups: dict[str, list[Device]] = defaultdict(list)
         for device in devices:
@@ -128,13 +122,9 @@ class OpenRGBCoordinator(DataUpdateCoordinator[dict[str, Device]]):
     def _get_device_key(self, device: Device) -> str:
         """Build a stable device key.
 
-        Note: the OpenRGB device.id is intentionally not used because it is just
-        a positional index that can change when devices are added or removed.
-
-        For HID devices, the location string is excluded because it contains a
-        platform-specific path (e.g. DevSrvsID on macOS) that changes every time
-        the device is reconnected.
-        For non-HID devices (e.g. I2C), location is more stable and is included.
+        ``device.id`` is intentionally excluded (positional index).
+        HID locations are replaced with ``hid`` because they change on reconnect;
+        non-HID locations (e.g. I2C) are stable and kept as-is.
         """
         location = device.metadata.location or "none"
         serial = device.metadata.serial or "none"

--- a/homeassistant/components/openrgb/coordinator.py
+++ b/homeassistant/components/openrgb/coordinator.py
@@ -1,6 +1,7 @@
 """DataUpdateCoordinator for OpenRGB."""
 
 import asyncio
+from collections import defaultdict
 import logging
 
 from openrgb import OpenRGBClient
@@ -89,8 +90,31 @@ class OpenRGBCoordinator(DataUpdateCoordinator[dict[str, Device]]):
                     },
                 ) from err
 
-        # Return devices indexed by their key
-        return {self._get_device_key(device): device for device in self.client.devices}
+        return self._index_devices(self.client.devices)
+
+    def _index_devices(self, devices: list[Device]) -> dict[str, Device]:
+        """Build a dict of devices keyed by their stable unique key.
+
+        HID devices that share the same base key (identical model, no serial)
+        are sorted by their raw location string and then assigned incrementing
+        suffixes (hid_0, hid_1, …).  This matches the ordering used by the
+        unique-ID migration so indices stay consistent.
+        """
+        result: dict[str, Device] = {}
+        hid_groups: dict[str, list[Device]] = defaultdict(list)
+        for device in devices:
+            base_key = self._get_device_key(device)
+            if base_key.endswith(f"{UID_SEPARATOR}hid"):
+                hid_groups[base_key].append(device)
+            else:
+                result[base_key] = device
+
+        for base_key, group in hid_groups.items():
+            group.sort(key=lambda d: d.metadata.location or "")
+            for idx, device in enumerate(group):
+                result[f"{base_key}_{idx}"] = device
+
+        return result
 
     def _client_update(self) -> None:
         try:

--- a/homeassistant/components/openrgb/coordinator.py
+++ b/homeassistant/components/openrgb/coordinator.py
@@ -107,18 +107,17 @@ class OpenRGBCoordinator(DataUpdateCoordinator[dict[str, Device]]):
         Note: the OpenRGB device.id is intentionally not used because it is just
         a positional index that can change when devices are added or removed.
 
-        For HID devices without a serial number, the location string is excluded
-        because it contains a platform-specific path (e.g. DevSrvsID on macOS)
-        that changes every time the device is reconnected. For devices with a
-        serial number, location is not needed since serial is already unique.
+        For HID devices, the location string is excluded because it contains a
+        platform-specific path (e.g. DevSrvsID on macOS) that changes every time
+        the device is reconnected.
         For non-HID devices (e.g. I2C), location is more stable and is included.
         """
         location = device.metadata.location or "none"
         serial = device.metadata.serial or "none"
 
         # HID location paths change on reconnect, so only include location
-        # for non-HID devices without a serial number
-        if location.startswith("HID:") or serial != "none":
+        # for non-HID devices
+        if location.startswith("HID:"):
             location = "none"
 
         parts = (

--- a/homeassistant/components/openrgb/coordinator.py
+++ b/homeassistant/components/openrgb/coordinator.py
@@ -118,7 +118,7 @@ class OpenRGBCoordinator(DataUpdateCoordinator[dict[str, Device]]):
         # HID location paths change on reconnect, so only include location
         # for non-HID devices
         if location.startswith("HID:"):
-            location = "none"
+            location = "hid"
 
         parts = (
             self.entry_id,

--- a/tests/components/openrgb/conftest.py
+++ b/tests/components/openrgb/conftest.py
@@ -116,6 +116,23 @@ def mock_openrgb_client(mock_openrgb_device: MagicMock) -> Generator[MagicMock]:
 
 
 @pytest.fixture
+def create_mock_device(mock_openrgb_device: MagicMock):
+    """Factory to create a clone of the default mock device with overrides."""
+
+    def _create(**overrides: Any) -> MagicMock:
+        device = MagicMock()
+        for attr in ("type", "name", "modes", "colors", "zones", "leds", "active_mode"):
+            setattr(device, attr, getattr(mock_openrgb_device, attr))
+        for attr in ("vendor", "description", "serial", "location", "version"):
+            setattr(device.metadata, attr, getattr(mock_openrgb_device.metadata, attr))
+        for key, value in overrides.items():
+            setattr(device, key, value)
+        return device
+
+    return _create
+
+
+@pytest.fixture
 async def init_integration(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,

--- a/tests/components/openrgb/test_init.py
+++ b/tests/components/openrgb/test_init.py
@@ -347,3 +347,76 @@ async def test_normal_update_without_errors(
     state = hass.states.get("light.ene_dram")
     assert state
     assert state.state == STATE_ON
+
+
+async def test_device_key_stable_across_hid_reconnect(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_openrgb_client: MagicMock,
+    mock_openrgb_device: MagicMock,
+) -> None:
+    """Test that device key does not change when HID location changes on reconnect."""
+    mock_config_entry.add_to_hass(hass)
+
+    # Set HID location (like a USB keyboard)
+    mock_openrgb_device.metadata.location = "HID: DevSrvsID:4295213270"
+    mock_openrgb_device.metadata.serial = ""
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data
+    key_before = coordinator._get_device_key(mock_openrgb_device)
+
+    # Simulate reconnect with changed location
+    mock_openrgb_device.metadata.location = "HID: DevSrvsID:4295217216"
+    key_after = coordinator._get_device_key(mock_openrgb_device)
+
+    assert key_before == key_after
+
+
+async def test_device_key_uses_serial_ignores_location(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_openrgb_client: MagicMock,
+    mock_openrgb_device: MagicMock,
+) -> None:
+    """Test that device key uses serial and ignores location when serial is present."""
+    mock_config_entry.add_to_hass(hass)
+
+    mock_openrgb_device.metadata.serial = "ABC123"
+    mock_openrgb_device.metadata.location = "HID: DevSrvsID:111"
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data
+    key1 = coordinator._get_device_key(mock_openrgb_device)
+
+    mock_openrgb_device.metadata.location = "HID: DevSrvsID:222"
+    key2 = coordinator._get_device_key(mock_openrgb_device)
+
+    assert key1 == key2
+    assert "ABC123" in key1
+    assert "DevSrvsID" not in key1
+
+
+async def test_device_key_includes_location_for_i2c(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_openrgb_client: MagicMock,
+    mock_openrgb_device: MagicMock,
+) -> None:
+    """Test that device key includes location for non-HID devices without serial."""
+    mock_config_entry.add_to_hass(hass)
+
+    mock_openrgb_device.metadata.serial = ""
+    mock_openrgb_device.metadata.location = "I2C: PIIX4, address 0x70"
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data
+    key = coordinator._get_device_key(mock_openrgb_device)
+
+    assert "I2C: PIIX4, address 0x70" in key

--- a/tests/components/openrgb/test_init.py
+++ b/tests/components/openrgb/test_init.py
@@ -366,13 +366,16 @@ async def test_device_key_stable_across_hid_reconnect(
     await hass.async_block_till_done()
 
     coordinator = mock_config_entry.runtime_data
-    key_before = coordinator._get_device_key(mock_openrgb_device)
+    keys_before = list(coordinator.data.keys())
 
     # Simulate reconnect with changed location
     mock_openrgb_device.metadata.location = "HID: DevSrvsID:4295217216"
-    key_after = coordinator._get_device_key(mock_openrgb_device)
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
 
-    assert key_before == key_after
+    keys_after = list(coordinator.data.keys())
+    assert keys_before == keys_after
+    assert keys_before[0].endswith("hid_0")
 
 
 async def test_device_key_ignores_hid_location_with_serial(
@@ -391,14 +394,16 @@ async def test_device_key_ignores_hid_location_with_serial(
     await hass.async_block_till_done()
 
     coordinator = mock_config_entry.runtime_data
-    key1 = coordinator._get_device_key(mock_openrgb_device)
+    keys_before = list(coordinator.data.keys())
 
     mock_openrgb_device.metadata.location = "HID: DevSrvsID:222"
-    key2 = coordinator._get_device_key(mock_openrgb_device)
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
 
-    assert key1 == key2
-    assert "ABC123" in key1
-    assert "DevSrvsID" not in key1
+    keys_after = list(coordinator.data.keys())
+    assert keys_before == keys_after
+    assert "ABC123" in keys_before[0]
+    assert "DevSrvsID" not in keys_before[0]
 
 
 async def test_device_key_includes_location_for_i2c(
@@ -417,9 +422,51 @@ async def test_device_key_includes_location_for_i2c(
     await hass.async_block_till_done()
 
     coordinator = mock_config_entry.runtime_data
-    key = coordinator._get_device_key(mock_openrgb_device)
+    key = next(iter(coordinator.data))
 
     assert "I2C: PIIX4, address 0x70" in key
+
+
+async def test_device_key_duplicate_hid_devices(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_openrgb_client: MagicMock,
+    mock_openrgb_device: MagicMock,
+) -> None:
+    """Test that two identical HID devices get distinct indexed keys."""
+    mock_config_entry.add_to_hass(hass)
+
+    mock_openrgb_device.metadata.serial = ""
+    mock_openrgb_device.metadata.location = "HID: DevSrvsID:111"
+    mock_openrgb_device.id = 0
+
+    # Create a second identical device with a different HID location
+    second_device = MagicMock()
+    second_device.type = mock_openrgb_device.type
+    second_device.name = mock_openrgb_device.name
+    second_device.modes = mock_openrgb_device.modes
+    second_device.colors = mock_openrgb_device.colors
+    second_device.zones = mock_openrgb_device.zones
+    second_device.leds = mock_openrgb_device.leds
+    second_device.active_mode = mock_openrgb_device.active_mode
+    second_device.metadata.vendor = mock_openrgb_device.metadata.vendor
+    second_device.metadata.description = mock_openrgb_device.metadata.description
+    second_device.metadata.serial = ""
+    second_device.metadata.location = "HID: DevSrvsID:222"
+    second_device.metadata.version = mock_openrgb_device.metadata.version
+    second_device.id = 1
+
+    mock_openrgb_client.devices = [mock_openrgb_device, second_device]
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data
+    keys = list(coordinator.data.keys())
+
+    assert len(keys) == 2
+    assert keys[0].endswith("hid_0")
+    assert keys[1].endswith("hid_1")
 
 
 @pytest.mark.parametrize(
@@ -428,13 +475,13 @@ async def test_device_key_includes_location_for_i2c(
         pytest.param(
             "none",
             "HID: DevSrvsID:4295213270",
-            "hid",
+            "hid_0",
             id="hid_without_serial",
         ),
         pytest.param(
             "ABC123",
             "HID: DevSrvsID:111",
-            "hid",
+            "hid_0",
             id="hid_with_serial",
         ),
     ],
@@ -488,6 +535,61 @@ async def test_unique_id_migration(
     assert device_registry.async_get_device(identifiers={(DOMAIN, old_uid)}) is None
 
 
+async def test_unique_id_migration_duplicate_hid_devices(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_openrgb_client: MagicMock,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that two old HID entries with same base key get distinct indices."""
+    mock_config_entry.add_to_hass(hass)
+    entry_id = mock_config_entry.entry_id
+
+    old_uid_1 = UID_SEPARATOR.join(
+        [entry_id, "KEYBOARD", "Corsair", "K70", "none", "HID: DevSrvsID:111"]
+    )
+    old_uid_2 = UID_SEPARATOR.join(
+        [entry_id, "KEYBOARD", "Corsair", "K70", "none", "HID: DevSrvsID:222"]
+    )
+
+    for old_uid in (old_uid_1, old_uid_2):
+        device_registry.async_get_or_create(
+            config_entry_id=entry_id,
+            identifiers={(DOMAIN, old_uid)},
+            name="Corsair K70",
+        )
+        entity_registry.async_get_or_create(
+            "light",
+            DOMAIN,
+            old_uid,
+            config_entry=mock_config_entry,
+        )
+
+    await hass.config_entries.async_setup(entry_id)
+    await hass.async_block_till_done()
+
+    base = UID_SEPARATOR.join([entry_id, "KEYBOARD", "Corsair", "K70", "none"])
+    new_uid_0 = f"{base}{UID_SEPARATOR}hid_0"
+    new_uid_1 = f"{base}{UID_SEPARATOR}hid_1"
+
+    # Both entities should exist with indexed unique IDs
+    assert entity_registry.async_get_entity_id("light", DOMAIN, new_uid_0) is not None
+    assert entity_registry.async_get_entity_id("light", DOMAIN, new_uid_1) is not None
+
+    # Old unique IDs should no longer exist
+    assert entity_registry.async_get_entity_id("light", DOMAIN, old_uid_1) is None
+    assert entity_registry.async_get_entity_id("light", DOMAIN, old_uid_2) is None
+
+    # Device identifiers should be migrated
+    assert (
+        device_registry.async_get_device(identifiers={(DOMAIN, new_uid_0)}) is not None
+    )
+    assert (
+        device_registry.async_get_device(identifiers={(DOMAIN, new_uid_1)}) is not None
+    )
+
+
 async def test_unique_id_migration_no_change_for_i2c(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
@@ -528,7 +630,7 @@ async def test_unique_id_migration_already_migrated(
     mock_config_entry.add_to_hass(hass)
     entry_id = mock_config_entry.entry_id
 
-    uid = UID_SEPARATOR.join([entry_id, "KEYBOARD", "Corsair", "K70", "none", "hid"])
+    uid = UID_SEPARATOR.join([entry_id, "KEYBOARD", "Corsair", "K70", "none", "hid_0"])
 
     entity_registry.async_get_or_create(
         "light",

--- a/tests/components/openrgb/test_init.py
+++ b/tests/components/openrgb/test_init.py
@@ -1,6 +1,7 @@
 """Tests for the OpenRGB integration init."""
 
 import socket
+from typing import Any
 from unittest.mock import MagicMock
 
 from freezegun.api import FrozenDateTimeFactory
@@ -349,82 +350,55 @@ async def test_normal_update_without_errors(
     assert state.state == STATE_ON
 
 
-async def test_device_key_stable_across_hid_reconnect(
+@pytest.mark.parametrize(
+    ("serial", "location", "expected_suffix", "reconnect_location"),
+    [
+        pytest.param(
+            "", "HID: DevSrvsID:111", "hid_0", "HID: DevSrvsID:222", id="hid_no_serial"
+        ),
+        pytest.param(
+            "ABC123",
+            "HID: DevSrvsID:111",
+            "hid_0",
+            "HID: DevSrvsID:222",
+            id="hid_with_serial",
+        ),
+        pytest.param(
+            "",
+            "I2C: PIIX4, address 0x70",
+            "I2C: PIIX4, address 0x70",
+            None,
+            id="i2c",
+        ),
+    ],
+)
+async def test_device_key_stability(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_openrgb_client: MagicMock,
     mock_openrgb_device: MagicMock,
+    serial: str,
+    location: str,
+    expected_suffix: str,
+    reconnect_location: str | None,
 ) -> None:
-    """Test that device key does not change when HID location changes on reconnect."""
+    """Test device key format and stability across reconnects."""
     mock_config_entry.add_to_hass(hass)
-
-    # Set HID location (like a USB keyboard)
-    mock_openrgb_device.metadata.location = "HID: DevSrvsID:4295213270"
-    mock_openrgb_device.metadata.serial = ""
-
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    coordinator = mock_config_entry.runtime_data
-    keys_before = list(coordinator.data.keys())
-
-    # Simulate reconnect with changed location
-    mock_openrgb_device.metadata.location = "HID: DevSrvsID:4295217216"
-    await coordinator.async_refresh()
-    await hass.async_block_till_done()
-
-    keys_after = list(coordinator.data.keys())
-    assert keys_before == keys_after
-    assert keys_before[0].endswith("hid_0")
-
-
-async def test_device_key_ignores_hid_location_with_serial(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_openrgb_client: MagicMock,
-    mock_openrgb_device: MagicMock,
-) -> None:
-    """Test that device key ignores HID location even when serial is present."""
-    mock_config_entry.add_to_hass(hass)
-
-    mock_openrgb_device.metadata.serial = "ABC123"
-    mock_openrgb_device.metadata.location = "HID: DevSrvsID:111"
-
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    coordinator = mock_config_entry.runtime_data
-    keys_before = list(coordinator.data.keys())
-
-    mock_openrgb_device.metadata.location = "HID: DevSrvsID:222"
-    await coordinator.async_refresh()
-    await hass.async_block_till_done()
-
-    keys_after = list(coordinator.data.keys())
-    assert keys_before == keys_after
-    assert "ABC123" in keys_before[0]
-    assert "DevSrvsID" not in keys_before[0]
-
-
-async def test_device_key_includes_location_for_i2c(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_openrgb_client: MagicMock,
-    mock_openrgb_device: MagicMock,
-) -> None:
-    """Test that device key includes location for non-HID devices without serial."""
-    mock_config_entry.add_to_hass(hass)
-
-    mock_openrgb_device.metadata.serial = ""
-    mock_openrgb_device.metadata.location = "I2C: PIIX4, address 0x70"
+    mock_openrgb_device.metadata.serial = serial
+    mock_openrgb_device.metadata.location = location
 
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
     coordinator = mock_config_entry.runtime_data
     key = next(iter(coordinator.data))
+    assert key.endswith(expected_suffix)
 
-    assert "I2C: PIIX4, address 0x70" in key
+    if reconnect_location is not None:
+        mock_openrgb_device.metadata.location = reconnect_location
+        await coordinator.async_refresh()
+        await hass.async_block_till_done()
+        assert list(coordinator.data.keys()) == [key]
 
 
 async def test_device_key_duplicate_hid_devices(
@@ -432,6 +406,7 @@ async def test_device_key_duplicate_hid_devices(
     mock_config_entry: MockConfigEntry,
     mock_openrgb_client: MagicMock,
     mock_openrgb_device: MagicMock,
+    create_mock_device: Any,
 ) -> None:
     """Test that two identical HID devices get distinct indexed keys."""
     mock_config_entry.add_to_hass(hass)
@@ -440,21 +415,9 @@ async def test_device_key_duplicate_hid_devices(
     mock_openrgb_device.metadata.location = "HID: DevSrvsID:111"
     mock_openrgb_device.id = 0
 
-    # Create a second identical device with a different HID location
-    second_device = MagicMock()
-    second_device.type = mock_openrgb_device.type
-    second_device.name = mock_openrgb_device.name
-    second_device.modes = mock_openrgb_device.modes
-    second_device.colors = mock_openrgb_device.colors
-    second_device.zones = mock_openrgb_device.zones
-    second_device.leds = mock_openrgb_device.leds
-    second_device.active_mode = mock_openrgb_device.active_mode
-    second_device.metadata.vendor = mock_openrgb_device.metadata.vendor
-    second_device.metadata.description = mock_openrgb_device.metadata.description
+    second_device = create_mock_device(id=1)
     second_device.metadata.serial = ""
     second_device.metadata.location = "HID: DevSrvsID:222"
-    second_device.metadata.version = mock_openrgb_device.metadata.version
-    second_device.id = 1
 
     mock_openrgb_client.devices = [mock_openrgb_device, second_device]
 
@@ -470,20 +433,22 @@ async def test_device_key_duplicate_hid_devices(
 
 
 @pytest.mark.parametrize(
-    ("old_serial", "old_location", "expected_location"),
+    ("old_serial", "old_location", "expected_location", "expect_migration"),
     [
         pytest.param(
-            "none",
-            "HID: DevSrvsID:4295213270",
-            "hid_0",
-            id="hid_without_serial",
+            "none", "HID: DevSrvsID:4295213270", "hid_0", True, id="hid_without_serial"
         ),
         pytest.param(
-            "ABC123",
-            "HID: DevSrvsID:111",
-            "hid_0",
-            id="hid_with_serial",
+            "ABC123", "HID: DevSrvsID:111", "hid_0", True, id="hid_with_serial"
         ),
+        pytest.param(
+            "none",
+            "I2C: PIIX4, address 0x70",
+            "I2C: PIIX4, address 0x70",
+            False,
+            id="i2c_no_change",
+        ),
+        pytest.param("none", "hid_0", "hid_0", False, id="already_migrated"),
     ],
 )
 async def test_unique_id_migration(
@@ -495,8 +460,9 @@ async def test_unique_id_migration(
     old_serial: str,
     old_location: str,
     expected_location: str,
+    expect_migration: bool,
 ) -> None:
-    """Test that old-format unique IDs are migrated on setup."""
+    """Test unique ID migration for various location formats."""
     mock_config_entry.add_to_hass(hass)
     entry_id = mock_config_entry.entry_id
 
@@ -507,7 +473,6 @@ async def test_unique_id_migration(
         [entry_id, "DRAM", "ENE", "ENE DRAM", old_serial, expected_location]
     )
 
-    # Pre-create device and entity with old-format unique IDs
     device_registry.async_get_or_create(
         config_entry_id=entry_id,
         identifiers={(DOMAIN, old_uid)},
@@ -523,16 +488,14 @@ async def test_unique_id_migration(
     await hass.config_entries.async_setup(entry_id)
     await hass.async_block_till_done()
 
-    # Entity should be migrated
-    migrated = entity_registry.async_get_entity_id("light", DOMAIN, new_uid)
-    assert migrated is not None
-
-    # Old unique ID should no longer exist
-    assert entity_registry.async_get_entity_id("light", DOMAIN, old_uid) is None
-
-    # Device identifier should be migrated
+    assert entity_registry.async_get_entity_id("light", DOMAIN, new_uid) is not None
     assert device_registry.async_get_device(identifiers={(DOMAIN, new_uid)}) is not None
-    assert device_registry.async_get_device(identifiers={(DOMAIN, old_uid)}) is None
+    assert (
+        entity_registry.async_get_entity_id("light", DOMAIN, old_uid) is None
+    ) == expect_migration
+    assert (
+        device_registry.async_get_device(identifiers={(DOMAIN, old_uid)}) is None
+    ) == expect_migration
 
 
 async def test_unique_id_migration_duplicate_hid_devices(
@@ -588,59 +551,3 @@ async def test_unique_id_migration_duplicate_hid_devices(
     assert (
         device_registry.async_get_device(identifiers={(DOMAIN, new_uid_1)}) is not None
     )
-
-
-async def test_unique_id_migration_no_change_for_i2c(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_openrgb_client: MagicMock,
-    device_registry: dr.DeviceRegistry,
-    entity_registry: er.EntityRegistry,
-) -> None:
-    """Test that I2C devices without serial keep their location in the unique ID."""
-    mock_config_entry.add_to_hass(hass)
-    entry_id = mock_config_entry.entry_id
-
-    uid = UID_SEPARATOR.join(
-        [entry_id, "DRAM", "ENE", "ENE DRAM", "none", "I2C: PIIX4, address 0x70"]
-    )
-
-    # Pre-create entity with I2C location (should not be migrated)
-    entity_registry.async_get_or_create(
-        "light",
-        DOMAIN,
-        uid,
-        config_entry=mock_config_entry,
-    )
-
-    await hass.config_entries.async_setup(entry_id)
-    await hass.async_block_till_done()
-
-    # Entity should remain unchanged
-    assert entity_registry.async_get_entity_id("light", DOMAIN, uid) is not None
-
-
-async def test_unique_id_migration_already_migrated(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_openrgb_client: MagicMock,
-    entity_registry: er.EntityRegistry,
-) -> None:
-    """Test that already-migrated unique IDs are not changed again."""
-    mock_config_entry.add_to_hass(hass)
-    entry_id = mock_config_entry.entry_id
-
-    uid = UID_SEPARATOR.join([entry_id, "KEYBOARD", "Corsair", "K70", "none", "hid_0"])
-
-    entity_registry.async_get_or_create(
-        "light",
-        DOMAIN,
-        uid,
-        config_entry=mock_config_entry,
-    )
-
-    await hass.config_entries.async_setup(entry_id)
-    await hass.async_block_till_done()
-
-    # Entity should remain unchanged
-    assert entity_registry.async_get_entity_id("light", DOMAIN, uid) is not None

--- a/tests/components/openrgb/test_init.py
+++ b/tests/components/openrgb/test_init.py
@@ -12,7 +12,7 @@ from homeassistant.components.openrgb.const import DOMAIN, SCAN_INTERVAL, UID_SE
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -420,3 +420,131 @@ async def test_device_key_includes_location_for_i2c(
     key = coordinator._get_device_key(mock_openrgb_device)
 
     assert "I2C: PIIX4, address 0x70" in key
+
+
+@pytest.mark.parametrize(
+    ("old_serial", "old_location", "expected_location"),
+    [
+        pytest.param(
+            "none",
+            "HID: DevSrvsID:4295213270",
+            "none",
+            id="hid_without_serial",
+        ),
+        pytest.param(
+            "ABC123",
+            "HID: DevSrvsID:111",
+            "none",
+            id="hid_with_serial",
+        ),
+        pytest.param(
+            "ABC123",
+            "I2C: PIIX4, address 0x70",
+            "none",
+            id="non_hid_with_serial",
+        ),
+    ],
+)
+async def test_unique_id_migration(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_openrgb_client: MagicMock,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    old_serial: str,
+    old_location: str,
+    expected_location: str,
+) -> None:
+    """Test that old-format unique IDs are migrated on setup."""
+    mock_config_entry.add_to_hass(hass)
+    entry_id = mock_config_entry.entry_id
+
+    old_uid = UID_SEPARATOR.join(
+        [entry_id, "DRAM", "ENE", "ENE DRAM", old_serial, old_location]
+    )
+    new_uid = UID_SEPARATOR.join(
+        [entry_id, "DRAM", "ENE", "ENE DRAM", old_serial, expected_location]
+    )
+
+    # Pre-create device and entity with old-format unique IDs
+    device_registry.async_get_or_create(
+        config_entry_id=entry_id,
+        identifiers={(DOMAIN, old_uid)},
+        name="ENE DRAM",
+    )
+    entity_registry.async_get_or_create(
+        "light",
+        DOMAIN,
+        old_uid,
+        config_entry=mock_config_entry,
+    )
+
+    await hass.config_entries.async_setup(entry_id)
+    await hass.async_block_till_done()
+
+    # Entity should be migrated
+    migrated = entity_registry.async_get_entity_id("light", DOMAIN, new_uid)
+    assert migrated is not None
+
+    # Old unique ID should no longer exist
+    assert entity_registry.async_get_entity_id("light", DOMAIN, old_uid) is None
+
+    # Device identifier should be migrated
+    assert device_registry.async_get_device(identifiers={(DOMAIN, new_uid)}) is not None
+    assert device_registry.async_get_device(identifiers={(DOMAIN, old_uid)}) is None
+
+
+async def test_unique_id_migration_no_change_for_i2c(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_openrgb_client: MagicMock,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that I2C devices without serial keep their location in the unique ID."""
+    mock_config_entry.add_to_hass(hass)
+    entry_id = mock_config_entry.entry_id
+
+    uid = UID_SEPARATOR.join(
+        [entry_id, "DRAM", "ENE", "ENE DRAM", "none", "I2C: PIIX4, address 0x70"]
+    )
+
+    # Pre-create entity with I2C location (should not be migrated)
+    entity_registry.async_get_or_create(
+        "light",
+        DOMAIN,
+        uid,
+        config_entry=mock_config_entry,
+    )
+
+    await hass.config_entries.async_setup(entry_id)
+    await hass.async_block_till_done()
+
+    # Entity should remain unchanged
+    assert entity_registry.async_get_entity_id("light", DOMAIN, uid) is not None
+
+
+async def test_unique_id_migration_already_migrated(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_openrgb_client: MagicMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that already-migrated unique IDs are not changed again."""
+    mock_config_entry.add_to_hass(hass)
+    entry_id = mock_config_entry.entry_id
+
+    uid = UID_SEPARATOR.join([entry_id, "KEYBOARD", "Corsair", "K70", "none", "none"])
+
+    entity_registry.async_get_or_create(
+        "light",
+        DOMAIN,
+        uid,
+        config_entry=mock_config_entry,
+    )
+
+    await hass.config_entries.async_setup(entry_id)
+    await hass.async_block_till_done()
+
+    # Entity should remain unchanged
+    assert entity_registry.async_get_entity_id("light", DOMAIN, uid) is not None

--- a/tests/components/openrgb/test_init.py
+++ b/tests/components/openrgb/test_init.py
@@ -375,13 +375,13 @@ async def test_device_key_stable_across_hid_reconnect(
     assert key_before == key_after
 
 
-async def test_device_key_uses_serial_ignores_location(
+async def test_device_key_ignores_hid_location_with_serial(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_openrgb_client: MagicMock,
     mock_openrgb_device: MagicMock,
 ) -> None:
-    """Test that device key uses serial and ignores location when serial is present."""
+    """Test that device key ignores HID location even when serial is present."""
     mock_config_entry.add_to_hass(hass)
 
     mock_openrgb_device.metadata.serial = "ABC123"
@@ -436,12 +436,6 @@ async def test_device_key_includes_location_for_i2c(
             "HID: DevSrvsID:111",
             "none",
             id="hid_with_serial",
-        ),
-        pytest.param(
-            "ABC123",
-            "I2C: PIIX4, address 0x70",
-            "none",
-            id="non_hid_with_serial",
         ),
     ],
 )

--- a/tests/components/openrgb/test_init.py
+++ b/tests/components/openrgb/test_init.py
@@ -428,13 +428,13 @@ async def test_device_key_includes_location_for_i2c(
         pytest.param(
             "none",
             "HID: DevSrvsID:4295213270",
-            "none",
+            "hid",
             id="hid_without_serial",
         ),
         pytest.param(
             "ABC123",
             "HID: DevSrvsID:111",
-            "none",
+            "hid",
             id="hid_with_serial",
         ),
     ],
@@ -528,7 +528,7 @@ async def test_unique_id_migration_already_migrated(
     mock_config_entry.add_to_hass(hass)
     entry_id = mock_config_entry.entry_id
 
-    uid = UID_SEPARATOR.join([entry_id, "KEYBOARD", "Corsair", "K70", "none", "none"])
+    uid = UID_SEPARATOR.join([entry_id, "KEYBOARD", "Corsair", "K70", "none", "hid"])
 
     entity_registry.async_get_or_create(
         "light",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Currently, the OpenRGB integration uses the device location for defining the unique id.

However, for HID devices, the location can change whenever it's plugged into another port.

This fixes the unique id generation for OpenRGB to not take HID device's location into account.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is a follow-up to https://github.com/home-assistant/core/pull/167603

- This PR fixes or closes issue:
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
