### PR TITLE
Retry webdav setup on connection errors

### DIFF
--- a/homeassistant/components/webdav/__init__.py
+++ b/homeassistant/components/webdav/__init__.py
@@ -3,7 +3,11 @@
 import logging
 
 from aiowebdav2.client import Client
-from aiowebdav2.exceptions import UnauthorizedError
+from aiowebdav2.exceptions import (
+    ConnectionExceptionError,
+    NoConnectionError,
+    UnauthorizedError,
+)
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_URL, CONF_USERNAME, CONF_VERIFY_SSL
@@ -34,6 +38,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: WebDavConfigEntry) -> bo
         raise ConfigEntryError(
             translation_domain=DOMAIN,
             translation_key="invalid_username_password",
+        ) from err
+    except (ConnectionExceptionError, NoConnectionError, TimeoutError) as err:
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN,
+            translation_key="cannot_connect",
         ) from err
 
     # Check if we can connect to the WebDAV server

--- a/tests/components/webdav/test_init.py
+++ b/tests/components/webdav/test_init.py
@@ -2,7 +2,12 @@
 
 from unittest.mock import AsyncMock
 
-from aiowebdav2.exceptions import AccessDeniedError, UnauthorizedError
+from aiowebdav2.exceptions import (
+    AccessDeniedError,
+    ConnectionExceptionError,
+    NoConnectionError,
+    UnauthorizedError,
+)
 import pytest
 
 from homeassistant.components.webdav.const import CONF_BACKUP_PATH, DOMAIN
@@ -28,8 +33,29 @@ from tests.common import MockConfigEntry
             "Access denied to /access_denied",
             ConfigEntryState.SETUP_ERROR,
         ),
+        (
+            ConnectionExceptionError(ConnectionError("Connection refused")),
+            "Connection refused",
+            ConfigEntryState.SETUP_RETRY,
+        ),
+        (
+            NoConnectionError("webdav.demo"),
+            "No connection with webdav.demo",
+            ConfigEntryState.SETUP_RETRY,
+        ),
+        (
+            TimeoutError(),
+            "",
+            ConfigEntryState.SETUP_RETRY,
+        ),
     ],
-    ids=["UnauthorizedError", "AccessDeniedError"],
+    ids=[
+        "UnauthorizedError",
+        "AccessDeniedError",
+        "ConnectionExceptionError",
+        "NoConnectionError",
+        "TimeoutError",
+    ],
 )
 async def test_error_during_setup(
     hass: HomeAssistant,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When the WebDAV server is unreachable during setup (network timeout, DNS failure, server down), `ConnectionExceptionError`, `NoConnectionError`, or `TimeoutError` propagates uncaught from `client.check()`. This causes the config entry to fail with an unhandled error, and Home Assistant does not schedule automatic retries for unhandled exceptions.

This catches those connection-related errors and raises `ConfigEntryNotReady` instead, so Home Assistant automatically retries setup when the server becomes available again. This follows the standard pattern used across many other integrations.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/173068
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr