### PR TITLE
Fix Duco error placeholders and test typing

### DIFF
--- a/homeassistant/components/duco/coordinator.py
+++ b/homeassistant/components/duco/coordinator.py
@@ -69,19 +69,16 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
             raise ConfigEntryError(
                 translation_domain=DOMAIN,
                 translation_key="api_error",
-                translation_placeholders={"error": repr(err)},
             ) from err
         except DucoConnectionError as err:
             raise UpdateFailed(
                 translation_domain=DOMAIN,
                 translation_key="cannot_connect",
-                translation_placeholders={"error": repr(err)},
             ) from err
         except DucoError as err:
             raise ConfigEntryError(
                 translation_domain=DOMAIN,
                 translation_key="api_error",
-                translation_placeholders={"error": repr(err)},
             ) from err
 
     async def _async_update_data(self) -> DucoData:
@@ -92,13 +89,11 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
             raise UpdateFailed(
                 translation_domain=DOMAIN,
                 translation_key="cannot_connect",
-                translation_placeholders={"error": repr(err)},
             ) from err
         except DucoError as err:
             raise UpdateFailed(
                 translation_domain=DOMAIN,
                 translation_key="api_error",
-                translation_placeholders={"error": repr(err)},
             ) from err
 
         try:

--- a/homeassistant/components/duco/diagnostics.py
+++ b/homeassistant/components/duco/diagnostics.py
@@ -64,7 +64,6 @@ async def async_get_config_entry_diagnostics(
         raise HomeAssistantError(
             translation_domain=DOMAIN,
             translation_key="api_error",
-            translation_placeholders={"error": repr(err)},
         ) from err
 
     api_info: dict[str, Any] = {"public_api_version": api_info_obj.public_api_version}

--- a/homeassistant/components/duco/strings.json
+++ b/homeassistant/components/duco/strings.json
@@ -111,10 +111,10 @@
   },
   "exceptions": {
     "api_error": {
-      "message": "Unexpected error from the Duco API: {error}"
+      "message": "Unexpected error from the Duco API."
     },
     "cannot_connect": {
-      "message": "An error occurred while trying to connect to the Duco instance: {error}"
+      "message": "Could not connect to the Duco device."
     },
     "connection_error": {
       "message": "Could not connect to the Duco device."

--- a/tests/components/duco/test_init.py
+++ b/tests/components/duco/test_init.py
@@ -10,6 +10,7 @@ from duco_connectivity import (
     DucoResponseError,
     LanInfo,
     Node,
+    NodeListActionItemList,
 )
 import pytest
 
@@ -44,14 +45,14 @@ from tests.common import MockConfigEntry
             DucoError("Unexpected API error"),
             ConfigEntryState.SETUP_ERROR,
             "api_error",
-            True,
+            False,
         ),
         (
             "async_get_board_info",
             DucoResponseError(500, "/info"),
             ConfigEntryState.SETUP_ERROR,
             "api_error",
-            True,
+            False,
         ),
         (
             "async_get_nodes",
@@ -212,7 +213,7 @@ async def test_setup_entry_creates_http_client(
     mock_config_entry: MockConfigEntry,
     mock_board_info: BoardInfo,
     mock_lan_info: LanInfo,
-    mock_node_actions,
+    mock_node_actions: NodeListActionItemList,
     mock_nodes: list[Node],
 ) -> None:
     """Test that setup creates the Duco client with the provided host."""


### PR DESCRIPTION
## Proposed change
This change removes raw exception text from Duco user-facing translated errors by dropping `translation_placeholders` for runtime API/connection errors and updating the related exception strings to generic messages.

It also adds the missing `NodeListActionItemList` type annotation to `mock_node_actions` in `test_init.py` and updates setup error expectations to match the new generic error behavior.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr