### PR TITLE
Add announcements and communications switches to Alexa Devices

### DIFF
--- a/homeassistant/components/alexa_devices/icons.json
+++ b/homeassistant/components/alexa_devices/icons.json
@@ -9,6 +9,26 @@
       "voc_index": {
         "default": "mdi:molecule"
       }
+    },
+    "switch": {
+      "announcements": {
+        "default": "mdi:microphone-message",
+        "state": {
+          "off": "mdi:microphone-message-off"
+        }
+      },
+      "communications": {
+        "default": "mdi:message-bulleted",
+        "state": {
+          "off": "mdi:message-bulleted-off"
+        }
+      },
+      "do_not_disturb": {
+        "default": "mdi:bell",
+        "state": {
+          "off": "mdi:bell-off"
+        }
+      }
     }
   },
   "services": {

--- a/homeassistant/components/alexa_devices/strings.json
+++ b/homeassistant/components/alexa_devices/strings.json
@@ -93,6 +93,12 @@
       }
     },
     "switch": {
+      "announcements": {
+        "name": "Announcements"
+      },
+      "communications": {
+        "name": "Communications"
+      },
       "do_not_disturb": {
         "name": "Do not disturb"
       }

--- a/homeassistant/components/alexa_devices/switch.py
+++ b/homeassistant/components/alexa_devices/switch.py
@@ -11,6 +11,7 @@ from homeassistant.components.switch import (
     SwitchEntity,
     SwitchEntityDescription,
 )
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -19,6 +20,9 @@ from .entity import AmazonEntity
 from .utils import async_remove_dnd_from_virtual_group, async_update_unique_id
 
 PARALLEL_UPDATES = 1
+
+TYPE_SENSOR = "sensor"
+TYPE_COMMUNICATION = "communication"
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -32,14 +36,42 @@ class AmazonSwitchEntityDescription(SwitchEntityDescription):
         and sensor.error is False
     )
     method: str
+    switch_type: str
 
 
-SWITCHES: Final = (
+SENSOR_SWITCHES: Final = (
     AmazonSwitchEntityDescription(
         key="dnd",
         translation_key="do_not_disturb",
         is_on_fn=lambda device: bool(device.sensors["dnd"].value),
         method="set_do_not_disturb",
+        switch_type=TYPE_SENSOR,
+    ),
+)
+COMMUNICATION_SWITCHES: Final = (
+    AmazonSwitchEntityDescription(
+        key="announcements",
+        translation_key="announcements",
+        entity_category=EntityCategory.CONFIG,
+        is_on_fn=lambda device: device.communication_settings["announcements"] == "ON",
+        is_available_fn=lambda device, key: (
+            device.online
+            and device.communication_settings.get(key) is not None
+            and device.communication_settings.get("communications") != "OFF"
+        ),
+        method="set_announcement_status",
+        switch_type=TYPE_COMMUNICATION,
+    ),
+    AmazonSwitchEntityDescription(
+        key="communications",
+        translation_key="communications",
+        entity_category=EntityCategory.CONFIG,
+        is_on_fn=lambda device: device.communication_settings["communications"] == "ON",
+        is_available_fn=lambda device, key: (
+            device.online and device.communication_settings.get(key) is not None
+        ),
+        method="set_communication_status",
+        switch_type=TYPE_COMMUNICATION,
     ),
 )
 
@@ -70,12 +102,20 @@ async def async_setup_entry(
         new_devices = current_devices - known_devices
         if new_devices:
             known_devices.update(new_devices)
-            async_add_entities(
+            sensor_switches = [
                 AmazonSwitchEntity(coordinator, serial_num, switch_desc)
-                for switch_desc in SWITCHES
+                for switch_desc in SENSOR_SWITCHES
                 for serial_num in new_devices
                 if switch_desc.key in coordinator.data[serial_num].sensors
-            )
+            ]
+            communication_switches = [
+                AmazonSwitchEntity(coordinator, serial_num, switch_desc)
+                for switch_desc in COMMUNICATION_SWITCHES
+                for serial_num in new_devices
+                if switch_desc.key
+                in coordinator.data[serial_num].communication_settings
+            ]
+            async_add_entities(sensor_switches + communication_switches)
 
     _check_device()
     entry.async_on_unload(coordinator.async_add_listener(_check_device))
@@ -95,9 +135,14 @@ class AmazonSwitchEntity(AmazonEntity, SwitchEntity):
 
         async with alexa_api_call(self.coordinator):
             await method(self.device, state)
-        self.coordinator.data[self.device.serial_number].sensors[
-            self.entity_description.key
-        ].value = state
+        if self.entity_description.switch_type == TYPE_SENSOR:
+            self.coordinator.data[self.device.serial_number].sensors[
+                self.entity_description.key
+            ].value = state
+        elif self.entity_description.switch_type == TYPE_COMMUNICATION:
+            self.coordinator.data[self.device.serial_number].communication_settings[
+                self.entity_description.key
+            ] = "ON" if state else "OFF"
         self.async_write_ha_state()
 
     async def async_turn_on(self, **kwargs: Any) -> None:

--- a/tests/components/alexa_devices/const.py
+++ b/tests/components/alexa_devices/const.py
@@ -78,10 +78,8 @@ TEST_DEVICE_1 = AmazonDevice(
     },
     media_player_supported=True,
     communication_settings={
-        "calling": None,
-        "communications": "ON",
         "announcements": "ON",
-        "messaging": None,
+        "communications": "ON",
         "dropin": "All",
     },
 )

--- a/tests/components/alexa_devices/const.py
+++ b/tests/components/alexa_devices/const.py
@@ -77,7 +77,13 @@ TEST_DEVICE_1 = AmazonDevice(
         ),
     },
     media_player_supported=True,
-    communication_settings={},
+    communication_settings={
+        "calling": None,
+        "communications": "ON",
+        "announcements": "ON",
+        "messaging": None,
+        "dropin": "All",
+    },
 )
 
 TEST_DEVICE_2_SN = "echo_test_2_serial_number"

--- a/tests/components/alexa_devices/snapshots/test_services.ambr
+++ b/tests/components/alexa_devices/snapshots/test_services.ambr
@@ -10,10 +10,8 @@
         ]),
         'communication_settings': dict({
           'announcements': 'ON',
-          'calling': None,
           'communications': 'ON',
           'dropin': 'All',
-          'messaging': None,
         }),
         'device_cluster_members': dict({
           'echo_test_serial_number': 'echo_test_device_id',
@@ -88,10 +86,8 @@
         ]),
         'communication_settings': dict({
           'announcements': 'ON',
-          'calling': None,
           'communications': 'ON',
           'dropin': 'All',
-          'messaging': None,
         }),
         'device_cluster_members': dict({
           'echo_test_serial_number': 'echo_test_device_id',
@@ -166,10 +162,8 @@
         ]),
         'communication_settings': dict({
           'announcements': 'ON',
-          'calling': None,
           'communications': 'ON',
           'dropin': 'All',
-          'messaging': None,
         }),
         'device_cluster_members': dict({
           'echo_test_serial_number': 'echo_test_device_id',

--- a/tests/components/alexa_devices/snapshots/test_services.ambr
+++ b/tests/components/alexa_devices/snapshots/test_services.ambr
@@ -9,6 +9,11 @@
           'MICROPHONE',
         ]),
         'communication_settings': dict({
+          'announcements': 'ON',
+          'calling': None,
+          'communications': 'ON',
+          'dropin': 'All',
+          'messaging': None,
         }),
         'device_cluster_members': dict({
           'echo_test_serial_number': 'echo_test_device_id',
@@ -82,6 +87,11 @@
           'MICROPHONE',
         ]),
         'communication_settings': dict({
+          'announcements': 'ON',
+          'calling': None,
+          'communications': 'ON',
+          'dropin': 'All',
+          'messaging': None,
         }),
         'device_cluster_members': dict({
           'echo_test_serial_number': 'echo_test_device_id',
@@ -155,6 +165,11 @@
           'MICROPHONE',
         ]),
         'communication_settings': dict({
+          'announcements': 'ON',
+          'calling': None,
+          'communications': 'ON',
+          'dropin': 'All',
+          'messaging': None,
         }),
         'device_cluster_members': dict({
           'echo_test_serial_number': 'echo_test_device_id',

--- a/tests/components/alexa_devices/snapshots/test_switch.ambr
+++ b/tests/components/alexa_devices/snapshots/test_switch.ambr
@@ -1,4 +1,104 @@
 # serializer version: 1
+# name: test_all_entities[switch.echo_test_announcements-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.echo_test_announcements',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Announcements',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Announcements',
+    'platform': 'alexa_devices',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'announcements',
+    'unique_id': 'echo_test_serial_number-announcements',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[switch.echo_test_announcements-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Echo Test Announcements',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.echo_test_announcements',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_all_entities[switch.echo_test_communications-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.echo_test_communications',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Communications',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Communications',
+    'platform': 'alexa_devices',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'communications',
+    'unique_id': 'echo_test_serial_number-communications',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[switch.echo_test_communications-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Echo Test Communications',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.echo_test_communications',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
 # name: test_all_entities[switch.echo_test_do_not_disturb-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/alexa_devices/test_switch.py
+++ b/tests/components/alexa_devices/test_switch.py
@@ -189,10 +189,8 @@ async def test_switch_communication(
 
     device_data = deepcopy(TEST_DEVICE_1)
     device_data.communication_settings = {
-        "calling": None,
-        "communications": "OFF",
         "announcements": "ON",
-        "messaging": None,
+        "communications": "OFF",
         "dropin": "All",
     }
 
@@ -214,10 +212,8 @@ async def test_switch_communication(
         blocking=True,
     )
     device_data.communication_settings = {
-        "calling": None,
-        "communications": "ON",
         "announcements": "ON",
-        "messaging": None,
+        "communications": "ON",
         "dropin": "All",
     }
 

--- a/tests/components/alexa_devices/test_switch.py
+++ b/tests/components/alexa_devices/test_switch.py
@@ -162,3 +162,73 @@ async def test_offline_device(
 
     assert (state := hass.states.get(ENTITY_ID))
     assert state.state != STATE_UNAVAILABLE
+
+
+async def test_switch_communication(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_amazon_devices_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test switching Communication."""
+    await setup_integration(hass, mock_config_entry)
+
+    entity_id = "switch.echo_test_communications"
+
+    assert (state := hass.states.get(entity_id))
+    assert state.state == STATE_ON
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+
+    assert mock_amazon_devices_client.set_communication_status.call_count == 1
+
+    device_data = deepcopy(TEST_DEVICE_1)
+    device_data.communication_settings = {
+        "calling": None,
+        "communications": "OFF",
+        "announcements": "ON",
+        "messaging": None,
+        "dropin": "All",
+    }
+
+    mock_amazon_devices_client.get_devices_data.return_value = {
+        TEST_DEVICE_1_SN: device_data
+    }
+
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert (state := hass.states.get(entity_id))
+    assert state.state == STATE_OFF
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    device_data.communication_settings = {
+        "calling": None,
+        "communications": "ON",
+        "announcements": "ON",
+        "messaging": None,
+        "dropin": "All",
+    }
+
+    mock_amazon_devices_client.get_devices_data.return_value = {
+        TEST_DEVICE_1_SN: device_data
+    }
+
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert mock_amazon_devices_client.set_communication_status.call_count == 2
+    assert (state := hass.states.get(entity_id))
+    assert state.state == STATE_ON


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add announcements and communications switches to Alexa Devices

Note: added also missing icons to DND switch

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
