### PR TITLE
Preserve inner spaces in Adax local Wi-Fi password

### DIFF
--- a/homeassistant/components/adax/config_flow.py
+++ b/homeassistant/components/adax/config_flow.py
@@ -86,7 +86,7 @@ class AdaxConfigFlow(ConfigFlow, domain=DOMAIN):
             )
 
         wifi_ssid = user_input[WIFI_SSID]
-        wifi_pswd = user_input[WIFI_PSWD].replace(" ", "")
+        wifi_pswd = user_input[WIFI_PSWD].strip()
         configurator = adax_local.AdaxConfig(wifi_ssid, wifi_pswd)
 
         try:

--- a/tests/components/adax/test_config_flow.py
+++ b/tests/components/adax/test_config_flow.py
@@ -183,6 +183,49 @@ async def test_local_create_entry(hass: HomeAssistant) -> None:
     }
 
 
+async def test_local_create_entry_strips_password_whitespace(
+    hass: HomeAssistant,
+) -> None:
+    """Test surrounding whitespace is stripped while inner spaces are kept."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONNECTION_TYPE: LOCAL,
+        },
+    )
+    assert result2["type"] is FlowResultType.FORM
+
+    with (
+        patch(
+            "homeassistant.components.adax.async_setup_entry",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.adax.config_flow.adax_local.AdaxConfig",
+            autospec=True,
+        ) as mock_client_class,
+    ):
+        client = mock_client_class.return_value
+        client.configure_device.return_value = True
+        client.device_ip = "192.168.1.4"
+        client.access_token = "token"
+        client.mac_id = "8383838"
+        result = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
+            {
+                WIFI_SSID: "ssid",
+                WIFI_PSWD: "  pass word  ",
+            },
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    mock_client_class.assert_called_once_with("ssid", "pass word")
+
+
 async def test_local_flow_entry_already_exists(hass: HomeAssistant) -> None:
     """Test user input for config_entry that already exists."""
 


### PR DESCRIPTION


The Adax **local** config flow sanitised the Wi-Fi password with
`user_input[WIFI_PSWD].replace(" ", "")`, which removes **all** spaces — so a
password that legitimately contains spaces is corrupted before being sent to the
heater, resulting in an invalid-credentials/connection failure during setup.

This changes it to `str.strip()`, which trims only surrounding whitespace while
preserving inner spaces. A regression test is added asserting that a password
like `"  pass word  "` is passed to `adax_local.AdaxConfig` as `"pass word"`.

The SSID line is intentionally left unchanged (it was never run through
`replace`).




<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr