### PR TITLE
Refactor inels load/unload tests

### DIFF
--- a/tests/components/inels/test_init.py
+++ b/tests/components/inels/test_init.py
@@ -6,7 +6,7 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
 from . import HA_INELS_PATH
-from .common import DOMAIN, inels
+from .common import DOMAIN
 
 from tests.common import MockConfigEntry
 from tests.typing import MqttMockHAClient
@@ -21,10 +21,7 @@ async def test_ha_mqtt_publish(
 
     with (
         patch(f"{HA_INELS_PATH}.InelsDiscovery") as mock_discovery_class,
-        patch(
-            "homeassistant.config_entries.ConfigEntries.async_forward_entry_setups",
-            return_value=None,
-        ),
+        patch("homeassistant.components.inels.PLATFORMS", []),
     ):
         mock_discovery = AsyncMock()
         mock_discovery.start.return_value = []
@@ -49,10 +46,7 @@ async def test_ha_mqtt_subscribe(
 
     with (
         patch(f"{HA_INELS_PATH}.InelsDiscovery") as mock_discovery_class,
-        patch(
-            "homeassistant.config_entries.ConfigEntries.async_forward_entry_setups",
-            return_value=None,
-        ),
+        patch("homeassistant.components.inels.PLATFORMS", []),
     ):
         mock_discovery = AsyncMock()
         mock_discovery.start.return_value = []
@@ -82,20 +76,25 @@ async def test_ha_mqtt_not_available(
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_unload_entry(hass: HomeAssistant, mock_mqtt) -> None:
+async def test_unload_entry(
+    hass: HomeAssistant, mqtt_mock: MqttMockHAClient, mock_mqtt
+) -> None:
     """Test unload entry."""
     config_entry = MockConfigEntry(domain=DOMAIN, data={})
     config_entry.add_to_hass(hass)
 
-    config_entry.runtime_data = inels.InelsData(mqtt=mock_mqtt, devices=[])
+    with (
+        patch(f"{HA_INELS_PATH}.InelsDiscovery") as mock_discovery_class,
+        patch("homeassistant.components.inels.PLATFORMS", []),
+    ):
+        mock_discovery = AsyncMock()
+        mock_discovery.start.return_value = []
+        mock_discovery_class.return_value = mock_discovery
 
-    with patch(
-        "homeassistant.config_entries.ConfigEntries.async_unload_platforms",
-        return_value=True,
-    ) as mock_unload_platforms:
-        result = await inels.async_unload_entry(hass, config_entry)
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+
+        result = await hass.config_entries.async_unload(config_entry.entry_id)
 
         assert result is True
         mock_mqtt.unsubscribe_topics.assert_called_once()
         mock_mqtt.unsubscribe_listeners.assert_called_once()
-        mock_unload_platforms.assert_called_once()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Avoid setting `runtime_data` directly, and avoid calling `component.async_unload_entry` directly in `inels`.

Needed for #173870

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
