### PR TITLE
Add API_GEN_4 support to Subaru integration

### DIFF
--- a/homeassistant/components/subaru/const.py
+++ b/homeassistant/components/subaru/const.py
@@ -29,6 +29,7 @@ VEHICLE_STATUS = "vehicle_status"
 API_GEN_1 = "g1"
 API_GEN_2 = "g2"
 API_GEN_3 = "g3"
+API_GEN_4 = "g4"
 MANUFACTURER = "Subaru"
 
 PLATFORMS = [

--- a/homeassistant/components/subaru/sensor.py
+++ b/homeassistant/components/subaru/sensor.py
@@ -24,6 +24,7 @@ from . import get_device_info
 from .const import (
     API_GEN_2,
     API_GEN_3,
+    API_GEN_4,
     VEHICLE_API_GEN,
     VEHICLE_HAS_EV,
     VEHICLE_STATUS,
@@ -153,10 +154,10 @@ def create_vehicle_sensors(
     sensor_descriptions_to_add = []
     sensor_descriptions_to_add.extend(SAFETY_SENSORS)
 
-    if vehicle_info[VEHICLE_API_GEN] in [API_GEN_2, API_GEN_3]:
+    if vehicle_info[VEHICLE_API_GEN] in [API_GEN_2, API_GEN_3, API_GEN_4]:
         sensor_descriptions_to_add.extend(API_GEN_2_SENSORS)
 
-    if vehicle_info[VEHICLE_API_GEN] == API_GEN_3:
+    if vehicle_info[VEHICLE_API_GEN] in [API_GEN_3, API_GEN_4]:
         sensor_descriptions_to_add.extend(API_GEN_3_SENSORS)
 
     if vehicle_info[VEHICLE_HAS_EV]:

--- a/tests/components/subaru/api_responses.py
+++ b/tests/components/subaru/api_responses.py
@@ -6,6 +6,7 @@ from homeassistant.components.subaru.const import (
     API_GEN_1,
     API_GEN_2,
     API_GEN_3,
+    API_GEN_4,
     VEHICLE_API_GEN,
     VEHICLE_HAS_EV,
     VEHICLE_HAS_REMOTE_SERVICE,
@@ -21,6 +22,7 @@ from homeassistant.components.subaru.const import (
 TEST_VIN_1_G1 = "JF2ABCDE6L0000001"
 TEST_VIN_2_EV = "JF2ABCDE6L0000002"
 TEST_VIN_3_G3 = "JF2ABCDE6L0000003"
+TEST_VIN_4_G4 = "JF2ABCDE6L0000004"
 
 VEHICLE_DATA = {
     TEST_VIN_1_G1: {
@@ -52,6 +54,17 @@ VEHICLE_DATA = {
         VEHICLE_NAME: "test_vehicle_3",
         VEHICLE_HAS_EV: False,
         VEHICLE_API_GEN: API_GEN_3,
+        VEHICLE_HAS_REMOTE_START: True,
+        VEHICLE_HAS_REMOTE_SERVICE: True,
+        VEHICLE_HAS_SAFETY_SERVICE: True,
+    },
+    TEST_VIN_4_G4: {
+        VEHICLE_VIN: TEST_VIN_4_G4,
+        VEHICLE_MODEL_YEAR: "2026",
+        VEHICLE_MODEL_NAME: "Outback",
+        VEHICLE_NAME: "test_vehicle_4",
+        VEHICLE_HAS_EV: False,
+        VEHICLE_API_GEN: API_GEN_4,
         VEHICLE_HAS_REMOTE_START: True,
         VEHICLE_HAS_REMOTE_SERVICE: True,
         VEHICLE_HAS_SAFETY_SERVICE: True,

--- a/tests/components/subaru/test_init.py
+++ b/tests/components/subaru/test_init.py
@@ -12,12 +12,14 @@ from homeassistant.components.subaru.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from .api_responses import (
     TEST_VIN_1_G1,
     TEST_VIN_2_EV,
     TEST_VIN_3_G3,
+    TEST_VIN_4_G4,
     VEHICLE_DATA,
     VEHICLE_STATUS_EV,
     VEHICLE_STATUS_G3,
@@ -56,6 +58,29 @@ async def test_setup_g3(hass: HomeAssistant, subaru_config_entry) -> None:
     check_entry = hass.config_entries.async_get_entry(subaru_config_entry.entry_id)
     assert check_entry
     assert check_entry.state is ConfigEntryState.LOADED
+
+
+async def test_setup_g4(hass: HomeAssistant, subaru_config_entry) -> None:
+    """Test setup with a G4 vehicle (2026+ models report api_gen "g4")."""
+    await setup_subaru_config_entry(
+        hass,
+        subaru_config_entry,
+        vehicle_list=[TEST_VIN_4_G4],
+        vehicle_data=VEHICLE_DATA[TEST_VIN_4_G4],
+        vehicle_status=VEHICLE_STATUS_G3,
+    )
+    check_entry = hass.config_entries.async_get_entry(subaru_config_entry.entry_id)
+    assert check_entry
+    assert check_entry.state is ConfigEntryState.LOADED
+    # Gen4 must receive both Gen2+ and Gen3+ sensor sets; without this, only
+    # the odometer was created on 2026 model year vehicles.
+    entity_registry = er.async_get(hass)
+    assert entity_registry.async_get_entity_id(
+        "sensor", DOMAIN, f"{TEST_VIN_4_G4}_AVG_FUEL_CONSUMPTION"
+    )
+    assert entity_registry.async_get_entity_id(
+        "sensor", DOMAIN, f"{TEST_VIN_4_G4}_REMAINING_FUEL_PERCENT"
+    )
 
 
 async def test_setup_g1(hass: HomeAssistant, subaru_config_entry) -> None:


### PR DESCRIPTION
## Breaking change


## Proposed change

2026 model year Subaru vehicles report their API generation as `g4`, but
`create_vehicle_sensors` in `sensor.py` only matched `g2` and `g3` in its gen
check. The existing Gen2+/Gen3+ sensor sets (`AVG_FUEL_CONSUMPTION`,
`DIST_TO_EMPTY`, tire pressures, `REMAINING_FUEL_PERCENT`, etc.) were
therefore filtered out and only the odometer entity was created on these
cars — an effective regression for owners of 2026 vehicles after upgrading
their model year.

This PR is a small targeted fix:

- Add `API_GEN_4 = "g4"` to `const.py`.
- Include `API_GEN_4` in both the Gen2-and-newer and Gen3-and-newer
  branches of the gen check in `sensor.py`.
- Add a `TEST_VIN_4_G4` fixture vehicle and a `test_setup_g4` test that
  asserts both an Gen2+ sensor (`AVG_FUEL_CONSUMPTION`) and a Gen3+
  sensor (`REMAINING_FUEL_PERCENT`) are registered for that vehicle.

Carved out from #172522 (which expands sensors / adds binary sensors / etc.)
so this fix can be considered for a patch release independent of the larger
feature work.

Verified against debug diagnostics from a 2026 Outback Wilderness.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: \`python3 -m script.hassfest\`.
- [x] New or updated dependencies have been added to \`requirements_all.txt\`.  
      Updated by running \`python3 -m script.gen_requirements_all\`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.