### PR TITLE
Use http ApiConfig instead of parsing raw http config in hassio

### DIFF
--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -1,12 +1,10 @@
 """Support for Hass.io."""
 
 import asyncio
-from dataclasses import replace
 from functools import partial
 import logging
 import os
 import struct
-from typing import Any
 
 from aiohasupervisor import SupervisorBadRequestError, SupervisorError
 from aiohasupervisor.models import (
@@ -20,19 +18,9 @@ from homeassistant.auth.const import GROUP_ID_ADMIN
 from homeassistant.auth.models import RefreshToken, User
 from homeassistant.components import frontend
 from homeassistant.components.homeassistant import async_set_stop_handler
-from homeassistant.components.http import (
-    CONF_SERVER_HOST,
-    CONF_SERVER_PORT,
-    CONF_SSL_CERTIFICATE,
-)
 from homeassistant.components.onboarding import async_is_onboarded
 from homeassistant.config_entries import SOURCE_SYSTEM, ConfigEntry
-from homeassistant.const import (
-    EVENT_CORE_CONFIG_UPDATE,
-    HASSIO_USER_NAME,
-    SERVER_PORT,
-    Platform,
-)
+from homeassistant.const import EVENT_CORE_CONFIG_UPDATE, HASSIO_USER_NAME, Platform
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import (
@@ -69,7 +57,6 @@ from .const import (
     DATA_COMPONENT,
     DATA_CONFIG_STORE,
     DATA_HASSIO_HOST,
-    DATA_HASSIO_HTTP_CONFIG,
     DATA_HASSIO_SUPERVISOR_USER,
     DATA_KEY_SUPERVISOR_ISSUES,
     DOMAIN,
@@ -246,7 +233,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     websession = async_get_clientsession(hass)
     hass.data[DATA_COMPONENT] = HassIO(hass.loop, websession, host)
     hass.data[DATA_HASSIO_HOST] = host
-    hass.data[DATA_HASSIO_HTTP_CONFIG] = config.get("http", {})
 
     # Load the store
     config_store = HassioConfig(hass)
@@ -399,22 +385,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     entry.async_on_unload(hass.bus.async_listen(EVENT_CORE_CONFIG_UPDATE, push_config))
 
-    http_config: dict[str, Any] = hass.data.get(DATA_HASSIO_HTTP_CONFIG, {})
-
     async def update_hass_api(refresh_token: RefreshToken) -> None:
         """Update Home Assistant API data on Hass.io."""
+        # hass.config.api is always set here: hassio depends on http, and the
+        # http integration assigns hass.config.api during its async_setup.
+        assert hass.config.api is not None
         options = HomeAssistantOptions(
-            ssl=CONF_SSL_CERTIFICATE in http_config,
-            port=http_config.get(CONF_SERVER_PORT) or SERVER_PORT,
+            ssl=hass.config.api.use_ssl,
+            port=hass.config.api.port,
             refresh_token=refresh_token.token,
         )
-
-        if http_config.get(CONF_SERVER_HOST) is not None:
-            options = replace(options, watchdog=False)
-            _LOGGER.warning(
-                "Found incompatible HTTP option 'server_host'. Watchdog feature"
-                " disabled"
-            )
 
         try:
             await supervisor_client.homeassistant.set_options(options)

--- a/homeassistant/components/hassio/const.py
+++ b/homeassistant/components/hassio/const.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from homeassistant.util.hass_dict import HassKey
 
@@ -145,7 +145,6 @@ DATA_KEY_CORE = "core"
 DATA_KEY_HOST = "host"
 DATA_KEY_SUPERVISOR_ISSUES: HassKey[SupervisorIssues] = HassKey("supervisor_issues")
 DATA_KEY_MOUNTS = "mounts"
-DATA_HASSIO_HTTP_CONFIG: HassKey[dict[str, Any]] = HassKey("hassio_http_config")
 DATA_HASSIO_HOST: HassKey[str] = HassKey("hassio_host")
 DATA_HASSIO_SUPERVISOR_USER: HassKey[User] = HassKey("hassio_supervisor_user")
 

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -308,7 +308,11 @@ async def test_setup_api_push_api_data_error(
 async def test_setup_api_push_api_data_server_host(
     hass: HomeAssistant, supervisor_client: AsyncMock
 ) -> None:
-    """Test setup with API push with active server host."""
+    """Test setup with API push with active server host.
+
+    A configured server_host no longer disables the watchdog: Supervisor
+    reaches Core over the Unix socket, independent of the HTTP bind address.
+    """
     with patch.dict(os.environ, MOCK_ENVIRON):
         result = await async_setup_component(
             hass,
@@ -320,7 +324,7 @@ async def test_setup_api_push_api_data_server_host(
     assert result
     assert len(supervisor_client.mock_calls) == 16
     supervisor_client.homeassistant.set_options.assert_called_once_with(
-        HomeAssistantOptions(ssl=False, port=9999, refresh_token=ANY, watchdog=False)
+        HomeAssistantOptions(ssl=False, port=9999, refresh_token=ANY)
     )
 
 


### PR DESCRIPTION
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The `hassio` integration built the Home Assistant options it pushes to Supervisor (`port`, `ssl`) by parsing the raw `http:` YAML config dict. Reading the resolved `hass.config.api` (`ApiConfig`) object instead is both simpler and more correct: the manual parsing duplicates work the `http` integration already does, and the resolved object has been available all along. `hass.config.api` already exposed the port and SSL flag when this parsing was introduced in #9679 (Oct 2017, then as `hass.config.api = rem.API(host, api_password, port, use_ssl)`; today the `ApiConfig` dataclass), so reading the raw dict was a stylistic choice rather than a necessity.

It also becomes the only correct option as the HTTP server settings move to a UI-managed config store (see the [HTTP Server Configuration epic](https://github.com/home-assistant/epics/issues/48)): once `port`/`ssl` can be set in the UI, the YAML dict no longer carries them, and `hassio` would silently fall back to the default port (`8123`) and report the wrong port to Supervisor. Sourcing them from `hass.config.api` reflects the active configuration regardless of whether it came from YAML or the UI store.

This is safe with respect to load order: `hassio` declares `http` as a hard dependency, and the `http` integration assigns `hass.config.api` synchronously during its `async_setup`, so it is always populated by the time `update_hass_api` runs in `async_setup_entry`.

While here, this also drops the `server_host` → `watchdog=False` workaround:

- Since Supervisor reaches Core over a Unix socket (Core: home-assistant/core#163907; Supervisor: home-assistant/supervisor#6590, enabled by default in home-assistant/supervisor#6815), the API watchdog no longer depends on the HTTP bind address, so a custom `server_host` can no longer prevent Supervisor from reaching Core.
- The `watchdog` flag is a user-managed Supervisor setting, so we leave it untouched (the field defaults to `None` and is omitted from the request) rather than setting it from Core.

Note that installs which previously had `server_host` configured had `watchdog=False` repeatedly persisted to Supervisor by the old logic; since we no longer write the flag, the watchdog stays disabled for them. We can't distinguish between user config or `server_host` related disable. For some users the API watchdog causes false positives, leaving the API watchdog disabled is the safer choice here.

The now-unused `DATA_HASSIO_HTTP_CONFIG` store is removed.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #174262
- This PR is related to issue: home-assistant/epics#48, #169835
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
