### PR TITLE
unifiprotect: abort RTSPS repair flow when camera is unavailable

### DIFF
--- a/homeassistant/components/unifiprotect/repairs.py
+++ b/homeassistant/components/unifiprotect/repairs.py
@@ -4,6 +4,7 @@ from typing import cast
 
 from uiprotect import ProtectApiClient
 from uiprotect.data import Bootstrap, Camera
+from uiprotect.exceptions import NvrError
 import voluptuous as vol
 
 from homeassistant.components.repairs import (
@@ -105,16 +106,23 @@ class RTSPRepair(ProtectRepair):
 
         return self._bootstrap
 
-    async def _get_camera(self) -> Camera:
+    async def _get_camera(self) -> Camera | None:
         if self._camera is None:
             bootstrap = await self._get_boostrap()
             self._camera = bootstrap.cameras.get(self._camera_id)
-            assert self._camera is not None
         return self._camera
 
     async def _enable_rtsp(self) -> None:
         camera = await self._get_camera()
+        if camera is None:
+            return
         await camera.create_rtsps_streams(qualities="high")
+
+    async def _get_updated_camera(self) -> Camera | None:
+        try:
+            return await self._api.get_camera(self._camera_id)
+        except NvrError:
+            return None
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
@@ -130,7 +138,8 @@ class RTSPRepair(ProtectRepair):
 
         if user_input is None:
             # make sure camera object is loaded for placeholders
-            await self._get_camera()
+            if await self._get_camera() is None:
+                return self.async_abort(reason="camera_unavailable")
             placeholders = self._async_get_placeholders()
             return self.async_show_form(
                 step_id="start",
@@ -138,11 +147,13 @@ class RTSPRepair(ProtectRepair):
                 description_placeholders=placeholders,
             )
 
-        updated_camera = await self._api.get_camera(self._camera_id)
+        if (updated_camera := await self._get_updated_camera()) is None:
+            return self.async_abort(reason="camera_unavailable")
         if not any(c.is_rtsp_enabled for c in updated_camera.channels):
             await self._enable_rtsp()
 
-        updated_camera = await self._api.get_camera(self._camera_id)
+        if (updated_camera := await self._get_updated_camera()) is None:
+            return self.async_abort(reason="camera_unavailable")
         if any(c.is_rtsp_enabled for c in updated_camera.channels):
             await self.hass.config_entries.async_reload(self._entry.entry_id)
             return self.async_create_entry(data={})

--- a/homeassistant/components/unifiprotect/strings.json
+++ b/homeassistant/components/unifiprotect/strings.json
@@ -749,6 +749,9 @@
     },
     "rtsp_disabled_readonly": {
       "fix_flow": {
+        "abort": {
+          "camera_unavailable": "Camera is unavailable"
+        },
         "step": {
           "confirm": {
             "description": "Are you sure you want to leave RTSPS disabled for {camera}?",
@@ -764,6 +767,9 @@
     },
     "rtsp_disabled_writable": {
       "fix_flow": {
+        "abort": {
+          "camera_unavailable": "[%key:component::unifiprotect::issues::rtsp_disabled_readonly::fix_flow::abort::camera_unavailable%]"
+        },
         "step": {
           "confirm": {
             "description": "[%key:component::unifiprotect::issues::rtsp_disabled_readonly::fix_flow::step::confirm::description%]",

--- a/tests/components/unifiprotect/test_repairs.py
+++ b/tests/components/unifiprotect/test_repairs.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 from unittest.mock import AsyncMock
 
 from uiprotect.data import Camera, CloudAccount, Version
+from uiprotect.exceptions import NvrError
 
 from homeassistant.components.unifiprotect.const import CONF_DISABLE_RTSP, DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH
@@ -254,6 +255,77 @@ async def test_rtsp_writable_fix_when_not_setup(
     assert data["type"] == "create_entry"
 
     ufp.api.create_camera_rtsps_streams.assert_called_with(doorbell.id, "high")
+
+
+async def test_rtsp_fix_aborts_if_camera_missing_from_bootstrap(
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+    doorbell: Camera,
+    hass_client: ClientSessionGenerator,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test RTSP disabled repair aborts if the camera is unavailable."""
+
+    for channel in doorbell.channels:
+        channel.is_rtsp_enabled = False
+
+    await init_entry(hass, ufp, [doorbell])
+    await async_process_repairs_platforms(hass)
+    ws_client = await hass_ws_client(hass)
+    client = await hass_client()
+
+    issue_id = f"rtsp_disabled_{doorbell.id}"
+
+    await ws_client.send_json({"id": 1, "type": "repairs/list_issues"})
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    assert any(i["issue_id"] == issue_id for i in msg["result"]["issues"])
+
+    del ufp.api.bootstrap.cameras[doorbell.id]
+
+    data = await start_repair_fix_flow(client, DOMAIN, issue_id)
+
+    assert data["type"] == "abort"
+    assert data["reason"] == "camera_unavailable"
+
+
+async def test_rtsp_fix_aborts_if_camera_missing_on_submit(
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+    doorbell: Camera,
+    hass_client: ClientSessionGenerator,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test RTSP disabled repair aborts if the camera disappears on submit."""
+
+    for channel in doorbell.channels:
+        channel.is_rtsp_enabled = False
+
+    await init_entry(hass, ufp, [doorbell])
+    await async_process_repairs_platforms(hass)
+    ws_client = await hass_ws_client(hass)
+    client = await hass_client()
+
+    issue_id = f"rtsp_disabled_{doorbell.id}"
+
+    await ws_client.send_json({"id": 1, "type": "repairs/list_issues"})
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    assert any(i["issue_id"] == issue_id for i in msg["result"]["issues"])
+
+    data = await start_repair_fix_flow(client, DOMAIN, issue_id)
+
+    flow_id = data["flow_id"]
+    assert data["step_id"] == "start"
+
+    ufp.api.get_camera = AsyncMock(side_effect=NvrError("Camera not found"))
+
+    data = await process_repair_fix_flow(client, flow_id)
+
+    assert data["type"] == "abort"
+    assert data["reason"] == "camera_unavailable"
 
 
 async def test_rtsp_no_fix_if_third_party(


### PR DESCRIPTION
## Summary

- Abort the UniFi Protect RTSPS repair flow when the referenced camera is no longer available.
- Handle both missing bootstrap camera data and `NvrError` from fresh camera lookups.
- Add repair-flow coverage for the display and submit paths.

Fixes #173518

## Tests

- `pytest tests/components/unifiprotect/test_repairs.py -k 'camera_missing' -q` — 2 passed
- `pytest tests/components/unifiprotect/test_repairs.py -q` — 9 passed
- `ruff check homeassistant/components/unifiprotect/repairs.py tests/components/unifiprotect/test_repairs.py`
- `python -m script.hassfest --integration-path homeassistant/components/unifiprotect`
- `git diff --check`

AI-assisted (Opus); human-reviewed.
