### PR TITLE
Add Tuya support for GIEX watering timer

### DIFF
--- a/homeassistant/components/tuya/const.py
+++ b/homeassistant/components/tuya/const.py
@@ -852,6 +852,7 @@ class DPCode(StrEnum):
     SITUATION_SET = "situation_set"
     SLEEP = "sleep"  # Sleep function
     SLOW_FEED = "slow_feed"
+    SMART_WEATHER = "smart_weather"
     SMOKE_SENSOR_STATE = "smoke_sensor_state"
     SMOKE_SENSOR_STATUS = "smoke_sensor_status"
     SMOKE_SENSOR_VALUE = "smoke_sensor_value"

--- a/homeassistant/components/tuya/sensor.py
+++ b/homeassistant/components/tuya/sensor.py
@@ -511,7 +511,13 @@ SENSORS: dict[DeviceCategory, tuple[TuyaSensorEntityDescription, ...]] = {
             state_class=SensorStateClass.MEASUREMENT,
         ),
     ),
-    DeviceCategory.GGQ: BATTERY_SENSORS,
+    DeviceCategory.GGQ: (
+        *BATTERY_SENSORS,
+        TuyaSensorEntityDescription(
+            key=DPCode.SMART_WEATHER,
+            translation_key="weather",
+        ),
+    ),
     DeviceCategory.HJJCY: (
         TuyaSensorEntityDescription(
             key=DPCode.AIR_QUALITY_INDEX,

--- a/homeassistant/components/tuya/strings.json
+++ b/homeassistant/components/tuya/strings.json
@@ -991,6 +991,15 @@
       "water_time": {
         "name": "Water usage duration"
       },
+      "weather": {
+        "name": "Weather",
+        "state": {
+          "cloudy": "Cloudy",
+          "rainy": "Rainy",
+          "snowy": "Snowy",
+          "sunny": "Sunny"
+        }
+      },
       "wind_chill_index_temperature": {
         "name": "Wind chill index"
       },

--- a/homeassistant/components/tuya/switch.py
+++ b/homeassistant/components/tuya/switch.py
@@ -263,6 +263,11 @@ SWITCHES: dict[DeviceCategory, tuple[SwitchEntityDescription, ...]] = {
     ),
     DeviceCategory.GGQ: (
         SwitchEntityDescription(
+            key=DPCode.SWITCH,
+            translation_key="switch",
+            entity_category=EntityCategory.CONFIG,
+        ),
+        SwitchEntityDescription(
             key=DPCode.SWITCH_1,
             translation_key="indexed_switch",
             translation_placeholders={"index": "1"},

--- a/homeassistant/components/tuya/valve.py
+++ b/homeassistant/components/tuya/valve.py
@@ -21,6 +21,13 @@ from .coordinator import TuyaConfigEntry
 from .entity import TuyaEntity
 
 VALVES: dict[DeviceCategory, tuple[ValveEntityDescription, ...]] = {
+    DeviceCategory.GGQ: (
+        ValveEntityDescription(
+            key=DPCode.START,
+            translation_key="valve",
+            device_class=ValveDeviceClass.WATER,
+        ),
+    ),
     DeviceCategory.SFKZQ: (
         ValveEntityDescription(
             key=DPCode.SWITCH,

--- a/tests/components/tuya/snapshots/test_init.ambr
+++ b/tests/components/tuya/snapshots/test_init.ambr
@@ -8297,7 +8297,7 @@
     'labels': set({
     }),
     'manufacturer': 'Tuya',
-    'model': 'GIEX Watering Timer (unsupported)',
+    'model': 'GIEX Watering Timer',
     'model_id': '7ytb3h8u',
     'name': 'GIEX Watering Timer',
     'name_by_user': None,

--- a/tests/components/tuya/snapshots/test_sensor.ambr
+++ b/tests/components/tuya/snapshots/test_sensor.ambr
@@ -9144,6 +9144,70 @@
     'state': '0.0',
   })
 # ---
+# name: test_platform_setup_and_discovery[sensor.giex_watering_timer_weather-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'sunny',
+        'cloudy',
+        'rainy',
+        'snowy',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.giex_watering_timer_weather',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Weather',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Weather',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'weather',
+    'unique_id': 'tuya.u8h3bty7qggsmart_weather',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.giex_watering_timer_weather-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'GIEX Watering Timer Weather',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'sunny',
+        'cloudy',
+        'rainy',
+        'snowy',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.giex_watering_timer_weather',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'sunny',
+  })
+# ---
 # name: test_platform_setup_and_discovery[sensor.greenhouse_battery_state-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/tuya/snapshots/test_switch.ambr
+++ b/tests/components/tuya/snapshots/test_switch.ambr
@@ -5041,6 +5041,56 @@
     'state': 'on',
   })
 # ---
+# name: test_platform_setup_and_discovery[switch.giex_watering_timer_switch-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.giex_watering_timer_switch',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Switch',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Switch',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'switch',
+    'unique_id': 'tuya.u8h3bty7qggswitch',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[switch.giex_watering_timer_switch-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'GIEX Watering Timer Switch',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.giex_watering_timer_switch',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_platform_setup_and_discovery[switch.ha_socket_delta_test_child_lock-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/tuya/snapshots/test_valve.ambr
+++ b/tests/components/tuya/snapshots/test_valve.ambr
@@ -105,6 +105,59 @@
     'state': 'closed',
   })
 # ---
+# name: test_platform_setup_and_discovery[valve.giex_watering_timer_valve-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'valve',
+    'entity_category': None,
+    'entity_id': 'valve.giex_watering_timer_valve',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Valve',
+    'options': dict({
+    }),
+    'original_device_class': <ValveDeviceClass.WATER: 'water'>,
+    'original_icon': None,
+    'original_name': 'Valve',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ValveEntityFeature: 3>,
+    'translation_key': 'valve',
+    'unique_id': 'tuya.u8h3bty7qggstart',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[valve.giex_watering_timer_valve-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'water',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'GIEX Watering Timer Valve',
+      <ValveEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
+      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <ValveEntityFeature: 3>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'valve.giex_watering_timer_valve',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'closed',
+  })
+# ---
 # name: test_platform_setup_and_discovery[valve.jie_hashui_fa_valve_1-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([


### PR DESCRIPTION
## Proposed change
Add Tuya support for GIEX Watering Timer devices in category `ggq` that expose the generic datapoints used by product `7ytb3h8u`.

This maps:
- `start` to a water valve entity for manual watering
- `switch` to a config switch for the timer enable control
- `smart_weather` to a read-only enum weather sensor

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration or service within an existing integration
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
Validated locally on Home Assistant 2026.6.3 using a custom Tuya override with a real GIEX Watering Timer diagnostic. Home Assistant created the expected entities:
- `sensor.giex_watering_timer_weather`
- `switch.giex_watering_timer_switch`
- `valve.giex_watering_timer_valve`

## Checklist
- [x] The code change is tested and works locally.
- [ ] Local tests pass. Your PR cannot be merged unless tests pass.
- [x] There is no commented out code in this PR.

## Tests
- `python3 -m py_compile homeassistant/components/tuya/const.py homeassistant/components/tuya/valve.py homeassistant/components/tuya/switch.py homeassistant/components/tuya/sensor.py tests/components/tuya/__init__.py tests/components/tuya/test_valve.py tests/components/tuya/test_switch.py tests/components/tuya/test_sensor.py`
- `python3 -m json.tool homeassistant/components/tuya/strings.json`

Pytest was not run in this local checkout because the Home Assistant test dependencies are not installed in the environment.