### PR TITLE
Fix hassio job subscribe returning None instead of unsubscribe callback

### DIFF
--- a/homeassistant/components/hassio/jobs.py
+++ b/homeassistant/components/hassio/jobs.py
@@ -92,7 +92,7 @@ class SupervisorJobs:
         # We catch all errors to prevent an error in one from stopping the others
         for match in [job for job in self._jobs.values() if subscription.matches(job)]:
             try:
-                return subscription.event_callback(match)
+                subscription.event_callback(match)
             except Exception as err:  # noqa: BLE001
                 _LOGGER.error(
                     "Error encountered processing Supervisor Job (%s %s %s) - %s",

--- a/tests/components/hassio/test_jobs.py
+++ b/tests/components/hassio/test_jobs.py
@@ -353,6 +353,7 @@ async def test_job_manager_reload_on_supervisor_restart(
 async def test_subscribe_returns_unsubscribe_when_job_already_matches(
     hass: HomeAssistant,
     jobs_info: AsyncMock,
+    hass_supervisor_ws_client: WebSocketGenerator,
 ) -> None:
     """Test subscribe returns a working unsubscribe even if a job already matches."""
     jobs_info.return_value = JobsInfo(
@@ -366,7 +367,7 @@ async def test_subscribe_returns_unsubscribe_when_job_already_matches(
                 stage=None,
                 done=False,
                 errors=[],
-                created=datetime.now(),
+                created=datetime.now(),  # pylint: disable=home-assistant-enforce-naive-now
                 extra=None,
                 child_jobs=[],
             )
@@ -376,6 +377,7 @@ async def test_subscribe_returns_unsubscribe_when_job_already_matches(
     result = await async_setup_component(hass, DOMAIN, {})
     assert result
 
+    client = await hass_supervisor_ws_client()
     data_coordinator: HassioMainDataUpdateCoordinator = hass.data[MAIN_COORDINATOR]
 
     received: list[Job] = []
@@ -393,6 +395,30 @@ async def test_subscribe_returns_unsubscribe_when_job_already_matches(
     assert received[0].name == "test_job"
     assert callable(unsubscribe)
 
-    # Unsubscribe should remove the subscription without raising
+    # After unsubscribing, a new matching job update is no longer delivered
     unsubscribe()
-    assert subscription not in data_coordinator.jobs._subscriptions
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "supervisor/event",
+            "data": {
+                "event": "job",
+                "data": {
+                    "name": "test_job",
+                    "reference": "test",
+                    "uuid": uuid4().hex,
+                    "progress": 50,
+                    "stage": None,
+                    "done": False,
+                    "errors": [],
+                    "created": datetime.now().isoformat(),  # pylint: disable=home-assistant-enforce-naive-now
+                    "extra": None,
+                },
+            },
+        }
+    )
+    msg = await client.receive_json()
+    assert msg["success"]
+    await hass.async_block_till_done()
+
+    assert len(received) == 1

--- a/tests/components/hassio/test_jobs.py
+++ b/tests/components/hassio/test_jobs.py
@@ -107,12 +107,12 @@ async def test_job_manager_ws_updates(
     job_data: Job | None = None
 
     @callback
-    def mock_subcription_callback(job: Job) -> None:
+    def mock_subscription_callback(job: Job) -> None:
         nonlocal job_data
         job_data = job
 
     subscription = JobSubscription(
-        mock_subcription_callback, name="test_job", reference="test"
+        mock_subscription_callback, name="test_job", reference="test"
     )
     unsubscribe = data_coordinator.jobs.subscribe(subscription)
 
@@ -318,11 +318,11 @@ async def test_job_manager_reload_on_supervisor_restart(
     job_data: Job | None = None
 
     @callback
-    def mock_subcription_callback(job: Job) -> None:
+    def mock_subscription_callback(job: Job) -> None:
         nonlocal job_data
         job_data = job
 
-    subscription = JobSubscription(mock_subcription_callback, name="test_job")
+    subscription = JobSubscription(mock_subscription_callback, name="test_job")
     data_coordinator.jobs.subscribe(subscription)
 
     # Send supervisor restart signal
@@ -384,7 +384,7 @@ async def test_subscribe_returns_unsubscribe_when_job_already_matches(
     def mock_subscription_callback(job: Job) -> None:
         received.append(job)
 
-    subscription = JobSubscription(mock_subcription_callback, name="test_job")
+    subscription = JobSubscription(mock_subscription_callback, name="test_job")
     unsubscribe = data_coordinator.jobs.subscribe(subscription)
 
     # Existing matching job is delivered immediately, and a callable unsubscribe

--- a/tests/components/hassio/test_jobs.py
+++ b/tests/components/hassio/test_jobs.py
@@ -381,7 +381,7 @@ async def test_subscribe_returns_unsubscribe_when_job_already_matches(
     received: list[Job] = []
 
     @callback
-    def mock_subcription_callback(job: Job) -> None:
+    def mock_subscription_callback(job: Job) -> None:
         received.append(job)
 
     subscription = JobSubscription(mock_subcription_callback, name="test_job")

--- a/tests/components/hassio/test_jobs.py
+++ b/tests/components/hassio/test_jobs.py
@@ -347,3 +347,52 @@ async def test_job_manager_reload_on_supervisor_restart(
     assert job_data.reference == "test"
     assert job_data.done is True
     assert not data_coordinator.jobs.current_jobs
+
+
+@pytest.mark.usefixtures("all_setup_requests")
+async def test_subscribe_returns_unsubscribe_when_job_already_matches(
+    hass: HomeAssistant,
+    jobs_info: AsyncMock,
+) -> None:
+    """Test subscribe returns a working unsubscribe even if a job already matches."""
+    jobs_info.return_value = JobsInfo(
+        ignore_conditions=[],
+        jobs=[
+            Job(
+                name="test_job",
+                reference="test",
+                uuid=uuid4(),
+                progress=0,
+                stage=None,
+                done=False,
+                errors=[],
+                created=datetime.now(),
+                extra=None,
+                child_jobs=[],
+            )
+        ],
+    )
+
+    result = await async_setup_component(hass, DOMAIN, {})
+    assert result
+
+    data_coordinator: HassioMainDataUpdateCoordinator = hass.data[MAIN_COORDINATOR]
+
+    received: list[Job] = []
+
+    @callback
+    def mock_subcription_callback(job: Job) -> None:
+        received.append(job)
+
+    subscription = JobSubscription(mock_subcription_callback, name="test_job")
+    unsubscribe = data_coordinator.jobs.subscribe(subscription)
+
+    # Existing matching job is delivered immediately, and a callable unsubscribe
+    # is returned (not the None result of the callback)
+    assert len(received) == 1
+    assert received[0].name == "test_job"
+    assert callable(unsubscribe)
+
+    # Unsubscribe should remove the subscription without raising
+    unsubscribe()
+    assert subscription not in data_coordinator.jobs._subscriptions


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`SupervisorJobs.subscribe()` is supposed to register the subscription, deliver any jobs that already match at subscribe time, and return a callable used to unsubscribe.

The loop that delivers existing matches used `return subscription.event_callback(match)`. Since `event_callback` is a `@callback` returning `None`, this meant that whenever a matching job already existed, `subscribe()` returned `None` instead of the unsubscribe callable, and only the first matching job was ever delivered.

The `None` is then registered by entities via `async_on_remove(...)`. On the next platform reload, entity removal calls the registered on-remove callbacks and trips over the `None`, raising `TypeError: 'NoneType' object is not callable`. This surfaced for `update.home_assistant_core_update` whenever a matching update job was already present at subscribe time, and also led to a follow-up `Platform hassio does not generate unique IDs ... already exists` error, because the failed removal left the entity registered when the platform was set up again.

```
2026-06-16 17:00:34.949 ERROR (MainThread) [homeassistant.components.update] Error while removing entity update.home_assistant_core_update
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1460, in async_remove
    await self.__async_remove_impl(force_remove)
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1473, in __async_remove_impl
    self._call_on_remove_callbacks()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1423, in _call_on_remove_callbacks
    self._on_remove.pop()()
    ~~~~~~~~~~~~~~~~~~~~~^^
TypeError: 'NoneType' object is not callable

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 1066, in async_reset
    await entity.async_remove()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1465, in async_remove
    self.__remove_future.set_result(None)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
asyncio.exceptions.InvalidStateError: invalid state
...
2026-06-16 17:00:35.424 ERROR (MainThread) [homeassistant.components.update] Platform hassio does not generate unique IDs. ID home_assistant_core_version_latest already exists - ignoring update.home_assistant_core_update
```

The fix invokes the callback for every existing match and always returns the unsubscribe callable. A regression test is added.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
