### PR TITLE
Migrate sky_hub to ScannerEntity

### DIFF
--- a/homeassistant/components/sky_hub/__init__.py
+++ b/homeassistant/components/sky_hub/__init__.py
@@ -1,1 +1,22 @@
 """The Sky Hub integration."""
+
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+from .coordinator import SkyHubConfigEntry, SkyHubDataUpdateCoordinator
+
+PLATFORMS = [Platform.DEVICE_TRACKER]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: SkyHubConfigEntry) -> bool:
+    """Set up Sky Hub from a config entry."""
+    coordinator = SkyHubDataUpdateCoordinator(hass, entry)
+    await coordinator.async_config_entry_first_refresh()
+    entry.runtime_data = coordinator
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: SkyHubConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/sky_hub/config_flow.py
+++ b/homeassistant/components/sky_hub/config_flow.py
@@ -1,0 +1,55 @@
+"""Config flow for the Sky Hub integration."""
+
+from typing import Any
+
+import aiohttp
+from pyskyqhub.skyq_hub import SkyQHub
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_HOST
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .const import DEFAULT_HOST, DOMAIN
+
+STEP_USER_DATA_SCHEMA = vol.Schema({vol.Required(CONF_HOST, default=DEFAULT_HOST): str})
+
+
+class SkyHubConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Sky Hub."""
+
+    VERSION = 1
+
+    async def _async_can_connect(self, host: str) -> bool:
+        """Return True if the Sky Hub at host returns data."""
+        hub = SkyQHub(async_get_clientsession(self.hass), host)
+        try:
+            return await hub.async_get_skyhub_data() is not None
+        except aiohttp.ClientError, TimeoutError:
+            return False
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            self._async_abort_entries_match({CONF_HOST: user_input[CONF_HOST]})
+            if await self._async_can_connect(user_input[CONF_HOST]):
+                return self.async_create_entry(
+                    title=user_input[CONF_HOST], data=user_input
+                )
+            errors["base"] = "cannot_connect"
+
+        return self.async_show_form(
+            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+        )
+
+    async def async_step_import(self, import_data: dict[str, Any]) -> ConfigFlowResult:
+        """Import existing configuration from configuration.yaml."""
+        self._async_abort_entries_match({CONF_HOST: import_data[CONF_HOST]})
+        if await self._async_can_connect(import_data[CONF_HOST]):
+            return self.async_create_entry(
+                title=import_data[CONF_HOST], data=import_data
+            )
+        return self.async_abort(reason="cannot_connect")

--- a/homeassistant/components/sky_hub/config_flow.py
+++ b/homeassistant/components/sky_hub/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for the Sky Hub integration."""
 
-from typing import Any
+from typing import Any, override
 
 import aiohttp
 from pyskyqhub.skyq_hub import SkyQHub
@@ -28,6 +28,7 @@ class SkyHubConfigFlow(ConfigFlow, domain=DOMAIN):
         except aiohttp.ClientError, TimeoutError:
             return False
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/sky_hub/const.py
+++ b/homeassistant/components/sky_hub/const.py
@@ -1,0 +1,5 @@
+"""Constants for the Sky Hub integration."""
+
+DOMAIN = "sky_hub"
+
+DEFAULT_HOST = "192.168.1.254"

--- a/homeassistant/components/sky_hub/coordinator.py
+++ b/homeassistant/components/sky_hub/coordinator.py
@@ -1,0 +1,51 @@
+"""DataUpdateCoordinator for the Sky Hub integration."""
+
+from datetime import timedelta
+import logging
+
+import aiohttp
+from pyskyqhub.skyq_hub import SkyQHub
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+UPDATE_INTERVAL = timedelta(seconds=30)
+
+type SkyHubConfigEntry = ConfigEntry[SkyHubDataUpdateCoordinator]
+
+
+class SkyHubDataUpdateCoordinator(DataUpdateCoordinator[dict[str, str]]):
+    """Class to manage fetching data from the Sky Hub."""
+
+    config_entry: SkyHubConfigEntry
+
+    def __init__(self, hass: HomeAssistant, config_entry: SkyHubConfigEntry) -> None:
+        """Initialize the coordinator using the config entry."""
+        self.host = config_entry.data[CONF_HOST]
+        self.hub = SkyQHub(async_get_clientsession(hass), self.host)
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=config_entry,
+            name=f"{DOMAIN} - {self.host}",
+            update_interval=UPDATE_INTERVAL,
+        )
+
+    async def _async_update_data(self) -> dict[str, str]:
+        """Fetch the connected devices from the Sky Hub, keyed by MAC address."""
+        try:
+            data = await self.hub.async_get_skyhub_data()
+        except (aiohttp.ClientError, TimeoutError) as err:
+            raise UpdateFailed(
+                f"Failed to fetch data from Sky Hub {self.host}"
+            ) from err
+        if data is None:
+            raise UpdateFailed(f"Failed to fetch data from Sky Hub {self.host}")
+        return {device.mac: device.name for device in data}

--- a/homeassistant/components/sky_hub/coordinator.py
+++ b/homeassistant/components/sky_hub/coordinator.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import logging
+from typing import override
 
 import aiohttp
 from pyskyqhub.skyq_hub import SkyQHub
@@ -38,6 +39,7 @@ class SkyHubDataUpdateCoordinator(DataUpdateCoordinator[dict[str, str]]):
             update_interval=UPDATE_INTERVAL,
         )
 
+    @override
     async def _async_update_data(self) -> dict[str, str]:
         """Fetch the connected devices from the Sky Hub, keyed by MAC address."""
         try:

--- a/homeassistant/components/sky_hub/device_tracker.py
+++ b/homeassistant/components/sky_hub/device_tracker.py
@@ -49,6 +49,8 @@ async def async_setup_scanner(
         )
         return False
 
+    # A previous failed import may have raised this issue; clear it on success.
+    ir.async_delete_issue(hass, DOMAIN, "yaml_import_cannot_connect")
     ir.async_create_issue(
         hass,
         HOMEASSISTANT_DOMAIN,

--- a/homeassistant/components/sky_hub/device_tracker.py
+++ b/homeassistant/components/sky_hub/device_tracker.py
@@ -1,5 +1,7 @@
 """Support for Sky Hub device tracking using a coordinator."""
 
+from typing import override
+
 import voluptuous as vol
 
 from homeassistant.components.device_tracker import (
@@ -103,16 +105,19 @@ class SkyHubScannerEntity(
         self._attr_name = coordinator.data.get(mac) or mac
 
     @property
+    @override
     def is_connected(self) -> bool:
         """Return true if the device is connected to the Sky Hub."""
         return self._mac in self.coordinator.data
 
     @property
+    @override
     def mac_address(self) -> str:
         """Return the MAC address of the device."""
         return self._mac
 
     @property
+    @override
     def hostname(self) -> str | None:
         """Return the hostname of the device."""
         return self.coordinator.data.get(self._mac)

--- a/homeassistant/components/sky_hub/device_tracker.py
+++ b/homeassistant/components/sky_hub/device_tracker.py
@@ -1,83 +1,116 @@
-"""Support for Sky Hub."""
+"""Support for Sky Hub device tracking using a coordinator."""
 
-import logging
-from typing import override
-
-from pyskyqhub.skyq_hub import SkyQHub
 import voluptuous as vol
 
 from homeassistant.components.device_tracker import (
-    DOMAIN as DEVICE_TRACKER_DOMAIN,
     PLATFORM_SCHEMA as DEVICE_TRACKER_PLATFORM_SCHEMA,
-    DeviceScanner,
+    AsyncSeeCallback,
+    ScannerEntity,
 )
+from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import CONF_HOST
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant, callback
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import config_validation as cv, issue_registry as ir
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-_LOGGER = logging.getLogger(__name__)
+from .const import DEFAULT_HOST, DOMAIN
+from .coordinator import SkyHubConfigEntry, SkyHubDataUpdateCoordinator
 
 PLATFORM_SCHEMA = DEVICE_TRACKER_PLATFORM_SCHEMA.extend(
     {vol.Optional(CONF_HOST): cv.string}
 )
 
 
-async def async_get_scanner(
-    hass: HomeAssistant, config: ConfigType
-) -> SkyHubDeviceScanner | None:
-    """Return a Sky Hub scanner if successful."""
-    host = config[DEVICE_TRACKER_DOMAIN].get(CONF_HOST, "192.168.1.254")
-    websession = async_get_clientsession(hass)
-    hub = SkyQHub(websession, host)
+async def async_setup_scanner(
+    hass: HomeAssistant,
+    config: ConfigType,
+    _async_see: AsyncSeeCallback,
+    _discovery_info: DiscoveryInfoType | None = None,
+) -> bool:
+    """Set up the legacy Sky Hub device tracker."""
+    import_data = {CONF_HOST: config.get(CONF_HOST, DEFAULT_HOST)}
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=import_data
+    )
 
-    _LOGGER.debug("Initialising Sky Hub")
-    await hub.async_connect()
-    if hub.success_init:
-        return SkyHubDeviceScanner(hub)
-
-    return None
-
-
-class SkyHubDeviceScanner(DeviceScanner):
-    """Class which queries a Sky Hub router."""
-
-    def __init__(self, hub):
-        """Initialise the scanner."""
-        self._hub = hub
-        self.last_results = {}
-
-    @override
-    async def async_scan_devices(self):
-        """Scan for new devices and return a list with found device IDs."""
-        await self._async_update_info()
-        return [device.mac for device in self.last_results]
-
-    @override
-    async def async_get_device_name(self, device):
-        """Return the name of the given device."""
-        return next(
-            (result.name for result in self.last_results if result.mac == device),
-            None,
+    if result["type"] is FlowResultType.ABORT and result["reason"] == "cannot_connect":
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            "yaml_import_cannot_connect",
+            is_fixable=False,
+            issue_domain=DOMAIN,
+            severity=ir.IssueSeverity.ERROR,
+            translation_key="yaml_import_cannot_connect",
+            translation_placeholders={"host": import_data[CONF_HOST]},
         )
+        return False
 
-    @override
-    async def async_get_extra_attributes(self, device):
-        """Get extra attributes of a device."""
-        device = next(
-            (result for result in self.last_results if result.mac == device), None
-        )
-        if device is None:
-            return {}
+    ir.async_create_issue(
+        hass,
+        HOMEASSISTANT_DOMAIN,
+        f"deprecated_yaml_{DOMAIN}",
+        is_fixable=False,
+        issue_domain=DOMAIN,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="deprecated_yaml",
+        translation_placeholders={
+            "domain": DOMAIN,
+            "integration_title": "Sky Hub",
+        },
+    )
+    return True
 
-        return device.asdict()
 
-    async def _async_update_info(self):
-        """Ensure the information from the Sky Hub is up to date."""
-        _LOGGER.debug("Scanning")
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: SkyHubConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the Sky Hub device tracker from a config entry."""
+    coordinator = config_entry.runtime_data
+    tracked: set[str] = set()
 
-        if not (data := await self._hub.async_get_skyhub_data()):
-            return
+    @callback
+    def _async_add_new_devices() -> None:
+        """Add newly discovered devices from the coordinator."""
+        new_entities: list[SkyHubScannerEntity] = []
+        for mac in coordinator.data:
+            if mac not in tracked:
+                tracked.add(mac)
+                new_entities.append(SkyHubScannerEntity(coordinator, mac))
+        if new_entities:
+            async_add_entities(new_entities)
 
-        self.last_results = data
+    config_entry.async_on_unload(coordinator.async_add_listener(_async_add_new_devices))
+    _async_add_new_devices()
+
+
+class SkyHubScannerEntity(
+    CoordinatorEntity[SkyHubDataUpdateCoordinator], ScannerEntity
+):
+    """Representation of a device connected to the Sky Hub."""
+
+    def __init__(self, coordinator: SkyHubDataUpdateCoordinator, mac: str) -> None:
+        """Initialize the tracked device."""
+        super().__init__(coordinator)
+        self._mac = mac
+        self._attr_name = coordinator.data.get(mac) or mac
+
+    @property
+    def is_connected(self) -> bool:
+        """Return true if the device is connected to the Sky Hub."""
+        return self._mac in self.coordinator.data
+
+    @property
+    def mac_address(self) -> str:
+        """Return the MAC address of the device."""
+        return self._mac
+
+    @property
+    def hostname(self) -> str | None:
+        """Return the hostname of the device."""
+        return self.coordinator.data.get(self._mac)

--- a/homeassistant/components/sky_hub/manifest.json
+++ b/homeassistant/components/sky_hub/manifest.json
@@ -4,9 +4,9 @@
   "codeowners": [],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/sky_hub",
+  "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["pyskyqhub"],
   "quality_scale": "legacy",
-  "requirements": ["pyskyqhub==0.1.4"],
-  "integration_type": "hub"
+  "requirements": ["pyskyqhub==0.1.4"]
 }

--- a/homeassistant/components/sky_hub/manifest.json
+++ b/homeassistant/components/sky_hub/manifest.json
@@ -2,6 +2,7 @@
   "domain": "sky_hub",
   "name": "Sky Hub",
   "codeowners": [],
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/sky_hub",
   "iot_class": "local_polling",
   "loggers": ["pyskyqhub"],

--- a/homeassistant/components/sky_hub/manifest.json
+++ b/homeassistant/components/sky_hub/manifest.json
@@ -7,5 +7,6 @@
   "iot_class": "local_polling",
   "loggers": ["pyskyqhub"],
   "quality_scale": "legacy",
-  "requirements": ["pyskyqhub==0.1.4"]
+  "requirements": ["pyskyqhub==0.1.4"],
+  "integration_type": "hub"
 }

--- a/homeassistant/components/sky_hub/strings.json
+++ b/homeassistant/components/sky_hub/strings.json
@@ -1,0 +1,23 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]"
+        }
+      }
+    }
+  },
+  "issues": {
+    "yaml_import_cannot_connect": {
+      "description": "The YAML configuration for Sky Hub at `{host}` could not be imported because the connection failed.\n\nPlease check that `{host}` is reachable, update your `configuration.yaml` if needed, and restart Home Assistant.",
+      "title": "YAML configuration import failed: cannot connect"
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -685,6 +685,7 @@ FLOWS = {
         "simplefin",
         "simplepush",
         "simplisafe",
+        "sky_hub",
         "sky_remote",
         "skybell",
         "slack",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -6468,7 +6468,7 @@
       "integrations": {
         "sky_hub": {
           "integration_type": "hub",
-          "config_flow": false,
+          "config_flow": true,
           "iot_class": "local_polling",
           "name": "Sky Hub"
         },

--- a/tests/components/sky_hub/__init__.py
+++ b/tests/components/sky_hub/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Sky Hub integration."""

--- a/tests/components/sky_hub/conftest.py
+++ b/tests/components/sky_hub/conftest.py
@@ -1,0 +1,47 @@
+"""Common fixtures for the Sky Hub integration tests."""
+
+from collections.abc import Generator
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from homeassistant.components.sky_hub.const import DOMAIN
+from homeassistant.const import CONF_HOST
+
+from tests.common import MockConfigEntry
+
+MOCK_HOST = "192.168.1.254"
+
+MOCK_CONFIG = {CONF_HOST: MOCK_HOST}
+
+MOCK_DEVICES = [
+    SimpleNamespace(mac="AA:BB:CC:DD:EE:FF", name="my-phone"),
+    SimpleNamespace(mac="11:22:33:44:55:66", name="my-laptop"),
+]
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.sky_hub.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        yield mock_setup_entry
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return a mock config entry."""
+    return MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, title=MOCK_HOST)
+
+
+@pytest.fixture
+def mock_skyqhub() -> Generator[MagicMock]:
+    """Mock SkyQHub to return known devices."""
+    with (
+        patch("homeassistant.components.sky_hub.coordinator.SkyQHub") as mock,
+        patch("homeassistant.components.sky_hub.config_flow.SkyQHub", new=mock),
+    ):
+        mock.return_value.async_get_skyhub_data = AsyncMock(return_value=MOCK_DEVICES)
+        yield mock

--- a/tests/components/sky_hub/test_config_flow.py
+++ b/tests/components/sky_hub/test_config_flow.py
@@ -1,0 +1,130 @@
+"""Tests for the Sky Hub config flow."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+
+from homeassistant.components.sky_hub.const import DOMAIN
+from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from .conftest import MOCK_CONFIG, MOCK_DEVICES, MOCK_HOST
+
+from tests.common import MockConfigEntry
+
+
+async def test_user_flow_success(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_skyqhub: MagicMock
+) -> None:
+    """Test a successful user config flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_HOST: MOCK_HOST}
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == MOCK_HOST
+    assert result["data"] == MOCK_CONFIG
+
+
+async def test_user_flow_cannot_connect(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_skyqhub: MagicMock
+) -> None:
+    """Test the user flow shows an error on failure and recovers."""
+    mock_skyqhub.return_value.async_get_skyhub_data.return_value = None
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_HOST: MOCK_HOST}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+    mock_skyqhub.return_value.async_get_skyhub_data.return_value = MOCK_DEVICES
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_HOST: MOCK_HOST}
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+
+async def test_user_flow_cannot_connect_exception(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_skyqhub: MagicMock
+) -> None:
+    """Test the user flow treats a network exception as cannot_connect."""
+    mock_skyqhub.return_value.async_get_skyhub_data.side_effect = aiohttp.ClientError
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_HOST: MOCK_HOST}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_user_flow_already_configured(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_skyqhub: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the user flow aborts when the host is already configured."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=MOCK_CONFIG
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_import_flow(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_skyqhub: MagicMock
+) -> None:
+    """Test a successful import flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=MOCK_CONFIG
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == MOCK_HOST
+    assert result["data"] == MOCK_CONFIG
+
+
+async def test_import_flow_already_configured(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_skyqhub: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the import flow aborts when already configured."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=MOCK_CONFIG
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_import_flow_cannot_connect(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_skyqhub: MagicMock
+) -> None:
+    """Test the import flow aborts on connection failure."""
+    mock_skyqhub.return_value.async_get_skyhub_data.return_value = None
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=MOCK_CONFIG
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"

--- a/tests/components/sky_hub/test_device_tracker.py
+++ b/tests/components/sky_hub/test_device_tracker.py
@@ -1,16 +1,20 @@
 """Tests for the Sky Hub device tracker."""
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+import pytest
 
 from homeassistant.components.sky_hub.const import DOMAIN
-from homeassistant.config_entries import SOURCE_IMPORT
+from homeassistant.components.sky_hub.device_tracker import async_setup_scanner
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntryState
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_registry import EntityRegistry
 from homeassistant.helpers.issue_registry import IssueRegistry
 from homeassistant.setup import async_setup_component
 
-from .conftest import MOCK_HOST
+from .conftest import MOCK_DEVICES, MOCK_HOST
 
 from tests.common import MockConfigEntry
 
@@ -73,3 +77,46 @@ async def test_legacy_platform_creates_issue_on_cannot_connect(
     assert issue is not None
     assert issue.translation_key == "yaml_import_cannot_connect"
     assert issue.translation_placeholders == {"host": MOCK_HOST}
+
+
+@pytest.mark.parametrize(
+    ("return_value", "side_effect"),
+    [(None, None), (None, aiohttp.ClientError)],
+    ids=["returns_none", "raises_client_error"],
+)
+async def test_setup_entry_retries_when_hub_unavailable(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_skyqhub: MagicMock,
+    return_value: None,
+    side_effect: type[Exception] | None,
+) -> None:
+    """Test the config entry retries when the hub returns no data or errors."""
+    mock_skyqhub.return_value.async_get_skyhub_data.return_value = return_value
+    mock_skyqhub.return_value.async_get_skyhub_data.side_effect = side_effect
+    mock_config_entry.add_to_hass(hass)
+
+    assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_legacy_import_clears_stale_cannot_connect_issue(
+    hass: HomeAssistant, mock_skyqhub: MagicMock, issue_registry: IssueRegistry
+) -> None:
+    """Test a successful YAML import removes a stale cannot_connect repair issue."""
+    config = {CONF_HOST: MOCK_HOST}
+
+    # A first import that cannot connect raises the repair issue.
+    mock_skyqhub.return_value.async_get_skyhub_data.return_value = None
+    assert not await async_setup_scanner(hass, config, AsyncMock())
+    assert (
+        issue_registry.async_get_issue(DOMAIN, "yaml_import_cannot_connect") is not None
+    )
+
+    # A later successful import clears it.
+    mock_skyqhub.return_value.async_get_skyhub_data.return_value = MOCK_DEVICES
+    assert await async_setup_scanner(hass, config, AsyncMock())
+    await hass.async_block_till_done()
+    assert issue_registry.async_get_issue(DOMAIN, "yaml_import_cannot_connect") is None

--- a/tests/components/sky_hub/test_device_tracker.py
+++ b/tests/components/sky_hub/test_device_tracker.py
@@ -1,0 +1,75 @@
+"""Tests for the Sky Hub device tracker."""
+
+from unittest.mock import MagicMock
+
+from homeassistant.components.sky_hub.const import DOMAIN
+from homeassistant.config_entries import SOURCE_IMPORT
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_registry import EntityRegistry
+from homeassistant.helpers.issue_registry import IssueRegistry
+from homeassistant.setup import async_setup_component
+
+from .conftest import MOCK_HOST
+
+from tests.common import MockConfigEntry
+
+
+async def test_entities_created(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_skyqhub: MagicMock,
+    entity_registry: EntityRegistry,
+) -> None:
+    """Test device tracker entities are created from the coordinator data."""
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entries = [
+        entry
+        for entry in entity_registry.entities.values()
+        if entry.domain == "device_tracker" and entry.platform == DOMAIN
+    ]
+    assert len(entries) == 2
+
+    entity_ids = {entry.entity_id for entry in entries}
+    assert any(eid.startswith("device_tracker.my_phone") for eid in entity_ids)
+    assert any(eid.startswith("device_tracker.my_laptop") for eid in entity_ids)
+
+
+async def test_legacy_platform_imports_config_entry(
+    hass: HomeAssistant, mock_skyqhub: MagicMock
+) -> None:
+    """Test the legacy device_tracker platform imports a config entry."""
+    assert await async_setup_component(
+        hass,
+        "device_tracker",
+        {"device_tracker": [{"platform": DOMAIN, CONF_HOST: MOCK_HOST}]},
+    )
+    await hass.async_block_till_done()
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].data == {CONF_HOST: MOCK_HOST}
+    assert entries[0].source == SOURCE_IMPORT
+
+
+async def test_legacy_platform_creates_issue_on_cannot_connect(
+    hass: HomeAssistant, mock_skyqhub: MagicMock, issue_registry: IssueRegistry
+) -> None:
+    """Test an issue is raised when the legacy YAML import cannot connect."""
+    mock_skyqhub.return_value.async_get_skyhub_data.return_value = None
+
+    assert await async_setup_component(
+        hass,
+        "device_tracker",
+        {"device_tracker": [{"platform": DOMAIN, CONF_HOST: MOCK_HOST}]},
+    )
+    await hass.async_block_till_done()
+
+    issue = issue_registry.async_get_issue(DOMAIN, "yaml_import_cannot_connect")
+    assert issue is not None
+    assert issue.translation_key == "yaml_import_cannot_connect"
+    assert issue.translation_placeholders == {"host": MOCK_HOST}

--- a/tests/components/sky_hub/test_device_tracker.py
+++ b/tests/components/sky_hub/test_device_tracker.py
@@ -80,19 +80,18 @@ async def test_legacy_platform_creates_issue_on_cannot_connect(
 
 
 @pytest.mark.parametrize(
-    ("return_value", "side_effect"),
-    [(None, None), (None, aiohttp.ClientError)],
+    "side_effect",
+    [None, aiohttp.ClientError],
     ids=["returns_none", "raises_client_error"],
 )
 async def test_setup_entry_retries_when_hub_unavailable(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_skyqhub: MagicMock,
-    return_value: None,
     side_effect: type[Exception] | None,
 ) -> None:
     """Test the config entry retries when the hub returns no data or errors."""
-    mock_skyqhub.return_value.async_get_skyhub_data.return_value = return_value
+    mock_skyqhub.return_value.async_get_skyhub_data.return_value = None
     mock_skyqhub.return_value.async_get_skyhub_data.side_effect = side_effect
     mock_config_entry.add_to_hass(hass)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Not a breaking change. The existing YAML configuration is imported automatically
into a config entry and a deprecation repair issue is raised, so current setups
keep working.

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrate the `sky_hub` device tracker from the legacy `DeviceScanner` to the modern,
config-entry based `ScannerEntity`, following the parent epic #50326:

- Add a config flow (host only) with import of the existing YAML configuration and
  a deprecation repair issue.
- Add a `DataUpdateCoordinator` that polls the Sky Hub.
- Represent each connected device as a `ScannerEntity` (using the MAC for identity).
- Add tests for the config flow and the device tracker.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #143035
- This PR is related to issue: #50326
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

---

AI-assisted (Opus); human-reviewed.
