### PR TITLE
Add read/write fan mode values for Modbus climate

### DIFF
--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -172,6 +172,11 @@ from .validators import (
 _LOGGER = logging.getLogger(__name__)
 
 
+FAN_MODE_VALUE_SCHEMA = vol.Any(
+    cv.positive_int,
+    vol.All(cv.ensure_list, vol.ExactSequence([cv.positive_int, cv.positive_int])),
+)
+
 BASE_SCHEMA = vol.Schema({vol.Optional(CONF_NAME, default=DEFAULT_HUB): cv.string})
 
 
@@ -371,16 +376,16 @@ CLIMATE_SCHEMA = vol.All(
                     {
                         vol.Required(CONF_ADDRESS): register_int_list_validator,
                         CONF_FAN_MODE_VALUES: {
-                            vol.Optional(CONF_FAN_MODE_ON): cv.positive_int,
-                            vol.Optional(CONF_FAN_MODE_OFF): cv.positive_int,
-                            vol.Optional(CONF_FAN_MODE_AUTO): cv.positive_int,
-                            vol.Optional(CONF_FAN_MODE_LOW): cv.positive_int,
-                            vol.Optional(CONF_FAN_MODE_MEDIUM): cv.positive_int,
-                            vol.Optional(CONF_FAN_MODE_HIGH): cv.positive_int,
-                            vol.Optional(CONF_FAN_MODE_TOP): cv.positive_int,
-                            vol.Optional(CONF_FAN_MODE_MIDDLE): cv.positive_int,
-                            vol.Optional(CONF_FAN_MODE_FOCUS): cv.positive_int,
-                            vol.Optional(CONF_FAN_MODE_DIFFUSE): cv.positive_int,
+                            vol.Optional(CONF_FAN_MODE_ON): FAN_MODE_VALUE_SCHEMA,
+                            vol.Optional(CONF_FAN_MODE_OFF): FAN_MODE_VALUE_SCHEMA,
+                            vol.Optional(CONF_FAN_MODE_AUTO): FAN_MODE_VALUE_SCHEMA,
+                            vol.Optional(CONF_FAN_MODE_LOW): FAN_MODE_VALUE_SCHEMA,
+                            vol.Optional(CONF_FAN_MODE_MEDIUM): FAN_MODE_VALUE_SCHEMA,
+                            vol.Optional(CONF_FAN_MODE_HIGH): FAN_MODE_VALUE_SCHEMA,
+                            vol.Optional(CONF_FAN_MODE_TOP): FAN_MODE_VALUE_SCHEMA,
+                            vol.Optional(CONF_FAN_MODE_MIDDLE): FAN_MODE_VALUE_SCHEMA,
+                            vol.Optional(CONF_FAN_MODE_FOCUS): FAN_MODE_VALUE_SCHEMA,
+                            vol.Optional(CONF_FAN_MODE_DIFFUSE): FAN_MODE_VALUE_SCHEMA,
                         },
                     },
                     duplicate_fan_mode_validator,

--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -258,9 +258,13 @@ class ModbusThermostat(ModbusStructEntity, RestoreEntity, ClimateEntity):
                 (CONF_FAN_MODE_DIFFUSE, FAN_DIFFUSE),
             ):
                 if fan_mode_kw in mode_value_config:
-                    value = mode_value_config[fan_mode_kw]
-                    self._fan_mode_mapping_from_modbus[value] = fan_mode
-                    self._fan_mode_mapping_to_modbus[fan_mode] = value
+                    values = mode_value_config[fan_mode_kw]
+                    if isinstance(values, list):
+                        read_value, write_value = values
+                    else:
+                        read_value = write_value = values
+                    self._fan_mode_mapping_from_modbus[read_value] = fan_mode
+                    self._fan_mode_mapping_to_modbus[fan_mode] = write_value
                     self._attr_fan_modes.append(fan_mode)
         else:
             # No FAN modes defined

--- a/homeassistant/components/modbus/validators.py
+++ b/homeassistant/components/modbus/validators.py
@@ -239,10 +239,15 @@ def nan_validator(value: Any) -> int:
 
 def duplicate_fan_mode_validator(config: dict[str, Any]) -> dict:
     """Control modbus climate fan mode values for duplicates."""
-    fan_modes: set[int] = set()
+    read_fan_modes: set[int] = set()
+    write_fan_modes: set[int] = set()
     errors = []
     for key, value in config[CONF_FAN_MODE_VALUES].items():
-        if value in fan_modes:
+        if isinstance(value, list):
+            read_value, write_value = value
+        else:
+            read_value = write_value = value
+        if read_value in read_fan_modes or write_value in write_fan_modes:
             warn = (
                 f"Modbus fan mode {key} has a duplicate value"
                 f" {value}, not loaded, values must be unique!"
@@ -250,7 +255,8 @@ def duplicate_fan_mode_validator(config: dict[str, Any]) -> dict:
             _LOGGER.warning(warn)
             errors.append(key)
         else:
-            fan_modes.add(value)
+            read_fan_modes.add(read_value)
+            write_fan_modes.add(write_value)
 
     for key in reversed(errors):
         del config[CONF_FAN_MODE_VALUES][key]

--- a/tests/components/modbus/test_climate.py
+++ b/tests/components/modbus/test_climate.py
@@ -1124,6 +1124,31 @@ async def test_service_climate_action_update(
             FAN_TOP,
             [0x03],
         ),
+        (
+            {
+                CONF_CLIMATES: [
+                    {
+                        CONF_NAME: TEST_ENTITY_NAME,
+                        CONF_TARGET_TEMP: 117,
+                        CONF_ADDRESS: 117,
+                        CONF_SLAVE: 10,
+                        CONF_SCAN_INTERVAL: 0,
+                        CONF_DATA_TYPE: DataType.INT32,
+                        CONF_FAN_MODE_REGISTER: {
+                            CONF_ADDRESS: [118],
+                            CONF_FAN_MODE_VALUES: {
+                                CONF_FAN_MODE_LOW: 0,
+                                CONF_FAN_MODE_MEDIUM: 1,
+                                CONF_FAN_MODE_HIGH: 2,
+                                CONF_FAN_MODE_TOP: [3, 4],
+                            },
+                        },
+                    },
+                ]
+            },
+            FAN_TOP,
+            [0x03],
+        ),
     ],
 )
 async def test_service_climate_fan_update(
@@ -1531,6 +1556,29 @@ async def test_service_set_hvac_mode(
                             CONF_FAN_MODE_VALUES: {
                                 CONF_FAN_MODE_ON: 1,
                                 CONF_FAN_MODE_OFF: 2,
+                            },
+                        },
+                    }
+                ]
+            },
+        ),
+        (
+            FAN_TOP,
+            [0x04],
+            {
+                CONF_CLIMATES: [
+                    {
+                        CONF_NAME: TEST_ENTITY_NAME,
+                        CONF_TARGET_TEMP: 117,
+                        CONF_ADDRESS: 117,
+                        CONF_SLAVE: 10,
+                        CONF_FAN_MODE_REGISTER: {
+                            CONF_ADDRESS: 118,
+                            CONF_FAN_MODE_VALUES: {
+                                CONF_FAN_MODE_LOW: 0,
+                                CONF_FAN_MODE_MEDIUM: 1,
+                                CONF_FAN_MODE_HIGH: 2,
+                                CONF_FAN_MODE_TOP: [3, 4],
                             },
                         },
                     }


### PR DESCRIPTION
## Proposed change

Add support for asymmetric Modbus climate fan mode values while keeping the existing configuration format backwards compatible.

Today each `fan_mode_register.values` entry maps one Home Assistant fan mode to one Modbus value used for both reads and writes:

```yaml
fan_mode_register:
  address: 118
  values:
    state_fan_low: 0
    state_fan_medium: 1
    state_fan_high: 2
```

Some Modbus climate devices report one value for a fan mode but require a different value when writing that same fan mode. This PR allows those modes to be configured as `[read value, write value]`:

```yaml
fan_mode_register:
  address: 118
  values:
    state_fan_low: 0
    state_fan_medium: 1
    state_fan_high: 2
    state_fan_top: [3, 4]
```

Single integer values keep the current behavior. Two-item lists only need to be used for fan modes where read and write values differ.

This reworks the earlier closed PR https://github.com/home-assistant/core/pull/148242 using the compact approach suggested in review there, instead of adding separate `read_values` and `write_values` maps.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: asymmetric Modbus fan mode read/write values for climate devices, including the Gree Multi VRF BMS Modbus use case discussed in https://github.com/home-assistant/core/pull/148242
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/46291
- Link to developer documentation pull request:
- Link to frontend pull request:

## Local validation

Tested on a Home Assistant 2025.3.0 installation running a custom Modbus climate setup for a Gree VRF/BMS gateway. A room climate was configured with compact fan mappings:

```yaml
state_fan_medium: [5, 4]
state_fan_top: [8, 7]
```

Validation result:

- `homeassistant.check_config` returned `[]`
- `modbus.reload` returned `[]`
- direct Modbus read showed register `5` mapped to Home Assistant fan mode `medium`
- `climate.set_fan_mode` to `top` wrote the configured write value and the device reported read value `8`, mapped back to `top`
- `climate.set_fan_mode` back to `medium` restored the device to read value `5`, mapped back to `medium`

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr