### PR TITLE
Migrate actiontec to ScannerEntity

### DIFF
--- a/homeassistant/components/actiontec/__init__.py
+++ b/homeassistant/components/actiontec/__init__.py
@@ -1,1 +1,22 @@
 """The Actiontec integration."""
+
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+from .coordinator import ActiontecConfigEntry, ActiontecDataUpdateCoordinator
+
+PLATFORMS = [Platform.DEVICE_TRACKER]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ActiontecConfigEntry) -> bool:
+    """Set up Actiontec from a config entry."""
+    coordinator = ActiontecDataUpdateCoordinator(hass, entry)
+    await coordinator.async_config_entry_first_refresh()
+    entry.runtime_data = coordinator
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ActiontecConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/actiontec/config_flow.py
+++ b/homeassistant/components/actiontec/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for the Actiontec integration."""
 
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -34,6 +34,7 @@ class ActiontecConfigFlow(ConfigFlow, domain=DOMAIN):
         )
         return devices is not None
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -55,5 +56,7 @@ class ActiontecConfigFlow(ConfigFlow, domain=DOMAIN):
         """Import existing configuration from configuration.yaml."""
         self._async_abort_entries_match({CONF_HOST: import_data[CONF_HOST]})
         if await self._async_can_connect(import_data):
-            return self.async_create_entry(title=import_data[CONF_HOST], data=import_data)
+            return self.async_create_entry(
+                title=import_data[CONF_HOST], data=import_data
+            )
         return self.async_abort(reason="cannot_connect")

--- a/homeassistant/components/actiontec/config_flow.py
+++ b/homeassistant/components/actiontec/config_flow.py
@@ -26,15 +26,12 @@ class ActiontecConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def _async_can_connect(self, user_input: dict[str, Any]) -> bool:
         """Return true if the Actiontec router returns data."""
-        try:
-            devices = await self.hass.async_add_executor_job(
-                get_actiontec_data,
-                user_input[CONF_HOST],
-                user_input[CONF_USERNAME],
-                user_input[CONF_PASSWORD],
-            )
-        except OSError:
-            return False
+        devices = await self.hass.async_add_executor_job(
+            get_actiontec_data,
+            user_input[CONF_HOST],
+            user_input[CONF_USERNAME],
+            user_input[CONF_PASSWORD],
+        )
         return devices is not None
 
     async def async_step_user(

--- a/homeassistant/components/actiontec/config_flow.py
+++ b/homeassistant/components/actiontec/config_flow.py
@@ -1,0 +1,62 @@
+"""Config flow for the Actiontec integration."""
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+
+from .const import DOMAIN
+from .coordinator import get_actiontec_data
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): str,
+        vol.Required(CONF_USERNAME): str,
+        vol.Required(CONF_PASSWORD): str,
+    }
+)
+
+
+class ActiontecConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Actiontec."""
+
+    VERSION = 1
+
+    async def _async_can_connect(self, user_input: dict[str, Any]) -> bool:
+        """Return true if the Actiontec router returns data."""
+        try:
+            devices = await self.hass.async_add_executor_job(
+                get_actiontec_data,
+                user_input[CONF_HOST],
+                user_input[CONF_USERNAME],
+                user_input[CONF_PASSWORD],
+            )
+        except OSError:
+            return False
+        return devices is not None
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            self._async_abort_entries_match({CONF_HOST: user_input[CONF_HOST]})
+            if await self._async_can_connect(user_input):
+                return self.async_create_entry(
+                    title=user_input[CONF_HOST], data=user_input
+                )
+            errors["base"] = "cannot_connect"
+
+        return self.async_show_form(
+            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+        )
+
+    async def async_step_import(self, import_data: dict[str, Any]) -> ConfigFlowResult:
+        """Import existing configuration from configuration.yaml."""
+        self._async_abort_entries_match({CONF_HOST: import_data[CONF_HOST]})
+        if await self._async_can_connect(import_data):
+            return self.async_create_entry(title=import_data[CONF_HOST], data=import_data)
+        return self.async_abort(reason="cannot_connect")

--- a/homeassistant/components/actiontec/const.py
+++ b/homeassistant/components/actiontec/const.py
@@ -5,6 +5,8 @@ from typing import Final
 
 # mypy: disallow-any-generics
 
+DOMAIN: Final = "actiontec"
+
 LEASES_REGEX: Final[re.Pattern[str]] = re.compile(
     r"(?P<ip>([0-9]{1,3}[\.]){3}[0-9]{1,3})"
     r"\smac:\s(?P<mac>([0-9a-f]{2}[:-]){5}([0-9a-f]{2}))"

--- a/homeassistant/components/actiontec/coordinator.py
+++ b/homeassistant/components/actiontec/coordinator.py
@@ -1,0 +1,86 @@
+"""Data update coordinator for the Actiontec integration."""
+
+from datetime import timedelta
+import logging
+
+import telnetlib  # pylint: disable=deprecated-module
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN, LEASES_REGEX
+from .model import Device
+
+_LOGGER = logging.getLogger(__name__)
+
+UPDATE_INTERVAL = timedelta(seconds=30)
+
+type ActiontecConfigEntry = ConfigEntry[ActiontecDataUpdateCoordinator]
+
+
+def get_actiontec_data(
+    host: str, username: str, password: str
+) -> list[Device] | None:
+    """Retrieve data from Actiontec MI424WR and return parsed result."""
+    try:
+        telnet = telnetlib.Telnet(host)
+        telnet.read_until(b"Username: ")
+        telnet.write((f"{username}\n").encode("ascii"))
+        telnet.read_until(b"Password: ")
+        telnet.write((f"{password}\n").encode("ascii"))
+        prompt = telnet.read_until(b"Wireless Broadband Router> ").split(b"\n")[-1]
+        telnet.write(b"firewall mac_cache_dump\n")
+        telnet.write(b"\n")
+        telnet.read_until(prompt)
+        leases_result = telnet.read_until(prompt).split(b"\n")[1:-1]
+        telnet.write(b"exit\n")
+    except EOFError:
+        _LOGGER.exception("Unexpected response from router")
+        return None
+    except OSError:
+        _LOGGER.exception("Could not connect to router. Telnet enabled?")
+        return None
+
+    devices: list[Device] = []
+    for lease in leases_result:
+        match = LEASES_REGEX.search(lease.decode("utf-8"))
+        if match is not None:
+            devices.append(
+                Device(
+                    match.group("ip"),
+                    match.group("mac").upper(),
+                    int(match.group("timevalid")),
+                )
+            )
+    return devices
+
+
+class ActiontecDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
+    """Class to manage fetching data from the Actiontec router."""
+
+    config_entry: ActiontecConfigEntry
+
+    def __init__(self, hass: HomeAssistant, config_entry: ActiontecConfigEntry) -> None:
+        """Initialize the coordinator using the config entry."""
+        self.host = config_entry.data[CONF_HOST]
+        self.username = config_entry.data[CONF_USERNAME]
+        self.password = config_entry.data[CONF_PASSWORD]
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=config_entry,
+            name=f"{DOMAIN} - {self.host}",
+            update_interval=UPDATE_INTERVAL,
+        )
+
+    async def _async_update_data(self) -> list[Device]:
+        """Fetch connected devices from the Actiontec router."""
+        if (
+            devices := await self.hass.async_add_executor_job(
+                get_actiontec_data, self.host, self.username, self.password
+            )
+        ) is None:
+            raise UpdateFailed(f"Failed to fetch data from Actiontec router {self.host}")
+        return [device for device in devices if device.timevalid > -60]

--- a/homeassistant/components/actiontec/coordinator.py
+++ b/homeassistant/components/actiontec/coordinator.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import logging
+from typing import override
 
 import telnetlib  # pylint: disable=deprecated-module
 
@@ -20,9 +21,7 @@ UPDATE_INTERVAL = timedelta(seconds=30)
 type ActiontecConfigEntry = ConfigEntry[ActiontecDataUpdateCoordinator]
 
 
-def get_actiontec_data(
-    host: str, username: str, password: str
-) -> list[Device] | None:
+def get_actiontec_data(host: str, username: str, password: str) -> list[Device] | None:
     """Retrieve data from Actiontec MI424WR and return parsed result."""
     try:
         telnet = telnetlib.Telnet(host)
@@ -75,6 +74,7 @@ class ActiontecDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
             update_interval=UPDATE_INTERVAL,
         )
 
+    @override
     async def _async_update_data(self) -> list[Device]:
         """Fetch connected devices from the Actiontec router."""
         if (
@@ -82,5 +82,7 @@ class ActiontecDataUpdateCoordinator(DataUpdateCoordinator[list[Device]]):
                 get_actiontec_data, self.host, self.username, self.password
             )
         ) is None:
-            raise UpdateFailed(f"Failed to fetch data from Actiontec router {self.host}")
+            raise UpdateFailed(
+                f"Failed to fetch data from Actiontec router {self.host}"
+            )
         return [device for device in devices if device.timevalid > -60]

--- a/homeassistant/components/actiontec/device_tracker.py
+++ b/homeassistant/components/actiontec/device_tracker.py
@@ -1,5 +1,7 @@
 """Support for Actiontec MI424WR (Verizon FIOS) routers."""
 
+from typing import override
+
 import voluptuous as vol
 
 from homeassistant.components.device_tracker import (
@@ -128,11 +130,13 @@ class ActiontecScannerEntity(
         )
 
     @property
+    @override
     def is_connected(self) -> bool:
         """Return true if the device is connected to the Actiontec router."""
         return self._device is not None
 
     @property
+    @override
     def ip_address(self) -> str | None:
         """Return the primary IP address of the device."""
         if (device := self._device) is not None:
@@ -140,6 +144,7 @@ class ActiontecScannerEntity(
         return None
 
     @property
+    @override
     def mac_address(self) -> str:
         """Return the MAC address of the device."""
         return self._mac_address

--- a/homeassistant/components/actiontec/device_tracker.py
+++ b/homeassistant/components/actiontec/device_tracker.py
@@ -112,7 +112,6 @@ class ActiontecScannerEntity(
         """Initialize the tracked device."""
         super().__init__(coordinator)
         self._mac_address = mac_address
-        self._attr_unique_id = mac_address
         if (device := self._device) is not None:
             self._attr_name = device.ip_address
 
@@ -144,8 +143,3 @@ class ActiontecScannerEntity(
     def mac_address(self) -> str:
         """Return the MAC address of the device."""
         return self._mac_address
-
-    @property
-    def hostname(self) -> str | None:
-        """Return the hostname of the device."""
-        return None

--- a/homeassistant/components/actiontec/device_tracker.py
+++ b/homeassistant/components/actiontec/device_tracker.py
@@ -1,27 +1,26 @@
 """Support for Actiontec MI424WR (Verizon FIOS) routers."""
 
-import logging
-from typing import Final, override
-
-import telnetlib  # pylint: disable=deprecated-module
 import voluptuous as vol
 
 from homeassistant.components.device_tracker import (
-    DOMAIN as DEVICE_TRACKER_DOMAIN,
     PLATFORM_SCHEMA as DEVICE_TRACKER_PLATFORM_SCHEMA,
-    DeviceScanner,
+    AsyncSeeCallback,
+    ScannerEntity,
 )
+from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant, callback
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import config_validation as cv, issue_registry as ir
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import LEASES_REGEX
+from .const import DOMAIN
+from .coordinator import ActiontecConfigEntry, ActiontecDataUpdateCoordinator
 from .model import Device
 
-_LOGGER: Final = logging.getLogger(__name__)
-
-PLATFORM_SCHEMA: Final = DEVICE_TRACKER_PLATFORM_SCHEMA.extend(
+PLATFORM_SCHEMA = DEVICE_TRACKER_PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_HOST): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
@@ -30,87 +29,123 @@ PLATFORM_SCHEMA: Final = DEVICE_TRACKER_PLATFORM_SCHEMA.extend(
 )
 
 
-def get_scanner(
-    hass: HomeAssistant, config: ConfigType
-) -> ActiontecDeviceScanner | None:
-    """Validate the configuration and return an Actiontec scanner."""
-    scanner = ActiontecDeviceScanner(config[DEVICE_TRACKER_DOMAIN])
-    return scanner if scanner.success_init else None
+async def async_setup_scanner(
+    hass: HomeAssistant,
+    config: ConfigType,
+    _async_see: AsyncSeeCallback,
+    _discovery_info: DiscoveryInfoType | None = None,
+) -> bool:
+    """Set up the legacy Actiontec device tracker."""
+    import_data = {
+        CONF_HOST: config[CONF_HOST],
+        CONF_USERNAME: config[CONF_USERNAME],
+        CONF_PASSWORD: config[CONF_PASSWORD],
+    }
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=import_data
+    )
+
+    if result["type"] is FlowResultType.ABORT and result["reason"] == "cannot_connect":
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            "yaml_import_cannot_connect",
+            is_fixable=False,
+            issue_domain=DOMAIN,
+            severity=ir.IssueSeverity.ERROR,
+            translation_key="yaml_import_cannot_connect",
+            translation_placeholders={"host": import_data[CONF_HOST]},
+        )
+        return False
+
+    # A previous failed import may have raised this issue; clear it on success.
+    ir.async_delete_issue(hass, DOMAIN, "yaml_import_cannot_connect")
+    ir.async_create_issue(
+        hass,
+        HOMEASSISTANT_DOMAIN,
+        f"deprecated_yaml_{DOMAIN}",
+        is_fixable=False,
+        issue_domain=DOMAIN,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="deprecated_yaml",
+        translation_placeholders={
+            "domain": DOMAIN,
+            "integration_title": "Actiontec",
+        },
+    )
+    return True
 
 
-class ActiontecDeviceScanner(DeviceScanner):
-    """Class which queries an actiontec router for connected devices."""
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ActiontecConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the Actiontec device tracker from a config entry."""
+    coordinator = config_entry.runtime_data
+    tracked: set[str] = set()
 
-    def __init__(self, config: ConfigType) -> None:
-        """Initialize the scanner."""
-        self.host: str = config[CONF_HOST]
-        self.username: str = config[CONF_USERNAME]
-        self.password: str = config[CONF_PASSWORD]
-        self.last_results: list[Device] = []
-        data = self.get_actiontec_data()
-        self.success_init = data is not None
+    @callback
+    def _async_add_new_devices() -> None:
+        """Add newly discovered devices from the coordinator."""
+        new_entities: list[ActiontecScannerEntity] = []
+        for device in coordinator.data:
+            if device.mac_address in tracked:
+                continue
+            tracked.add(device.mac_address)
+            new_entities.append(ActiontecScannerEntity(coordinator, device.mac_address))
+        if new_entities:
+            async_add_entities(new_entities)
 
-    @override
-    def scan_devices(self) -> list[str]:
-        """Scan for new devices and return a list with found device IDs."""
-        self._update_info()
-        return [client.mac_address for client in self.last_results]
+    config_entry.async_on_unload(coordinator.async_add_listener(_async_add_new_devices))
+    _async_add_new_devices()
 
-    @override
-    def get_device_name(self, device: str) -> str | None:
-        """Return the name of the given device or None if we don't know."""
-        for client in self.last_results:
-            if client.mac_address == device:
-                return client.ip_address
+
+class ActiontecScannerEntity(
+    CoordinatorEntity[ActiontecDataUpdateCoordinator], ScannerEntity
+):
+    """Representation of a device connected to the Actiontec router."""
+
+    def __init__(
+        self, coordinator: ActiontecDataUpdateCoordinator, mac_address: str
+    ) -> None:
+        """Initialize the tracked device."""
+        super().__init__(coordinator)
+        self._mac_address = mac_address
+        self._attr_unique_id = mac_address
+        if (device := self._device) is not None:
+            self._attr_name = device.ip_address
+
+    @property
+    def _device(self) -> Device | None:
+        """Return the current device data."""
+        return next(
+            (
+                device
+                for device in self.coordinator.data
+                if device.mac_address == self._mac_address
+            ),
+            None,
+        )
+
+    @property
+    def is_connected(self) -> bool:
+        """Return true if the device is connected to the Actiontec router."""
+        return self._device is not None
+
+    @property
+    def ip_address(self) -> str | None:
+        """Return the primary IP address of the device."""
+        if (device := self._device) is not None:
+            return device.ip_address
         return None
 
-    def _update_info(self) -> bool:
-        """Ensure the information from the router is up to date.
+    @property
+    def mac_address(self) -> str:
+        """Return the MAC address of the device."""
+        return self._mac_address
 
-        Return boolean if scanning successful.
-        """
-        _LOGGER.debug("Scanning")
-        if not self.success_init:
-            return False
-
-        if (actiontec_data := self.get_actiontec_data()) is None:
-            return False
-        self.last_results = [
-            device for device in actiontec_data if device.timevalid > -60
-        ]
-        _LOGGER.debug("Scan successful")
-        return True
-
-    def get_actiontec_data(self) -> list[Device] | None:
-        """Retrieve data from Actiontec MI424WR and return parsed result."""
-        try:
-            telnet = telnetlib.Telnet(self.host)
-            telnet.read_until(b"Username: ")
-            telnet.write((f"{self.username}\n").encode("ascii"))
-            telnet.read_until(b"Password: ")
-            telnet.write((f"{self.password}\n").encode("ascii"))
-            prompt = telnet.read_until(b"Wireless Broadband Router> ").split(b"\n")[-1]
-            telnet.write(b"firewall mac_cache_dump\n")
-            telnet.write(b"\n")
-            telnet.read_until(prompt)
-            leases_result = telnet.read_until(prompt).split(b"\n")[1:-1]
-            telnet.write(b"exit\n")
-        except EOFError:
-            _LOGGER.exception("Unexpected response from router")
-            return None
-        except ConnectionRefusedError:
-            _LOGGER.exception("Connection refused by router. Telnet enabled?")
-            return None
-
-        devices: list[Device] = []
-        for lease in leases_result:
-            match = LEASES_REGEX.search(lease.decode("utf-8"))
-            if match is not None:
-                devices.append(
-                    Device(
-                        match.group("ip"),
-                        match.group("mac").upper(),
-                        int(match.group("timevalid")),
-                    )
-                )
-        return devices
+    @property
+    def hostname(self) -> str | None:
+        """Return the hostname of the device."""
+        return None

--- a/homeassistant/components/actiontec/manifest.json
+++ b/homeassistant/components/actiontec/manifest.json
@@ -2,7 +2,9 @@
   "domain": "actiontec",
   "name": "Actiontec",
   "codeowners": [],
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/actiontec",
+  "integration_type": "hub",
   "iot_class": "local_polling",
   "quality_scale": "legacy"
 }

--- a/homeassistant/components/actiontec/strings.json
+++ b/homeassistant/components/actiontec/strings.json
@@ -1,17 +1,17 @@
 {
   "config": {
     "abort": {
-      "already_configured": "Device is already configured"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     },
     "error": {
-      "cannot_connect": "Failed to connect"
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     },
     "step": {
       "user": {
         "data": {
-          "host": "Host",
-          "password": "Password",
-          "username": "Username"
+          "host": "[%key:common::config_flow::data::host%]",
+          "password": "[%key:common::config_flow::data::password%]",
+          "username": "[%key:common::config_flow::data::username%]"
         }
       }
     }

--- a/homeassistant/components/actiontec/strings.json
+++ b/homeassistant/components/actiontec/strings.json
@@ -18,7 +18,7 @@
   },
   "issues": {
     "yaml_import_cannot_connect": {
-      "description": "The YAML configuration for Actiontec at `{host}` could not be imported because the connection failed.\n\nPlease check that `{host}` is reachable, telnet is enabled, update your `configuration.yaml` if needed, and restart Home Assistant.",
+      "description": "The YAML configuration for Actiontec at `{host}` could not be imported because the connection failed.\n\nPlease check that `{host}` is reachable and telnet is enabled. If needed, update your `configuration.yaml` and restart Home Assistant.",
       "title": "YAML configuration import failed: cannot connect"
     }
   }

--- a/homeassistant/components/actiontec/strings.json
+++ b/homeassistant/components/actiontec/strings.json
@@ -1,0 +1,25 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "Device is already configured"
+    },
+    "error": {
+      "cannot_connect": "Failed to connect"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "host": "Host",
+          "password": "Password",
+          "username": "Username"
+        }
+      }
+    }
+  },
+  "issues": {
+    "yaml_import_cannot_connect": {
+      "description": "The YAML configuration for Actiontec at `{host}` could not be imported because the connection failed.\n\nPlease check that `{host}` is reachable, telnet is enabled, update your `configuration.yaml` if needed, and restart Home Assistant.",
+      "title": "YAML configuration import failed: cannot connect"
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -29,6 +29,7 @@ FLOWS = {
         "acaia",
         "accuweather",
         "acmeda",
+        "actiontec",
         "actron_air",
         "adax",
         "adguard",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -38,7 +38,7 @@
     "actiontec": {
       "name": "Actiontec",
       "integration_type": "hub",
-      "config_flow": false,
+      "config_flow": true,
       "iot_class": "local_polling"
     },
     "actron_air": {

--- a/tests/components/actiontec/__init__.py
+++ b/tests/components/actiontec/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Actiontec integration."""

--- a/tests/components/actiontec/conftest.py
+++ b/tests/components/actiontec/conftest.py
@@ -46,11 +46,14 @@ def mock_config_entry() -> MockConfigEntry:
 def mock_get_actiontec_data() -> Generator[MagicMock]:
     """Mock Actiontec data fetching."""
     mock_get_data = MagicMock(return_value=MOCK_DEVICES)
-    with patch(
-        "homeassistant.components.actiontec.coordinator.get_actiontec_data",
-        new=mock_get_data,
-    ), patch(
-        "homeassistant.components.actiontec.config_flow.get_actiontec_data",
-        new=mock_get_data,
+    with (
+        patch(
+            "homeassistant.components.actiontec.coordinator.get_actiontec_data",
+            new=mock_get_data,
+        ),
+        patch(
+            "homeassistant.components.actiontec.config_flow.get_actiontec_data",
+            new=mock_get_data,
+        ),
     ):
         yield mock_get_data

--- a/tests/components/actiontec/conftest.py
+++ b/tests/components/actiontec/conftest.py
@@ -1,0 +1,56 @@
+"""Common fixtures for the Actiontec integration tests."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from homeassistant.components.actiontec.const import DOMAIN
+from homeassistant.components.actiontec.model import Device
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+
+from tests.common import MockConfigEntry
+
+MOCK_HOST = "192.168.1.1"
+MOCK_USERNAME = "admin"
+MOCK_PASSWORD = "password"
+
+MOCK_CONFIG = {
+    CONF_HOST: MOCK_HOST,
+    CONF_USERNAME: MOCK_USERNAME,
+    CONF_PASSWORD: MOCK_PASSWORD,
+}
+
+MOCK_DEVICES = [
+    Device("192.168.1.10", "AA:BB:CC:DD:EE:FF", 300),
+    Device("192.168.1.11", "11:22:33:44:55:66", 300),
+]
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.actiontec.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        yield mock_setup_entry
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return a mock config entry."""
+    return MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, title=MOCK_HOST)
+
+
+@pytest.fixture
+def mock_get_actiontec_data() -> Generator[MagicMock]:
+    """Mock Actiontec data fetching."""
+    mock_get_data = MagicMock(return_value=MOCK_DEVICES)
+    with patch(
+        "homeassistant.components.actiontec.coordinator.get_actiontec_data",
+        new=mock_get_data,
+    ), patch(
+        "homeassistant.components.actiontec.config_flow.get_actiontec_data",
+        new=mock_get_data,
+    ):
+        yield mock_get_data

--- a/tests/components/actiontec/test_config_flow.py
+++ b/tests/components/actiontec/test_config_flow.py
@@ -1,6 +1,8 @@
 """Tests for the Actiontec config flow."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
+
+import pytest
 
 from homeassistant.components.actiontec.const import DOMAIN
 from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
@@ -12,10 +14,9 @@ from .conftest import MOCK_CONFIG, MOCK_HOST
 from tests.common import MockConfigEntry
 
 
+@pytest.mark.usefixtures("mock_setup_entry", "mock_get_actiontec_data")
 async def test_user_flow_success(
     hass: HomeAssistant,
-    mock_setup_entry: AsyncMock,
-    mock_get_actiontec_data: MagicMock,
 ) -> None:
     """Test a successful user config flow."""
     result = await hass.config_entries.flow.async_init(
@@ -31,9 +32,9 @@ async def test_user_flow_success(
     assert result["data"] == MOCK_CONFIG
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_user_flow_cannot_connect(
     hass: HomeAssistant,
-    mock_setup_entry: AsyncMock,
     mock_get_actiontec_data: MagicMock,
 ) -> None:
     """Test the user flow shows an error on connection failure."""
@@ -49,10 +50,9 @@ async def test_user_flow_cannot_connect(
     assert result["errors"] == {"base": "cannot_connect"}
 
 
+@pytest.mark.usefixtures("mock_setup_entry", "mock_get_actiontec_data")
 async def test_user_flow_already_configured(
     hass: HomeAssistant,
-    mock_setup_entry: AsyncMock,
-    mock_get_actiontec_data: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test the user flow aborts when the host is already configured."""
@@ -68,10 +68,9 @@ async def test_user_flow_already_configured(
     assert result["reason"] == "already_configured"
 
 
+@pytest.mark.usefixtures("mock_setup_entry", "mock_get_actiontec_data")
 async def test_import_flow(
     hass: HomeAssistant,
-    mock_setup_entry: AsyncMock,
-    mock_get_actiontec_data: MagicMock,
 ) -> None:
     """Test a successful import flow."""
     result = await hass.config_entries.flow.async_init(
@@ -82,10 +81,9 @@ async def test_import_flow(
     assert result["data"] == MOCK_CONFIG
 
 
+@pytest.mark.usefixtures("mock_setup_entry", "mock_get_actiontec_data")
 async def test_import_flow_already_configured(
     hass: HomeAssistant,
-    mock_setup_entry: AsyncMock,
-    mock_get_actiontec_data: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test the import flow aborts when already configured."""
@@ -98,9 +96,9 @@ async def test_import_flow_already_configured(
     assert result["reason"] == "already_configured"
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_import_flow_cannot_connect(
     hass: HomeAssistant,
-    mock_setup_entry: AsyncMock,
     mock_get_actiontec_data: MagicMock,
 ) -> None:
     """Test the import flow aborts on connection failure."""

--- a/tests/components/actiontec/test_config_flow.py
+++ b/tests/components/actiontec/test_config_flow.py
@@ -1,0 +1,113 @@
+"""Tests for the Actiontec config flow."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from homeassistant.components.actiontec.const import DOMAIN
+from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from .conftest import MOCK_CONFIG, MOCK_HOST
+
+from tests.common import MockConfigEntry
+
+
+async def test_user_flow_success(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_get_actiontec_data: MagicMock,
+) -> None:
+    """Test a successful user config flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=MOCK_CONFIG
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == MOCK_HOST
+    assert result["data"] == MOCK_CONFIG
+
+
+async def test_user_flow_cannot_connect(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_get_actiontec_data: MagicMock,
+) -> None:
+    """Test the user flow shows an error on connection failure."""
+    mock_get_actiontec_data.return_value = None
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=MOCK_CONFIG
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_user_flow_already_configured(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_get_actiontec_data: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the user flow aborts when the host is already configured."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=MOCK_CONFIG
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_import_flow(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_get_actiontec_data: MagicMock,
+) -> None:
+    """Test a successful import flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=MOCK_CONFIG
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == MOCK_HOST
+    assert result["data"] == MOCK_CONFIG
+
+
+async def test_import_flow_already_configured(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_get_actiontec_data: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the import flow aborts when already configured."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=MOCK_CONFIG
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_import_flow_cannot_connect(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_get_actiontec_data: MagicMock,
+) -> None:
+    """Test the import flow aborts on connection failure."""
+    mock_get_actiontec_data.return_value = None
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=MOCK_CONFIG
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"

--- a/tests/components/actiontec/test_device_tracker.py
+++ b/tests/components/actiontec/test_device_tracker.py
@@ -67,8 +67,9 @@ async def test_entities_created(
     assert state.attributes[ScannerEntityStateAttribute.MAC] == "AA:BB:CC:DD:EE:FF"
 
 
+@pytest.mark.usefixtures("mock_get_actiontec_data")
 async def test_legacy_platform_imports_config_entry(
-    hass: HomeAssistant, mock_get_actiontec_data: MagicMock
+    hass: HomeAssistant,
 ) -> None:
     """Test the legacy device_tracker platform imports a config entry."""
     assert await async_setup_component(

--- a/tests/components/actiontec/test_device_tracker.py
+++ b/tests/components/actiontec/test_device_tracker.py
@@ -5,7 +5,9 @@ from unittest.mock import AsyncMock, MagicMock
 from homeassistant.components.actiontec.const import DOMAIN
 from homeassistant.components.actiontec.device_tracker import async_setup_scanner
 from homeassistant.components.actiontec.model import Device
+from homeassistant.components.device_tracker.const import ScannerEntityStateAttribute
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntryState
+from homeassistant.const import STATE_HOME, STATE_NOT_HOME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_registry import EntityRegistry
 from homeassistant.helpers.issue_registry import IssueRegistry
@@ -21,6 +23,7 @@ async def test_entities_created(
     mock_config_entry: MockConfigEntry,
     mock_get_actiontec_data: MagicMock,
     entity_registry: EntityRegistry,
+    entity_registry_enabled_by_default: None,
 ) -> None:
     """Test device tracker entities are created from the coordinator data."""
     mock_config_entry.add_to_hass(hass)
@@ -38,6 +41,28 @@ async def test_entities_created(
     entity_ids = {entry.entity_id for entry in entries}
     assert any(eid.startswith("device_tracker.192_168_1_10") for eid in entity_ids)
     assert any(eid.startswith("device_tracker.192_168_1_11") for eid in entity_ids)
+
+    entries_by_mac = {entry.unique_id: entry for entry in entries}
+    assert entries_by_mac.keys() == {
+        "AA:BB:CC:DD:EE:FF",
+        "11:22:33:44:55:66",
+    }
+
+    state = hass.states.get(entries_by_mac["AA:BB:CC:DD:EE:FF"].entity_id)
+    assert state is not None
+    assert state.state == STATE_HOME
+    assert state.attributes[ScannerEntityStateAttribute.IP] == "192.168.1.10"
+    assert state.attributes[ScannerEntityStateAttribute.MAC] == "AA:BB:CC:DD:EE:FF"
+
+    mock_get_actiontec_data.return_value = [MOCK_DEVICES[1]]
+    await mock_config_entry.runtime_data.async_request_refresh()
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entries_by_mac["AA:BB:CC:DD:EE:FF"].entity_id)
+    assert state is not None
+    assert state.state == STATE_NOT_HOME
+    assert ScannerEntityStateAttribute.IP not in state.attributes
+    assert state.attributes[ScannerEntityStateAttribute.MAC] == "AA:BB:CC:DD:EE:FF"
 
 
 async def test_legacy_platform_imports_config_entry(

--- a/tests/components/actiontec/test_device_tracker.py
+++ b/tests/components/actiontec/test_device_tracker.py
@@ -1,0 +1,132 @@
+"""Tests for the Actiontec device tracker."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from homeassistant.components.actiontec.const import DOMAIN
+from homeassistant.components.actiontec.device_tracker import async_setup_scanner
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntryState
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_registry import EntityRegistry
+from homeassistant.helpers.issue_registry import IssueRegistry
+from homeassistant.setup import async_setup_component
+
+from .conftest import MOCK_CONFIG, MOCK_DEVICES, MOCK_HOST
+
+from tests.common import MockConfigEntry
+
+
+async def test_entities_created(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_get_actiontec_data: MagicMock,
+    entity_registry: EntityRegistry,
+) -> None:
+    """Test device tracker entities are created from the coordinator data."""
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entries = [
+        entry
+        for entry in entity_registry.entities.values()
+        if entry.domain == "device_tracker" and entry.platform == DOMAIN
+    ]
+    assert len(entries) == 2
+
+    entity_ids = {entry.entity_id for entry in entries}
+    assert any(eid.startswith("device_tracker.192_168_1_10") for eid in entity_ids)
+    assert any(eid.startswith("device_tracker.192_168_1_11") for eid in entity_ids)
+
+
+async def test_legacy_platform_imports_config_entry(
+    hass: HomeAssistant, mock_get_actiontec_data: MagicMock
+) -> None:
+    """Test the legacy device_tracker platform imports a config entry."""
+    assert await async_setup_component(
+        hass,
+        "device_tracker",
+        {"device_tracker": [{"platform": DOMAIN, **MOCK_CONFIG}]},
+    )
+    await hass.async_block_till_done()
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].data == MOCK_CONFIG
+    assert entries[0].source == SOURCE_IMPORT
+
+
+async def test_legacy_platform_creates_issue_on_cannot_connect(
+    hass: HomeAssistant,
+    mock_get_actiontec_data: MagicMock,
+    issue_registry: IssueRegistry,
+) -> None:
+    """Test an issue is raised when the legacy YAML import cannot connect."""
+    mock_get_actiontec_data.return_value = None
+
+    assert await async_setup_component(
+        hass,
+        "device_tracker",
+        {"device_tracker": [{"platform": DOMAIN, **MOCK_CONFIG}]},
+    )
+    await hass.async_block_till_done()
+
+    issue = issue_registry.async_get_issue(DOMAIN, "yaml_import_cannot_connect")
+    assert issue is not None
+    assert issue.translation_key == "yaml_import_cannot_connect"
+    assert issue.translation_placeholders == {"host": MOCK_HOST}
+
+
+async def test_setup_entry_retries_when_router_unavailable(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_get_actiontec_data: MagicMock,
+) -> None:
+    """Test the config entry retries when the router returns no data."""
+    mock_get_actiontec_data.return_value = None
+    mock_config_entry.add_to_hass(hass)
+
+    assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_coordinator_filters_expired_devices(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_get_actiontec_data: MagicMock,
+    entity_registry: EntityRegistry,
+) -> None:
+    """Test expired devices are not added as connected scanner entities."""
+    expired = MOCK_DEVICES[0].__class__("192.168.1.12", "22:33:44:55:66:77", -120)
+    mock_get_actiontec_data.return_value = [*MOCK_DEVICES, expired]
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entries = [
+        entry
+        for entry in entity_registry.entities.values()
+        if entry.domain == "device_tracker" and entry.platform == DOMAIN
+    ]
+    assert len(entries) == 2
+
+
+async def test_legacy_import_clears_stale_cannot_connect_issue(
+    hass: HomeAssistant,
+    mock_get_actiontec_data: MagicMock,
+    issue_registry: IssueRegistry,
+) -> None:
+    """Test a successful YAML import removes a stale cannot_connect repair issue."""
+    mock_get_actiontec_data.return_value = None
+    assert not await async_setup_scanner(hass, MOCK_CONFIG, AsyncMock())
+    assert (
+        issue_registry.async_get_issue(DOMAIN, "yaml_import_cannot_connect") is not None
+    )
+
+    mock_get_actiontec_data.return_value = MOCK_DEVICES
+    assert await async_setup_scanner(hass, MOCK_CONFIG, AsyncMock())
+    await hass.async_block_till_done()
+    assert issue_registry.async_get_issue(DOMAIN, "yaml_import_cannot_connect") is None

--- a/tests/components/actiontec/test_device_tracker.py
+++ b/tests/components/actiontec/test_device_tracker.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
 from homeassistant.components.actiontec.const import DOMAIN
 from homeassistant.components.actiontec.device_tracker import async_setup_scanner
 from homeassistant.components.actiontec.model import Device
@@ -18,12 +20,12 @@ from .conftest import MOCK_CONFIG, MOCK_DEVICES, MOCK_HOST
 from tests.common import MockConfigEntry
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_entities_created(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_get_actiontec_data: MagicMock,
     entity_registry: EntityRegistry,
-    entity_registry_enabled_by_default: None,
 ) -> None:
     """Test device tracker entities are created from the coordinator data."""
     mock_config_entry.add_to_hass(hass)

--- a/tests/components/actiontec/test_device_tracker.py
+++ b/tests/components/actiontec/test_device_tracker.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 from homeassistant.components.actiontec.const import DOMAIN
 from homeassistant.components.actiontec.device_tracker import async_setup_scanner
+from homeassistant.components.actiontec.model import Device
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_registry import EntityRegistry
@@ -99,7 +100,7 @@ async def test_coordinator_filters_expired_devices(
     entity_registry: EntityRegistry,
 ) -> None:
     """Test expired devices are not added as connected scanner entities."""
-    expired = MOCK_DEVICES[0].__class__("192.168.1.12", "22:33:44:55:66:77", -120)
+    expired = Device("192.168.1.12", "22:33:44:55:66:77", -120)
     mock_get_actiontec_data.return_value = [*MOCK_DEVICES, expired]
     mock_config_entry.add_to_hass(hass)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR migrates the Actiontec legacy `DeviceScanner` platform to a
config-entry-backed `ScannerEntity`:

- Add a config flow and YAML import path for existing `device_tracker`
  configuration.
- Add coordinator-backed polling and repair issues for failed YAML imports.
- Add tests for config flow paths, entity setup, coordinator retry behavior, and
  stale repair issue cleanup.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #143018
- This PR is related to issue: #50326
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

AI-assisted (Opus); human-reviewed.
