### PR TITLE
Bump py_ccm15 to 0.6.0

### DIFF
--- a/homeassistant/components/ccm15/manifest.json
+++ b/homeassistant/components/ccm15/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/ccm15",
   "integration_type": "hub",
   "iot_class": "local_polling",
-  "requirements": ["py_ccm15==0.1.2"]
+  "requirements": ["py_ccm15==0.6.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1996,7 +1996,7 @@ pyW215==0.8.0
 pyW800rf32==0.4
 
 # homeassistant.components.ccm15
-py_ccm15==0.1.2
+py_ccm15==0.6.0
 
 # homeassistant.components.html5
 py_vapid==1.9.4


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bumps the `ccm15` integration's `py_ccm15` dependency from `0.1.2` to `0.6.0`.

Split out from #173652 as its own dependency bump, per @joostlek's review request to keep the version bump separate from the code fixes.

All releases between `0.1.2` and `0.6.0` are additive features or bug fixes — none change the API Home Assistant calls (`CCM15Device(...)`, `get_status_async`, `async_set_state` → still `bool`, `CCM15SlaveDevice` fields). The new constructor params and `TriState` desired-value fields are all optional/opt-in, so default behavior is unchanged.

Full delta: [`v0.1.2...v0.6.0`](https://github.com/HomeOps/py-ccm15/compare/v0.1.2...v0.6.0)

Runtime-relevant changes:
- **0.2.2** — handle non-contiguous slots and slaves >= 32 (decode side)
- **0.2.4** — tolerate transient controller dropouts; per-device data age
- **0.3.0** — accept an injected `httpx.AsyncClient` (lets HA stop building the client on the event loop)
- **0.4.0 / 0.5.0 / 0.6.0** — opt-in `pwd=` auth, swing, and electric-heater (all default-off, no behavior change unless a caller opts in)

The next breaking release is `1.0.0` (write return type changes `bool` -> `CCM15ReturnCode`); it is intentionally **not** included here and will need a coordinated code change.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #173652 (consumes the injected client), #173793 (needs the swing API)
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
