### PR TITLE
Suppress SMTPException from quit() during SMTP notify retry

### DIFF
--- a/homeassistant/components/smtp/notify.py
+++ b/homeassistant/components/smtp/notify.py
@@ -1,5 +1,6 @@
 """Mail (SMTP) notification service."""
 
+from contextlib import suppress
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 import email.utils
@@ -236,7 +237,8 @@ class MailNotifyEntity(NotifyEntity):
                         translation_key="send_mail_connection_error",
                     ) from e
             finally:
-                client.quit()
+                with suppress(SMTPException):
+                    client.quit()
 
 
 class MailNotificationService(SmtpClient, BaseNotificationService):
@@ -316,10 +318,13 @@ class MailNotificationService(SmtpClient, BaseNotificationService):
                 _LOGGER.warning(
                     "SMTPServerDisconnected sending mail: retrying connection"
                 )
-                mail.quit()
+                with suppress(SMTPException):
+                    mail.quit()
                 mail = self.connect()
             except SMTPException:
                 _LOGGER.warning("SMTPException sending mail: retrying connection")
-                mail.quit()
+                with suppress(SMTPException):
+                    mail.quit()
                 mail = self.connect()
-        mail.quit()
+        with suppress(SMTPException):
+            mail.quit()

--- a/tests/components/smtp/test_notify.py
+++ b/tests/components/smtp/test_notify.py
@@ -330,12 +330,12 @@ async def test_notify_send_message_exceptions(
     assert e.value.translation_key == translation_key
 
 
+@pytest.mark.usefixtures("make_msgid")
 @pytest.mark.freeze_time("2026-05-03T03:09:37+00:00")
 async def test_notify_retry_on_disconnect_with_broken_quit(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     smtp: MagicMock,
-    make_msgid: None,
 ) -> None:
     """Test retry succeeds when quit() raises on a dead connection."""
 

--- a/tests/components/smtp/test_notify.py
+++ b/tests/components/smtp/test_notify.py
@@ -328,3 +328,34 @@ async def test_notify_send_message_exceptions(
         )
 
     assert e.value.translation_key == translation_key
+
+
+@pytest.mark.freeze_time("2026-05-03T03:09:37+00:00")
+async def test_notify_retry_on_disconnect_with_broken_quit(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    smtp: MagicMock,
+    make_msgid: None,
+) -> None:
+    """Test retry succeeds when quit() raises on a dead connection."""
+
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    smtp.sendmail.side_effect = [SMTPServerDisconnected("gone"), None]
+    smtp.quit.side_effect = SMTPServerDisconnected("please run connect() first")
+
+    await hass.services.async_call(
+        NOTIFY_DOMAIN,
+        SERVICE_SEND_MESSAGE,
+        {
+            ATTR_ENTITY_ID: "notify.home_assistant_recipient",
+            ATTR_MESSAGE: "Hello World",
+        },
+        blocking=True,
+    )
+
+    assert smtp.sendmail.call_count == 2


### PR DESCRIPTION
## Proposed change

When an SMTP server closes an idle connection, the retry logic in `_send_email` calls `mail.quit()` on the dead connection before reconnecting. This raises `SMTPServerDisconnected("please run connect() first")`, which is uncaught and propagates up, aborting the calling automation. The retry never gets a chance to reconnect.

This wraps all `quit()` calls in `contextlib.suppress(SMTPException)` so that a failed quit on a dead connection does not prevent the retry from proceeding. Both the entity-based and legacy notification service code paths are fixed.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/174086
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr