### PR TITLE
Redact raw payload fields in Duco diagnostics

### DIFF
--- a/homeassistant/components/duco/diagnostics.py
+++ b/homeassistant/components/duco/diagnostics.py
@@ -19,11 +19,19 @@ from .coordinator import DucoConfigEntry
 TO_REDACT = {
     CONF_HOST,
     "mac",
+    "Mac",
     "host_name",
+    "HostName",
     "serial_board_box",
+    "SerialBoardBox",
     "serial_board_comm",
+    "SerialBoardComm",
     "serial_duco_box",
+    "SerialDucoBox",
     "serial_duco_comm",
+    "SerialDucoComm",
+    "WifiApKey",
+    "WifiApSsid",
 }
 
 

--- a/tests/components/duco/test_diagnostics.py
+++ b/tests/components/duco/test_diagnostics.py
@@ -132,3 +132,51 @@ async def test_diagnostics_without_optional_api_metadata(
             mock_duco_client.async_get_api_info.return_value.api_version
         )
     }
+
+
+async def test_diagnostics_redacts_raw_payload_keys(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_config_entry: MockConfigEntry,
+    mock_duco_client: AsyncMock,
+) -> None:
+    """Test that raw payload API key variants are redacted."""
+    mock_duco_client.async_get_board_info.return_value = replace(
+        mock_duco_client.async_get_board_info.return_value,
+        raw_payload={
+            "SerialBoardBox": {"Val": "ABC123"},
+            "SerialBoardComm": {"Val": "DEF456"},
+            "SerialDucoBox": {"Val": "GHI789"},
+            "SerialDucoComm": {"Val": "JKL012"},
+        },
+    )
+    mock_duco_client.async_get_lan_info.return_value = replace(
+        mock_duco_client.async_get_lan_info.return_value,
+        raw_payload={
+            "Mac": {"Val": "aa:bb:cc:dd:ee:ff"},
+            "HostName": {"Val": "duco-box"},
+            "WifiApKey": {"Val": "12345678"},
+            "WifiApSsid": {"Val": "DUCO"},
+        },
+    )
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    diagnostics = await get_diagnostics_for_config_entry(
+        hass, hass_client, mock_config_entry
+    )
+
+    assert diagnostics["board_info"]["raw_payload"] == {
+        "SerialBoardBox": "**REDACTED**",
+        "SerialBoardComm": "**REDACTED**",
+        "SerialDucoBox": "**REDACTED**",
+        "SerialDucoComm": "**REDACTED**",
+    }
+    assert diagnostics["lan_info"]["raw_payload"] == {
+        "Mac": "**REDACTED**",
+        "HostName": "**REDACTED**",
+        "WifiApKey": "**REDACTED**",
+        "WifiApSsid": "**REDACTED**",
+    }


### PR DESCRIPTION
## Proposed change
This change fixes a privacy leak in Duco diagnostics where sensitive values inside preserved `raw_payload` data were not redacted because the diagnostics redaction list only covered the normalized snake_case field names.

Thanks to @witterholt for responsibly reporting this privacy issue.

The diagnostics payload now also redacts the API-style raw payload keys for MAC address, host name, serial identifiers, and Wi-Fi access point fields. A regression test covers the raw payload variants so diagnostics no longer expose those values in support exports.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr