### PR TITLE
Rename advanced settings/options in MQTT subentry translation strings

### DIFF
--- a/homeassistant/components/mqtt/config_flow.py
+++ b/homeassistant/components/mqtt/config_flow.py
@@ -1124,7 +1124,7 @@ def validate_light_platform_config(user_data: dict[str, Any]) -> dict[str, str]:
     if user_data.get(CONF_MIN_KELVIN, DEFAULT_MIN_KELVIN) >= user_data.get(
         CONF_MAX_KELVIN, DEFAULT_MAX_KELVIN
     ):
-        errors["advanced_settings"] = "max_below_min_kelvin"
+        errors["other_settings"] = "max_below_min_kelvin"
     return errors
 
 
@@ -1217,7 +1217,7 @@ def validate_text_platform_config(
         and CONF_MAX in config
         and config[CONF_MIN] > config[CONF_MAX]
     ):
-        errors["text_advanced_settings"] = "max_below_min"
+        errors["text_other_settings"] = "max_below_min"
 
     return errors
 
@@ -1506,7 +1506,7 @@ PLATFORM_ENTITY_FIELDS: dict[Platform, dict[str, PlatformField]] = {
             selector=SUGGESTED_DISPLAY_PRECISION_SELECTOR,
             required=False,
             validator=cv.positive_int,
-            section="advanced_settings",
+            section="other_settings",
         ),
         CONF_OPTIONS: PlatformField(
             selector=OPTIONS_SELECTOR,
@@ -1678,13 +1678,13 @@ PLATFORM_MQTT_FIELDS: dict[Platform, dict[str, PlatformField]] = {
             selector=TIMEOUT_SELECTOR,
             required=False,
             validator=cv.positive_int,
-            section="advanced_settings",
+            section="other_settings",
         ),
         CONF_OFF_DELAY: PlatformField(
             selector=TIMEOUT_SELECTOR,
             required=False,
             validator=cv.positive_int,
-            section="advanced_settings",
+            section="other_settings",
         ),
     },
     Platform.BUTTON: {
@@ -3125,7 +3125,7 @@ PLATFORM_MQTT_FIELDS: dict[Platform, dict[str, PlatformField]] = {
             default=False,
             validator=cv.boolean,
             conditions=({CONF_SCHEMA: "json"},),
-            section="advanced_settings",
+            section="other_settings",
         ),
         CONF_FLASH_TIME_SHORT: PlatformField(
             selector=FLASH_TIME_SELECTOR,
@@ -3133,7 +3133,7 @@ PLATFORM_MQTT_FIELDS: dict[Platform, dict[str, PlatformField]] = {
             validator=cv.positive_int,
             default=2,
             conditions=({CONF_SCHEMA: "json"},),
-            section="advanced_settings",
+            section="other_settings",
         ),
         CONF_FLASH_TIME_LONG: PlatformField(
             selector=FLASH_TIME_SELECTOR,
@@ -3141,7 +3141,7 @@ PLATFORM_MQTT_FIELDS: dict[Platform, dict[str, PlatformField]] = {
             validator=cv.positive_int,
             default=10,
             conditions=({CONF_SCHEMA: "json"},),
-            section="advanced_settings",
+            section="other_settings",
         ),
         CONF_TRANSITION: PlatformField(
             selector=BOOLEAN_SELECTOR,
@@ -3149,21 +3149,21 @@ PLATFORM_MQTT_FIELDS: dict[Platform, dict[str, PlatformField]] = {
             default=False,
             validator=cv.boolean,
             conditions=({CONF_SCHEMA: "json"},),
-            section="advanced_settings",
+            section="other_settings",
         ),
         CONF_MAX_KELVIN: PlatformField(
             selector=KELVIN_SELECTOR,
             required=False,
             validator=cv.positive_int,
             default=DEFAULT_MAX_KELVIN,
-            section="advanced_settings",
+            section="other_settings",
         ),
         CONF_MIN_KELVIN: PlatformField(
             selector=KELVIN_SELECTOR,
             required=False,
             validator=cv.positive_int,
             default=DEFAULT_MIN_KELVIN,
-            section="advanced_settings",
+            section="other_settings",
         ),
     },
     Platform.LOCK: {
@@ -3372,7 +3372,7 @@ PLATFORM_MQTT_FIELDS: dict[Platform, dict[str, PlatformField]] = {
             selector=TIMEOUT_SELECTOR,
             required=False,
             validator=cv.positive_int,
-            section="advanced_settings",
+            section="other_settings",
         ),
     },
     Platform.SIREN: {
@@ -3437,7 +3437,7 @@ PLATFORM_MQTT_FIELDS: dict[Platform, dict[str, PlatformField]] = {
             required=False,
             validator=validate(cv.template),
             error="invalid_template",
-            section="siren_advanced_settings",
+            section="siren_other_settings",
         ),
     },
     Platform.SWITCH: {
@@ -3516,26 +3516,26 @@ PLATFORM_MQTT_FIELDS: dict[Platform, dict[str, PlatformField]] = {
             selector=TEXT_SIZE_SELECTOR,
             required=True,
             default=0,
-            section="text_advanced_settings",
+            section="text_other_settings",
         ),
         CONF_MAX: PlatformField(
             selector=TEXT_SIZE_SELECTOR,
             required=True,
             default=255,
-            section="text_advanced_settings",
+            section="text_other_settings",
         ),
         CONF_MODE: PlatformField(
             selector=TEXT_MODE_SELECTOR,
             required=True,
             default=TextSelectorType.TEXT.value,
-            section="text_advanced_settings",
+            section="text_other_settings",
         ),
         CONF_PATTERN: PlatformField(
             selector=TEXT_SELECTOR,
             required=False,
             validator=validate(cv.is_regex),
             error="invalid_regular_expression",
-            section="text_advanced_settings",
+            section="text_other_settings",
         ),
     },
     Platform.TIME: {
@@ -3798,10 +3798,10 @@ PLATFORM_MQTT_FIELDS: dict[Platform, dict[str, PlatformField]] = {
 MQTT_DEVICE_PLATFORM_FIELDS = {
     CONF_NAME: PlatformField(selector=TEXT_SELECTOR, required=True),
     CONF_SW_VERSION: PlatformField(
-        selector=TEXT_SELECTOR, required=False, section="advanced_settings"
+        selector=TEXT_SELECTOR, required=False, section="other_settings"
     ),
     CONF_HW_VERSION: PlatformField(
-        selector=TEXT_SELECTOR, required=False, section="advanced_settings"
+        selector=TEXT_SELECTOR, required=False, section="other_settings"
     ),
     CONF_MODEL: PlatformField(selector=TEXT_SELECTOR, required=False),
     CONF_MODEL_ID: PlatformField(selector=TEXT_SELECTOR, required=False),
@@ -4686,8 +4686,8 @@ class MQTTSubentryFlowHandler(ConfigSubentryFlow):
         if user_input is not None:
             new_device_data: dict[str, Any] = user_input.copy()
             _, errors = validate_user_input(user_input, MQTT_DEVICE_PLATFORM_FIELDS)
-            if "advanced_settings" in new_device_data:
-                new_device_data |= new_device_data.pop("advanced_settings")
+            if "other_settings" in new_device_data:
+                new_device_data |= new_device_data.pop("other_settings")
             if not errors:
                 self._subentry_data[CONF_DEVICE] = cast(MqttDeviceData, new_device_data)
                 if self.source == SOURCE_RECONFIGURE:

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -193,7 +193,7 @@
                 "hw_version": "The hardware version of the device. E.g. 'v1.0 rev a'.",
                 "sw_version": "The software version of the device. E.g. '2025.1.0'."
               },
-              "name": "Advanced device settings"
+              "name": "Other device settings"
             },
             "mqtt_settings": {
               "data": {
@@ -293,7 +293,7 @@
               "data_description": {
                 "suggested_display_precision": "The number of decimals which should be used in the {platform} entity state after rounding. [Learn more.]({url}#suggested_display_precision)"
               },
-              "name": "Advanced options"
+              "name": "Other settings"
             }
           },
           "title": "Configure MQTT device \"{mqtt_device}\""
@@ -459,7 +459,7 @@
                 "off_delay": "For sensors that only send \"on\" state updates (like PIRs), this variable sets a delay in seconds after which the sensor’s state will be updated back to \"off\".",
                 "transition": "Enable the transition feature for this light"
               },
-              "name": "Advanced settings"
+              "name": "Other settings"
             },
             "alarm_control_panel_payload_settings": {
               "data": {
@@ -923,7 +923,7 @@
               "data_description": {
                 "command_off_template": "The [template]({command_templating_url}) for \"off\" state changes. By default the \"[Command template]({url}#command_template)\" will be used.  [Learn more.]({url}#command_off_template)"
               },
-              "name": "Advanced siren settings"
+              "name": "Other siren settings"
             },
             "target_humidity_settings": {
               "data": {
@@ -998,7 +998,7 @@
                 "mode": "Mode of the text input",
                 "pattern": "A valid regex pattern"
               },
-              "name": "Advanced text entity settings"
+              "name": "Other text entity settings"
             },
             "valve_payload_settings": {
               "data": {

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -184,17 +184,6 @@
           },
           "description": "Enter the MQTT device details:",
           "sections": {
-            "advanced_settings": {
-              "data": {
-                "hw_version": "Hardware version",
-                "sw_version": "Software version"
-              },
-              "data_description": {
-                "hw_version": "The hardware version of the device. E.g. 'v1.0 rev a'.",
-                "sw_version": "The software version of the device. E.g. '2025.1.0'."
-              },
-              "name": "Other device settings"
-            },
             "mqtt_settings": {
               "data": {
                 "message_expiry_interval": "Message Expiry Interval",
@@ -205,6 +194,17 @@
                 "qos": "The Quality of Service value the device's entities should use."
               },
               "name": "MQTT settings"
+            },
+            "other_settings": {
+              "data": {
+                "hw_version": "Hardware version",
+                "sw_version": "Software version"
+              },
+              "data_description": {
+                "hw_version": "The hardware version of the device. E.g. 'v1.0 rev a'.",
+                "sw_version": "The software version of the device. E.g. '2025.1.0'."
+              },
+              "name": "Other device settings"
             }
           },
           "title": "Configure MQTT device details"
@@ -286,7 +286,7 @@
           },
           "description": "Please configure specific details for {platform} entity \"{entity}\":",
           "sections": {
-            "advanced_settings": {
+            "other_settings": {
               "data": {
                 "suggested_display_precision": "Suggested display precision"
               },
@@ -438,29 +438,6 @@
           },
           "description": "Please configure MQTT specific details for {platform} entity \"{entity}\":",
           "sections": {
-            "advanced_settings": {
-              "data": {
-                "expire_after": "Expire after",
-                "flash": "Flash support",
-                "flash_time_long": "Flash time long",
-                "flash_time_short": "Flash time short",
-                "max_kelvin": "Max Kelvin",
-                "min_kelvin": "Min Kelvin",
-                "off_delay": "OFF delay",
-                "transition": "Transition support"
-              },
-              "data_description": {
-                "expire_after": "If set, it defines the number of seconds after the sensor’s state expires, if it’s not updated. After expiry, the sensor’s state becomes unavailable. If not set, the sensor's state never expires. [Learn more.]({url}#expire_after)",
-                "flash": "Enable the flash feature for this light",
-                "flash_time_long": "The duration, in seconds, of a \"long\" flash.",
-                "flash_time_short": "The duration, in seconds, of a \"short\" flash.",
-                "max_kelvin": "The maximum color temperature in Kelvin.",
-                "min_kelvin": "The minimum color temperature in Kelvin.",
-                "off_delay": "For sensors that only send \"on\" state updates (like PIRs), this variable sets a delay in seconds after which the sensor’s state will be updated back to \"off\".",
-                "transition": "Enable the transition feature for this light"
-              },
-              "name": "Other settings"
-            },
             "alarm_control_panel_payload_settings": {
               "data": {
                 "payload_arm_away": "Payload \"arm away\"",
@@ -916,7 +893,30 @@
               },
               "name": "Lock payload settings"
             },
-            "siren_advanced_settings": {
+            "other_settings": {
+              "data": {
+                "expire_after": "Expire after",
+                "flash": "Flash support",
+                "flash_time_long": "Flash time long",
+                "flash_time_short": "Flash time short",
+                "max_kelvin": "Max Kelvin",
+                "min_kelvin": "Min Kelvin",
+                "off_delay": "OFF delay",
+                "transition": "Transition support"
+              },
+              "data_description": {
+                "expire_after": "If set, it defines the number of seconds after the sensor’s state expires, if it’s not updated. After expiry, the sensor’s state becomes unavailable. If not set, the sensor's state never expires. [Learn more.]({url}#expire_after)",
+                "flash": "Enable the flash feature for this light",
+                "flash_time_long": "The duration, in seconds, of a \"long\" flash.",
+                "flash_time_short": "The duration, in seconds, of a \"short\" flash.",
+                "max_kelvin": "The maximum color temperature in Kelvin.",
+                "min_kelvin": "The minimum color temperature in Kelvin.",
+                "off_delay": "For sensors that only send \"on\" state updates (like PIRs), this variable sets a delay in seconds after which the sensor’s state will be updated back to \"off\".",
+                "transition": "Enable the transition feature for this light"
+              },
+              "name": "Other settings"
+            },
+            "siren_other_settings": {
               "data": {
                 "command_off_template": "Command \"off\" template"
               },
@@ -985,7 +985,7 @@
               },
               "name": "Target temperature settings"
             },
-            "text_advanced_settings": {
+            "text_other_settings": {
               "data": {
                 "max": "Maximum length",
                 "min": "Minimum length",

--- a/tests/components/mqtt/test_config_flow.py
+++ b/tests/components/mqtt/test_config_flow.py
@@ -2754,7 +2754,7 @@ async def test_migrate_config_entry(
             {
                 "state_topic": "test-topic",
                 "value_template": "{{ value_json.value }}",
-                "advanced_settings": {"expire_after": 1200, "off_delay": 5},
+                "other_settings": {"expire_after": 1200, "off_delay": 5},
             },
             (
                 (
@@ -3418,10 +3418,10 @@ async def test_migrate_config_entry(
                 (
                     {
                         "command_topic": "test-topic",
-                        "advanced_settings": {"max_kelvin": 2000, "min_kelvin": 2000},
+                        "other_settings": {"max_kelvin": 2000, "min_kelvin": 2000},
                     },
                     {
-                        "advanced_settings": "max_below_min_kelvin",
+                        "other_settings": "max_below_min_kelvin",
                     },
                 ),
             ),
@@ -3700,7 +3700,7 @@ async def test_migrate_config_entry(
             {
                 "state_topic": "test-topic",
                 "value_template": "{{ value_json.value }}",
-                "advanced_settings": {"expire_after": 30},
+                "other_settings": {"expire_after": 30},
             },
             (
                 (
@@ -3766,7 +3766,7 @@ async def test_migrate_config_entry(
                 "available_tones": ["Happy hour", "Cooling alarm"],
                 "support_duration": True,
                 "support_volume_set": True,
-                "siren_advanced_settings": {
+                "siren_other_settings": {
                     "command_off_template": "{{ value }}",
                 },
             },
@@ -3827,7 +3827,7 @@ async def test_migrate_config_entry(
                 "state_topic": "test-topic",
                 "value_template": "{{ value_json.value }}",
                 "retain": False,
-                "text_advanced_settings": {
+                "text_other_settings": {
                     "min": 0,
                     "max": 10,
                     "mode": "password",
@@ -3849,26 +3849,26 @@ async def test_migrate_config_entry(
                 (
                     {
                         "command_topic": "test-topic",
-                        "text_advanced_settings": {
+                        "text_other_settings": {
                             "min": 20,
                             "max": 10,
                             "mode": "password",
                             "pattern": "^[a-z_]*$",
                         },
                     },
-                    {"text_advanced_settings": "max_below_min"},
+                    {"text_other_settings": "max_below_min"},
                 ),
                 (
                     {
                         "command_topic": "test-topic",
-                        "text_advanced_settings": {
+                        "text_other_settings": {
                             "min": 0,
                             "max": 10,
                             "mode": "password",
                             "pattern": "(",
                         },
                     },
-                    {"text_advanced_settings": "invalid_regular_expression"},
+                    {"text_other_settings": "invalid_regular_expression"},
                 ),
             ),
             "Milk notifier MOTD",
@@ -4761,7 +4761,7 @@ async def test_subentry_reconfigure_edit_entity_multi_entitites(
                 "device_class": "battery",
                 "state_class": "measurement",
                 "unit_of_measurement": "%",
-                "advanced_settings": {"suggested_display_precision": 1},
+                "other_settings": {"suggested_display_precision": 1},
             },
             {
                 "state_topic": "test-topic1-updated",
@@ -5225,21 +5225,21 @@ async def test_subentry_reconfigure_update_device_properties(
         "model_id": {"suggested_value": "mn002"},
         "manufacturer": {"suggested_value": "Milk Masters"},
         "configuration_url": {"suggested_value": "https://example.com"},
-        "advanced_settings": None,
+        "other_settings": None,
         "mqtt_settings": None,
     }
 
-    advanced_settings_key_descriptions = {
+    other_settings_key_descriptions = {
         key: key.description
         for key, value in result["data_schema"]
-        .schema["advanced_settings"]
+        .schema["other_settings"]
         .schema.schema.items()
     }
-    assert advanced_settings_key_descriptions == {
+    assert other_settings_key_descriptions == {
         "sw_version": {"suggested_value": "1.0"},
         "hw_version": {"suggested_value": "2.1 rev a"},
     }
-    assert result["data_schema"].schema["advanced_settings"].options == {
+    assert result["data_schema"].schema["other_settings"].options == {
         "collapsed": False
     }
 
@@ -5264,7 +5264,7 @@ async def test_subentry_reconfigure_update_device_properties(
         result["flow_id"],
         user_input={
             "name": "Beer notifier",
-            "advanced_settings": {"sw_version": "1.1"},
+            "other_settings": {"sw_version": "1.1"},
             "model": "Beer bottle XL",
             "model_id": "bn003",
             "manufacturer": "Beer Masters",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Renames the term "advanced" to "other" for MQTT subentry translation strings.
The keys are nor renamed to avoid the loss of translations.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #174029
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
