### PR TITLE
Add service helper to get a single loaded config entry

### DIFF
--- a/homeassistant/components/abode/services.py
+++ b/homeassistant/components/abode/services.py
@@ -7,8 +7,7 @@ import voluptuous as vol
 
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant, ServiceCall, callback
-from homeassistant.exceptions import ServiceValidationError
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import config_validation as cv, service
 from homeassistant.helpers.dispatcher import dispatcher_send
 
 from .const import DOMAIN, LOGGER
@@ -31,10 +30,8 @@ AUTOMATION_SCHEMA = vol.Schema({ATTR_ENTITY_ID: cv.entity_ids})
 
 def _get_abode_system(hass: HomeAssistant) -> AbodeSystem:
     """Return the Abode system for the loaded config entry."""
-    entries: list[AbodeConfigEntry] = hass.config_entries.async_loaded_entries(DOMAIN)
-    if not entries:
-        raise ServiceValidationError("Abode integration is not loaded")
-    return entries[0].runtime_data
+    entry: AbodeConfigEntry = service.get_single_loaded_config_entry(hass, DOMAIN)
+    return entry.runtime_data
 
 
 def _change_setting(call: ServiceCall) -> None:

--- a/homeassistant/components/abode/services.py
+++ b/homeassistant/components/abode/services.py
@@ -30,7 +30,7 @@ AUTOMATION_SCHEMA = vol.Schema({ATTR_ENTITY_ID: cv.entity_ids})
 
 def _get_abode_system(hass: HomeAssistant) -> AbodeSystem:
     """Return the Abode system for the loaded config entry."""
-    entry: AbodeConfigEntry = service.get_single_loaded_config_entry(hass, DOMAIN)
+    entry: AbodeConfigEntry = service.async_get_config_entry(hass, DOMAIN, None)
     return entry.runtime_data
 
 

--- a/homeassistant/components/homeassistant/strings.json
+++ b/homeassistant/components/homeassistant/strings.json
@@ -66,6 +66,12 @@
     "service_does_not_support_response": {
       "message": "An action which does not return responses can't be called with {return_response}."
     },
+    "service_found_multiple_config_entry_for_domain": {
+      "message": "Found multiple config entries for integration {domain}."
+    },
+    "service_found_no_config_entry_for_domain": {
+      "message": "Could not find config entry for integration {domain}."
+    },
     "service_lacks_response_request": {
       "message": "The action requires responses and must be called with {return_response}."
     },

--- a/homeassistant/components/ness_alarm/services.py
+++ b/homeassistant/components/ness_alarm/services.py
@@ -24,16 +24,16 @@ SERVICE_SCHEMA_AUX = vol.Schema(
 
 async def _handle_panic(call: ServiceCall) -> None:
     """Handle panic service call."""
-    entry: NessAlarmConfigEntry = service.get_single_loaded_config_entry(
-        call.hass, DOMAIN
+    entry: NessAlarmConfigEntry = service.async_get_config_entry(
+        call.hass, DOMAIN, None
     )
     await entry.runtime_data.panic(call.data[ATTR_CODE])
 
 
 async def _handle_aux(call: ServiceCall) -> None:
     """Handle aux service call."""
-    entry: NessAlarmConfigEntry = service.get_single_loaded_config_entry(
-        call.hass, DOMAIN
+    entry: NessAlarmConfigEntry = service.async_get_config_entry(
+        call.hass, DOMAIN, None
     )
     await entry.runtime_data.aux(call.data[ATTR_OUTPUT_ID], call.data[ATTR_STATE])
 

--- a/homeassistant/components/ness_alarm/services.py
+++ b/homeassistant/components/ness_alarm/services.py
@@ -1,13 +1,17 @@
 """Services for the Ness Alarm integration."""
 
+from typing import TYPE_CHECKING
+
 import voluptuous as vol
 
 from homeassistant.const import ATTR_CODE, ATTR_STATE
-from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.exceptions import ServiceValidationError
-from homeassistant.helpers import config_validation as cv
+from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.helpers import config_validation as cv, service
 
 from .const import ATTR_OUTPUT_ID, DOMAIN, SERVICE_AUX, SERVICE_PANIC
+
+if TYPE_CHECKING:
+    from . import NessAlarmConfigEntry
 
 SERVICE_SCHEMA_PANIC = vol.Schema({vol.Required(ATTR_CODE): cv.string})
 SERVICE_SCHEMA_AUX = vol.Schema(
@@ -18,34 +22,29 @@ SERVICE_SCHEMA_AUX = vol.Schema(
 )
 
 
+async def _handle_panic(call: ServiceCall) -> None:
+    """Handle panic service call."""
+    entry: NessAlarmConfigEntry = service.get_single_loaded_config_entry(
+        call.hass, DOMAIN
+    )
+    await entry.runtime_data.panic(call.data[ATTR_CODE])
+
+
+async def _handle_aux(call: ServiceCall) -> None:
+    """Handle aux service call."""
+    entry: NessAlarmConfigEntry = service.get_single_loaded_config_entry(
+        call.hass, DOMAIN
+    )
+    await entry.runtime_data.aux(call.data[ATTR_OUTPUT_ID], call.data[ATTR_STATE])
+
+
+@callback
 def async_setup_services(hass: HomeAssistant) -> None:
     """Register Ness Alarm services."""
 
-    async def handle_panic(call: ServiceCall) -> None:
-        """Handle panic service call."""
-        entries = call.hass.config_entries.async_loaded_entries(DOMAIN)
-        if not entries:
-            raise ServiceValidationError(
-                translation_domain=DOMAIN,
-                translation_key="no_config_entry",
-            )
-        client = entries[0].runtime_data
-        await client.panic(call.data[ATTR_CODE])
-
-    async def handle_aux(call: ServiceCall) -> None:
-        """Handle aux service call."""
-        entries = call.hass.config_entries.async_loaded_entries(DOMAIN)
-        if not entries:
-            raise ServiceValidationError(
-                translation_domain=DOMAIN,
-                translation_key="no_config_entry",
-            )
-        client = entries[0].runtime_data
-        await client.aux(call.data[ATTR_OUTPUT_ID], call.data[ATTR_STATE])
-
     hass.services.async_register(
-        DOMAIN, SERVICE_PANIC, handle_panic, schema=SERVICE_SCHEMA_PANIC
+        DOMAIN, SERVICE_PANIC, _handle_panic, schema=SERVICE_SCHEMA_PANIC
     )
     hass.services.async_register(
-        DOMAIN, SERVICE_AUX, handle_aux, schema=SERVICE_SCHEMA_AUX
+        DOMAIN, SERVICE_AUX, _handle_aux, schema=SERVICE_SCHEMA_AUX
     )

--- a/homeassistant/components/ness_alarm/strings.json
+++ b/homeassistant/components/ness_alarm/strings.json
@@ -59,11 +59,6 @@
       }
     }
   },
-  "exceptions": {
-    "no_config_entry": {
-      "message": "No Ness Alarm configuration entry is loaded"
-    }
-  },
   "issues": {
     "deprecated_yaml_import_issue_cannot_connect": {
       "description": "Configuring {integration_title} via YAML is deprecated and will be removed in a future release. While importing your configuration, a connection error occurred. Please correct your YAML configuration and restart Home Assistant, or remove the {domain} key from your configuration and configure the integration via the UI.",

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -1416,9 +1416,8 @@ def _async_get_single_loaded_config_entry(
     """Retrieve single loaded config entry.
 
     This is a fallback for services that do not request (or have not been
-    provided with) a config entry ID. It will raise an error if there are
-    no loaded config entries or if there are multiple loaded config entries
-    for the domain.
+    provided with) a config entry ID. Only one config entry should exist
+    for the domain, and it must be loaded.
     """
     config_entries = hass.config_entries.async_entries(
         domain, include_ignore=False, include_disabled=False

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -1405,3 +1405,34 @@ def async_get_config_entry(
             },
         )
     return config_entry
+
+
+@callback
+def get_single_loaded_config_entry(hass: HomeAssistant, domain: str) -> ConfigEntry:
+    """Retrieve single loaded config entry."""
+    config_entries = hass.config_entries.async_entries(
+        domain, include_ignore=False, include_disabled=False
+    )
+    if not config_entries:
+        raise ServiceValidationError(
+            translation_domain=HOMEASSISTANT_DOMAIN,
+            translation_key="service_found_no_config_entry_for_domain",
+            translation_placeholders={"domain": domain},
+        )
+    if len(config_entries) > 1:
+        raise ServiceValidationError(
+            translation_domain=HOMEASSISTANT_DOMAIN,
+            translation_key="service_found_multiple_config_entry_for_domain",
+            translation_placeholders={"domain": domain},
+        )
+    config_entry = config_entries[0]
+    if config_entry.state is not ConfigEntryState.LOADED:
+        raise ServiceValidationError(
+            translation_domain=HOMEASSISTANT_DOMAIN,
+            translation_key="service_config_entry_not_loaded",
+            translation_placeholders={
+                "domain": domain,
+                "entry_title": config_entry.title,
+            },
+        )
+    return config_entry

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -1373,9 +1373,11 @@ def async_register_batched_platform_entity_service[_EntityT: Entity](
 
 @callback
 def async_get_config_entry(
-    hass: HomeAssistant, domain: str, entry_id: str
+    hass: HomeAssistant, domain: str, entry_id: str | None
 ) -> ConfigEntry:
     """Get and validate a service config entry."""
+    if entry_id is None:
+        return _async_get_single_loaded_config_entry(hass, domain)
     config_entry = hass.config_entries.async_get_entry(entry_id)
     if not config_entry:
         raise ServiceValidationError(
@@ -1408,8 +1410,16 @@ def async_get_config_entry(
 
 
 @callback
-def get_single_loaded_config_entry(hass: HomeAssistant, domain: str) -> ConfigEntry:
-    """Retrieve single loaded config entry."""
+def _async_get_single_loaded_config_entry(
+    hass: HomeAssistant, domain: str
+) -> ConfigEntry:
+    """Retrieve single loaded config entry.
+
+    This is a fallback for services that do not request (or have not been
+    provided with) a config entry ID. It will raise an error if there are
+    no loaded config entries or if there are multiple loaded config entries
+    for the domain.
+    """
     config_entries = hass.config_entries.async_entries(
         domain, include_ignore=False, include_disabled=False
     )

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -3396,14 +3396,14 @@ async def test_get_single_loaded_config_entry(hass: HomeAssistant) -> None:
 
     # No config entry exists
     with pytest.raises(exceptions.ServiceValidationError) as err:
-        service.get_single_loaded_config_entry(hass, domain)
+        service.async_get_config_entry(hass, domain, None)
     assert err.value.translation_key == "service_found_no_config_entry_for_domain"
 
     # A single config entry exists and is loaded
     entry1 = MockConfigEntry(domain=domain)
     entry1.add_to_hass(hass)
     entry1.mock_state(hass, config_entries.ConfigEntryState.LOADED)
-    assert service.get_single_loaded_config_entry(hass, domain) is entry1
+    assert service.async_get_config_entry(hass, domain, None) is entry1
 
     # Ignored and disabled entries are not counted
     ignored_entry = MockConfigEntry(domain=domain, source=config_entries.SOURCE_IGNORE)
@@ -3412,19 +3412,19 @@ async def test_get_single_loaded_config_entry(hass: HomeAssistant) -> None:
         domain=domain, disabled_by=config_entries.ConfigEntryDisabler.USER
     )
     disabled_entry.add_to_hass(hass)
-    assert service.get_single_loaded_config_entry(hass, domain) is entry1
+    assert service.async_get_config_entry(hass, domain, None) is entry1
 
     # Multiple config entries exist
     entry2 = MockConfigEntry(domain=domain)
     entry2.add_to_hass(hass)
     entry2.mock_state(hass, config_entries.ConfigEntryState.LOADED)
     with pytest.raises(exceptions.ServiceValidationError) as err:
-        service.get_single_loaded_config_entry(hass, domain)
+        service.async_get_config_entry(hass, domain, None)
     assert err.value.translation_key == "service_found_multiple_config_entry_for_domain"
 
     # A single config entry exists, but is not loaded
     await hass.config_entries.async_remove(entry2.entry_id)
     entry1.mock_state(hass, config_entries.ConfigEntryState.NOT_LOADED)
     with pytest.raises(exceptions.ServiceValidationError) as err:
-        service.get_single_loaded_config_entry(hass, domain)
+        service.async_get_config_entry(hass, domain, None)
     assert err.value.translation_key == "service_config_entry_not_loaded"

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -3390,8 +3390,8 @@ async def test_get_service_config_entry(hass: HomeAssistant) -> None:
     assert err.value.translation_key == "service_config_entry_not_loaded"
 
 
-async def test_get_single_loaded_config_entry(hass: HomeAssistant) -> None:
-    """Test that we can get a single loaded config entry."""
+async def test_get_service_config_entry_none(hass: HomeAssistant) -> None:
+    """Test that we can get a service config entry if no entry ID is provided."""
     domain = "mock_integration"
 
     # No config entry exists

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -3388,3 +3388,43 @@ async def test_get_service_config_entry(hass: HomeAssistant) -> None:
     with pytest.raises(exceptions.ServiceValidationError) as err:
         service.async_get_config_entry(hass, domain, entry_id)
     assert err.value.translation_key == "service_config_entry_not_loaded"
+
+
+async def test_get_single_loaded_config_entry(hass: HomeAssistant) -> None:
+    """Test that we can get a single loaded config entry."""
+    domain = "mock_integration"
+
+    # No config entry exists
+    with pytest.raises(exceptions.ServiceValidationError) as err:
+        service.get_single_loaded_config_entry(hass, domain)
+    assert err.value.translation_key == "service_found_no_config_entry_for_domain"
+
+    # A single config entry exists and is loaded
+    entry1 = MockConfigEntry(domain=domain)
+    entry1.add_to_hass(hass)
+    entry1.mock_state(hass, config_entries.ConfigEntryState.LOADED)
+    assert service.get_single_loaded_config_entry(hass, domain) is entry1
+
+    # Ignored and disabled entries are not counted
+    ignored_entry = MockConfigEntry(domain=domain, source=config_entries.SOURCE_IGNORE)
+    ignored_entry.add_to_hass(hass)
+    disabled_entry = MockConfigEntry(
+        domain=domain, disabled_by=config_entries.ConfigEntryDisabler.USER
+    )
+    disabled_entry.add_to_hass(hass)
+    assert service.get_single_loaded_config_entry(hass, domain) is entry1
+
+    # Multiple config entries exist
+    entry2 = MockConfigEntry(domain=domain)
+    entry2.add_to_hass(hass)
+    entry2.mock_state(hass, config_entries.ConfigEntryState.LOADED)
+    with pytest.raises(exceptions.ServiceValidationError) as err:
+        service.get_single_loaded_config_entry(hass, domain)
+    assert err.value.translation_key == "service_found_multiple_config_entry_for_domain"
+
+    # A single config entry exists, but is not loaded
+    await hass.config_entries.async_remove(entry2.entry_id)
+    entry1.mock_state(hass, config_entries.ConfigEntryState.NOT_LOADED)
+    with pytest.raises(exceptions.ServiceValidationError) as err:
+        service.get_single_loaded_config_entry(hass, domain)
+    assert err.value.translation_key == "service_config_entry_not_loaded"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I was looking at #174126 and #174131, and noticed that both currently expect a single loaded config entry.

Although long term it would be good to add an argument to select a specific config entry, I think adding this helper would greatly facilitate the parent epic: https://github.com/home-assistant/epics/issues/65

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
