### PR TITLE
Fix summary for aw check requirements

### DIFF
--- a/.github/workflows/check-requirements.md
+++ b/.github/workflows/check-requirements.md
@@ -164,6 +164,9 @@ Read the JSON directly for the full schema. Key fields:
   - `{{CHECK_DETAIL:<pkg>:<kind>}}` → `<icon> <one-line explanation>`
     (the bullet's `- **<label>**:` prefix is already rendered; replace
     only the placeholder).
+  - `{{SUMMARY}}` → the single top-of-comment summary line, present only
+    when at least one check needed resolving. Fill it **after** resolving
+    every check, based on the final cell verdicts (see Step 3).
 
 Do not modify other content in `rendered_comment`, do not re-evaluate
 deterministic checks, do not add or remove packages. If `needs_agent`
@@ -191,6 +194,13 @@ Replace every placeholder with the resolved value and emit
 `rendered_comment` via `add_comment`. Preserve the leading
 `<!-- requirements-check -->` marker. The PR target is already wired;
 do not pass `item_number`.
+
+If a `{{SUMMARY}}` placeholder is present, replace it last, once every
+`{{CHECK_CELL:…}}` is resolved:
+- `All requirements checks passed. ✅` — when every check cell across all
+  packages is `✅` or `☑️` (treat `—`/skipped as not a problem).
+- `⚠️ Some checks require attention — see the details below.` — when any
+  cell is `⚠️` or `❌`.
 
 ## Check instructions
 

--- a/script/check_requirements/render.py
+++ b/script/check_requirements/render.py
@@ -34,6 +34,14 @@ _ICONS: dict[CheckStatus, str] = {
 }
 SKIPPED = "—"
 
+SUMMARY_PASS = "All requirements checks passed. ✅"
+SUMMARY_ATTENTION = "⚠️ Some checks require attention — see the details below."
+# Emitted when at least one check still needs the agent. The agent resolves it
+# to one of the two lines above once it has replaced the cell/detail
+# placeholders, so the summary reflects the final verdicts rather than the
+# deterministic-stage state.
+SUMMARY_PLACEHOLDER = "{{SUMMARY}}"
+
 
 def _placeholder(slot: str, pkg: PackageChange, kind: CheckKind) -> str:
     """Placeholder marker the agent replaces before posting."""
@@ -57,9 +65,12 @@ def _overall_status(pkg: PackageChange) -> CheckStatus | None:
 
 
 def _summary_line(packages: list[PackageChange]) -> str:
-    if all(_overall_status(p) == CheckStatus.PASS for p in packages):
-        return "All requirements checks passed. ✅"
-    return "⚠️ Some checks require attention — see the details below."
+    statuses = [_overall_status(p) for p in packages]
+    if None in statuses:
+        return SUMMARY_PLACEHOLDER
+    if all(status == CheckStatus.PASS for status in statuses):
+        return SUMMARY_PASS
+    return SUMMARY_ATTENTION
 
 
 def _cell(pkg: PackageChange, kind: CheckKind) -> str:

--- a/tests/scripts/check_requirements/test_render.py
+++ b/tests/scripts/check_requirements/test_render.py
@@ -66,6 +66,51 @@ def test_render_needs_agent_emits_generic_placeholders() -> None:
     assert "{{CHECK_CELL:pkg:async_blocking}}" in rendered
     assert "{{CHECK_DETAIL:pkg:async_blocking}}" in rendered
     assert "<details open>" in rendered
+    # A deterministic WARN (CI_UPLOAD) already forces the attention verdict
+    # regardless of how the agent resolves the pending checks, so the summary
+    # is rendered directly rather than deferred to the agent.
+    assert "⚠️ Some checks require attention — see the details below." in rendered
+    assert "{{SUMMARY}}" not in rendered
+
+
+def test_render_pass_or_pending_defers_summary_to_agent() -> None:
+    """With only PASS and NEEDS_AGENT checks, the summary is left as a placeholder.
+
+    The final verdict depends entirely on how the agent resolves the pending
+    checks, so the deterministic stage must not bake in a summary line.
+    """
+    pkg = PackageChange(
+        name="pkg",
+        old_version=None,
+        new_version="1.0.0",
+        repo_url="https://github.com/x/pkg",
+        checks={
+            CheckKind.CI_UPLOAD: _pass("attestation found"),
+            CheckKind.SECURITY: CheckResult(CheckStatus.NEEDS_AGENT, ""),
+            CheckKind.ASYNC_BLOCKING: CheckResult(CheckStatus.NEEDS_AGENT, ""),
+        },
+    )
+    rendered = render_comment(CheckRunResult(pr_number=1, packages=[pkg]))
+    assert "{{SUMMARY}}" in rendered
+    assert "All requirements checks passed. ✅" not in rendered
+    assert "⚠️ Some checks require attention" not in rendered
+
+
+def test_render_deterministic_warn_renders_attention_summary() -> None:
+    """A WARN with no agent-pending checks renders the attention line directly."""
+    pkg = PackageChange(
+        name="pkg",
+        old_version="1.0.0",
+        new_version="1.1.0",
+        repo_url="https://github.com/x/pkg",
+        checks={
+            CheckKind.CI_UPLOAD: _pass("attestation found"),
+            CheckKind.SECURITY: CheckResult(CheckStatus.WARN, "partial scan"),
+        },
+    )
+    rendered = render_comment(CheckRunResult(pr_number=1, packages=[pkg]))
+    assert "⚠️ Some checks require attention — see the details below." in rendered
+    assert "{{SUMMARY}}" not in rendered
 
 
 def test_render_empty_change_set() -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix summary for aw check requirements

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
