### PR TITLE
Refactor thermopro tests to avoid `thermopro_sensor.async_setup_entry`

### DIFF
--- a/tests/components/thermopro/test_sensor.py
+++ b/tests/components/thermopro/test_sensor.py
@@ -1,15 +1,6 @@
 """Test the ThermoPro sensors."""
 
-from unittest.mock import MagicMock
-
-import pytest
-
-from homeassistant.components.bluetooth.passive_update_processor import (
-    PassiveBluetoothDataProcessor,
-)
-from homeassistant.components.sensor import ATTR_STATE_CLASS, SensorEntityDescription
-import homeassistant.components.thermopro as thermopro_integration
-from homeassistant.components.thermopro import sensor as thermopro_sensor
+from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.components.thermopro.const import DOMAIN
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
 from homeassistant.core import HomeAssistant
@@ -17,7 +8,10 @@ from homeassistant.core import HomeAssistant
 from . import TP357_SERVICE_INFO, TP962R_SERVICE_INFO, TP962R_SERVICE_INFO_2
 
 from tests.common import MockConfigEntry
-from tests.components.bluetooth import inject_bluetooth_service_info
+from tests.components.bluetooth import (
+    inject_bluetooth_service_info,
+    patch_discovered_devices,
+)
 
 
 async def test_sensors_tp962r(hass: HomeAssistant) -> None:
@@ -136,125 +130,32 @@ async def test_sensors(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
 
-class CoordinatorStub:
-    """Coordinator stub for testing entity restoration behavior."""
-
-    instances: list[CoordinatorStub] = []
-
-    def __init__(
-        self,
-        hass: HomeAssistant | None = None,
-        logger: MagicMock | None = None,
-        *,
-        address: str | None = None,
-        mode: MagicMock | None = None,
-        update_method: MagicMock | None = None,
-    ) -> None:
-        """Initialize coordinator stub with signature matching real coordinator."""
-        # Track created instances to avoid direct hass.data access in tests
-        CoordinatorStub.instances.append(self)
-        self.calls: list[tuple[MagicMock, type | None]] = []
-        self._saw_sensor_entity_description = False
-        self._restore_cb: MagicMock | None = None
-
-    def async_register_processor(
-        self, processor: MagicMock, entity_description_cls: type | None = None
-    ) -> MagicMock:
-        """Register a processor and track if SensorEntityDescription was provided."""
-        self.calls.append((processor, entity_description_cls))
-
-        if entity_description_cls is SensorEntityDescription:
-            self._saw_sensor_entity_description = True
-
-        return lambda: None
-
-    def async_start(self) -> MagicMock:
-        """Return a no-op unsub function for start lifecycle."""
-        return lambda: None
-
-    def trigger_restore_from_test(self) -> None:
-        """Trigger restoration callback if available."""
-        if self._saw_sensor_entity_description and self._restore_cb:
-            self._restore_cb([])
-
-    def set_restore_callback(self, callback: MagicMock) -> None:
-        """Set the callback used to restore entities during the test."""
-        self._restore_cb = callback
-
-
-async def test_thermopro_restores_entities_on_restart_behavior(
-    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Test that entities are restored on restart via SensorEntityDescription."""
-
-    add_entities_callbacks: list[MagicMock] = []
-
-    orig_add_listener = PassiveBluetoothDataProcessor.async_add_entities_listener
-
-    def wrapped_add_listener(
-        self: PassiveBluetoothDataProcessor,
-        entity_cls: type,
-        add_entities: MagicMock,
-    ) -> MagicMock:
-        add_entities_callbacks.append(add_entities)
-        return orig_add_listener(self, entity_cls, add_entities)
-
-    monkeypatch.setattr(
-        PassiveBluetoothDataProcessor,
-        "async_add_entities_listener",
-        wrapped_add_listener,
+async def test_sensors_restored_on_restart(hass: HomeAssistant) -> None:
+    """Test sensors are restored on restart before a new advertisement arrives."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="4125DDBA-2774-4851-9889-6AADDD4CAC3D",
     )
+    entry.add_to_hass(hass)
 
-    first_called = {"v": False}
-    second_called = {"v": False}
-
-    def add_entities_first(entities: list) -> None:
-        first_called["v"] = True
-
-    def add_entities_second(entities: list) -> None:
-        second_called["v"] = True
-
-    # Patch the integration to avoid platform forwarding and use the coordinator stub
-    monkeypatch.setattr(thermopro_integration, "PLATFORMS", [])
-    monkeypatch.setattr(
-        thermopro_integration, "PassiveBluetoothProcessorCoordinator", CoordinatorStub
-    )
-    # Ensure a clean slate for stub instance tracking
-    CoordinatorStub.instances.clear()
-
-    # First setup using real config entry setup to populate hass.data
-    entry1 = MockConfigEntry(domain=DOMAIN, unique_id="00:11:22:33:44:55")
-    entry1.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(entry1.entry_id)
+    assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    # Manually set up sensor platform with our callback
-    # pylint: disable-next=home-assistant-tests-direct-platform-async-setup-entry
-    await thermopro_sensor.async_setup_entry(hass, entry1, add_entities_first)
+    inject_bluetooth_service_info(hass, TP357_SERVICE_INFO)
+    await hass.async_block_till_done()
+    assert len(hass.states.async_all()) == 3
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
-    coord = CoordinatorStub.instances[0]
-    assert coord.calls, "Processor was not registered on first setup"
-    assert not first_called["v"]
+    # Simulate a restart with no fresh advertisement: drop the leftover states
+    # and clear the cached advertisements so only the restore storage can
+    # recreate the entities.
+    for state in hass.states.async_all():
+        hass.states.async_remove(state.entity_id)
 
-    # Second setup (simulating restart)
-    entry2 = MockConfigEntry(domain=DOMAIN, unique_id="AA:BB:CC:DD:EE:FF")
-    entry2.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(entry2.entry_id)
-    await hass.async_block_till_done()
+    with patch_discovered_devices([]):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
 
-    # pylint: disable-next=home-assistant-tests-direct-platform-async-setup-entry
-    await thermopro_sensor.async_setup_entry(hass, entry2, add_entities_second)
-    await hass.async_block_till_done()
-
-    assert add_entities_callbacks, "No add_entities callback was registered"
-    coord2 = CoordinatorStub.instances[1]
-    coord2.set_restore_callback(add_entities_callbacks[-1])
-
-    coord2.trigger_restore_from_test()
-    await hass.async_block_till_done()
-
-    assert second_called["v"], (
-        "ThermoPro did not trigger restoration on startup. "
-        "Ensure async_register_processor(processor, SensorEntityDescription) is used."
-    )
+    assert len(hass.states.async_all()) == 3


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
### What the violation was
The rule (W7420, epic #77) forbids tests from calling a platform's `async_setup_entry` directly — they should drive setup through `hass.config_entries.async_setup` so platforms load via the normal HA flow. The test `test_thermopro_restores_entities_on_restart_behavior` called `thermopro_sensor.async_setup_entry(...)` directly (twice), suppressing the warning with `# pylint: disable-next` comments. It did this via a hand-rolled `CoordinatorStub` and monkeypatching `PLATFORMS = []` — a white-box test of the framework internals.

### What I changed
Replaced the white-box test (and the `CoordinatorStub` class plus now-unused imports) with a behavioral test, `test_sensors_restored_on_restart`, that drives everything through `hass.config_entries.async_setup`:

1 - Set up the entry, inject an advertisement → 3 sensors created.
2 - Unload (simulating shutdown).
3 - Simulate a fresh process: drop leftover states and use `patch_discovered_devices([])` so no cached advertisement is replayed.
4 - Set up again → assert the 3 sensors are restored from storage without any new advertisement.

### Why this is a meaningful test, not just a rule-silencer
The original fix (PR #155929) added `SensorEntityDescription` to `async_register_processor`, which enables restore-from-storage. I verified the new test actually guards that regression: with the fix it restores 3 entities, and after reverting the one-line production change it restores 0. The key was eliminating the two confounders that otherwise mask the difference — advertisement replay (`patch_discovered_devices([])`) and stale `unavailable` states left behind by unload.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #171875
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
