### PR TITLE
Simplify target helper callback comments

### DIFF
--- a/homeassistant/helpers/target.py
+++ b/homeassistant/helpers/target.py
@@ -380,12 +380,9 @@ class TargetStateChangeTracker(TargetEntityChangeTracker):
         """Initialize the state change tracker.
 
         `on_entities_update` may be a plain callback or a coroutine function.
-        A coroutine is awaited for the initial entity set (so setup is
-        deterministic) and scheduled as a background task for later
-        registry-driven changes. It is called with the added and removed
-        entity ids and the states of all currently targeted entities; the
-        states mapping is only valid during the synchronous call, so a
-        coroutine must copy what it needs before awaiting.
+        It is called with the added and removed entity ids and the states of
+        all currently targeted entities; the states mapping is only valid during
+        the synchronous call, so a coroutine must copy what it needs before awaiting.
         """
         super().__init__(
             hass,
@@ -404,9 +401,7 @@ class TargetStateChangeTracker(TargetEntityChangeTracker):
         """Set up tracking, awaiting the update for the initial entity set.
 
         The initial update is awaited so that a coroutine `on_entities_update`
-        (e.g. one that loads history) completes before setup returns. Later
-        registry-driven updates instead arrive via the callback
-        `_handle_entities_update` and are scheduled as background tasks.
+        (e.g. one that loads history) completes before setup returns.
         """
         self._setup_registry_listeners()
         entities = self._referenced_entities()
@@ -511,9 +506,7 @@ async def async_track_target_selector_state_change_event(
 
     `on_entities_update` is called with the added and removed entity ids and
     the states of all currently targeted entities. It may be a coroutine
-    function; it is awaited for the initial entity set and scheduled as a
-    task for later registry-driven changes, so this function must itself be
-    awaited. The states mapping is only valid during the synchronous call.
+    function; The states mapping is only valid during the synchronous call.
     """
     target_selection = TargetSelection(target_selector_config)
     if not target_selection.has_any_target:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
While looking at this helper, the comments about the `on_entities_update` helper confused me more than they clarified. They were also documenting things that happened elsewhere in the code (i.e., a public method detailing behavior of an internal method elsewhere).

This PR removes the internal behavior details, keeping only the details relevant to the user of the helper.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
