### PR TITLE
Add config subentries for Teslemetry vehicles and energy sites

### DIFF
--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -663,7 +663,11 @@ def _migrate_devices_to_subentries(
         if device.via_device_id is not None:
             wall_connectors.append((device, device.via_device_id))
             continue
-        identifier = next(i[1] for i in device.identifiers if i[0] == DOMAIN)
+        identifier = next((i[1] for i in device.identifiers if i[0] == DOMAIN), None)
+        if identifier is None:
+            # Skip stale or manually created devices that have no Teslemetry
+            # identifier; there is no product to map them to.
+            continue
         if identifier.isdigit():
             subentry_id = _ensure_subentry(
                 hass,
@@ -688,6 +692,11 @@ def _migrate_devices_to_subentries(
     for device, via_device_id in wall_connectors:
         if wall_connector_subentry_id := site_subentry_by_device_id.get(via_device_id):
             _bind(device, wall_connector_subentry_id)
+        else:
+            LOGGER.debug(
+                "No energy site subentry for wall connector device %s; skipping",
+                device.id,
+            )
 
 
 async def async_migrate_entry(

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -3,6 +3,7 @@
 import asyncio
 from collections.abc import Callable
 from functools import partial
+from types import MappingProxyType
 from typing import Any, Final, cast
 
 from aiohttp import ClientError
@@ -21,7 +22,7 @@ from homeassistant.components.application_credentials import (
     ClientCredential,
     async_import_client_credential,
 )
-from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState, ConfigSubentry
 from homeassistant.const import CONF_ACCESS_TOKEN, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import (
@@ -33,6 +34,7 @@ from homeassistant.exceptions import (
 from homeassistant.helpers import (
     config_validation as cv,
     device_registry as dr,
+    entity_registry as er,
     issue_registry as ir,
 )
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -44,7 +46,14 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.typing import ConfigType
 
-from .const import CLIENT_ID, DOMAIN, LOGGER, VEHICLE_ISSUE_LEARN_MORE
+from .const import (
+    CLIENT_ID,
+    DOMAIN,
+    LOGGER,
+    SUBENTRY_TYPE_ENERGY_SITE,
+    SUBENTRY_TYPE_VEHICLE,
+    VEHICLE_ISSUE_LEARN_MORE,
+)
 from .coordinator import (
     TeslemetryEnergyHistoryCoordinator,
     TeslemetryEnergySiteInfoCoordinator,
@@ -246,6 +255,33 @@ def _setup_vehicle_repairs(
     )
 
 
+def _ensure_subentry(
+    hass: HomeAssistant,
+    entry: TeslemetryConfigEntry,
+    subentry_type: str,
+    unique_id: str,
+    title: str,
+    data: dict[str, Any],
+) -> str:
+    """Return the subentry id for unique_id, creating or updating it as needed."""
+    for subentry in entry.subentries.values():
+        if subentry.subentry_type == subentry_type and subentry.unique_id == unique_id:
+            if subentry.title != title or dict(subentry.data) != data:
+                hass.config_entries.async_update_subentry(
+                    entry, subentry, title=title, data=data
+                )
+            return subentry.subentry_id
+
+    subentry = ConfigSubentry(
+        data=MappingProxyType(data),
+        subentry_type=subentry_type,
+        title=title,
+        unique_id=unique_id,
+    )
+    hass.config_entries.async_add_subentry(entry, subentry)
+    return subentry.subentry_id
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -> bool:
     """Set up Teslemetry config."""
 
@@ -370,6 +406,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
             )
             stream_vehicle = stream.get_vehicle(vin)
 
+            subentry_id = _ensure_subentry(
+                hass,
+                entry,
+                SUBENTRY_TYPE_VEHICLE,
+                vin,
+                product["display_name"],
+                {"vin": vin},
+            )
+
             vehicles.append(
                 TeslemetryVehicleData(
                     api=vehicle,
@@ -381,6 +426,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
                     vin=vin,
                     firmware=firmware or "Unknown",
                     device=device,
+                    subentry_id=subentry_id,
                 )
             )
 
@@ -448,6 +494,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
                     translation_key="not_ready_api_error",
                 ) from e
 
+            subentry_id = _ensure_subentry(
+                hass,
+                entry,
+                SUBENTRY_TYPE_ENERGY_SITE,
+                str(site_id),
+                product.get("site_name", "Energy Site"),
+                {"site_id": site_id},
+            )
+
             energysites.append(
                 TeslemetryEnergyData(
                     api=energy_site,
@@ -468,6 +523,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
                     ),
                     id=site_id,
                     device=device,
+                    subentry_id=subentry_id,
                 )
             )
 
@@ -513,6 +569,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
                 remove_config_entry_id=entry.entry_id,
             )
 
+    # Remove subentries that no longer have a matching vehicle or energy site
+    current_subentry_ids = {vehicle.subentry_id for vehicle in vehicles} | {
+        energysite.subentry_id for energysite in energysites
+    }
+    for subentry in list(entry.subentries.values()):
+        if subentry.subentry_id not in current_subentry_ids:
+            LOGGER.debug("Removing stale subentry %s", subentry.subentry_id)
+            hass.config_entries.async_remove_subentry(entry, subentry.subentry_id)
+
     entry.runtime_data = TeslemetryData(
         vehicles=vehicles,
         energysites=energysites,
@@ -550,6 +615,81 @@ async def async_unload_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) 
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
+def _migrate_devices_to_subentries(
+    hass: HomeAssistant, entry: TeslemetryConfigEntry
+) -> None:
+    """Create subentries for existing devices and rebind devices and entities.
+
+    Older entries had every device and entity linked directly to the config
+    entry. Derive the vehicle and energy site subentries from the existing
+    devices (no API call needed) and move each device and its entities onto the
+    matching subentry.
+    """
+    device_registry = dr.async_get(hass)
+    entity_registry = er.async_get(hass)
+    devices = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
+
+    # Energy site device id -> subentry id, used to attach wall connectors which
+    # are children of an energy site rather than products in their own right.
+    site_subentry_by_device_id: dict[str, str] = {}
+
+    def _bind(device: dr.DeviceEntry, subentry_id: str) -> None:
+        # Move entities onto the subentry first, so that stripping the bare entry
+        # link from the device below does not drop entities still tied to it.
+        for entity in er.async_entries_for_device(
+            entity_registry, device.id, include_disabled_entities=True
+        ):
+            entity_registry.async_update_entity(
+                entity.entity_id, config_subentry_id=subentry_id
+            )
+        # Two steps on purpose: adding and removing the same config entry in a
+        # single call would delete the device. Add the subentry link, then drop
+        # the original bare (subentry-less) link.
+        device_registry.async_update_device(
+            device.id,
+            add_config_entry_id=entry.entry_id,
+            add_config_subentry_id=subentry_id,
+        )
+        device_registry.async_update_device(
+            device.id,
+            remove_config_entry_id=entry.entry_id,
+            remove_config_subentry_id=None,
+        )
+
+    # Wall connectors reference their energy site via via_device, so handle them
+    # only once every energy site subentry exists.
+    wall_connectors: list[tuple[dr.DeviceEntry, str]] = []
+    for device in devices:
+        if device.via_device_id is not None:
+            wall_connectors.append((device, device.via_device_id))
+            continue
+        identifier = next(i[1] for i in device.identifiers if i[0] == DOMAIN)
+        if identifier.isdigit():
+            subentry_id = _ensure_subentry(
+                hass,
+                entry,
+                SUBENTRY_TYPE_ENERGY_SITE,
+                identifier,
+                device.name or "Energy Site",
+                {"site_id": int(identifier)},
+            )
+            site_subentry_by_device_id[device.id] = subentry_id
+        else:
+            subentry_id = _ensure_subentry(
+                hass,
+                entry,
+                SUBENTRY_TYPE_VEHICLE,
+                identifier,
+                device.name or identifier,
+                {"vin": identifier},
+            )
+        _bind(device, subentry_id)
+
+    for device, via_device_id in wall_connectors:
+        if wall_connector_subentry_id := site_subentry_by_device_id.get(via_device_id):
+            _bind(device, wall_connector_subentry_id)
+
+
 async def async_migrate_entry(
     hass: HomeAssistant, config_entry: TeslemetryConfigEntry
 ) -> bool:
@@ -573,11 +713,16 @@ async def async_migrate_entry(
         # Add auth_implementation for OAuth2 flow compatibility
         data["auth_implementation"] = DOMAIN
 
-        return hass.config_entries.async_update_entry(
+        hass.config_entries.async_update_entry(
             config_entry,
             data=data,
             version=2,
         )
+
+    if config_entry.minor_version < 2:
+        _migrate_devices_to_subentries(hass, config_entry)
+        hass.config_entries.async_update_entry(config_entry, minor_version=2)
+
     return True
 
 
@@ -621,7 +766,9 @@ def async_setup_energy_device(
         energysite.device["sw_version"] = version
 
     device_registry.async_get_or_create(
-        config_entry_id=entry.entry_id, **energysite.device
+        config_entry_id=entry.entry_id,
+        config_subentry_id=energysite.subentry_id,
+        **energysite.device,
     )
 
     entry.async_on_unload(

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -648,6 +648,8 @@ def _migrate_devices_to_subentries(
         for entity in er.async_entries_for_device(
             entity_registry, device.id, include_disabled_entities=True
         ):
+            if entity.config_entry_id != entry.entry_id:
+                continue
             entity_registry.async_update_entity(
                 entity.entity_id, config_subentry_id=subentry_id
             )

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -282,6 +282,91 @@ def _ensure_subentry(
     return subentry.subentry_id
 
 
+async def _create_energy_site(
+    hass: HomeAssistant,
+    entry: TeslemetryConfigEntry,
+    teslemetry: Teslemetry,
+    product: dict[str, Any],
+) -> TeslemetryEnergyData | None:
+    """Build the energy site data for one product, or None if it has no relevant components."""
+    site_id = product["energy_site_id"]
+    powerwall = product["components"]["battery"] or product["components"]["solar"]
+    wall_connector = "wall_connectors" in product["components"]
+    if not powerwall and not wall_connector:
+        LOGGER.debug(
+            "Skipping Energy Site %s as it has no components",
+            site_id,
+        )
+        return None
+
+    energy_site = teslemetry.energySites.create(site_id)
+    device = DeviceInfo(
+        identifiers={(DOMAIN, str(site_id))},
+        manufacturer="Tesla",
+        configuration_url=f"https://teslemetry.com/console/energy/{site_id}",
+        name=product.get("site_name", "Energy Site"),
+        serial_number=str(site_id),
+    )
+
+    # For initial setup, raise auth errors properly
+    try:
+        live_status = (await energy_site.live_status())["response"]
+    except InvalidToken as e:
+        raise ConfigEntryAuthFailed(
+            translation_domain=DOMAIN,
+            translation_key="auth_failed_invalid_token",
+        ) from e
+    except LoginRequired as e:
+        raise ConfigEntryAuthFailed(
+            translation_domain=DOMAIN,
+            translation_key="auth_failed_login_required",
+        ) from e
+    except SubscriptionRequired as e:
+        raise ConfigEntryAuthFailed(
+            translation_domain=DOMAIN,
+            translation_key="auth_failed_subscription_required",
+        ) from e
+    except Forbidden as e:
+        raise ConfigEntryAuthFailed(
+            translation_domain=DOMAIN,
+            translation_key="auth_failed_invalid_token",
+        ) from e
+    except TeslaFleetError as e:
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN,
+            translation_key="not_ready_api_error",
+        ) from e
+
+    subentry_id = _ensure_subentry(
+        hass,
+        entry,
+        SUBENTRY_TYPE_ENERGY_SITE,
+        str(site_id),
+        product.get("site_name", "Energy Site"),
+        {"site_id": site_id},
+    )
+
+    return TeslemetryEnergyData(
+        api=energy_site,
+        live_coordinator=(
+            TeslemetryEnergySiteLiveCoordinator(hass, entry, energy_site, live_status)
+            if isinstance(live_status, dict)
+            else None
+        ),
+        info_coordinator=TeslemetryEnergySiteInfoCoordinator(
+            hass, entry, energy_site, product
+        ),
+        history_coordinator=(
+            TeslemetryEnergyHistoryCoordinator(hass, entry, energy_site)
+            if powerwall
+            else None
+        ),
+        id=site_id,
+        device=device,
+        subentry_id=subentry_id,
+    )
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -> bool:
     """Set up Teslemetry config."""
 
@@ -439,93 +524,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
         ):
             site_id = product["energy_site_id"]
 
-            powerwall = (
-                product["components"]["battery"] or product["components"]["solar"]
-            )
-            wall_connector = "wall_connectors" in product["components"]
-            if not powerwall and not wall_connector:
-                LOGGER.debug(
-                    "Skipping Energy Site %s as it has no components",
-                    site_id,
-                )
+            energysite = await _create_energy_site(hass, entry, teslemetry, product)
+            if energysite is None:
                 continue
 
             current_devices.add((DOMAIN, str(site_id)))
-            if wall_connector:
+            if "wall_connectors" in product["components"]:
                 current_devices |= {
                     (DOMAIN, c["din"]) for c in product["components"]["wall_connectors"]
                 }
 
-            energy_site = teslemetry.energySites.create(site_id)
-            device = DeviceInfo(
-                identifiers={(DOMAIN, str(site_id))},
-                manufacturer="Tesla",
-                configuration_url=f"https://teslemetry.com/console/energy/{site_id}",
-                name=product.get("site_name", "Energy Site"),
-                serial_number=str(site_id),
-            )
-
-            # For initial setup, raise auth errors properly
-            try:
-                live_status = (await energy_site.live_status())["response"]
-            except InvalidToken as e:
-                raise ConfigEntryAuthFailed(
-                    translation_domain=DOMAIN,
-                    translation_key="auth_failed_invalid_token",
-                ) from e
-            except LoginRequired as e:
-                raise ConfigEntryAuthFailed(
-                    translation_domain=DOMAIN,
-                    translation_key="auth_failed_login_required",
-                ) from e
-            except SubscriptionRequired as e:
-                raise ConfigEntryAuthFailed(
-                    translation_domain=DOMAIN,
-                    translation_key="auth_failed_subscription_required",
-                ) from e
-            except Forbidden as e:
-                raise ConfigEntryAuthFailed(
-                    translation_domain=DOMAIN,
-                    translation_key="auth_failed_invalid_token",
-                ) from e
-            except TeslaFleetError as e:
-                raise ConfigEntryNotReady(
-                    translation_domain=DOMAIN,
-                    translation_key="not_ready_api_error",
-                ) from e
-
-            subentry_id = _ensure_subentry(
-                hass,
-                entry,
-                SUBENTRY_TYPE_ENERGY_SITE,
-                str(site_id),
-                product.get("site_name", "Energy Site"),
-                {"site_id": site_id},
-            )
-
-            energysites.append(
-                TeslemetryEnergyData(
-                    api=energy_site,
-                    live_coordinator=(
-                        TeslemetryEnergySiteLiveCoordinator(
-                            hass, entry, energy_site, live_status
-                        )
-                        if isinstance(live_status, dict)
-                        else None
-                    ),
-                    info_coordinator=TeslemetryEnergySiteInfoCoordinator(
-                        hass, entry, energy_site, product
-                    ),
-                    history_coordinator=(
-                        TeslemetryEnergyHistoryCoordinator(hass, entry, energy_site)
-                        if powerwall
-                        else None
-                    ),
-                    id=site_id,
-                    device=device,
-                    subentry_id=subentry_id,
-                )
-            )
+            energysites.append(energysite)
 
     # Run all first refreshes
     await asyncio.gather(

--- a/homeassistant/components/teslemetry/binary_sensor.py
+++ b/homeassistant/components/teslemetry/binary_sensor.py
@@ -552,8 +552,10 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Teslemetry binary sensor platform from a config entry."""
 
-    entities: list[BinarySensorEntity] = []
+    entities: list[BinarySensorEntity]
+
     for vehicle in entry.runtime_data.vehicles:
+        entities = []
         for description in VEHICLE_DESCRIPTIONS:
             if (
                 not vehicle.poll
@@ -567,22 +569,22 @@ async def async_setup_entry(
                 entities.append(
                     TeslemetryVehiclePollingBinarySensorEntity(vehicle, description)
                 )
+        async_add_entities(entities, config_subentry_id=vehicle.subentry_id)
 
-    entities.extend(
-        TeslemetryEnergyLiveBinarySensorEntity(energysite, description)
-        for energysite in entry.runtime_data.energysites
-        if energysite.live_coordinator
-        for description in ENERGY_LIVE_DESCRIPTIONS
-        if description.key in energysite.live_coordinator.data
-    )
-    entities.extend(
-        TeslemetryEnergyInfoBinarySensorEntity(energysite, description)
-        for energysite in entry.runtime_data.energysites
-        for description in ENERGY_INFO_DESCRIPTIONS
-        if description.key in energysite.info_coordinator.data
-    )
-
-    async_add_entities(entities)
+    for energysite in entry.runtime_data.energysites:
+        entities = []
+        if energysite.live_coordinator:
+            entities.extend(
+                TeslemetryEnergyLiveBinarySensorEntity(energysite, description)
+                for description in ENERGY_LIVE_DESCRIPTIONS
+                if description.key in energysite.live_coordinator.data
+            )
+        entities.extend(
+            TeslemetryEnergyInfoBinarySensorEntity(energysite, description)
+            for description in ENERGY_INFO_DESCRIPTIONS
+            if description.key in energysite.info_coordinator.data
+        )
+        async_add_entities(entities, config_subentry_id=energysite.subentry_id)
 
 
 class TeslemetryVehiclePollingBinarySensorEntity(

--- a/homeassistant/components/teslemetry/button.py
+++ b/homeassistant/components/teslemetry/button.py
@@ -64,12 +64,15 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Teslemetry Button platform from a config entry."""
 
-    async_add_entities(
-        TeslemetryButtonEntity(vehicle, description)
-        for vehicle in entry.runtime_data.vehicles
-        for description in DESCRIPTIONS
-        if Scope.VEHICLE_CMDS in entry.runtime_data.scopes
-    )
+    for vehicle in entry.runtime_data.vehicles:
+        async_add_entities(
+            (
+                TeslemetryButtonEntity(vehicle, description)
+                for description in DESCRIPTIONS
+                if Scope.VEHICLE_CMDS in entry.runtime_data.scopes
+            ),
+            config_subentry_id=vehicle.subentry_id,
+        )
 
 
 class TeslemetryButtonEntity(TeslemetryVehicleStreamEntity, ButtonEntity):

--- a/homeassistant/components/teslemetry/calendar.py
+++ b/homeassistant/components/teslemetry/calendar.py
@@ -21,21 +21,20 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Teslemetry Calendar platform from a config entry."""
 
-    entities_to_add: list[CalendarEntity] = []
+    for energy in entry.runtime_data.energysites:
+        entities_to_add: list[CalendarEntity] = []
 
-    entities_to_add.extend(
-        TeslemetryTariffSchedule(energy, "tariff_content_v2")
-        for energy in entry.runtime_data.energysites
-        if energy.info_coordinator.data.get("tariff_content_v2_seasons")
-    )
+        if energy.info_coordinator.data.get("tariff_content_v2_seasons"):
+            entities_to_add.append(
+                TeslemetryTariffSchedule(energy, "tariff_content_v2")
+            )
 
-    entities_to_add.extend(
-        TeslemetryTariffSchedule(energy, "tariff_content_v2_sell_tariff")
-        for energy in entry.runtime_data.energysites
-        if energy.info_coordinator.data.get("tariff_content_v2_sell_tariff_seasons")
-    )
+        if energy.info_coordinator.data.get("tariff_content_v2_sell_tariff_seasons"):
+            entities_to_add.append(
+                TeslemetryTariffSchedule(energy, "tariff_content_v2_sell_tariff")
+            )
 
-    async_add_entities(entities_to_add)
+        async_add_entities(entities_to_add, config_subentry_id=energy.subentry_id)
 
 
 def _is_day_in_range(day_of_week: int, from_day: int, to_day: int) -> bool:

--- a/homeassistant/components/teslemetry/climate.py
+++ b/homeassistant/components/teslemetry/climate.py
@@ -1,6 +1,5 @@
 """Climate platform for Teslemetry integration."""
 
-from itertools import chain
 from typing import Any, cast, override
 
 from tesla_fleet_api import firmware_at_least
@@ -60,30 +59,26 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Teslemetry Climate platform from a config entry."""
 
-    async_add_entities(
-        chain(
-            (
+    for vehicle in entry.runtime_data.vehicles:
+        async_add_entities(
+            [
                 TeslemetryVehiclePollingClimateEntity(
                     vehicle, TeslemetryClimateSide.DRIVER, entry.runtime_data.scopes
                 )
                 if vehicle.poll or not firmware_at_least(vehicle.firmware, "2024.44.25")
                 else TeslemetryStreamingClimateEntity(
                     vehicle, TeslemetryClimateSide.DRIVER, entry.runtime_data.scopes
-                )
-                for vehicle in entry.runtime_data.vehicles
-            ),
-            (
+                ),
                 TeslemetryVehiclePollingCabinOverheatProtectionEntity(
                     vehicle, entry.runtime_data.scopes
                 )
                 if vehicle.poll or not firmware_at_least(vehicle.firmware, "2024.44.25")
                 else TeslemetryStreamingCabinOverheatProtectionEntity(
                     vehicle, entry.runtime_data.scopes
-                )
-                for vehicle in entry.runtime_data.vehicles
-            ),
+                ),
+            ],
+            config_subentry_id=vehicle.subentry_id,
         )
-    )
 
 
 class TeslemetryClimateEntity(TeslemetryRootEntity, ClimateEntity):

--- a/homeassistant/components/teslemetry/config_flow.py
+++ b/homeassistant/components/teslemetry/config_flow.py
@@ -34,6 +34,7 @@ class OAuth2FlowHandler(
 
     DOMAIN = DOMAIN
     VERSION = 2
+    MINOR_VERSION = 2
 
     def __init__(self) -> None:
         """Initialize config flow."""

--- a/homeassistant/components/teslemetry/const.py
+++ b/homeassistant/components/teslemetry/const.py
@@ -12,6 +12,10 @@ AUTHORIZE_URL = "https://teslemetry.com/connect"
 TOKEN_URL = "https://api.teslemetry.com/oauth/token"
 CLIENT_ID = "homeassistant"
 
+# Config subentry types
+SUBENTRY_TYPE_VEHICLE = "vehicle"
+SUBENTRY_TYPE_ENERGY_SITE = "energy_site"
+
 ENERGY_HISTORY_FIELDS = [
     "solar_energy_exported",
     "generator_energy_exported",

--- a/homeassistant/components/teslemetry/const.py
+++ b/homeassistant/components/teslemetry/const.py
@@ -12,7 +12,6 @@ AUTHORIZE_URL = "https://teslemetry.com/connect"
 TOKEN_URL = "https://api.teslemetry.com/oauth/token"
 CLIENT_ID = "homeassistant"
 
-# Config subentry types
 SUBENTRY_TYPE_VEHICLE = "vehicle"
 SUBENTRY_TYPE_ENERGY_SITE = "energy_site"
 

--- a/homeassistant/components/teslemetry/cover.py
+++ b/homeassistant/components/teslemetry/cover.py
@@ -1,6 +1,5 @@
 """Cover platform for Teslemetry integration."""
 
-from itertools import chain
 from typing import Any, override
 
 from tesla_fleet_api import firmware_at_least
@@ -40,52 +39,30 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Teslemetry cover platform from a config entry."""
 
-    async_add_entities(
-        chain(
-            (
-                TeslemetryVehiclePollingWindowEntity(vehicle, entry.runtime_data.scopes)
-                if vehicle.poll or not firmware_at_least(vehicle.firmware, "2024.26")
-                else TeslemetryStreamingWindowEntity(vehicle, entry.runtime_data.scopes)
-                for vehicle in entry.runtime_data.vehicles
+    for vehicle in entry.runtime_data.vehicles:
+        entities: list[CoverEntity] = [
+            TeslemetryVehiclePollingWindowEntity(vehicle, entry.runtime_data.scopes)
+            if vehicle.poll or not firmware_at_least(vehicle.firmware, "2024.26")
+            else TeslemetryStreamingWindowEntity(vehicle, entry.runtime_data.scopes),
+            TeslemetryVehiclePollingChargePortEntity(vehicle, entry.runtime_data.scopes)
+            if vehicle.poll or not firmware_at_least(vehicle.firmware, "2024.44.25")
+            else TeslemetryStreamingChargePortEntity(
+                vehicle, entry.runtime_data.scopes
             ),
-            (
-                TeslemetryVehiclePollingChargePortEntity(
-                    vehicle, entry.runtime_data.scopes
-                )
-                if vehicle.poll or not firmware_at_least(vehicle.firmware, "2024.44.25")
-                else TeslemetryStreamingChargePortEntity(
-                    vehicle, entry.runtime_data.scopes
-                )
-                for vehicle in entry.runtime_data.vehicles
+            TeslemetryVehiclePollingFrontTrunkEntity(vehicle, entry.runtime_data.scopes)
+            if vehicle.poll or not firmware_at_least(vehicle.firmware, "2024.26")
+            else TeslemetryStreamingFrontTrunkEntity(
+                vehicle, entry.runtime_data.scopes
             ),
-            (
-                TeslemetryVehiclePollingFrontTrunkEntity(
-                    vehicle, entry.runtime_data.scopes
-                )
-                if vehicle.poll or not firmware_at_least(vehicle.firmware, "2024.26")
-                else TeslemetryStreamingFrontTrunkEntity(
-                    vehicle, entry.runtime_data.scopes
-                )
-                for vehicle in entry.runtime_data.vehicles
-            ),
-            (
-                TeslemetryVehiclePollingRearTrunkEntity(
-                    vehicle, entry.runtime_data.scopes
-                )
-                if vehicle.poll or not firmware_at_least(vehicle.firmware, "2024.26")
-                else TeslemetryStreamingRearTrunkEntity(
-                    vehicle, entry.runtime_data.scopes
-                )
-                for vehicle in entry.runtime_data.vehicles
-            ),
-            (
-                TeslemetrySunroofEntity(vehicle, entry.runtime_data.scopes)
-                for vehicle in entry.runtime_data.vehicles
-                if vehicle.poll
-                and vehicle.coordinator.data.get("vehicle_config_sun_roof_installed")
-            ),
-        )
-    )
+            TeslemetryVehiclePollingRearTrunkEntity(vehicle, entry.runtime_data.scopes)
+            if vehicle.poll or not firmware_at_least(vehicle.firmware, "2024.26")
+            else TeslemetryStreamingRearTrunkEntity(vehicle, entry.runtime_data.scopes),
+        ]
+        if vehicle.poll and vehicle.coordinator.data.get(
+            "vehicle_config_sun_roof_installed"
+        ):
+            entities.append(TeslemetrySunroofEntity(vehicle, entry.runtime_data.scopes))
+        async_add_entities(entities, config_subentry_id=vehicle.subentry_id)
 
 
 class CoverRestoreEntity(RestoreEntity, CoverEntity):

--- a/homeassistant/components/teslemetry/device_tracker.py
+++ b/homeassistant/components/teslemetry/device_tracker.py
@@ -69,15 +69,15 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Teslemetry device tracker platform from a config entry."""
 
-    entities: list[
-        TeslemetryVehiclePollingDeviceTrackerEntity
-        | TeslemetryStreamingDeviceTrackerEntity
-    ] = []
     # Only add vehicle location entities if the user has granted vehicle location scope.
     if Scope.VEHICLE_LOCATION not in entry.runtime_data.scopes:
         return
 
     for vehicle in entry.runtime_data.vehicles:
+        entities: list[
+            TeslemetryVehiclePollingDeviceTrackerEntity
+            | TeslemetryStreamingDeviceTrackerEntity
+        ] = []
         for description in DESCRIPTIONS:
             if vehicle.poll or not firmware_at_least(
                 vehicle.firmware, description.streaming_firmware
@@ -93,7 +93,7 @@ async def async_setup_entry(
                     TeslemetryStreamingDeviceTrackerEntity(vehicle, description)
                 )
 
-    async_add_entities(entities)
+        async_add_entities(entities, config_subentry_id=vehicle.subentry_id)
 
 
 class TeslemetryVehiclePollingDeviceTrackerEntity(

--- a/homeassistant/components/teslemetry/lock.py
+++ b/homeassistant/components/teslemetry/lock.py
@@ -1,6 +1,5 @@
 """Lock platform for Teslemetry integration."""
 
-from itertools import chain
 from typing import Any, override
 
 from tesla_fleet_api import firmware_at_least
@@ -35,30 +34,26 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Teslemetry lock platform from a config entry."""
 
-    async_add_entities(
-        chain(
-            (
+    for vehicle in entry.runtime_data.vehicles:
+        async_add_entities(
+            [
                 TeslemetryVehiclePollingVehicleLockEntity(
                     vehicle, Scope.VEHICLE_CMDS in entry.runtime_data.scopes
                 )
                 if vehicle.poll or not firmware_at_least(vehicle.firmware, "2024.26")
                 else TeslemetryStreamingVehicleLockEntity(
                     vehicle, Scope.VEHICLE_CMDS in entry.runtime_data.scopes
-                )
-                for vehicle in entry.runtime_data.vehicles
-            ),
-            (
+                ),
                 TeslemetryVehiclePollingCableLockEntity(
                     vehicle, Scope.VEHICLE_CMDS in entry.runtime_data.scopes
                 )
                 if vehicle.poll or not firmware_at_least(vehicle.firmware, "2024.26")
                 else TeslemetryStreamingCableLockEntity(
                     vehicle, Scope.VEHICLE_CMDS in entry.runtime_data.scopes
-                )
-                for vehicle in entry.runtime_data.vehicles
-            ),
+                ),
+            ],
+            config_subentry_id=vehicle.subentry_id,
         )
-    )
 
 
 class TeslemetryVehicleLockEntity(TeslemetryRootEntity, LockEntity):

--- a/homeassistant/components/teslemetry/media_player.py
+++ b/homeassistant/components/teslemetry/media_player.py
@@ -52,12 +52,15 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Teslemetry Media platform from a config entry."""
 
-    async_add_entities(
-        TeslemetryVehiclePollingMediaEntity(vehicle, entry.runtime_data.scopes)
-        if vehicle.poll or not firmware_at_least(vehicle.firmware, "2025.2.6")
-        else TeslemetryStreamingMediaEntity(vehicle, entry.runtime_data.scopes)
-        for vehicle in entry.runtime_data.vehicles
-    )
+    for vehicle in entry.runtime_data.vehicles:
+        async_add_entities(
+            [
+                TeslemetryVehiclePollingMediaEntity(vehicle, entry.runtime_data.scopes)
+                if vehicle.poll or not firmware_at_least(vehicle.firmware, "2025.2.6")
+                else TeslemetryStreamingMediaEntity(vehicle, entry.runtime_data.scopes)
+            ],
+            config_subentry_id=vehicle.subentry_id,
+        )
 
 
 class TeslemetryMediaEntity(TeslemetryRootEntity, MediaPlayerEntity):

--- a/homeassistant/components/teslemetry/models.py
+++ b/homeassistant/components/teslemetry/models.py
@@ -43,6 +43,7 @@ class TeslemetryVehicleData:
     vin: str
     firmware: str
     device: DeviceInfo
+    subentry_id: str
     wakelock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
 
@@ -56,3 +57,4 @@ class TeslemetryEnergyData:
     history_coordinator: TeslemetryEnergyHistoryCoordinator | None
     id: int
     device: DeviceInfo
+    subentry_id: str

--- a/homeassistant/components/teslemetry/number.py
+++ b/homeassistant/components/teslemetry/number.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from itertools import chain
 from typing import Any, override
 
 from tesla_fleet_api import firmware_at_least
@@ -135,8 +134,8 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Teslemetry number platform from a config entry."""
 
-    async_add_entities(
-        chain(
+    for vehicle in entry.runtime_data.vehicles:
+        async_add_entities(
             (
                 TeslemetryVehiclePollingNumberEntity(
                     vehicle,
@@ -149,22 +148,25 @@ async def async_setup_entry(
                     description,
                     entry.runtime_data.scopes,
                 )
-                for vehicle in entry.runtime_data.vehicles
                 for description in VEHICLE_DESCRIPTIONS
             ),
+            config_subentry_id=vehicle.subentry_id,
+        )
+
+    for energysite in entry.runtime_data.energysites:
+        async_add_entities(
             (
                 TeslemetryEnergyInfoNumberSensorEntity(
                     energysite,
                     description,
                     entry.runtime_data.scopes,
                 )
-                for energysite in entry.runtime_data.energysites
                 for description in ENERGY_INFO_DESCRIPTIONS
                 if description.requires is None
                 or energysite.info_coordinator.data.get(description.requires)
             ),
+            config_subentry_id=energysite.subentry_id,
         )
-    )
 
 
 class TeslemetryVehicleNumberEntity(TeslemetryRootEntity, NumberEntity):

--- a/homeassistant/components/teslemetry/select.py
+++ b/homeassistant/components/teslemetry/select.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from itertools import chain
 from typing import Any, override
 
 from tesla_fleet_api import firmware_at_least
@@ -214,8 +213,8 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Teslemetry select platform from a config entry."""
 
-    async_add_entities(
-        chain(
+    for vehicle in entry.runtime_data.vehicles:
+        async_add_entities(
             (
                 TeslemetryVehiclePollingSelectEntity(
                     vehicle, description, entry.runtime_data.scopes
@@ -227,26 +226,28 @@ async def async_setup_entry(
                     vehicle, description, entry.runtime_data.scopes
                 )
                 for description in VEHICLE_DESCRIPTIONS
-                for vehicle in entry.runtime_data.vehicles
                 if description.supported_fn(
                     entry.runtime_data.metadata_coordinator.data.get("vehicles", {})
                     .get(vehicle.vin, {})
                     .get("config", {})
                 )
             ),
-            (
-                TeslemetryOperationSelectEntity(energysite, entry.runtime_data.scopes)
-                for energysite in entry.runtime_data.energysites
-                if energysite.info_coordinator.data.get("components_battery")
-            ),
-            (
-                TeslemetryExportRuleSelectEntity(energysite, entry.runtime_data.scopes)
-                for energysite in entry.runtime_data.energysites
-                if energysite.info_coordinator.data.get("components_battery")
-                and energysite.info_coordinator.data.get("components_solar")
-            ),
+            config_subentry_id=vehicle.subentry_id,
         )
-    )
+
+    for energysite in entry.runtime_data.energysites:
+        entities: list[SelectEntity] = []
+        if energysite.info_coordinator.data.get("components_battery"):
+            entities.append(
+                TeslemetryOperationSelectEntity(energysite, entry.runtime_data.scopes)
+            )
+            if energysite.info_coordinator.data.get("components_solar"):
+                entities.append(
+                    TeslemetryExportRuleSelectEntity(
+                        energysite, entry.runtime_data.scopes
+                    )
+                )
+        async_add_entities(entities, config_subentry_id=energysite.subentry_id)
 
 
 class TeslemetrySelectEntity(TeslemetryRootEntity, SelectEntity):

--- a/homeassistant/components/teslemetry/sensor.py
+++ b/homeassistant/components/teslemetry/sensor.py
@@ -1600,8 +1600,10 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Teslemetry sensor platform from a config entry."""
 
-    entities: list[SensorEntity] = []
+    entities: list[SensorEntity]
+
     for vehicle in entry.runtime_data.vehicles:
+        entities = []
         for description in VEHICLE_DESCRIPTIONS:
             if (
                 not vehicle.poll
@@ -1623,51 +1625,45 @@ async def async_setup_entry(
                 entities.append(
                     TeslemetryVehicleTimeSensorEntity(vehicle, time_description)
                 )
+        async_add_entities(entities, config_subentry_id=vehicle.subentry_id)
 
-    entities.extend(
-        TeslemetryEnergyLiveSensorEntity(energysite, description)
-        for energysite in entry.runtime_data.energysites
-        if energysite.live_coordinator
-        for description in ENERGY_LIVE_DESCRIPTIONS
-        if description.key in energysite.live_coordinator.data
-        or description.key == "percentage_charged"
-    )
-
-    entities.extend(
-        TeslemetryWallConnectorSensorEntity(energysite, din, description)
-        for energysite in entry.runtime_data.energysites
-        if energysite.live_coordinator
-        for din in energysite.live_coordinator.data.get("wall_connectors", {})
-        for description in WALL_CONNECTOR_DESCRIPTIONS
-    )
-
-    entities.extend(
-        TeslemetryEnergyInfoSensorEntity(energysite, description)
-        for energysite in entry.runtime_data.energysites
-        for description in ENERGY_INFO_DESCRIPTIONS
-        if description.key in energysite.info_coordinator.data
-    )
-
-    entities.extend(
-        TeslemetryEnergyHistorySensorEntity(energysite, description)
-        for energysite in entry.runtime_data.energysites
-        for description in ENERGY_HISTORY_DESCRIPTIONS
-        if energysite.history_coordinator is not None
-    )
+    for energysite in entry.runtime_data.energysites:
+        entities = []
+        if energysite.live_coordinator:
+            entities.extend(
+                TeslemetryEnergyLiveSensorEntity(energysite, description)
+                for description in ENERGY_LIVE_DESCRIPTIONS
+                if description.key in energysite.live_coordinator.data
+                or description.key == "percentage_charged"
+            )
+            entities.extend(
+                TeslemetryWallConnectorSensorEntity(energysite, din, description)
+                for din in energysite.live_coordinator.data.get("wall_connectors", {})
+                for description in WALL_CONNECTOR_DESCRIPTIONS
+            )
+        entities.extend(
+            TeslemetryEnergyInfoSensorEntity(energysite, description)
+            for description in ENERGY_INFO_DESCRIPTIONS
+            if description.key in energysite.info_coordinator.data
+        )
+        if energysite.history_coordinator is not None:
+            entities.extend(
+                TeslemetryEnergyHistorySensorEntity(energysite, description)
+                for description in ENERGY_HISTORY_DESCRIPTIONS
+            )
+        async_add_entities(entities, config_subentry_id=energysite.subentry_id)
 
     if entry.runtime_data.stream is not None:
-        entities.extend(
-            (
+        async_add_entities(
+            [
                 TeslemetryCreditBalanceSensor(
                     entry.unique_id or entry.entry_id, entry.runtime_data.stream
                 ),
                 TeslemetryCreditQuotaSensor(
                     entry.unique_id or entry.entry_id, entry.runtime_data.stream
                 ),
-            )
+            ]
         )
-
-    async_add_entities(entities)
 
 
 class TeslemetryStreamSensorEntity(TeslemetryVehicleStreamEntity, RestoreSensor):

--- a/homeassistant/components/teslemetry/switch.py
+++ b/homeassistant/components/teslemetry/switch.py
@@ -159,9 +159,10 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Teslemetry Switch platform from a config entry."""
 
-    entities: list[SwitchEntity] = []
+    entities: list[SwitchEntity]
 
     for vehicle in entry.runtime_data.vehicles:
+        entities = []
         for description in VEHICLE_DESCRIPTIONS:
             if vehicle.poll or not firmware_at_least(
                 vehicle.firmware, description.streaming_firmware
@@ -178,23 +179,24 @@ async def async_setup_entry(
                         vehicle, description, entry.runtime_data.scopes
                     )
                 )
+        async_add_entities(entities, config_subentry_id=vehicle.subentry_id)
 
-    entities.extend(
-        TeslemetryChargeFromGridSwitchEntity(
-            energysite,
-            entry.runtime_data.scopes,
-        )
-        for energysite in entry.runtime_data.energysites
-        if energysite.info_coordinator.data.get("components_battery")
-        and energysite.info_coordinator.data.get("components_solar")
-    )
-    entities.extend(
-        TeslemetryStormModeSwitchEntity(energysite, entry.runtime_data.scopes)
-        for energysite in entry.runtime_data.energysites
-        if energysite.info_coordinator.data.get("components_storm_mode_capable")
-    )
-
-    async_add_entities(entities)
+    for energysite in entry.runtime_data.energysites:
+        entities = []
+        if energysite.info_coordinator.data.get(
+            "components_battery"
+        ) and energysite.info_coordinator.data.get("components_solar"):
+            entities.append(
+                TeslemetryChargeFromGridSwitchEntity(
+                    energysite,
+                    entry.runtime_data.scopes,
+                )
+            )
+        if energysite.info_coordinator.data.get("components_storm_mode_capable"):
+            entities.append(
+                TeslemetryStormModeSwitchEntity(energysite, entry.runtime_data.scopes)
+            )
+        async_add_entities(entities, config_subentry_id=energysite.subentry_id)
 
 
 class TeslemetryVehicleSwitchEntity(TeslemetryRootEntity, SwitchEntity):

--- a/homeassistant/components/teslemetry/update.py
+++ b/homeassistant/components/teslemetry/update.py
@@ -36,12 +36,15 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Teslemetry update platform from a config entry."""
 
-    async_add_entities(
-        TeslemetryVehiclePollingUpdateEntity(vehicle, entry.runtime_data.scopes)
-        if vehicle.poll or not firmware_at_least(vehicle.firmware, "2024.44.25")
-        else TeslemetryStreamingUpdateEntity(vehicle, entry.runtime_data.scopes)
-        for vehicle in entry.runtime_data.vehicles
-    )
+    for vehicle in entry.runtime_data.vehicles:
+        async_add_entities(
+            [
+                TeslemetryVehiclePollingUpdateEntity(vehicle, entry.runtime_data.scopes)
+                if vehicle.poll or not firmware_at_least(vehicle.firmware, "2024.44.25")
+                else TeslemetryStreamingUpdateEntity(vehicle, entry.runtime_data.scopes)
+            ],
+            config_subentry_id=vehicle.subentry_id,
+        )
 
 
 class TeslemetryUpdateEntity(TeslemetryRootEntity, UpdateEntity):

--- a/tests/components/teslemetry/__init__.py
+++ b/tests/components/teslemetry/__init__.py
@@ -19,6 +19,7 @@ def mock_config_entry() -> MockConfigEntry:
     return MockConfigEntry(
         domain=DOMAIN,
         version=2,
+        minor_version=2,
         unique_id="abc-123",
         data={
             "auth_implementation": DOMAIN,

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -703,6 +703,61 @@ async def test_migrate_adds_subentries(
     assert migrated.config_subentry_id == vehicle_subentry
 
 
+async def test_migrate_ignores_foreign_and_orphan_devices(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """Test migration skips devices without our identifier and orphan wall connectors."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=2,
+        minor_version=1,
+        unique_id=UNIQUE_ID,
+        data={
+            "auth_implementation": DOMAIN,
+            "token": {
+                "access_token": "test_access_token",
+                "refresh_token": "test_refresh_token",
+                "expires_at": int(time.time()) + 3600,
+            },
+        },
+    )
+    entry.add_to_hass(hass)
+
+    # A stale/manually created device linked to the entry without our identifier,
+    # and a wall connector whose parent is that foreign (non-energy-site) device.
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={("other_domain", "foreign")},
+        name="Foreign",
+    )
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "orphan-wall-connector")},
+        via_device=("other_domain", "foreign"),
+        name="Orphan Wall Connector",
+    )
+    vehicle_device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, VEHICLE_VIN)},
+        name="Test",
+    )
+
+    with patch("homeassistant.components.teslemetry.PLATFORMS", [Platform.SENSOR]):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    # Migration completed without raising on the foreign or orphan devices.
+    assert entry.state is ConfigEntryState.LOADED
+    assert entry.minor_version == 2
+    assert not any(s.unique_id == "foreign" for s in entry.subentries.values())
+
+    # The real vehicle device still migrated correctly.
+    vehicle_subentry = _subentry_id(entry, "vehicle", VEHICLE_VIN)
+    assert device_registry.async_get(vehicle_device.id).config_entries_subentries == {
+        entry.entry_id: {vehicle_subentry}
+    }
+
+
 async def test_migrate_from_future_version_fails(hass: HomeAssistant) -> None:
     """Test migration fails for future versions."""
     mock_entry = MockConfigEntry(

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -48,7 +48,7 @@ from homeassistant.exceptions import (
     OAuth2TokenRequestReauthError,
     OAuth2TokenRequestTransientError,
 )
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.config_entry_oauth2_flow import OAuth2Session
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
@@ -59,6 +59,7 @@ from .const import (
     LIVE_STATUS,
     METADATA,
     METADATA_NOSCOPE,
+    PRODUCTS,
     PRODUCTS_MODERN,
     SITE_INFO,
     UNIQUE_ID,
@@ -118,6 +119,140 @@ async def test_devices(
 
     for device in devices:
         assert device == snapshot(name=f"{device.identifiers}")
+
+
+VEHICLE_VIN = "LRW3F7EK4NC700000"
+ENERGY_SITE_ID = "123456"
+WALL_CONNECTOR_DINS = ("abd-123", "bcd-234")
+
+
+def _subentry_id(entry: MockConfigEntry, subentry_type: str, unique_id: str) -> str:
+    """Return the id of the subentry matching type and unique_id."""
+    for subentry in entry.subentries.values():
+        if subentry.subentry_type == subentry_type and subentry.unique_id == unique_id:
+            return subentry.subentry_id
+    pytest.fail(f"No {subentry_type} subentry with unique_id {unique_id}")
+
+
+async def test_subentries_created(hass: HomeAssistant) -> None:
+    """Test a subentry is created for each discovered vehicle and energy site."""
+    entry = await setup_platform(hass)
+
+    subentries = sorted(
+        entry.subentries.values(), key=lambda s: (s.subentry_type, s.unique_id)
+    )
+    assert [
+        (s.subentry_type, s.unique_id, s.title, dict(s.data)) for s in subentries
+    ] == [
+        ("energy_site", ENERGY_SITE_ID, "Energy Site", {"site_id": 123456}),
+        ("vehicle", VEHICLE_VIN, "Test", {"vin": VEHICLE_VIN}),
+    ]
+
+
+async def test_devices_bound_to_subentries(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """Test every device is bound to its subentry and not the bare entry."""
+    entry = await setup_platform(hass)
+
+    vehicle_subentry = _subentry_id(entry, "vehicle", VEHICLE_VIN)
+    energy_subentry = _subentry_id(entry, "energy_site", ENERGY_SITE_ID)
+
+    expected = {
+        (DOMAIN, VEHICLE_VIN): vehicle_subentry,
+        (DOMAIN, ENERGY_SITE_ID): energy_subentry,
+        (DOMAIN, WALL_CONNECTOR_DINS[0]): energy_subentry,
+        (DOMAIN, WALL_CONNECTOR_DINS[1]): energy_subentry,
+    }
+    devices = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
+    assert devices
+    for device in devices:
+        identifier = next(iter(device.identifiers))
+        assert device.config_entries_subentries == {
+            entry.entry_id: {expected[identifier]}
+        }
+
+
+async def test_entities_bound_to_subentries(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test every entity with a device is bound to that device's subentry."""
+    entry = await setup_platform(hass, [Platform.SENSOR])
+
+    entities = [
+        entity
+        for entity in er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+        if entity.device_id is not None
+    ]
+    assert entities
+    for entity in entities:
+        device = device_registry.async_get(entity.device_id)
+        assert entity.config_subentry_id is not None
+        assert device.config_entries_subentries == {
+            entry.entry_id: {entity.config_subentry_id}
+        }
+
+
+async def test_account_entity_not_in_subentry(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test the account-level credit balance sensor stays on the main entry."""
+    await setup_platform(hass, [Platform.SENSOR])
+
+    credit_balance = entity_registry.async_get("sensor.teslemetry_command_credits")
+    assert credit_balance is not None
+    assert credit_balance.device_id is None
+    assert credit_balance.config_subentry_id is None
+
+
+async def test_reload_idempotent_subentries(hass: HomeAssistant) -> None:
+    """Test reloading does not duplicate subentries."""
+    entry = await setup_platform(hass)
+    before = set(entry.subentries)
+
+    await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert set(entry.subentries) == before
+
+
+async def test_unsubscribed_product_removes_subentry(hass: HomeAssistant) -> None:
+    """Test a subentry is removed when its product is no longer available."""
+    entry = await setup_platform(hass)
+    assert entry.subentries
+
+    with patch(
+        "tesla_fleet_api.teslemetry.Teslemetry.products",
+        return_value={"response": []},
+    ):
+        await hass.config_entries.async_reload(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert not entry.subentries
+
+
+async def test_subentry_title_updates_when_renamed(hass: HomeAssistant) -> None:
+    """Test a subentry title is updated when the product is renamed."""
+    entry = await setup_platform(hass)
+    vehicle_subentry = _subentry_id(entry, "vehicle", VEHICLE_VIN)
+    assert entry.subentries[vehicle_subentry].title == "Test"
+
+    renamed = deepcopy(PRODUCTS)
+    for product in renamed["response"]:
+        if product.get("vin") == VEHICLE_VIN:
+            product["display_name"] = "Renamed"
+
+    with patch(
+        "tesla_fleet_api.teslemetry.Teslemetry.products",
+        return_value=renamed,
+    ):
+        await hass.config_entries.async_reload(entry.entry_id)
+        await hass.async_block_till_done()
+
+    # Same subentry id is reused, only the title changes.
+    assert entry.subentries[vehicle_subentry].title == "Renamed"
 
 
 @pytest.mark.parametrize(("side_effect", "state"), VEHICLE_ERRORS)
@@ -490,6 +625,82 @@ async def test_migrate_version_2_no_migration_needed(hass: HomeAssistant) -> Non
     # Verify data was not modified
     assert entry.data == oauth_config
     assert entry.state is ConfigEntryState.LOADED
+
+
+async def test_migrate_adds_subentries(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test minor migration creates subentries and rebinds devices and entities."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=2,
+        minor_version=1,
+        unique_id=UNIQUE_ID,
+        data={
+            "auth_implementation": DOMAIN,
+            "token": {
+                "access_token": "test_access_token",
+                "refresh_token": "test_refresh_token",
+                "expires_at": int(time.time()) + 3600,
+            },
+        },
+    )
+    entry.add_to_hass(hass)
+
+    # Pre-seed the registries the way a pre-subentry (minor_version 1) install looks:
+    # devices and entities linked to the bare config entry with no subentry.
+    energy_device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, ENERGY_SITE_ID)},
+        name="Energy Site",
+    )
+    wall_connector_device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, WALL_CONNECTOR_DINS[0])},
+        via_device=(DOMAIN, ENERGY_SITE_ID),
+        name="Wall Connector",
+    )
+    vehicle_device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, VEHICLE_VIN)},
+        name="Test",
+    )
+    legacy_entity = entity_registry.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{VEHICLE_VIN}-migration_marker",
+        config_entry=entry,
+        device_id=vehicle_device.id,
+    )
+    entity_registry.async_update_entity(legacy_entity.entity_id, name="My Car")
+
+    with patch("homeassistant.components.teslemetry.PLATFORMS", [Platform.SENSOR]):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.minor_version == 2
+
+    vehicle_subentry = _subentry_id(entry, "vehicle", VEHICLE_VIN)
+    energy_subentry = _subentry_id(entry, "energy_site", ENERGY_SITE_ID)
+
+    # Every pre-existing device is rebound to its subentry with no bare entry link.
+    assert device_registry.async_get(vehicle_device.id).config_entries_subentries == {
+        entry.entry_id: {vehicle_subentry}
+    }
+    assert device_registry.async_get(energy_device.id).config_entries_subentries == {
+        entry.entry_id: {energy_subentry}
+    }
+    assert device_registry.async_get(
+        wall_connector_device.id
+    ).config_entries_subentries == {entry.entry_id: {energy_subentry}}
+
+    # The pre-existing entity survives migration (customization intact) and is rebound.
+    migrated = entity_registry.async_get(legacy_entity.entity_id)
+    assert migrated is not None
+    assert migrated.name == "My Car"
+    assert migrated.config_subentry_id == vehicle_subentry
 
 
 async def test_migrate_from_future_version_fails(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Proposed change

Adds two programmatically-managed config subentry types to the Teslemetry integration: `vehicle` and `energy_site`. Each discovered vehicle and energy site is now represented by a config subentry (keyed by VIN / energy site id), with its devices and entities bound to that subentry via `config_subentry_id`.

Subentries are created and removed automatically during `async_setup_entry` to mirror the products available on the Tesla account (the integration already reloads when subscriptions change). The account-level credit-balance sensor intentionally stays on the main entry.

Existing installs are migrated via a config entry minor-version bump (`MINOR_VERSION = 2`): `async_migrate_entry` derives the subentries from the existing device registry (no extra API calls), then rebinds each device and its entities from the bare config entry onto the matching subentry, preserving user customizations. Wall-connector devices are attached to their parent energy site's subentry.

No `ConfigSubentryFlow` is registered yet (there are no per-subentry settings to configure, and registering would add spurious "Add" buttons). This change lays the groundwork for future features scoped to individual vehicles or energy sites, such as Bluetooth connectivity and local network connectivity.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr