### PR TITLE
Convert epoch to datetime for ESPHome uptime sensor device class

### DIFF
--- a/homeassistant/components/esphome/sensor.py
+++ b/homeassistant/components/esphome/sensor.py
@@ -106,7 +106,10 @@ class EsphomeSensor(EsphomeEntity[SensorInfo, SensorState], SensorEntity):
         state_float = state.state
         if not math.isfinite(state_float):
             return None
-        if self.device_class is SensorDeviceClass.TIMESTAMP:
+        if self.device_class in (
+            SensorDeviceClass.TIMESTAMP,
+            SensorDeviceClass.UPTIME,
+        ):
             return dt_util.utc_from_timestamp(state_float)
         return state_float
 

--- a/tests/components/esphome/test_sensor.py
+++ b/tests/components/esphome/test_sensor.py
@@ -236,6 +236,33 @@ async def test_generic_numeric_sensor_device_class_timestamp(
     assert state.state == "2023-06-22T18:43:52+00:00"
 
 
+async def test_generic_numeric_sensor_device_class_uptime(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_generic_device_entry: MockGenericDeviceEntryType,
+) -> None:
+    """Test a sensor entity that uses uptime (epoch)."""
+    entity_info = [
+        SensorInfo(
+            object_id="mysensor",
+            key=1,
+            name="my sensor",
+            device_class="uptime",
+        )
+    ]
+    states = [SensorState(key=1, state=1687459432.466624)]
+    user_service = []
+    await mock_generic_device_entry(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        user_service=user_service,
+        states=states,
+    )
+    state = hass.states.get("sensor.test_my_sensor")
+    assert state is not None
+    assert state.state == "2023-06-22T18:43:52+00:00"
+
+
 async def test_generic_numeric_sensor_legacy_last_reset_convert(
     hass: HomeAssistant,
     mock_client: APIClient,


### PR DESCRIPTION
## Breaking change

N/A

## Proposed change

ESPHome numeric sensors transmit their value as a `float`. `EsphomeSensor.native_value` converts that float into a `datetime` only when the device class is `timestamp`. The `uptime` device class is also datetime-valued (it represents the point in time a device last booted), so an ESPHome sensor reporting its boot time as an epoch with `device_class: uptime` was passed through as a raw float and rejected by the sensor entity, making it unavailable.

This converts the epoch for `uptime` as well as `timestamp`.

Context: ESPHome 2026.6.0 switched its uptime "timestamp" sensor to `device_class: uptime`, which surfaced this gap (esphome/esphome#17031). ESPHome is reverting to `timestamp` for immediate relief (esphome/esphome#17037); this change is what allows the semantically-correct `uptime` class to work from ESPHome going forward.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: esphome/esphome#17031
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr