### PR TITLE
Use reachability diagnostics for __init__.py in HueBLE

### DIFF
--- a/homeassistant/components/hue_ble/__init__.py
+++ b/homeassistant/components/hue_ble/__init__.py
@@ -4,14 +4,17 @@ import logging
 
 from HueBLE import ConnectionError, HueBleError, HueBleLight
 
+from homeassistant.components import bluetooth
 from homeassistant.components.bluetooth import (
+    BluetoothReachabilityIntent,
     async_ble_device_from_address,
-    async_scanner_count,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,15 +29,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: HueBLEConfigEntry) -> bo
 
     ble_device = async_ble_device_from_address(hass, address, connectable=True)
 
-    if ble_device is None:
-        count_scanners = async_scanner_count(hass, connectable=True)
-        _LOGGER.debug("Count of BLE scanners: %i", count_scanners)
-
-        if count_scanners < 1:
-            raise ConfigEntryNotReady(
-                "No Bluetooth scanners are available to search for the light."
-            )
-        raise ConfigEntryNotReady("The light was not found.")
+    if not ble_device:
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN,
+            translation_key="device_not_found",
+            translation_placeholders={
+                "name": entry.title,
+                "mac": address,
+                "reason": bluetooth.async_address_reachability_diagnostics(
+                    hass,
+                    address.upper(),
+                    BluetoothReachabilityIntent.CONNECTION,
+                ),
+            },
+        )
 
     light = HueBleLight(ble_device)
 

--- a/homeassistant/components/hue_ble/strings.json
+++ b/homeassistant/components/hue_ble/strings.json
@@ -27,5 +27,10 @@
         "description": "[%key:component::bluetooth::config::step::user::description%]"
       }
     }
+  },
+  "exceptions": {
+    "device_not_found": {
+      "message": "The light {name} ({mac}) was not found: {reason}"
+    }
   }
 }

--- a/tests/components/hue_ble/test_init.py
+++ b/tests/components/hue_ble/test_init.py
@@ -20,7 +20,7 @@ from tests.components.bluetooth import generate_ble_device
 @pytest.mark.parametrize(
     (
         "ble_device",
-        "scanner_count",
+        "reachability_reason",
         "connect_result",
         "poll_state_result",
         "message",
@@ -28,47 +28,42 @@ from tests.components.bluetooth import generate_ble_device
     [
         (
             None,
-            2,
+            "Bad vibes",
             True,
             None,
-            "The light was not found.",
-        ),
-        (
-            None,
-            0,
-            True,
-            None,
-            "No Bluetooth scanners are available to search for the light.",
+            f"The light {TEST_DEVICE_NAME} ({TEST_DEVICE_MAC}) was not found: Bad vibes",
         ),
         (
             generate_ble_device(TEST_DEVICE_MAC, TEST_DEVICE_NAME),
-            2,
+            None,
             False,
             ConnectionError,
             "Device found but unable to connect.",
         ),
         (
             generate_ble_device(TEST_DEVICE_MAC, TEST_DEVICE_NAME),
-            2,
+            None,
             True,
             HueBleError,
             "Device found and connected but unable to poll values from it.",
         ),
     ],
-    ids=["no_device", "no_scanners", "error_connect", "error_poll"],
+    ids=["no_device", "error_connect", "error_poll"],
 )
 async def test_setup_error(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
+    reachability_reason: str,
     ble_device: BLEDevice | None,
-    scanner_count: int,
     connect_result: Exception | None,
     poll_state_result: Exception | None,
     message: str,
 ) -> None:
     """Test that ConfigEntryNotReady is raised if there is an error condition."""
 
-    entry = MockConfigEntry(domain=DOMAIN, unique_id="abcd", data={})
+    entry = MockConfigEntry(
+        domain=DOMAIN, title=TEST_DEVICE_NAME, unique_id=TEST_DEVICE_MAC, data={}
+    )
     entry.add_to_hass(hass)
     with (
         patch(
@@ -76,8 +71,8 @@ async def test_setup_error(
             return_value=ble_device,
         ),
         patch(
-            "homeassistant.components.hue_ble.async_scanner_count",
-            return_value=scanner_count,
+            "homeassistant.components.hue_ble.bluetooth.async_address_reachability_diagnostics",
+            return_value=reachability_reason,
         ),
         patch(
             "homeassistant.components.hue_ble.HueBleLight.connect",
@@ -105,10 +100,6 @@ async def test_setup(
         patch(
             "homeassistant.components.hue_ble.async_ble_device_from_address",
             return_value=generate_ble_device(TEST_DEVICE_MAC, TEST_DEVICE_NAME),
-        ),
-        patch(
-            "homeassistant.components.hue_ble.async_scanner_count",
-            return_value=1,
         ),
         patch(
             "homeassistant.components.hue_ble.HueBleLight.connect",

--- a/tests/components/hue_ble/test_light.py
+++ b/tests/components/hue_ble/test_light.py
@@ -13,7 +13,6 @@ from tests.common import MockConfigEntry, snapshot_platform
 
 async def test_light(
     hass: HomeAssistant,
-    mock_scanner_count: AsyncMock,
     mock_light: AsyncMock,
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This implements reachability diagnostics for HueBLE in `__init__.py` as requested [here](https://github.com/home-assistant/core/issues/172788).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #172788
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
