### PR TITLE
Fix CCM15 temperature unit to follow the device's C/F setting

### DIFF
--- a/homeassistant/components/ccm15/climate.py
+++ b/homeassistant/components/ccm15/climate.py
@@ -94,7 +94,13 @@ class CCM15Climate(CoordinatorEntity[CCM15Coordinator], ClimateEntity):
 
     @property
     def temperature_unit(self) -> str:
-        """Return the unit of measurement reported by the device."""
+        """Return the unit of measurement reported by the device.
+
+        The CCM15 ships in Celsius and only reports Fahrenheit when the user
+        explicitly switches the controller to it, so Celsius is both the
+        default and the fallback when no data has been read yet. Fahrenheit is
+        returned only when the device states it via ``is_celsius``.
+        """
         if (data := self.data) is not None and not data.is_celsius:
             return UnitOfTemperature.FAHRENHEIT
         return UnitOfTemperature.CELSIUS

--- a/homeassistant/components/ccm15/climate.py
+++ b/homeassistant/components/ccm15/climate.py
@@ -94,14 +94,7 @@ class CCM15Climate(CoordinatorEntity[CCM15Coordinator], ClimateEntity):
 
     @property
     def temperature_unit(self) -> str:
-        """Return the unit of measurement reported by the device.
-
-        The CCM15 ships in Celsius and only reports Fahrenheit when the user
-        explicitly switches the controller to it, so Celsius is both the
-        default and the fallback when no data has been read yet. Fahrenheit is
-        returned only when the device signals non-Celsius mode (``is_celsius``
-        is ``False``).
-        """
+        """Return the unit of measurement reported by the device."""
         if (data := self.data) is not None and not data.is_celsius:
             return UnitOfTemperature.FAHRENHEIT
         return UnitOfTemperature.CELSIUS

--- a/homeassistant/components/ccm15/climate.py
+++ b/homeassistant/components/ccm15/climate.py
@@ -49,7 +49,6 @@ async def async_setup_entry(
 class CCM15Climate(CoordinatorEntity[CCM15Coordinator], ClimateEntity):
     """Climate device for CCM15 coordinator."""
 
-    _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_has_entity_name = True
     _attr_target_temperature_step = PRECISION_WHOLE
     _attr_hvac_modes = [
@@ -92,6 +91,13 @@ class CCM15Climate(CoordinatorEntity[CCM15Coordinator], ClimateEntity):
     def data(self) -> CCM15SlaveDevice | None:
         """Return device data."""
         return self.coordinator.get_ac_data(self._ac_index)
+
+    @property
+    def temperature_unit(self) -> str:
+        """Return the unit of measurement reported by the device."""
+        if (data := self.data) is not None and not data.is_celsius:
+            return UnitOfTemperature.FAHRENHEIT
+        return UnitOfTemperature.CELSIUS
 
     @property
     def current_temperature(self) -> int | None:

--- a/homeassistant/components/ccm15/climate.py
+++ b/homeassistant/components/ccm15/climate.py
@@ -99,7 +99,8 @@ class CCM15Climate(CoordinatorEntity[CCM15Coordinator], ClimateEntity):
         The CCM15 ships in Celsius and only reports Fahrenheit when the user
         explicitly switches the controller to it, so Celsius is both the
         default and the fallback when no data has been read yet. Fahrenheit is
-        returned only when the device states it via ``is_celsius``.
+        returned only when the device signals non-Celsius mode (``is_celsius``
+        is ``False``).
         """
         if (data := self.data) is not None and not data.is_celsius:
             return UnitOfTemperature.FAHRENHEIT

--- a/tests/components/ccm15/test_climate.py
+++ b/tests/components/ccm15/test_climate.py
@@ -22,7 +22,13 @@ from homeassistant.components.climate import (
     SERVICE_TURN_ON,
     HVACMode,
 )
-from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST, CONF_PORT, SERVICE_TURN_OFF
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_HOST,
+    CONF_PORT,
+    SERVICE_TURN_OFF,
+    UnitOfTemperature,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
@@ -135,14 +141,7 @@ async def test_climate_state(
 
 
 async def test_climate_fahrenheit_unit(hass: HomeAssistant) -> None:
-    """A controller set to Fahrenheit is reported in Fahrenheit.
-
-    Byte 0 bit 0 of the status flags the unit; this device reports it set, so
-    the entity must expose Fahrenheit rather than the hardcoded Celsius. Under
-    the US unit system the device's native values then pass through unconverted
-    (target 86 °F, current 75 °F); were the entity still reporting Celsius they
-    would be converted and differ.
-    """
+    """A controller set to Fahrenheit is reported in Fahrenheit."""
     hass.config.units = US_CUSTOMARY_SYSTEM
     device_state = CCM15DeviceState(
         devices={0: CCM15SlaveDevice(bytes.fromhex("01000041c0004b"))}
@@ -161,6 +160,15 @@ async def test_climate_fahrenheit_unit(hass: HomeAssistant) -> None:
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
+    # The entity must report the device's Fahrenheit unit, not hardcoded Celsius.
+    climate_component = hass.data[CLIMATE_DOMAIN]
+    entity = climate_component.get_entity("climate.midea_0")
+    assert entity is not None
+    assert entity.temperature_unit == UnitOfTemperature.FAHRENHEIT
+
+    # With the entity already in Fahrenheit under the US system, the device's
+    # native values pass through unconverted; were it still Celsius they would
+    # be converted and differ.
     state = hass.states.get("climate.midea_0")
     assert state is not None
     assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 75

--- a/tests/components/ccm15/test_climate.py
+++ b/tests/components/ccm15/test_climate.py
@@ -140,12 +140,12 @@ async def test_climate_fahrenheit_unit(hass: HomeAssistant) -> None:
     Byte 0 bit 0 of the status flags the unit; this device reports it set, so
     the entity must expose Fahrenheit rather than the hardcoded Celsius. Under
     the US unit system the device's native values then pass through unconverted
-    (target 86 °F, current 26 °F); were the entity still reporting Celsius they
+    (target 86 °F, current 75 °F); were the entity still reporting Celsius they
     would be converted and differ.
     """
     hass.config.units = US_CUSTOMARY_SYSTEM
     device_state = CCM15DeviceState(
-        devices={0: CCM15SlaveDevice(bytes.fromhex("01000041c0001a"))}
+        devices={0: CCM15SlaveDevice(bytes.fromhex("01000041c0004b"))}
     )
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -163,5 +163,5 @@ async def test_climate_fahrenheit_unit(hass: HomeAssistant) -> None:
 
     state = hass.states.get("climate.midea_0")
     assert state is not None
-    assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 26
+    assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 75
     assert state.attributes[ATTR_TEMPERATURE] == 86

--- a/tests/components/ccm15/test_climate.py
+++ b/tests/components/ccm15/test_climate.py
@@ -3,13 +3,14 @@
 from datetime import timedelta
 from unittest.mock import patch
 
-from ccm15 import CCM15DeviceState
+from ccm15 import CCM15DeviceState, CCM15SlaveDevice
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.ccm15.const import DOMAIN
 from homeassistant.components.climate import (
+    ATTR_CURRENT_TEMPERATURE,
     ATTR_FAN_MODE,
     ATTR_HVAC_MODE,
     ATTR_TEMPERATURE,
@@ -24,6 +25,7 @@ from homeassistant.components.climate import (
 from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST, CONF_PORT, SERVICE_TURN_OFF
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.util.unit_system import US_CUSTOMARY_UNITS
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -130,3 +132,36 @@ async def test_climate_state(
 
     assert hass.states.get("climate.midea_0") == snapshot
     assert hass.states.get("climate.midea_1") == snapshot
+
+
+async def test_climate_fahrenheit_unit(hass: HomeAssistant) -> None:
+    """A controller set to Fahrenheit is reported in Fahrenheit.
+
+    Byte 0 bit 0 of the status flags the unit; this device reports it set, so
+    the entity must expose Fahrenheit rather than the hardcoded Celsius. Under
+    the US unit system the device's native values then pass through unconverted
+    (target 86 °F, current 26 °F); were the entity still reporting Celsius they
+    would be converted and differ.
+    """
+    hass.config.units = US_CUSTOMARY_UNITS
+    device_state = CCM15DeviceState(
+        devices={0: CCM15SlaveDevice(bytes.fromhex("01000041c0001a"))}
+    )
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="1.1.1.1",
+        data={CONF_HOST: "1.1.1.1", CONF_PORT: 80},
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.ccm15.coordinator.CCM15Device.get_status_async",
+        return_value=device_state,
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("climate.midea_0")
+    assert state is not None
+    assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 26
+    assert state.attributes[ATTR_TEMPERATURE] == 86

--- a/tests/components/ccm15/test_climate.py
+++ b/tests/components/ccm15/test_climate.py
@@ -25,7 +25,7 @@ from homeassistant.components.climate import (
 from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST, CONF_PORT, SERVICE_TURN_OFF
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
-from homeassistant.util.unit_system import US_CUSTOMARY_UNITS
+from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -143,7 +143,7 @@ async def test_climate_fahrenheit_unit(hass: HomeAssistant) -> None:
     (target 86 °F, current 26 °F); were the entity still reporting Celsius they
     would be converted and differ.
     """
-    hass.config.units = US_CUSTOMARY_UNITS
+    hass.config.units = US_CUSTOMARY_SYSTEM
     device_state = CCM15DeviceState(
         devices={0: CCM15SlaveDevice(bytes.fromhex("01000041c0001a"))}
     )


### PR DESCRIPTION
## Proposed change

The CCM15 controller can be configured (by the user, on the hardware) to report
temperatures in either Celsius or Fahrenheit. The `py_ccm15` library already
decodes this and exposes it as `CCM15SlaveDevice.is_celsius`, applying the
appropriate scaling to the setpoint. The integration, however, hardcodes
`_attr_temperature_unit = UnitOfTemperature.CELSIUS` and ignores the flag, so a
Fahrenheit-configured device shows its values labeled as `°C`, and the
target-temperature slider range is wrong.

This change derives `temperature_unit` from `is_celsius` instead of hardcoding
Celsius. Celsius remains the default (the CCM15 ships in Celsius and the
no-data fallback stays Celsius); Fahrenheit is returned only when the device
explicitly reports it. For the common Celsius case behaviour is unchanged; for
Fahrenheit devices both the setpoint and the current temperature are now
correctly labeled `°F` and the base `ClimateEntity` converts the default
min/max bounds into the reported unit. The controller reports the current
temperature directly in the active display unit and the library scales the
setpoint accordingly (verified on a real unit).

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr