### PR TITLE
Bump victron-mqtt to 2026.6.6

### DIFF
--- a/homeassistant/components/victron_gx/entity.py
+++ b/homeassistant/components/victron_gx/entity.py
@@ -62,6 +62,9 @@ class VictronBaseEntity(Entity):
         )
 
     def _native_unit_of_measurement(self) -> str | None:
+        if self._metric.metric_type == MetricType.COST:
+            return self.hass.config.currency
+
         unit_of_measurement = self._metric.unit_of_measurement
         # We need to provide a native unit in three cases:
         if (

--- a/homeassistant/components/victron_gx/entity.py
+++ b/homeassistant/components/victron_gx/entity.py
@@ -61,7 +61,9 @@ class VictronBaseEntity(Entity):
             metric.generic_short_id not in ENTITIES_DISABLE_BY_DEFAULT
         )
 
-    def _native_unit_of_measurement(self) -> str | None:
+    @property
+    def native_unit_of_measurement(self) -> str | None:
+        """Return the metric unit before entity registration."""
         if self._metric.metric_type == MetricType.COST:
             return self.hass.config.currency
 

--- a/homeassistant/components/victron_gx/manifest.json
+++ b/homeassistant/components/victron_gx/manifest.json
@@ -7,7 +7,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "quality_scale": "platinum",
-  "requirements": ["victron-mqtt==2026.6.1.1"],
+  "requirements": ["victron-mqtt==2026.6.6"],
   "ssdp": [
     {
       "X_MqttOnLan": "1",

--- a/homeassistant/components/victron_gx/number.py
+++ b/homeassistant/components/victron_gx/number.py
@@ -76,7 +76,6 @@ class VictronNumber(VictronBaseEntity, NumberEntity):
     ) -> None:
         """Initialize the number entity."""
         super().__init__(device, metric, device_info, installation_id)
-        self._attr_native_unit_of_measurement = None
         self._attr_device_class = METRIC_TYPE_TO_DEVICE_CLASS.get(metric.metric_type)
         self._attr_native_value = metric.value
         if metric.min_value is not None:
@@ -90,11 +89,6 @@ class VictronNumber(VictronBaseEntity, NumberEntity):
     def _on_update_cb(self, value: Any) -> None:
         self._attr_native_value = value
         self.async_write_ha_state()
-
-    async def async_added_to_hass(self) -> None:
-        """Run when entity about to be added to hass."""
-        self._attr_native_unit_of_measurement = self._native_unit_of_measurement()
-        await super().async_added_to_hass()
 
     async def async_set_native_value(self, value: float) -> None:
         """Set a new value."""

--- a/homeassistant/components/victron_gx/number.py
+++ b/homeassistant/components/victron_gx/number.py
@@ -29,6 +29,11 @@ METRIC_TYPE_TO_DEVICE_CLASS: dict[MetricType, NumberDeviceClass] = {
     MetricType.FREQUENCY: NumberDeviceClass.FREQUENCY,
     MetricType.ELECTRIC_STORAGE_PERCENTAGE: NumberDeviceClass.BATTERY,
     MetricType.TEMPERATURE: NumberDeviceClass.TEMPERATURE,
+    MetricType.HUMIDITY: NumberDeviceClass.HUMIDITY,
+    MetricType.PRESSURE: NumberDeviceClass.PRESSURE,
+    MetricType.DISTANCE: NumberDeviceClass.DISTANCE,
+    MetricType.POWER_FACTOR: NumberDeviceClass.POWER_FACTOR,
+    MetricType.COST: NumberDeviceClass.MONETARY,
     MetricType.SPEED: NumberDeviceClass.SPEED,
     MetricType.LIQUID_VOLUME: NumberDeviceClass.VOLUME_STORAGE,
     MetricType.DURATION: NumberDeviceClass.DURATION,
@@ -71,8 +76,8 @@ class VictronNumber(VictronBaseEntity, NumberEntity):
     ) -> None:
         """Initialize the number entity."""
         super().__init__(device, metric, device_info, installation_id)
+        self._attr_native_unit_of_measurement = None
         self._attr_device_class = METRIC_TYPE_TO_DEVICE_CLASS.get(metric.metric_type)
-        self._attr_native_unit_of_measurement = self._native_unit_of_measurement()
         self._attr_native_value = metric.value
         if metric.min_value is not None:
             self._attr_native_min_value = metric.min_value
@@ -85,6 +90,11 @@ class VictronNumber(VictronBaseEntity, NumberEntity):
     def _on_update_cb(self, value: Any) -> None:
         self._attr_native_value = value
         self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity about to be added to hass."""
+        self._attr_native_unit_of_measurement = self._native_unit_of_measurement()
+        await super().async_added_to_hass()
 
     async def async_set_native_value(self, value: float) -> None:
         """Set a new value."""

--- a/homeassistant/components/victron_gx/sensor.py
+++ b/homeassistant/components/victron_gx/sensor.py
@@ -94,7 +94,6 @@ class VictronSensor(VictronBaseEntity, SensorEntity):
     ) -> None:
         """Initialize the sensor."""
         super().__init__(device, metric, device_info, installation_id)
-        self._attr_native_unit_of_measurement = None
         self._attr_device_class = METRIC_TYPE_TO_DEVICE_CLASS.get(metric.metric_type)
         # Enum sensors must not have a state class
         if self._attr_device_class == SensorDeviceClass.ENUM:
@@ -116,8 +115,3 @@ class VictronSensor(VictronBaseEntity, SensorEntity):
         if isinstance(value, VictronEnum):
             return value.id
         return value
-
-    async def async_added_to_hass(self) -> None:
-        """Run when entity about to be added to hass."""
-        self._attr_native_unit_of_measurement = self._native_unit_of_measurement()
-        await super().async_added_to_hass()

--- a/homeassistant/components/victron_gx/sensor.py
+++ b/homeassistant/components/victron_gx/sensor.py
@@ -34,6 +34,11 @@ METRIC_TYPE_TO_DEVICE_CLASS: dict[MetricType, SensorDeviceClass] = {
     MetricType.FREQUENCY: SensorDeviceClass.FREQUENCY,
     MetricType.ELECTRIC_STORAGE_PERCENTAGE: SensorDeviceClass.BATTERY,
     MetricType.TEMPERATURE: SensorDeviceClass.TEMPERATURE,
+    MetricType.HUMIDITY: SensorDeviceClass.HUMIDITY,
+    MetricType.PRESSURE: SensorDeviceClass.PRESSURE,
+    MetricType.DISTANCE: SensorDeviceClass.DISTANCE,
+    MetricType.POWER_FACTOR: SensorDeviceClass.POWER_FACTOR,
+    MetricType.COST: SensorDeviceClass.MONETARY,
     MetricType.SPEED: SensorDeviceClass.SPEED,
     MetricType.LIQUID_VOLUME: SensorDeviceClass.VOLUME_STORAGE,
     MetricType.DURATION: SensorDeviceClass.DURATION,
@@ -89,6 +94,7 @@ class VictronSensor(VictronBaseEntity, SensorEntity):
     ) -> None:
         """Initialize the sensor."""
         super().__init__(device, metric, device_info, installation_id)
+        self._attr_native_unit_of_measurement = None
         self._attr_device_class = METRIC_TYPE_TO_DEVICE_CLASS.get(metric.metric_type)
         # Enum sensors must not have a state class
         if self._attr_device_class == SensorDeviceClass.ENUM:
@@ -97,7 +103,6 @@ class VictronSensor(VictronBaseEntity, SensorEntity):
             self._attr_state_class = METRIC_NATURE_TO_STATE_CLASS.get(
                 metric.metric_nature
             )
-        self._attr_native_unit_of_measurement = self._native_unit_of_measurement()
         self._attr_native_value = VictronSensor._normalize_value(metric.value)
 
     @callback
@@ -111,3 +116,8 @@ class VictronSensor(VictronBaseEntity, SensorEntity):
         if isinstance(value, VictronEnum):
             return value.id
         return value
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity about to be added to hass."""
+        self._attr_native_unit_of_measurement = self._native_unit_of_measurement()
+        await super().async_added_to_hass()

--- a/homeassistant/components/victron_gx/strings.json
+++ b/homeassistant/components/victron_gx/strings.json
@@ -20,12 +20,14 @@
     "current": "Current",
     "current_limit": "Current limit",
     "current_on_phase": "Current on {phase}",
-    "current_phase": "Current {phase}",
     "current_sensor_issue": "Current sensor issue",
+    "dc_current": "DC current",
     "dc_output_current": "DC output current",
     "dc_output_power": "DC output power",
     "dc_output_voltage": "DC output voltage",
+    "dc_power": "DC power",
     "dc_temperature": "DC temperature",
+    "dc_voltage": "DC voltage",
     "equalize": "Equalize",
     "error_code": "Error code",
     "ess_mode": "ESS mode",
@@ -49,6 +51,7 @@
     "lost_communication_with_device": "Lost communication with device",
     "low_battery_alarm": "Low battery alarm",
     "low_power": "Low power",
+    "low_temperature": "Low temperature",
     "max_power_today": "Max power today",
     "max_power_yesterday": "Max power yesterday",
     "mppt_active": "MPPT active",
@@ -90,6 +93,7 @@
     "synchronized_charging_config_issue": "Synchronized charging config issue",
     "temperature": "Temperature",
     "terminals_overheated": "Terminals overheated",
+    "total_energy": "Total energy",
     "total_pv_yield_user": "Total PV yield user",
     "total_yield": "Total yield",
     "unknown": "Unknown",
@@ -183,6 +187,15 @@
   },
   "entity": {
     "binary_sensor": {
+      "battery_allow_to_charge": {
+        "name": "Allow to charge"
+      },
+      "battery_allow_to_discharge": {
+        "name": "Allow to discharge"
+      },
+      "ev_at_site": {
+        "name": "At site"
+      },
       "evcharger_connected": {
         "name": "[%key:common::state::connected%]"
       },
@@ -241,6 +254,9 @@
       }
     },
     "device_tracker": {
+      "ev_gps_location": {
+        "name": "[%key:common::config_flow::data::location%]"
+      },
       "gps_location": {
         "name": "[%key:common::config_flow::data::location%]"
       }
@@ -569,6 +585,14 @@
       "battery_average_discharge": {
         "name": "Average discharge"
       },
+      "battery_bms_cable": {
+        "name": "BMS cable",
+        "state": {
+          "alarm": "[%key:component::victron_gx::common::alarm%]",
+          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
+          "warning": "[%key:component::victron_gx::common::warning%]"
+        }
+      },
       "battery_capacity": {
         "name": "Capacity"
       },
@@ -604,6 +628,22 @@
       "battery_discharged_energy": {
         "name": "Discharged energy"
       },
+      "battery_fuse_blown": {
+        "name": "Fuse blown",
+        "state": {
+          "alarm": "[%key:component::victron_gx::common::alarm%]",
+          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
+          "warning": "[%key:component::victron_gx::common::warning%]"
+        }
+      },
+      "battery_high_cell_voltage": {
+        "name": "High cell voltage",
+        "state": {
+          "alarm": "[%key:component::victron_gx::common::alarm%]",
+          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
+          "warning": "[%key:component::victron_gx::common::warning%]"
+        }
+      },
       "battery_high_charge_current": {
         "name": "High charge current",
         "state": {
@@ -622,6 +662,30 @@
       },
       "battery_high_discharge_current": {
         "name": "High discharge current",
+        "state": {
+          "alarm": "[%key:component::victron_gx::common::alarm%]",
+          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
+          "warning": "[%key:component::victron_gx::common::warning%]"
+        }
+      },
+      "battery_high_internal_temperature": {
+        "name": "High internal temperature",
+        "state": {
+          "alarm": "[%key:component::victron_gx::common::alarm%]",
+          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
+          "warning": "[%key:component::victron_gx::common::warning%]"
+        }
+      },
+      "battery_high_temperature": {
+        "name": "High temperature",
+        "state": {
+          "alarm": "[%key:component::victron_gx::common::alarm%]",
+          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
+          "warning": "[%key:component::victron_gx::common::warning%]"
+        }
+      },
+      "battery_high_voltage": {
+        "name": "High voltage",
         "state": {
           "alarm": "[%key:component::victron_gx::common::alarm%]",
           "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
@@ -652,6 +716,30 @@
       },
       "battery_low_charge_temperature": {
         "name": "Low charge temperature",
+        "state": {
+          "alarm": "[%key:component::victron_gx::common::alarm%]",
+          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
+          "warning": "[%key:component::victron_gx::common::warning%]"
+        }
+      },
+      "battery_low_soc": {
+        "name": "Low state of charge",
+        "state": {
+          "alarm": "[%key:component::victron_gx::common::alarm%]",
+          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
+          "warning": "[%key:component::victron_gx::common::warning%]"
+        }
+      },
+      "battery_low_temperature": {
+        "name": "[%key:component::victron_gx::common::low_temperature%]",
+        "state": {
+          "alarm": "[%key:component::victron_gx::common::alarm%]",
+          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
+          "warning": "[%key:component::victron_gx::common::warning%]"
+        }
+      },
+      "battery_low_voltage": {
+        "name": "Low voltage",
         "state": {
           "alarm": "[%key:component::victron_gx::common::alarm%]",
           "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
@@ -727,6 +815,14 @@
       },
       "battery_soh": {
         "name": "State of health"
+      },
+      "battery_state_of_health_alarm": {
+        "name": "State of health alarm",
+        "state": {
+          "alarm": "[%key:component::victron_gx::common::alarm%]",
+          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
+          "warning": "[%key:component::victron_gx::common::warning%]"
+        }
       },
       "battery_temperature": {
         "name": "[%key:component::victron_gx::common::temperature%]"
@@ -926,6 +1022,85 @@
           "touch_input_control": "Touch input control"
         }
       },
+      "ev_ac_current": {
+        "name": "AC current"
+      },
+      "ev_ac_energy_forward": {
+        "name": "[%key:component::victron_gx::common::total_energy%]"
+      },
+      "ev_ac_max_charge_current": {
+        "name": "Max charge current"
+      },
+      "ev_ac_min_charge_current": {
+        "name": "Min charge current"
+      },
+      "ev_ac_nr_of_phases": {
+        "name": "Number of phases"
+      },
+      "ev_ac_power": {
+        "name": "AC power"
+      },
+      "ev_ac_voltage": {
+        "name": "AC voltage"
+      },
+      "ev_alarm_starter_battery_low": {
+        "name": "Starter battery low",
+        "state": {
+          "alarm": "[%key:component::victron_gx::common::alarm%]",
+          "no_alarm": "[%key:component::victron_gx::common::no_alarm%]",
+          "warning": "[%key:component::victron_gx::common::warning%]"
+        }
+      },
+      "ev_battery_capacity": {
+        "name": "Battery capacity"
+      },
+      "ev_battery_temperature": {
+        "name": "Battery temperature"
+      },
+      "ev_charging_started": {
+        "name": "Charging started"
+      },
+      "ev_charging_state": {
+        "name": "Charging state",
+        "state": {
+          "blocked": "Blocked",
+          "charging": "[%key:common::state::charging%]",
+          "discharging": "[%key:common::state::discharging%]",
+          "low_power_mode": "Low power mode",
+          "not_charging": "Not charging",
+          "scheduled_charging": "Scheduled charging",
+          "sustain": "[%key:component::victron_gx::common::sustain%]",
+          "unavailable": "Unavailable",
+          "wake_up": "Wake up"
+        }
+      },
+      "ev_dc_current": {
+        "name": "[%key:component::victron_gx::common::dc_current%]"
+      },
+      "ev_dc_power": {
+        "name": "[%key:component::victron_gx::common::dc_power%]"
+      },
+      "ev_dc_voltage": {
+        "name": "[%key:component::victron_gx::common::dc_voltage%]"
+      },
+      "ev_last_ev_contact": {
+        "name": "Last EV contact"
+      },
+      "ev_odometer": {
+        "name": "Odometer"
+      },
+      "ev_range_to_go": {
+        "name": "Range to go"
+      },
+      "ev_soc": {
+        "name": "State of charge"
+      },
+      "ev_target_soc": {
+        "name": "Target state of charge"
+      },
+      "ev_vin": {
+        "name": "VIN"
+      },
       "evcharger_current": {
         "name": "[%key:component::victron_gx::common::current%]"
       },
@@ -949,8 +1124,7 @@
         "name": "[%key:component::victron_gx::common::power_phase%]"
       },
       "evcharger_session_cost": {
-        "name": "Last session cost",
-        "unit_of_measurement": "$"
+        "name": "Last session cost"
       },
       "evcharger_session_energy": {
         "name": "Last session energy"
@@ -988,7 +1162,7 @@
         }
       },
       "evcharger_total_energy": {
-        "name": "Total energy"
+        "name": "[%key:component::victron_gx::common::total_energy%]"
       },
       "generator_next_test_run": {
         "name": "Next test run"
@@ -1181,13 +1355,13 @@
         "name": "AC-in-1 to inverter"
       },
       "multi_acin_current_phase": {
-        "name": "[%key:component::victron_gx::common::current_phase%]"
+        "name": "Input current on {phase}"
       },
       "multi_acin_power_phase": {
-        "name": "[%key:component::victron_gx::common::power_on_phase%]"
+        "name": "Input power on {phase}"
       },
       "multi_acin_voltage_phase": {
-        "name": "[%key:component::victron_gx::common::voltage_on_phase%]"
+        "name": "Input voltage on {phase}"
       },
       "multi_acout_current_phase": {
         "name": "Output current on {phase}"
@@ -1330,7 +1504,7 @@
         "name": "Installed version"
       },
       "pvinverter_current_phase": {
-        "name": "[%key:component::victron_gx::common::current_phase%]"
+        "name": "Current {phase}"
       },
       "pvinverter_power_phase": {
         "name": "[%key:component::victron_gx::common::power_phase%]"
@@ -1362,7 +1536,7 @@
           "active_alarm": "Active alarm",
           "analysing_input_voltage": "Analysing input voltage",
           "engine_shutdown": "Engine shutdown on low input voltage",
-          "low_temperature": "Low temperature",
+          "low_temperature": "[%key:component::victron_gx::common::low_temperature%]",
           "need_token": "Need token for operation",
           "no_battery_power": "No/low battery power",
           "no_input_power": "No/low input power",
@@ -1587,6 +1761,15 @@
       },
       "system_dc_pv_power": {
         "name": "PV power"
+      },
+      "system_dvcc_state": {
+        "name": "DVCC state",
+        "state": {
+          "forced_off": "Forced off",
+          "forced_on": "Forced on",
+          "off": "[%key:common::state::off%]",
+          "on": "[%key:common::state::on%]"
+        }
       },
       "system_dynamicess_available_overhead": {
         "name": "Dynamic ESS available overhead"
@@ -1943,16 +2126,16 @@
         "name": "[%key:component::victron_gx::common::current_limit%]"
       },
       "vebus_inverter_dc_current": {
-        "name": "DC current"
+        "name": "[%key:component::victron_gx::common::dc_current%]"
       },
       "vebus_inverter_dc_power": {
-        "name": "DC power"
+        "name": "[%key:component::victron_gx::common::dc_power%]"
       },
       "vebus_inverter_dc_temperature": {
         "name": "[%key:component::victron_gx::common::dc_temperature%]"
       },
       "vebus_inverter_dc_voltage": {
-        "name": "DC voltage"
+        "name": "[%key:component::victron_gx::common::dc_voltage%]"
       },
       "vebus_inverter_ignoreacin1_state": {
         "name": "State of ignore AC-in-1",
@@ -2067,6 +2250,9 @@
       },
       "switchable_output_output_state": {
         "name": "[%key:component::victron_gx::common::state%]"
+      },
+      "system_dvcc": {
+        "name": "DVCC"
       },
       "system_ess_battery_use": {
         "name": "ESS only critical loads from battery"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3311,7 +3311,7 @@ viaggiatreno_ha==0.2.4
 victron-ble-ha-parser==0.7.0
 
 # homeassistant.components.victron_gx
-victron-mqtt==2026.6.1.1
+victron-mqtt==2026.6.6
 
 # homeassistant.components.victron_remote_monitoring
 victron-vrm==0.1.12

--- a/tests/components/victron_gx/test_number.py
+++ b/tests/components/victron_gx/test_number.py
@@ -41,14 +41,17 @@ async def test_victron_number_with_step(
         == f"{MOCK_INSTALLATION_ID}_system_0_system_ess_max_charge_voltage"
     )
     assert entity.original_device_class is NumberDeviceClass.VOLTAGE
-    assert entity.unit_of_measurement == "V"
     assert entity.translation_key == "system_ess_max_charge_voltage"
 
+    # Unit is resolved in async_added_to_hass (needs hass.config), so it is not
+    # available in the entity registry at registration time. Verify it via the
+    # state attributes, which are written after async_added_to_hass completes.
     state = hass.states.get(entity.entity_id)
     assert state is not None
+    assert state.attributes["unit_of_measurement"] == "V"
+
     assert state.state == "57.6"
     assert state.attributes["device_class"] == "voltage"
-    assert state.attributes["unit_of_measurement"] == "V"
     assert state.attributes["step"] == 0.1
     assert state.attributes["min"] == 0.0
     assert state.attributes["max"] == 100.0

--- a/tests/components/victron_gx/test_number.py
+++ b/tests/components/victron_gx/test_number.py
@@ -41,11 +41,8 @@ async def test_victron_number_with_step(
         == f"{MOCK_INSTALLATION_ID}_system_0_system_ess_max_charge_voltage"
     )
     assert entity.original_device_class is NumberDeviceClass.VOLTAGE
+    assert entity.unit_of_measurement == "V"
     assert entity.translation_key == "system_ess_max_charge_voltage"
-
-    # Unit is resolved in async_added_to_hass (needs hass.config), so it is not
-    # available in the entity registry at registration time. Verify it via the
-    # state attributes, which are written after async_added_to_hass completes.
     state = hass.states.get(entity.entity_id)
     assert state is not None
     assert state.attributes["unit_of_measurement"] == "V"

--- a/tests/components/victron_gx/test_sensor.py
+++ b/tests/components/victron_gx/test_sensor.py
@@ -1,12 +1,20 @@
 """Tests for Victron GX MQTT sensors."""
 
+from unittest.mock import MagicMock
+
 from victron_mqtt import Hub as VictronVenusHub
 from victron_mqtt.testing import finalize_injection, inject_message
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.components.victron_gx.const import DOMAIN
+from homeassistant.components.victron_gx.sensor import VictronSensor
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers import (
+    device_registry as dr,
+    entity_platform,
+    entity_registry as er,
+)
+from homeassistant.helpers.device_registry import DeviceInfo
 
 from .const import MOCK_INSTALLATION_ID
 
@@ -152,3 +160,166 @@ async def test_victron_main_topic_sensor(
     assert state.state == "mppt_active"
     # Entity uses device name only (no separate entity name)
     assert state.attributes["friendly_name"] == "Multi RS Solar"
+
+
+async def test_native_unit_of_measurement_with_device_class(
+    hass: HomeAssistant,
+    init_integration: tuple[VictronVenusHub, MockConfigEntry],
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test native_unit_of_measurement returns unit for metrics with device class."""
+    victron_hub, mock_config_entry = init_integration
+
+    # Inject a current sensor (has device class)
+    await inject_message(
+        victron_hub,
+        f"N/{MOCK_INSTALLATION_ID}/battery/0/Dc/0/Current",
+        '{"value": 10.5}',
+    )
+    await finalize_injection(victron_hub)
+    await hass.async_block_till_done()
+
+    entities = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+
+    # Get the battery current entity
+    entity = next(
+        (e for e in entities if e.entity_id == "sensor.battery_dc_bus_current"), None
+    )
+    assert entity is not None
+
+    # Get the actual entity object from the platform and call the property directly
+    platforms = entity_platform.async_get_platforms(hass, DOMAIN)
+    sensor_platform = next(p for p in platforms if p.domain == "sensor")
+    actual_entity = next(
+        (
+            e
+            for e in sensor_platform.entities.values()
+            if e.entity_id == entity.entity_id
+        ),
+        None,
+    )
+
+    assert actual_entity is not None
+    # CURRENT metric type has device class, so native_unit_of_measurement should return "A"
+    # This exercises the "or self._attr_device_class is not None" path
+    assert actual_entity.native_unit_of_measurement == "A"
+
+
+async def test_native_unit_of_measurement_special_unit(
+    hass: HomeAssistant,
+    init_integration: tuple[VictronVenusHub, MockConfigEntry],
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test native_unit_of_measurement returns special units like %."""
+    victron_hub, mock_config_entry = init_integration
+
+    # Inject battery state of charge (percentage metric with % unit)
+    await inject_message(
+        victron_hub,
+        f"N/{MOCK_INSTALLATION_ID}/battery/0/Soc",
+        '{"value": 85}',
+    )
+    await finalize_injection(victron_hub)
+    await hass.async_block_till_done()
+
+    entities = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+
+    # Get any battery entity with % unit
+    entity = next(
+        (e for e in entities if e.unit_of_measurement == "%"),
+        None,
+    )
+    assert entity is not None
+
+    # Get the actual entity object from the platform and call the property directly
+    platforms = entity_platform.async_get_platforms(hass, DOMAIN)
+    sensor_platform = next(p for p in platforms if p.domain == "sensor")
+    actual_entity = next(
+        (
+            e
+            for e in sensor_platform.entities.values()
+            if e.entity_id == entity.entity_id
+        ),
+        None,
+    )
+
+    assert actual_entity is not None
+    # Even though this metric has a device class, the special unit "%" should still be returned
+    # This exercises the "unit_of_measurement in SPECIAL_NATIVE_UNITS" path (checked first in the condition)
+    assert actual_entity.native_unit_of_measurement == "%"
+
+
+async def test_native_unit_of_measurement_return_none(
+    hass: HomeAssistant,
+) -> None:
+    """Test native_unit_of_measurement returns None when no conditions are met."""
+    # Create mock device and metric without special conditions
+    mock_device = MagicMock()
+    mock_metric = MagicMock()
+    # Use a metric type without device class
+    mock_metric.metric_type = MagicMock()  # Not any known type
+    mock_metric.unit_of_measurement = "arbitrary_unit"  # Not in SPECIAL_NATIVE_UNITS
+    mock_metric.precision = 0
+    mock_metric.generic_short_id = "test_metric"
+    mock_metric.key_values = {}
+    mock_metric.main_topic = False
+    mock_metric.unique_id = "test_unique_id"
+
+    device_info = DeviceInfo(
+        identifiers={(DOMAIN, "test_device")},
+        manufacturer="Victron Energy",
+        model="Test",
+        name="Test Device",
+    )
+
+    # Create sensor entity
+    sensor = VictronSensor(mock_device, mock_metric, device_info, "installation_123")
+    sensor.hass = hass
+    # Ensure no device class is set
+    sensor._attr_device_class = None
+
+    # Assert that native_unit_of_measurement returns None (line 87)
+    assert sensor.native_unit_of_measurement is None
+
+
+async def test_native_unit_of_measurement_cost_metric(
+    hass: HomeAssistant,
+    init_integration: tuple[VictronVenusHub, MockConfigEntry],
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test native_unit_of_measurement returns currency for COST metric type."""
+    victron_hub, mock_config_entry = init_integration
+
+    await inject_message(
+        victron_hub,
+        f"N/{MOCK_INSTALLATION_ID}/evcharger/0/Session/Cost",
+        '{"value": 12.34}',
+    )
+    await finalize_injection(victron_hub)
+    await hass.async_block_till_done()
+
+    entity = next(
+        e
+        for e in er.async_entries_for_config_entry(
+            entity_registry, mock_config_entry.entry_id
+        )
+        if e.translation_key == "evcharger_session_cost"
+    )
+
+    platforms = entity_platform.async_get_platforms(hass, DOMAIN)
+    sensor_platform = next(p for p in platforms if p.domain == "sensor")
+    actual_entity = next(
+        (
+            e
+            for e in sensor_platform.entities.values()
+            if e.entity_id == entity.entity_id
+        ),
+        None,
+    )
+
+    assert actual_entity is not None
+    assert actual_entity.native_unit_of_measurement == hass.config.currency

--- a/tests/components/victron_gx/test_sensor.py
+++ b/tests/components/victron_gx/test_sensor.py
@@ -57,15 +57,18 @@ async def test_victron_battery_sensor(
     entity = next(e for e in entities if e.entity_id == "sensor.battery_dc_bus_current")
     assert entity.unique_id == f"{MOCK_INSTALLATION_ID}_battery_0_battery_current"
     assert entity.original_device_class is SensorDeviceClass.CURRENT
-    assert entity.unit_of_measurement == "A"
     assert entity.translation_key == "battery_current"
 
+    # Unit is resolved in async_added_to_hass (needs hass.config), so it is not
+    # available in the entity registry at registration time. Verify it via the
+    # state attributes, which are written after async_added_to_hass completes.
     state = hass.states.get(entity.entity_id)
     assert state is not None
+    assert state.attributes["unit_of_measurement"] == "A"
+
     assert state.state == "10.5"
     assert state.attributes["state_class"] == SensorStateClass.MEASUREMENT
     assert state.attributes["device_class"] == "current"
-    assert state.attributes["unit_of_measurement"] == "A"
 
     # Verify device info was registered correctly
     device = device_registry.async_get_device(

--- a/tests/components/victron_gx/test_sensor.py
+++ b/tests/components/victron_gx/test_sensor.py
@@ -57,11 +57,8 @@ async def test_victron_battery_sensor(
     entity = next(e for e in entities if e.entity_id == "sensor.battery_dc_bus_current")
     assert entity.unique_id == f"{MOCK_INSTALLATION_ID}_battery_0_battery_current"
     assert entity.original_device_class is SensorDeviceClass.CURRENT
+    assert entity.unit_of_measurement == "A"
     assert entity.translation_key == "battery_current"
-
-    # Unit is resolved in async_added_to_hass (needs hass.config), so it is not
-    # available in the entity registry at registration time. Verify it via the
-    # state attributes, which are written after async_added_to_hass completes.
     state = hass.states.get(entity.entity_id)
     assert state is not None
     assert state.attributes["unit_of_measurement"] == "A"


### PR DESCRIPTION
## Proposed change

Bump `victron-mqtt` library from `2026.6.1.1` to `2026.6.6` for the `victron_gx` integration.

Changes include:
- Update `victron-mqtt` dependency version in `manifest.json` and requirements files
- Update entity translations (`strings.json`) from latest topic definitions

Changelog: https://github.com/tomer-w/victron_mqtt/compare/v2026.6.1.1...v2026.6.6

## Type of change

- [x] Dependency upgrade

## Additional information

- This PR is related to issue:
- Link to documentation pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40m+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr