### PR TITLE
Use console name in UniFi Access discovery title

### DIFF
--- a/homeassistant/components/unifi_access/config_flow.py
+++ b/homeassistant/components/unifi_access/config_flow.py
@@ -160,7 +160,11 @@ class UnifiAccessConfigFlow(ConfigFlow, domain=DOMAIN):
                     data=merged_input,
                 )
 
-        name = discovery_info.get("hostname") or discovery_info.get("platform")
+        name = (
+            discovery_info.get("name")
+            or discovery_info.get("hostname")
+            or discovery_info.get("product_name")
+        )
         if not name:
             short_mac = discovery_info["hw_addr"].replace(":", "").upper()[-6:]
             name = f"Access {short_mac}"

--- a/homeassistant/components/unifi_access/strings.json
+++ b/homeassistant/components/unifi_access/strings.json
@@ -11,6 +11,7 @@
       "protect_api_key": "This API key is associated with UniFi Protect, not UniFi Access. Please generate a new API key from the UniFi Access application settings.",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
+    "flow_title": "{name} ({ip_address})",
     "step": {
       "discovery_confirm": {
         "data": {

--- a/tests/components/unifi_access/test_config_flow.py
+++ b/tests/components/unifi_access/test_config_flow.py
@@ -820,3 +820,40 @@ async def test_discovery_fallback_name_from_mac(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "discovery_confirm"
     assert result["description_placeholders"]["name"] == "Access DDEEFF"
+
+
+@pytest.mark.usefixtures("mock_setup_entry")
+@pytest.mark.parametrize(
+    ("extra_info", "expected_name"),
+    [
+        (
+            {"name": "Front Gate", "hostname": "unvr", "product_name": "UNVR"},
+            "Front Gate",
+        ),
+        ({"hostname": "unvr", "product_name": "UNVR"}, "unvr"),
+        ({"product_name": "UniFi Dream Machine"}, "UniFi Dream Machine"),
+    ],
+    ids=["console-name", "hostname", "product-name"],
+)
+async def test_discovery_name_resolution(
+    hass: HomeAssistant,
+    mock_client: MagicMock,
+    extra_info: dict[str, str],
+    expected_name: str,
+) -> None:
+    """Test the discovered-device name prefers the console name over raw codes."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_INTEGRATION_DISCOVERY},
+        data={
+            "source_ip": "10.0.0.5",
+            "hw_addr": "aa:bb:cc:dd:ee:ff",
+            "services": {"Access": True},
+            "direct_connect_domain": "x.ui.direct",
+            **extra_info,
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "discovery_confirm"
+    assert result["description_placeholders"]["name"] == expected_name


### PR DESCRIPTION
## Proposed change

The UniFi Access discovery title fell back to the raw platform code (e.g. `unvr`), producing unrecognizable entries on the discovery card and confirm step.

`unifi-discovery` 1.5.0 (already pulled in via the `unifi_discovery` integration) exposes the console's own `name`, so this resolves the discovered-device name as `name → hostname → product_name` — mirroring the UniFi Network discovery title — and drops the raw `platform` fallback. A `flow_title` is also added so the discovery card reads `<name> (<ip>)` instead of just "UniFi Access".

No manifest change is needed: `unifi_access` inherits the library version through its `unifi_discovery` dependency.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is not related to an open issue.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
