### PR TITLE
Fix BSCO2 sensors not being added in Duco

### DIFF
--- a/homeassistant/components/duco/sensor.py
+++ b/homeassistant/components/duco/sensor.py
@@ -95,7 +95,12 @@ SENSOR_DESCRIPTIONS: tuple[DucoSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
         value_fn=lambda node: node.sensor.co2 if node.sensor else None,
-        node_types=(NodeType.UCCO2, NodeType.VLVCO2, NodeType.VLVCO2RH),
+        node_types=(
+            NodeType.BSCO2,
+            NodeType.UCCO2,
+            NodeType.VLVCO2,
+            NodeType.VLVCO2RH,
+        ),
     ),
     DucoSensorEntityDescription(
         key="iaq_co2",
@@ -104,7 +109,12 @@ SENSOR_DESCRIPTIONS: tuple[DucoSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
         value_fn=lambda node: node.sensor.iaq_co2 if node.sensor else None,
-        node_types=(NodeType.UCCO2, NodeType.VLVCO2, NodeType.VLVCO2RH),
+        node_types=(
+            NodeType.BSCO2,
+            NodeType.UCCO2,
+            NodeType.VLVCO2,
+            NodeType.VLVCO2RH,
+        ),
     ),
     DucoSensorEntityDescription(
         key="humidity",

--- a/tests/components/duco/fixtures/dynamic_sensor_nodes.json
+++ b/tests/components/duco/fixtures/dynamic_sensor_nodes.json
@@ -50,5 +50,31 @@
       "iaq_rh": null,
       "temp": 20.5
     }
+  },
+  {
+    "node_id": 202,
+    "general": {
+      "node_type": "BSCO2",
+      "sub_type": 0,
+      "network_type": "VIRT",
+      "parent": 1,
+      "asso": 1,
+      "name": "New box co2 sensor",
+      "identify": 0
+    },
+    "ventilation": {
+      "state": "AUTO",
+      "time_state_remain": 0,
+      "time_state_end": 0,
+      "mode": "-",
+      "flow_lvl_tgt": null
+    },
+    "sensor": {
+      "co2": 421,
+      "iaq_co2": 100,
+      "rh": null,
+      "iaq_rh": null,
+      "temp": null
+    }
   }
 ]

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -140,23 +140,37 @@ async def test_lan_info_failures_keep_node_entities_available(
 
 
 @pytest.mark.parametrize(
-    ("node_id", "expected_entity_id", "expected_state"),
+    (
+        "node_id",
+        "expected_entity_id",
+        "expected_state",
+        "expected_disabled_entity_id",
+    ),
     [
         (
             200,
             "sensor.new_rh_sensor_humidity",
             "55.0",
+            "sensor.new_rh_sensor_humidity_air_quality_index",
         ),
         (
             201,
             "sensor.new_valve_carbon_dioxide",
             "575",
+            "sensor.new_valve_co2_air_quality_index",
+        ),
+        (
+            202,
+            "sensor.new_box_co2_sensor_carbon_dioxide",
+            "421",
+            "sensor.new_box_co2_sensor_co2_air_quality_index",
         ),
     ],
 )
 @pytest.mark.usefixtures("init_integration")
 async def test_new_node_added_dynamically(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     mock_duco_client: AsyncMock,
     mock_sensor_nodes: list[Node],
     dynamic_sensor_nodes: dict[int, Node],
@@ -164,6 +178,7 @@ async def test_new_node_added_dynamically(
     node_id: int,
     expected_entity_id: str,
     expected_state: str,
+    expected_disabled_entity_id: str,
 ) -> None:
     """Test a new node appearing in coordinator data creates entities automatically."""
     assert hass.states.get(expected_entity_id) is None
@@ -178,6 +193,10 @@ async def test_new_node_added_dynamically(
     state = hass.states.get(expected_entity_id)
     assert state is not None
     assert state.state == expected_state
+
+    entry = entity_registry.async_get(expected_disabled_entity_id)
+    assert entry is not None
+    assert entry.disabled_by == er.RegistryEntryDisabler.INTEGRATION
 
 
 @pytest.mark.usefixtures("init_integration")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
This change fixes Duco `BSCO2` nodes not being exposed as Home Assistant sensors even though the device reports valid CO2 data.

The integration currently creates CO2 entities only for a subset of known node types. `BSCO2` was missing from that capability mapping, so these nodes were skipped during entity setup. This change adds `BSCO2` to the CO2 and IAQ CO2 sensor mappings and extends the existing dynamic node regression coverage to include that node type.

Thanks to @witterholt for raising the feature request and providing the diagnostics context that made the missing node type easy to pinpoint.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr