### PR TITLE
Rename advanced settings title in anthropic integration

### DIFF
--- a/homeassistant/components/anthropic/strings.json
+++ b/homeassistant/components/anthropic/strings.json
@@ -124,7 +124,7 @@
             "chat_model": "The model to serve the responses.",
             "prompt_caching": "Optimize your API cost and response times based on your usage."
           },
-          "title": "Advanced settings"
+          "title": "More options"
         },
         "init": {
           "data": {


### PR DESCRIPTION
Proposed change

This PR updates the user-facing title "Advanced settings" to "More options" in the Anthropic integration.

The goal is to align with Home Assistant's ongoing effort to replace "Advanced" and "Expert" terminology with more neutral and user-friendly wording.

This change only affects displayed text. No functionality, configuration flow behavior, translation keys, entity IDs, service IDs, or internal identifiers are modified.

Type of change

- [x] Code quality improvements to existing code or addition of tests

Additional information

- Fixes #174038

Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change has been tested locally.
- [x] There is no commented-out code in this PR.
- [x] I have followed the development checklist.
- [x] I have followed the perfect PR recommendations.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.