### PR TITLE
Raise ServiceValidationError for unmatched Teslemetry service devices

### DIFF
--- a/homeassistant/components/teslemetry/services.py
+++ b/homeassistant/components/teslemetry/services.py
@@ -1,11 +1,11 @@
 """Service calls for the Teslemetry integration."""
 
 import logging
+from typing import TYPE_CHECKING
 
 import voluptuous as vol
 from voluptuous import All, Range
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_ID,
     ATTR_LOCATION,
@@ -22,6 +22,9 @@ from homeassistant.helpers import config_validation as cv, device_registry as dr
 from .const import DOMAIN
 from .helpers import handle_command, handle_vehicle_command
 from .models import TeslemetryEnergyData, TeslemetryVehicleData
+
+if TYPE_CHECKING:
+    from . import TeslemetryConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -79,38 +82,47 @@ def async_get_device_for_service_call(
 
 def async_get_config_for_device(
     hass: HomeAssistant, device_entry: dr.DeviceEntry
-) -> ConfigEntry:
+) -> TeslemetryConfigEntry:
     """Get the config entry related to a device entry."""
-    config_entry: ConfigEntry
     for entry_id in device_entry.config_entries:
         if entry := hass.config_entries.async_get_entry(entry_id):
             if entry.domain == DOMAIN:
-                config_entry = entry
-    return config_entry
+                return entry
+    raise ServiceValidationError(
+        translation_domain=DOMAIN,
+        translation_key="no_config_entry_for_device",
+        translation_placeholders={"device_id": device_entry.id},
+    )
 
 
 def async_get_vehicle_for_entry(
-    hass: HomeAssistant, device: dr.DeviceEntry, config: ConfigEntry
+    hass: HomeAssistant, device: dr.DeviceEntry, config: TeslemetryConfigEntry
 ) -> TeslemetryVehicleData:
     """Get the vehicle data for a config entry."""
-    vehicle_data: TeslemetryVehicleData
     assert device.serial_number is not None
     for vehicle in config.runtime_data.vehicles:
         if vehicle.vin == device.serial_number:
-            vehicle_data = vehicle
-    return vehicle_data
+            return vehicle
+    raise ServiceValidationError(
+        translation_domain=DOMAIN,
+        translation_key="no_vehicle_data_for_device",
+        translation_placeholders={"device_id": device.id},
+    )
 
 
 def async_get_energy_site_for_entry(
-    hass: HomeAssistant, device: dr.DeviceEntry, config: ConfigEntry
+    hass: HomeAssistant, device: dr.DeviceEntry, config: TeslemetryConfigEntry
 ) -> TeslemetryEnergyData:
     """Get the energy site data for a config entry."""
-    energy_data: TeslemetryEnergyData
     assert device.serial_number is not None
     for energysite in config.runtime_data.energysites:
         if str(energysite.id) == device.serial_number:
-            energy_data = energysite
-    return energy_data
+            return energysite
+    raise ServiceValidationError(
+        translation_domain=DOMAIN,
+        translation_key="no_energy_site_data_for_device",
+        translation_placeholders={"device_id": device.id},
+    )
 
 
 @callback

--- a/tests/components/teslemetry/test_services.py
+++ b/tests/components/teslemetry/test_services.py
@@ -420,3 +420,33 @@ async def test_service_validation_errors(
             blocking=True,
         )
     assert exc_info.value.translation_key == "set_scheduled_departure_off_peak"
+
+    energy_device = entity_registry.async_get(
+        "sensor.energy_site_battery_power"
+    ).device_id
+
+    # Vehicle-only service targeting an energy-site device -> no vehicle match
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_NAVIGATE_ATTR_GPS_REQUEST,
+            {
+                CONF_DEVICE_ID: energy_device,
+                ATTR_GPS: {CONF_LATITUDE: lat, CONF_LONGITUDE: lon},
+            },
+            blocking=True,
+        )
+    assert exc_info.value.translation_key == "no_vehicle_data_for_device"
+
+    # Energy-only service targeting a vehicle device -> no energy-site match
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_TIME_OF_USE,
+            {
+                CONF_DEVICE_ID: vehicle_device,
+                ATTR_TOU_SETTINGS: {"utility": "test"},
+            },
+            blocking=True,
+        )
+    assert exc_info.value.translation_key == "no_energy_site_data_for_device"

--- a/tests/components/teslemetry/test_services.py
+++ b/tests/components/teslemetry/test_services.py
@@ -44,10 +44,12 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import setup_platform
 from .const import COMMAND_ERROR, COMMAND_OK
+
+from tests.common import MockConfigEntry
 
 lat = -27.9699373
 lon = 153.3726526
@@ -360,6 +362,7 @@ async def test_services(
 
 async def test_service_validation_errors(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Tests that the custom services handle bad data."""
@@ -450,3 +453,23 @@ async def test_service_validation_errors(
             blocking=True,
         )
     assert exc_info.value.translation_key == "no_energy_site_data_for_device"
+
+    other_entry = MockConfigEntry(domain="other")
+    other_entry.add_to_hass(hass)
+    other_device = device_registry.async_get_or_create(
+        config_entry_id=other_entry.entry_id,
+        identifiers={("other", "unrelated")},
+    )
+
+    # Teslemetry service targeting a device with no Teslemetry config entry
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_NAVIGATE_ATTR_GPS_REQUEST,
+            {
+                CONF_DEVICE_ID: other_device.id,
+                ATTR_GPS: {CONF_LATITUDE: lat, CONF_LONGITUDE: lon},
+            },
+            blocking=True,
+        )
+    assert exc_info.value.translation_key == "no_config_entry_for_device"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Three Teslemetry service device-lookup helpers (`async_get_config_for_device`, `async_get_vehicle_for_entry`, `async_get_energy_site_for_entry`) assigned their result only inside a loop and then returned it unconditionally, so a service call targeting a device with no matching entry fell off the end of the loop and raised a bare `UnboundLocalError` instead of a useful error. This is reachable today, for example when a vehicle-only service such as `navigation_gps_request` is targeted at an energy-site device (or an energy-only service at a vehicle device). The helpers now return on the first match and otherwise raise `ServiceValidationError`, wiring up the integration's existing but previously-unused translation keys `no_config_entry_for_device`, `no_vehicle_data_for_device`, and `no_energy_site_data_for_device`. They also now take the typed `TeslemetryConfigEntry` so `config.runtime_data` is correctly typed. Tests were added covering the vehicle/energy device-mismatch cases.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
