### PR TITLE
Add command error-path tests to Teslemetry

### DIFF
--- a/tests/components/teslemetry/test_cover.py
+++ b/tests/components/teslemetry/test_cover.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from tesla_fleet_api.exceptions import InvalidCommand
 from teslemetry_stream import Signal
 
 from homeassistant.components.cover import (
@@ -15,10 +16,11 @@ from homeassistant.components.cover import (
 )
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
 from . import assert_entities, setup_platform
-from .const import COMMAND_OK, METADATA_NOSCOPE, VEHICLE_DATA_ALT
+from .const import COMMAND_ERRORS, COMMAND_OK, METADATA_NOSCOPE, VEHICLE_DATA_ALT
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
@@ -219,6 +221,49 @@ async def test_cover_services(
         state = hass.states.get(entity_id)
         assert state
         assert state.state == CoverState.CLOSED
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "mock_legacy")
+@pytest.mark.parametrize("response", COMMAND_ERRORS)
+async def test_cover_command_errors(hass: HomeAssistant, response: dict) -> None:
+    """Tests that vehicle command failures raise HomeAssistantError."""
+
+    await setup_platform(hass, [Platform.COVER])
+
+    with (
+        patch(
+            "tesla_fleet_api.teslemetry.Vehicle.window_control",
+            return_value=response,
+        ),
+        pytest.raises(HomeAssistantError),
+    ):
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_OPEN_COVER,
+            {ATTR_ENTITY_ID: ["cover.test_windows"]},
+            blocking=True,
+        )
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "mock_legacy")
+async def test_cover_command_exception(hass: HomeAssistant) -> None:
+    """Tests that a command SDK exception raises HomeAssistantError."""
+
+    await setup_platform(hass, [Platform.COVER])
+
+    with (
+        patch(
+            "tesla_fleet_api.teslemetry.Vehicle.window_control",
+            side_effect=InvalidCommand,
+        ),
+        pytest.raises(HomeAssistantError),
+    ):
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_OPEN_COVER,
+            {ATTR_ENTITY_ID: ["cover.test_windows"]},
+            blocking=True,
+        )
 
 
 async def test_cover_streaming(

--- a/tests/components/teslemetry/test_lock.py
+++ b/tests/components/teslemetry/test_lock.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from tesla_fleet_api.exceptions import InvalidCommand
 from teslemetry_stream.const import Signal
 
 from homeassistant.components.lock import (
@@ -14,11 +15,11 @@ from homeassistant.components.lock import (
 )
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 
 from . import assert_entities, reload_platform, setup_platform
-from .const import COMMAND_OK, VEHICLE_DATA_ALT
+from .const import COMMAND_ERRORS, COMMAND_OK, VEHICLE_DATA_ALT
 
 
 async def test_lock(
@@ -107,6 +108,47 @@ async def test_lock_services(
         state = hass.states.get(entity_id)
         assert state.state == LockState.UNLOCKED
         call.assert_called_once()
+
+
+@pytest.mark.parametrize("response", COMMAND_ERRORS)
+async def test_lock_command_errors(hass: HomeAssistant, response: dict) -> None:
+    """Tests that vehicle command failures raise HomeAssistantError."""
+
+    await setup_platform(hass, [Platform.LOCK])
+
+    with (
+        patch(
+            "tesla_fleet_api.teslemetry.Vehicle.door_lock",
+            return_value=response,
+        ),
+        pytest.raises(HomeAssistantError),
+    ):
+        await hass.services.async_call(
+            LOCK_DOMAIN,
+            SERVICE_LOCK,
+            {ATTR_ENTITY_ID: "lock.test_lock"},
+            blocking=True,
+        )
+
+
+async def test_lock_command_exception(hass: HomeAssistant) -> None:
+    """Tests that a command SDK exception raises HomeAssistantError."""
+
+    await setup_platform(hass, [Platform.LOCK])
+
+    with (
+        patch(
+            "tesla_fleet_api.teslemetry.Vehicle.door_lock",
+            side_effect=InvalidCommand,
+        ),
+        pytest.raises(HomeAssistantError),
+    ):
+        await hass.services.async_call(
+            LOCK_DOMAIN,
+            SERVICE_LOCK,
+            {ATTR_ENTITY_ID: "lock.test_lock"},
+            blocking=True,
+        )
 
 
 async def test_lock_streaming(

--- a/tests/components/teslemetry/test_media_player.py
+++ b/tests/components/teslemetry/test_media_player.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from tesla_fleet_api.exceptions import InvalidCommand
 from teslemetry_stream import Signal
 
 from homeassistant.components.media_player import (
@@ -18,10 +19,11 @@ from homeassistant.components.media_player import (
 )
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
 from . import assert_entities, assert_entities_alt, reload_platform, setup_platform
-from .const import COMMAND_OK, METADATA_NOSCOPE, VEHICLE_DATA_ALT
+from .const import COMMAND_ERRORS, COMMAND_OK, METADATA_NOSCOPE, VEHICLE_DATA_ALT
 
 
 async def test_media_player(
@@ -142,6 +144,55 @@ async def test_media_player_services(
         )
         state = hass.states.get(entity_id)
         call.assert_called_once()
+
+
+@pytest.mark.usefixtures("mock_legacy")
+@pytest.mark.parametrize("response", COMMAND_ERRORS)
+async def test_media_player_command_errors(hass: HomeAssistant, response: dict) -> None:
+    """Tests that vehicle command failures raise HomeAssistantError."""
+
+    await setup_platform(hass, [Platform.MEDIA_PLAYER])
+
+    with (
+        patch(
+            "tesla_fleet_api.teslemetry.Vehicle.adjust_volume",
+            return_value=response,
+        ),
+        pytest.raises(HomeAssistantError),
+    ):
+        await hass.services.async_call(
+            MEDIA_PLAYER_DOMAIN,
+            SERVICE_VOLUME_SET,
+            {
+                ATTR_ENTITY_ID: "media_player.test_media_player",
+                ATTR_MEDIA_VOLUME_LEVEL: 0.5,
+            },
+            blocking=True,
+        )
+
+
+@pytest.mark.usefixtures("mock_legacy")
+async def test_media_player_command_exception(hass: HomeAssistant) -> None:
+    """Tests that a command SDK exception raises HomeAssistantError."""
+
+    await setup_platform(hass, [Platform.MEDIA_PLAYER])
+
+    with (
+        patch(
+            "tesla_fleet_api.teslemetry.Vehicle.adjust_volume",
+            side_effect=InvalidCommand,
+        ),
+        pytest.raises(HomeAssistantError),
+    ):
+        await hass.services.async_call(
+            MEDIA_PLAYER_DOMAIN,
+            SERVICE_VOLUME_SET,
+            {
+                ATTR_ENTITY_ID: "media_player.test_media_player",
+                ATTR_MEDIA_VOLUME_LEVEL: 0.5,
+            },
+            blocking=True,
+        )
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")

--- a/tests/components/teslemetry/test_number.py
+++ b/tests/components/teslemetry/test_number.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from tesla_fleet_api.exceptions import InvalidCommand
 from teslemetry_stream import Signal
 
 from homeassistant.components.number import (
@@ -13,10 +14,11 @@ from homeassistant.components.number import (
 )
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
 from . import assert_entities, reload_platform, setup_platform
-from .const import COMMAND_OK, VEHICLE_DATA_ALT
+from .const import COMMAND_ERRORS, COMMAND_OK, VEHICLE_DATA_ALT
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
@@ -102,6 +104,50 @@ async def test_number_services(
         state = hass.states.get(entity_id)
         assert state.state == "88"
         call.assert_called_once()
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+@pytest.mark.parametrize("response", COMMAND_ERRORS)
+async def test_number_command_errors(
+    hass: HomeAssistant, mock_vehicle_data: AsyncMock, response: dict
+) -> None:
+    """Tests that vehicle command failures raise HomeAssistantError."""
+    mock_vehicle_data.return_value = VEHICLE_DATA_ALT
+    await setup_platform(hass, [Platform.NUMBER])
+
+    with (
+        patch(
+            "tesla_fleet_api.teslemetry.Vehicle.set_charging_amps",
+            return_value=response,
+        ),
+        pytest.raises(HomeAssistantError),
+    ):
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: "number.test_charge_current", ATTR_VALUE: 16},
+            blocking=True,
+        )
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_number_command_exception(hass: HomeAssistant) -> None:
+    """Tests that an energy command SDK exception raises HomeAssistantError."""
+    await setup_platform(hass, [Platform.NUMBER])
+
+    with (
+        patch(
+            "tesla_fleet_api.teslemetry.EnergySite.backup",
+            side_effect=InvalidCommand,
+        ),
+        pytest.raises(HomeAssistantError),
+    ):
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: "number.energy_site_backup_reserve", ATTR_VALUE: 80},
+            blocking=True,
+        )
 
 
 async def test_number_streaming(

--- a/tests/components/teslemetry/test_select.py
+++ b/tests/components/teslemetry/test_select.py
@@ -7,6 +7,7 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 from tesla_fleet_api.const import EnergyExportMode, EnergyOperationMode
+from tesla_fleet_api.exceptions import InvalidCommand
 from teslemetry_stream.const import Signal
 
 from homeassistant.components.select import (
@@ -18,10 +19,11 @@ from homeassistant.components.teslemetry.coordinator import ENERGY_INFO_INTERVAL
 from homeassistant.components.teslemetry.select import LOW
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
 from . import assert_entities, reload_platform, setup_platform
-from .const import COMMAND_OK, SITE_INFO, VEHICLE_DATA_ALT
+from .const import COMMAND_ERRORS, COMMAND_OK, SITE_INFO, VEHICLE_DATA_ALT
 
 from tests.common import async_fire_time_changed
 
@@ -106,6 +108,51 @@ async def test_select_services(hass: HomeAssistant, mock_vehicle_data) -> None:
         state = hass.states.get(entity_id)
         assert state.state == EnergyExportMode.BATTERY_OK.value
         call.assert_called_once()
+
+
+@pytest.mark.parametrize("response", COMMAND_ERRORS)
+async def test_select_command_errors(
+    hass: HomeAssistant, mock_vehicle_data: AsyncMock, response: dict
+) -> None:
+    """Tests that vehicle command failures raise HomeAssistantError."""
+    mock_vehicle_data.return_value = VEHICLE_DATA_ALT
+    await setup_platform(hass, [Platform.SELECT])
+
+    with (
+        patch(
+            "tesla_fleet_api.teslemetry.Vehicle.remote_seat_heater_request",
+            return_value=response,
+        ),
+        pytest.raises(HomeAssistantError),
+    ):
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {ATTR_ENTITY_ID: "select.test_seat_heater_front_left", ATTR_OPTION: LOW},
+            blocking=True,
+        )
+
+
+async def test_select_command_exception(hass: HomeAssistant) -> None:
+    """Tests that an energy command SDK exception raises HomeAssistantError."""
+    await setup_platform(hass, [Platform.SELECT])
+
+    with (
+        patch(
+            "tesla_fleet_api.teslemetry.EnergySite.operation",
+            side_effect=InvalidCommand,
+        ),
+        pytest.raises(HomeAssistantError),
+    ):
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {
+                ATTR_ENTITY_ID: "select.energy_site_operation_mode",
+                ATTR_OPTION: EnergyOperationMode.AUTONOMOUS.value,
+            },
+            blocking=True,
+        )
 
 
 async def test_select_invalid_data(

--- a/tests/components/teslemetry/test_switch.py
+++ b/tests/components/teslemetry/test_switch.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from tesla_fleet_api.exceptions import InvalidCommand
 from teslemetry_stream import Signal
 
 from homeassistant.components.switch import (
@@ -13,10 +14,11 @@ from homeassistant.components.switch import (
 )
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
 from . import assert_entities, assert_entities_alt, reload_platform, setup_platform
-from .const import COMMAND_OK, VEHICLE_DATA_ALT
+from .const import COMMAND_ERRORS, COMMAND_OK, VEHICLE_DATA_ALT
 
 
 async def test_switch(
@@ -122,6 +124,49 @@ async def test_switch_services(
         state = hass.states.get(entity_id)
         assert state.state == STATE_OFF
         call.assert_called_once()
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+@pytest.mark.parametrize("response", COMMAND_ERRORS)
+async def test_switch_command_errors(hass: HomeAssistant, response: dict) -> None:
+    """Tests that vehicle command failures raise HomeAssistantError."""
+
+    await setup_platform(hass, [Platform.SWITCH])
+
+    with (
+        patch(
+            "tesla_fleet_api.teslemetry.Vehicle.charge_start",
+            return_value=response,
+        ),
+        pytest.raises(HomeAssistantError),
+    ):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "switch.test_charge"},
+            blocking=True,
+        )
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_switch_command_exception(hass: HomeAssistant) -> None:
+    """Tests that an energy command SDK exception raises HomeAssistantError."""
+
+    await setup_platform(hass, [Platform.SWITCH])
+
+    with (
+        patch(
+            "tesla_fleet_api.teslemetry.EnergySite.storm_mode",
+            side_effect=InvalidCommand,
+        ),
+        pytest.raises(HomeAssistantError),
+    ):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "switch.energy_site_storm_watch"},
+            blocking=True,
+        )
 
 
 async def test_switch_streaming(


### PR DESCRIPTION
## Proposed change

This Platinum integration funnels nearly every controllable entity's commands through two helpers in `homeassistant/components/teslemetry/helpers.py`: `handle_vehicle_command` (which raises `HomeAssistantError` on missing/error/rejected responses) and `handle_command` (which raises only on an SDK `TeslaFleetError`). Previously only `test_climate.py` exercised these error paths, so the failure-prone real-world flows (vehicle asleep, command rejected, malformed response, SDK exception) were untested for the cover, switch, select, number, lock, and media_player platforms. This PR adds error-path tests for each: a parametrized test over `COMMAND_ERRORS` for a representative vehicle command, plus a `side_effect=InvalidCommand` test (using an energy command for switch/select/number, since energy commands only raise on SDK exceptions). No source code changes — `helpers.py` now reaches 100% coverage.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr