### PR TITLE
openevse: Add reconfigure flow

### DIFF
--- a/homeassistant/components/openevse/config_flow.py
+++ b/homeassistant/components/openevse/config_flow.py
@@ -224,7 +224,7 @@ class OpenEVSEConfigFlow(ConfigFlow, domain=DOMAIN):
             username = user_input.get(CONF_USERNAME) or None
             password = user_input.get(CONF_PASSWORD) or None
 
-            errors, _ = await self.check_status(host, username, password)
+            errors, serial = await self.check_status(host, username, password)
             if errors:
                 return self.async_show_form(
                     step_id="reconfigure",
@@ -233,6 +233,10 @@ class OpenEVSEConfigFlow(ConfigFlow, domain=DOMAIN):
                     ),
                     errors=errors,
                 )
+
+            if serial is not None:
+                await self.async_set_unique_id(serial)
+                self._abort_if_unique_id_mismatch()
 
             data_updates = {
                 CONF_HOST: host,

--- a/homeassistant/components/openevse/config_flow.py
+++ b/homeassistant/components/openevse/config_flow.py
@@ -17,6 +17,11 @@ from homeassistant.const import (
 )
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.selector import (
+    TextSelector,
+    TextSelectorConfig,
+    TextSelectorType,
+)
 from homeassistant.helpers.service_info import zeroconf
 
 from .const import CONF_SERIAL, DOMAIN
@@ -29,9 +34,16 @@ AUTH_SCHEMA = vol.Schema(
 
 RECONFIGURE_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_HOST): cv.string,
-        vol.Optional(CONF_USERNAME): cv.string,
-        vol.Optional(CONF_PASSWORD): cv.string,
+        vol.Required(CONF_HOST): TextSelector(),
+        vol.Optional(CONF_USERNAME): TextSelector(
+            TextSelectorConfig(autocomplete="username")
+        ),
+        vol.Optional(CONF_PASSWORD): TextSelector(
+            TextSelectorConfig(
+                type=TextSelectorType.PASSWORD,
+                autocomplete="current-password",
+            )
+        ),
     }
 )
 
@@ -248,15 +260,13 @@ class OpenEVSEConfigFlow(ConfigFlow, domain=DOMAIN):
                 await self.async_set_unique_id(serial)
                 self._abort_if_unique_id_mismatch()
 
-            data_updates = {
-                CONF_HOST: host,
-                CONF_USERNAME: username,
-                CONF_PASSWORD: password,
-            }
-
             return self.async_update_reload_and_abort(
                 reconfigure_entry,
-                data_updates=data_updates,
+                data_updates={
+                    CONF_HOST: host,
+                    CONF_USERNAME: username,
+                    CONF_PASSWORD: password,
+                },
             )
 
         return self.async_show_form(

--- a/homeassistant/components/openevse/config_flow.py
+++ b/homeassistant/components/openevse/config_flow.py
@@ -7,7 +7,7 @@ from openevsehttp.__main__ import OpenEVSE
 from openevsehttp.exceptions import AuthenticationError, MissingSerial
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult
 from homeassistant.const import (
     CONF_HOST,
     CONF_ID,
@@ -221,28 +221,28 @@ class OpenEVSEConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             host = user_input[CONF_HOST]
-            username = user_input.get(CONF_USERNAME)
-            password = user_input.get(CONF_PASSWORD)
+            username = user_input.get(CONF_USERNAME) or None
+            password = user_input.get(CONF_PASSWORD) or None
 
             errors, _ = await self.check_status(host, username, password)
-            if not errors:
-                data_updates: dict[str, Any] = {CONF_HOST: host}
-                if username:
-                    data_updates[CONF_USERNAME] = username
-                if password:
-                    data_updates[CONF_PASSWORD] = password
-
-                return self.async_update_reload_and_abort(
-                    reconfigure_entry,
-                    data_updates=data_updates,
+            if errors:
+                return self.async_show_form(
+                    step_id="reconfigure",
+                    data_schema=self.add_suggested_values_to_schema(
+                        self._get_reconfigure_schema(reconfigure_entry), user_input
+                    ),
+                    errors=errors,
                 )
 
-            return self.async_show_form(
-                step_id="reconfigure",
-                data_schema=self.add_suggested_values_to_schema(
-                    self._get_reconfigure_schema(reconfigure_entry), user_input
-                ),
-                errors=errors,
+            data_updates = {
+                CONF_HOST: host,
+                CONF_USERNAME: username,
+                CONF_PASSWORD: password,
+            }
+
+            return self.async_update_reload_and_abort(
+                reconfigure_entry,
+                data_updates=data_updates,
             )
 
         return self.async_show_form(
@@ -252,25 +252,18 @@ class OpenEVSEConfigFlow(ConfigFlow, domain=DOMAIN):
             ),
         )
 
-    def _get_reconfigure_schema(self, config_entry: Any) -> vol.Schema:
+    def _get_reconfigure_schema(self, config_entry: ConfigEntry) -> vol.Schema:
         """Get the reconfigure schema."""
         data = config_entry.data
-
-        if CONF_USERNAME in data or CONF_PASSWORD in data:
-            return vol.Schema(
-                {
-                    vol.Required(CONF_HOST, default=data.get(CONF_HOST, "")): cv.string,
-                    vol.Optional(
-                        CONF_USERNAME, default=data.get(CONF_USERNAME, "")
-                    ): cv.string,
-                    vol.Optional(
-                        CONF_PASSWORD, default=data.get(CONF_PASSWORD, "")
-                    ): cv.string,
-                }
-            )
 
         return vol.Schema(
             {
                 vol.Required(CONF_HOST, default=data.get(CONF_HOST, "")): cv.string,
+                vol.Optional(
+                    CONF_USERNAME, default=data.get(CONF_USERNAME, "")
+                ): cv.string,
+                vol.Optional(
+                    CONF_PASSWORD, default=data.get(CONF_PASSWORD, "")
+                ): cv.string,
             }
         )

--- a/homeassistant/components/openevse/config_flow.py
+++ b/homeassistant/components/openevse/config_flow.py
@@ -7,7 +7,7 @@ from openevsehttp.__main__ import OpenEVSE
 from openevsehttp.exceptions import AuthenticationError, MissingSerial
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import (
     CONF_HOST,
     CONF_ID,
@@ -25,6 +25,14 @@ USER_SCHEMA = vol.Schema({vol.Required(CONF_HOST): cv.string})
 
 AUTH_SCHEMA = vol.Schema(
     {vol.Required(CONF_USERNAME): cv.string, vol.Required(CONF_PASSWORD): cv.string}
+)
+
+RECONFIGURE_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): cv.string,
+        vol.Optional(CONF_USERNAME): cv.string,
+        vol.Optional(CONF_PASSWORD): cv.string,
+    }
 )
 
 
@@ -224,12 +232,14 @@ class OpenEVSEConfigFlow(ConfigFlow, domain=DOMAIN):
             username = user_input.get(CONF_USERNAME) or None
             password = user_input.get(CONF_PASSWORD) or None
 
+            self._async_abort_entries_match({CONF_HOST: host})
+
             errors, serial = await self.check_status(host, username, password)
             if errors:
                 return self.async_show_form(
                     step_id="reconfigure",
                     data_schema=self.add_suggested_values_to_schema(
-                        self._get_reconfigure_schema(reconfigure_entry), user_input
+                        RECONFIGURE_SCHEMA, user_input
                     ),
                     errors=errors,
                 )
@@ -252,22 +262,6 @@ class OpenEVSEConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="reconfigure",
             data_schema=self.add_suggested_values_to_schema(
-                self._get_reconfigure_schema(reconfigure_entry), None
+                RECONFIGURE_SCHEMA, reconfigure_entry.data
             ),
-        )
-
-    def _get_reconfigure_schema(self, config_entry: ConfigEntry) -> vol.Schema:
-        """Get the reconfigure schema."""
-        data = config_entry.data
-
-        return vol.Schema(
-            {
-                vol.Required(CONF_HOST, default=data.get(CONF_HOST, "")): cv.string,
-                vol.Optional(
-                    CONF_USERNAME, default=data.get(CONF_USERNAME, "")
-                ): cv.string,
-                vol.Optional(
-                    CONF_PASSWORD, default=data.get(CONF_PASSWORD, "")
-                ): cv.string,
-            }
         )

--- a/homeassistant/components/openevse/config_flow.py
+++ b/homeassistant/components/openevse/config_flow.py
@@ -212,3 +212,65 @@ class OpenEVSEConfigFlow(ConfigFlow, domain=DOMAIN):
             description_placeholders={CONF_HOST: reauth_entry.data[CONF_HOST]},
             errors=errors,
         )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reconfiguration of the integration."""
+        reconfigure_entry = self._get_reconfigure_entry()
+
+        if user_input is not None:
+            host = user_input[CONF_HOST]
+            username = user_input.get(CONF_USERNAME)
+            password = user_input.get(CONF_PASSWORD)
+
+            errors, _ = await self.check_status(host, username, password)
+            if not errors:
+                data_updates: dict[str, Any] = {CONF_HOST: host}
+                if username:
+                    data_updates[CONF_USERNAME] = username
+                if password:
+                    data_updates[CONF_PASSWORD] = password
+
+                return self.async_update_reload_and_abort(
+                    reconfigure_entry,
+                    data_updates=data_updates,
+                )
+
+            return self.async_show_form(
+                step_id="reconfigure",
+                data_schema=self.add_suggested_values_to_schema(
+                    self._get_reconfigure_schema(reconfigure_entry), user_input
+                ),
+                errors=errors,
+            )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=self.add_suggested_values_to_schema(
+                self._get_reconfigure_schema(reconfigure_entry), None
+            ),
+        )
+
+    def _get_reconfigure_schema(self, config_entry: Any) -> vol.Schema:
+        """Get the reconfigure schema."""
+        data = config_entry.data
+
+        if CONF_USERNAME in data or CONF_PASSWORD in data:
+            return vol.Schema(
+                {
+                    vol.Required(CONF_HOST, default=data.get(CONF_HOST, "")): cv.string,
+                    vol.Optional(
+                        CONF_USERNAME, default=data.get(CONF_USERNAME, "")
+                    ): cv.string,
+                    vol.Optional(
+                        CONF_PASSWORD, default=data.get(CONF_PASSWORD, "")
+                    ): cv.string,
+                }
+            )
+
+        return vol.Schema(
+            {
+                vol.Required(CONF_HOST, default=data.get(CONF_HOST, "")): cv.string,
+            }
+        )

--- a/homeassistant/components/openevse/quality_scale.yaml
+++ b/homeassistant/components/openevse/quality_scale.yaml
@@ -60,7 +60,7 @@ rules:
   entity-translations: done
   exception-translations: todo
   icon-translations: todo
-  reconfiguration-flow: todo
+  reconfiguration-flow: done
   repair-issues:
     status: done
     comment: Integration creates repair issues for YAML deprecation.

--- a/homeassistant/components/openevse/strings.json
+++ b/homeassistant/components/openevse/strings.json
@@ -41,8 +41,8 @@
         },
         "data_description": {
           "host": "Enter the IP address of your OpenEVSE.",
-          "password": "The password to access your OpenEVSE charger",
-          "username": "The username to access your OpenEVSE charger"
+          "password": "[%key:component::openevse::config::step::auth::data_description::password%]",
+          "username": "[%key:component::openevse::config::step::auth::data_description::username%]"
         },
         "description": "Update the configuration for your OpenEVSE charger."
       },

--- a/homeassistant/components/openevse/strings.json
+++ b/homeassistant/components/openevse/strings.json
@@ -3,6 +3,7 @@
     "abort": {
       "already_configured": "This charger is already configured",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
       "unavailable_host": "Unable to connect to host"
     },
     "error": {
@@ -30,6 +31,19 @@
           "username": "[%key:component::openevse::config::step::auth::data_description::username%]"
         },
         "description": "The credentials for your OpenEVSE charger at {host} are no longer valid. Please enter your current username and password."
+      },
+      "reconfigure": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "password": "[%key:common::config_flow::data::password%]",
+          "username": "[%key:common::config_flow::data::username%]"
+        },
+        "data_description": {
+          "host": "Enter the IP address of your OpenEVSE.",
+          "password": "The password to access your OpenEVSE charger",
+          "username": "The username to access your OpenEVSE charger"
+        },
+        "description": "Update the configuration for your OpenEVSE charger."
       },
       "user": {
         "data": {

--- a/homeassistant/components/openevse/strings.json
+++ b/homeassistant/components/openevse/strings.json
@@ -4,7 +4,8 @@
       "already_configured": "This charger is already configured",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
       "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
-      "unavailable_host": "Unable to connect to host"
+      "unavailable_host": "Unable to connect to host",
+      "unique_id_mismatch": "The charger identifier does not match the previous identifier"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",

--- a/tests/components/openevse/test_config_flow.py
+++ b/tests/components/openevse/test_config_flow.py
@@ -7,7 +7,12 @@ from openevsehttp.exceptions import AuthenticationError, MissingSerial
 import pytest
 
 from homeassistant.components.openevse.const import DOMAIN
-from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER, SOURCE_ZEROCONF
+from homeassistant.config_entries import (
+    SOURCE_IMPORT,
+    SOURCE_RECONFIGURE,
+    SOURCE_USER,
+    SOURCE_ZEROCONF,
+)
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -541,3 +546,129 @@ async def test_reauth_flow_errors(
         CONF_USERNAME: "newuser",
         CONF_PASSWORD: "newpassword",
     }
+
+
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_reconfigure_flow_host_only(
+    hass: HomeAssistant, mock_charger: MagicMock
+) -> None:
+    """Test reconfiguration flow for entry with host only."""
+    config_entry = MockConfigEntry(
+        title="openevse_mock_config",
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.1.100"},
+        entry_id="FAKE",
+        unique_id="deadbeeffeed",
+    )
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_RECONFIGURE, "entry_id": config_entry.entry_id},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: "192.168.1.101"}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert config_entry.data == {CONF_HOST: "192.168.1.101"}
+
+
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_reconfigure_flow_with_auth(
+    hass: HomeAssistant, mock_charger: MagicMock
+) -> None:
+    """Test reconfiguration flow for entry with credentials."""
+    config_entry = MockConfigEntry(
+        title="openevse_mock_config",
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "192.168.1.100",
+            CONF_USERNAME: "olduser",
+            CONF_PASSWORD: "oldpassword",
+        },
+        entry_id="FAKE",
+        unique_id="deadbeeffeed",
+    )
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_RECONFIGURE, "entry_id": config_entry.entry_id},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_HOST: "192.168.1.101",
+            CONF_USERNAME: "newuser",
+            CONF_PASSWORD: "newpassword",
+        },
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert config_entry.data == {
+        CONF_HOST: "192.168.1.101",
+        CONF_USERNAME: "newuser",
+        CONF_PASSWORD: "newpassword",
+    }
+
+
+@pytest.mark.parametrize(
+    ("exception", "error_base"),
+    [
+        (AuthenticationError, "invalid_auth"),
+        (TimeoutError, "cannot_connect"),
+    ],
+)
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_reconfigure_flow_errors(
+    hass: HomeAssistant,
+    mock_charger: MagicMock,
+    exception: Exception,
+    error_base: str,
+) -> None:
+    """Test reconfiguration flow handles connection errors."""
+    config_entry = MockConfigEntry(
+        title="openevse_mock_config",
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.1.100"},
+        entry_id="FAKE",
+        unique_id="deadbeeffeed",
+    )
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_RECONFIGURE, "entry_id": config_entry.entry_id},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    mock_charger.test_and_get.side_effect = exception
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: "192.168.1.101"}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+    assert result["errors"] == {"base": error_base}
+
+    mock_charger.test_and_get.side_effect = None
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: "192.168.1.102"}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert config_entry.data == {CONF_HOST: "192.168.1.102"}

--- a/tests/components/openevse/test_config_flow.py
+++ b/tests/components/openevse/test_config_flow.py
@@ -627,6 +627,46 @@ async def test_reconfigure_flow_with_auth(
     }
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_reconfigure_flow_duplicate_host(
+    hass: HomeAssistant, mock_charger: MagicMock
+) -> None:
+    """Test reconfiguration flow aborts when host matches another entry."""
+    other_entry = MockConfigEntry(
+        title="openevse_other_config",
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.1.101"},
+        entry_id="OTHER",
+        unique_id="otherfeedfeed",
+    )
+    other_entry.add_to_hass(hass)
+
+    config_entry = MockConfigEntry(
+        title="openevse_mock_config",
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.1.100"},
+        entry_id="FAKE",
+        unique_id="deadbeeffeed",
+    )
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_RECONFIGURE, "entry_id": config_entry.entry_id},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: "192.168.1.101"}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert config_entry.data == {CONF_HOST: "192.168.1.100"}
+
+
 @pytest.mark.parametrize(
     ("exception", "error_base"),
     [
@@ -677,41 +717,6 @@ async def test_reconfigure_flow_errors(
     assert result["reason"] == "reconfigure_successful"
     assert config_entry.data == {
         CONF_HOST: "192.168.1.102",
-        CONF_USERNAME: None,
-        CONF_PASSWORD: None,
-    }
-
-
-@pytest.mark.usefixtures("mock_setup_entry")
-async def test_reconfigure_flow_matching_serial(
-    hass: HomeAssistant, mock_charger: MagicMock
-) -> None:
-    """Test reconfiguration flow succeeds when device serial matches."""
-    config_entry = MockConfigEntry(
-        title="openevse_mock_config",
-        domain=DOMAIN,
-        data={CONF_HOST: "192.168.1.100"},
-        entry_id="FAKE",
-        unique_id="deadbeeffeed",
-    )
-    config_entry.add_to_hass(hass)
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_RECONFIGURE, "entry_id": config_entry.entry_id},
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure"
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {CONF_HOST: "192.168.1.101"}
-    )
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "reconfigure_successful"
-    assert config_entry.data == {
-        CONF_HOST: "192.168.1.101",
         CONF_USERNAME: None,
         CONF_PASSWORD: None,
     }

--- a/tests/components/openevse/test_config_flow.py
+++ b/tests/components/openevse/test_config_flow.py
@@ -576,7 +576,11 @@ async def test_reconfigure_flow_host_only(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
-    assert config_entry.data == {CONF_HOST: "192.168.1.101"}
+    assert config_entry.data == {
+        CONF_HOST: "192.168.1.101",
+        CONF_USERNAME: None,
+        CONF_PASSWORD: None,
+    }
 
 
 @pytest.mark.usefixtures("mock_setup_entry")
@@ -671,4 +675,115 @@ async def test_reconfigure_flow_errors(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
-    assert config_entry.data == {CONF_HOST: "192.168.1.102"}
+    assert config_entry.data == {
+        CONF_HOST: "192.168.1.102",
+        CONF_USERNAME: None,
+        CONF_PASSWORD: None,
+    }
+
+
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_reconfigure_flow_matching_serial(
+    hass: HomeAssistant, mock_charger: MagicMock
+) -> None:
+    """Test reconfiguration flow succeeds when device serial matches."""
+    config_entry = MockConfigEntry(
+        title="openevse_mock_config",
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.1.100"},
+        entry_id="FAKE",
+        unique_id="deadbeeffeed",
+    )
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_RECONFIGURE, "entry_id": config_entry.entry_id},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: "192.168.1.101"}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert config_entry.data == {
+        CONF_HOST: "192.168.1.101",
+        CONF_USERNAME: None,
+        CONF_PASSWORD: None,
+    }
+
+
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_reconfigure_flow_changed_serial(
+    hass: HomeAssistant, mock_charger: MagicMock
+) -> None:
+    """Test reconfiguration flow aborts when device serial changes."""
+    config_entry = MockConfigEntry(
+        title="openevse_mock_config",
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.1.100"},
+        entry_id="FAKE",
+        unique_id="deadbeeffeed",
+    )
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_RECONFIGURE, "entry_id": config_entry.entry_id},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    mock_charger.test_and_get.return_value = {
+        "serial": "newfeedfeed",
+        "model": "openevse_wifi_v1",
+    }
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: "192.168.1.101"}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "unique_id_mismatch"
+
+
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_reconfigure_flow_no_serial(
+    hass: HomeAssistant, mock_charger: MagicMock
+) -> None:
+    """Test reconfiguration flow when device doesn't return serial."""
+    config_entry = MockConfigEntry(
+        title="openevse_mock_config",
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.1.100"},
+        entry_id="FAKE",
+        unique_id=None,
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_charger.test_and_get.return_value = {"model": "openevse_wifi_v1"}
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_RECONFIGURE, "entry_id": config_entry.entry_id},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: "192.168.1.101"}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert config_entry.data == {
+        CONF_HOST: "192.168.1.101",
+        CONF_USERNAME: None,
+        CONF_PASSWORD: None,
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a reconfigure flow, allowing you to change the hostname without having to delete and make a new one. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
