### PR TITLE
Wrap cloud OAuth2 token refresh errors into proper exception types

### DIFF
--- a/homeassistant/components/cloud/account_link.py
+++ b/homeassistant/components/cloud/account_link.py
@@ -1,6 +1,7 @@
 """Account linking via the cloud."""
 
 from datetime import datetime
+from http import HTTPStatus
 import logging
 from typing import Any
 
@@ -10,6 +11,11 @@ from hass_nabucasa import account_link
 
 from homeassistant.const import __version__ as HA_VERSION
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import (
+    OAuth2TokenRequestError,
+    OAuth2TokenRequestReauthError,
+    OAuth2TokenRequestTransientError,
+)
 from homeassistant.helpers import config_entry_oauth2_flow, event
 
 from .const import DATA_CLOUD, DOMAIN
@@ -146,7 +152,35 @@ class CloudOAuth2Implementation(config_entry_oauth2_flow.AbstractOAuth2Implement
 
     async def _async_refresh_token(self, token: dict) -> dict:
         """Refresh a token."""
-        new_token = await account_link.async_fetch_access_token(
-            self.hass.data[DATA_CLOUD], self.service, token["refresh_token"]
-        )
+        try:
+            new_token = await account_link.async_fetch_access_token(
+                self.hass.data[DATA_CLOUD], self.service, token["refresh_token"]
+            )
+        except aiohttp.ClientResponseError as err:
+            if err.status == HTTPStatus.TOO_MANY_REQUESTS or 500 <= err.status <= 599:
+                raise OAuth2TokenRequestTransientError(
+                    request_info=err.request_info,
+                    history=err.history,
+                    status=err.status,
+                    message=err.message,
+                    headers=err.headers,
+                    domain=self.service,
+                ) from err
+            if 400 <= err.status <= 499:
+                raise OAuth2TokenRequestReauthError(
+                    request_info=err.request_info,
+                    history=err.history,
+                    status=err.status,
+                    message=err.message,
+                    headers=err.headers,
+                    domain=self.service,
+                ) from err
+            raise OAuth2TokenRequestError(
+                request_info=err.request_info,
+                history=err.history,
+                status=err.status,
+                message=err.message,
+                headers=err.headers,
+                domain=self.service,
+            ) from err
         return {**token, **new_token}

--- a/tests/components/cloud/test_account_link.py
+++ b/tests/components/cloud/test_account_link.py
@@ -6,13 +6,20 @@ import logging
 from time import time
 from unittest.mock import AsyncMock, Mock, patch
 
+from aiohttp import ClientResponseError, RequestInfo
 import pytest
+from yarl import URL
 
 from homeassistant import config_entries
 from homeassistant.components.cloud import account_link
 from homeassistant.components.cloud.const import DATA_CLOUD
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.exceptions import (
+    OAuth2TokenRequestError,
+    OAuth2TokenRequestReauthError,
+    OAuth2TokenRequestTransientError,
+)
 from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.util.dt import utcnow
 
@@ -246,3 +253,53 @@ async def test_implementation(
         )
         is impl
     )
+
+
+def _mock_client_response_error(status: int) -> ClientResponseError:
+    """Create a ClientResponseError with the given status."""
+    return ClientResponseError(
+        request_info=RequestInfo(
+            url=URL("https://example.com/token"),
+            method="POST",
+            headers={},
+            real_url=URL("https://example.com/token"),
+        ),
+        history=(),
+        status=status,
+        message="error",
+    )
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_exception"),
+    [
+        (400, OAuth2TokenRequestReauthError),
+        (401, OAuth2TokenRequestReauthError),
+        (403, OAuth2TokenRequestReauthError),
+        (429, OAuth2TokenRequestTransientError),
+        (500, OAuth2TokenRequestTransientError),
+        (503, OAuth2TokenRequestTransientError),
+    ],
+)
+async def test_refresh_token_error(
+    hass: HomeAssistant,
+    status: int,
+    expected_exception: type[OAuth2TokenRequestError],
+) -> None:
+    """Test that _async_refresh_token wraps ClientResponseError."""
+    hass.data[DATA_CLOUD] = None
+    impl = account_link.CloudOAuth2Implementation(hass, "test")
+
+    with (
+        patch(
+            "hass_nabucasa.account_link.async_fetch_access_token",
+            side_effect=_mock_client_response_error(status),
+        ),
+        pytest.raises(expected_exception) as exc_info,
+    ):
+        await impl._async_refresh_token(
+            {"refresh_token": "mock-refresh", "access_token": "mock-access"}
+        )
+
+    assert exc_info.value.status == status
+    assert exc_info.value.domain == "test"

--- a/tests/components/cloud/test_account_link.py
+++ b/tests/components/cloud/test_account_link.py
@@ -279,6 +279,7 @@ def _mock_client_response_error(status: int) -> ClientResponseError:
         (429, OAuth2TokenRequestTransientError),
         (500, OAuth2TokenRequestTransientError),
         (503, OAuth2TokenRequestTransientError),
+        (302, OAuth2TokenRequestError),
     ],
 )
 async def test_refresh_token_error(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`CloudOAuth2Implementation._async_refresh_token` did not wrap `aiohttp.ClientResponseError` into the expected `OAuth2TokenRequestError` hierarchy. When a cloud OAuth2 token refresh failed (for example, HTTP 400 from the account link server), the raw `ClientResponseError` bubbled up uncaught. Integrations like August and SmartThings would then raise `ConfigEntryNotReady`, causing infinite retries instead of prompting the user for re-authentication via `ConfigEntryAuthFailed`.

The abstract base class contract (`AbstractOAuth2Implementation._async_refresh_token`) requires raising `OAuth2TokenRequestError` on failure. `LocalOAuth2Implementation._token_request` already does this correctly; the cloud implementation was the only one missing this error wrapping.

This PR adds a try/except in `_async_refresh_token` that maps `ClientResponseError` to:

- `OAuth2TokenRequestReauthError` for 4xx status codes (triggers re-auth)
- `OAuth2TokenRequestTransientError` for 429 and 5xx (recoverable, retry is appropriate)
- `OAuth2TokenRequestError` for anything else

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #174201
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr