### PR TITLE
Remove radio firmware version from device info in homeassistant_yellow

### DIFF
--- a/homeassistant/components/homeassistant_yellow/update.py
+++ b/homeassistant/components/homeassistant_yellow/update.py
@@ -166,7 +166,7 @@ class FirmwareUpdateEntity(BaseFirmwareUpdateEntity):
             name=MODEL,
             model=MODEL,
             manufacturer=MANUFACTURER,
-            sw_version=None,  # Radio FW exposed by the update entity, removed in 2026.6.0
+            sw_version=None,  # Radio FW exposed by the update entity, removed in 2026.7.0
         )
 
         # Use the cached firmware info if it exists

--- a/homeassistant/components/homeassistant_yellow/update.py
+++ b/homeassistant/components/homeassistant_yellow/update.py
@@ -18,7 +18,7 @@ from homeassistant.components.homeassistant_hardware.util import (
 from homeassistant.components.update import UpdateDeviceClass
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -166,6 +166,7 @@ class FirmwareUpdateEntity(BaseFirmwareUpdateEntity):
             name=MODEL,
             model=MODEL,
             manufacturer=MANUFACTURER,
+            sw_version=None,  # Radio FW exposed by the update entity, removed in 2026.6.0
         )
 
         # Use the cached firmware info if it exists
@@ -177,20 +178,6 @@ class FirmwareUpdateEntity(BaseFirmwareUpdateEntity):
                 owners=[],
                 source="homeassistant_yellow",
             )
-
-    def _update_attributes(self) -> None:
-        """Recompute the attributes of the entity."""
-        super()._update_attributes()
-
-        assert self.device_entry is not None
-        device_registry = dr.async_get(self.hass)
-        device_registry.async_update_device(
-            device_id=self.device_entry.id,
-            sw_version=(
-                f"{self.entity_description.firmware_name}"
-                f" {self._attr_installed_version}"
-            ),
-        )
 
     @callback
     def _firmware_info_callback(self, firmware_info: FirmwareInfo) -> None:

--- a/tests/components/homeassistant_yellow/test_init.py
+++ b/tests/components/homeassistant_yellow/test_init.py
@@ -21,7 +21,7 @@ from homeassistant.components.usb import SerialDevice, async_scan_serial_ports
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers import device_registry as dr, issue_registry as ir
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry, MockModule, mock_integration
@@ -546,3 +546,46 @@ async def test_migrate_entry(
     assert config_entry.options == {}
     assert config_entry.minor_version == HomeAssistantYellowConfigFlow.MINOR_VERSION
     assert config_entry.version == HomeAssistantYellowConfigFlow.VERSION
+
+
+async def test_setup_entry_clears_sw_version(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test setup clears the redundant firmware version from the device."""
+    mock_integration(hass, MockModule("hassio"))
+    await async_setup_component(hass, HASSIO_DOMAIN, {})
+
+    config_entry = MockConfigEntry(
+        data={"firmware": "ezsp", "firmware_version": "7.3.1.0"},
+        domain=DOMAIN,
+        options={},
+        title="Home Assistant Yellow",
+        version=1,
+        minor_version=4,
+    )
+    config_entry.add_to_hass(hass)
+
+    device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, "yellow")},
+        sw_version="EmberZNet Zigbee 7.3.1.0",
+    )
+    assert device.sw_version == "EmberZNet Zigbee 7.3.1.0"
+
+    with (
+        patch(
+            "homeassistant.components.homeassistant_yellow.get_os_info",
+            return_value={"board": "yellow"},
+        ),
+        patch(
+            "homeassistant.components.homeassistant_yellow.multi_pan_addon_using_device",
+            return_value=False,
+        ),
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    device = device_registry.async_get(device.id)
+    assert device is not None
+    assert device.sw_version is None


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The radio firmware is reported as sw_version by homeassistant_yellow integration, which results in "Firmware: ..." being shown in the Device info section of the device detail page. This is redundant with the information provided by the "Radio firmware" update entity, and would become outright confusing when we expose CM firmware update entity (in PR #172929), which would show separate "Firmware" and "Radio firmware", while reporting radio firmware version in device info.


<img width="662" height="385" alt="Screenshot_2026-06-17_11-47-40" src="https://github.com/user-attachments/assets/9a90ab25-3459-4fe0-9cb6-5749e09656a2" />

We have no way to easily change the "Firmware:" prefix, so stop providing the version in sw_info instead and set it to None to clear it in the device registry (similarly to what was done in #150844). User doesn't lose any information, as it's still one click away.

(marking as "bugfix" as fixes the otherwise upcoming confusion, not sure we there's more fitting option)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
