### PR TITLE
Fix Light Turn Off with transition in Matter where possible

### DIFF
--- a/homeassistant/components/matter/light.py
+++ b/homeassistant/components/matter/light.py
@@ -317,7 +317,8 @@ class MatterLight(MatterEntity, LightEntity):
             # The light was turned off with a transition, which left it at the
             # minimum level. Restore the brightness it had before being turned off.
             brightness = self._off_brightness
-            self._off_brightness = None
+        # Any turn_on consumes or supersedes the cached value, so clear it.
+        self._off_brightness = None
 
         if self.supported_color_modes is not None:
             if hs_color is not None and ColorMode.HS in self.supported_color_modes:

--- a/homeassistant/components/matter/light.py
+++ b/homeassistant/components/matter/light.py
@@ -107,6 +107,8 @@ class MatterLight(MatterEntity, LightEntity):
     _supports_color = False
     _supports_color_temperature = False
     _transitions_disabled = False
+    _off_with_transition = False
+    _off_brightness: int | None = None
     _platform_translation_key = "light"
     _attr_min_color_temp_kelvin = DEFAULT_MIN_KELVIN
     _attr_max_color_temp_kelvin = DEFAULT_MAX_KELVIN
@@ -312,6 +314,15 @@ class MatterLight(MatterEntity, LightEntity):
         if self._transitions_disabled:
             transition = 0
 
+        if (
+            brightness is None
+            and self._off_with_transition
+            and self._off_brightness is not None
+        ):
+            # The light was turned off with a transition, which left it at the
+            # minimum level. Restore the brightness it had before being turned off.
+            brightness = self._off_brightness
+
         if self.supported_color_modes is not None:
             if hs_color is not None and ColorMode.HS in self.supported_color_modes:
                 await self._set_hs_color(hs_color, transition)
@@ -342,6 +353,10 @@ class MatterLight(MatterEntity, LightEntity):
             # light off, so this fades the light down and then turns it off.
             level_control = self._endpoint.get_cluster(clusters.LevelControl)
             assert level_control is not None
+            # Remember the brightness so the next plain turn_on can restore it
+            # instead of coming back at the minimum level we faded down to.
+            self._off_with_transition = True
+            self._off_brightness = self._attr_brightness
             await self.send_device_command(
                 clusters.LevelControl.Commands.MoveToLevelWithOnOff(
                     level=level_control.minLevel or 1,
@@ -434,9 +449,15 @@ class MatterLight(MatterEntity, LightEntity):
             )
 
         # set current values
+        previously_on = self._attr_is_on
         self._attr_is_on = self.get_matter_attribute_value(
             clusters.OnOff.Attributes.OnOff
         )
+        if self._attr_is_on and not previously_on:
+            # The light was turned on (possibly by another fabric), so any cached
+            # brightness from a previous "off with transition" is no longer valid.
+            self._off_with_transition = False
+            self._off_brightness = None
 
         if self._supports_brightness:
             self._attr_brightness = self._get_brightness()

--- a/homeassistant/components/matter/light.py
+++ b/homeassistant/components/matter/light.py
@@ -317,6 +317,7 @@ class MatterLight(MatterEntity, LightEntity):
             # The light was turned off with a transition, which left it at the
             # minimum level. Restore the brightness it had before being turned off.
             brightness = self._off_brightness
+            self._off_brightness = None
 
         if self.supported_color_modes is not None:
             if hs_color is not None and ColorMode.HS in self.supported_color_modes:

--- a/homeassistant/components/matter/light.py
+++ b/homeassistant/components/matter/light.py
@@ -333,6 +333,24 @@ class MatterLight(MatterEntity, LightEntity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn light off."""
+        transition = kwargs.get(ATTR_TRANSITION, 0)
+        if self._transitions_disabled:
+            transition = 0
+
+        if transition > 0 and self._supports_brightness:
+            # Per the Matter spec, moving to the minimum level turns the
+            # light off, so this fades the light down and then turns it off.
+            level_control = self._endpoint.get_cluster(clusters.LevelControl)
+            assert level_control is not None
+            await self.send_device_command(
+                clusters.LevelControl.Commands.MoveToLevelWithOnOff(
+                    level=level_control.minLevel or 1,
+                    # transition in matter is measured in tenths of a second
+                    transitionTime=int(transition * 10),
+                )
+            )
+            return
+
         await self.send_device_command(
             clusters.OnOff.Commands.Off(),
         )

--- a/homeassistant/components/matter/light.py
+++ b/homeassistant/components/matter/light.py
@@ -107,7 +107,6 @@ class MatterLight(MatterEntity, LightEntity):
     _supports_color = False
     _supports_color_temperature = False
     _transitions_disabled = False
-    _off_with_transition = False
     _off_brightness: int | None = None
     _platform_translation_key = "light"
     _attr_min_color_temp_kelvin = DEFAULT_MIN_KELVIN
@@ -314,11 +313,7 @@ class MatterLight(MatterEntity, LightEntity):
         if self._transitions_disabled:
             transition = 0
 
-        if (
-            brightness is None
-            and self._off_with_transition
-            and self._off_brightness is not None
-        ):
+        if brightness is None and self._off_brightness is not None:
             # The light was turned off with a transition, which left it at the
             # minimum level. Restore the brightness it had before being turned off.
             brightness = self._off_brightness
@@ -351,15 +346,18 @@ class MatterLight(MatterEntity, LightEntity):
         if transition > 0 and self._supports_brightness:
             # Per the Matter spec, moving to the minimum level turns the
             # light off, so this fades the light down and then turns it off.
-            level_control = self._endpoint.get_cluster(clusters.LevelControl)
-            assert level_control is not None
+            min_level = (
+                self.get_matter_attribute_value(
+                    clusters.LevelControl.Attributes.MinLevel
+                )
+                or 1
+            )
             # Remember the brightness so the next plain turn_on can restore it
             # instead of coming back at the minimum level we faded down to.
-            self._off_with_transition = True
             self._off_brightness = self._attr_brightness
             await self.send_device_command(
                 clusters.LevelControl.Commands.MoveToLevelWithOnOff(
-                    level=level_control.minLevel or 1,
+                    level=min_level,
                     # transition in matter is measured in tenths of a second
                     transitionTime=int(transition * 10),
                 )
@@ -456,7 +454,6 @@ class MatterLight(MatterEntity, LightEntity):
         if self._attr_is_on and not previously_on:
             # The light was turned on (possibly by another fabric), so any cached
             # brightness from a previous "off with transition" is no longer valid.
-            self._off_with_transition = False
             self._off_brightness = None
 
         if self._supports_brightness:

--- a/tests/components/matter/test_light.py
+++ b/tests/components/matter/test_light.py
@@ -117,6 +117,94 @@ async def test_light_turn_on_off(
 @pytest.mark.parametrize(
     ("node_fixture", "entity_id"),
     [
+        ("mock_dimmable_light", "light.mock_dimmable_light"),
+    ],
+)
+async def test_dimmable_light_turn_off_transition(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+    entity_id: str,
+) -> None:
+    """Test turning a dimmable light off with a transition."""
+
+    # A transition fades to the minimum level, which turns the light off
+    await hass.services.async_call(
+        "light",
+        "turn_off",
+        {
+            "entity_id": entity_id,
+            "transition": 3,
+        },
+        blocking=True,
+    )
+
+    assert matter_client.send_device_command.call_count == 1
+    assert matter_client.send_device_command.call_args == call(
+        node_id=matter_node.node_id,
+        endpoint_id=1,
+        command=clusters.LevelControl.Commands.MoveToLevelWithOnOff(
+            level=1,
+            transitionTime=30,
+        ),
+    )
+    matter_client.send_device_command.reset_mock()
+
+    # Without a transition the OnOff cluster is used
+    await hass.services.async_call(
+        "light",
+        "turn_off",
+        {
+            "entity_id": entity_id,
+        },
+        blocking=True,
+    )
+
+    assert matter_client.send_device_command.call_count == 1
+    assert matter_client.send_device_command.call_args == call(
+        node_id=matter_node.node_id,
+        endpoint_id=1,
+        command=clusters.OnOff.Commands.Off(),
+    )
+    matter_client.send_device_command.reset_mock()
+
+
+@pytest.mark.parametrize(
+    ("node_fixture", "entity_id"),
+    [
+        ("mock_onoff_light", "light.mock_onoff_light"),
+    ],
+)
+async def test_onoff_light_turn_off_transition(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+    entity_id: str,
+) -> None:
+    """Test that a light without brightness ignores the off transition."""
+
+    await hass.services.async_call(
+        "light",
+        "turn_off",
+        {
+            "entity_id": entity_id,
+            "transition": 3,
+        },
+        blocking=True,
+    )
+
+    assert matter_client.send_device_command.call_count == 1
+    assert matter_client.send_device_command.call_args == call(
+        node_id=matter_node.node_id,
+        endpoint_id=1,
+        command=clusters.OnOff.Commands.Off(),
+    )
+    matter_client.send_device_command.reset_mock()
+
+
+@pytest.mark.parametrize(
+    ("node_fixture", "entity_id"),
+    [
         ("extended_color_light", "light.mock_extended_color_light"),
         ("color_temperature_light", "light.mock_color_temperature_light"),
         ("mock_dimmable_light", "light.mock_dimmable_light"),

--- a/tests/components/matter/test_light.py
+++ b/tests/components/matter/test_light.py
@@ -172,6 +172,128 @@ async def test_dimmable_light_turn_off_transition(
 @pytest.mark.parametrize(
     ("node_fixture", "entity_id"),
     [
+        ("mock_dimmable_light", "light.mock_dimmable_light"),
+    ],
+)
+async def test_dimmable_light_restore_brightness_after_off_transition(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+    entity_id: str,
+) -> None:
+    """Test the brightness is restored after turning off with a transition."""
+
+    # The light is on at level 50 (out of 254)
+    set_node_attribute(matter_node, 1, 8, 0, 50)
+    await trigger_subscription_callback(hass, matter_client)
+
+    # Turn the light off with a transition, fading it down to the minimum level
+    await hass.services.async_call(
+        "light",
+        "turn_off",
+        {"entity_id": entity_id, "transition": 3},
+        blocking=True,
+    )
+
+    assert matter_client.send_device_command.call_args == call(
+        node_id=matter_node.node_id,
+        endpoint_id=1,
+        command=clusters.LevelControl.Commands.MoveToLevelWithOnOff(
+            level=1,
+            transitionTime=30,
+        ),
+    )
+    matter_client.send_device_command.reset_mock()
+
+    # The device reports it has reached the minimum level and turned off
+    set_node_attribute(matter_node, 1, 8, 0, 1)
+    set_node_attribute(matter_node, 1, 6, 0, False)
+    await trigger_subscription_callback(hass, matter_client)
+
+    # Turning back on without a brightness should restore the previous brightness
+    # instead of coming back at the minimum level we faded down to
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {"entity_id": entity_id},
+        blocking=True,
+    )
+
+    assert matter_client.send_device_command.call_count == 1
+    assert matter_client.send_device_command.call_args == call(
+        node_id=matter_node.node_id,
+        endpoint_id=1,
+        command=clusters.LevelControl.Commands.MoveToLevelWithOnOff(
+            level=50,
+            transitionTime=0,
+        ),
+    )
+    matter_client.send_device_command.reset_mock()
+
+
+@pytest.mark.parametrize(
+    ("node_fixture", "entity_id"),
+    [
+        ("mock_dimmable_light", "light.mock_dimmable_light"),
+    ],
+)
+async def test_off_transition_brightness_invalidated_when_turned_on_externally(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+    entity_id: str,
+) -> None:
+    """Test the cached brightness is dropped when another fabric turns the light on.
+
+    A Matter device can be part of multiple fabrics, so we must not restore our
+    cached "off with transition" brightness once the light has been turned on
+    again by someone else.
+    """
+
+    # The light is on at level 50 (out of 254)
+    set_node_attribute(matter_node, 1, 8, 0, 50)
+    await trigger_subscription_callback(hass, matter_client)
+
+    # Turn the light off with a transition, caching the previous brightness
+    await hass.services.async_call(
+        "light",
+        "turn_off",
+        {"entity_id": entity_id, "transition": 3},
+        blocking=True,
+    )
+    matter_client.send_device_command.reset_mock()
+
+    # The device reports it has reached the minimum level and turned off
+    set_node_attribute(matter_node, 1, 8, 0, 1)
+    set_node_attribute(matter_node, 1, 6, 0, False)
+    await trigger_subscription_callback(hass, matter_client)
+
+    # Another fabric turns the light back on at a different level
+    set_node_attribute(matter_node, 1, 8, 0, 200)
+    set_node_attribute(matter_node, 1, 6, 0, True)
+    await trigger_subscription_callback(hass, matter_client)
+
+    # A plain turn_on must not restore the cached brightness anymore and should
+    # simply use the OnOff cluster, respecting the device's current state
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {"entity_id": entity_id},
+        blocking=True,
+    )
+
+    assert matter_client.send_device_command.call_count == 1
+    assert matter_client.send_device_command.call_args == call(
+        node_id=matter_node.node_id,
+        endpoint_id=1,
+        command=clusters.OnOff.Commands.On(),
+    )
+    matter_client.send_device_command.reset_mock()
+
+
+@pytest.mark.parametrize(
+    ("node_fixture", "entity_id"),
+    [
         ("mock_onoff_light", "light.mock_onoff_light"),
     ],
 )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This implements light.turn_off with transition for Matter lights, using the `MoveToLevelWithOnOff` Command with the target level set to `minLevel`, which according to the spec turns off the light after transitioning to `minLevel`.

> If any command that has the effect of setting the CurrentLevel attribute to the minimum level
> allowed by the device, the OnOff attribute of the On/Off cluster on the same endpoint, if imple
> mented, SHALL be set to FALSE (‘Off’).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #160066
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
