### PR TITLE
Track public devices websocket health for UniFi Protect public-API entities

### DIFF
--- a/homeassistant/components/unifiprotect/alarm_control_panel.py
+++ b/homeassistant/components/unifiprotect/alarm_control_panel.py
@@ -74,14 +74,14 @@ class ProtectNVRAlarmControlPanel(ProtectNVREntity, AlarmControlPanelEntity):
         arm_mode = api.public_bootstrap.arm_mode if api.has_public_bootstrap else None
         if arm_mode is None:
             # No alarm data available — force unavailable regardless of the
-            # private WebSocket state managed by the base class.
+            # websocket state managed by the base class.
             self._attr_available = False
             self._attr_alarm_state = None
             return
-        # Do NOT set _attr_available = True here.  Availability when alarm data
-        # is present is determined exclusively by the base class via
-        # last_update_success (private WebSocket health). Only force it to
-        # False as an additional condition when alarm data is missing.
+        # arm_mode is delivered over the public devices websocket, so
+        # availability tracks the public WS health (like relay/siren), not the
+        # private connection the base class would otherwise apply for the NVR.
+        self._attr_available = self.data.last_public_update_success
         # Fall back to DISARMED for unknown future status values rather than
         # rendering the entity as ``unknown``.
         self._attr_alarm_state = _UIPROTECT_TO_HA.get(

--- a/homeassistant/components/unifiprotect/data.py
+++ b/homeassistant/components/unifiprotect/data.py
@@ -94,6 +94,7 @@ class ProtectData:
         self._auth_failures = 0
         self.auth_retries = 0
         self.last_update_success = False
+        self.last_public_update_success = False
         self.api = protect
         self.adopt_signal = _async_dispatch_id(entry, DISPATCH_ADOPT)
         self.add_signal = _async_dispatch_id(entry, DISPATCH_ADD)
@@ -162,6 +163,7 @@ class ProtectData:
     def async_setup(self) -> None:
         """Subscribe and do the refresh."""
         self.last_update_success = True
+        self.last_public_update_success = True
         self._async_update_change(True, force_update=True)
         api = self.api
         self._unsubs = [
@@ -176,6 +178,7 @@ class ProtectData:
             api.subscribe_devices_websocket(
                 self._async_process_public_devices_ws_message
             ),
+            api.subscribe_devices_websocket_state(self._async_public_ws_state_changed),
         ]
 
     @callback
@@ -202,12 +205,7 @@ class ProtectData:
             self._async_signal_device_update(self.api.bootstrap.nvr)
             return
         if new_obj.model is ModelType.RELAY:
-            relay = cast(Relay, new_obj)
-            mac = relay.mac
-            if subscriptions := self._relay_subscriptions.get(mac):
-                _LOGGER.debug("Updating relay: %s (%s)", relay.name, mac)
-                for update_callback in subscriptions:
-                    update_callback(relay)
+            self._async_signal_relay_update(cast(Relay, new_obj))
             return
         if new_obj.model is ModelType.SIREN:
             self._async_signal_siren_update(cast(Siren, new_obj))
@@ -216,6 +214,28 @@ class ProtectData:
     def _async_websocket_state_changed(self, state: WebsocketState) -> None:
         """Handle a change in the websocket state."""
         self._async_update_change(state is WebsocketState.CONNECTED)
+
+    @callback
+    def _async_public_ws_state_changed(self, state: WebsocketState) -> None:
+        """Handle a change in the public devices websocket state."""
+        success = state is WebsocketState.CONNECTED
+        if success == self.last_public_update_success:
+            return
+        self.last_public_update_success = success
+        self._async_process_public_updates()
+
+    @callback
+    def _async_process_public_updates(self) -> None:
+        """Re-signal public-API entities after a public websocket state change."""
+        api = self.api
+        if not api.has_public_bootstrap:
+            return
+        # The NVR alarm panel reads the public arm_mode, so refresh it too.
+        self._async_signal_device_update(api.bootstrap.nvr)
+        for relay in api.public_bootstrap.relays.values():
+            self._async_signal_relay_update(relay)
+        for siren in api.public_bootstrap.sirens.values():
+            self._async_signal_siren_update(siren)
 
     def _async_update_change(
         self,
@@ -380,17 +400,14 @@ class ProtectData:
 
     @callback
     def _async_process_updates(self) -> None:
-        """Process update from the protect data."""
+        """Process an update from the private protect connection.
+
+        Public-API entities (relay/siren/alarm) are driven by the public
+        websocket via ``_async_process_public_updates``, not from here.
+        """
         self._async_signal_device_update(self.api.bootstrap.nvr)
         for device in self.get_by_types(DEVICES_THAT_ADOPT):
             self._async_signal_device_update(device)
-        if self.api.has_public_bootstrap:
-            for relay in self.api.public_bootstrap.relays.values():
-                if subscriptions := self._relay_subscriptions.get(relay.mac):
-                    for subscription_callback in subscriptions:
-                        subscription_callback(relay)
-            for siren in self.api.public_bootstrap.sirens.values():
-                self._async_signal_siren_update(siren)
 
     @callback
     def _async_poll(self, now: datetime) -> None:
@@ -462,6 +479,16 @@ class ProtectData:
         _LOGGER.debug("Updating device: %s (%s)", device.name, mac)
         for update_callback in subscriptions:
             update_callback(device)
+
+    @callback
+    def _async_signal_relay_update(self, relay: Relay) -> None:
+        """Call the callbacks for a relay mac."""
+        mac = relay.mac
+        if not (subscriptions := self._relay_subscriptions.get(mac)):
+            return
+        _LOGGER.debug("Updating relay: %s (%s)", relay.name, mac)
+        for update_callback in subscriptions:
+            update_callback(relay)
 
     @callback
     def _async_signal_siren_update(self, siren: Siren) -> None:

--- a/homeassistant/components/unifiprotect/siren.py
+++ b/homeassistant/components/unifiprotect/siren.py
@@ -91,7 +91,7 @@ class ProtectSiren(SirenEntity):
     @callback
     def _update_from_siren(self, siren: Siren) -> None:
         """Refresh cached attributes from the siren object."""
-        self._attr_available = self.data.last_update_success
+        self._attr_available = self.data.last_public_update_success
         self._attr_is_on = siren.is_active
 
     @callback

--- a/homeassistant/components/unifiprotect/switch.py
+++ b/homeassistant/components/unifiprotect/switch.py
@@ -648,7 +648,7 @@ class ProtectRelayOutputSwitch(SwitchEntity):
             self._attr_available = False
             self._attr_is_on = None
             return
-        self._attr_available = self.data.last_update_success
+        self._attr_available = self.data.last_public_update_success
         self._attr_is_on = (
             _RELAY_STATE_MAP.get(output.state) if output.state is not None else None
         )

--- a/tests/components/unifiprotect/conftest.py
+++ b/tests/components/unifiprotect/conftest.py
@@ -190,9 +190,16 @@ def mock_entry(
             ufp.devices_ws_subscription = ws_callback
             return Mock()
 
+        def subscribe_devices_websocket_state(
+            ws_state_subscription: Callable[[WebsocketState], None],
+        ) -> Any:
+            ufp.devices_ws_state_subscription = ws_state_subscription
+            return Mock()
+
         ufp_client.subscribe_websocket = subscribe
         ufp_client.subscribe_websocket_state = subscribe_websocket_state
         ufp_client.subscribe_devices_websocket = subscribe_devices_websocket
+        ufp_client.subscribe_devices_websocket_state = subscribe_devices_websocket_state
         ufp_client.update_public = AsyncMock()
         ufp_client.has_public_bootstrap = False
         yield ufp

--- a/tests/components/unifiprotect/test_alarm_control_panel.py
+++ b/tests/components/unifiprotect/test_alarm_control_panel.py
@@ -286,7 +286,7 @@ async def test_alarm_panel_unavailable_on_ws_disconnect(
     hass: HomeAssistant,
     ufp: MockUFPFixture,
 ) -> None:
-    """Entity becomes unavailable when the private WebSocket disconnects."""
+    """Entity becomes unavailable when the public devices WebSocket disconnects."""
     arm_mode = _make_arm_mode(NvrArmModeStatus.ARMED)
     pb = _make_public_bootstrap(arm_mode)
     ufp.api.has_public_bootstrap = True
@@ -298,16 +298,47 @@ async def test_alarm_panel_unavailable_on_ws_disconnect(
     assert state is not None
     assert state.state == AlarmControlPanelState.ARMED_AWAY
 
-    ufp.ws_state_subscription(WebsocketState.DISCONNECTED)
+    ufp.devices_ws_state_subscription(WebsocketState.DISCONNECTED)
     await hass.async_block_till_done()
 
     state = hass.states.get(ALARM_ENTITY_ID)
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
 
-    ufp.ws_state_subscription(WebsocketState.CONNECTED)
+    ufp.devices_ws_state_subscription(WebsocketState.CONNECTED)
     await hass.async_block_till_done()
 
     state = hass.states.get(ALARM_ENTITY_ID)
     assert state is not None
     assert state.state == AlarmControlPanelState.ARMED_AWAY
+
+
+async def test_alarm_panel_availability_decoupled_from_private_websocket(
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+) -> None:
+    """Alarm availability follows the public WS only: private loss is a no-op."""
+    arm_mode = _make_arm_mode(NvrArmModeStatus.ARMED)
+    pb = _make_public_bootstrap(arm_mode)
+    ufp.api.has_public_bootstrap = True
+    ufp.api.public_bootstrap = pb
+
+    await init_entry(hass, ufp, [])
+    state = hass.states.get(ALARM_ENTITY_ID)
+    assert state is not None
+    assert state.state == AlarmControlPanelState.ARMED_AWAY
+
+    # A private WS loss does not affect the alarm panel.
+    assert ufp.ws_state_subscription is not None
+    ufp.ws_state_subscription(WebsocketState.DISCONNECTED)
+    await hass.async_block_till_done()
+    state = hass.states.get(ALARM_ENTITY_ID)
+    assert state is not None
+    assert state.state == AlarmControlPanelState.ARMED_AWAY
+
+    # The public WS loss does flip it unavailable.
+    ufp.devices_ws_state_subscription(WebsocketState.DISCONNECTED)
+    await hass.async_block_till_done()
+    state = hass.states.get(ALARM_ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE

--- a/tests/components/unifiprotect/test_relay.py
+++ b/tests/components/unifiprotect/test_relay.py
@@ -375,20 +375,83 @@ async def test_relay_switch_availability_follows_websocket_state(
 
     assert hass.states.get(SWITCH_ENTITY_ID).state == STATE_ON  # type: ignore[union-attr]
 
-    assert ufp.ws_state_subscription is not None
-    ufp.ws_state_subscription(WebsocketState.DISCONNECTED)
+    assert ufp.devices_ws_state_subscription is not None
+    ufp.devices_ws_state_subscription(WebsocketState.DISCONNECTED)
     await hass.async_block_till_done()
 
     state = hass.states.get(SWITCH_ENTITY_ID)
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
 
-    ufp.ws_state_subscription(WebsocketState.CONNECTED)
+    ufp.devices_ws_state_subscription(WebsocketState.CONNECTED)
     await hass.async_block_till_done()
 
     state = hass.states.get(SWITCH_ENTITY_ID)
     assert state is not None
     assert state.state == STATE_ON
+
+
+async def test_relay_switch_availability_decoupled_from_private_websocket(
+    hass: HomeAssistant,
+    ufp_with_relay: tuple[MockUFPFixture, Mock],
+) -> None:
+    """Relay availability follows the public WS only: private loss is a no-op."""
+    ufp, relay = ufp_with_relay
+    relay.outputs[0].state = RelayOutputState.ON
+    await init_entry(hass, ufp, [])
+    assert hass.states.get(SWITCH_ENTITY_ID).state == STATE_ON  # type: ignore[union-attr]
+
+    # A private WS loss does not affect the relay.
+    assert ufp.ws_state_subscription is not None
+    ufp.ws_state_subscription(WebsocketState.DISCONNECTED)
+    await hass.async_block_till_done()
+    state = hass.states.get(SWITCH_ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_ON
+
+    # The public WS loss does flip it unavailable.
+    ufp.devices_ws_state_subscription(WebsocketState.DISCONNECTED)
+    await hass.async_block_till_done()
+    state = hass.states.get(SWITCH_ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+
+async def test_relay_ws_update_without_subscription_is_ignored(
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+) -> None:
+    """A public relay WS update for an unsubscribed relay is a no-op."""
+    await init_entry(hass, ufp, [])
+    assert ufp.devices_ws_subscription is not None
+
+    mock_msg = Mock()
+    mock_msg.new_obj = _make_relay()
+    ufp.devices_ws_subscription(mock_msg)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(SWITCH_ENTITY_ID) is None
+
+
+async def test_public_ws_state_change_without_public_bootstrap(
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+) -> None:
+    """Public WS state changes flip the flag but no-op without a bootstrap."""
+    await init_entry(hass, ufp, [])
+    data = ufp.entry.runtime_data
+    assert data.last_public_update_success is True
+    assert ufp.devices_ws_state_subscription is not None
+
+    # No public bootstrap -> re-signal step returns early.
+    ufp.devices_ws_state_subscription(WebsocketState.DISCONNECTED)
+    await hass.async_block_till_done()
+    assert data.last_public_update_success is False
+
+    # Same state again -> handler early-returns.
+    ufp.devices_ws_state_subscription(WebsocketState.DISCONNECTED)
+    await hass.async_block_till_done()
+    assert data.last_public_update_success is False
 
 
 async def test_relay_public_ws_message_with_none_new_obj(

--- a/tests/components/unifiprotect/test_siren.py
+++ b/tests/components/unifiprotect/test_siren.py
@@ -113,6 +113,19 @@ async def test_siren_not_created_without_public_bootstrap(
     assert_entity_counts(hass, Platform.SIREN, 0, 0)
 
 
+async def test_siren_ws_update_without_subscription_is_ignored(
+    hass: HomeAssistant, ufp: MockUFPFixture
+) -> None:
+    """A public siren WS update for an unsubscribed siren is a no-op."""
+    await init_entry(hass, ufp, [])
+    assert ufp.devices_ws_subscription is not None
+
+    ufp.devices_ws_subscription(_make_ws_msg(_make_siren()))
+    await hass.async_block_till_done()
+
+    assert_entity_counts(hass, Platform.SIREN, 0, 0)
+
+
 async def test_siren_created_off(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
@@ -411,15 +424,15 @@ async def test_siren_availability_follows_websocket_state(
     assert state is not None
     assert state.state == STATE_OFF
 
-    assert ufp_with_siren.ws_state_subscription is not None
-    ufp_with_siren.ws_state_subscription(WebsocketState.DISCONNECTED)
+    assert ufp_with_siren.devices_ws_state_subscription is not None
+    ufp_with_siren.devices_ws_state_subscription(WebsocketState.DISCONNECTED)
     await hass.async_block_till_done()
 
     state = hass.states.get(SIREN_ENTITY_ID)
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
 
-    ufp_with_siren.ws_state_subscription(WebsocketState.CONNECTED)
+    ufp_with_siren.devices_ws_state_subscription(WebsocketState.CONNECTED)
     await hass.async_block_till_done()
 
     state = hass.states.get(SIREN_ENTITY_ID)

--- a/tests/components/unifiprotect/utils.py
+++ b/tests/components/unifiprotect/utils.py
@@ -37,6 +37,7 @@ class MockUFPFixture:
     ws_subscription: Callable[[WSSubscriptionMessage], None] | None = None
     ws_state_subscription: Callable[[WebsocketState], None] | None = None
     devices_ws_subscription: Callable[[WSSubscriptionMessage], None] | None = None
+    devices_ws_state_subscription: Callable[[WebsocketState], None] | None = None
 
     def ws_msg(self, msg: WSSubscriptionMessage) -> None:
         """Emit WS message for testing."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

UniFi Protect's public-API entities — the relay-output switches, sirens and the
NVR alarm panel — take their *state* from the public devices websocket, but
their *availability* was tied to the private websocket health
(`last_update_success`). When the public websocket dropped while the private one
stayed up, these entities kept reporting as available with stale data.

This adds `ProtectData.last_public_update_success`, driven by the library's
`subscribe_devices_websocket_state`, and points the availability of all
public-API entities at it. A public websocket state change re-signals those
entities so they go unavailable/available with the connection that actually
delivers their data. Cleanups that fall out of this:

- The private update path (`_async_process_updates`) no longer re-signals the
  public-API entities — it never affected their state.
- Relay dispatch is unified into a `_async_signal_relay_update` helper, matching
  the existing `_async_signal_siren_update`.

Behaviour note for users: these entities now become unavailable on a public
websocket outage (previously they stayed available with stale data), and remain
available during a private-only outage. In practice both websockets share one
host and drop together, so divergence is rare.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
