### PR TITLE
Filter out closed sites in Amber Electric config flow

### DIFF
--- a/homeassistant/components/amberelectric/config_flow.py
+++ b/homeassistant/components/amberelectric/config_flow.py
@@ -34,11 +34,13 @@ def generate_site_selector_name(site: Site) -> str:
 
 
 def filter_sites(sites: list[Site]) -> list[Site]:
-    """Deduplicates the list of sites."""
+    """Filter out closed sites and deduplicate the list of sites."""
     filtered: list[Site] = []
     filtered_nmi: set[str] = set()
 
     for site in sorted(sites, key=lambda site: site.status):
+        if site.status == SiteStatus.CLOSED:
+            continue
         if site.status == SiteStatus.ACTIVE or site.nmi not in filtered_nmi:
             filtered.append(site)
             filtered_nmi.add(site.nmi)

--- a/tests/components/amberelectric/test_config_flow.py
+++ b/tests/components/amberelectric/test_config_flow.py
@@ -216,34 +216,15 @@ async def test_single_site(hass: HomeAssistant, single_site_api: Mock) -> None:
 async def test_single_closed_site_no_closed_date(
     hass: HomeAssistant, single_site_closed_no_close_date_api: Mock
 ) -> None:
-    """Test single closed site with no closed date."""
-    initial_result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
-    assert initial_result.get("type") is FlowResultType.FORM
-    assert initial_result.get("step_id") == "user"
-
-    # Test filling in API key
+    """Test single closed site with no closed date is filtered out."""
     enter_api_key_result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_USER},
         data={CONF_API_TOKEN: API_KEY},
     )
     assert enter_api_key_result.get("type") is FlowResultType.FORM
-    assert enter_api_key_result.get("step_id") == "site"
-
-    select_site_result = await hass.config_entries.flow.async_configure(
-        enter_api_key_result["flow_id"],
-        {CONF_SITE_ID: "01FG0AGP818PXK0DWHXJRRT2DH", CONF_SITE_NAME: "Home"},
-    )
-
-    # Show available sites
-    assert select_site_result.get("type") is FlowResultType.CREATE_ENTRY
-    assert select_site_result.get("title") == "Home"
-    data = select_site_result.get("data")
-    assert data
-    assert data[CONF_API_TOKEN] == API_KEY
-    assert data[CONF_SITE_ID] == "01FG0AGP818PXK0DWHXJRRT2DH"
+    assert enter_api_key_result.get("step_id") == "user"
+    assert enter_api_key_result.get("errors") == {"api_token": "no_site"}
 
 
 async def test_single_site_rejoin(
@@ -333,13 +314,9 @@ async def test_unknown_error(hass: HomeAssistant, api_error: Mock) -> None:
     assert result.get("errors") == {"api_token": "unknown_error"}
 
 
-async def test_site_deduplication(single_site_rejoin_api: Mock) -> None:
-    """Test site deduplication."""
+async def test_site_filtering(single_site_rejoin_api: Mock) -> None:
+    """Test that closed sites are filtered out and remaining sites are deduplicated."""
     filtered = filter_sites(single_site_rejoin_api.get_sites())
-    assert len(filtered) == 2
-    assert (
-        next(s for s in filtered if s.nmi == "11111111111").status == SiteStatus.ACTIVE
-    )
-    assert (
-        next(s for s in filtered if s.nmi == "11111111112").status == SiteStatus.CLOSED
-    )
+    assert len(filtered) == 1
+    assert filtered[0].nmi == "11111111111"
+    assert filtered[0].status == SiteStatus.ACTIVE


### PR DESCRIPTION
## Proposed change

The `filter_sites()` function in the Amber Electric config flow was not properly excluding closed sites. Closed sites were still included in the filtered list due to the deduplication logic allowing them through when they had a unique NMI. This meant users could see and select closed sites during configuration.

This change adds an explicit check to skip closed sites entirely before the deduplication logic runs.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/173961
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr