### PR TITLE
Stop ONVIF events during unload

### DIFF
--- a/homeassistant/components/onvif/__init__.py
+++ b/homeassistant/components/onvif/__init__.py
@@ -108,7 +108,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ONVIFConfigEntry) -> boo
 
 async def _async_stop_device(hass: HomeAssistant, device: ONVIFDevice) -> None:
     """Stop the ONVIF device."""
-    if (events := device.events) is not None:
+    # getattr is intentional: this callback is registered on AsyncExitStack before
+    # async_initialize runs, so it can fire during setup failure before self.events exists.
+    if (events := getattr(device, "events", None)) is not None:
         try:
             await events.async_stop()
         except TimeoutError, ONVIFError, Fault, aiohttp.ClientError, TransportError:

--- a/homeassistant/components/onvif/__init__.py
+++ b/homeassistant/components/onvif/__init__.py
@@ -108,8 +108,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ONVIFConfigEntry) -> boo
 
 async def _async_stop_device(hass: HomeAssistant, device: ONVIFDevice) -> None:
     """Stop the ONVIF device."""
-    # getattr is intentional: this callback is registered on AsyncExitStack before
-    # async_initialize runs, so it can fire during setup failure before self.events exists.
     if (events := getattr(device, "events", None)) is not None:
         try:
             await events.async_stop()

--- a/homeassistant/components/onvif/__init__.py
+++ b/homeassistant/components/onvif/__init__.py
@@ -108,7 +108,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ONVIFConfigEntry) -> boo
 
 async def _async_stop_device(hass: HomeAssistant, device: ONVIFDevice) -> None:
     """Stop the ONVIF device."""
-    if (events := getattr(device, "events", None)) is not None:
+    if (events := device.events) is not None:
         try:
             await events.async_stop()
         except TimeoutError, ONVIFError, Fault, aiohttp.ClientError, TransportError:

--- a/homeassistant/components/onvif/__init__.py
+++ b/homeassistant/components/onvif/__init__.py
@@ -108,11 +108,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ONVIFConfigEntry) -> boo
 
 async def _async_stop_device(hass: HomeAssistant, device: ONVIFDevice) -> None:
     """Stop the ONVIF device."""
-    if (events := getattr(device, "events", None)) is not None:
-        try:
-            await events.async_stop()
-        except TimeoutError, ONVIFError, Fault, aiohttp.ClientError, TransportError:
-            LOGGER.warning("Error while stopping events: %s", device.name)
+    try:
+        await device.events.async_stop()
+    except TimeoutError, ONVIFError, Fault, aiohttp.ClientError, TransportError:
+        LOGGER.warning("Error while stopping events: %s", device.name)
     await device.device.close()
 
 

--- a/homeassistant/components/onvif/__init__.py
+++ b/homeassistant/components/onvif/__init__.py
@@ -108,7 +108,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ONVIFConfigEntry) -> boo
 
 async def _async_stop_device(hass: HomeAssistant, device: ONVIFDevice) -> None:
     """Stop the ONVIF device."""
-    if events := getattr(device, "events", None):
+    if (events := device.events) is not None:
         try:
             await events.async_stop()
         except TimeoutError, ONVIFError, Fault, aiohttp.ClientError, TransportError:

--- a/homeassistant/components/onvif/__init__.py
+++ b/homeassistant/components/onvif/__init__.py
@@ -108,9 +108,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ONVIFConfigEntry) -> boo
 
 async def _async_stop_device(hass: HomeAssistant, device: ONVIFDevice) -> None:
     """Stop the ONVIF device."""
-    if device.capabilities.events and device.events.started:
+    if events := getattr(device, "events", None):
         try:
-            await device.events.async_stop()
+            await events.async_stop()
         except TimeoutError, ONVIFError, Fault, aiohttp.ClientError, TransportError:
             LOGGER.warning("Error while stopping events: %s", device.name)
     await device.device.close()

--- a/homeassistant/components/onvif/__init__.py
+++ b/homeassistant/components/onvif/__init__.py
@@ -108,7 +108,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ONVIFConfigEntry) -> boo
 
 async def _async_stop_device(hass: HomeAssistant, device: ONVIFDevice) -> None:
     """Stop the ONVIF device."""
-    if (events := device.events) is not None:
+    if (events := getattr(device, "events", None)) is not None:
         try:
             await events.async_stop()
         except TimeoutError, ONVIFError, Fault, aiohttp.ClientError, TransportError:

--- a/homeassistant/components/onvif/device.py
+++ b/homeassistant/components/onvif/device.py
@@ -61,7 +61,6 @@ class ONVIFDevice:
         self.info: DeviceInfo = DeviceInfo()
         self.capabilities: Capabilities = Capabilities()
         self.onvif_capabilities: dict[str, Any] | None = None
-        self.events: EventManager | None = None
         self.profiles: list[Profile] = []
         self.max_resolution: int = 0
         self.platforms: list[Platform] = []

--- a/homeassistant/components/onvif/device.py
+++ b/homeassistant/components/onvif/device.py
@@ -109,7 +109,6 @@ class ONVIFDevice:
             password=self.config_entry.data[CONF_PASSWORD],
         )
 
-        assert self.config_entry.unique_id
         self.events = EventManager(self.hass, self.device, self.config_entry, self.name)
 
         # Get all device info

--- a/homeassistant/components/onvif/device.py
+++ b/homeassistant/components/onvif/device.py
@@ -61,6 +61,7 @@ class ONVIFDevice:
         self.info: DeviceInfo = DeviceInfo()
         self.capabilities: Capabilities = Capabilities()
         self.onvif_capabilities: dict[str, Any] | None = None
+        self.events: EventManager | None = None
         self.profiles: list[Profile] = []
         self.max_resolution: int = 0
         self.platforms: list[Platform] = []

--- a/homeassistant/components/onvif/device.py
+++ b/homeassistant/components/onvif/device.py
@@ -109,6 +109,10 @@ class ONVIFDevice:
             password=self.config_entry.data[CONF_PASSWORD],
         )
 
+        # Cleanup on failed setup relies on self.events existing before any await
+        assert self.config_entry.unique_id
+        self.events = EventManager(self.hass, self.device, self.config_entry, self.name)
+
         # Get all device info
         await self.device.update_xaddrs()
         LOGGER.debug("%s: xaddrs = %s", self.name, self.device.xaddrs)
@@ -117,10 +121,6 @@ class ONVIFDevice:
         self.onvif_capabilities = await self.device.get_capabilities()
 
         await self.async_check_date_and_time()
-
-        # Create event manager
-        assert self.config_entry.unique_id
-        self.events = EventManager(self.hass, self.device, self.config_entry, self.name)
 
         # Fetch basic device info and capabilities
         self.info = await self.async_get_device_info()
@@ -172,8 +172,7 @@ class ONVIFDevice:
 
     async def async_stop(self, event=None):
         """Shut it all down."""
-        if self.events:
-            await self.events.async_stop()
+        await self.events.async_stop()
         await self.device.close()
 
     async def async_manually_set_date_and_time(self) -> None:

--- a/homeassistant/components/onvif/device.py
+++ b/homeassistant/components/onvif/device.py
@@ -109,7 +109,6 @@ class ONVIFDevice:
             password=self.config_entry.data[CONF_PASSWORD],
         )
 
-        # Cleanup on failed setup relies on self.events existing before any await
         assert self.config_entry.unique_id
         self.events = EventManager(self.hass, self.device, self.config_entry, self.name)
 

--- a/homeassistant/components/onvif/event_manager.py
+++ b/homeassistant/components/onvif/event_manager.py
@@ -123,14 +123,6 @@ class EventManager:
         self._events: dict[str, Event] = {}
         self._listeners: list[CALLBACK_TYPE] = []
 
-    @property
-    def started(self) -> bool:
-        """Return True if event manager is started."""
-        return (
-            self.webhook_manager.state is WebHookManagerState.STARTED
-            or self.pullpoint_manager.state is PullPointManagerState.STARTED
-        )
-
     @callback
     def async_add_listener(self, update_callback: CALLBACK_TYPE) -> Callable[[], None]:
         """Listen for data updates."""

--- a/tests/components/onvif/test_init.py
+++ b/tests/components/onvif/test_init.py
@@ -148,7 +148,7 @@ async def test_setup_entry(hass: HomeAssistant) -> None:
     assert (host, port, username, password) == (HOST, PORT, USERNAME, PASSWORD)
 
 
-async def test_stop_device_stops_existing_event_manager(
+async def test_unload_entry_stops_event_manager(
     hass: HomeAssistant,
 ) -> None:
     """Test that unload stops the event manager even when capabilities.events is False."""
@@ -162,10 +162,10 @@ async def test_stop_device_stops_existing_event_manager(
     mock_device.events.async_stop.assert_awaited_once()
 
 
-async def test_stop_device_when_setup_fails_before_events_created(
+async def test_setup_failure_runs_cleanup(
     hass: HomeAssistant,
 ) -> None:
-    """Test cleanup runs when setup fails before the event manager exists."""
+    """Test cleanup completes when setup fails before events are started."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         title=NAME,

--- a/tests/components/onvif/test_init.py
+++ b/tests/components/onvif/test_init.py
@@ -153,11 +153,39 @@ async def test_stop_device_stops_existing_event_manager(
 ) -> None:
     """Test that unload stops the event manager even when capabilities.events is False."""
     entry, _, mock_device = await setup_onvif_integration(hass)
-    # Mirrors the bug where a partial subscription leaves the event manager
-    # running while capabilities.events stays False.
     assert mock_device.capabilities.events is False
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
     mock_device.events.async_stop.assert_awaited_once()
+
+
+async def test_stop_device_when_setup_fails_before_events_created(
+    hass: HomeAssistant,
+) -> None:
+    """Test cleanup runs when setup fails before the event manager exists."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=NAME,
+        unique_id=MAC,
+        data={
+            CONF_NAME: NAME,
+            CONF_HOST: HOST,
+            CONF_PORT: PORT,
+            CONF_USERNAME: USERNAME,
+            CONF_PASSWORD: PASSWORD,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.onvif.device.ONVIFCamera"
+    ) as mock_onvif_camera_cls:
+        setup_mock_onvif_camera(mock_onvif_camera_cls, update_xaddrs_fail=True)
+
+        assert not await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+    mock_onvif_camera_cls.close.assert_awaited_once()

--- a/tests/components/onvif/test_init.py
+++ b/tests/components/onvif/test_init.py
@@ -154,6 +154,7 @@ async def test_stop_device_stops_existing_event_manager(
     """Test that unload stops the event manager even when capabilities.events is False."""
     entry, _, mock_device = await setup_onvif_integration(hass)
     assert mock_device.capabilities.events is False
+    mock_device.events.async_stop.assert_not_awaited()
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/onvif/test_init.py
+++ b/tests/components/onvif/test_init.py
@@ -1,8 +1,7 @@
 """Tests for the ONVIF integration __init__ module."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
-from homeassistant.components.onvif import _async_stop_device
 from homeassistant.components.onvif.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
@@ -24,6 +23,7 @@ from . import (
     USERNAME,
     setup_mock_device,
     setup_mock_onvif_camera,
+    setup_onvif_integration,
 )
 
 from tests.common import MockConfigEntry
@@ -151,15 +151,14 @@ async def test_setup_entry(hass: HomeAssistant) -> None:
 async def test_stop_device_stops_existing_event_manager(
     hass: HomeAssistant,
 ) -> None:
-    """Test stopping a device cleans up events even when not marked started."""
-    device = MagicMock()
-    device.name = NAME
-    device.capabilities.events = False
-    device.events.started = False
-    device.events.async_stop = AsyncMock()
-    device.device.close = AsyncMock()
+    """Test that unload stops the event manager even when capabilities.events is False."""
+    entry, _, mock_device = await setup_onvif_integration(hass)
+    # Default setup: capabilities.events=False, but mock_device.events exists.
+    # This mirrors the bug scenario where a partial subscription leaves background
+    # tasks running while capabilities.events stays False.
+    assert mock_device.capabilities.events is False
 
-    await _async_stop_device(hass, device)
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
 
-    device.events.async_stop.assert_awaited_once()
-    device.device.close.assert_awaited_once()
+    mock_device.events.async_stop.assert_awaited_once()

--- a/tests/components/onvif/test_init.py
+++ b/tests/components/onvif/test_init.py
@@ -153,9 +153,8 @@ async def test_stop_device_stops_existing_event_manager(
 ) -> None:
     """Test that unload stops the event manager even when capabilities.events is False."""
     entry, _, mock_device = await setup_onvif_integration(hass)
-    # Default setup: capabilities.events=False, but mock_device.events exists.
-    # This mirrors the bug scenario where a partial subscription leaves background
-    # tasks running while capabilities.events stays False.
+    # Mirrors the bug where a partial subscription leaves the event manager
+    # running while capabilities.events stays False.
     assert mock_device.capabilities.events is False
 
     assert await hass.config_entries.async_unload(entry.entry_id)

--- a/tests/components/onvif/test_init.py
+++ b/tests/components/onvif/test_init.py
@@ -1,7 +1,8 @@
 """Tests for the ONVIF integration __init__ module."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
+from homeassistant.components.onvif import _async_stop_device
 from homeassistant.components.onvif.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
@@ -145,3 +146,20 @@ async def test_setup_entry(hass: HomeAssistant) -> None:
     mock_onvif_camera_cls.assert_called_once()
     host, port, username, password = mock_onvif_camera_cls.call_args.args[:4]
     assert (host, port, username, password) == (HOST, PORT, USERNAME, PASSWORD)
+
+
+async def test_stop_device_stops_existing_event_manager(
+    hass: HomeAssistant,
+) -> None:
+    """Test stopping a device cleans up events even when not marked started."""
+    device = MagicMock()
+    device.name = NAME
+    device.capabilities.events = False
+    device.events.started = False
+    device.events.async_stop = AsyncMock()
+    device.device.close = AsyncMock()
+
+    await _async_stop_device(hass, device)
+
+    device.events.async_stop.assert_awaited_once()
+    device.device.close.assert_awaited_once()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR makes ONVIF event subscriptions stop reliably when a config entry is
unloaded or disabled:

- Stop the event manager unconditionally instead of gating on
  `capabilities.events` and `events.started`. Both can be false at unload while
  a PullPoint subscription still holds a live renewal task, which then keeps
  firing against the closed aiohttp session (#174057). `async_stop()` is a
  no-op when nothing is running.
- Create the event manager before the first await in `ONVIFDevice.async_setup`,
  so the cleanup registered in `async_setup_entry` can rely on `device.events`
  existing even when setup fails early.
- Remove the now-unused `EventManager.started` property.
- Add regression tests for the unload path and for cleanup after a failed setup.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #174057
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

AI-assisted (Opus); reviewed by a human.

