### PR TITLE
Add display brightness and max volume numbers to Yoto

### DIFF
--- a/homeassistant/components/yoto/__init__.py
+++ b/homeassistant/components/yoto/__init__.py
@@ -22,6 +22,7 @@ from .coordinator import YotoConfigEntry, YotoDataUpdateCoordinator
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.MEDIA_PLAYER,
+    Platform.NUMBER,
     Platform.SENSOR,
     Platform.TIME,
 ]

--- a/homeassistant/components/yoto/icons.json
+++ b/homeassistant/components/yoto/icons.json
@@ -8,6 +8,20 @@
         "default": "mdi:headphones"
       }
     },
+    "number": {
+      "day_mode_brightness": {
+        "default": "mdi:brightness-7"
+      },
+      "day_mode_max_volume": {
+        "default": "mdi:volume-high"
+      },
+      "night_mode_brightness": {
+        "default": "mdi:brightness-4"
+      },
+      "night_mode_max_volume": {
+        "default": "mdi:volume-high"
+      }
+    },
     "sensor": {
       "card_insertion_state": {
         "default": "mdi:card-bulleted-outline",

--- a/homeassistant/components/yoto/number.py
+++ b/homeassistant/components/yoto/number.py
@@ -1,0 +1,134 @@
+"""Number platform for the Yoto integration."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from yoto_api import PlayerConfig, YotoPlayer
+
+from homeassistant.components.number import (
+    NumberEntity,
+    NumberEntityDescription,
+    NumberMode,
+)
+from homeassistant.const import PERCENTAGE, EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import YotoConfigEntry, YotoDataUpdateCoordinator
+from .entity import YotoConfigEntity
+
+PARALLEL_UPDATES = 1
+
+
+@dataclass(frozen=True, kw_only=True)
+class YotoNumberEntityDescription(NumberEntityDescription):
+    """Describes a Yoto number entity.
+
+    ``config_field`` is the ``set_player_config`` kwarg written on change.
+    ``available_fn`` hides the entity while the value is managed automatically.
+    """
+
+    value_fn: Callable[[PlayerConfig], int | None]
+    config_field: str
+    available_fn: Callable[[PlayerConfig], bool] = lambda config: True
+
+
+NUMBERS: tuple[YotoNumberEntityDescription, ...] = (
+    YotoNumberEntityDescription(
+        key="day_mode_brightness",
+        translation_key="day_mode_brightness",
+        entity_category=EntityCategory.CONFIG,
+        native_min_value=0,
+        native_max_value=100,
+        native_step=1,
+        native_unit_of_measurement=PERCENTAGE,
+        mode=NumberMode.SLIDER,
+        value_fn=lambda config: config.day_display_brightness,
+        config_field="day_display_brightness",
+        available_fn=lambda config: not config.day_display_brightness_auto,
+    ),
+    YotoNumberEntityDescription(
+        key="night_mode_brightness",
+        translation_key="night_mode_brightness",
+        entity_category=EntityCategory.CONFIG,
+        native_min_value=0,
+        native_max_value=100,
+        native_step=1,
+        native_unit_of_measurement=PERCENTAGE,
+        mode=NumberMode.SLIDER,
+        value_fn=lambda config: config.night_display_brightness,
+        config_field="night_display_brightness",
+        available_fn=lambda config: not config.night_display_brightness_auto,
+    ),
+    YotoNumberEntityDescription(
+        key="day_mode_max_volume",
+        translation_key="day_mode_max_volume",
+        entity_category=EntityCategory.CONFIG,
+        native_min_value=0,
+        native_max_value=16,
+        native_step=1,
+        mode=NumberMode.SLIDER,
+        value_fn=lambda config: config.day_max_volume_limit,
+        config_field="day_max_volume_limit",
+    ),
+    YotoNumberEntityDescription(
+        key="night_mode_max_volume",
+        translation_key="night_mode_max_volume",
+        entity_category=EntityCategory.CONFIG,
+        native_min_value=0,
+        native_max_value=16,
+        native_step=1,
+        mode=NumberMode.SLIDER,
+        value_fn=lambda config: config.night_max_volume_limit,
+        config_field="night_max_volume_limit",
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: YotoConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the Yoto number platform."""
+    coordinator = entry.runtime_data
+    async_add_entities(
+        YotoNumber(coordinator, player, description)
+        for player in coordinator.client.players.values()
+        for description in NUMBERS
+    )
+
+
+class YotoNumber(YotoConfigEntity, NumberEntity):
+    """Representation of a Yoto player config number."""
+
+    entity_description: YotoNumberEntityDescription
+
+    def __init__(
+        self,
+        coordinator: YotoDataUpdateCoordinator,
+        player: YotoPlayer,
+        description: YotoNumberEntityDescription,
+    ) -> None:
+        """Initialize the number."""
+        super().__init__(coordinator, player)
+        self.entity_description = description
+        self._attr_unique_id = f"{player.id}_{description.key}"
+
+    @property
+    def available(self) -> bool:
+        """Return if the entity is available."""
+        return super().available and self.entity_description.available_fn(
+            self.player.info.config
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the configured value."""
+        return self.entity_description.value_fn(self.player.info.config)
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Update the configured value."""
+        await self._async_set_config(
+            **{self.entity_description.config_field: int(value)}
+        )

--- a/homeassistant/components/yoto/strings.json
+++ b/homeassistant/components/yoto/strings.json
@@ -45,6 +45,20 @@
         "name": "Headphones"
       }
     },
+    "number": {
+      "day_mode_brightness": {
+        "name": "Day mode brightness"
+      },
+      "day_mode_max_volume": {
+        "name": "Day mode maximum volume"
+      },
+      "night_mode_brightness": {
+        "name": "Night mode brightness"
+      },
+      "night_mode_max_volume": {
+        "name": "Night mode maximum volume"
+      }
+    },
     "sensor": {
       "card_insertion_state": {
         "name": "Card slot",

--- a/tests/components/yoto/conftest.py
+++ b/tests/components/yoto/conftest.py
@@ -94,6 +94,10 @@ def _build_player() -> YotoPlayer:
         config=PlayerConfig(
             day_time=dt_time(7, 0),
             night_time=dt_time(19, 0),
+            day_display_brightness=100,
+            night_display_brightness=50,
+            day_max_volume_limit=16,
+            night_max_volume_limit=8,
         ),
     )
     player.status = PlayerStatus(

--- a/tests/components/yoto/snapshots/test_number.ambr
+++ b/tests/components/yoto/snapshots/test_number.ambr
@@ -1,0 +1,239 @@
+# serializer version: 1
+# name: test_all_entities[number.nursery_yoto_day_mode_brightness-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 100,
+      'min': 0,
+      'mode': <NumberMode.SLIDER: 'slider'>,
+      'step': 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.nursery_yoto_day_mode_brightness',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Day mode brightness',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Day mode brightness',
+    'platform': 'yoto',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'day_mode_brightness',
+    'unique_id': 'player-test_day_mode_brightness',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_all_entities[number.nursery_yoto_day_mode_brightness-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Nursery Yoto Day mode brightness',
+      'max': 100,
+      'min': 0,
+      'mode': <NumberMode.SLIDER: 'slider'>,
+      'step': 1,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.nursery_yoto_day_mode_brightness',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '100',
+  })
+# ---
+# name: test_all_entities[number.nursery_yoto_day_mode_maximum_volume-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 16,
+      'min': 0,
+      'mode': <NumberMode.SLIDER: 'slider'>,
+      'step': 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.nursery_yoto_day_mode_maximum_volume',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Day mode maximum volume',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Day mode maximum volume',
+    'platform': 'yoto',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'day_mode_max_volume',
+    'unique_id': 'player-test_day_mode_max_volume',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[number.nursery_yoto_day_mode_maximum_volume-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Nursery Yoto Day mode maximum volume',
+      'max': 16,
+      'min': 0,
+      'mode': <NumberMode.SLIDER: 'slider'>,
+      'step': 1,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.nursery_yoto_day_mode_maximum_volume',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '16',
+  })
+# ---
+# name: test_all_entities[number.nursery_yoto_night_mode_brightness-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 100,
+      'min': 0,
+      'mode': <NumberMode.SLIDER: 'slider'>,
+      'step': 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.nursery_yoto_night_mode_brightness',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Night mode brightness',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Night mode brightness',
+    'platform': 'yoto',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'night_mode_brightness',
+    'unique_id': 'player-test_night_mode_brightness',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_all_entities[number.nursery_yoto_night_mode_brightness-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Nursery Yoto Night mode brightness',
+      'max': 100,
+      'min': 0,
+      'mode': <NumberMode.SLIDER: 'slider'>,
+      'step': 1,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.nursery_yoto_night_mode_brightness',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '50',
+  })
+# ---
+# name: test_all_entities[number.nursery_yoto_night_mode_maximum_volume-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 16,
+      'min': 0,
+      'mode': <NumberMode.SLIDER: 'slider'>,
+      'step': 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.nursery_yoto_night_mode_maximum_volume',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Night mode maximum volume',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Night mode maximum volume',
+    'platform': 'yoto',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'night_mode_max_volume',
+    'unique_id': 'player-test_night_mode_max_volume',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[number.nursery_yoto_night_mode_maximum_volume-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Nursery Yoto Night mode maximum volume',
+      'max': 16,
+      'min': 0,
+      'mode': <NumberMode.SLIDER: 'slider'>,
+      'step': 1,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.nursery_yoto_night_mode_maximum_volume',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '8',
+  })
+# ---

--- a/tests/components/yoto/test_number.py
+++ b/tests/components/yoto/test_number.py
@@ -1,0 +1,152 @@
+"""Tests for the Yoto number platform."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+from yoto_api import YotoError
+
+from homeassistant.components.number import (
+    ATTR_VALUE,
+    DOMAIN as NUMBER_DOMAIN,
+    SERVICE_SET_VALUE,
+)
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+from .conftest import PLAYER_ID
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+pytestmark = pytest.mark.usefixtures("setup_credentials")
+
+
+async def _setup(hass: HomeAssistant, mock_config_entry: MockConfigEntry) -> None:
+    """Set up the integration with only the number platform."""
+    with patch("homeassistant.components.yoto.PLATFORMS", [Platform.NUMBER]):
+        await setup_integration(hass, mock_config_entry)
+
+
+@pytest.mark.usefixtures("mock_yoto_client")
+async def test_all_entities(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Snapshot every Yoto number entity."""
+    await _setup(hass, mock_config_entry)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_available_when_offline(
+    hass: HomeAssistant,
+    mock_yoto_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Config is written over REST, so entities stay available when offline."""
+    player = next(iter(mock_yoto_client.players.values()))
+    player.is_online = False
+
+    await _setup(hass, mock_config_entry)
+
+    state = hass.states.get("number.nursery_yoto_day_mode_maximum_volume")
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+
+
+async def test_brightness_unavailable_when_auto(
+    hass: HomeAssistant,
+    mock_yoto_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """A brightness number is unavailable while auto-brightness manages it."""
+    player = next(iter(mock_yoto_client.players.values()))
+    player.info.config.day_display_brightness_auto = True
+    player.info.config.day_display_brightness = None
+
+    await _setup(hass, mock_config_entry)
+
+    state = hass.states.get("number.nursery_yoto_day_mode_brightness")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "value", "expected_fields"),
+    [
+        pytest.param(
+            "number.nursery_yoto_day_mode_brightness",
+            75,
+            {"day_display_brightness": 75},
+            id="day-mode-brightness",
+        ),
+        pytest.param(
+            "number.nursery_yoto_night_mode_brightness",
+            75,
+            {"night_display_brightness": 75},
+            id="night-mode-brightness",
+        ),
+        pytest.param(
+            "number.nursery_yoto_day_mode_maximum_volume",
+            10,
+            {"day_max_volume_limit": 10},
+            id="day-mode-max-volume",
+        ),
+        pytest.param(
+            "number.nursery_yoto_night_mode_maximum_volume",
+            10,
+            {"night_max_volume_limit": 10},
+            id="night-mode-max-volume",
+        ),
+    ],
+)
+async def test_set_value(
+    hass: HomeAssistant,
+    mock_yoto_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    entity_id: str,
+    value: int,
+    expected_fields: dict[str, int],
+) -> None:
+    """Setting a number writes the matching player config field."""
+    await _setup(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: value},
+        blocking=True,
+    )
+
+    mock_yoto_client.set_player_config.assert_awaited_once_with(
+        PLAYER_ID, **expected_fields
+    )
+    mock_yoto_client.update_player_info.assert_awaited_once_with(PLAYER_ID)
+
+
+async def test_set_value_failure(
+    hass: HomeAssistant,
+    mock_yoto_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """A failed config write raises a Home Assistant error."""
+    await _setup(hass, mock_config_entry)
+    mock_yoto_client.set_player_config.side_effect = YotoError("MQTT timeout")
+
+    with pytest.raises(
+        HomeAssistantError, match="Failed to update Yoto player settings"
+    ):
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {
+                ATTR_ENTITY_ID: "number.nursery_yoto_day_mode_maximum_volume",
+                ATTR_VALUE: 10,
+            },
+            blocking=True,
+        )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds number entities for the per-mode display settings the Yoto app exposes under Day/Night mode:

- Day/Night mode brightness (0-100%)
- Day/Night maximum volume (0-16)

The brightness numbers become unavailable when the player is set to automatic brightness, since there is no manual value to show or change. This matches the app, where the manual slider is disabled while auto is on. Toggling auto off is left to a follow-up switch PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/46239
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
