### PR TITLE
usb: Avoid importing aioesphomeapi in serial proxy stub

### DIFF
--- a/homeassistant/components/usb/serial_proxy_stub.py
+++ b/homeassistant/components/usb/serial_proxy_stub.py
@@ -1,29 +1,120 @@
 """ESPHome serial proxy URI handler stub for serialx."""
 
-from collections.abc import Callable
-from typing import override
+from collections.abc import Buffer, Callable
+from typing import Unpack, override
 
-from serialx import register_uri_handler
-from serialx.platforms.serial_esphome import ESPHomeSerial, ESPHomeSerialTransport
+from serialx import BaseSerial, BaseSerialTransport, ModemPins, register_uri_handler
+from serialx.common import ConnectKwargs
 
 from homeassistant.core import Event, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 
+_NOT_READY = "ESPHome has not loaded yet"
 
-class HassESPHomeSerialStub(ESPHomeSerial):
-    """ESPHomeSerial that throws `ConfigEntryNotReady` until ESPHome itself loads."""
+
+class HassESPHomeSerialStub(BaseSerial):
+    """Serial stub that raises `ConfigEntryNotReady` until ESPHome itself loads."""
 
     @override
-    async def _async_open(self) -> None:
+    def _open(self) -> None:
         """Open a connection."""
-        raise ConfigEntryNotReady("ESPHome has not loaded yet")
+        raise ConfigEntryNotReady(_NOT_READY)
+
+    @override
+    def _configure_port(self) -> None:
+        """Configure the serial port settings."""
+
+    @override
+    def _close(self) -> None:
+        """Close the serial port."""
+
+    @property
+    @override
+    def is_open(self) -> bool:
+        """Return whether the serial port is open."""
+        return False
+
+    @override
+    def _get_modem_pins(self) -> ModemPins:
+        """Get modem control bits."""
+        return ModemPins()
+
+    @override
+    def _set_modem_pins(self, modem_pins: ModemPins) -> None:
+        """Set modem control bits."""
+
+    @override
+    def _readinto(self, b: Buffer, *, timeout: float | None) -> int:
+        """Read bytes from the serial port into a buffer."""
+        return 0
+
+    @override
+    def _write(self, data: Buffer, *, timeout: float | None) -> int:
+        """Write bytes to the serial port."""
+        return 0
+
+    @override
+    def _flush(self) -> None:
+        """Flush write buffers."""
+
+    @override
+    def _reset_read_buffer(self) -> None:
+        """Reset the read buffer."""
+
+    @override
+    def _reset_write_buffer(self) -> None:
+        """Reset the write buffer."""
+
+    @override
+    def num_unread_bytes(self) -> int:
+        """Return the number of bytes waiting to be read."""
+        return 0
+
+    @override
+    def num_unwritten_bytes(self) -> int:
+        """Return the number of bytes waiting to be written."""
+        return 0
 
 
-class HassESPHomeSerialStubTransport(ESPHomeSerialTransport):
-    """Transport variant that constructs `HassESPHomeSerialStub`."""
+class HassESPHomeSerialStubTransport(BaseSerialTransport):
+    """Transport stub that raises `ConfigEntryNotReady` until ESPHome itself loads."""
 
     transport_name = "esphome-hass"
-    _serial_cls = HassESPHomeSerialStub
+
+    @override
+    async def _connect(
+        self, *, path: str | None = None, **kwargs: Unpack[ConnectKwargs]
+    ) -> None:
+        """Connect to the serial port."""
+        raise ConfigEntryNotReady(_NOT_READY)
+
+    @override
+    def close(self) -> None:
+        """Close the transport."""
+        if self._closing:
+            return
+        self._closing = True
+        self._mark_user_closed()
+        # Resolve the closed waiter so `connect()`'s failure path doesn't hang.
+        self._call_protocol_connection_lost(None)
+
+    @override
+    def abort(self) -> None:
+        """Abort the transport immediately."""
+        self.close()
+
+    @override
+    async def _flush(self) -> None:
+        """Flush write buffers."""
+
+    @override
+    async def _get_modem_pins(self) -> ModemPins:
+        """Get modem control bits."""
+        return ModemPins()
+
+    @override
+    async def _set_modem_pins(self, modem_pins: ModemPins) -> None:
+        """Set modem control bits."""
 
 
 def register_serialx_transport() -> Callable[[Event], None]:


### PR DESCRIPTION
## Proposed change

Provide a standalone stub to avoid aioesphomeapi dependency.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
Dependency introduced by https://github.com/home-assistant/core/commit/8ce14877a41faa27baf335fd40c09c849aea09a5 via https://github.com/home-assistant/core/blame/409ac3fd82f82e72d51d68a7fd671507e478bef9/homeassistant/components/usb/serial_proxy_stub.py#L6.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
