### PR TITLE
Add reauthentication flow to WattWächter Plus

### DIFF
--- a/homeassistant/components/wattwaechter/config_flow.py
+++ b/homeassistant/components/wattwaechter/config_flow.py
@@ -1,5 +1,6 @@
 """Config flow for the WattWächter Plus integration."""
 
+from collections.abc import Mapping
 import logging
 from typing import Any
 
@@ -206,5 +207,41 @@ class WattwaechterConfigFlow(ConfigFlow, domain=DOMAIN):
                     vol.Required(CONF_TOKEN): str,
                 }
             ),
+            errors=errors,
+        )
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Handle reauthentication when the stored token is no longer valid."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Confirm reauthentication with a new token."""
+        reauth_entry = self._get_reauth_entry()
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            errors, system_info, _ = await self._async_test_connection(
+                reauth_entry.data[CONF_HOST], user_input[CONF_TOKEN]
+            )
+            if not errors:
+                assert system_info is not None
+                await self.async_set_unique_id(system_info.get_value("esp", "esp_id"))
+                self._abort_if_unique_id_mismatch(reason="wrong_device")
+                return self.async_update_reload_and_abort(
+                    reauth_entry, data_updates={CONF_TOKEN: user_input[CONF_TOKEN]}
+                )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_TOKEN): str,
+                }
+            ),
+            description_placeholders={"host": reauth_entry.data[CONF_HOST]},
             errors=errors,
         )

--- a/homeassistant/components/wattwaechter/coordinator.py
+++ b/homeassistant/components/wattwaechter/coordinator.py
@@ -14,6 +14,7 @@ from aio_wattwaechter.models import MeterData
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_DEVICE_ID, CONF_HOST, CONF_MAC, CONF_MODEL
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import CONF_FW_VERSION, DEFAULT_SCAN_INTERVAL, DOMAIN
@@ -61,7 +62,7 @@ class WattwaechterCoordinator(DataUpdateCoordinator[MeterData]):
                 translation_placeholders={"host": self.host},
             ) from err
         except WattwaechterAuthenticationError as err:
-            raise UpdateFailed(
+            raise ConfigEntryAuthFailed(
                 translation_domain=DOMAIN,
                 translation_key="auth_failed",
                 translation_placeholders={"error": str(err)},

--- a/homeassistant/components/wattwaechter/quality_scale.yaml
+++ b/homeassistant/components/wattwaechter/quality_scale.yaml
@@ -36,7 +36,7 @@ rules:
   integration-owner: done
   log-when-unavailable: done
   parallel-updates: done
-  reauthentication-flow: todo
+  reauthentication-flow: done
   test-coverage: done
 
   # Gold

--- a/homeassistant/components/wattwaechter/strings.json
+++ b/homeassistant/components/wattwaechter/strings.json
@@ -2,7 +2,9 @@
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "wrong_device": "The re-authenticated device does not match the original WattWächter Plus device."
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
@@ -18,6 +20,16 @@
           "token": "The API token for your WattWächter Plus device."
         },
         "title": "Authentication required"
+      },
+      "reauth_confirm": {
+        "data": {
+          "token": "[%key:common::config_flow::data::api_token%]"
+        },
+        "data_description": {
+          "token": "[%key:component::wattwaechter::config::step::auth::data_description::token%]"
+        },
+        "description": "The API token for {host} is no longer valid. Enter a new token to reconnect.",
+        "title": "Re-authenticate WattWächter Plus"
       },
       "user": {
         "data": {

--- a/tests/components/wattwaechter/test_config_flow.py
+++ b/tests/components/wattwaechter/test_config_flow.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from ipaddress import ip_address
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 from aio_wattwaechter import (
     WattwaechterAuthenticationError,
@@ -398,3 +398,84 @@ async def test_zeroconf_flow_device_name_fetch_fails(
         CONF_MAC: MOCK_MAC,
     }
     assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_reauth_flow_success(
+    hass: HomeAssistant,
+    mock_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reauthentication updates the stored token."""
+    result = await mock_config_entry.start_reauth_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_TOKEN: "new-token"}
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert mock_config_entry.data[CONF_TOKEN] == "new-token"
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "expected_error"),
+    [
+        (WattwaechterAuthenticationError("Invalid token"), "invalid_auth"),
+        (WattwaechterConnectionError("Connection lost"), "cannot_connect"),
+    ],
+)
+async def test_reauth_flow_errors(
+    hass: HomeAssistant,
+    mock_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    side_effect: Exception,
+    expected_error: str,
+) -> None:
+    """Test reauth recovers after an invalid token or connection failure."""
+    result = await mock_config_entry.start_reauth_flow(hass)
+    assert result["step_id"] == "reauth_confirm"
+
+    mock_client.system_info.side_effect = side_effect
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_TOKEN: "bad-token"}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+    assert result["errors"]["base"] == expected_error
+
+    # Retry with a working token succeeds
+    mock_client.system_info.side_effect = None
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_TOKEN: MOCK_TOKEN}
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert mock_config_entry.data[CONF_TOKEN] == MOCK_TOKEN
+
+
+async def test_reauth_flow_wrong_device(
+    hass: HomeAssistant,
+    mock_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reauth aborts when the host now points to a different device."""
+    result = await mock_config_entry.start_reauth_flow(hass)
+    assert result["step_id"] == "reauth_confirm"
+
+    # Device reports a different esp_id than the one stored in the entry
+    mock_client.system_info.return_value = MagicMock(
+        **{"get_value.return_value": "WRONG-DEVICE"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_TOKEN: "new-token"}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "wrong_device"
+    assert mock_config_entry.data[CONF_TOKEN] == MOCK_TOKEN

--- a/tests/components/wattwaechter/test_init.py
+++ b/tests/components/wattwaechter/test_init.py
@@ -12,7 +12,7 @@ from aio_wattwaechter import (
 )
 import pytest
 
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
@@ -53,10 +53,10 @@ async def test_setup_entry_connection_error(
     ("attribute", "value"),
     [
         ("side_effect", WattwaechterNoDataError("No data")),
-        ("side_effect", WattwaechterAuthenticationError("Invalid token")),
+        ("side_effect", WattwaechterConnectionError("Connection refused")),
         ("return_value", None),
     ],
-    ids=["no_data", "auth_error", "returns_none"],
+    ids=["no_data", "connection_error", "returns_none"],
 )
 async def test_setup_entry_retries_on_meter_data_failure(
     hass: HomeAssistant,
@@ -72,3 +72,24 @@ async def test_setup_entry_retries_on_meter_data_failure(
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_setup_entry_auth_error_starts_reauth(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_client: AsyncMock,
+) -> None:
+    """Test an authentication error during setup starts the reauth flow."""
+    mock_client.meter_data.side_effect = WattwaechterAuthenticationError(
+        "Invalid token"
+    )
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+    assert flows[0]["context"]["source"] == SOURCE_REAUTH
+    assert flows[0]["context"]["entry_id"] == mock_config_entry.entry_id


### PR DESCRIPTION
## Proposed change

Adds a reauthentication flow to the WattWächter Plus integration, completing the silver `reauthentication-flow` quality scale rule.

When the device's API token expires or is revoked, the coordinator now raises `ConfigEntryAuthFailed` instead of `UpdateFailed`, so Home Assistant starts a reauth flow rather than silently retrying. The new `reauth_confirm` step lets the user enter a new token, validates it against the device, and — before storing it — verifies the device identity (`esp_id`) against the existing entry, aborting with `wrong_device` if the stored host now points to a different device.

`quality_scale.yaml` is updated to mark `reauthentication-flow` as `done`. The `manifest.json` quality scale level is intentionally **not** bumped to silver yet, since the remaining silver docs rules (`docs-configuration-parameters`, `docs-installation-parameters`) are tracked in a separate documentation PR.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
