### PR TITLE
Bump pypck to 0.9.13

### DIFF
--- a/homeassistant/components/lcn/manifest.json
+++ b/homeassistant/components/lcn/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_polling",
   "loggers": ["pypck"],
   "quality_scale": "silver",
-  "requirements": ["pypck==0.9.11", "lcn-frontend==0.2.9"]
+  "requirements": ["pypck==0.9.13", "lcn-frontend==0.2.9"]
 }

--- a/homeassistant/components/lcn/sensor.py
+++ b/homeassistant/components/lcn/sensor.py
@@ -175,7 +175,7 @@ class LcnLedLogicSensor(LcnEntity, SensorEntity):
     async def async_update(self) -> None:
         """Update the state of the entity."""
         self._attr_available = (
-            await self.device_connection.request_status_led_and_logic_ops(
+            await self.device_connection.request_status_leds_and_logic_ops(
                 SCAN_INTERVAL.seconds
             )
             is not None

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2453,7 +2453,7 @@ pypaperless==4.1.1
 pypca==0.0.7
 
 # homeassistant.components.lcn
-pypck==0.9.11
+pypck==0.9.13
 
 # homeassistant.components.pglab
 pypglab==0.0.5

--- a/tests/components/lcn/conftest.py
+++ b/tests/components/lcn/conftest.py
@@ -40,7 +40,7 @@ class MockDeviceConnection(DeviceConnection):
     request_status_motor_position = AsyncMock()
     request_status_binary_sensors = AsyncMock()
     request_status_variable = AsyncMock()
-    request_status_led_and_logic_ops = AsyncMock()
+    request_status_leds_and_logic_ops = AsyncMock()
     request_status_locked_keys = AsyncMock()
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:

--- a/tests/components/lcn/test_sensor.py
+++ b/tests/components/lcn/test_sensor.py
@@ -105,7 +105,7 @@ async def test_pushed_ledlogicop_status_change(
         ),
         (
             SENSOR_LED6,
-            "request_status_led_and_logic_ops",
+            "request_status_leds_and_logic_ops",
             ModStatusLedsAndLogicOps(
                 LcnAddr(0, 7, False), [LedStatus.OFF] * 12, [LogicOpStatus.NONE] * 4
             ),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bump pypck from 0.9.11 to 0.9.13.

Upstream fixes:

1. **Fix RelayStateModifier in control_relays_timer** ([alengwenus/pypck#183](https://github.com/alengwenus/pypck/pull/183)): Fixes the relay timer command which was using incorrect state modifiers.
2. **Fix name of LED status request method** ([alengwenus/pypck#187](https://github.com/alengwenus/pypck/pull/187)): Renames `request_status_led_and_logic_ops` to `request_status_leds_and_logic_ops` for consistency. The HA integration and tests have been updated accordingly.

Also includes new features: lock thresholds command ([#186](https://github.com/alengwenus/pypck/pull/186)) and `from_string`/`to_string` methods for `LcnAddr` ([#188](https://github.com/alengwenus/pypck/pull/188)).

**Changelog:** https://github.com/alengwenus/pypck/releases/tag/0.9.13
**Diff:** https://github.com/alengwenus/pypck/compare/0.9.11...0.9.13

HA side change: updated `request_status_led_and_logic_ops` to `request_status_leds_and_logic_ops` in `sensor.py` and tests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr