### PR TITLE
Add repair issues for Teslemetry vehicle metadata problems

### DIFF
--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -176,11 +176,12 @@ def _async_update_vehicle_repairs(
     vehicle_metadata: dict[str, Any],
 ) -> None:
     """Create or remove repair issues based on each vehicle's metadata issue."""
-    for vin, info in vehicle_metadata.items():
+    for vin in vins | set(vehicle_metadata):
+        info = vehicle_metadata.get(vin, {})
         issue = info.get("issue")
         for issue_type, learn_more_url in VEHICLE_ISSUE_LEARN_MORE.items():
             issue_id = f"{issue_type}_{vin}"
-            if vin in vins and issue == issue_type:
+            if vin in vins and info.get("access") and issue == issue_type:
                 ir.async_create_issue(
                     hass,
                     DOMAIN,

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -24,7 +24,11 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ACCESS_TOKEN, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
-from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry as dr,
+    issue_registry as ir,
+)
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.config_entry_oauth2_flow import (
     ImplementationUnavailableError,
@@ -34,7 +38,7 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.typing import ConfigType
 
-from .const import CLIENT_ID, DOMAIN, LOGGER
+from .const import CLIENT_ID, DOMAIN, LOGGER, VEHICLE_ISSUE_LEARN_MORE
 from .coordinator import (
     TeslemetryEnergyHistoryCoordinator,
     TeslemetryEnergySiteInfoCoordinator,
@@ -159,6 +163,62 @@ def _setup_dynamic_discovery(
                 removed_sites or "none",
             )
             hass.config_entries.async_schedule_reload(entry.entry_id)
+
+    entry.async_on_unload(
+        metadata_coordinator.async_add_listener(_handle_metadata_update)
+    )
+
+
+def _async_update_vehicle_repairs(
+    hass: HomeAssistant,
+    entry: TeslemetryConfigEntry,
+    vins: set[str],
+    vehicle_metadata: dict[str, Any],
+) -> None:
+    """Create or remove repair issues based on each vehicle's metadata issue."""
+    for vin, info in vehicle_metadata.items():
+        issue = info.get("issue")
+        for issue_type, learn_more_url in VEHICLE_ISSUE_LEARN_MORE.items():
+            issue_id = f"{issue_type}_{vin}"
+            if vin in vins and issue == issue_type:
+                ir.async_create_issue(
+                    hass,
+                    DOMAIN,
+                    issue_id,
+                    is_fixable=True,
+                    severity=ir.IssueSeverity.WARNING,
+                    translation_key=issue_type,
+                    translation_placeholders={"vehicle": info.get("name") or vin},
+                    learn_more_url=learn_more_url,
+                    data={
+                        "entry_id": entry.entry_id,
+                        "vin": vin,
+                        "issue_type": issue_type,
+                        "vehicle": info.get("name") or vin,
+                    },
+                )
+            else:
+                ir.async_delete_issue(hass, DOMAIN, issue_id)
+
+
+def _setup_vehicle_repairs(
+    hass: HomeAssistant,
+    entry: TeslemetryConfigEntry,
+    metadata_coordinator: TeslemetryMetadataCoordinator,
+    vins: set[str],
+    vehicle_metadata: dict[str, Any],
+) -> None:
+    """Track vehicle metadata issues and keep repair issues in sync."""
+
+    _async_update_vehicle_repairs(hass, entry, vins, vehicle_metadata)
+
+    @callback
+    def _handle_metadata_update() -> None:
+        """Re-evaluate vehicle repair issues when metadata changes."""
+        data = metadata_coordinator.data
+        if not data:
+            return
+        _async_update_vehicle_repairs(hass, entry, vins, data["vehicles"])
 
     entry.async_on_unload(
         metadata_coordinator.async_add_listener(_handle_metadata_update)
@@ -435,6 +495,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
         metadata_coordinator,
         known_vins,
         known_site_ids,
+    )
+
+    _setup_vehicle_repairs(
+        hass,
+        entry,
+        metadata_coordinator,
+        {vehicle.vin for vehicle in vehicles},
+        vehicle_metadata,
     )
 
     if stream:

--- a/homeassistant/components/teslemetry/const.py
+++ b/homeassistant/components/teslemetry/const.py
@@ -37,6 +37,15 @@ ENERGY_HISTORY_FIELDS = [
 ]
 
 
+# Vehicle metadata "issue" values that map to an actionable repair issue, with
+# an optional "learn more" URL the user can visit to resolve it. The "no_data"
+# issue is intentionally ignored as it is not user-actionable.
+VEHICLE_ISSUE_LEARN_MORE: dict[str, str | None] = {
+    "key": "https://teslemetry.com/key",
+    "streaming_toggle": None,
+}
+
+
 class TeslemetryState(StrEnum):
     """Teslemetry Vehicle States."""
 

--- a/homeassistant/components/teslemetry/repairs.py
+++ b/homeassistant/components/teslemetry/repairs.py
@@ -1,0 +1,76 @@
+"""Repairs for the Teslemetry integration."""
+
+from homeassistant.components.repairs import (
+    ConfirmRepairFlow,
+    RepairsFlow,
+    RepairsFlowResult,
+)
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from . import TeslemetryConfigEntry
+from .const import VEHICLE_ISSUE_LEARN_MORE
+
+
+class VehicleMetadataRepairFlow(RepairsFlow):
+    """Handle a repair that clears once the vehicle metadata issue resolves."""
+
+    def __init__(
+        self, entry: TeslemetryConfigEntry, vin: str, issue_type: str, vehicle: str
+    ) -> None:
+        """Create flow."""
+        self.entry = entry
+        self.vin = vin
+        self.issue_type = issue_type
+        self.placeholders = {
+            "vehicle": vehicle,
+            "link": VEHICLE_ISSUE_LEARN_MORE.get(issue_type) or "",
+        }
+
+    async def async_step_init(
+        self, user_input: dict[str, str] | None = None
+    ) -> RepairsFlowResult:
+        """Handle the first step of a fix flow."""
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(
+        self, user_input: dict[str, str] | None = None
+    ) -> RepairsFlowResult:
+        """Handle the confirm step of a fix flow."""
+        if user_input is not None:
+            coordinator = self.entry.runtime_data.metadata_coordinator
+            await coordinator.async_refresh()
+            vehicles = (coordinator.data or {}).get("vehicles", {})
+            still_present = vehicles.get(self.vin, {}).get("issue") == self.issue_type
+            if coordinator.last_update_success and not still_present:
+                return self.async_create_entry(data={})
+            return self.async_show_form(
+                step_id="confirm",
+                description_placeholders=self.placeholders,
+                errors={"base": "not_resolved"},
+            )
+
+        return self.async_show_form(
+            step_id="confirm",
+            description_placeholders=self.placeholders,
+        )
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant,
+    issue_id: str,
+    data: dict[str, str | int | float | None] | None,
+) -> RepairsFlow:
+    """Create flow."""
+    if (
+        data is not None
+        and isinstance(entry_id := data.get("entry_id"), str)
+        and isinstance(vin := data.get("vin"), str)
+        and isinstance(issue_type := data.get("issue_type"), str)
+        and isinstance(vehicle := data.get("vehicle"), str)
+        and (entry := hass.config_entries.async_get_entry(entry_id)) is not None
+        and entry.state is ConfigEntryState.LOADED
+    ):
+        return VehicleMetadataRepairFlow(entry, vin, issue_type, vehicle)
+
+    return ConfirmRepairFlow()

--- a/homeassistant/components/teslemetry/strings.json
+++ b/homeassistant/components/teslemetry/strings.json
@@ -1186,6 +1186,36 @@
       "message": "Timed out trying to wake up vehicle"
     }
   },
+  "issues": {
+    "key": {
+      "fix_flow": {
+        "error": {
+          "not_resolved": "The virtual key still appears to be unpaired. Please complete the pairing at {link}, then try again."
+        },
+        "step": {
+          "confirm": {
+            "description": "Home Assistant cannot send commands to {vehicle} because the Teslemetry virtual key is not paired with the vehicle. Until it is paired, commands such as locking, climate control and charging will not work.\n\n1. Open {link}.\n2. Follow the prompts to add the virtual key to {vehicle}.\n3. Select **Submit** below to re-check.",
+            "title": "[%key:component::teslemetry::issues::key::title%]"
+          }
+        }
+      },
+      "title": "Pair the virtual key for {vehicle}"
+    },
+    "streaming_toggle": {
+      "fix_flow": {
+        "error": {
+          "not_resolved": "Data streaming still appears to be disabled. Please enable \"Allow Third-Party App Data Streaming\" in the vehicle's Safety settings, then try again."
+        },
+        "step": {
+          "confirm": {
+            "description": "Home Assistant cannot receive streaming data from {vehicle} because the \"Allow Third-Party App Data Streaming\" toggle is disabled. This option is only available on older Model S and Model X vehicles with Intel-based computers.\n\n1. In {vehicle}, open Controls > Safety.\n2. Enable **Allow Third-Party App Data Streaming**.\n3. Select **Submit** below to re-check.",
+            "title": "[%key:component::teslemetry::issues::streaming_toggle::title%]"
+          }
+        }
+      },
+      "title": "Enable data streaming for {vehicle}"
+    }
+  },
   "selector": {
     "days_of_week": {
       "options": {

--- a/tests/components/teslemetry/test_repairs.py
+++ b/tests/components/teslemetry/test_repairs.py
@@ -38,6 +38,20 @@ def _metadata_with_issue(issue: str | None) -> dict[str, Any]:
     return metadata
 
 
+def _metadata_without_vehicle() -> dict[str, Any]:
+    """Return a copy of the metadata without the vehicle."""
+    metadata = deepcopy(METADATA)
+    del metadata["vehicles"][VEHICLE_VIN]
+    return metadata
+
+
+def _metadata_with_vehicle_access(access: bool) -> dict[str, Any]:
+    """Return a copy of the metadata with the vehicle access set."""
+    metadata = _metadata_with_issue("key")
+    metadata["vehicles"][VEHICLE_VIN]["access"] = access
+    return metadata
+
+
 @pytest.mark.parametrize("issue_type", ["key", "streaming_toggle"])
 async def test_repair_issue_created(
     hass: HomeAssistant,
@@ -101,6 +115,42 @@ async def test_repair_issue_auto_resolves(
     with patch(
         "tesla_fleet_api.teslemetry.Teslemetry.metadata",
         return_value=_metadata_with_issue(None),
+    ):
+        freezer.tick(METADATA_INTERVAL)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+    assert issue_registry.async_get_issue(DOMAIN, f"key_{VEHICLE_VIN}") is None
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        pytest.param(_metadata_without_vehicle(), id="removed"),
+        pytest.param(
+            _metadata_with_vehicle_access(False),
+            id="access_revoked",
+        ),
+    ],
+)
+async def test_repair_issue_removed_when_vehicle_no_longer_available(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    issue_registry: ir.IssueRegistry,
+    metadata: dict[str, Any],
+) -> None:
+    """Test a repair issue is removed once the vehicle is no longer available."""
+    with patch(
+        "tesla_fleet_api.teslemetry.Teslemetry.metadata",
+        return_value=_metadata_with_issue("key"),
+    ):
+        entry = await setup_platform(hass)
+    assert entry.state is ConfigEntryState.LOADED
+    assert issue_registry.async_get_issue(DOMAIN, f"key_{VEHICLE_VIN}") is not None
+
+    with patch(
+        "tesla_fleet_api.teslemetry.Teslemetry.metadata",
+        return_value=metadata,
     ):
         freezer.tick(METADATA_INTERVAL)
         async_fire_time_changed(hass)

--- a/tests/components/teslemetry/test_repairs.py
+++ b/tests/components/teslemetry/test_repairs.py
@@ -1,0 +1,172 @@
+"""Test the Teslemetry repairs."""
+
+from copy import deepcopy
+from typing import Any
+from unittest.mock import patch
+
+from freezegun.api import FrozenDateTimeFactory
+import pytest
+
+from homeassistant.components.repairs import ConfirmRepairFlow
+from homeassistant.components.teslemetry.const import DOMAIN
+from homeassistant.components.teslemetry.coordinator import METADATA_INTERVAL
+from homeassistant.components.teslemetry.repairs import async_create_fix_flow
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import issue_registry as ir
+from homeassistant.setup import async_setup_component
+
+from . import setup_platform
+from .const import METADATA
+
+from tests.common import async_fire_time_changed
+from tests.components.repairs import (
+    async_process_repairs_platforms,
+    process_repair_fix_flow,
+    start_repair_fix_flow,
+)
+from tests.typing import ClientSessionGenerator
+
+VEHICLE_VIN = "LRW3F7EK4NC700000"
+
+
+def _metadata_with_issue(issue: str | None) -> dict[str, Any]:
+    """Return a copy of the metadata with the vehicle issue set."""
+    metadata = deepcopy(METADATA)
+    metadata["vehicles"][VEHICLE_VIN]["issue"] = issue
+    return metadata
+
+
+@pytest.mark.parametrize("issue_type", ["key", "streaming_toggle"])
+async def test_repair_issue_created(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    issue_type: str,
+) -> None:
+    """Test a repair issue is created for an unresolved vehicle metadata issue."""
+    with patch(
+        "tesla_fleet_api.teslemetry.Teslemetry.metadata",
+        return_value=_metadata_with_issue(issue_type),
+    ):
+        entry = await setup_platform(hass)
+    assert entry.state is ConfigEntryState.LOADED
+
+    issue = issue_registry.async_get_issue(DOMAIN, f"{issue_type}_{VEHICLE_VIN}")
+    assert issue is not None
+    assert issue.translation_key == issue_type
+    assert issue.data == {
+        "entry_id": entry.entry_id,
+        "vin": VEHICLE_VIN,
+        "issue_type": issue_type,
+        "vehicle": "Home Assistant",
+    }
+
+
+@pytest.mark.parametrize("issue", [None, "no_data"])
+async def test_no_repair_issue(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    issue: str | None,
+) -> None:
+    """Test no repair issue is created when there is no actionable issue."""
+    with patch(
+        "tesla_fleet_api.teslemetry.Teslemetry.metadata",
+        return_value=_metadata_with_issue(issue),
+    ):
+        entry = await setup_platform(hass)
+    assert entry.state is ConfigEntryState.LOADED
+
+    assert issue_registry.async_get_issue(DOMAIN, f"key_{VEHICLE_VIN}") is None
+    assert (
+        issue_registry.async_get_issue(DOMAIN, f"streaming_toggle_{VEHICLE_VIN}")
+        is None
+    )
+
+
+async def test_repair_issue_auto_resolves(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a repair issue is removed once the metadata issue clears."""
+    with patch(
+        "tesla_fleet_api.teslemetry.Teslemetry.metadata",
+        return_value=_metadata_with_issue("key"),
+    ):
+        entry = await setup_platform(hass)
+    assert entry.state is ConfigEntryState.LOADED
+    assert issue_registry.async_get_issue(DOMAIN, f"key_{VEHICLE_VIN}") is not None
+
+    with patch(
+        "tesla_fleet_api.teslemetry.Teslemetry.metadata",
+        return_value=_metadata_with_issue(None),
+    ):
+        freezer.tick(METADATA_INTERVAL)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+    assert issue_registry.async_get_issue(DOMAIN, f"key_{VEHICLE_VIN}") is None
+
+
+async def test_repair_fix_flow(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test the fix flow re-checks metadata and resolves once fixed."""
+    assert await async_setup_component(hass, "repairs", {})
+    await async_process_repairs_platforms(hass)
+    client = await hass_client()
+
+    with patch(
+        "tesla_fleet_api.teslemetry.Teslemetry.metadata",
+        return_value=_metadata_with_issue("key"),
+    ):
+        entry = await setup_platform(hass)
+    assert entry.state is ConfigEntryState.LOADED
+
+    issue_id = f"key_{VEHICLE_VIN}"
+    assert issue_registry.async_get_issue(DOMAIN, issue_id) is not None
+
+    result = await start_repair_fix_flow(client, DOMAIN, issue_id)
+    flow_id = result["flow_id"]
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "confirm"
+
+    # Submitting while the key is still unpaired keeps the form open
+    with patch(
+        "tesla_fleet_api.teslemetry.Teslemetry.metadata",
+        return_value=_metadata_with_issue("key"),
+    ):
+        result = await process_repair_fix_flow(client, flow_id, json={})
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "confirm"
+    assert result["errors"] == {"base": "not_resolved"}
+    assert issue_registry.async_get_issue(DOMAIN, issue_id) is not None
+
+    # Once the key is paired, re-checking resolves the issue
+    with patch(
+        "tesla_fleet_api.teslemetry.Teslemetry.metadata",
+        return_value=_metadata_with_issue(None),
+    ):
+        result = await process_repair_fix_flow(client, flow_id, json={})
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert issue_registry.async_get_issue(DOMAIN, issue_id) is None
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        None,
+        {"entry_id": "missing"},
+        {"entry_id": 123, "vin": VEHICLE_VIN, "issue_type": "key", "vehicle": "Car"},
+    ],
+)
+async def test_repair_invalid_data_returns_confirm_flow(
+    hass: HomeAssistant,
+    data: dict[str, Any] | None,
+) -> None:
+    """Test invalid repair flow data falls back to a confirm flow."""
+    flow = await async_create_fix_flow(hass, "key_VIN", data)
+    assert isinstance(flow, ConfirmRepairFlow)


### PR DESCRIPTION
## Proposed change

Adds repair issues for Teslemetry vehicles when their metadata reports a configuration problem. An unpaired virtual key raises a repair directing the user to https://teslemetry.com/key, and a disabled "Allow Third-Party App Data Streaming" safety toggle raises a repair explaining how to enable it (older Intel-based Model S/X). Issues are created on setup, kept in sync with the metadata coordinator so they auto-resolve when the problem clears, and can be re-checked from a repair fix flow.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
