### PR TITLE
Add enabled entity limit per config entry

### DIFF
--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -32,6 +32,7 @@ from homeassistant.exceptions import (
     PlatformNotReady,
 )
 from homeassistant.generated import languages
+from homeassistant.loader import async_suggest_report_issue
 from homeassistant.setup import SetupPhases, async_start_setup
 from homeassistant.util.async_ import create_eager_task
 from homeassistant.util.hass_dict import HassKey
@@ -52,6 +53,8 @@ SLOW_SETUP_WARNING = 10
 SLOW_SETUP_MAX_WAIT = 60
 SLOW_ADD_ENTITY_MAX_WAIT = 15  # Per Entity
 SLOW_ADD_MIN_TIMEOUT = 500
+
+MAX_ENABLED_ENTITIES_PER_CONFIG_ENTRY = 10000
 
 PLATFORM_NOT_READY_RETRIES = 10
 DATA_ENTITY_PLATFORM: HassKey[dict[str, list[EntityPlatform]]] = HassKey(
@@ -276,6 +279,8 @@ class EntityPlatform:
         # Storage for entities for this specific platform only
         # which are indexed by entity_id
         self.entities: dict[str, Entity] = {}
+        # Whether we already warned about reaching the config entry entity limit
+        self._entity_limit_warned = False
         self._tasks: list[asyncio.Task[None]] = []
         # Stop tracking tasks after setup is completed
         self._setup_complete = False
@@ -958,6 +963,32 @@ class EntityPlatform:
             if not entity.entity_registry_visible_default:
                 hidden_by = RegistryEntryHider.INTEGRATION
 
+            if (
+                disabled_by is None
+                and not registered_entity_id
+                and self.config_entry is not None
+                and entity_registry.entities.get_enabled_count_for_config_entry_id(
+                    self.config_entry.entry_id
+                )
+                >= MAX_ENABLED_ENTITIES_PER_CONFIG_ENTRY
+            ):
+                if not self._entity_limit_warned:
+                    report_issue = async_suggest_report_issue(
+                        self.hass, integration_domain=self.platform_name
+                    )
+                    self.logger.warning(
+                        "Reached the maximum of %s enabled entities for config entry "
+                        "%s; not adding more entities for integration %s until "
+                        "existing entities are removed or disabled, please %s",
+                        MAX_ENABLED_ENTITIES_PER_CONFIG_ENTRY,
+                        self.config_entry.entry_id,
+                        self.platform_name,
+                        report_issue,
+                    )
+                    self._entity_limit_warned = True
+                entity.add_to_platform_abort()
+                return
+
             entry = entity_registry.async_get_or_create(
                 self.domain,
                 self.platform_name,
@@ -1053,6 +1084,7 @@ class EntityPlatform:
         This method must be run in the event loop.
         """
         self.async_cancel_retry_setup()
+        self._entity_limit_warned = False
 
         if not self.entities:
             return

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -934,6 +934,8 @@ class EntityRegistryItems(BaseRegistryItems[RegistryEntry]):
     - device_id -> dict[key, True]
     - area_id -> dict[key, True]
     - label -> dict[key, True]
+
+    Also maintains a count of enabled entries per config entry id.
     """
 
     def __init__(self) -> None:
@@ -942,6 +944,7 @@ class EntityRegistryItems(BaseRegistryItems[RegistryEntry]):
         self._entry_ids: dict[str, RegistryEntry] = {}
         self._index: dict[tuple[str, str, str], str] = {}
         self._config_entry_id_index: RegistryIndexType = defaultdict(dict)
+        self._config_entry_id_enabled_count: dict[str, int] = {}
         self._device_id_index: RegistryIndexType = defaultdict(dict)
         self._area_id_index: RegistryIndexType = defaultdict(dict)
         self._labels_index: RegistryIndexType = defaultdict(dict)
@@ -954,6 +957,10 @@ class EntityRegistryItems(BaseRegistryItems[RegistryEntry]):
         # https://discuss.python.org/t/add-orderedset-to-stdlib/12730
         if (config_entry_id := entry.config_entry_id) is not None:
             self._config_entry_id_index[config_entry_id][key] = True
+            if not entry.disabled_by:
+                self._config_entry_id_enabled_count[config_entry_id] = (
+                    self._config_entry_id_enabled_count.get(config_entry_id, 0) + 1
+                )
         if (device_id := entry.device_id) is not None:
             self._device_id_index[device_id][key] = True
         if (area_id := entry.area_id) is not None:
@@ -970,6 +977,12 @@ class EntityRegistryItems(BaseRegistryItems[RegistryEntry]):
         del self._index[(entry.domain, entry.platform, entry.unique_id)]
         if config_entry_id := entry.config_entry_id:
             self._unindex_entry_value(key, config_entry_id, self._config_entry_id_index)
+            if not entry.disabled_by:
+                count = self._config_entry_id_enabled_count[config_entry_id] - 1
+                if count:
+                    self._config_entry_id_enabled_count[config_entry_id] = count
+                else:
+                    del self._config_entry_id_enabled_count[config_entry_id]
         if device_id := entry.device_id:
             self._unindex_entry_value(key, device_id, self._device_id_index)
         if area_id := entry.area_id:
@@ -1009,6 +1022,10 @@ class EntityRegistryItems(BaseRegistryItems[RegistryEntry]):
         return [
             data[key] for key in self._config_entry_id_index.get(config_entry_id, ())
         ]
+
+    def get_enabled_count_for_config_entry_id(self, config_entry_id: str) -> int:
+        """Return the number of enabled entries for a config entry."""
+        return self._config_entry_id_enabled_count.get(config_entry_id, 0)
 
     def get_entries_for_area_id(self, area_id: str) -> list[RegistryEntry]:
         """Get entries for area."""

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -818,6 +818,182 @@ async def test_registry_respect_entity_disabled(hass: HomeAssistant) -> None:
     assert hass.states.async_entity_ids() == []
 
 
+async def test_entity_limit_per_config_entry(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test the number of enabled entities per config entry is limited."""
+    config_entry = MockConfigEntry()
+    config_entry.add_to_hass(hass)
+    platform = MockEntityPlatform(hass)
+    platform.config_entry = config_entry
+
+    with patch.object(entity_platform, "MAX_ENABLED_ENTITIES_PER_CONFIG_ENTRY", 2):
+        await platform.async_add_entities(
+            [
+                MockEntity(unique_id="1", name="ent1"),
+                MockEntity(unique_id="2", name="ent2"),
+            ]
+        )
+        assert len(hass.states.async_entity_ids()) == 2
+        assert "Reached the maximum" not in caplog.text
+
+        # Adding another enabled entity is rejected once the limit is reached
+        await platform.async_add_entities([MockEntity(unique_id="3", name="ent3")])
+
+    assert len(hass.states.async_entity_ids()) == 2
+    assert hass.states.get("test_domain.ent3") is None
+    assert (
+        entity_registry.async_get_entity_id("test_domain", "test_platform", "3") is None
+    )
+    assert "Reached the maximum of 2 enabled entities" in caplog.text
+    assert "please create a bug report at" in caplog.text
+
+
+async def test_entity_limit_per_config_entry_warns_once(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test the over-limit warning is only logged once per episode."""
+    config_entry = MockConfigEntry()
+    config_entry.add_to_hass(hass)
+    platform = MockEntityPlatform(hass)
+    platform.config_entry = config_entry
+
+    with patch.object(entity_platform, "MAX_ENABLED_ENTITIES_PER_CONFIG_ENTRY", 1):
+        await platform.async_add_entities([MockEntity(unique_id="1", name="ent1")])
+        await platform.async_add_entities(
+            [
+                MockEntity(unique_id="2", name="ent2"),
+                MockEntity(unique_id="3", name="ent3"),
+            ]
+        )
+
+    assert caplog.text.count("Reached the maximum of 1 enabled entities") == 1
+
+    # Resetting the platform starts a new warning episode
+    caplog.clear()
+    await platform.async_reset()
+    with patch.object(entity_platform, "MAX_ENABLED_ENTITIES_PER_CONFIG_ENTRY", 1):
+        await platform.async_add_entities([MockEntity(unique_id="4", name="ent4")])
+    assert "Reached the maximum of 1 enabled entities" in caplog.text
+
+
+async def test_entity_limit_per_config_entry_ignores_disabled_entities(
+    hass: HomeAssistant,
+) -> None:
+    """Test entities disabled by default don't count towards the limit."""
+    config_entry = MockConfigEntry()
+    config_entry.add_to_hass(hass)
+    platform = MockEntityPlatform(hass)
+    platform.config_entry = config_entry
+
+    with patch.object(entity_platform, "MAX_ENABLED_ENTITIES_PER_CONFIG_ENTRY", 1):
+        await platform.async_add_entities(
+            [
+                MockEntity(
+                    unique_id="1",
+                    name="ent1",
+                    entity_registry_enabled_default=False,
+                ),
+                MockEntity(
+                    unique_id="2",
+                    name="ent2",
+                    entity_registry_enabled_default=False,
+                ),
+                MockEntity(unique_id="3", name="ent3"),
+            ]
+        )
+
+    # The two disabled entities don't count, so the enabled one is still added
+    assert hass.states.get("test_domain.ent3") is not None
+
+
+async def test_entity_limit_per_config_entry_frees_slot_when_disabled(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test a new entity can be added after the count drops below the limit."""
+    config_entry = MockConfigEntry()
+    config_entry.add_to_hass(hass)
+    platform = MockEntityPlatform(hass)
+    platform.config_entry = config_entry
+
+    with patch.object(entity_platform, "MAX_ENABLED_ENTITIES_PER_CONFIG_ENTRY", 1):
+        await platform.async_add_entities([MockEntity(unique_id="1", name="ent1")])
+        await platform.async_add_entities([MockEntity(unique_id="2", name="ent2")])
+        assert hass.states.get("test_domain.ent2") is None
+
+        # Disabling the first entity frees up a slot
+        entity_registry.async_update_entity(
+            "test_domain.ent1", disabled_by=er.RegistryEntryDisabler.USER
+        )
+        await platform.async_add_entities([MockEntity(unique_id="3", name="ent3")])
+
+    assert hass.states.get("test_domain.ent3") is not None
+
+
+async def test_entity_limit_per_config_entry_allows_existing_entities(
+    hass: HomeAssistant,
+) -> None:
+    """Test already registered entities can still be added when at the limit."""
+    config_entry = MockConfigEntry()
+    config_entry.add_to_hass(hass)
+    platform = MockEntityPlatform(hass)
+    platform.config_entry = config_entry
+
+    with patch.object(entity_platform, "MAX_ENABLED_ENTITIES_PER_CONFIG_ENTRY", 1):
+        await platform.async_add_entities([MockEntity(unique_id="1", name="ent1")])
+        await platform.async_reset()
+
+        # Re-adding the same entity while at the limit must still work
+        await platform.async_add_entities([MockEntity(unique_id="1", name="ent1")])
+
+    assert hass.states.get("test_domain.ent1") is not None
+
+
+async def test_entity_limit_per_config_entry_is_shared_across_platforms(
+    hass: HomeAssistant,
+) -> None:
+    """Test the limit is shared by all platforms of a config entry."""
+    config_entry = MockConfigEntry()
+    config_entry.add_to_hass(hass)
+    platform1 = MockEntityPlatform(
+        hass, domain="domain1", platform_name="test_platform"
+    )
+    platform1.config_entry = config_entry
+    platform2 = MockEntityPlatform(
+        hass, domain="domain2", platform_name="test_platform"
+    )
+    platform2.config_entry = config_entry
+
+    with patch.object(entity_platform, "MAX_ENABLED_ENTITIES_PER_CONFIG_ENTRY", 1):
+        await platform1.async_add_entities([MockEntity(unique_id="1", name="ent1")])
+        await platform2.async_add_entities([MockEntity(unique_id="2", name="ent2")])
+
+    assert hass.states.get("domain1.ent1") is not None
+    assert hass.states.get("domain2.ent2") is None
+
+
+async def test_entity_limit_not_applied_without_config_entry(
+    hass: HomeAssistant,
+) -> None:
+    """Test the limit does not apply to platforms without a config entry."""
+    platform = MockEntityPlatform(hass)
+
+    with patch.object(entity_platform, "MAX_ENABLED_ENTITIES_PER_CONFIG_ENTRY", 1):
+        await platform.async_add_entities(
+            [
+                MockEntity(unique_id="1", name="ent1"),
+                MockEntity(unique_id="2", name="ent2"),
+            ]
+        )
+
+    assert hass.states.get("test_domain.ent1") is not None
+    assert hass.states.get("test_domain.ent2") is not None
+
+
 async def test_unique_id_conflict_has_priority_over_disabled_entity(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -1064,6 +1064,64 @@ async def test_removing_config_entry_id(
     }
 
 
+async def test_enabled_count_for_config_entry(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test counting enabled entries for a config entry."""
+    mock_config = MockConfigEntry(domain="light", entry_id="mock-id-1")
+    mock_config.add_to_hass(hass)
+
+    def enabled_count() -> int:
+        return entity_registry.entities.get_enabled_count_for_config_entry_id(
+            "mock-id-1"
+        )
+
+    assert enabled_count() == 0
+
+    # Enabled entry increments the count
+    entry1 = entity_registry.async_get_or_create(
+        "light", "hue", "1", config_entry=mock_config
+    )
+    assert enabled_count() == 1
+
+    # Disabled-by-default entry does not count
+    entity_registry.async_get_or_create(
+        "light",
+        "hue",
+        "2",
+        config_entry=mock_config,
+        disabled_by=er.RegistryEntryDisabler.INTEGRATION,
+    )
+    assert enabled_count() == 1
+
+    # Disabling an enabled entry decrements the count
+    entity_registry.async_update_entity(
+        entry1.entity_id, disabled_by=er.RegistryEntryDisabler.USER
+    )
+    assert enabled_count() == 0
+
+    # Re-enabling increments it again
+    entity_registry.async_update_entity(entry1.entity_id, disabled_by=None)
+    assert enabled_count() == 1
+
+    # Removing an enabled entry decrements the count
+    entity_registry.async_remove(entry1.entity_id)
+    assert enabled_count() == 0
+
+    # The count matches a filtered scan of the index
+    entity_registry.async_get_or_create("light", "hue", "3", config_entry=mock_config)
+    entity_registry.async_get_or_create("light", "hue", "4", config_entry=mock_config)
+    assert enabled_count() == len(
+        [
+            entry
+            for entry in entity_registry.entities.get_entries_for_config_entry_id(
+                "mock-id-1"
+            )
+            if not entry.disabled
+        ]
+    )
+
+
 async def test_deleted_entity_removing_config_entry_id(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- We've seen reports where some users have tens of thousands of entities for a config entry, which stops the frontend from responding and stops the user from being to resolve that problem.
- Integrations should take care not to add this amount of entities. It's not normal. But we also want to protect users from this problem and integrations that misbehave, and also protect the rest of Home Assistant.
- Set an upper limit on the number of enabled entities per config entry.
- For now the suggestion is max 10k enabled entities per config entry.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/173882
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
