### PR TITLE
Handle SMTP quit failures during retry

### DIFF
--- a/homeassistant/components/smtp/notify.py
+++ b/homeassistant/components/smtp/notify.py
@@ -92,6 +92,14 @@ PLATFORM_SCHEMA = NOTIFY_PLATFORM_SCHEMA.extend(
 )
 
 
+def _quit_smtp_client(client: SMTP_SSL | SMTP) -> None:
+    """Close an SMTP client without masking the original send outcome."""
+    try:
+        client.quit()
+    except (OSError, SMTPException):
+        _LOGGER.debug("Ignoring exception while closing SMTP connection", exc_info=True)
+
+
 async def async_get_service(
     hass: HomeAssistant,
     config: ConfigType,
@@ -236,7 +244,7 @@ class MailNotifyEntity(NotifyEntity):
                         translation_key="send_mail_connection_error",
                     ) from e
             finally:
-                client.quit()
+                _quit_smtp_client(client)
 
 
 class MailNotificationService(SmtpClient, BaseNotificationService):
@@ -316,10 +324,10 @@ class MailNotificationService(SmtpClient, BaseNotificationService):
                 _LOGGER.warning(
                     "SMTPServerDisconnected sending mail: retrying connection"
                 )
-                mail.quit()
+                _quit_smtp_client(mail)
                 mail = self.connect()
             except SMTPException:
                 _LOGGER.warning("SMTPException sending mail: retrying connection")
-                mail.quit()
+                _quit_smtp_client(mail)
                 mail = self.connect()
-        mail.quit()
+        _quit_smtp_client(mail)

--- a/homeassistant/components/smtp/notify.py
+++ b/homeassistant/components/smtp/notify.py
@@ -96,7 +96,7 @@ def _quit_smtp_client(client: SMTP_SSL | SMTP) -> None:
     """Close an SMTP client without masking the original send outcome."""
     try:
         client.quit()
-    except (OSError, SMTPException):
+    except OSError:
         _LOGGER.debug("Ignoring exception while closing SMTP connection", exc_info=True)
 
 

--- a/tests/components/smtp/test_notify.py
+++ b/tests/components/smtp/test_notify.py
@@ -1,5 +1,6 @@
 """The tests for the notify smtp platform."""
 
+from email.mime.text import MIMEText
 from pathlib import Path
 import re
 from smtplib import (
@@ -216,6 +217,36 @@ def test_send_target_message(target, hass: HomeAssistant, message) -> None:
 
         _, recipient = message.send_message(message_data, target=target)
         assert recipient == expected_recipient
+
+
+@pytest.mark.parametrize(
+    "quit_exception",
+    [
+        SMTPServerDisconnected("please run connect() first"),
+        ConnectionResetError("connection reset by peer"),
+    ],
+)
+def test_legacy_service_retries_when_quit_raises_after_disconnect(
+    message, quit_exception: Exception
+) -> None:
+    """Test a stale SMTP connection does not abort the retry cleanup."""
+    stale_client = MagicMock()
+    fresh_client = MagicMock()
+    stale_client.sendmail.side_effect = SMTPServerDisconnected(
+        "please run connect() first"
+    )
+    stale_client.quit.side_effect = quit_exception
+    fresh_client.quit.side_effect = quit_exception
+
+    with patch.object(message, "connect", side_effect=[stale_client, fresh_client]):
+        MailNotificationService._send_email(
+            message, MIMEText("Test msg"), ["recip1@example.com"]
+        )
+
+    stale_client.sendmail.assert_called_once()
+    stale_client.quit.assert_called_once()
+    fresh_client.sendmail.assert_called_once()
+    fresh_client.quit.assert_called_once()
 
 
 @pytest.mark.usefixtures("smtp")


### PR DESCRIPTION
## Summary

- guard SMTP client cleanup so `quit()` on a disconnected connection cannot abort retry handling
- reuse the guarded cleanup for final SMTP shutdown in both SMTP notify paths
- add a regression test for the legacy SMTP notify service retrying after `SMTPServerDisconnected`

## Tests

- `uv run ruff check homeassistant/components/smtp tests/components/smtp`
- `uv run python -m script.hassfest --integration-path homeassistant/components/smtp`
- `git diff --check`
- WSL: `/root/ha-smtp-venv/bin/python -m pytest -q tests/components/smtp`

Disclosure: This contribution was prepared with AI assistance and manually reviewed.

Fixes #174086
