### PR TITLE
Guard SMTP quit() on already-disconnected connection in smtp notify

### DIFF
--- a/homeassistant/components/smtp/notify.py
+++ b/homeassistant/components/smtp/notify.py
@@ -1,5 +1,6 @@
 """Mail (SMTP) notification service."""
 
+import contextlib
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 import email.utils
@@ -90,6 +91,16 @@ PLATFORM_SCHEMA = NOTIFY_PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
     }
 )
+
+
+def _close_connection(mail: SMTP_SSL | SMTP) -> None:
+    """Close an SMTP connection, ignoring errors from an already-dead socket.
+
+    quit() on a connection the server already dropped raises
+    SMTPServerDisconnected; that must not abort sending or mask a retry.
+    """
+    with contextlib.suppress(SMTPException):
+        mail.quit()
 
 
 async def async_get_service(
@@ -236,7 +247,7 @@ class MailNotifyEntity(NotifyEntity):
                         translation_key="send_mail_connection_error",
                     ) from e
             finally:
-                client.quit()
+                _close_connection(client)
 
 
 class MailNotificationService(SmtpClient, BaseNotificationService):
@@ -316,10 +327,10 @@ class MailNotificationService(SmtpClient, BaseNotificationService):
                 _LOGGER.warning(
                     "SMTPServerDisconnected sending mail: retrying connection"
                 )
-                mail.quit()
+                _close_connection(mail)
                 mail = self.connect()
             except SMTPException:
                 _LOGGER.warning("SMTPException sending mail: retrying connection")
-                mail.quit()
+                _close_connection(mail)
                 mail = self.connect()
-        mail.quit()
+        _close_connection(mail)

--- a/tests/components/smtp/test_notify.py
+++ b/tests/components/smtp/test_notify.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 import re
 from smtplib import (
+    SMTP,
     SMTPAuthenticationError,
     SMTPHeloError,
     SMTPSenderRefused,
@@ -218,6 +219,40 @@ def test_send_target_message(target, hass: HomeAssistant, message) -> None:
         assert recipient == expected_recipient
 
 
+def test_send_message_recovers_after_disconnect() -> None:
+    """Verify a dropped connection is retried without quit() aborting the send.
+
+    quit() on a connection the server already closed raises
+    SMTPServerDisconnected("please run connect() first"). That must not be
+    re-raised, otherwise the retry never happens and the calling automation
+    aborts at the notify step.
+    """
+    service = MailNotificationService(
+        config={
+            CONF_SERVER: "localhost",
+            CONF_PORT: 25,
+            CONF_TIMEOUT: 5,
+            CONF_SENDER: "test@test.com",
+            CONF_ENCRYPTION: 1,
+            CONF_USERNAME: "testuser",
+            CONF_PASSWORD: "testpass",
+            CONF_RECIPIENT: ["recip1@example.com"],
+            CONF_SENDER_NAME: "Home Assistant",
+            CONF_VERIFY_SSL: True,
+        },
+        ssl_context=create_client_context(),
+    )
+
+    mock_mail = MagicMock(spec=SMTP)
+    mock_mail.sendmail.side_effect = [SMTPServerDisconnected(), None]
+    mock_mail.quit.side_effect = SMTPServerDisconnected("please run connect() first")
+
+    with patch.object(service, "connect", return_value=mock_mail):
+        service.send_message("Test msg")
+
+    assert mock_mail.sendmail.call_count == 2
+
+
 @pytest.mark.usefixtures("smtp")
 async def test_notify_platform(
     hass: HomeAssistant,
@@ -328,3 +363,41 @@ async def test_notify_send_message_exceptions(
         )
 
     assert e.value.translation_key == translation_key
+
+
+@pytest.mark.usefixtures("make_msgid")
+@pytest.mark.freeze_time("2026-05-03T03:09:37+00:00")
+async def test_notify_send_message_recovers_after_disconnect(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    smtp: MagicMock,
+) -> None:
+    """Test the notify entity retries after the connection was dropped.
+
+    quit() on the already-closed connection raises SMTPServerDisconnected; that
+    must not abort the retry or propagate out of the notify action.
+    """
+
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    smtp.sendmail.side_effect = [SMTPServerDisconnected(), None]
+    smtp.quit.side_effect = SMTPServerDisconnected("please run connect() first")
+
+    await hass.services.async_call(
+        NOTIFY_DOMAIN,
+        SERVICE_SEND_MESSAGE,
+        {
+            ATTR_ENTITY_ID: "notify.home_assistant_recipient",
+            ATTR_MESSAGE: "Hello World",
+        },
+        blocking=True,
+    )
+
+    assert smtp.sendmail.call_count == 2
+    state = hass.states.get("notify.home_assistant_recipient")
+    assert state
+    assert state.state == "2026-05-03T03:09:37+00:00"


### PR DESCRIPTION
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When an SMTP server has dropped an idle connection (e.g. Postfix closing an
idle keep-alive), the next email send hits the integration's retry/cleanup
path, which calls `quit()` on the already-dead socket. `smtplib` then raises
`SMTPServerDisconnected("please run connect() first")` from that `quit()`.

That exception was uncaught, so:

- the retry that was meant to recover the connection never happened,
- the email was never sent, and
- the raw exception propagated out of the notify action, **aborting the whole
  automation at the notify step** — any subsequent actions never ran.

This PR guards every `quit()` with a small shared helper that suppresses
`SMTPException`, so a failed cleanup of a dead connection can neither abort a
send nor mask a retry. It is applied in both code paths:

- `MailNotificationService._send_email` — the legacy YAML notify path reported
  in the issue (three `quit()` call sites).
- `MailNotifyEntity._send_email` — the current config-entry path, which had the
  same root cause in its `finally: client.quit()`. There, a raising `quit()`
  additionally masked the translated `HomeAssistantError` raised on the last
  attempt, so callers received a raw `smtplib` error instead.

Two regression tests reproduce the scenario (a dropped connection on the first
attempt while `quit()` raises on the dead socket) for both paths, and assert
that the send recovers on retry. Both tests fail without the fix.

Note: the legacy `MailNotificationService._send_email` loop still silently
gives up after `tries` failed attempts (unlike the entity path, which raises
`HomeAssistantError`). That pre-existing behavior is intentionally left
unchanged here to keep this fix focused.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #174086
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
