### PR TITLE
Cast SwitchBot Cloud device sw_version to string

### DIFF
--- a/homeassistant/components/switchbot_cloud/entity.py
+++ b/homeassistant/components/switchbot_cloud/entity.py
@@ -36,8 +36,11 @@ class SwitchBotCloudEntity(CoordinatorEntity[SwitchBotCoordinator]):
         self._api = api
         self._attr_unique_id = device.device_id
         _sw_version = None
-        if self.coordinator.data is not None:
-            _sw_version = self.coordinator.data.get("version")
+        if (
+            self.coordinator.data is not None
+            and (_version := self.coordinator.data.get("version")) is not None
+        ):
+            _sw_version = str(_version)
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, device.device_id)},
             name=device.device_name,

--- a/tests/components/switchbot_cloud/test_entity.py
+++ b/tests/components/switchbot_cloud/test_entity.py
@@ -1,0 +1,52 @@
+"""Test for the switchbot_cloud base entity."""
+
+from unittest.mock import patch
+
+from homeassistant.components.switchbot_cloud.const import DOMAIN
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from . import METER_INFO, configure_integration
+
+
+async def test_sw_version_cast_to_string(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mock_list_devices,
+    mock_get_status,
+    mock_setup_webhook,
+) -> None:
+    """Test the device sw_version is a string when the API returns an int."""
+    mock_list_devices.return_value = [METER_INFO]
+    mock_get_status.return_value = {"version": 123}
+
+    with patch("homeassistant.components.switchbot_cloud.PLATFORMS", [Platform.SENSOR]):
+        await configure_integration(hass)
+
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, METER_INFO.device_id)}
+    )
+    assert device is not None
+    assert device.sw_version == "123"
+
+
+async def test_sw_version_none_when_missing(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mock_list_devices,
+    mock_get_status,
+    mock_setup_webhook,
+) -> None:
+    """Test the device sw_version is None when the API omits the version."""
+    mock_list_devices.return_value = [METER_INFO]
+    mock_get_status.return_value = {}
+
+    with patch("homeassistant.components.switchbot_cloud.PLATFORMS", [Platform.SENSOR]):
+        await configure_integration(hass)
+
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, METER_INFO.device_id)}
+    )
+    assert device is not None
+    assert device.sw_version is None


### PR DESCRIPTION
## Proposed change

Home Assistant logs a deprecation warning for every SwitchBot Cloud device on startup:

```
Detected that integration 'switchbot_cloud' passes a non-string value of type int as sw_version to the device registry
```

The cloud API reports the firmware `version` as an integer, and the base entity passed it directly to `DeviceInfo(sw_version=...)`. This casts the value to a string so the device registry receives the expected type, and keeps `sw_version` as `None` when the API reports no version so the registry never stores a literal `"None"`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: N/A (resolves a deprecation warning logged on every startup)

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
