### PR TITLE
Bump fyta_cli to 0.7.3

### DIFF
--- a/homeassistant/components/fyta/manifest.json
+++ b/homeassistant/components/fyta/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["fyta_cli"],
   "quality_scale": "platinum",
-  "requirements": ["fyta_cli==0.7.2"]
+  "requirements": ["fyta_cli==0.7.3"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1062,7 +1062,7 @@ fritzconnection[qr]==1.15.1
 fumis==0.4.0
 
 # homeassistant.components.fyta
-fyta_cli==0.7.2
+fyta_cli==0.7.3
 
 # homeassistant.components.google_translate
 gTTS==2.5.3


### PR DESCRIPTION
## Proposed change

Bump fyta_cli from 0.7.2 to 0.7.3.

**Upstream links:**
- Changelog: https://github.com/dontinelli/fyta_cli/blob/master/CHANGELOG.md
- Release: https://github.com/dontinelli/fyta_cli/releases/tag/v0.7.3
- Diff: https://github.com/dontinelli/fyta_cli/compare/v0.7.2...v0.7.3

**Changes in 0.7.3:**
- Fix inverted token expiration check before API requests ([dontinelli/fyta_cli#36](https://github.com/dontinelli/fyta_cli/pull/36))
- Dependency bumps (aiohttp)

The main fix corrects an inverted token expiration check that could cause unnecessary token refreshes or stale token usage. No changes needed on the Home Assistant side.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr