### PR TITLE
Use console name in UniFi Network discovery title

### DIFF
--- a/homeassistant/components/unifi/config_flow.py
+++ b/homeassistant/components/unifi/config_flow.py
@@ -24,6 +24,7 @@ from homeassistant.config_entries import (
 )
 from homeassistant.const import (
     CONF_HOST,
+    CONF_NAME,
     CONF_PASSWORD,
     CONF_PORT,
     CONF_USERNAME,
@@ -192,7 +193,7 @@ class UnifiFlowHandler(ConfigFlow, domain=DOMAIN):
 
         self.context["title_placeholders"] = {
             CONF_HOST: reauth_entry.data[CONF_HOST],
-            CONF_SITE_ID: reauth_entry.title,
+            CONF_NAME: reauth_entry.title,
         }
 
         self.reauth_schema = {
@@ -230,9 +231,22 @@ class UnifiFlowHandler(ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(mac_address)
         self._abort_if_unique_id_configured(updates=self.config, reload_on_update=False)
 
+        # Build a recognizable discovery title, e.g. "Dream Machine Pro
+        # (192.168.1.1)", instead of "default (<direct-connect domain>)":
+        # - show the console's own name, falling back to hostname then
+        #   product_name (model is omitted on purpose: it is None in the
+        #   discovery payload for current consoles);
+        # - show the LAN IP rather than the opaque direct-connect domain,
+        #   which is more recognizable on the discovery card (the connection
+        #   host in CONF_HOST is unchanged and still prefers direct-connect).
         self.context["title_placeholders"] = {
-            CONF_HOST: host,
-            CONF_SITE_ID: DEFAULT_SITE_ID,
+            CONF_NAME: (
+                discovery_info.get("name")
+                or discovery_info.get("hostname")
+                or discovery_info.get("product_name")
+                or "UniFi Network"
+            ),
+            CONF_HOST: source_ip,
         }
         self.context["configuration_url"] = f"https://{host}"
 

--- a/homeassistant/components/unifi/config_flow.py
+++ b/homeassistant/components/unifi/config_flow.py
@@ -231,14 +231,6 @@ class UnifiFlowHandler(ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(mac_address)
         self._abort_if_unique_id_configured(updates=self.config, reload_on_update=False)
 
-        # Build a recognizable discovery title, e.g. "Dream Machine Pro
-        # (192.168.1.1)", instead of "default (<direct-connect domain>)":
-        # - show the console's own name, falling back to hostname then
-        #   product_name (model is omitted on purpose: it is None in the
-        #   discovery payload for current consoles);
-        # - show the LAN IP rather than the opaque direct-connect domain,
-        #   which is more recognizable on the discovery card (the connection
-        #   host in CONF_HOST is unchanged and still prefers direct-connect).
         self.context["title_placeholders"] = {
             CONF_NAME: (
                 discovery_info.get("name")

--- a/homeassistant/components/unifi/strings.json
+++ b/homeassistant/components/unifi/strings.json
@@ -11,7 +11,7 @@
       "service_unavailable": "[%key:common::config_flow::error::cannot_connect%]",
       "unknown_client_mac": "No client available on that MAC address"
     },
-    "flow_title": "{site} ({host})",
+    "flow_title": "{name} ({host})",
     "step": {
       "site": {
         "data": {

--- a/tests/components/unifi/test_config_flow.py
+++ b/tests/components/unifi/test_config_flow.py
@@ -319,6 +319,16 @@ async def test_reauth_flow_update_configuration(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
 
+    context = next(
+        flow["context"]
+        for flow in hass.config_entries.flow.async_progress()
+        if flow["flow_id"] == result["flow_id"]
+    )
+    assert context["title_placeholders"] == {
+        "host": config_entry.data[CONF_HOST],
+        "name": config_entry.title,
+    }
+
     with patch(
         "homeassistant.components.unifi.UnifiHub.available", new_callable=PropertyMock
     ) as ws_mock:
@@ -439,7 +449,9 @@ async def test_discover_unifi_negative(hass: HomeAssistant) -> None:
 INTEGRATION_DISCOVERY_INFO = {
     "source_ip": "10.0.0.1",
     "hw_addr": "e0:63:da:20:14:a9",
+    "name": "Dream Machine Pro",
     "hostname": "UniFi-Dream-Machine",
+    "product_name": "UDMPRO",
     "platform": "UCG-Ultra",
     "direct_connect_domain": "x.ui.direct",
 }
@@ -461,11 +473,52 @@ async def test_flow_integration_discovery(hass: HomeAssistant) -> None:
         for flow in hass.config_entries.flow.async_progress()
         if flow["flow_id"] == result["flow_id"]
     )
-    assert context["title_placeholders"] == {
-        "host": "x.ui.direct",
-        "site": "default",
-    }
     assert context["configuration_url"] == "https://x.ui.direct"
+
+
+@pytest.mark.parametrize(
+    ("extra_info", "expected_name"),
+    [
+        (
+            {
+                "name": "Dream Machine Pro",
+                "hostname": "UniFi-Dream-Machine",
+                "product_name": "UDMPRO",
+            },
+            "Dream Machine Pro",
+        ),
+        (
+            {"hostname": "UniFi-Dream-Machine", "product_name": "UDMPRO"},
+            "UniFi-Dream-Machine",
+        ),
+        ({"product_name": "UDMPRO"}, "UDMPRO"),
+        ({}, "UniFi Network"),
+    ],
+    ids=["name", "hostname", "product_name", "fallback"],
+)
+async def test_flow_integration_discovery_title(
+    hass: HomeAssistant, extra_info: dict[str, str], expected_name: str
+) -> None:
+    """Test discovery title priority: name, hostname, product_name, then fallback."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
+        data={
+            "source_ip": "10.0.0.1",
+            "hw_addr": "e0:63:da:20:14:a9",
+            "direct_connect_domain": "x.ui.direct",
+            **extra_info,
+        },
+    )
+    context = next(
+        flow["context"]
+        for flow in hass.config_entries.flow.async_progress()
+        if flow["flow_id"] == result["flow_id"]
+    )
+    assert context["title_placeholders"] == {
+        "host": "10.0.0.1",
+        "name": expected_name,
+    }
 
 
 @pytest.mark.usefixtures("config_entry")
@@ -496,16 +549,6 @@ async def test_flow_integration_discovery_uses_direct_connect_domain(
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
-
-    context = next(
-        flow["context"]
-        for flow in hass.config_entries.flow.async_progress()
-        if flow["flow_id"] == result["flow_id"]
-    )
-    assert context["title_placeholders"] == {
-        "host": "x.ui.direct",
-        "site": "default",
-    }
 
     schema_defaults = {
         marker.schema: marker.default()
@@ -599,6 +642,6 @@ async def test_flow_integration_discovery_gets_form_with_ignored_entry(
         if flow["flow_id"] == result["flow_id"]
     )
     assert context["title_placeholders"] == {
-        "host": "x.ui.direct",
-        "site": "default",
+        "host": "10.0.0.1",
+        "name": "Dream Machine Pro",
     }


### PR DESCRIPTION
## Proposed change

The integration-discovery entry for a UniFi OS console showed up in the
discovery list with an unhelpful title: the site was hardcoded to `default`
and the host fell back to the opaque direct-connect domain, e.g.
`default (<direct-connect-domain>)`.

`unifi-discovery` already passes the console's `name` / `hostname` /
`product_name` through to the integration discovery, so use them for the
discovery title (preferring `name`, then `hostname`, then `product_name`,
then a generic fallback) and show the LAN IP instead of the direct-connect
domain, e.g. `Dream Machine Pro (192.168.1.1)`.

To do this the first `flow_title` placeholder is renamed from the (misused)
site id to a generic `name`. Only the discovery-card *display* changes; the
connection host (`CONF_HOST`), verify-SSL behaviour, dedupe and unique id are
untouched.

Enabler: the richer console fields are populated by unifi-discovery 1.5.0
(library bump in #173927); with an older library the title gracefully falls
back to whatever fields are present.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: relates to the unifi-discovery 1.5.0 bump (#173927)
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
