### PR TITLE
Add Tuya fixture for GIEX watering timer

### DIFF
--- a/tests/components/tuya/fixtures/ggq_7ytb3h8u.json
+++ b/tests/components/tuya/fixtures/ggq_7ytb3h8u.json
@@ -1,0 +1,52 @@
+{
+  "endpoint": "https://apigw.tuyaeu.com",
+  "mqtt_connected": true,
+  "disabled_by": null,
+  "disabled_polling": false,
+  "name": "GIEX Watering Timer",
+  "category": "ggq",
+  "product_id": "7ytb3h8u",
+  "product_name": "GIEX Watering Timer",
+  "online": true,
+  "sub": true,
+  "time_zone": "+01:00",
+  "active_time": "2026-04-29T18:52:57+00:00",
+  "create_time": "2026-04-29T18:52:57+00:00",
+  "update_time": "2026-04-29T18:52:57+00:00",
+  "function": {
+    "switch": {
+      "type": "Boolean",
+      "value": "{}"
+    },
+    "start": {
+      "type": "Boolean",
+      "value": "{}"
+    },
+    "smart_weather": {
+      "type": "Enum",
+      "value": "{\"range\":[\"sunny\",\"cloudy\",\"rainy\",\"snowy\"]}"
+    }
+  },
+  "status_range": {
+    "switch": {
+      "type": "Boolean",
+      "value": "{}",
+      "report_type": null
+    },
+    "start": {
+      "type": "Boolean",
+      "value": "{}",
+      "report_type": null
+    },
+    "smart_weather": {
+      "type": "Enum",
+      "value": "{\"range\":[\"sunny\",\"cloudy\",\"rainy\",\"snowy\"]}",
+      "report_type": null
+    }
+  },
+  "status": {
+    "switch": false,
+    "start": false,
+    "smart_weather": "sunny"
+  }
+}

--- a/tests/components/tuya/snapshots/test_init.ambr
+++ b/tests/components/tuya/snapshots/test_init.ambr
@@ -8276,6 +8276,37 @@
     'via_device_id': None,
   })
 # ---
+# name: test_device_registry[u8h3bty7qgg]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'config_entries_subentries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'tuya',
+        'u8h3bty7qgg',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'Tuya',
+    'model': 'GIEX Watering Timer (unsupported)',
+    'model_id': '7ytb3h8u',
+    'name': 'GIEX Watering Timer',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
 # name: test_device_registry[uBLyTOvlhoRWXKjrps]
   DeviceRegistryEntrySnapshot({
     'area_id': None,


### PR DESCRIPTION
## Proposed change
Add a Tuya fixture for the GIEX Watering Timer diagnostic dump, product `7ytb3h8u`, category `ggq`.

This is the preliminary fixture-only PR requested in review of #174085. It intentionally does not add support mappings.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration or service within an existing integration
- [x] Code quality improvements to existing code or addition of tests

## Additional information
The fixture is sanitized from the Home Assistant Tuya diagnostics export for a real GIEX Watering Timer. Since current Tuya mappings do not generate entities for this device, the associated snapshot change is the device registry entry showing the model as unsupported.

Follow-up support PR: #174085

## Checklist
- [x] The code change is tested and works locally.
- [ ] Local tests pass. Your PR cannot be merged unless tests pass.
- [x] There is no commented out code in this PR.

## Tests
- `python3 -m json.tool tests/components/tuya/fixtures/ggq_7ytb3h8u.json`
- `git diff --check`

Pytest was not run locally because the Home Assistant test dependencies are not installed in this checkout.