### PR TITLE
Use console name in UniFi Protect discovery title

### DIFF
--- a/homeassistant/components/unifiprotect/config_flow.py
+++ b/homeassistant/components/unifiprotect/config_flow.py
@@ -286,8 +286,9 @@ class ProtectFlowHandler(ConfigFlow, domain=DOMAIN):
                 form_data[CONF_API_KEY] = user_input[CONF_API_KEY]
 
         placeholders = {
-            "name": discovery_info["hostname"]
-            or discovery_info["platform"]
+            "name": discovery_info.get("name")
+            or discovery_info.get("hostname")
+            or discovery_info.get("product_name")
             or f"NVR {_async_short_mac(discovery_info['hw_addr'])}",
             "ip_address": discovery_info["source_ip"],
         }

--- a/tests/components/unifiprotect/test_config_flow.py
+++ b/tests/components/unifiprotect/test_config_flow.py
@@ -918,6 +918,38 @@ async def test_discovered_by_unifi_discovery_partial(
     assert len(mock_setup.mock_calls) == 1
 
 
+@pytest.mark.parametrize(
+    ("overrides", "expected_name"),
+    [
+        (
+            {"name": "Front Gate", "hostname": "unvr", "product_name": "UNVR"},
+            "Front Gate",
+        ),
+        ({"name": None, "hostname": "unvr", "product_name": "UNVR"}, "unvr"),
+        (
+            {"name": None, "hostname": None, "product_name": "Dream Machine"},
+            "Dream Machine",
+        ),
+    ],
+    ids=["console-name", "hostname", "product-name"],
+)
+async def test_discovery_name_resolution(
+    hass: HomeAssistant, overrides: dict[str, str | None], expected_name: str
+) -> None:
+    """Test the discovery title prefers the console name over raw platform codes."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
+        data={**UNIFI_DISCOVERY_DICT, **overrides},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "discovery_confirm"
+    flows = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
+    assert flows[0]["context"]["title_placeholders"]["name"] == expected_name
+
+
 async def test_discovered_by_unifi_discovery_direct_connect_on_different_interface(
     hass: HomeAssistant,
 ) -> None:


### PR DESCRIPTION
## Proposed change

The UniFi Protect discovery title fell back to the raw platform code (e.g. `unvr`) when building the discovery card name. `unifi-discovery` 1.5.0 (already pulled in via the `unifi_discovery` integration) exposes the console's own `name`, so the discovered-device name now resolves as `name → hostname → product_name` — mirroring the UniFi Network and Access discovery titles — and drops the raw `platform` string. The `NVR <mac>` fallback and the existing `flow_title` (`{name} ({ip_address})`) are unchanged.

This is the UniFi Protect counterpart to the same alignment for UniFi Network (#173931) and UniFi Access (#173962).

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is not related to an open issue.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
