### PR TITLE
Avoid flooding the recorder when priming condition history

### DIFF
--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -115,6 +115,9 @@ from .trace import (
 )
 from .typing import UNDEFINED, ConfigType, TemplateVarsType, UndefinedType
 
+if TYPE_CHECKING:
+    from homeassistant.components.recorder import Recorder
+
 ASYNC_FROM_CONFIG_FORMAT = "async_{}_from_config"
 FROM_CONFIG_FORMAT = "{}_from_config"
 VALIDATE_CONFIG_FORMAT = "{}_validate_config"
@@ -201,6 +204,7 @@ async def async_setup(hass: HomeAssistant) -> None:
     hass.data[CONDITION_DISABLED_CONDITIONS] = set()
     hass.data[CONDITION_PLATFORM_SUBSCRIPTIONS] = []
     hass.data[CONDITIONS] = {}
+    hass.data[_DATA_HISTORY_PRIMING_MANAGER] = _HistoryPrimingManager(hass)
 
     async def new_triggers_conditions_listener(
         _event_data: labs.EventLabsUpdatedData,
@@ -469,6 +473,79 @@ ENTITY_STATE_CONDITION_SCHEMA_ANY_ALL = vol.Schema(
 )
 
 
+_DATA_HISTORY_PRIMING_MANAGER: HassKey[_HistoryPrimingManager] = HassKey(
+    "condition_history_priming_manager"
+)
+
+
+class _HistoryPrimingManager:
+    """Serialize and coalesce the recorder reads that prime condition durations.
+
+    At startup many conditions may prime at once. Letting each hit the recorder
+    independently would force a separate commit per condition and run every read
+    on the shared DB executor in parallel — a flood. So the reads run one at a
+    time, and a single commit flush is shared by each "generation" of conditions
+    that arrive while the previous flush is running.
+
+    The flush a condition relies on must begin after that condition started
+    tracking its entities, or the read could miss a change still queued in the
+    recorder and compute too generous an anchor. A condition therefore never
+    rides a flush that was already running when it arrived (the lobby); it waits
+    that one out and joins the next.
+    """
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the manager."""
+        self._hass = hass
+        self._flush_condition = asyncio.Condition()
+        self._flushing = False
+        self._query_lock = asyncio.Lock()
+
+    async def async_prime[_T](
+        self, job: Callable[[Recorder], Coroutine[Any, Any, _T]]
+    ) -> _T:
+        """Flush the recorder, then run `job`, coordinated with other primings."""
+        await self._async_flush()
+        async with self._query_lock:
+            return await job(get_instance(self._hass))
+
+    async def _async_flush(self) -> None:
+        """Return once a recorder flush that began no earlier than this call ends.
+
+        The first condition of a generation performs the flush; the rest ride it.
+        """
+        async with self._flush_condition:
+            # Lobby: a flush already running began before we arrived, so it may
+            # not capture our entity's queued changes. Wait it out, don't ride it.
+            if self._flushing:
+                await self._flush_condition.wait()
+
+        do_flush = False
+        while True:
+            async with self._flush_condition:
+                if not self._flushing:
+                    # First past the lobby this generation: we run the flush.
+                    self._flushing = True
+                    do_flush = True
+                    break
+                # A peer began a fresh flush after we cleared the lobby; it
+                # covers us too, so wait for it and ride it.
+                await self._flush_condition.wait()
+                break
+
+        if not do_flush:
+            return
+
+        instance = get_instance(self._hass)
+        try:
+            if (commit_future := instance.async_get_commit_future()) is not None:
+                await commit_future
+        finally:
+            async with self._flush_condition:
+                self._flushing = False
+                self._flush_condition.notify_all()
+
+
 class EntityConditionBase(Condition):
     """Base class for entity conditions."""
 
@@ -668,28 +745,34 @@ class EntityConditionBase(Condition):
             assert self._duration is not None
         lookback = min(self._duration, MAX_HISTORY_PRIMING_LOOKBACK)
         start_time = dt_util.utcnow() - lookback
-        instance = get_instance(self._hass)
-        try:
-            async with asyncio.timeout(HISTORY_PRIMING_TIMEOUT):
-                # The history query only sees committed rows. Wait for the
-                # recorder to flush its queue first.
-                if (commit_future := instance.async_get_commit_future()) is not None:
-                    await commit_future
-                historical_states = await instance.async_add_executor_job(
-                    ft.partial(
-                        history.get_significant_states,
-                        self._hass,
-                        start_time,
-                        entity_ids=list(anchors),
-                        include_start_time_state=True,
-                        # Mandatory: the default (True) drops attribute-only
-                        # changes for entities outside SIGNIFICANT_DOMAINS, which
-                        # are exactly the transitions attribute-based conditions
-                        # depend on.
-                        significant_changes_only=False,
-                        minimal_response=False,
-                    )
+
+        async def _read_history(
+            instance: Recorder,
+        ) -> dict[str, list[State | dict[str, Any]]]:
+            # The history query only sees committed rows; the priming manager
+            # flushes the recorder queue before running this.
+            return await instance.async_add_executor_job(
+                ft.partial(
+                    history.get_significant_states,
+                    self._hass,
+                    start_time,
+                    entity_ids=list(anchors),
+                    include_start_time_state=True,
+                    # Mandatory: the default (True) drops attribute-only changes
+                    # for entities outside SIGNIFICANT_DOMAINS, which are exactly
+                    # the transitions attribute-based conditions depend on.
+                    significant_changes_only=False,
+                    minimal_response=False,
                 )
+            )
+
+        manager = self._hass.data[_DATA_HISTORY_PRIMING_MANAGER]
+        try:
+            # The timeout also covers waiting for our turn, so under a flood of
+            # primings a condition falls back to its conservative anchor rather
+            # than blocking on the queue indefinitely.
+            async with asyncio.timeout(HISTORY_PRIMING_TIMEOUT):
+                historical_states = await manager.async_prime(_read_history)
         except (SQLAlchemyError, TimeoutError) as err:
             # Best effort: keep the conservative anchors rather than failing.
             _LOGGER.debug("Error priming condition durations from history: %s", err)

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -59,6 +59,7 @@ from homeassistant.helpers.automation import (
     move_top_level_schema_fields_to_options,
 )
 from homeassistant.helpers.condition import (
+    _DATA_HISTORY_PRIMING_MANAGER,
     ATTR_BEHAVIOR,
     BEHAVIOR_ALL,
     BEHAVIOR_ANY,
@@ -69,6 +70,7 @@ from homeassistant.helpers.condition import (
     EntityConditionBase,
     EntityNumericalConditionWithUnitBase,
     _async_get_condition_platform,
+    _HistoryPrimingManager,
     async_validate_condition_config,
     make_entity_numerical_condition,
     make_entity_numerical_condition_with_unit,
@@ -5860,6 +5862,152 @@ async def test_state_condition_attr_duration_history_flushes_before_query(
         )
 
     assert call_order == ["flush", "query"]
+
+
+async def test_async_setup_creates_history_priming_manager(
+    hass: HomeAssistant,
+) -> None:
+    """The priming manager is created during condition setup, not on demand."""
+    # condition.async_setup runs as part of the test hass fixture.
+    assert isinstance(hass.data[_DATA_HISTORY_PRIMING_MANAGER], _HistoryPrimingManager)
+
+
+async def test_history_priming_manager_serializes_queries(
+    recorder_mock: Recorder, hass: HomeAssistant
+) -> None:
+    """Queries run one at a time even when many conditions prime together."""
+    manager = _HistoryPrimingManager(hass)
+    instance = get_instance(hass)
+
+    running = 0
+    max_running = 0
+    release = asyncio.Event()
+    started = asyncio.Event()
+
+    async def _job(_recorder: Recorder) -> str:
+        nonlocal running, max_running
+        running += 1
+        max_running = max(max_running, running)
+        started.set()
+        await release.wait()
+        running -= 1
+        return "ok"
+
+    # No pending commit, so flushing is instant and only query serialization
+    # is exercised.
+    with patch.object(instance, "async_get_commit_future", return_value=None):
+        tasks = [asyncio.create_task(manager.async_prime(_job)) for _ in range(5)]
+        # The first job holds the query lock; the rest must queue behind it.
+        await started.wait()
+        await asyncio.sleep(0)
+        assert running == 1
+        release.set()
+        results = await asyncio.gather(*tasks)
+
+    assert results == ["ok"] * 5
+    assert max_running == 1
+
+
+async def test_history_priming_manager_does_not_ride_in_flight_flush(
+    recorder_mock: Recorder, hass: HomeAssistant
+) -> None:
+    """A priming never rides a flush that began before it arrived (the lobby).
+
+    The flush commits changes still queued in the recorder so the history read
+    sees them. A condition that started tracking after an in-flight flush began
+    could miss its own just-queued change if it rode that flush, so it waits the
+    flush out and a fresh one is performed for it. Without the lobby step this
+    test fails: the late arrivals would ride the first flush (one flush total)
+    instead of sharing a second, fresh one.
+    """
+    manager = _HistoryPrimingManager(hass)
+    instance = get_instance(hass)
+
+    flush_futures: list[asyncio.Future[None]] = []
+
+    def _spy_commit_future() -> asyncio.Future[None]:
+        fut = hass.loop.create_future()
+        flush_futures.append(fut)
+        return fut
+
+    async def _job(_recorder: Recorder) -> str:
+        return "done"
+
+    with patch.object(instance, "async_get_commit_future", _spy_commit_future):
+        # C0 claims the flush and is mid-flush (its commit future is pending).
+        c0 = asyncio.create_task(manager.async_prime(_job))
+        for _ in range(10):
+            await asyncio.sleep(0)
+            if flush_futures:
+                break
+        assert len(flush_futures) == 1
+
+        # Two conditions arrive while C0's flush runs; they must not ride it.
+        c1 = asyncio.create_task(manager.async_prime(_job))
+        c2 = asyncio.create_task(manager.async_prime(_job))
+        for _ in range(5):
+            await asyncio.sleep(0)
+        # Parked in the lobby: no new flush yet, none finished.
+        assert len(flush_futures) == 1
+        assert not c1.done()
+        assert not c2.done()
+
+        # C0's flush completes; C1 now performs a fresh flush and C2 rides it.
+        flush_futures[0].set_result(None)
+        assert await c0 == "done"
+        for _ in range(10):
+            await asyncio.sleep(0)
+        # Exactly one fresh flush is shared by C1 and C2, not one each: this is
+        # the assertion that fails without the lobby (it would stay 1).
+        assert len(flush_futures) == 2
+        flush_futures[1].set_result(None)
+        assert await asyncio.gather(c1, c2) == ["done", "done"]
+
+
+async def test_history_priming_manager_cancelled_lobby_waiter(
+    recorder_mock: Recorder, hass: HomeAssistant
+) -> None:
+    """A priming cancelled while waiting in the lobby doesn't wedge later ones.
+
+    A condition whose timeout fires while it waits for an in-flight flush is
+    cancelled. That must leave the manager able to flush for the next priming.
+    """
+    manager = _HistoryPrimingManager(hass)
+    instance = get_instance(hass)
+
+    flush_futures: list[asyncio.Future[None]] = []
+
+    def _spy_commit_future() -> asyncio.Future[None]:
+        fut = hass.loop.create_future()
+        flush_futures.append(fut)
+        return fut
+
+    async def _job(_recorder: Recorder) -> str:
+        return "done"
+
+    with patch.object(instance, "async_get_commit_future", _spy_commit_future):
+        c0 = asyncio.create_task(manager.async_prime(_job))
+        for _ in range(10):
+            await asyncio.sleep(0)
+            if flush_futures:
+                break
+        # A second priming parks in the lobby, then its timeout cancels it.
+        waiter = asyncio.create_task(manager.async_prime(_job))
+        for _ in range(3):
+            await asyncio.sleep(0)
+        waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiter
+
+        # C0 finishes; a later priming still flushes and completes normally.
+        flush_futures[0].set_result(None)
+        assert await c0 == "done"
+        later = asyncio.create_task(manager.async_prime(_job))
+        for _ in range(10):
+            await asyncio.sleep(0)
+        assert len(flush_futures) == 2
+        flush_futures[1].set_result(None)
+        assert await later == "done"
 
 
 async def test_state_condition_multi_state_duration_uses_history(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Avoid flooding the recorder when priming condition history

This is a follow-up to https://github.com/home-assistant/core/pull/173426

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
