### PR TITLE
Use throttling to rate-limit WMS status calls to once per 500ms

### DIFF
--- a/homeassistant/components/wmspro/const.py
+++ b/homeassistant/components/wmspro/const.py
@@ -1,5 +1,8 @@
 """Constants for the WMS WebControl pro API integration."""
 
+from datetime import timedelta
+from typing import Final
+
 DOMAIN = "wmspro"
 SUGGESTED_HOST = "webcontrol"
 
@@ -7,3 +10,4 @@ ATTRIBUTION = "Data provided by WMS WebControl pro API"
 MANUFACTURER = "WAREMA Renkhoff SE"
 
 BRIGHTNESS_SCALE = (1, 100)
+MIN_TIME_BETWEEN_UPDATES: Final = timedelta(milliseconds=500)

--- a/homeassistant/components/wmspro/entity.py
+++ b/homeassistant/components/wmspro/entity.py
@@ -1,11 +1,14 @@
 """Generic entity for the WMS WebControl pro API integration."""
 
+import asyncio
+
 from wmspro.destination import Destination
 
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
 
-from .const import ATTRIBUTION, DOMAIN, MANUFACTURER
+from .const import ATTRIBUTION, DOMAIN, MANUFACTURER, MIN_TIME_BETWEEN_UPDATES
 
 
 class WebControlProGenericEntity(Entity):
@@ -34,7 +37,16 @@ class WebControlProGenericEntity(Entity):
 
     async def async_update(self) -> None:
         """Update the entity."""
-        await self._dest.refresh()
+        while True:
+            if await self._dest_refresh() is None:
+                await asyncio.sleep(MIN_TIME_BETWEEN_UPDATES.total_seconds())
+            else:
+                break
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    async def _dest_refresh(self) -> bool:
+        """Refresh the destination data."""
+        return await self._dest.refresh()
 
     @property
     def available(self) -> bool:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Try to use throttling to rate-limit WMS status calls to once per 500ms in order to avoid overloading the WMS radio channel as described in https://github.com/home-assistant/core/issues/173356.

This is a first attempt to solve the issue which will need to be tested by the community (users with many WMS devices). It will also be necessary to find a way to avoid the throttling during test runs.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #169792
- This PR is related to issue: #173356
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
