### PR TITLE
Add new values for Compit sensor

### DIFF
--- a/homeassistant/components/compit/sensor.py
+++ b/homeassistant/components/compit/sensor.py
@@ -228,14 +228,6 @@ DESCRIPTIONS: dict[CompitParameter, SensorEntityDescription] = {
         entity_category=EntityCategory.DIAGNOSTIC,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
     ),
-    CompitParameter.DHW_CURRENT_TEMPERATURE: SensorEntityDescription(
-        key=CompitParameter.DHW_CURRENT_TEMPERATURE.value,
-        translation_key="dhw_current_temperature",
-        device_class=SensorDeviceClass.TEMPERATURE,
-        state_class=SensorStateClass.MEASUREMENT,
-        entity_category=EntityCategory.DIAGNOSTIC,
-        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-    ),
     CompitParameter.DHW_MEASURED_TEMPERATURE: SensorEntityDescription(
         key=CompitParameter.DHW_MEASURED_TEMPERATURE.value,
         translation_key="dhw_measured_temperature",
@@ -867,9 +859,6 @@ DEVICE_DEFINITIONS: dict[int, CompitDeviceDescription] = {
         parameters={
             CompitParameter.ACTUAL_BUFFER_TEMP: DESCRIPTIONS[
                 CompitParameter.ACTUAL_BUFFER_TEMP
-            ],
-            CompitParameter.DHW_CURRENT_TEMPERATURE: DESCRIPTIONS[
-                CompitParameter.DHW_CURRENT_TEMPERATURE
             ],
             CompitParameter.ACTUAL_HC1_TEMPERATURE: DESCRIPTIONS[
                 CompitParameter.ACTUAL_HC1_TEMPERATURE

--- a/homeassistant/components/compit/sensor.py
+++ b/homeassistant/components/compit/sensor.py
@@ -228,6 +228,14 @@ DESCRIPTIONS: dict[CompitParameter, SensorEntityDescription] = {
         entity_category=EntityCategory.DIAGNOSTIC,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
     ),
+    CompitParameter.DHW_CURRENT_TEMPERATURE: SensorEntityDescription(
+        key=CompitParameter.DHW_CURRENT_TEMPERATURE.value,
+        translation_key="dhw_current_temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+    ),
     CompitParameter.DHW_MEASURED_TEMPERATURE: SensorEntityDescription(
         key=CompitParameter.DHW_MEASURED_TEMPERATURE.value,
         translation_key="dhw_measured_temperature",
@@ -574,6 +582,9 @@ DEVICE_DEFINITIONS: dict[int, CompitDeviceDescription] = {
             CompitParameter.VENTILATION_ALARM: DESCRIPTIONS[
                 CompitParameter.VENTILATION_ALARM
             ],
+            CompitParameter.VENTILATION_GEAR: DESCRIPTIONS[
+                CompitParameter.VENTILATION_GEAR
+            ],
         },
     ),
     14: CompitDeviceDescription(
@@ -856,6 +867,9 @@ DEVICE_DEFINITIONS: dict[int, CompitDeviceDescription] = {
         parameters={
             CompitParameter.ACTUAL_BUFFER_TEMP: DESCRIPTIONS[
                 CompitParameter.ACTUAL_BUFFER_TEMP
+            ],
+            CompitParameter.DHW_CURRENT_TEMPERATURE: DESCRIPTIONS[
+                CompitParameter.DHW_CURRENT_TEMPERATURE
             ],
             CompitParameter.ACTUAL_HC1_TEMPERATURE: DESCRIPTIONS[
                 CompitParameter.ACTUAL_HC1_TEMPERATURE

--- a/tests/components/compit/snapshots/test_sensor.ambr
+++ b/tests/components/compit/snapshots/test_sensor.ambr
@@ -757,6 +757,64 @@
     'state': 'unknown',
   })
 # ---
+# name: test_sensor_entities_snapshot[sensor.r_900_dhw_current_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.r_900_dhw_current_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'DHW current temperature',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'DHW current temperature',
+    'platform': 'compit',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'dhw_current_temperature',
+    'unique_id': '1_DHW_CURRENT_TEMPERATURE',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensor_entities_snapshot[sensor.r_900_dhw_current_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'R 900 DHW current temperature',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.r_900_dhw_current_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '50.0',
+  })
+# ---
 # name: test_sensor_entities_snapshot[sensor.r_900_heating_circuit_1_target_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/compit/snapshots/test_sensor.ambr
+++ b/tests/components/compit/snapshots/test_sensor.ambr
@@ -757,64 +757,6 @@
     'state': 'unknown',
   })
 # ---
-# name: test_sensor_entities_snapshot[sensor.r_900_dhw_current_temperature-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.r_900_dhw_current_temperature',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'DHW current temperature',
-    'options': dict({
-      'sensor': dict({
-        'suggested_display_precision': 1,
-      }),
-    }),
-    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
-    'original_icon': None,
-    'original_name': 'DHW current temperature',
-    'platform': 'compit',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'dhw_current_temperature',
-    'unique_id': '1_DHW_CURRENT_TEMPERATURE',
-    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
-  })
-# ---
-# name: test_sensor_entities_snapshot[sensor.r_900_dhw_current_temperature-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'temperature',
-      'friendly_name': 'R 900 DHW current temperature',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.r_900_dhw_current_temperature',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '50.0',
-  })
-# ---
 # name: test_sensor_entities_snapshot[sensor.r_900_heating_circuit_1_target_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/46321
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
