### PR TITLE
Skip fill sensor for Rituals diffusers without fill data

### DIFF
--- a/homeassistant/components/rituals_perfume_genie/sensor.py
+++ b/homeassistant/components/rituals_perfume_genie/sensor.py
@@ -40,6 +40,7 @@ ENTITY_DESCRIPTIONS = (
         key="fill",
         translation_key="fill",
         value_fn=lambda diffuser: diffuser.fill,
+        has_fn=lambda diffuser: "fillc" in diffuser.hub_data.get("sensors", {}),
     ),
     RitualsSensorEntityDescription(
         key="perfume",

--- a/tests/components/rituals_perfume_genie/common.py
+++ b/tests/components/rituals_perfume_genie/common.py
@@ -63,12 +63,31 @@ def mock_diffuser(
     diffuser_mock.version = version
     diffuser_mock.wifi_percentage = wifi_percentage
     diffuser_mock.data = load_json_object_fixture("data.json", DOMAIN)
+    diffuser_mock.hub_data = diffuser_mock.data["hub"]
     return diffuser_mock
 
 
 def mock_diffuser_v1_battery_cartridge() -> MagicMock:
     """Create and return a mock version 1 Diffuser with battery and a cartridge."""
     return mock_diffuser(hublot="lot123v1")
+
+
+def mock_diffuser_v3_no_battery_no_fill() -> MagicMock:
+    """Create and return a mock version 3 Diffuser without battery or fill sensor."""
+    diffuser = mock_diffuser(
+        hublot="lot123v3",
+        battery_percentage=Exception(),
+        charging=Exception(),
+        fill="",
+        has_battery=False,
+        has_cartridge=True,
+        name="Genie V3",
+        perfume="Ritual of Sakura",
+        version="6.0",
+    )
+    diffuser.data = load_json_object_fixture("data_no_fill.json", DOMAIN)
+    diffuser.hub_data = diffuser.data["hub"]
+    return diffuser
 
 
 def mock_diffuser_v2_no_battery_no_cartridge() -> MagicMock:

--- a/tests/components/rituals_perfume_genie/fixtures/data_no_fill.json
+++ b/tests/components/rituals_perfume_genie/fixtures/data_no_fill.json
@@ -1,0 +1,70 @@
+{
+  "hub": {
+    "hublot": "LOT456",
+    "hash": "abcdef1234567890ghijklmnopqrstuvwxyz",
+    "status": 1,
+    "title": null,
+    "current_time": "2023-06-09T20:50",
+    "cached_time": "2023-06-09T20:48",
+    "ping_update": "25",
+    "attributes": {
+      "roomc": "4",
+      "speedc": "3",
+      "fanc": "1",
+      "roomnamec": "Living room",
+      "resetc": "",
+      "fspacenamec": "",
+      "fspacetypec": ""
+    },
+    "sensors": {
+      "wific": {
+        "id": 10,
+        "sensor_id": 1,
+        "title": "High",
+        "description": "",
+        "icon": "icon-signal.png",
+        "image": "",
+        "discover_image": "",
+        "discover_url": null,
+        "min_value": "-69.99",
+        "max_value": "-0.00",
+        "interval": "1",
+        "created_at": "2017-03-10 16:17:30",
+        "updated_at": "2020-06-17 16:57:53",
+        "default": 0
+      },
+      "rfidc": {
+        "id": 54,
+        "sensor_id": 4,
+        "title": "Private Collection Sweet Jasmine",
+        "description": "",
+        "icon": "icon-jasmine.png",
+        "image": "background-jasmine.png",
+        "discover_image": "discover-jasmine.png",
+        "discover_url": "sweet-jasmine-cartridge-1105402.html",
+        "min_value": "05377650",
+        "max_value": "05377650",
+        "interval": "",
+        "created_at": "2019-04-04 07:53:32",
+        "updated_at": "2021-01-26 14:17:03",
+        "default": 0
+      },
+      "versionc": "6.0",
+      "ipc": "1682963060"
+    },
+    "settings": [
+      {
+        "schedule_id": 1835730,
+        "start": "07:30",
+        "end": "08:30",
+        "mon": 1,
+        "tue": 1,
+        "wed": 1,
+        "thu": 1,
+        "fri": 1,
+        "sat": 1,
+        "sun": 1
+      }
+    ]
+  }
+}

--- a/tests/components/rituals_perfume_genie/test_sensor.py
+++ b/tests/components/rituals_perfume_genie/test_sensor.py
@@ -14,6 +14,7 @@ from .common import (
     init_integration,
     mock_config_entry,
     mock_diffuser_v1_battery_cartridge,
+    mock_diffuser_v3_no_battery_no_fill,
 )
 
 
@@ -63,3 +64,19 @@ async def test_sensors_diffuser_v1_battery_cartridge(
     assert entry
     assert entry.unique_id == f"{hublot}-wifi_percentage"
     assert entry.entity_category == EntityCategory.DIAGNOSTIC
+
+
+async def test_sensors_diffuser_v3_no_fill(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test that a Genie 3.0 without fill sensor data does not create a fill entity."""
+    config_entry = mock_config_entry(unique_id="id_123_sensor_test_diffuser_v3")
+    diffuser = mock_diffuser_v3_no_battery_no_fill()
+    await init_integration(hass, config_entry, [diffuser])
+
+    assert hass.states.get("sensor.genie_v3_fill") is None
+    assert entity_registry.async_get("sensor.genie_v3_fill") is None
+
+    state = hass.states.get("sensor.genie_v3_perfume")
+    assert state
+    assert state.state == diffuser.perfume


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The Rituals Perfume Genie 3.0 does not report fill sensor data (`fillc`) from the API. However, the integration unconditionally creates a fill sensor entity for every diffuser, resulting in a permanently "unknown" entity for Genie 3.0 devices.

This adds a `has_fn` to the fill sensor description (matching the pattern already used by the battery sensor) that checks whether `fillc` is present in the hub's sensor data. If the device doesn't report fill data, the entity is not created.

Note: the related issue also reports that the Genie 3.0 is misidentified as model "2.0". That requires upstream `pyrituals` library changes and is not addressed by this PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: #173780
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr