### PR TITLE
Fix SwitchBot TRV reporting heating action when target temperature achieved

### DIFF
--- a/homeassistant/components/switchbot/climate.py
+++ b/homeassistant/components/switchbot/climate.py
@@ -105,24 +105,27 @@ class SwitchBotClimateEntity(SwitchbotEntity, ClimateEntity):
     @property
     def hvac_action(self) -> HVACAction | None:
         """Return the current HVAC action."""
-        # --- UNIVERSAL OPTIMIZED ACTION PATCH ---
-        # 1. Early Guard Clause: Skip thresholds if values are missing
+        # Check thresholds to infer IDLE state since certain hardware profiles
+        # continue to broadcast active state constants when target is met.
         if self.current_temperature is not None and self.target_temperature is not None:
-            # 2. Dynamic Hysteresis Deadband based on system temperature units
-            deadband = (
-                0.5 if self.temperature_unit == UnitOfTemperature.CELSIUS else 1.0
+            # Fetch the underlying action to prevent overriding native OFF states
+            raw_action = SWITCHBOT_ACTION_TO_HASS_HVAC_ACTION.get(
+                self._device.hvac_action, HVACAction.OFF
             )
 
-            # 3. Mode Evaluation
-            if self.hvac_mode == HVACMode.HEAT:
-                if self.current_temperature >= (self.target_temperature + deadband):
-                    return HVACAction.IDLE
+            if raw_action != HVACAction.OFF:
+                deadband = (
+                    0.5 if self.temperature_unit == UnitOfTemperature.CELSIUS else 1.0
+                )
 
-            elif self.hvac_mode == HVACMode.COOL:
-                if self.current_temperature <= (self.target_temperature - deadband):
-                    return HVACAction.IDLE
+                if self.hvac_mode == HVACMode.HEAT:
+                    if self.current_temperature >= (self.target_temperature + deadband):
+                        return HVACAction.IDLE
 
-        # Fall back to standard hardware tracking if outside thresholds or if data missing
+                elif self.hvac_mode == HVACMode.COOL:
+                    if self.current_temperature <= (self.target_temperature - deadband):
+                        return HVACAction.IDLE
+
         return SWITCHBOT_ACTION_TO_HASS_HVAC_ACTION.get(
             self._device.hvac_action, HVACAction.OFF
         )

--- a/homeassistant/components/switchbot/climate.py
+++ b/homeassistant/components/switchbot/climate.py
@@ -105,20 +105,25 @@ class SwitchBotClimateEntity(SwitchbotEntity, ClimateEntity):
     @property
     def hvac_action(self) -> HVACAction | None:
         """Return the current HVAC action."""
-
         # Simple threshold check
         # Ensure the threshold checks are gated on the correct active HVAC mode
         if self.hvac_mode == HVACMode.HEAT:
-            if self.current_temperature is not None and self.target_temperature is not None:
+            if (
+                self.current_temperature is not None
+                and self.target_temperature is not None
+            ):
                 if self.current_temperature >= self.target_temperature:
                     return HVACAction.IDLE
 
         elif self.hvac_mode == HVACMode.COOL:
-            if self.current_temperature is not None and self.target_temperature is not None:
+            if (
+                self.current_temperature is not None
+                and self.target_temperature is not None
+            ):
                 if self.current_temperature <= self.target_temperature:
                     return HVACAction.IDLE
 
-        # Fall back to standard tracking if thresholds aren't actively hit
+        # Fall back to standard hardware tracking if thresholds aren't actively hit
         return SWITCHBOT_ACTION_TO_HASS_HVAC_ACTION.get(
             self._device.hvac_action, HVACAction.OFF
         )

--- a/homeassistant/components/switchbot/climate.py
+++ b/homeassistant/components/switchbot/climate.py
@@ -105,6 +105,12 @@ class SwitchBotClimateEntity(SwitchbotEntity, ClimateEntity):
     @property
     def hvac_action(self) -> HVACAction | None:
         """Return the current HVAC action."""
+
+        # Simple threshold check
+        if self.current_temperature is not None and self.target_temperature is not None:
+            if self.current_temperature >= self.target_temperature:
+                return HVACAction.IDLE
+
         return SWITCHBOT_ACTION_TO_HASS_HVAC_ACTION.get(
             self._device.hvac_action, HVACAction.OFF
         )

--- a/homeassistant/components/switchbot/climate.py
+++ b/homeassistant/components/switchbot/climate.py
@@ -107,10 +107,18 @@ class SwitchBotClimateEntity(SwitchbotEntity, ClimateEntity):
         """Return the current HVAC action."""
 
         # Simple threshold check
-        if self.current_temperature is not None and self.target_temperature is not None:
-            if self.current_temperature >= self.target_temperature:
-                return HVACAction.IDLE
+        # Ensure the threshold checks are gated on the correct active HVAC mode
+        if self.hvac_mode == HVACMode.HEAT:
+            if self.current_temperature is not None and self.target_temperature is not None:
+                if self.current_temperature >= self.target_temperature:
+                    return HVACAction.IDLE
 
+        elif self.hvac_mode == HVACMode.COOL:
+            if self.current_temperature is not None and self.target_temperature is not None:
+                if self.current_temperature <= self.target_temperature:
+                    return HVACAction.IDLE
+
+        # Fall back to standard tracking if thresholds aren't actively hit
         return SWITCHBOT_ACTION_TO_HASS_HVAC_ACTION.get(
             self._device.hvac_action, HVACAction.OFF
         )

--- a/homeassistant/components/switchbot/climate.py
+++ b/homeassistant/components/switchbot/climate.py
@@ -105,14 +105,14 @@ class SwitchBotClimateEntity(SwitchbotEntity, ClimateEntity):
     @property
     def hvac_action(self) -> HVACAction | None:
         """Return the current HVAC action."""
-        # Simple threshold check
-        # Ensure the threshold checks are gated on the correct active HVAC mode
+        # --- CLIMATE SAFE ACTION PATCH WITH HYSTERESIS ---
+        # Add a 0.5 degree deadband buffer to prevent dashboard state flickering
         if self.hvac_mode == HVACMode.HEAT:
             if (
                 self.current_temperature is not None
                 and self.target_temperature is not None
             ):
-                if self.current_temperature >= self.target_temperature:
+                if self.current_temperature >= (self.target_temperature + 0.5):
                     return HVACAction.IDLE
 
         elif self.hvac_mode == HVACMode.COOL:
@@ -120,14 +120,13 @@ class SwitchBotClimateEntity(SwitchbotEntity, ClimateEntity):
                 self.current_temperature is not None
                 and self.target_temperature is not None
             ):
-                if self.current_temperature <= self.target_temperature:
+                if self.current_temperature <= (self.target_temperature - 0.5):
                     return HVACAction.IDLE
 
-        # Fall back to standard hardware tracking if thresholds aren't actively hit
+        # Fall back to standard hardware tracking if outside the deadband threshold
         return SWITCHBOT_ACTION_TO_HASS_HVAC_ACTION.get(
             self._device.hvac_action, HVACAction.OFF
         )
-
     @property
     def current_temperature(self) -> float | None:
         """Return the current temperature."""

--- a/homeassistant/components/switchbot/climate.py
+++ b/homeassistant/components/switchbot/climate.py
@@ -127,6 +127,7 @@ class SwitchBotClimateEntity(SwitchbotEntity, ClimateEntity):
         return SWITCHBOT_ACTION_TO_HASS_HVAC_ACTION.get(
             self._device.hvac_action, HVACAction.OFF
         )
+
     @property
     def current_temperature(self) -> float | None:
         """Return the current temperature."""

--- a/homeassistant/components/switchbot/climate.py
+++ b/homeassistant/components/switchbot/climate.py
@@ -38,6 +38,9 @@ SWITCHBOT_ACTION_TO_HASS_HVAC_ACTION = {
     SwitchBotClimateAction.OFF: HVACAction.OFF,
 }
 
+_DEADBAND_CELSIUS = 0.5
+_DEADBAND_FAHRENHEIT = 1.0
+
 _LOGGER = logging.getLogger(__name__)
 PARALLEL_UPDATES = 0
 
@@ -105,30 +108,32 @@ class SwitchBotClimateEntity(SwitchbotEntity, ClimateEntity):
     @property
     def hvac_action(self) -> HVACAction | None:
         """Return the current HVAC action."""
-        # Check thresholds to infer IDLE state since certain hardware profiles
-        # continue to broadcast active state constants when target is met.
-        if self.current_temperature is not None and self.target_temperature is not None:
-            # Fetch the underlying action to prevent overriding native OFF states
-            raw_action = SWITCHBOT_ACTION_TO_HASS_HVAC_ACTION.get(
-                self._device.hvac_action, HVACAction.OFF
-            )
-
-            if raw_action != HVACAction.OFF:
-                deadband = (
-                    0.5 if self.temperature_unit == UnitOfTemperature.CELSIUS else 1.0
-                )
-
-                if self.hvac_mode == HVACMode.HEAT:
-                    if self.current_temperature >= (self.target_temperature + deadband):
-                        return HVACAction.IDLE
-
-                elif self.hvac_mode == HVACMode.COOL:
-                    if self.current_temperature <= (self.target_temperature - deadband):
-                        return HVACAction.IDLE
-
-        return SWITCHBOT_ACTION_TO_HASS_HVAC_ACTION.get(
+        # Calculate the base hardware action once to avoid redundant dictionary mapping lookups
+        raw_action = SWITCHBOT_ACTION_TO_HASS_HVAC_ACTION.get(
             self._device.hvac_action, HVACAction.OFF
         )
+
+        # Check thresholds to infer IDLE state if the system isn't explicitly turned off
+        if (
+            raw_action != HVACAction.OFF
+            and self.current_temperature is not None
+            and self.target_temperature is not None
+        ):
+            deadband = (
+                _DEADBAND_CELSIUS
+                if self.temperature_unit == UnitOfTemperature.CELSIUS
+                else _DEADBAND_FAHRENHEIT
+            )
+
+            if self.hvac_mode == HVACMode.HEAT:
+                if self.current_temperature >= (self.target_temperature + deadband):
+                    return HVACAction.IDLE
+
+            elif self.hvac_mode == HVACMode.COOL:
+                if self.current_temperature <= (self.target_temperature - deadband):
+                    return HVACAction.IDLE
+
+        return raw_action
 
     @property
     def current_temperature(self) -> float | None:

--- a/homeassistant/components/switchbot/climate.py
+++ b/homeassistant/components/switchbot/climate.py
@@ -105,25 +105,24 @@ class SwitchBotClimateEntity(SwitchbotEntity, ClimateEntity):
     @property
     def hvac_action(self) -> HVACAction | None:
         """Return the current HVAC action."""
-        # --- CLIMATE SAFE ACTION PATCH WITH HYSTERESIS ---
-        # Add a 0.5 degree deadband buffer to prevent dashboard state flickering
-        if self.hvac_mode == HVACMode.HEAT:
-            if (
-                self.current_temperature is not None
-                and self.target_temperature is not None
-            ):
-                if self.current_temperature >= (self.target_temperature + 0.5):
+        # --- UNIVERSAL OPTIMIZED ACTION PATCH ---
+        # 1. Early Guard Clause: Skip thresholds if values are missing
+        if self.current_temperature is not None and self.target_temperature is not None:
+            # 2. Dynamic Hysteresis Deadband based on system temperature units
+            deadband = (
+                0.5 if self.temperature_unit == UnitOfTemperature.CELSIUS else 1.0
+            )
+
+            # 3. Mode Evaluation
+            if self.hvac_mode == HVACMode.HEAT:
+                if self.current_temperature >= (self.target_temperature + deadband):
                     return HVACAction.IDLE
 
-        elif self.hvac_mode == HVACMode.COOL:
-            if (
-                self.current_temperature is not None
-                and self.target_temperature is not None
-            ):
-                if self.current_temperature <= (self.target_temperature - 0.5):
+            elif self.hvac_mode == HVACMode.COOL:
+                if self.current_temperature <= (self.target_temperature - deadband):
                     return HVACAction.IDLE
 
-        # Fall back to standard hardware tracking if outside the deadband threshold
+        # Fall back to standard hardware tracking if outside thresholds or if data missing
         return SWITCHBOT_ACTION_TO_HASS_HVAC_ACTION.get(
             self._device.hvac_action, HVACAction.OFF
         )


### PR DESCRIPTION
## Description
The SwitchBot TRV firmware natively continues to broadcast an active heating mode preset flag (`09 & 0x07 = 1`) even when the radiator valve position has dropped to zero or the target ambient temperature has been met. This causes the Home Assistant frontend dashboard card to remain permanently stuck in an active "Heating" state.

This patch adds a dynamic threshold evaluation layer directly into the climate entity's `hvac_action` property. If the current measured room temperature meets or exceeds the user's target set point temperature, the front-end will gracefully drop down and accurately report an `IDLE` state action.

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] The code change is tested and works locally.
- [x] Local formatting validation tests passed via pre-commit.