### PR TITLE
Bump solax to 3.2.4

### DIFF
--- a/homeassistant/components/solax/manifest.json
+++ b/homeassistant/components/solax/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["solax"],
-  "requirements": ["solax==3.2.3"]
+  "requirements": ["solax==3.2.4"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3064,7 +3064,7 @@ solarlog_cli==0.7.1
 solarman-opendata==0.0.3
 
 # homeassistant.components.solax
-solax==3.2.3
+solax==3.2.4
 
 # homeassistant.components.somfy_mylink
 somfy-mylink-synergy==1.0.6


### PR DESCRIPTION
## Proposed change

Bump solax from 3.2.3 to 3.2.4.

**Upstream links:**
- Diff: https://github.com/squishykid/solax/compare/v3.2.3...v3.2.4

**Changes in 3.2.4:**
- Fix discovery for X1 Smart with v3 firmware ([squishykid/solax#184](https://github.com/squishykid/solax/pull/184))
- Fix unique IDs error for battery_mode on X3hybridG4 ([squishykid/solax#186](https://github.com/squishykid/solax/pull/186))
- Fix X3 Hybrid G4 with PocketWiFi V2 not working via LAN ([squishykid/solax#189](https://github.com/squishykid/solax/pull/189))
- Add X1-Lite-LV inverter support ([squishykid/solax#190](https://github.com/squishykid/solax/pull/190))

Bug fixes for several inverter models and new device support. No changes needed on the Home Assistant side.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr