### PR TITLE
Add Hydrawise option to configure the cloud request rate limit

### DIFF
--- a/homeassistant/components/hydrawise/__init__.py
+++ b/homeassistant/components/hydrawise/__init__.py
@@ -1,12 +1,18 @@
 """Support for Hydrawise cloud."""
 
 from pydrawise import auth, hybrid
+from pydrawise.hybrid import Throttler
 
 from homeassistant.const import CONF_API_KEY, CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 
-from .const import APP_ID
+from .const import (
+    APP_ID,
+    CONF_GQL_TOKENS_PER_EPOCH,
+    DEFAULT_GQL_TOKENS_PER_EPOCH,
+    GQL_THROTTLE_EPOCH,
+)
 from .coordinator import (
     HydrawiseConfigEntry,
     HydrawiseMainDataUpdateCoordinator,
@@ -32,6 +38,11 @@ async def async_setup_entry(
         # If we are missing any required authentication keys, trigger a reauth flow.
         raise ConfigEntryAuthFailed
 
+    tokens_per_epoch = int(
+        config_entry.options.get(
+            CONF_GQL_TOKENS_PER_EPOCH, DEFAULT_GQL_TOKENS_PER_EPOCH
+        )
+    )
     hydrawise = hybrid.HybridClient(
         auth.HybridAuth(
             config_entry.data[CONF_USERNAME],
@@ -39,6 +50,10 @@ async def async_setup_entry(
             config_entry.data[CONF_API_KEY],
         ),
         app_id=APP_ID,
+        gql_throttle=Throttler(
+            epoch_interval=GQL_THROTTLE_EPOCH,
+            tokens_per_epoch=tokens_per_epoch,
+        ),
     )
 
     main_coordinator = HydrawiseMainDataUpdateCoordinator(hass, config_entry, hydrawise)

--- a/homeassistant/components/hydrawise/config_flow.py
+++ b/homeassistant/components/hydrawise/config_flow.py
@@ -8,10 +8,27 @@ from pydrawise import auth as pydrawise_auth, hybrid
 from pydrawise.exceptions import NotAuthorizedError
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigFlow,
+    ConfigFlowResult,
+    OptionsFlowWithReload,
+)
 from homeassistant.const import CONF_API_KEY, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import callback
+from homeassistant.helpers.selector import (
+    NumberSelector,
+    NumberSelectorConfig,
+    NumberSelectorMode,
+)
 
-from .const import APP_ID, DOMAIN, LOGGER
+from .const import (
+    APP_ID,
+    CONF_GQL_TOKENS_PER_EPOCH,
+    DEFAULT_GQL_TOKENS_PER_EPOCH,
+    DOMAIN,
+    LOGGER,
+)
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
@@ -30,6 +47,14 @@ class HydrawiseConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
     MINOR_VERSION = 2
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: ConfigEntry,
+    ) -> HydrawiseOptionsFlow:
+        """Get the options flow for this handler."""
+        return HydrawiseOptionsFlow()
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -94,6 +119,35 @@ class HydrawiseConfigFlow(ConfigFlow, domain=DOMAIN):
     def _show_reauth_form(self, errors: dict[str, str]) -> ConfigFlowResult:
         return self.async_show_form(
             step_id="reauth_confirm", data_schema=STEP_REAUTH_DATA_SCHEMA, errors=errors
+        )
+
+
+class HydrawiseOptionsFlow(OptionsFlowWithReload):
+    """Handle Hydrawise options."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage the Hydrawise options."""
+        if user_input is not None:
+            return self.async_create_entry(data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_GQL_TOKENS_PER_EPOCH,
+                        default=self.config_entry.options.get(
+                            CONF_GQL_TOKENS_PER_EPOCH, DEFAULT_GQL_TOKENS_PER_EPOCH
+                        ),
+                    ): NumberSelector(
+                        NumberSelectorConfig(
+                            min=1, max=30, step=1, mode=NumberSelectorMode.BOX
+                        )
+                    ),
+                }
+            ),
         )
 
 

--- a/homeassistant/components/hydrawise/const.py
+++ b/homeassistant/components/hydrawise/const.py
@@ -18,6 +18,14 @@ MODEL_ZONE = "Zone"
 MAIN_SCAN_INTERVAL = timedelta(minutes=5)
 WATER_USE_SCAN_INTERVAL = timedelta(minutes=60)
 
+CONF_GQL_TOKENS_PER_EPOCH = "gql_tokens_per_epoch"
+# pydrawise's HybridClient throttles GraphQL calls to a number of "tokens" per
+# 30-minute epoch (default: 5) to stay within the Hydrawise cloud rate limit.
+# Accounts with several controllers or zones can exhaust that budget, leaving
+# data stale, so the limit is exposed as an option.
+GQL_THROTTLE_EPOCH = timedelta(minutes=30)
+DEFAULT_GQL_TOKENS_PER_EPOCH = 5
+
 SIGNAL_UPDATE_HYDRAWISE = "hydrawise_update"
 
 SERVICE_RESUME = "resume"

--- a/homeassistant/components/hydrawise/strings.json
+++ b/homeassistant/components/hydrawise/strings.json
@@ -36,6 +36,18 @@
       }
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "gql_tokens_per_epoch": "Cloud requests per 30 minutes"
+        },
+        "data_description": {
+          "gql_tokens_per_epoch": "Maximum number of requests Home Assistant makes to the Hydrawise cloud every 30 minutes. Raising this fetches fresher data for accounts with many controllers or zones, but a value that is too high may cause the Hydrawise cloud to rate-limit your account. The default of 5 matches the recommended limit."
+        }
+      }
+    }
+  },
   "entity": {
     "binary_sensor": {
       "rain_sensor": {

--- a/tests/components/hydrawise/test_config_flow.py
+++ b/tests/components/hydrawise/test_config_flow.py
@@ -8,7 +8,7 @@ from pydrawise.schema import User
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components.hydrawise.const import DOMAIN
+from homeassistant.components.hydrawise.const import CONF_GQL_TOKENS_PER_EPOCH, DOMAIN
 from homeassistant.const import CONF_API_KEY, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -245,3 +245,25 @@ async def test_reauth_fails(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
+
+
+async def test_options_flow(
+    hass: HomeAssistant,
+    mock_added_config_entry: MockConfigEntry,
+) -> None:
+    """Test the options flow sets the GraphQL throttle limit."""
+    result = await hass.config_entries.options.async_init(
+        mock_added_config_entry.entry_id
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={CONF_GQL_TOKENS_PER_EPOCH: 15},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == {CONF_GQL_TOKENS_PER_EPOCH: 15}
+    assert mock_added_config_entry.options == {CONF_GQL_TOKENS_PER_EPOCH: 15}


### PR DESCRIPTION
## Proposed change

The `pydrawise` `HybridClient` throttles GraphQL requests to the Hydrawise cloud to **5 tokens per 30-minute epoch** by default, to stay within Hunter's API rate limit. Accounts with several controllers or a large number of zones can exhaust that budget, which causes the coordinators to be throttled and leaves sensor data stale until the next epoch.

This adds an **options flow** exposing the per-epoch GraphQL request budget as an integer option:

- New constant `CONF_GQL_TOKENS_PER_EPOCH` (default `5`, matching the library default — no behaviour change for existing users).
- The option is passed through to `HybridClient` as a custom `gql_throttle=Throttler(epoch_interval=30min, tokens_per_epoch=…)`.
- Changing the option reloads the config entry via an update listener.
- A `NumberSelector` (1–30) keeps the value within a sane range; the help text warns that values that are too high risk being rate-limited by the Hydrawise cloud.

## Type of change

- [x] New feature (which adds functionality to an existing integration)
