### PR TITLE
Default to port 80 and redirect legacy port 8123 under Supervisor

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -907,6 +907,10 @@ class ManifestJSONView(HomeAssistantView):
     """View to return a manifest.json."""
 
     requires_auth = False
+    # The landing page detects Core availability by reading this public
+    # resource cross-origin when its request is redirected from the legacy
+    # HTTP port to the default port.
+    cors_allowed = True
     url = "/manifest.json"
     name = "manifestjson"
 

--- a/homeassistant/components/http/config.py
+++ b/homeassistant/components/http/config.py
@@ -604,6 +604,7 @@ class HTTPConfigStore:
             elif (
                 failed_type is ActiveConfigType.DEFAULT
                 and ENV_SUPERVISOR in os.environ
+                # _DEFAULT_CONFIG depends on environment variables
                 and _DEFAULT_CONFIG[CONF_SERVER_PORT] != SERVER_PORT
             ):
                 # Under Supervisor the previous default port (8123) is still

--- a/homeassistant/components/http/config.py
+++ b/homeassistant/components/http/config.py
@@ -37,9 +37,11 @@ from .const import (
     DEFAULT_CORS,
     DOMAIN,
     ENV_SETUP_PORT,
+    ENV_SUPERVISOR,
     NO_LOGIN_ATTEMPT_THRESHOLD,
     SSL_INTERMEDIATE,
     SSL_MODERN,
+    SUPERVISOR_DEFAULT_PORT,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -48,12 +50,14 @@ _LOGGER = logging.getLogger(__name__)
 def default_server_port() -> int:
     """Return the default HTTP server port.
 
-    The built-in default port can be overridden via the
-    ``SETUP_PORT`` environment variable. An invalid value is ignored in favor
-    of the built-in default.
+    Under Supervisor the default is port 80, since Supervisor fronts Core on
+    the standard HTTP port; otherwise the default is ``SERVER_PORT``. The
+    default can be overridden via the ``SETUP_PORT`` environment variable; an
+    invalid value is ignored in favor of the default.
     """
+    default = SUPERVISOR_DEFAULT_PORT if ENV_SUPERVISOR in os.environ else SERVER_PORT
     if (env_value := os.environ.get(ENV_SETUP_PORT)) is None:
-        return SERVER_PORT
+        return default
     try:
         return cast(int, cv.port(env_value))
     except vol.Invalid:
@@ -61,9 +65,9 @@ def default_server_port() -> int:
             "Invalid port %r in %s environment variable; falling back to %s",
             env_value,
             ENV_SETUP_PORT,
-            SERVER_PORT,
+            default,
         )
-        return SERVER_PORT
+        return default
 
 
 STORAGE_KEY: Final = DOMAIN
@@ -115,6 +119,7 @@ class ActiveConfigType(StrEnum):
     STABLE = "stable"
     PENDING = "pending"
     DEFAULT = "default"
+    DEFAULT_LEGACY_PORT = "default_legacy_port"
 
 
 class _HTTPStoreData(TypedDict):
@@ -179,6 +184,15 @@ def _strip_meta(config: ConfData) -> ConfData:
         ConfData,
         {k: v for k, v in config.items() if k not in _META_KEYS},
     )
+
+
+# Last-resort fallback on the previous default port, tried when the default
+# config cannot be bound. Identical to _DEFAULT_CONFIG apart from the port, and
+# only distinct from it when the default port differs from SERVER_PORT - i.e.
+# under Supervisor (default 80) or when SETUP_PORT overrides the default.
+_DEFAULT_CONFIG_LEGACY_PORT: Final[ConfData] = cast(
+    ConfData, {**_DEFAULT_CONFIG, CONF_SERVER_PORT: SERVER_PORT}
+)
 
 
 async def async_load_config(hass: HomeAssistant, config: ConfigType) -> ConfData:
@@ -565,41 +579,62 @@ class HTTPConfigStore:
         if failed_type is ActiveConfigType.DEFAULT:
             # Never record the error on the shared default config.
             failed_config = _DEFAULT_CONFIG
+        elif failed_type is ActiveConfigType.DEFAULT_LEGACY_PORT:
+            failed_config = _DEFAULT_CONFIG_LEGACY_PORT
         else:
             failed_config = self._stable
             # In-memory only: _async_persist never saves an error on stable.
             failed_config[HTTP_CONFIG_ERROR] = ERROR_APPLY_FAILED
             failed_config[HTTP_CONFIG_ERROR_MESSAGE] = str(err)
 
+        # Determine the next config in the recovery fallback chain. Peer
+        # certificate verification never accepts an unverified fallback.
+        next_config: ConfData | None = None
+        next_type: ActiveConfigType | None = None
         if (
-            # In normal mode, fail setup so recovery mode can take over with a
-            # reachable configuration.
-            not self._hass.config.recovery_mode
-            # The chain is exhausted; nothing left to fall back to.
-            or failed_type is ActiveConfigType.DEFAULT
-            # With peer certificate verification configured, connections must
-            # never be accepted without a verified client certificate; there is
-            # no acceptable fallback config.
-            or CONF_SSL_PEER_CERTIFICATE in failed_config
+            self._hass.config.recovery_mode
+            and CONF_SSL_PEER_CERTIFICATE not in failed_config
         ):
-            # An unusable SSL configuration already carries a descriptive
-            # HomeAssistantError.
+            if failed_type not in (
+                ActiveConfigType.DEFAULT,
+                ActiveConfigType.DEFAULT_LEGACY_PORT,
+            ):
+                next_config = _DEFAULT_CONFIG.copy()
+                next_type = ActiveConfigType.DEFAULT
+            elif (
+                failed_type is ActiveConfigType.DEFAULT
+                and ENV_SUPERVISOR in os.environ
+                and _DEFAULT_CONFIG[CONF_SERVER_PORT] != SERVER_PORT
+            ):
+                # Under Supervisor the previous default port (8123) is still
+                # exposed; try it before giving up so the recovery UI stays
+                # reachable when the new default port cannot be bound.
+                next_config = _DEFAULT_CONFIG_LEGACY_PORT.copy()
+                next_type = ActiveConfigType.DEFAULT_LEGACY_PORT
+
+        if next_config is None:
+            # In normal mode, fail setup so recovery mode can take over with a
+            # reachable configuration. In recovery mode, the fallback chain is
+            # exhausted. An unusable SSL configuration already carries a
+            # descriptive HomeAssistantError.
             if isinstance(err, HomeAssistantError):
                 raise err
             raise HomeAssistantError(
                 f"Failed to create HTTP server at port {failed_config[CONF_SERVER_PORT]}: {err}"
             ) from err
 
-        # The config cannot be applied in recovery mode; fall back to the
-        # default config so the recovery UI stays reachable.
         _LOGGER.error(
             "The HTTP configuration could not be applied in recovery mode, "
-            "falling back to the default configuration: %s",
+            "falling back to %s: %s",
+            "the default configuration"
+            if next_type is ActiveConfigType.DEFAULT
+            else f"the previous default port {SERVER_PORT}",
             err,
         )
-        self._active_config_type = ActiveConfigType.DEFAULT
+        assert next_type is not None
+        self._active_config_type = next_type
         # Copied so the caller cannot mutate the shared default config.
-        return _DEFAULT_CONFIG.copy()
+        return next_config
 
 
 class _HTTPStore(Store[_HTTPStoreData]):

--- a/homeassistant/components/http/const.py
+++ b/homeassistant/components/http/const.py
@@ -30,6 +30,11 @@ SSL_MODERN: Final = "modern"
 SSL_INTERMEDIATE: Final = "intermediate"
 
 ENV_SETUP_PORT: Final = "SETUP_PORT"
+ENV_SUPERVISOR: Final = "SUPERVISOR"
+
+# Default HTTP port when running under Supervisor, which fronts Core on the
+# standard HTTP port.
+SUPERVISOR_DEFAULT_PORT: Final = 80
 
 # Cast to be able to load custom cards.
 # My to be able to check url and version info.

--- a/homeassistant/components/http/server.py
+++ b/homeassistant/components/http/server.py
@@ -27,6 +27,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
 from yarl import URL
 
+from homeassistant.const import SERVER_PORT
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.http import (
@@ -36,12 +37,13 @@ from homeassistant.helpers.http import (
     current_request,
 )
 from homeassistant.helpers.network import NoURLAvailableError, get_url
+from homeassistant.setup import async_when_setup
 from homeassistant.util import dt as dt_util, ssl as ssl_util
 from homeassistant.util.json import json_loads
 
 from .auth import async_setup_auth
 from .ban import setup_bans
-from .config import ConfData
+from .config import _DEFAULT_CONFIG, ConfData, _strip_meta
 from .const import (
     CONF_SERVER_HOST,
     CONF_SERVER_PORT,
@@ -50,6 +52,7 @@ from .const import (
     CONF_SSL_PEER_CERTIFICATE,
     CONF_SSL_PROFILE,
     CONF_TRUSTED_PROXIES,
+    ENV_SUPERVISOR,
     SSL_INTERMEDIATE,
 )
 from .cors import setup_cors
@@ -105,6 +108,14 @@ def make_server(
         ],
         ssl_profile=conf[CONF_SSL_PROFILE],
         supervisor_unix_socket_path=supervisor_unix_socket_path,
+        # Only the unconfigured default config on the new Supervisor default
+        # port bridges the previous one; compare without metadata so a default
+        # config reloaded from disk still matches.
+        port_transition=(
+            ENV_SUPERVISOR in os.environ
+            and _strip_meta(conf) == _strip_meta(_DEFAULT_CONFIG)
+            and conf[CONF_SERVER_PORT] != SERVER_PORT
+        ),
     )
 
 
@@ -191,6 +202,7 @@ class HomeAssistantHTTP:
         trusted_proxies: list[IPv4Network | IPv6Network],
         ssl_profile: str,
         supervisor_unix_socket_path: Path | None = None,
+        port_transition: bool = False,
     ) -> None:
         """Initialize the HTTP Home Assistant server."""
         self.app = HomeAssistantApplication(
@@ -214,6 +226,12 @@ class HomeAssistantHTTP:
         self.supervisor_site: HomeAssistantUnixSite | None = None
         self.context: ssl.SSLContext | None = None
         self._server: asyncio.Server | None = None
+        # Redirect the previous default port to the active one, bound to
+        # onboarding: it starts only while onboarding is pending and is torn
+        # down when onboarding completes.
+        self._port_transition = port_transition
+        self._legacy_redirect_runner: web.AppRunner | None = None
+        self._legacy_redirect_server: asyncio.Server | None = None
 
     async def async_bind(self) -> None:
         """Create the SSL context and the server, binding its sockets.
@@ -530,8 +548,80 @@ class HomeAssistantHTTP:
 
         _LOGGER.info("Now listening on port %d", self.server_port)
 
+        if self._port_transition:
+            # Defer to onboarding setup so async_is_onboarded and
+            # async_add_listener see loaded onboarding data. onboarding is a
+            # dependency of frontend, so it is always set up here.
+            async_when_setup(
+                self.hass, "onboarding", self._async_manage_port_transition
+            )
+
+    async def _async_manage_port_transition(
+        self, hass: HomeAssistant, _component: str
+    ) -> None:
+        """Start the legacy-port redirect until onboarding completes."""
+        from homeassistant.components import onboarding  # noqa: PLC0415
+
+        if onboarding.async_is_onboarded(hass):
+            return
+        await self._async_start_legacy_redirect()
+        if self._legacy_redirect_server is not None:
+            onboarding.async_add_listener(hass, self._on_onboarding_complete)
+
+    @callback
+    def _on_onboarding_complete(self) -> None:
+        """Tear down the transition once onboarding completes."""
+        self.hass.async_create_task(self._async_stop_legacy_redirect())
+
+    async def _async_start_legacy_redirect(self) -> None:
+        """Redirect the previous default port to the active port."""
+        target_port = self.server_port
+
+        async def _redirect(request: web.Request) -> web.StreamResponse:
+            # Temporary, method-preserving redirect so non-GET requests from
+            # existing clients keep working during the transition.
+            raise web.HTTPTemporaryRedirect(request.url.with_port(target_port))
+
+        redirect_app = web.Application()
+        redirect_app.router.add_route("*", "/{path:.*}", _redirect)
+        self._legacy_redirect_runner = web.AppRunner(redirect_app)
+        await self._legacy_redirect_runner.setup()
+        try:
+            self._legacy_redirect_server = await self._async_create_redirect_server()
+        except OSError as error:
+            _LOGGER.error(
+                "Failed to start legacy port %d redirect: %s", SERVER_PORT, error
+            )
+            await self._legacy_redirect_runner.cleanup()
+            self._legacy_redirect_runner = None
+            return
+
+        _LOGGER.info("Redirecting legacy port %d to port %d", SERVER_PORT, target_port)
+
+    async def _async_create_redirect_server(self) -> asyncio.Server:
+        """Bind the legacy redirect server on the previous default port."""
+        assert self._legacy_redirect_runner is not None
+        server_factory = self._legacy_redirect_runner.server
+        assert server_factory is not None
+        return await self.hass.loop.create_server(
+            server_factory,
+            self.server_host if self.server_host is not None else DEFAULT_BIND,
+            SERVER_PORT,
+        )
+
+    async def _async_stop_legacy_redirect(self) -> None:
+        """Stop the legacy redirect server and free its port."""
+        if self._legacy_redirect_server is not None:
+            self._legacy_redirect_server.close()
+            await self._legacy_redirect_server.wait_closed()
+            self._legacy_redirect_server = None
+        if self._legacy_redirect_runner is not None:
+            await self._legacy_redirect_runner.cleanup()
+            self._legacy_redirect_runner = None
+
     async def stop(self) -> None:
         """Stop the aiohttp server."""
+        await self._async_stop_legacy_redirect()
         if self.supervisor_site is not None:
             await self.supervisor_site.stop()
             if self.supervisor_unix_socket_path is not None:

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -1011,6 +1011,20 @@ async def test_manifest_json(hass: HomeAssistant, mock_http_client: TestClient) 
     assert json["theme_color"] != DEFAULT_THEME_COLOR
 
 
+async def test_manifest_json_cors(mock_http_client: TestClient) -> None:
+    """Test manifest.json is readable cross-origin.
+
+    The landing page detects Core availability by reading manifest.json
+    cross-origin when its request is redirected from the legacy HTTP port
+    to the default port.
+    """
+    resp = await mock_http_client.get(
+        "/manifest.json", headers={"Origin": "http://example.local:8123"}
+    )
+    assert resp.status == HTTPStatus.OK
+    assert resp.headers["Access-Control-Allow-Origin"] == "http://example.local:8123"
+
+
 async def test_static_path_cache(mock_http_client: TestClient) -> None:
     """Test static paths cache."""
     resp = await mock_http_client.get("/lovelace/default_view", allow_redirects=False)

--- a/tests/components/hassio/conftest.py
+++ b/tests/components/hassio/conftest.py
@@ -12,6 +12,8 @@ import pytest
 
 from homeassistant.components.hassio.const import DATA_HASSIO_SUPERVISOR_USER
 from homeassistant.components.hassio.handler import HassIO
+from homeassistant.components.http.config import _DEFAULT_CONFIG as HTTP_DEFAULT_CONFIG
+from homeassistant.components.http.const import CONF_SERVER_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
@@ -26,6 +28,24 @@ def disable_security_filter() -> Generator[None]:
     with patch(
         "homeassistant.components.http.security_filter.FILTERS",
         re.compile("not-matching-anything"),
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def http_supervisor_default_port() -> Generator[None]:
+    """Reflect the port-80 HTTP default that Core sees under Supervisor.
+
+    _DEFAULT_CONFIG is frozen at import (port 8123, since SUPERVISOR is not set
+    then in the test process). Under MOCK_ENVIRON the runtime default is 80, so
+    the store would treat the default as a pending change and schedule an
+    auto-revert restart - a state that cannot occur in a real Supervisor
+    process. Patch the default to port 80 to reproduce production.
+    """
+    default_80 = {**HTTP_DEFAULT_CONFIG, CONF_SERVER_PORT: 80}
+    with (
+        patch("homeassistant.components.http.config._DEFAULT_CONFIG", default_80),
+        patch("homeassistant.components.http.server._DEFAULT_CONFIG", default_80),
     ):
         yield
 

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -344,7 +344,7 @@ async def test_setup_api_push_api_data_default(
     assert result
     assert len(supervisor_client.mock_calls) == 16
     supervisor_client.homeassistant.set_options.assert_called_once_with(
-        HomeAssistantOptions(ssl=False, port=8123, refresh_token=ANY)
+        HomeAssistantOptions(ssl=False, port=80, refresh_token=ANY)
     )
     refresh_token = (
         supervisor_client.homeassistant.set_options.mock_calls[0].args[0].refresh_token
@@ -420,7 +420,7 @@ async def test_setup_api_existing_hassio_user(
     assert result
     assert len(supervisor_client.mock_calls) == 16
     supervisor_client.homeassistant.set_options.assert_called_once_with(
-        HomeAssistantOptions(ssl=False, port=8123, refresh_token=token.token)
+        HomeAssistantOptions(ssl=False, port=80, refresh_token=token.token)
     )
 
 
@@ -465,7 +465,7 @@ async def test_setup_migrates_legacy_hassio_store_to_config_entry(
 
     assert len(supervisor_client.mock_calls) == 16
     supervisor_client.homeassistant.set_options.assert_called_once_with(
-        HomeAssistantOptions(ssl=False, port=8123, refresh_token=token.token)
+        HomeAssistantOptions(ssl=False, port=80, refresh_token=token.token)
     )
 
 
@@ -513,7 +513,7 @@ async def test_setup_migrates_legacy_options_over_default_entry_options(
     assert entry.options[OPTION_CORE_BACKUP_BEFORE_UPDATE] is True
 
     supervisor_client.homeassistant.set_options.assert_called_once_with(
-        HomeAssistantOptions(ssl=False, port=8123, refresh_token=token.token)
+        HomeAssistantOptions(ssl=False, port=80, refresh_token=token.token)
     )
 
 

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -1,7 +1,8 @@
 """The tests for the Home Assistant HTTP component."""
 
 import asyncio
-from collections.abc import Callable, Generator
+from collections.abc import Callable, Generator, Iterator
+from contextlib import contextmanager
 import errno
 from http import HTTPStatus
 import logging
@@ -12,11 +13,12 @@ import ssl
 from typing import Any
 from unittest.mock import ANY, AsyncMock, Mock, patch
 
+import aiohttp
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.auth.providers.homeassistant import HassAuthProvider
-from homeassistant.components import cloud, http
+from homeassistant.components import cloud, http, onboarding
 from homeassistant.components.cloud import CloudNotAvailable
 from homeassistant.components.http import DOMAIN
 from homeassistant.components.http.config import (
@@ -29,7 +31,7 @@ from homeassistant.components.http.config import (
     async_get_and_load_store,
     default_server_port,
 )
-from homeassistant.components.http.const import ENV_SETUP_PORT
+from homeassistant.components.http.const import ENV_SETUP_PORT, ENV_SUPERVISOR
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, HASSIO_USER_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -98,6 +100,71 @@ def mock_create_server() -> Generator[Mock]:
     # Close any server that is not already closed (closing twice is a no-op).
     for server in servers:
         server.close()
+
+
+async def _bind_redirect_ephemeral(self: http.HomeAssistantHTTP) -> asyncio.Server:
+    """Bind the legacy redirect on an ephemeral localhost port instead of 8123."""
+    assert self._legacy_redirect_runner is not None
+    return await self.hass.loop.create_server(
+        self._legacy_redirect_runner.server, "127.0.0.1", 0, start_serving=False
+    )
+
+
+# A port-80 default config, standing in for _DEFAULT_CONFIG under Supervisor
+# (which is frozen at import to port 8123 in the test process).
+DEFAULT_80_CONFIG = HTTP_STORAGE_SCHEMA({"server_port": 80})
+
+
+@contextmanager
+def _supervisor_default_config() -> Iterator[None]:
+    """Simulate a fresh Supervisor install: the default config on port 80.
+
+    _DEFAULT_CONFIG is frozen at import (port 8123 without Supervisor in the
+    test process), so both references are patched to a port-80 default to
+    reproduce production, where SUPERVISOR is set before the module is
+    imported. The redirect binds an ephemeral localhost port instead of 8123.
+    """
+    with (
+        # clear=True so a developer/CI SETUP_PORT can't skew the simulation.
+        patch.dict(os.environ, {ENV_SUPERVISOR: "core"}, clear=True),
+        patch(
+            "homeassistant.components.http.config._DEFAULT_CONFIG", DEFAULT_80_CONFIG
+        ),
+        patch(
+            "homeassistant.components.http.server._DEFAULT_CONFIG", DEFAULT_80_CONFIG
+        ),
+        patch(
+            "homeassistant.components.http.server.HomeAssistantHTTP._async_create_redirect_server",
+            autospec=True,
+            side_effect=_bind_redirect_ephemeral,
+        ),
+    ):
+        yield
+
+
+async def _setup_http_with_onboarding(
+    hass: HomeAssistant, *, onboarded: bool = False
+) -> None:
+    """Set up http and onboarding, then start Home Assistant.
+
+    The legacy-port transition is bound to onboarding, so onboarding must be
+    set up (as it always is via frontend in production) for the redirect to
+    start.
+    """
+    assert await async_setup_component(hass, "http", {})
+    assert await async_setup_component(hass, "onboarding", {})
+    if onboarded:
+        hass.data[onboarding.DOMAIN].onboarded = True
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+
+def _complete_onboarding(hass: HomeAssistant) -> None:
+    """Mark onboarding complete and fire its listeners, as the views do."""
+    data = hass.data[onboarding.DOMAIN]
+    data.onboarded = True
+    for listener in list(data.listeners):
+        listener()
 
 
 def _setup_broken_ssl_pem_files(tmp_path: Path) -> tuple[Path, Path]:
@@ -1482,13 +1549,24 @@ async def test_setup_migrates_v2_1_storage_to_v2_2(
         pytest.param({ENV_SETUP_PORT: "0"}, 8123, id="out-of-range"),
         pytest.param({ENV_SETUP_PORT: "notaport"}, 8123, id="not-a-number"),
         pytest.param({ENV_SETUP_PORT: ""}, 8123, id="empty"),
+        pytest.param({ENV_SUPERVISOR: "core"}, 80, id="supervisor"),
+        pytest.param(
+            {ENV_SUPERVISOR: "core", ENV_SETUP_PORT: "8080"},
+            8080,
+            id="supervisor-setup-port-override",
+        ),
+        pytest.param(
+            {ENV_SUPERVISOR: "core", ENV_SETUP_PORT: "notaport"},
+            80,
+            id="supervisor-invalid-setup-port",
+        ),
     ],
 )
 def test_default_server_port(
     env: dict[str, str],
     expected_port: int,
 ) -> None:
-    """Test SETUP_PORT overrides the default port and invalid values fall back."""
+    """Test the default port, including Supervisor and SETUP_PORT overrides."""
     with patch.dict(os.environ, env, clear=True):
         assert default_server_port() == expected_port
 
@@ -1510,6 +1588,197 @@ async def test_setup_port_env_var_used_as_default(
     assert hass_storage["http"]["data"]["pending"] == _stored_config(
         {"server_port": 80}, created_at=dt_util.utcnow().isoformat()
     )
+
+
+async def test_default_config_under_supervisor_starts_redirect(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Test the default config under Supervisor uses port 80 and redirects 8123."""
+    with _supervisor_default_config():
+        await _setup_http_with_onboarding(hass)
+
+    assert hass.config.api.port == 80
+    assert hass.http._legacy_redirect_server is not None
+
+
+async def test_persisted_default_config_starts_redirect(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Test the redirect still starts for a default config loaded from disk.
+
+    A persisted default config carries created_at/error metadata, so the
+    transition gate must compare without it (not by identity or raw equality).
+    """
+    hass_storage[DOMAIN] = _stable_http_storage({"server_port": 80})
+
+    with _supervisor_default_config():
+        await _setup_http_with_onboarding(hass)
+
+    assert hass.config.api.port == 80
+    assert hass.http._legacy_redirect_server is not None
+
+
+async def test_no_redirect_when_already_onboarded(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Test the redirect is not started when onboarding is already complete."""
+    with _supervisor_default_config():
+        await _setup_http_with_onboarding(hass, onboarded=True)
+
+    assert hass.http._legacy_redirect_server is None
+
+
+async def test_redirect_stops_on_onboarding_complete(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Test the redirect is torn down once onboarding completes."""
+    with _supervisor_default_config():
+        await _setup_http_with_onboarding(hass)
+
+        server = hass.http
+        assert server._legacy_redirect_server is not None
+
+        _complete_onboarding(hass)
+        await hass.async_block_till_done()
+
+        assert server._legacy_redirect_server is None
+        assert server._legacy_redirect_runner is None
+
+
+async def test_no_redirect_without_supervisor(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Test no redirect is started for the default config outside Supervisor."""
+    assert await async_setup_component(hass, "http", {})
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    assert hass.config.api.port == 8123
+    assert hass.http._legacy_redirect_runner is None
+    assert hass.http._legacy_redirect_server is None
+
+
+async def test_no_redirect_with_setup_port_outside_supervisor(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Test SETUP_PORT alone (no Supervisor) does not start the redirect.
+
+    SETUP_PORT changes the default port for plain container installs too, but
+    the transition is Supervisor-only.
+    """
+    with (
+        patch(
+            "homeassistant.components.http.config._DEFAULT_CONFIG", DEFAULT_80_CONFIG
+        ),
+        patch(
+            "homeassistant.components.http.server._DEFAULT_CONFIG", DEFAULT_80_CONFIG
+        ),
+    ):
+        assert await async_setup_component(hass, "http", {})
+        await hass.async_start()
+        await hass.async_block_till_done()
+
+    assert hass.http._legacy_redirect_server is None
+
+
+async def test_no_redirect_when_http_configured(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Test no redirect is started once HTTP is configured (onboarding is over).
+
+    A user-configured config differs from the default, so even under Supervisor
+    the transition must not apply.
+    """
+    hass_storage[DOMAIN] = _stable_http_storage({"server_port": 9000})
+
+    with _supervisor_default_config():
+        assert await async_setup_component(hass, "http", {})
+        await hass.async_start()
+        await hass.async_block_till_done()
+
+    assert hass.config.api.port == 9000
+    assert hass.http._legacy_redirect_server is None
+
+
+async def test_redirect_bind_failure_is_handled(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Test setup continues when the legacy redirect server cannot bind."""
+    with (
+        patch.dict(os.environ, {ENV_SUPERVISOR: "core"}, clear=True),
+        patch(
+            "homeassistant.components.http.config._DEFAULT_CONFIG", DEFAULT_80_CONFIG
+        ),
+        patch(
+            "homeassistant.components.http.server._DEFAULT_CONFIG", DEFAULT_80_CONFIG
+        ),
+        patch(
+            "homeassistant.components.http.server.HomeAssistantHTTP._async_create_redirect_server",
+            autospec=True,
+            side_effect=OSError(errno.EADDRINUSE, "Address already in use"),
+        ),
+    ):
+        assert await async_setup_component(hass, "http", {})
+        assert await async_setup_component(hass, "onboarding", {})
+        await hass.async_start()
+        await hass.async_block_till_done()
+
+    server = hass.http
+    assert server._legacy_redirect_server is None
+    assert server._legacy_redirect_runner is None
+
+
+async def test_legacy_redirect_serves_method_preserving_307(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Test the legacy redirect serves a 307 to the active port for any method."""
+    captured: dict[str, int] = {}
+
+    async def _bind_serving(self: http.HomeAssistantHTTP) -> asyncio.Server:
+        assert self._legacy_redirect_runner is not None
+        server = await self.hass.loop.create_server(
+            self._legacy_redirect_runner.server, "127.0.0.1", 0
+        )
+        captured["port"] = server.sockets[0].getsockname()[1]
+        return server
+
+    with (
+        patch.dict(os.environ, {ENV_SUPERVISOR: "core"}, clear=True),
+        patch(
+            "homeassistant.components.http.config._DEFAULT_CONFIG", DEFAULT_80_CONFIG
+        ),
+        patch(
+            "homeassistant.components.http.server._DEFAULT_CONFIG", DEFAULT_80_CONFIG
+        ),
+        patch(
+            "homeassistant.components.http.server.HomeAssistantHTTP._async_create_redirect_server",
+            autospec=True,
+            side_effect=_bind_serving,
+        ),
+    ):
+        await _setup_http_with_onboarding(hass)
+        assert hass.http._legacy_redirect_server is not None
+
+        async with (
+            aiohttp.ClientSession() as session,
+            session.post(
+                f"http://127.0.0.1:{captured['port']}/api/foo?bar=1",
+                allow_redirects=False,
+            ) as resp,
+        ):
+            # 307 preserves the POST method; only the port changes (80 is
+            # the default HTTP port, so it is omitted from the URL).
+            assert resp.status == 307
+            assert resp.headers["Location"] == "http://127.0.0.1/api/foo?bar=1"
 
 
 @pytest.mark.usefixtures("freezer")
@@ -2356,6 +2625,68 @@ async def test_recovery_mode_default_config_bind_failure_fails_setup(
     assert f"Failed to create HTTP server at port {default_server_port()}" in (
         caplog.text
     )
+
+
+async def test_recovery_mode_supervisor_falls_back_to_legacy_port(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    caplog: pytest.LogCaptureFixture,
+    mock_create_server: Mock,
+) -> None:
+    """Under Supervisor, an unbindable default port 80 falls back to 8123.
+
+    _DEFAULT_CONFIG is frozen at import (port 8123 without Supervisor), so it is
+    patched to the port-80 Supervisor default; the legacy fallback uses the real
+    _DEFAULT_CONFIG_LEGACY_PORT (port 8123).
+    """
+    hass_storage[DOMAIN] = _stable_http_storage({"server_port": 80})
+    hass.config.recovery_mode = True
+
+    legacy_server = await _ephemeral_server(hass)
+    # stable (80) and default (80) fail; the legacy default (8123) binds.
+    mock_create_server.side_effect = [
+        OSError(errno.EADDRINUSE, "Address already in use"),
+        OSError(errno.EADDRINUSE, "Address already in use"),
+        legacy_server,
+    ]
+
+    with (
+        patch.dict(os.environ, {ENV_SUPERVISOR: "core"}),
+        patch(
+            "homeassistant.components.http.config._DEFAULT_CONFIG", DEFAULT_80_CONFIG
+        ),
+    ):
+        assert await async_setup_component(hass, DOMAIN, {})
+
+    assert "falling back to the previous default port 8123" in caplog.text
+    assert hass.config.api.port == 8123
+    legacy_server.close()
+    await legacy_server.wait_closed()
+
+
+async def test_recovery_mode_no_legacy_fallback_without_supervisor(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    caplog: pytest.LogCaptureFixture,
+    mock_create_server: Mock,
+) -> None:
+    """A non-Supervisor default-port override must not fall back to port 8123.
+
+    Port 8123 is not exposed for a plain container install using SETUP_PORT, so
+    recovery must fail instead of reporting success on an unreachable port.
+    """
+    hass_storage[DOMAIN] = _stable_http_storage({"server_port": 8080})
+    hass.config.recovery_mode = True
+
+    mock_create_server.side_effect = OSError(errno.EADDRINUSE, "Address already in use")
+
+    with patch(
+        "homeassistant.components.http.config._DEFAULT_CONFIG",
+        HTTP_STORAGE_SCHEMA({"server_port": 8080}),
+    ):
+        assert not await async_setup_component(hass, DOMAIN, {})
+
+    assert "previous default port" not in caplog.text
 
 
 async def test_pending_config_promote_cancels_revert(


### PR DESCRIPTION
## Breaking change

<!-- This is not a breaking change: the previous default (port 8123) still applies outside of Supervisor, and under Supervisor the legacy port is redirected to the new port while onboarding is in progress. -->

## Proposed change

When running under Supervisor, default the HTTP server to port 80 (the default HTTP port) instead of 8123. Outside of Supervisor the default stays 8123. The `SETUP_PORT` environment variable still takes precedence as an explicit override.

To keep already-flashed devices and bookmarks that target the old port working during the transition, a redirect server is started on the previous default port (8123) that redirects to the active port. The redirect is **bound to onboarding**: it only applies while serving the unconfigured default config on the new default port under Supervisor, and only while onboarding is still in progress. It is torn down as soon as onboarding completes (and is never started if the instance is already onboarded).

Because a cross-origin fetch that follows the redirect stays in CORS mode, the final response on the active port also needs CORS headers. This is scoped as tightly as possible: only responses to a request whose `Origin` is our own host on the previous default port get `Access-Control-Allow-Origin` (with credentials), keyed off the redirect server being active so it can never be left enabled without a redirect. The redirect uses a 307 (temporary, method-preserving) redirect so non-GET requests keep working.

Finally, the recovery-mode default-config fallback chain gains one more step: when the default port cannot be bound and it differs from the previous default (i.e. under Supervisor on port 80), fall back to the previous default port (8123) before failing setup, so the recovery UI stays reachable on the old port.

This builds on top of the `port-8123` work (`SETUP_PORT`, #174263, and the config trial/revert of #176384) which has since merged to `dev`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #174016
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
