### PR TITLE
Add command source abstraction to Teslemetry

### DIFF
--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -45,6 +45,7 @@ from .coordinator import (
 from .helpers import async_update_device_sw_version, flatten
 from .models import TeslemetryData, TeslemetryEnergyData, TeslemetryVehicleData
 from .services import async_setup_services
+from .source import EnergySource, VehicleSource
 
 PLATFORMS: Final = [
     Platform.BINARY_SENSOR,
@@ -282,7 +283,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
 
             vehicles.append(
                 TeslemetryVehicleData(
-                    api=vehicle,
+                    api=VehicleSource(vehicle),
                     config_entry=entry,
                     coordinator=coordinator,
                     poll=poll,
@@ -355,7 +356,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
 
             energysites.append(
                 TeslemetryEnergyData(
-                    api=energy_site,
+                    api=EnergySource(energy_site),
                     live_coordinator=(
                         TeslemetryEnergySiteLiveCoordinator(
                             hass, entry, energy_site, live_status

--- a/homeassistant/components/teslemetry/button.py
+++ b/homeassistant/components/teslemetry/button.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 from typing import Any
 
 from tesla_fleet_api.const import Scope
-from tesla_fleet_api.teslemetry import Vehicle
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.core import HomeAssistant
@@ -15,6 +14,7 @@ from . import TeslemetryConfigEntry
 from .entity import TeslemetryVehicleStreamEntity
 from .helpers import handle_command, handle_vehicle_command
 from .models import TeslemetryVehicleData
+from .source import VehicleSource
 
 PARALLEL_UPDATES = 0
 
@@ -75,7 +75,7 @@ async def async_setup_entry(
 class TeslemetryButtonEntity(TeslemetryVehicleStreamEntity, ButtonEntity):
     """Base class for Teslemetry buttons."""
 
-    api: Vehicle
+    api: VehicleSource
     entity_description: TeslemetryButtonEntityDescription
 
     def __init__(

--- a/homeassistant/components/teslemetry/climate.py
+++ b/homeassistant/components/teslemetry/climate.py
@@ -4,7 +4,6 @@ from itertools import chain
 from typing import Any, cast
 
 from tesla_fleet_api.const import CabinOverheatProtectionTemp, Scope
-from tesla_fleet_api.teslemetry import Vehicle
 
 from homeassistant.components.climate import (
     ATTR_HVAC_MODE,
@@ -33,6 +32,7 @@ from .entity import (
 )
 from .helpers import handle_vehicle_command
 from .models import TeslemetryVehicleData
+from .source import VehicleSource
 
 DEFAULT_MIN_TEMP = 15
 DEFAULT_MAX_TEMP = 28
@@ -88,7 +88,7 @@ async def async_setup_entry(
 class TeslemetryClimateEntity(TeslemetryRootEntity, ClimateEntity):
     """Vehicle Climate Control."""
 
-    api: Vehicle
+    api: VehicleSource
     _attr_precision = PRECISION_HALVES
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_hvac_modes = [HVACMode.HEAT_COOL, HVACMode.OFF]
@@ -369,7 +369,7 @@ COP_LEVELS = {
 class TeslemetryCabinOverheatProtectionEntity(TeslemetryRootEntity, ClimateEntity):
     """Vehicle Cabin Overheat Protection."""
 
-    api: Vehicle
+    api: VehicleSource
     _attr_precision = PRECISION_WHOLE
     _attr_target_temperature_step = 5
     _attr_min_temp = 30

--- a/homeassistant/components/teslemetry/cover.py
+++ b/homeassistant/components/teslemetry/cover.py
@@ -4,7 +4,6 @@ from itertools import chain
 from typing import Any
 
 from tesla_fleet_api.const import Scope, SunRoofCommand, Trunk, WindowCommand
-from tesla_fleet_api.teslemetry import Vehicle
 from teslemetry_stream import Signal
 from teslemetry_stream.const import WindowState
 
@@ -25,6 +24,7 @@ from .entity import (
 )
 from .helpers import handle_vehicle_command
 from .models import TeslemetryVehicleData
+from .source import VehicleSource
 
 OPEN = 1
 CLOSED = 0
@@ -103,7 +103,7 @@ class CoverRestoreEntity(RestoreEntity, CoverEntity):
 class TeslemetryWindowEntity(TeslemetryRootEntity, CoverEntity):
     """Base class for window cover entities."""
 
-    api: Vehicle
+    api: VehicleSource
     _attr_device_class = CoverDeviceClass.WINDOW
     _attr_supported_features = CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
 
@@ -233,7 +233,7 @@ class TeslemetryChargePortEntity(
 ):
     """Base class for for charge port cover entities."""
 
-    api: Vehicle
+    api: VehicleSource
     _attr_device_class = CoverDeviceClass.DOOR
     _attr_supported_features = CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
 
@@ -314,7 +314,7 @@ class TeslemetryStreamingChargePortEntity(
 class TeslemetryFrontTrunkEntity(TeslemetryRootEntity, CoverEntity):
     """Base class for the front trunk cover entities."""
 
-    api: Vehicle
+    api: VehicleSource
     _attr_device_class = CoverDeviceClass.DOOR
     _attr_supported_features = CoverEntityFeature.OPEN
 
@@ -377,7 +377,7 @@ class TeslemetryStreamingFrontTrunkEntity(
 class TeslemetryRearTrunkEntity(TeslemetryRootEntity, CoverEntity):
     """Cover entity for the rear trunk."""
 
-    api: Vehicle
+    api: VehicleSource
     _attr_device_class = CoverDeviceClass.DOOR
     _attr_supported_features = CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
 
@@ -447,7 +447,7 @@ class TeslemetryStreamingRearTrunkEntity(
 class TeslemetrySunroofEntity(TeslemetryVehiclePollingEntity, CoverEntity):
     """Cover entity for the sunroof."""
 
-    api: Vehicle
+    api: VehicleSource
     _attr_device_class = CoverDeviceClass.WINDOW
     _attr_supported_features = (
         CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE | CoverEntityFeature.STOP

--- a/homeassistant/components/teslemetry/entity.py
+++ b/homeassistant/components/teslemetry/entity.py
@@ -4,7 +4,6 @@ from abc import abstractmethod
 from typing import Any
 
 from tesla_fleet_api.const import Scope
-from tesla_fleet_api.teslemetry import EnergySite, Vehicle
 
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -20,6 +19,7 @@ from .coordinator import (
     TeslemetryVehicleDataCoordinator,
 )
 from .models import TeslemetryEnergyData, TeslemetryVehicleData
+from .source import EnergySource, VehicleSource
 
 
 class TeslemetryRootEntity(Entity):
@@ -102,7 +102,7 @@ class TeslemetryVehiclePollingEntity(TeslemetryPollingEntity):
     """Parent class for Teslemetry Vehicle entities."""
 
     _last_update: int = 0
-    api: Vehicle
+    api: VehicleSource
     vehicle: TeslemetryVehicleData
 
     def __init__(
@@ -133,7 +133,7 @@ class TeslemetryVehiclePollingEntity(TeslemetryPollingEntity):
 class TeslemetryEnergyLiveEntity(TeslemetryPollingEntity):
     """Parent class for Teslemetry Energy Site Live entities."""
 
-    api: EnergySite
+    api: EnergySource
 
     def __init__(
         self,
@@ -154,7 +154,7 @@ class TeslemetryEnergyLiveEntity(TeslemetryPollingEntity):
 class TeslemetryEnergyInfoEntity(TeslemetryPollingEntity):
     """Parent class for Teslemetry Energy Site Info Entities."""
 
-    api: EnergySite
+    api: EnergySource
 
     def __init__(
         self,
@@ -193,7 +193,7 @@ class TeslemetryWallConnectorEntity(TeslemetryPollingEntity):
     """Parent class for Teslemetry Wall Connector Entities."""
 
     _attr_has_entity_name = True
-    api: EnergySite
+    api: EnergySource
 
     def __init__(
         self,
@@ -249,7 +249,7 @@ class TeslemetryWallConnectorEntity(TeslemetryPollingEntity):
 class TeslemetryVehicleStreamEntity(TeslemetryRootEntity):
     """Parent class for Teslemetry Vehicle Stream entities."""
 
-    api: Vehicle
+    api: VehicleSource
 
     def __init__(self, data: TeslemetryVehicleData, key: str) -> None:
         """Initialize common aspects of a Teslemetry entity."""

--- a/homeassistant/components/teslemetry/lock.py
+++ b/homeassistant/components/teslemetry/lock.py
@@ -4,7 +4,6 @@ from itertools import chain
 from typing import Any
 
 from tesla_fleet_api.const import Scope
-from tesla_fleet_api.teslemetry import Vehicle
 
 from homeassistant.components.lock import LockEntity
 from homeassistant.core import HomeAssistant
@@ -21,6 +20,7 @@ from .entity import (
 )
 from .helpers import handle_vehicle_command
 from .models import TeslemetryVehicleData
+from .source import VehicleSource
 
 ENGAGED = "Engaged"
 
@@ -63,7 +63,7 @@ async def async_setup_entry(
 class TeslemetryVehicleLockEntity(TeslemetryRootEntity, LockEntity):
     """Base vehicle lock entity for Teslemetry."""
 
-    api: Vehicle
+    api: VehicleSource
 
     async def async_lock(self, **kwargs: Any) -> None:
         """Lock the doors."""
@@ -136,7 +136,7 @@ class TeslemetryStreamingVehicleLockEntity(
 class TeslemetryCableLockEntity(TeslemetryRootEntity, LockEntity):
     """Base cable Lock entity for Teslemetry."""
 
-    api: Vehicle
+    api: VehicleSource
 
     async def async_lock(self, **kwargs: Any) -> None:
         """Charge cable Lock cannot be manually locked."""

--- a/homeassistant/components/teslemetry/media_player.py
+++ b/homeassistant/components/teslemetry/media_player.py
@@ -1,7 +1,6 @@
 """Media player platform for Teslemetry integration."""
 
 from tesla_fleet_api.const import Scope
-from tesla_fleet_api.teslemetry import Vehicle
 
 from homeassistant.components.media_player import (
     MediaPlayerDeviceClass,
@@ -21,6 +20,7 @@ from .entity import (
 )
 from .helpers import handle_vehicle_command
 from .models import TeslemetryVehicleData
+from .source import VehicleSource
 
 STATES = {
     "Playing": MediaPlayerState.PLAYING,
@@ -60,7 +60,7 @@ async def async_setup_entry(
 class TeslemetryMediaEntity(TeslemetryRootEntity, MediaPlayerEntity):
     """Base vehicle media player class."""
 
-    api: Vehicle
+    api: VehicleSource
     _attr_device_class = MediaPlayerDeviceClass.SPEAKER
     _attr_volume_step = VOLUME_STEP
 

--- a/homeassistant/components/teslemetry/models.py
+++ b/homeassistant/components/teslemetry/models.py
@@ -4,7 +4,6 @@ import asyncio
 from dataclasses import dataclass, field
 
 from tesla_fleet_api.const import Scope
-from tesla_fleet_api.teslemetry import EnergySite, Vehicle
 from teslemetry_stream import TeslemetryStream, TeslemetryStreamVehicle
 
 from homeassistant.config_entries import ConfigEntry
@@ -17,6 +16,7 @@ from .coordinator import (
     TeslemetryMetadataCoordinator,
     TeslemetryVehicleDataCoordinator,
 )
+from .source import EnergySource, VehicleSource
 
 
 @dataclass
@@ -34,7 +34,7 @@ class TeslemetryData:
 class TeslemetryVehicleData:
     """Data for a vehicle in the Teslemetry integration."""
 
-    api: Vehicle
+    api: VehicleSource
     config_entry: ConfigEntry
     coordinator: TeslemetryVehicleDataCoordinator
     poll: bool
@@ -50,7 +50,7 @@ class TeslemetryVehicleData:
 class TeslemetryEnergyData:
     """Data for a vehicle in the Teslemetry integration."""
 
-    api: EnergySite
+    api: EnergySource
     live_coordinator: TeslemetryEnergySiteLiveCoordinator | None
     info_coordinator: TeslemetryEnergySiteInfoCoordinator
     history_coordinator: TeslemetryEnergyHistoryCoordinator | None

--- a/homeassistant/components/teslemetry/number.py
+++ b/homeassistant/components/teslemetry/number.py
@@ -6,7 +6,6 @@ from itertools import chain
 from typing import Any
 
 from tesla_fleet_api.const import Scope
-from tesla_fleet_api.teslemetry import EnergySite, Vehicle
 from teslemetry_stream import TeslemetryStreamVehicle
 
 from homeassistant.components.number import (
@@ -35,6 +34,7 @@ from .entity import (
 )
 from .helpers import handle_command, handle_vehicle_command
 from .models import TeslemetryEnergyData, TeslemetryVehicleData
+from .source import EnergySource, VehicleSource
 
 PARALLEL_UPDATES = 0
 
@@ -43,7 +43,7 @@ PARALLEL_UPDATES = 0
 class TeslemetryNumberVehicleEntityDescription(NumberEntityDescription):
     """Describes Teslemetry Number entity."""
 
-    func: Callable[[Vehicle, int], Awaitable[Any]]
+    func: Callable[[VehicleSource, int], Awaitable[Any]]
     min_key: str | None = None
     max_key: str
     native_min_value: float
@@ -96,7 +96,7 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetryNumberVehicleEntityDescription, ...] = (
 class TeslemetryNumberBatteryEntityDescription(NumberEntityDescription):
     """Describes Teslemetry Number entity."""
 
-    func: Callable[[EnergySite, float], Awaitable[Any]]
+    func: Callable[[EnergySource, float], Awaitable[Any]]
     requires: str | None = None
     scopes: list[Scope]
 
@@ -169,7 +169,7 @@ async def async_setup_entry(
 class TeslemetryVehicleNumberEntity(TeslemetryRootEntity, NumberEntity):
     """Vehicle number entity base class."""
 
-    api: Vehicle
+    api: VehicleSource
     entity_description: TeslemetryNumberVehicleEntityDescription
 
     async def async_set_native_value(self, value: float) -> None:

--- a/homeassistant/components/teslemetry/select.py
+++ b/homeassistant/components/teslemetry/select.py
@@ -6,7 +6,6 @@ from itertools import chain
 from typing import Any
 
 from tesla_fleet_api.const import EnergyExportMode, EnergyOperationMode, Scope, Seat
-from tesla_fleet_api.teslemetry import Vehicle
 from teslemetry_stream import TeslemetryStreamVehicle
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
@@ -23,6 +22,7 @@ from .entity import (
 )
 from .helpers import handle_command, handle_vehicle_command
 from .models import TeslemetryEnergyData, TeslemetryVehicleData
+from .source import VehicleSource
 
 OFF = "off"
 LOW = "low"
@@ -38,7 +38,7 @@ LEVEL = {OFF: 0, LOW: 1, MEDIUM: 2, HIGH: 3}
 class TeslemetrySelectEntityDescription(SelectEntityDescription):
     """Seat Heater entity description."""
 
-    select_fn: Callable[[Vehicle, int], Awaitable[Any]]
+    select_fn: Callable[[VehicleSource, int], Awaitable[Any]]
     supported_fn: Callable[[dict], bool] = lambda _: True
     streaming_listener: (
         Callable[
@@ -206,7 +206,7 @@ async def async_setup_entry(
 class TeslemetrySelectEntity(TeslemetryRootEntity, SelectEntity):
     """Parent vehicle select entity class."""
 
-    api: Vehicle
+    api: VehicleSource
     entity_description: TeslemetrySelectEntityDescription
     _climate: bool = False
 

--- a/homeassistant/components/teslemetry/source.py
+++ b/homeassistant/components/teslemetry/source.py
@@ -1,0 +1,367 @@
+"""Command source facades for Teslemetry.
+
+A "source" wraps the cloud API client for a single device and presents the
+command methods that the entities and services invoke. Wrapping the client
+behind a facade gives the integration one place to add local transports
+(BLE for vehicles, a local gateway for Powerwalls) that are read and commanded
+local-first with cloud fallback.
+
+In its current form a source forwards every command to the cloud client
+unchanged, so behaviour is identical to calling the cloud API directly. Local
+transports and the local-first dispatch logic are added in later iterations.
+"""
+
+from typing import Any
+
+from tesla_fleet_api.const import (
+    CabinOverheatProtectionTemp,
+    ClimateKeeperMode,
+    EnergyExportMode,
+    EnergyOperationMode,
+    Level,
+    Seat,
+    SunRoofCommand,
+    Trunk,
+    WindowCommand,
+)
+from tesla_fleet_api.teslemetry import EnergySite, Vehicle
+
+
+class VehicleSource:
+    """Command facade for a Tesla vehicle."""
+
+    def __init__(self, cloud: Vehicle) -> None:
+        """Initialize the vehicle source with its cloud client."""
+        self.cloud = cloud
+
+    async def wake_up(self) -> dict[str, Any]:
+        """Wake up the vehicle."""
+        return await self.cloud.wake_up()
+
+    async def flash_lights(self) -> dict[str, Any]:
+        """Flash the vehicle's lights."""
+        return await self.cloud.flash_lights()
+
+    async def honk_horn(self) -> dict[str, Any]:
+        """Honk the vehicle's horn."""
+        return await self.cloud.honk_horn()
+
+    async def remote_start_drive(self) -> dict[str, Any]:
+        """Enable keyless driving."""
+        return await self.cloud.remote_start_drive()
+
+    async def remote_boombox(self, sound: int) -> dict[str, Any]:
+        """Play a sound through the vehicle's external speaker."""
+        return await self.cloud.remote_boombox(sound=sound)
+
+    async def trigger_homelink(
+        self,
+        token: str | None = None,
+        lat: float | None = None,
+        lon: float | None = None,
+    ) -> dict[str, Any]:
+        """Trigger the nearest HomeLink device."""
+        return await self.cloud.trigger_homelink(token=token, lat=lat, lon=lon)
+
+    async def auto_conditioning_start(self) -> dict[str, Any]:
+        """Start climate control."""
+        return await self.cloud.auto_conditioning_start()
+
+    async def auto_conditioning_stop(self) -> dict[str, Any]:
+        """Stop climate control."""
+        return await self.cloud.auto_conditioning_stop()
+
+    async def set_temps(
+        self, driver_temp: float, passenger_temp: float
+    ) -> dict[str, Any]:
+        """Set the driver and passenger temperatures."""
+        return await self.cloud.set_temps(
+            driver_temp=driver_temp, passenger_temp=passenger_temp
+        )
+
+    async def set_climate_keeper_mode(
+        self, climate_keeper_mode: ClimateKeeperMode | int
+    ) -> dict[str, Any]:
+        """Set the climate keeper mode."""
+        return await self.cloud.set_climate_keeper_mode(
+            climate_keeper_mode=climate_keeper_mode
+        )
+
+    async def set_bioweapon_mode(
+        self, on: bool, manual_override: bool
+    ) -> dict[str, Any]:
+        """Set bioweapon defense mode."""
+        return await self.cloud.set_bioweapon_mode(
+            on=on, manual_override=manual_override
+        )
+
+    async def set_cop_temp(
+        self, cop_temp: CabinOverheatProtectionTemp | int
+    ) -> dict[str, Any]:
+        """Set the cabin overheat protection temperature."""
+        return await self.cloud.set_cop_temp(cop_temp=cop_temp)
+
+    async def set_cabin_overheat_protection(
+        self, on: bool, fan_only: bool
+    ) -> dict[str, Any]:
+        """Set cabin overheat protection."""
+        return await self.cloud.set_cabin_overheat_protection(on=on, fan_only=fan_only)
+
+    async def window_control(
+        self,
+        command: str | WindowCommand,
+        lat: float | None = None,
+        lon: float | None = None,
+    ) -> dict[str, Any]:
+        """Control the vehicle's windows."""
+        return await self.cloud.window_control(command=command, lat=lat, lon=lon)
+
+    async def charge_port_door_open(self) -> dict[str, Any]:
+        """Open the charge port door."""
+        return await self.cloud.charge_port_door_open()
+
+    async def charge_port_door_close(self) -> dict[str, Any]:
+        """Close the charge port door."""
+        return await self.cloud.charge_port_door_close()
+
+    async def actuate_trunk(self, which_trunk: Trunk | str) -> dict[str, Any]:
+        """Actuate the front or rear trunk."""
+        return await self.cloud.actuate_trunk(which_trunk=which_trunk)
+
+    async def sun_roof_control(self, state: str | SunRoofCommand) -> dict[str, Any]:
+        """Control the sunroof."""
+        return await self.cloud.sun_roof_control(state=state)
+
+    async def door_lock(self) -> dict[str, Any]:
+        """Lock the vehicle."""
+        return await self.cloud.door_lock()
+
+    async def door_unlock(self) -> dict[str, Any]:
+        """Unlock the vehicle."""
+        return await self.cloud.door_unlock()
+
+    async def adjust_volume(self, volume: float) -> dict[str, Any]:
+        """Adjust the media volume."""
+        return await self.cloud.adjust_volume(volume=volume)
+
+    async def media_toggle_playback(self) -> dict[str, Any]:
+        """Toggle media playback."""
+        return await self.cloud.media_toggle_playback()
+
+    async def media_next_track(self) -> dict[str, Any]:
+        """Skip to the next track."""
+        return await self.cloud.media_next_track()
+
+    async def media_prev_track(self) -> dict[str, Any]:
+        """Skip to the previous track."""
+        return await self.cloud.media_prev_track()
+
+    async def set_charging_amps(self, charging_amps: int) -> dict[str, Any]:
+        """Set the charging amps."""
+        return await self.cloud.set_charging_amps(charging_amps=charging_amps)
+
+    async def set_charge_limit(self, percent: int) -> dict[str, Any]:
+        """Set the charge limit."""
+        return await self.cloud.set_charge_limit(percent=percent)
+
+    async def remote_seat_heater_request(
+        self, seat_position: Seat | int, seat_heater_level: Level | int
+    ) -> dict[str, Any]:
+        """Set a seat heater level."""
+        return await self.cloud.remote_seat_heater_request(
+            seat_position=seat_position, seat_heater_level=seat_heater_level
+        )
+
+    async def remote_steering_wheel_heat_level_request(
+        self, level: Level | int
+    ) -> dict[str, Any]:
+        """Set the steering wheel heater level."""
+        return await self.cloud.remote_steering_wheel_heat_level_request(level=level)
+
+    async def navigation_gps_request(
+        self, lat: float, lon: float, order: int | None = None
+    ) -> dict[str, Any]:
+        """Send a GPS navigation request."""
+        return await self.cloud.navigation_gps_request(lat=lat, lon=lon, order=order)
+
+    async def set_scheduled_charging(self, enable: bool, time: int) -> dict[str, Any]:
+        """Set scheduled charging."""
+        return await self.cloud.set_scheduled_charging(enable=enable, time=time)
+
+    async def set_scheduled_departure(
+        self,
+        enable: bool = True,
+        preconditioning_enabled: bool = False,
+        preconditioning_weekdays_only: bool = False,
+        departure_time: int = 0,
+        off_peak_charging_enabled: bool = False,
+        off_peak_charging_weekdays_only: bool = False,
+        end_off_peak_time: int = 0,
+    ) -> dict[str, Any]:
+        """Set a scheduled departure."""
+        return await self.cloud.set_scheduled_departure(
+            enable=enable,
+            preconditioning_enabled=preconditioning_enabled,
+            preconditioning_weekdays_only=preconditioning_weekdays_only,
+            departure_time=departure_time,
+            off_peak_charging_enabled=off_peak_charging_enabled,
+            off_peak_charging_weekdays_only=off_peak_charging_weekdays_only,
+            end_off_peak_time=end_off_peak_time,
+        )
+
+    async def set_valet_mode(
+        self, on: bool, password: str | int | None = None
+    ) -> dict[str, Any]:
+        """Set valet mode."""
+        return await self.cloud.set_valet_mode(on=on, password=password)
+
+    async def speed_limit_activate(self, pin: str | int) -> dict[str, Any]:
+        """Activate the speed limit."""
+        return await self.cloud.speed_limit_activate(pin=pin)
+
+    async def speed_limit_deactivate(self, pin: str | int) -> dict[str, Any]:
+        """Deactivate the speed limit."""
+        return await self.cloud.speed_limit_deactivate(pin=pin)
+
+    async def add_charge_schedule(
+        self,
+        days_of_week: str | int,
+        enabled: bool,
+        lat: float,
+        lon: float,
+        start_time: int | None = None,
+        end_time: int | None = None,
+        one_time: bool | None = None,
+        id: int | None = None,
+        name: str | None = None,
+    ) -> dict[str, Any]:
+        """Add or modify a charge schedule."""
+        return await self.cloud.add_charge_schedule(
+            days_of_week=days_of_week,
+            enabled=enabled,
+            lat=lat,
+            lon=lon,
+            start_time=start_time,
+            end_time=end_time,
+            one_time=one_time,
+            id=id,
+            name=name,
+        )
+
+    async def remove_charge_schedule(self, id: int) -> dict[str, Any]:
+        """Remove a charge schedule."""
+        return await self.cloud.remove_charge_schedule(id=id)
+
+    async def add_precondition_schedule(
+        self,
+        days_of_week: str | int,
+        enabled: bool,
+        lat: float,
+        lon: float,
+        precondition_time: int,
+        id: int | None = None,
+        one_time: bool | None = None,
+        name: str | None = None,
+    ) -> dict[str, Any]:
+        """Add or modify a precondition schedule."""
+        return await self.cloud.add_precondition_schedule(
+            days_of_week=days_of_week,
+            enabled=enabled,
+            lat=lat,
+            lon=lon,
+            precondition_time=precondition_time,
+            id=id,
+            one_time=one_time,
+            name=name,
+        )
+
+    async def remove_precondition_schedule(self, id: int) -> dict[str, Any]:
+        """Remove a precondition schedule."""
+        return await self.cloud.remove_precondition_schedule(id=id)
+
+    async def set_sentry_mode(self, on: bool) -> dict[str, Any]:
+        """Set sentry mode."""
+        return await self.cloud.set_sentry_mode(on=on)
+
+    async def remote_auto_seat_climate_request(
+        self, auto_seat_position: int | Seat, auto_climate_on: bool
+    ) -> dict[str, Any]:
+        """Set automatic seat climate."""
+        return await self.cloud.remote_auto_seat_climate_request(
+            auto_seat_position=auto_seat_position, auto_climate_on=auto_climate_on
+        )
+
+    async def remote_auto_steering_wheel_heat_climate_request(
+        self, on: bool
+    ) -> dict[str, Any]:
+        """Set automatic steering wheel heating."""
+        return await self.cloud.remote_auto_steering_wheel_heat_climate_request(on=on)
+
+    async def set_preconditioning_max(
+        self, on: bool, manual_override: bool
+    ) -> dict[str, Any]:
+        """Set max defrost preconditioning."""
+        return await self.cloud.set_preconditioning_max(
+            on=on, manual_override=manual_override
+        )
+
+    async def charge_start(self) -> dict[str, Any]:
+        """Start charging."""
+        return await self.cloud.charge_start()
+
+    async def charge_stop(self) -> dict[str, Any]:
+        """Stop charging."""
+        return await self.cloud.charge_stop()
+
+    async def guest_mode(self, enable: bool) -> dict[str, Any]:
+        """Set guest mode."""
+        return await self.cloud.guest_mode(enable=enable)
+
+    async def schedule_software_update(self, offset_sec: int) -> dict[str, Any]:
+        """Schedule a software update."""
+        return await self.cloud.schedule_software_update(offset_sec=offset_sec)
+
+
+class EnergySource:
+    """Command facade for a Tesla energy site."""
+
+    def __init__(self, cloud: EnergySite) -> None:
+        """Initialize the energy source with its cloud client."""
+        self.cloud = cloud
+
+    async def backup(self, backup_reserve_percent: int) -> dict[str, Any]:
+        """Set the backup reserve percentage."""
+        return await self.cloud.backup(backup_reserve_percent=backup_reserve_percent)
+
+    async def off_grid_vehicle_charging_reserve(
+        self, off_grid_vehicle_charging_reserve_percent: int
+    ) -> dict[str, Any]:
+        """Set the off-grid vehicle charging reserve percentage."""
+        return await self.cloud.off_grid_vehicle_charging_reserve(
+            off_grid_vehicle_charging_reserve_percent=off_grid_vehicle_charging_reserve_percent
+        )
+
+    async def operation(
+        self, default_real_mode: EnergyOperationMode | str
+    ) -> dict[str, Any]:
+        """Set the operation mode."""
+        return await self.cloud.operation(default_real_mode=default_real_mode)
+
+    async def grid_import_export(
+        self,
+        disallow_charge_from_grid_with_solar_installed: bool | None = None,
+        customer_preferred_export_rule: EnergyExportMode | str | None = None,
+    ) -> dict[str, Any]:
+        """Set the grid import/export rules."""
+        return await self.cloud.grid_import_export(
+            disallow_charge_from_grid_with_solar_installed=disallow_charge_from_grid_with_solar_installed,
+            customer_preferred_export_rule=customer_preferred_export_rule,
+        )
+
+    async def storm_mode(self, enabled: bool) -> dict[str, Any]:
+        """Set storm watch mode."""
+        return await self.cloud.storm_mode(enabled=enabled)
+
+    async def time_of_use_settings(self, settings: dict[str, Any]) -> dict[str, Any]:
+        """Set the time of use settings."""
+        return await self.cloud.time_of_use_settings(settings=settings)

--- a/homeassistant/components/teslemetry/switch.py
+++ b/homeassistant/components/teslemetry/switch.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 from typing import Any
 
 from tesla_fleet_api.const import AutoSeat, Scope
-from tesla_fleet_api.teslemetry import Vehicle
 from teslemetry_stream import TeslemetryStreamVehicle
 
 from homeassistant.components.switch import (
@@ -27,6 +26,7 @@ from .entity import (
 )
 from .helpers import handle_command, handle_vehicle_command
 from .models import TeslemetryEnergyData, TeslemetryVehicleData
+from .source import VehicleSource
 
 PARALLEL_UPDATES = 0
 
@@ -36,8 +36,8 @@ class TeslemetrySwitchEntityDescription(SwitchEntityDescription):
     """Describes Teslemetry Switch entity."""
 
     polling: bool = False
-    on_func: Callable[[Vehicle], Awaitable[dict[str, Any]]]
-    off_func: Callable[[Vehicle], Awaitable[dict[str, Any]]]
+    on_func: Callable[[VehicleSource], Awaitable[dict[str, Any]]]
+    off_func: Callable[[VehicleSource], Awaitable[dict[str, Any]]]
     scopes: list[Scope]
     value_func: Callable[[StateType], bool] = bool
     streaming_listener: Callable[
@@ -197,7 +197,7 @@ async def async_setup_entry(
 class TeslemetryVehicleSwitchEntity(TeslemetryRootEntity, SwitchEntity):
     """Base class for all Teslemetry switch entities."""
 
-    api: Vehicle
+    api: VehicleSource
     _attr_device_class = SwitchDeviceClass.SWITCH
     entity_description: TeslemetrySwitchEntityDescription
 

--- a/homeassistant/components/teslemetry/update.py
+++ b/homeassistant/components/teslemetry/update.py
@@ -3,7 +3,6 @@
 from typing import Any
 
 from tesla_fleet_api.const import Scope
-from tesla_fleet_api.teslemetry import Vehicle
 
 from homeassistant.components.update import UpdateEntity, UpdateEntityFeature
 from homeassistant.core import HomeAssistant
@@ -18,6 +17,7 @@ from .entity import (
 )
 from .helpers import handle_vehicle_command
 from .models import TeslemetryVehicleData
+from .source import VehicleSource
 
 AVAILABLE = "available"
 DOWNLOADING = "downloading"
@@ -46,7 +46,7 @@ async def async_setup_entry(
 class TeslemetryUpdateEntity(TeslemetryRootEntity, UpdateEntity):
     """Teslemetry Updates entity."""
 
-    api: Vehicle
+    api: VehicleSource
     _attr_supported_features = UpdateEntityFeature.PROGRESS
 
     async def async_install(

--- a/tests/components/teslemetry/test_services.py
+++ b/tests/components/teslemetry/test_services.py
@@ -94,7 +94,13 @@ async def test_services(
             blocking=True,
         )
         set_scheduled_departure_off.assert_called_once_with(
-            False, False, False, 0, False, False, 0
+            enable=False,
+            preconditioning_enabled=False,
+            preconditioning_weekdays_only=False,
+            departure_time=0,
+            off_peak_charging_enabled=False,
+            off_peak_charging_weekdays_only=False,
+            end_off_peak_time=0,
         )
 
     with patch(
@@ -210,7 +216,7 @@ async def test_services(
             },
             blocking=True,
         )
-        set_time_of_use.assert_called_once_with({"utility": "test"})
+        set_time_of_use.assert_called_once_with(settings={"utility": "test"})
 
     # Test that tariff_content_v2 wrapper is unwrapped before passing to SDK
     with patch(
@@ -228,7 +234,7 @@ async def test_services(
             },
             blocking=True,
         )
-        set_time_of_use.assert_called_once_with({"utility": "test"})
+        set_time_of_use.assert_called_once_with(settings={"utility": "test"})
 
     with patch(
         "tesla_fleet_api.teslemetry.Vehicle.add_charge_schedule",

--- a/tests/components/teslemetry/test_source.py
+++ b/tests/components/teslemetry/test_source.py
@@ -1,0 +1,165 @@
+"""Tests for the Teslemetry command source facades."""
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from tesla_fleet_api.teslemetry import EnergySite, Vehicle
+
+from homeassistant.components.teslemetry.source import EnergySource, VehicleSource
+
+# Every vehicle command method the entities and services invoke on the facade,
+# with an explicit value for every parameter so faithful forwarding is asserted.
+VEHICLE_COMMANDS: list[tuple[str, dict[str, Any]]] = [
+    ("wake_up", {}),
+    ("flash_lights", {}),
+    ("honk_horn", {}),
+    ("remote_start_drive", {}),
+    ("remote_boombox", {"sound": 0}),
+    ("trigger_homelink", {"token": "abc", "lat": 1.0, "lon": 2.0}),
+    ("auto_conditioning_start", {}),
+    ("auto_conditioning_stop", {}),
+    ("set_temps", {"driver_temp": 21.0, "passenger_temp": 22.0}),
+    ("set_climate_keeper_mode", {"climate_keeper_mode": 1}),
+    ("set_bioweapon_mode", {"on": True, "manual_override": False}),
+    ("set_cop_temp", {"cop_temp": 30}),
+    ("set_cabin_overheat_protection", {"on": True, "fan_only": False}),
+    ("window_control", {"command": "vent", "lat": 1.0, "lon": 2.0}),
+    ("charge_port_door_open", {}),
+    ("charge_port_door_close", {}),
+    ("actuate_trunk", {"which_trunk": "front"}),
+    ("sun_roof_control", {"state": "vent"}),
+    ("door_lock", {}),
+    ("door_unlock", {}),
+    ("adjust_volume", {"volume": 0.5}),
+    ("media_toggle_playback", {}),
+    ("media_next_track", {}),
+    ("media_prev_track", {}),
+    ("set_charging_amps", {"charging_amps": 16}),
+    ("set_charge_limit", {"percent": 80}),
+    ("remote_seat_heater_request", {"seat_position": 1, "seat_heater_level": 2}),
+    ("remote_steering_wheel_heat_level_request", {"level": 1}),
+    ("navigation_gps_request", {"lat": 1.0, "lon": 2.0, "order": 0}),
+    ("set_scheduled_charging", {"enable": True, "time": 600}),
+    (
+        "set_scheduled_departure",
+        {
+            "enable": True,
+            "preconditioning_enabled": False,
+            "preconditioning_weekdays_only": False,
+            "departure_time": 0,
+            "off_peak_charging_enabled": False,
+            "off_peak_charging_weekdays_only": False,
+            "end_off_peak_time": 0,
+        },
+    ),
+    ("set_valet_mode", {"on": True, "password": "1234"}),
+    ("speed_limit_activate", {"pin": "1234"}),
+    ("speed_limit_deactivate", {"pin": "1234"}),
+    (
+        "add_charge_schedule",
+        {
+            "days_of_week": "All",
+            "enabled": True,
+            "lat": 1.0,
+            "lon": 2.0,
+            "start_time": 0,
+            "end_time": 60,
+            "one_time": False,
+            "id": 1,
+            "name": "Schedule",
+        },
+    ),
+    ("remove_charge_schedule", {"id": 1}),
+    (
+        "add_precondition_schedule",
+        {
+            "days_of_week": "All",
+            "enabled": True,
+            "lat": 1.0,
+            "lon": 2.0,
+            "precondition_time": 360,
+            "id": 1,
+            "one_time": False,
+            "name": "Schedule",
+        },
+    ),
+    ("remove_precondition_schedule", {"id": 1}),
+    ("set_sentry_mode", {"on": True}),
+    (
+        "remote_auto_seat_climate_request",
+        {"auto_seat_position": 1, "auto_climate_on": True},
+    ),
+    ("remote_auto_steering_wheel_heat_climate_request", {"on": True}),
+    ("set_preconditioning_max", {"on": True, "manual_override": False}),
+    ("charge_start", {}),
+    ("charge_stop", {}),
+    ("guest_mode", {"enable": True}),
+    ("schedule_software_update", {"offset_sec": 0}),
+]
+
+ENERGY_COMMANDS: list[tuple[str, dict[str, Any]]] = [
+    ("backup", {"backup_reserve_percent": 20}),
+    (
+        "off_grid_vehicle_charging_reserve",
+        {"off_grid_vehicle_charging_reserve_percent": 20},
+    ),
+    ("operation", {"default_real_mode": "autonomous"}),
+    (
+        "grid_import_export",
+        {
+            "disallow_charge_from_grid_with_solar_installed": False,
+            "customer_preferred_export_rule": "battery_ok",
+        },
+    ),
+    ("storm_mode", {"enabled": True}),
+    ("time_of_use_settings", {"settings": {"tariff": "content"}}),
+]
+
+
+@pytest.mark.parametrize(
+    ("method", "kwargs"),
+    [pytest.param(method, kwargs, id=method) for method, kwargs in VEHICLE_COMMANDS],
+)
+async def test_vehicle_source_forwards_to_cloud(
+    method: str, kwargs: dict[str, Any]
+) -> None:
+    """Test the vehicle source forwards each command to the cloud client."""
+    cloud = AsyncMock(spec=Vehicle)
+    source = VehicleSource(cloud)
+
+    result = await getattr(source, method)(**kwargs)
+
+    cloud_method = getattr(cloud, method)
+    cloud_method.assert_awaited_once_with(**kwargs)
+    assert result is cloud_method.return_value
+
+
+@pytest.mark.parametrize(
+    ("method", "kwargs"),
+    [pytest.param(method, kwargs, id=method) for method, kwargs in ENERGY_COMMANDS],
+)
+async def test_energy_source_forwards_to_cloud(
+    method: str, kwargs: dict[str, Any]
+) -> None:
+    """Test the energy source forwards each command to the cloud client."""
+    cloud = AsyncMock(spec=EnergySite)
+    source = EnergySource(cloud)
+
+    result = await getattr(source, method)(**kwargs)
+
+    cloud_method = getattr(cloud, method)
+    cloud_method.assert_awaited_once_with(**kwargs)
+    assert result is cloud_method.return_value
+
+
+def test_vehicle_source_exposes_cloud_client() -> None:
+    """Test the vehicle source exposes the wrapped cloud client."""
+    cloud = AsyncMock(spec=Vehicle)
+    assert VehicleSource(cloud).cloud is cloud
+
+
+def test_energy_source_exposes_cloud_client() -> None:
+    """Test the energy source exposes the wrapped cloud client."""
+    cloud = AsyncMock(spec=EnergySite)
+    assert EnergySource(cloud).cloud is cloud


### PR DESCRIPTION
## Proposed change

This is a pure refactor with **no functional or behavioral change**. It introduces a per-device command facade (a "source" layer) for Teslemetry so that command dispatch happens through a single, well-typed seam.

**The purpose is to provide an abstraction layer enabling both local and cloud connectivity seamlessly.**

I have a stacked series of PRs that will fold local device paths (local Powerwall over LAN, vehicles over BLE) into Teslemetry. Centralizing command forwarding behind one facade gives later PRs a single seam to add local-first / cloud-fallback dispatch behind the existing unified entities, without touching every platform again

A new `source.py` adds two facade classes:

- `VehicleSource` wraps the cloud `Vehicle` client and exposes 46 explicit, typed command methods.
- `EnergySource` wraps the cloud `EnergySite` client and exposes 6 command methods.

Before you suggest this should be implemented into the library, the purpose of the source abstraction is so the integration can use two different libraries depending on the context.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr