### PR TITLE
Add Teslemetry command quota sensor

### DIFF
--- a/homeassistant/components/teslemetry/sensor.py
+++ b/homeassistant/components/teslemetry/sensor.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from typing import cast
 
 from teslemetry_stream import TeslemetryStream, TeslemetryStreamVehicle
 
@@ -1655,9 +1656,14 @@ async def async_setup_entry(
     )
 
     if entry.runtime_data.stream is not None:
-        entities.append(
-            TeslemetryCreditBalanceSensor(
-                entry.unique_id or entry.entry_id, entry.runtime_data.stream
+        entities.extend(
+            (
+                TeslemetryCreditBalanceSensor(
+                    entry.unique_id or entry.entry_id, entry.runtime_data.stream
+                ),
+                TeslemetryCreditQuotaSensor(
+                    entry.unique_id or entry.entry_id, entry.runtime_data.stream
+                ),
             )
         )
 
@@ -1899,4 +1905,53 @@ class TeslemetryCreditBalanceSensor(RestoreSensor):
     def _async_update(self, value: int) -> None:
         """Handle updated data from the coordinator."""
         self._attr_native_value = value
+        self.async_write_ha_state()
+
+
+class TeslemetryCreditQuotaSensor(RestoreSensor):
+    """Entity for Teslemetry credit quota usage."""
+
+    _attr_has_entity_name = True
+    stream: TeslemetryStream
+    _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_suggested_display_precision = 1
+
+    def __init__(self, uid: str, stream: TeslemetryStream) -> None:
+        """Initialize common aspects of a Teslemetry entity."""
+
+        self._attr_translation_key = "credit_quota"
+        self._attr_unique_id = f"{uid}_credit_quota"
+        self.stream = stream
+
+    async def async_added_to_hass(self) -> None:
+        """Handle entity which will be added."""
+        await super().async_added_to_hass()
+
+        if (sensor_data := await self.async_get_last_sensor_data()) is not None:
+            self._attr_native_value = sensor_data.native_value
+
+        if (last_state := await self.async_get_last_state()) is not None:
+            self._attr_extra_state_attributes = {
+                "credits": last_state.attributes.get("credits"),
+                "reset": last_state.attributes.get("reset"),
+            }
+
+        self.async_on_remove(self.stream.listen_Credits(self._async_update))
+
+    def _async_update(self, credits: dict[str, str | int]) -> None:
+        """Handle updated data from the coordinator."""
+        quota = cast("dict[str, object] | None", credits.get("quota"))
+        if not isinstance(quota, dict):
+            return
+
+        fraction = quota.get("fraction")
+        if not isinstance(fraction, (float, int)) or isinstance(fraction, bool):
+            return
+
+        self._attr_native_value = fraction * 100
+        self._attr_extra_state_attributes = {
+            "credits": quota.get("used"),
+            "reset": quota.get("reset_at"),
+        }
         self.async_write_ha_state()

--- a/homeassistant/components/teslemetry/sensor.py
+++ b/homeassistant/components/teslemetry/sensor.py
@@ -1931,12 +1931,6 @@ class TeslemetryCreditQuotaSensor(RestoreSensor):
         if (sensor_data := await self.async_get_last_sensor_data()) is not None:
             self._attr_native_value = sensor_data.native_value
 
-        if (last_state := await self.async_get_last_state()) is not None:
-            self._attr_extra_state_attributes = {
-                "credits": last_state.attributes.get("credits"),
-                "reset": last_state.attributes.get("reset"),
-            }
-
         self.async_on_remove(self.stream.listen_Credits(self._async_update))
 
     def _async_update(self, credits: dict[str, Any]) -> None:
@@ -1950,8 +1944,4 @@ class TeslemetryCreditQuotaSensor(RestoreSensor):
             return
 
         self._attr_native_value = fraction * 100
-        self._attr_extra_state_attributes = {
-            "credits": quota.get("used"),
-            "reset": quota.get("reset_at"),
-        }
         self.async_write_ha_state()

--- a/homeassistant/components/teslemetry/sensor.py
+++ b/homeassistant/components/teslemetry/sensor.py
@@ -1934,7 +1934,7 @@ class TeslemetryCreditQuotaSensor(RestoreSensor):
         self.async_on_remove(self.stream.listen_Credits(self._async_update))
 
     def _async_update(self, credits: dict[str, Any]) -> None:
-        """Handle updated data from the coordinator."""
+        """Handle updated data from the stream."""
         quota = credits.get("quota")
         if not isinstance(quota, dict):
             return

--- a/homeassistant/components/teslemetry/sensor.py
+++ b/homeassistant/components/teslemetry/sensor.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import cast
+from typing import Any
 
 from teslemetry_stream import TeslemetryStream, TeslemetryStreamVehicle
 
@@ -1939,9 +1939,9 @@ class TeslemetryCreditQuotaSensor(RestoreSensor):
 
         self.async_on_remove(self.stream.listen_Credits(self._async_update))
 
-    def _async_update(self, credits: dict[str, str | int]) -> None:
+    def _async_update(self, credits: dict[str, Any]) -> None:
         """Handle updated data from the coordinator."""
-        quota = cast("dict[str, object] | None", credits.get("quota"))
+        quota = credits.get("quota")
         if not isinstance(quota, dict):
             return
 

--- a/homeassistant/components/teslemetry/strings.json
+++ b/homeassistant/components/teslemetry/strings.json
@@ -575,8 +575,11 @@
         "name": "Consumer imported from solar"
       },
       "credit_balance": {
-        "name": "Teslemetry credits",
+        "name": "Teslemetry command credits",
         "unit_of_measurement": "credits"
+      },
+      "credit_quota": {
+        "name": "Teslemetry command quota"
       },
       "cruise_follow_distance": {
         "name": "Cruise follow distance"

--- a/homeassistant/components/teslemetry/strings.json
+++ b/homeassistant/components/teslemetry/strings.json
@@ -579,7 +579,7 @@
         "unit_of_measurement": "credits"
       },
       "credit_quota": {
-        "name": "Teslemetry command quota"
+        "name": "Teslemetry command quota used"
       },
       "cruise_follow_distance": {
         "name": "Cruise follow distance"

--- a/tests/components/teslemetry/snapshots/test_sensor.ambr
+++ b/tests/components/teslemetry/snapshots/test_sensor.ambr
@@ -2530,7 +2530,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_sensors[sensor.teslemetry_command_quota-entry]
+# name: test_sensors[sensor.teslemetry_command_quota_used-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -2546,7 +2546,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.teslemetry_command_quota',
+    'entity_id': 'sensor.teslemetry_command_quota_used',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2554,7 +2554,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Teslemetry command quota',
+    'object_id_base': 'Teslemetry command quota used',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -2562,7 +2562,7 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Teslemetry command quota',
+    'original_name': 'Teslemetry command quota used',
     'platform': 'teslemetry',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -2572,30 +2572,30 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensors[sensor.teslemetry_command_quota-state]
+# name: test_sensors[sensor.teslemetry_command_quota_used-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Teslemetry command quota',
+      'friendly_name': 'Teslemetry command quota used',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.teslemetry_command_quota',
+    'entity_id': 'sensor.teslemetry_command_quota_used',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_sensors[sensor.teslemetry_command_quota-statealt]
+# name: test_sensors[sensor.teslemetry_command_quota_used-statealt]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Teslemetry command quota',
+      'friendly_name': 'Teslemetry command quota used',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.teslemetry_command_quota',
+    'entity_id': 'sensor.teslemetry_command_quota_used',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/teslemetry/snapshots/test_sensor.ambr
+++ b/tests/components/teslemetry/snapshots/test_sensor.ambr
@@ -2458,7 +2458,7 @@
     'state': '0',
   })
 # ---
-# name: test_sensors[sensor.teslemetry_credits-entry]
+# name: test_sensors[sensor.teslemetry_command_credits-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -2474,7 +2474,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.teslemetry_credits',
+    'entity_id': 'sensor.teslemetry_command_credits',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2482,7 +2482,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Teslemetry credits',
+    'object_id_base': 'Teslemetry command credits',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 0,
@@ -2490,7 +2490,7 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Teslemetry credits',
+    'original_name': 'Teslemetry command credits',
     'platform': 'teslemetry',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -2500,30 +2500,102 @@
     'unit_of_measurement': 'credits',
   })
 # ---
-# name: test_sensors[sensor.teslemetry_credits-state]
+# name: test_sensors[sensor.teslemetry_command_credits-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Teslemetry credits',
+      'friendly_name': 'Teslemetry command credits',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'credits',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.teslemetry_credits',
+    'entity_id': 'sensor.teslemetry_command_credits',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_sensors[sensor.teslemetry_credits-statealt]
+# name: test_sensors[sensor.teslemetry_command_credits-statealt]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Teslemetry credits',
+      'friendly_name': 'Teslemetry command credits',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'credits',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.teslemetry_credits',
+    'entity_id': 'sensor.teslemetry_command_credits',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensors[sensor.teslemetry_command_quota-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.teslemetry_command_quota',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Teslemetry command quota',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Teslemetry command quota',
+    'platform': 'teslemetry',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'credit_quota',
+    'unique_id': 'abc-123_credit_quota',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensors[sensor.teslemetry_command_quota-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Teslemetry command quota',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.teslemetry_command_quota',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensors[sensor.teslemetry_command_quota-statealt]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Teslemetry command quota',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.teslemetry_command_quota',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/teslemetry/test_sensor.py
+++ b/tests/components/teslemetry/test_sensor.py
@@ -97,7 +97,7 @@ async def test_sensors_streaming(
         }
     )
     await hass.async_block_till_done()
-    assert hass.states.get("sensor.teslemetry_command_quota").state == "21.2"
+    assert hass.states.get("sensor.teslemetry_command_quota_used").state == "21.2"
 
     # Reload the entry
     await hass.config_entries.async_reload(entry.entry_id)
@@ -112,7 +112,7 @@ async def test_sensors_streaming(
     assert hass.states.get("sensor.test_time_to_full_charge").state == "unknown"
     assert hass.states.get("sensor.test_time_to_arrival").state == "unknown"
     assert hass.states.get("sensor.teslemetry_command_credits").state == "1980"
-    assert (quota_state := hass.states.get("sensor.teslemetry_command_quota"))
+    assert (quota_state := hass.states.get("sensor.teslemetry_command_quota_used"))
     assert quota_state.state == "21.2"
 
 

--- a/tests/components/teslemetry/test_sensor.py
+++ b/tests/components/teslemetry/test_sensor.py
@@ -97,6 +97,7 @@ async def test_sensors_streaming(
         }
     )
     await hass.async_block_till_done()
+    assert hass.states.get("sensor.teslemetry_command_quota").state == "21.2"
 
     # Reload the entry
     await hass.config_entries.async_reload(entry.entry_id)

--- a/tests/components/teslemetry/test_sensor.py
+++ b/tests/components/teslemetry/test_sensor.py
@@ -78,8 +78,22 @@ async def test_sensors_streaming(
                 "cost": 20,
                 "name": "wake_up",
                 "balance": 1980,
+                "quota": {
+                    "used": 212,
+                    "fraction": 0.212,
+                    "reset_at": "2026-07-10T00:00:00.000Z",
+                },
             },
             "createdAt": "2024-10-04T10:45:17.537Z",
+        }
+    )
+    await hass.async_block_till_done()
+
+    # Balance-only credit events should not clear quota usage.
+    mock_add_listener.send(
+        {
+            "credits": {"balance": 1980},
+            "createdAt": "2024-10-04T10:45:18.537Z",
         }
     )
     await hass.async_block_till_done()
@@ -96,7 +110,11 @@ async def test_sensors_streaming(
     assert hass.states.get("sensor.test_charge_cable").state == "unknown"
     assert hass.states.get("sensor.test_time_to_full_charge").state == "unknown"
     assert hass.states.get("sensor.test_time_to_arrival").state == "unknown"
-    assert hass.states.get("sensor.teslemetry_credits").state == "1980"
+    assert hass.states.get("sensor.teslemetry_command_credits").state == "1980"
+    assert (quota_state := hass.states.get("sensor.teslemetry_command_quota"))
+    assert quota_state.state == "21.2"
+    assert quota_state.attributes["credits"] == 212
+    assert quota_state.attributes["reset"] == "2026-07-10T00:00:00.000Z"
 
 
 async def test_energy_history_no_time_series(

--- a/tests/components/teslemetry/test_sensor.py
+++ b/tests/components/teslemetry/test_sensor.py
@@ -113,8 +113,6 @@ async def test_sensors_streaming(
     assert hass.states.get("sensor.teslemetry_command_credits").state == "1980"
     assert (quota_state := hass.states.get("sensor.teslemetry_command_quota"))
     assert quota_state.state == "21.2"
-    assert quota_state.attributes["credits"] == 212
-    assert quota_state.attributes["reset"] == "2026-07-10T00:00:00.000Z"
 
 
 async def test_energy_history_no_time_series(


### PR DESCRIPTION
## Proposed change

Teslemetry now includes a quota of commands for its users every month. This PR add a new `TeslemetryCreditQuotaSensor` that reports command quota usage from the Teslemetry stream as a percentage, exposing the credits used and reset time as state attributes. The sensor restores its last value and attributes across restarts, and balance-only credit events no longer clear the recorded quota usage. The existing credit balance sensor is renamed to "Teslemetry command credits" to disambiguate it from the new quota sensor. Tests and snapshots are updated to cover the new entity.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr