### PR TITLE
Add Roborock Q10 map image entity

### DIFF
--- a/homeassistant/components/roborock/icons.json
+++ b/homeassistant/components/roborock/icons.json
@@ -40,6 +40,11 @@
         "default": "mdi:brush"
       }
     },
+    "image": {
+      "map": {
+        "default": "mdi:floor-plan"
+      }
+    },
     "number": {
       "volume": {
         "default": "mdi:volume-source"

--- a/homeassistant/components/roborock/image.py
+++ b/homeassistant/components/roborock/image.py
@@ -14,13 +14,15 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.util import dt as dt_util
 
 from .coordinator import (
+    RoborockB01Q10UpdateCoordinator,
     RoborockConfigEntry,
     RoborockCoordinatorType,
     RoborockDataUpdateCoordinator,
 )
-from .entity import RoborockCoordinatedEntityV1
+from .entity import RoborockCoordinatedEntityB01Q10, RoborockCoordinatedEntityV1
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -40,20 +42,22 @@ async def async_setup_entry(
         coordinator: RoborockCoordinatorType,
     ) -> None:
         """Add entities for a specific coordinator."""
-        if not isinstance(coordinator, RoborockDataUpdateCoordinator):
-            return
-        entities = [
-            RoborockMap(
-                config_entry,
-                coordinator,
-                coordinator.properties_api.home,
-                map_info.map_flag,
-                map_info.name,
+        entities: list[ImageEntity] = []
+        if isinstance(coordinator, RoborockDataUpdateCoordinator):
+            entities.extend(
+                RoborockMap(
+                    config_entry,
+                    coordinator,
+                    coordinator.properties_api.home,
+                    map_info.map_flag,
+                    map_info.name,
+                )
+                for map_info in (
+                    coordinator.properties_api.home.home_map_info or {}
+                ).values()
             )
-            for map_info in (
-                coordinator.properties_api.home.home_map_info or {}
-            ).values()
-        ]
+        elif isinstance(coordinator, RoborockB01Q10UpdateCoordinator):
+            entities.append(RoborockMapQ10(coordinator))
         async_add_entities(entities)
 
     for coordinator in coordinators.values():
@@ -134,3 +138,50 @@ class RoborockMap(RoborockCoordinatedEntityV1, ImageEntity):
         if (map_content := self._map_content) is None:
             raise HomeAssistantError("Map flag not found in coordinator maps")
         return map_content.image_content
+
+
+class RoborockMapQ10(RoborockCoordinatedEntityB01Q10, ImageEntity):
+    """A class to let you visualize the current map of a Q10 device.
+
+    The Q10 pushes its current map over MQTT rather than serving it on
+    request, and the multi-map list is not reachable on this channel, so the
+    device exposes a single push-driven map entity.
+    """
+
+    _attr_content_type = "image/png"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_translation_key = "map"
+
+    def __init__(self, coordinator: RoborockB01Q10UpdateCoordinator) -> None:
+        """Initialize a Roborock Q10 map."""
+        RoborockCoordinatedEntityB01Q10.__init__(
+            self, f"map_{coordinator.duid_slug}", coordinator
+        )
+        ImageEntity.__init__(self, coordinator.hass)
+        self._map_trait = coordinator.api.map
+        self._cached_map: bytes | None = None
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Register a trait listener for push-based map updates."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self._map_trait.add_update_listener(self._handle_map_update)
+        )
+        # Pick up a map that was pushed before the entity was added.
+        self._handle_map_update()
+
+    @callback
+    def _handle_map_update(self) -> None:
+        """Cache the newly pushed map if its content changed."""
+        image_content = self._map_trait.image_content
+        if image_content is None or image_content == self._cached_map:
+            return
+        self._cached_map = image_content
+        self._attr_image_last_updated = dt_util.utcnow()
+        self.async_write_ha_state()
+
+    @override
+    async def async_image(self) -> bytes | None:
+        """Get the cached image."""
+        return self._cached_map

--- a/homeassistant/components/roborock/strings.json
+++ b/homeassistant/components/roborock/strings.json
@@ -125,6 +125,11 @@
         "name": "Start"
       }
     },
+    "image": {
+      "map": {
+        "name": "Map"
+      }
+    },
     "number": {
       "volume": {
         "name": "Volume"

--- a/tests/components/roborock/conftest.py
+++ b/tests/components/roborock/conftest.py
@@ -239,6 +239,7 @@ def create_b01_q10_trait() -> Mock:
     q10_trait.button_light.disable = AsyncMock()
 
     q10_trait.map = Mock()
+    q10_trait.map.image_content = b"\x89PNG-q10"
     q10_trait.map.rooms = [
         Q10Room(id=9, raw_name="rr_bedroom", pixel_value=36, pixel_count=100),
         Q10Room(id=10, raw_name="rr_living_room", pixel_value=40, pixel_count=200),

--- a/tests/components/roborock/test_image.py
+++ b/tests/components/roborock/test_image.py
@@ -6,6 +6,7 @@ from http import HTTPStatus
 import logging
 from unittest.mock import patch
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 from roborock import MultiMapsList, RoborockException
 from roborock.data import RoborockStateCode
@@ -45,7 +46,7 @@ async def test_floorplan_image(
     fake_devices: list[FakeDevice],
 ) -> None:
     """Test floor plan map image is correctly set up."""
-    assert len(hass.states.async_all("image")) == 4
+    assert len(hass.states.async_all("image")) == 5
 
     assert hass.states.get("image.roborock_s7_maxv_upstairs") is not None
     # Load the image on demand
@@ -131,7 +132,7 @@ async def test_map_status_change(
     fake_vacuum: FakeDevice,
 ) -> None:
     """Test floor plan map image is correctly updated on status change."""
-    assert len(hass.states.async_all("image")) == 4
+    assert len(hass.states.async_all("image")) == 5
 
     assert hass.states.get("image.roborock_s7_maxv_upstairs") is not None
     client = await hass_client()
@@ -181,6 +182,7 @@ async def test_map_status_change(
                 "image.roborock_s7_2_upstairs",
                 "image.roborock_s7_maxv_downstairs",
                 "image.roborock_s7_maxv_upstairs",
+                "image.roborock_q10_s5_map",
             },
         ),
         (
@@ -191,6 +193,7 @@ async def test_map_status_change(
                 # Expect default names based on map flags
                 "image.roborock_s7_maxv_map_0",
                 "image.roborock_s7_maxv_map_1",
+                "image.roborock_q10_s5_map",
             },
         ),
     ],
@@ -222,3 +225,52 @@ async def test_image_entity_naming(
     assert {
         state.entity_id for state in hass.states.async_all("image")
     } == expected_entity_ids
+
+
+async def test_q10_map_image(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    hass_client: ClientSessionGenerator,
+    fake_q10_vacuum: FakeDevice,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test the push-driven Q10 map image."""
+    entity_id = "image.roborock_q10_s5_map"
+    assert hass.states.get(entity_id) is not None
+
+    # The map pushed before startup is served
+    client = await hass_client()
+    resp = await client.get(f"/api/image_proxy/{entity_id}")
+    assert resp.status == HTTPStatus.OK
+    assert await resp.read() == b"\x89PNG-q10"
+
+    assert fake_q10_vacuum.b01_q10_properties is not None
+    map_trait = fake_q10_vacuum.b01_q10_properties.map
+
+    def push_update() -> None:
+        for call in map_trait.add_update_listener.call_args_list:
+            call.args[0]()
+
+    # A push that does not change the map content must not update the entity
+    state = hass.states.get(entity_id)
+    assert state is not None
+    last_updated = state.state
+    freezer.tick(timedelta(seconds=30))
+    push_update()
+    await hass.async_block_till_done()
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == last_updated
+
+    # The device pushes an updated map
+    freezer.tick(timedelta(seconds=30))
+    map_trait.image_content = b"\x89PNG-q10-new"
+    push_update()
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state != last_updated
+    resp = await client.get(f"/api/image_proxy/{entity_id}")
+    assert resp.status == HTTPStatus.OK
+    assert await resp.read() == b"\x89PNG-q10-new"


### PR DESCRIPTION
## Proposed change

Adds the **map image entity** for the Roborock **Q10** (B01/ss07), continuing the existing Q10 support (vacuum, sensors, select, button, segment cleaning and switches are already merged). Split out to one platform per PR as requested in review; switch (#175731, merged) and number (#175732) are separate PRs.

The Q10 pushes its current map over MQTT — there is no request/response map API and the multi-map list is not reachable on this channel — so this is a single push-driven entity per device:

- Subscribes to the map trait's `add_update_listener` (unsubscribed via `async_on_remove`), picking up any map pushed before the entity was added.
- Only bumps `image_last_updated` (and writes state) when the pushed PNG content actually changes, so no-op pushes don't touch the state machine.
- `image/png` content type; `DIAGNOSTIC` entity category and `map_{duid_slug}` unique id, matching the V1 map entities' conventions.

No dependency bump: this targets the already-pinned `python-roborock` version. (The upcoming map-layers release only changes rendering internals; the trait API consumed here is identical — verified by running this test suite against that branch as well.)

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Sibling per-platform PRs from the same split: #175731 (switch, merged), #175732 (number).

Testing: new test covers serving the initially pushed map, a no-op push not updating the entity, and a content-changing push updating both the image and `image_last_updated`; image entity-count and naming assertions updated. Full `tests/components/roborock` suite passes locally (Python 3.14); ruff, mypy (strict) and hassfest clean.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
