### PR TITLE
Don't use infrared entity id as unique id for LG Infrared

### DIFF
--- a/homeassistant/components/lg_infrared/__init__.py
+++ b/homeassistant/components/lg_infrared/__init__.py
@@ -1,10 +1,14 @@
 """LG IR Remote integration for Home Assistant."""
 
+import logging
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
 PLATFORMS = [Platform.BUTTON, Platform.EVENT, Platform.MEDIA_PLAYER]
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -16,3 +20,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a LG IR config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate old config entry."""
+    if entry.version == 1:
+        # v1 used the infrared entity_id in the entry's unique_id, which is
+        # not stable and was removed in v2.
+        _LOGGER.debug("Migrating config entry from version 1 to 2")
+        hass.config_entries.async_update_entry(entry, unique_id=None, version=2)
+
+    return True

--- a/homeassistant/components/lg_infrared/config_flow.py
+++ b/homeassistant/components/lg_infrared/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for LG IR integration."""
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
 
@@ -35,7 +35,7 @@ DEVICE_TYPE_NAMES: dict[LGDeviceType, str] = {
 class LgIrConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle config flow for LG IR."""
 
-    VERSION = 1
+    VERSION = 2
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -49,24 +49,39 @@ class LgIrConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            if entity_id := user_input.get(CONF_INFRARED_ENTITY_ID) or user_input.get(
-                CONF_INFRARED_RECEIVER_ENTITY_ID
-            ):
+            emitter_id = user_input.get(CONF_INFRARED_ENTITY_ID)
+            receiver_id = user_input.get(CONF_INFRARED_RECEIVER_ENTITY_ID)
+            if emitter_id or receiver_id:
                 device_type = user_input[CONF_DEVICE_TYPE]
 
-                await self.async_set_unique_id(f"lg_ir_{device_type}_{entity_id}")
-                self._abort_if_unique_id_configured()
+                if emitter_id:
+                    self._async_abort_entries_match(
+                        {
+                            CONF_DEVICE_TYPE: device_type,
+                            CONF_INFRARED_ENTITY_ID: emitter_id,
+                        }
+                    )
+                if receiver_id:
+                    self._async_abort_entries_match(
+                        {
+                            CONF_DEVICE_TYPE: device_type,
+                            CONF_INFRARED_RECEIVER_ENTITY_ID: receiver_id,
+                        }
+                    )
 
                 # Get entity name for the title
+                title_entity_id = emitter_id or receiver_id
+                if TYPE_CHECKING:
+                    assert title_entity_id is not None
                 ent_reg = er.async_get(self.hass)
-                entry = ent_reg.async_get(entity_id)
-                entity_name = (
-                    entry.name or entry.original_name or entity_id
+                entry = ent_reg.async_get(title_entity_id)
+                title_entity_name = (
+                    entry.name or entry.original_name or title_entity_id
                     if entry
-                    else entity_id
+                    else title_entity_id
                 )
                 device_type_name = DEVICE_TYPE_NAMES[LGDeviceType(device_type)]
-                title = f"LG {device_type_name} via {entity_name}"
+                title = f"LG {device_type_name} via {title_entity_name}"
 
                 return self.async_create_entry(title=title, data=user_input)
 

--- a/tests/components/lg_infrared/conftest.py
+++ b/tests/components/lg_infrared/conftest.py
@@ -39,7 +39,6 @@ def mock_config_entry() -> MockConfigEntry:
             CONF_INFRARED_ENTITY_ID: MOCK_INFRARED_EMITTER_ENTITY_ID,
             CONF_INFRARED_RECEIVER_ENTITY_ID: MOCK_INFRARED_RECEIVER_ENTITY_ID,
         },
-        unique_id=f"lg_ir_tv_{MOCK_INFRARED_EMITTER_ENTITY_ID}",
     )
 
 

--- a/tests/components/lg_infrared/test_config_flow.py
+++ b/tests/components/lg_infrared/test_config_flow.py
@@ -22,12 +22,11 @@ from tests.components.infrared import (
 
 
 @pytest.mark.parametrize(
-    ("config", "expected_title", "unique_id_entity_id"),
+    ("config", "expected_title"),
     [
         (
             {CONF_INFRARED_ENTITY_ID: mock_infrared_emitter_entity_id},
             "LG TV via Test IR emitter",
-            mock_infrared_emitter_entity_id,
         ),
         (
             {
@@ -35,12 +34,10 @@ from tests.components.infrared import (
                 CONF_INFRARED_RECEIVER_ENTITY_ID: mock_infrared_receiver_entity_id,
             },
             "LG TV via Test IR emitter",
-            mock_infrared_emitter_entity_id,
         ),
         (
             {CONF_INFRARED_RECEIVER_ENTITY_ID: mock_infrared_receiver_entity_id},
             "LG TV via Test IR receiver",
-            mock_infrared_receiver_entity_id,
         ),
     ],
 )
@@ -51,7 +48,6 @@ async def test_user_flow_success(
     hass: HomeAssistant,
     config: dict[str, str],
     expected_title: str,
-    unique_id_entity_id: str,
 ) -> None:
     """Test successful user config flow."""
     result = await hass.config_entries.flow.async_init(
@@ -69,7 +65,7 @@ async def test_user_flow_success(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == expected_title
     assert result["data"] == {CONF_DEVICE_TYPE: LGDeviceType.TV, **config}
-    assert result["result"].unique_id == f"lg_ir_tv_{unique_id_entity_id}"
+    assert result["result"].unique_id is None
 
 
 @pytest.mark.usefixtures("mock_infrared_emitter_entity")
@@ -90,9 +86,33 @@ async def test_user_flow_requires_emitter_or_receiver(
     assert result["errors"] == {"base": "missing_infrared_entity"}
 
 
-@pytest.mark.usefixtures("mock_infrared_emitter_entity")
+@pytest.mark.usefixtures(
+    "mock_infrared_emitter_entity", "mock_infrared_receiver_entity"
+)
+@pytest.mark.parametrize(
+    "user_input",
+    [
+        pytest.param(
+            {CONF_INFRARED_ENTITY_ID: mock_infrared_emitter_entity_id},
+            id="emitter_conflict",
+        ),
+        pytest.param(
+            {CONF_INFRARED_RECEIVER_ENTITY_ID: mock_infrared_receiver_entity_id},
+            id="receiver_conflict",
+        ),
+        pytest.param(
+            {
+                CONF_INFRARED_ENTITY_ID: mock_infrared_emitter_entity_id,
+                CONF_INFRARED_RECEIVER_ENTITY_ID: mock_infrared_receiver_entity_id,
+            },
+            id="both_conflict",
+        ),
+    ],
+)
 async def test_user_flow_already_configured(
-    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    user_input: dict[str, str],
 ) -> None:
     """Test user flow aborts when entry is already configured."""
     mock_config_entry.add_to_hass(hass)
@@ -105,10 +125,7 @@ async def test_user_flow_already_configured(
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        user_input={
-            CONF_DEVICE_TYPE: LGDeviceType.TV,
-            CONF_INFRARED_ENTITY_ID: mock_infrared_emitter_entity_id,
-        },
+        user_input={CONF_DEVICE_TYPE: LGDeviceType.TV, **user_input},
     )
 
     assert result["type"] is FlowResultType.ABORT
@@ -155,6 +172,5 @@ async def test_user_flow_title_from_entity_name(
             CONF_INFRARED_ENTITY_ID: mock_infrared_emitter_entity_id,
         },
     )
-
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == expected_title

--- a/tests/components/lg_infrared/test_init.py
+++ b/tests/components/lg_infrared/test_init.py
@@ -1,9 +1,24 @@
 """Tests for the LG Infrared integration setup."""
 
+from homeassistant.components.lg_infrared.const import (
+    CONF_DEVICE_TYPE,
+    CONF_INFRARED_ENTITY_ID,
+    CONF_INFRARED_RECEIVER_ENTITY_ID,
+    DOMAIN,
+    LGDeviceType,
+)
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
+from tests.components.infrared import (
+    EMITTER_ENTITY_ID as MOCK_INFRARED_EMITTER_ENTITY_ID,
+    RECEIVER_ENTITY_ID as MOCK_INFRARED_RECEIVER_ENTITY_ID,
+)
+from tests.components.infrared.common import (
+    MockInfraredEmitterEntity,
+    MockInfraredReceiverEntity,
+)
 
 
 async def test_setup_and_unload_entry(
@@ -17,3 +32,30 @@ async def test_setup_and_unload_entry(
     await hass.async_block_till_done()
 
     assert entry.state is ConfigEntryState.NOT_LOADED
+
+
+async def test_migrate_v1_to_v2(
+    hass: HomeAssistant,
+    mock_infrared_emitter_entity: MockInfraredEmitterEntity,
+    mock_infrared_receiver_entity: MockInfraredReceiverEntity,
+    mock_lg_tv_code_to_command: None,
+) -> None:
+    """Test migration from v1 (legacy unique_id) to v2 (no unique_id)."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=1,
+        unique_id=f"lg_ir_tv_{MOCK_INFRARED_EMITTER_ENTITY_ID}",
+        data={
+            CONF_DEVICE_TYPE: LGDeviceType.TV,
+            CONF_INFRARED_ENTITY_ID: MOCK_INFRARED_EMITTER_ENTITY_ID,
+            CONF_INFRARED_RECEIVER_ENTITY_ID: MOCK_INFRARED_RECEIVER_ENTITY_ID,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert entry.version == 2
+    assert entry.unique_id is None


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As pointed out by @tr4nt0r , using the infrared entity id makes it impossible to implement a reconfig flow that allows choosing a different infrared entity.
This uses the entity to check for an existing config entry, but does not use it for the unique id.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
