### PR TITLE
Cast OpenTherm Gateway device info fields to string

### DIFF
--- a/homeassistant/components/opentherm_gw/__init__.py
+++ b/homeassistant/components/opentherm_gw/__init__.py
@@ -152,41 +152,63 @@ class OpenThermGatewayHub:
             _LOGGER.debug("Received report: %s", status)
             async_dispatcher_send(self.hass, self.update_signal, status)
 
-            boiler_manufacturer = status[OpenThermDataSource.BOILER].get(
-                gw_vars.DATA_SLAVE_MEMBERID
-            )
+            boiler_status = status[OpenThermDataSource.BOILER]
+            boiler_manufacturer = boiler_status.get(gw_vars.DATA_SLAVE_MEMBERID)
+            boiler_model_id = boiler_status.get(gw_vars.DATA_SLAVE_PRODUCT_TYPE)
+            boiler_hw_version = boiler_status.get(gw_vars.DATA_SLAVE_PRODUCT_VERSION)
+            boiler_sw_version = boiler_status.get(gw_vars.DATA_SLAVE_OT_VERSION)
             dev_reg.async_update_device(
                 boiler_device.id,
-                manufacturer=str(boiler_manufacturer)
-                if boiler_manufacturer is not None
-                else None,
-                model_id=status[OpenThermDataSource.BOILER].get(
-                    gw_vars.DATA_SLAVE_PRODUCT_TYPE
+                manufacturer=(
+                    str(boiler_manufacturer)
+                    if boiler_manufacturer is not None
+                    else None
                 ),
-                hw_version=status[OpenThermDataSource.BOILER].get(
-                    gw_vars.DATA_SLAVE_PRODUCT_VERSION
+                model_id=(
+                    str(boiler_model_id) if boiler_model_id is not None else None
                 ),
-                sw_version=status[OpenThermDataSource.BOILER].get(
-                    gw_vars.DATA_SLAVE_OT_VERSION
+                hw_version=(
+                    str(boiler_hw_version) if boiler_hw_version is not None else None
+                ),
+                sw_version=(
+                    str(boiler_sw_version) if boiler_sw_version is not None else None
                 ),
             )
 
-            thermostat_manufacturer = status[OpenThermDataSource.THERMOSTAT].get(
+            thermostat_status = status[OpenThermDataSource.THERMOSTAT]
+            thermostat_manufacturer = thermostat_status.get(
                 gw_vars.DATA_MASTER_MEMBERID
+            )
+            thermostat_model_id = thermostat_status.get(
+                gw_vars.DATA_MASTER_PRODUCT_TYPE
+            )
+            thermostat_hw_version = thermostat_status.get(
+                gw_vars.DATA_MASTER_PRODUCT_VERSION
+            )
+            thermostat_sw_version = thermostat_status.get(
+                gw_vars.DATA_MASTER_OT_VERSION
             )
             dev_reg.async_update_device(
                 thermostat_device.id,
-                manufacturer=str(thermostat_manufacturer)
-                if thermostat_manufacturer is not None
-                else None,
-                model_id=status[OpenThermDataSource.THERMOSTAT].get(
-                    gw_vars.DATA_MASTER_PRODUCT_TYPE
+                manufacturer=(
+                    str(thermostat_manufacturer)
+                    if thermostat_manufacturer is not None
+                    else None
                 ),
-                hw_version=status[OpenThermDataSource.THERMOSTAT].get(
-                    gw_vars.DATA_MASTER_PRODUCT_VERSION
+                model_id=(
+                    str(thermostat_model_id)
+                    if thermostat_model_id is not None
+                    else None
                 ),
-                sw_version=status[OpenThermDataSource.THERMOSTAT].get(
-                    gw_vars.DATA_MASTER_OT_VERSION
+                hw_version=(
+                    str(thermostat_hw_version)
+                    if thermostat_hw_version is not None
+                    else None
+                ),
+                sw_version=(
+                    str(thermostat_sw_version)
+                    if thermostat_sw_version is not None
+                    else None
                 ),
             )
 

--- a/tests/components/opentherm_gw/test_init.py
+++ b/tests/components/opentherm_gw/test_init.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock
 
+import pyotgw.vars as gw_vars
 from pyotgw.vars import OTGW, OTGW_ABOUT
 
 from homeassistant.components.opentherm_gw.const import (
@@ -68,3 +69,58 @@ async def test_device_registry_update(
     )
     assert gw_dev is not None
     assert gw_dev.sw_version == VERSION_NEW
+
+
+async def test_device_registry_report_numeric_fields(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_pyotgw: MagicMock,
+) -> None:
+    """Test that numeric device info fields from reports are cast to strings."""
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    subscribe_call = mock_pyotgw.return_value.subscribe
+    assert subscribe_call.call_count == 1
+    report_callback = subscribe_call.call_args[0][0]
+
+    await report_callback(
+        {
+            gw_vars.BOILER: {
+                gw_vars.DATA_SLAVE_MEMBERID: 42,
+                gw_vars.DATA_SLAVE_PRODUCT_TYPE: 3,
+                gw_vars.DATA_SLAVE_PRODUCT_VERSION: 7,
+                gw_vars.DATA_SLAVE_OT_VERSION: 2.5,
+            },
+            gw_vars.THERMOSTAT: {
+                gw_vars.DATA_MASTER_MEMBERID: 10,
+                gw_vars.DATA_MASTER_PRODUCT_TYPE: 1,
+                gw_vars.DATA_MASTER_PRODUCT_VERSION: 4,
+                gw_vars.DATA_MASTER_OT_VERSION: 3.0,
+            },
+        }
+    )
+    await hass.async_block_till_done()
+
+    boiler_dev = device_registry.async_get_device(
+        identifiers={(DOMAIN, f"{MOCK_GATEWAY_ID}-{OpenThermDeviceIdentifier.BOILER}")}
+    )
+    assert boiler_dev is not None
+    assert boiler_dev.manufacturer == "42"
+    assert boiler_dev.model_id == "3"
+    assert boiler_dev.hw_version == "7"
+    assert boiler_dev.sw_version == "2.5"
+
+    thermostat_dev = device_registry.async_get_device(
+        identifiers={
+            (DOMAIN, f"{MOCK_GATEWAY_ID}-{OpenThermDeviceIdentifier.THERMOSTAT}")
+        }
+    )
+    assert thermostat_dev is not None
+    assert thermostat_dev.manufacturer == "10"
+    assert thermostat_dev.model_id == "1"
+    assert thermostat_dev.hw_version == "4"
+    assert thermostat_dev.sw_version == "3.0"


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The `handle_report` callback in the OpenTherm Gateway integration passes `model_id`, `hw_version`, and `sw_version` to the device registry without converting them to strings. The pyotgw library returns `int` for product type and product version, and `float` for the OT protocol version. The device registry expects `str | None` for all of these fields.

The `manufacturer` field already had `str()` conversion with a `None` guard, but the other three fields were passed as raw numeric values.

This change applies the same `str(value) if value is not None else None` pattern to all device info fields for both the boiler and thermostat devices.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr