### PR TITLE
Add karakeep integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -942,6 +942,8 @@ CLAUDE.md @home-assistant/core
 /homeassistant/components/kaiterra/ @Michsior14
 /homeassistant/components/kaleidescape/ @SteveEasley
 /tests/components/kaleidescape/ @SteveEasley
+/homeassistant/components/karakeep/ @sli-cka
+/tests/components/karakeep/ @sli-cka
 /homeassistant/components/keba/ @dannerph
 /homeassistant/components/keenetic_ndms2/ @foxel
 /tests/components/keenetic_ndms2/ @foxel

--- a/homeassistant/components/karakeep/__init__.py
+++ b/homeassistant/components/karakeep/__init__.py
@@ -6,7 +6,7 @@ from homeassistant.const import CONF_TOKEN, CONF_URL, CONF_VERIFY_SSL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DEFAULT_VERIFY_SSL, PLATFORMS
+from .const import PLATFORMS
 from .coordinator import KarakeepConfigEntry, KarakeepDataUpdateCoordinator
 
 
@@ -15,9 +15,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: KarakeepConfigEntry) -> 
     client = KarakeepClient(
         entry.data[CONF_URL],
         entry.data[CONF_TOKEN],
-        async_get_clientsession(
-            hass, entry.data.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL)
-        ),
+        async_get_clientsession(hass, entry.data[CONF_VERIFY_SSL]),
     )
     coordinator = KarakeepDataUpdateCoordinator(hass, entry, client)
 

--- a/homeassistant/components/karakeep/__init__.py
+++ b/homeassistant/components/karakeep/__init__.py
@@ -2,15 +2,12 @@
 
 from aiokarakeep import KarakeepClient
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_TOKEN, CONF_URL, CONF_VERIFY_SSL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DEFAULT_VERIFY_SSL, PLATFORMS
-from .coordinator import KarakeepDataUpdateCoordinator
-
-type KarakeepConfigEntry = ConfigEntry[KarakeepDataUpdateCoordinator]
+from .coordinator import KarakeepConfigEntry, KarakeepDataUpdateCoordinator
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: KarakeepConfigEntry) -> bool:

--- a/homeassistant/components/karakeep/__init__.py
+++ b/homeassistant/components/karakeep/__init__.py
@@ -3,11 +3,11 @@
 from aiokarakeep import KarakeepClient
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_TOKEN, CONF_URL
+from homeassistant.const import CONF_TOKEN, CONF_URL, CONF_VERIFY_SSL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import PLATFORMS
+from .const import DEFAULT_VERIFY_SSL, PLATFORMS
 from .coordinator import KarakeepDataUpdateCoordinator
 
 type KarakeepConfigEntry = ConfigEntry[KarakeepDataUpdateCoordinator]
@@ -18,7 +18,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: KarakeepConfigEntry) -> 
     client = KarakeepClient(
         entry.data[CONF_URL],
         entry.data[CONF_TOKEN],
-        async_get_clientsession(hass),
+        async_get_clientsession(
+            hass, entry.data.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL)
+        ),
     )
     coordinator = KarakeepDataUpdateCoordinator(hass, entry, client)
 

--- a/homeassistant/components/karakeep/__init__.py
+++ b/homeassistant/components/karakeep/__init__.py
@@ -1,0 +1,36 @@
+"""The Karakeep integration."""
+
+from aiokarakeep import KarakeepClient
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_TOKEN, CONF_URL
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .const import PLATFORMS
+from .coordinator import KarakeepDataUpdateCoordinator
+
+type KarakeepConfigEntry = ConfigEntry[KarakeepDataUpdateCoordinator]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: KarakeepConfigEntry) -> bool:
+    """Set up Karakeep from a config entry."""
+    client = KarakeepClient(
+        entry.data[CONF_URL],
+        entry.data[CONF_TOKEN],
+        async_get_clientsession(hass),
+    )
+    coordinator = KarakeepDataUpdateCoordinator(hass, entry, client)
+
+    await coordinator.async_config_entry_first_refresh()
+
+    entry.runtime_data = coordinator
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: KarakeepConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/karakeep/config_flow.py
+++ b/homeassistant/components/karakeep/config_flow.py
@@ -13,8 +13,7 @@ from aiokarakeep import (
 import voluptuous as vol
 from yarl import URL
 
-from homeassistant import config_entries
-from homeassistant.config_entries import ConfigFlowResult
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_TOKEN, CONF_URL, CONF_VERIFY_SSL
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
@@ -31,7 +30,7 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
 )
 
 
-class KarakeepConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+class KarakeepConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Karakeep."""
 
     VERSION = 1

--- a/homeassistant/components/karakeep/config_flow.py
+++ b/homeassistant/components/karakeep/config_flow.py
@@ -1,5 +1,6 @@
 """Config flow for Karakeep."""
 
+from collections.abc import Mapping
 from typing import Any
 from urllib.parse import urlparse
 
@@ -13,11 +14,19 @@ from aiokarakeep import (
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.const import CONF_TOKEN, CONF_URL
-from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DOMAIN
+
+STEP_REAUTH_DATA_SCHEMA = vol.Schema({vol.Required(CONF_TOKEN): str})
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_URL): str,
+        vol.Required(CONF_TOKEN): str,
+    }
+)
 
 
 class KarakeepConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -25,9 +34,27 @@ class KarakeepConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    async def _async_validate_input(self, url: str, token: str) -> dict[str, str]:
+        """Validate the user input allows us to connect."""
+        errors: dict[str, str] = {}
+
+        session = async_get_clientsession(self.hass)
+        client = KarakeepClient(url, token, session)
+
+        try:
+            await client.async_get_stats()
+        except KarakeepAuthError:
+            errors["base"] = "invalid_auth"
+        except KarakeepConnectionError:
+            errors["base"] = "cannot_connect"
+        except KarakeepApiError, KarakeepInvalidResponseError:
+            errors["base"] = "api_error"
+
+        return errors
+
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Handle the initial step."""
         errors: dict[str, str] = {}
 
@@ -41,18 +68,8 @@ class KarakeepConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 await self.async_set_unique_id(url)
                 self._abort_if_unique_id_configured()
 
-                session = async_get_clientsession(self.hass)
-                client = KarakeepClient(url, token, session)
-
-                try:
-                    await client.async_get_stats()
-                except KarakeepAuthError:
-                    errors["base"] = "invalid_auth"
-                except KarakeepConnectionError:
-                    errors["base"] = "cannot_connect"
-                except KarakeepApiError, KarakeepInvalidResponseError:
-                    errors["base"] = "api_error"
-                else:
+                errors = await self._async_validate_input(url, token)
+                if not errors:
                     return self.async_create_entry(
                         title="Karakeep",
                         data={
@@ -63,12 +80,38 @@ class KarakeepConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_URL): str,
-                    vol.Required(CONF_TOKEN): str,
-                }
-            ),
+            data_schema=STEP_USER_DATA_SCHEMA,
+            errors=errors,
+        )
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Handle reauthentication."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Confirm reauthentication with a new API token."""
+        errors: dict[str, str] = {}
+        reauth_entry = self._get_reauth_entry()
+
+        if user_input is not None:
+            token = user_input[CONF_TOKEN].strip()
+            errors = await self._async_validate_input(
+                reauth_entry.data[CONF_URL], token
+            )
+
+            if not errors:
+                return self.async_update_reload_and_abort(
+                    reauth_entry,
+                    data={**reauth_entry.data, CONF_TOKEN: token},
+                )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=STEP_REAUTH_DATA_SCHEMA,
             errors=errors,
         )
 

--- a/homeassistant/components/karakeep/config_flow.py
+++ b/homeassistant/components/karakeep/config_flow.py
@@ -15,16 +15,17 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigFlowResult
-from homeassistant.const import CONF_TOKEN, CONF_URL
+from homeassistant.const import CONF_TOKEN, CONF_URL, CONF_VERIFY_SSL
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DOMAIN
+from .const import DEFAULT_VERIFY_SSL, DOMAIN
 
 STEP_REAUTH_DATA_SCHEMA = vol.Schema({vol.Required(CONF_TOKEN): str})
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_URL): str,
         vol.Required(CONF_TOKEN): str,
+        vol.Required(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): bool,
     }
 )
 
@@ -34,11 +35,13 @@ class KarakeepConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    async def _async_validate_input(self, url: str, token: str) -> dict[str, str]:
+    async def _async_validate_input(
+        self, url: str, token: str, verify_ssl: bool
+    ) -> dict[str, str]:
         """Validate the user input allows us to connect."""
         errors: dict[str, str] = {}
 
-        session = async_get_clientsession(self.hass)
+        session = async_get_clientsession(self.hass, verify_ssl)
         client = KarakeepClient(url, token, session)
 
         try:
@@ -61,6 +64,7 @@ class KarakeepConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             url = _normalize_url(user_input[CONF_URL])
             token = user_input[CONF_TOKEN].strip()
+            verify_ssl = user_input[CONF_VERIFY_SSL]
 
             if not _is_valid_url(url):
                 errors["base"] = "invalid_url_format"
@@ -68,13 +72,14 @@ class KarakeepConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 await self.async_set_unique_id(url)
                 self._abort_if_unique_id_configured()
 
-                errors = await self._async_validate_input(url, token)
+                errors = await self._async_validate_input(url, token, verify_ssl)
                 if not errors:
                     return self.async_create_entry(
                         title="Karakeep",
                         data={
                             CONF_URL: url,
                             CONF_TOKEN: token,
+                            CONF_VERIFY_SSL: verify_ssl,
                         },
                     )
 
@@ -100,7 +105,9 @@ class KarakeepConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             token = user_input[CONF_TOKEN].strip()
             errors = await self._async_validate_input(
-                reauth_entry.data[CONF_URL], token
+                reauth_entry.data[CONF_URL],
+                token,
+                reauth_entry.data.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL),
             )
 
             if not errors:

--- a/homeassistant/components/karakeep/config_flow.py
+++ b/homeassistant/components/karakeep/config_flow.py
@@ -1,0 +1,84 @@
+"""Config flow for Karakeep."""
+
+from typing import Any
+from urllib.parse import urlparse
+
+from aiokarakeep import (
+    KarakeepApiError,
+    KarakeepAuthError,
+    KarakeepClient,
+    KarakeepConnectionError,
+    KarakeepInvalidResponseError,
+)
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_TOKEN, CONF_URL
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .const import DOMAIN
+
+
+class KarakeepConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Karakeep."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            url = _normalize_url(user_input[CONF_URL])
+            token = user_input[CONF_TOKEN].strip()
+
+            if not _is_valid_url(url):
+                errors["base"] = "invalid_url_format"
+            else:
+                await self.async_set_unique_id(url)
+                self._abort_if_unique_id_configured()
+
+                session = async_get_clientsession(self.hass)
+                client = KarakeepClient(url, token, session)
+
+                try:
+                    await client.async_get_stats()
+                except KarakeepAuthError:
+                    errors["base"] = "invalid_auth"
+                except KarakeepConnectionError:
+                    errors["base"] = "cannot_connect"
+                except KarakeepApiError, KarakeepInvalidResponseError:
+                    errors["base"] = "api_error"
+                else:
+                    return self.async_create_entry(
+                        title="Karakeep",
+                        data={
+                            CONF_URL: url,
+                            CONF_TOKEN: token,
+                        },
+                    )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_URL): str,
+                    vol.Required(CONF_TOKEN): str,
+                }
+            ),
+            errors=errors,
+        )
+
+
+def _normalize_url(url: str) -> str:
+    """Normalize a Karakeep URL."""
+    return url.strip().rstrip("/")
+
+
+def _is_valid_url(url: str) -> bool:
+    """Return whether the URL looks valid."""
+    parsed = urlparse(url)
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)

--- a/homeassistant/components/karakeep/config_flow.py
+++ b/homeassistant/components/karakeep/config_flow.py
@@ -66,14 +66,13 @@ class KarakeepConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            parsed_url = URL(user_input[CONF_URL].strip())
+            url = _normalize_url(user_input[CONF_URL])
             token = user_input[CONF_TOKEN].strip()
             verify_ssl = user_input[CONF_VERIFY_SSL]
 
-            if parsed_url.scheme not in ("http", "https") or not parsed_url.host:
+            if url is None:
                 errors["base"] = "invalid_url_format"
             else:
-                url = str(parsed_url).rstrip("/")
                 self._async_abort_entries_match({CONF_URL: url})
 
                 errors = await self._async_validate_input(url, token, verify_ssl)
@@ -92,3 +91,14 @@ class KarakeepConfigFlow(ConfigFlow, domain=DOMAIN):
             data_schema=STEP_USER_DATA_SCHEMA,
             errors=errors,
         )
+
+
+def _normalize_url(raw_url: str) -> str | None:
+    """Return the normalized base URL, or None if it is not a valid URL."""
+    try:
+        parsed_url = URL(raw_url.strip())
+    except ValueError:
+        return None
+    if parsed_url.scheme not in ("http", "https") or not parsed_url.host:
+        return None
+    return str(parsed_url).rstrip("/")

--- a/homeassistant/components/karakeep/config_flow.py
+++ b/homeassistant/components/karakeep/config_flow.py
@@ -3,7 +3,6 @@
 from collections.abc import Mapping
 import logging
 from typing import Any
-from urllib.parse import urlparse
 
 from aiokarakeep import (
     KarakeepApiError,
@@ -13,6 +12,7 @@ from aiokarakeep import (
     KarakeepInvalidResponseError,
 )
 import voluptuous as vol
+from yarl import URL
 
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigFlowResult
@@ -68,13 +68,14 @@ class KarakeepConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            url = _normalize_url(user_input[CONF_URL])
+            parsed_url = URL(user_input[CONF_URL].strip())
             token = user_input[CONF_TOKEN].strip()
             verify_ssl = user_input[CONF_VERIFY_SSL]
 
-            if not _is_valid_url(url):
+            if parsed_url.scheme not in ("http", "https") or not parsed_url.host:
                 errors["base"] = "invalid_url_format"
             else:
+                url = str(parsed_url).rstrip("/")
                 self._async_abort_entries_match({CONF_URL: url})
 
                 errors = await self._async_validate_input(url, token, verify_ssl)
@@ -126,14 +127,3 @@ class KarakeepConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=STEP_REAUTH_DATA_SCHEMA,
             errors=errors,
         )
-
-
-def _normalize_url(url: str) -> str:
-    """Normalize a Karakeep URL."""
-    return url.strip().rstrip("/")
-
-
-def _is_valid_url(url: str) -> bool:
-    """Return whether the URL looks valid."""
-    parsed = urlparse(url)
-    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)

--- a/homeassistant/components/karakeep/config_flow.py
+++ b/homeassistant/components/karakeep/config_flow.py
@@ -53,7 +53,7 @@ class KarakeepConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors["base"] = "invalid_auth"
         except KarakeepConnectionError:
             errors["base"] = "cannot_connect"
-        except (KarakeepApiError, KarakeepInvalidResponseError):
+        except KarakeepApiError, KarakeepInvalidResponseError:
             errors["base"] = "api_error"
         except Exception:
             _LOGGER.exception("Unexpected exception")

--- a/homeassistant/components/karakeep/config_flow.py
+++ b/homeassistant/components/karakeep/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow for Karakeep."""
 
 from collections.abc import Mapping
+import logging
 from typing import Any
 from urllib.parse import urlparse
 
@@ -19,6 +20,8 @@ from homeassistant.const import CONF_TOKEN, CONF_URL, CONF_VERIFY_SSL
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DEFAULT_VERIFY_SSL, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
 
 STEP_REAUTH_DATA_SCHEMA = vol.Schema({vol.Required(CONF_TOKEN): str})
 STEP_USER_DATA_SCHEMA = vol.Schema(
@@ -50,8 +53,11 @@ class KarakeepConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors["base"] = "invalid_auth"
         except KarakeepConnectionError:
             errors["base"] = "cannot_connect"
-        except KarakeepApiError, KarakeepInvalidResponseError:
+        except (KarakeepApiError, KarakeepInvalidResponseError):
             errors["base"] = "api_error"
+        except Exception:
+            _LOGGER.exception("Unexpected exception")
+            errors["base"] = "unknown"
 
         return errors
 
@@ -69,8 +75,7 @@ class KarakeepConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if not _is_valid_url(url):
                 errors["base"] = "invalid_url_format"
             else:
-                await self.async_set_unique_id(url)
-                self._abort_if_unique_id_configured()
+                self._async_abort_entries_match({CONF_URL: url})
 
                 errors = await self._async_validate_input(url, token, verify_ssl)
                 if not errors:

--- a/homeassistant/components/karakeep/config_flow.py
+++ b/homeassistant/components/karakeep/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Karakeep."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from aiokarakeep import (
     KarakeepApiError,
@@ -58,6 +58,7 @@ class KarakeepConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return errors
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/karakeep/config_flow.py
+++ b/homeassistant/components/karakeep/config_flow.py
@@ -1,6 +1,5 @@
 """Config flow for Karakeep."""
 
-from collections.abc import Mapping
 import logging
 from typing import Any
 
@@ -23,7 +22,6 @@ from .const import DEFAULT_VERIFY_SSL, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-STEP_REAUTH_DATA_SCHEMA = vol.Schema({vol.Required(CONF_TOKEN): str})
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_URL): str,
@@ -92,38 +90,5 @@ class KarakeepConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user",
             data_schema=STEP_USER_DATA_SCHEMA,
-            errors=errors,
-        )
-
-    async def async_step_reauth(
-        self, entry_data: Mapping[str, Any]
-    ) -> ConfigFlowResult:
-        """Handle reauthentication."""
-        return await self.async_step_reauth_confirm()
-
-    async def async_step_reauth_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Confirm reauthentication with a new API token."""
-        errors: dict[str, str] = {}
-        reauth_entry = self._get_reauth_entry()
-
-        if user_input is not None:
-            token = user_input[CONF_TOKEN].strip()
-            errors = await self._async_validate_input(
-                reauth_entry.data[CONF_URL],
-                token,
-                reauth_entry.data[CONF_VERIFY_SSL],
-            )
-
-            if not errors:
-                return self.async_update_reload_and_abort(
-                    reauth_entry,
-                    data={**reauth_entry.data, CONF_TOKEN: token},
-                )
-
-        return self.async_show_form(
-            step_id="reauth_confirm",
-            data_schema=STEP_REAUTH_DATA_SCHEMA,
             errors=errors,
         )

--- a/homeassistant/components/karakeep/config_flow.py
+++ b/homeassistant/components/karakeep/config_flow.py
@@ -112,7 +112,7 @@ class KarakeepConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors = await self._async_validate_input(
                 reauth_entry.data[CONF_URL],
                 token,
-                reauth_entry.data.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL),
+                reauth_entry.data[CONF_VERIFY_SSL],
             )
 
             if not errors:

--- a/homeassistant/components/karakeep/const.py
+++ b/homeassistant/components/karakeep/const.py
@@ -4,6 +4,7 @@ from homeassistant.const import Platform
 
 DOMAIN = "karakeep"
 
+DEFAULT_VERIFY_SSL = False
 DEFAULT_SCAN_INTERVAL = 300
 
 PLATFORMS = [Platform.SENSOR]

--- a/homeassistant/components/karakeep/const.py
+++ b/homeassistant/components/karakeep/const.py
@@ -1,10 +1,12 @@
 """Constants for the Karakeep integration."""
 
+from datetime import timedelta
+
 from homeassistant.const import Platform
 
 DOMAIN = "karakeep"
 
 DEFAULT_VERIFY_SSL = False
-DEFAULT_SCAN_INTERVAL = 300
+UPDATE_INTERVAL = timedelta(seconds=300)
 
 PLATFORMS = [Platform.SENSOR]

--- a/homeassistant/components/karakeep/const.py
+++ b/homeassistant/components/karakeep/const.py
@@ -1,0 +1,9 @@
+"""Constants for the Karakeep integration."""
+
+from homeassistant.const import Platform
+
+DOMAIN = "karakeep"
+
+DEFAULT_SCAN_INTERVAL = 300
+
+PLATFORMS = [Platform.SENSOR]

--- a/homeassistant/components/karakeep/const.py
+++ b/homeassistant/components/karakeep/const.py
@@ -6,7 +6,7 @@ from homeassistant.const import Platform
 
 DOMAIN = "karakeep"
 
-DEFAULT_VERIFY_SSL = False
+DEFAULT_VERIFY_SSL = True
 UPDATE_INTERVAL = timedelta(seconds=300)
 
 PLATFORMS = [Platform.SENSOR]

--- a/homeassistant/components/karakeep/coordinator.py
+++ b/homeassistant/components/karakeep/coordinator.py
@@ -1,6 +1,7 @@
 """Data update coordinator for the Karakeep integration."""
 
 import logging
+from typing import override
 
 from aiokarakeep import (
     KarakeepApiError,
@@ -45,10 +46,12 @@ class KarakeepDataUpdateCoordinator(DataUpdateCoordinator[KarakeepStats]):
             config_entry=entry,
         )
 
+    @override
     async def _async_setup(self) -> None:
         """Fetch the server version once during setup."""
         self.version = await self.client.async_get_version()
 
+    @override
     async def _async_update_data(self) -> KarakeepStats:
         """Fetch data from Karakeep API."""
         try:

--- a/homeassistant/components/karakeep/coordinator.py
+++ b/homeassistant/components/karakeep/coordinator.py
@@ -14,7 +14,6 @@ from aiokarakeep import (
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN, UPDATE_INTERVAL
@@ -60,7 +59,7 @@ class KarakeepDataUpdateCoordinator(DataUpdateCoordinator[KarakeepStats]):
         try:
             return await self.client.async_get_stats()
         except KarakeepAuthError as err:
-            raise ConfigEntryAuthFailed("Invalid Karakeep API token") from err
+            raise UpdateFailed("Invalid Karakeep API token") from err
         except KarakeepConnectionError as err:
             raise UpdateFailed(f"Error communicating with Karakeep: {err}") from err
         except (KarakeepApiError, KarakeepInvalidResponseError) as err:

--- a/homeassistant/components/karakeep/coordinator.py
+++ b/homeassistant/components/karakeep/coordinator.py
@@ -1,5 +1,6 @@
 """Data update coordinator for the Karakeep integration."""
 
+from dataclasses import dataclass
 import logging
 
 from aiokarakeep import (
@@ -7,6 +8,7 @@ from aiokarakeep import (
     KarakeepAuthError,
     KarakeepClient,
     KarakeepConnectionError,
+    KarakeepError,
     KarakeepInvalidResponseError,
     KarakeepStats,
 )
@@ -23,7 +25,15 @@ _LOGGER = logging.getLogger(__name__)
 type KarakeepConfigEntry = ConfigEntry[KarakeepDataUpdateCoordinator]
 
 
-class KarakeepDataUpdateCoordinator(DataUpdateCoordinator[KarakeepStats]):
+@dataclass
+class KarakeepData:
+    """Data fetched from Karakeep."""
+
+    stats: KarakeepStats
+    version: str | None
+
+
+class KarakeepDataUpdateCoordinator(DataUpdateCoordinator[KarakeepData]):
     """Class to manage fetching Karakeep data."""
 
     config_entry: KarakeepConfigEntry
@@ -45,13 +55,22 @@ class KarakeepDataUpdateCoordinator(DataUpdateCoordinator[KarakeepStats]):
             config_entry=entry,
         )
 
-    async def _async_update_data(self) -> KarakeepStats:
+    async def _async_update_data(self) -> KarakeepData:
         """Fetch data from Karakeep API."""
         try:
-            return await self.client.async_get_stats()
+            stats = await self.client.async_get_stats()
         except KarakeepAuthError as err:
             raise ConfigEntryAuthFailed("Invalid Karakeep API token") from err
         except KarakeepConnectionError as err:
             raise UpdateFailed(f"Error communicating with Karakeep: {err}") from err
         except (KarakeepApiError, KarakeepInvalidResponseError) as err:
             raise UpdateFailed(f"Invalid response from Karakeep: {err}") from err
+
+        # The version is optional and must never fail the data update.
+        try:
+            version = await self.client.async_get_version()
+        except KarakeepError as err:
+            _LOGGER.debug("Could not fetch Karakeep version: %s", err)
+            version = None
+
+        return KarakeepData(stats=stats, version=version)

--- a/homeassistant/components/karakeep/coordinator.py
+++ b/homeassistant/components/karakeep/coordinator.py
@@ -1,0 +1,56 @@
+"""Data update coordinator for the Karakeep integration."""
+
+from datetime import timedelta
+import logging
+from typing import Any
+
+from aiokarakeep import (
+    KarakeepApiError,
+    KarakeepAuthError,
+    KarakeepClient,
+    KarakeepConnectionError,
+    KarakeepInvalidResponseError,
+)
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DEFAULT_SCAN_INTERVAL, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class KarakeepDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
+    """Class to manage fetching Karakeep data."""
+
+    config_entry: ConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+        client: KarakeepClient,
+    ) -> None:
+        """Initialize the coordinator."""
+        self.client = client
+
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=timedelta(seconds=DEFAULT_SCAN_INTERVAL),
+            config_entry=entry,
+        )
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        """Fetch data from Karakeep API."""
+        try:
+            return await self.client.async_get_stats()
+        except KarakeepAuthError as err:
+            raise ConfigEntryAuthFailed("Invalid Karakeep API token") from err
+        except KarakeepConnectionError as err:
+            raise UpdateFailed(f"Error communicating with Karakeep: {err}") from err
+        except (KarakeepApiError, KarakeepInvalidResponseError) as err:
+            raise UpdateFailed(f"Invalid response from Karakeep: {err}") from err

--- a/homeassistant/components/karakeep/coordinator.py
+++ b/homeassistant/components/karakeep/coordinator.py
@@ -2,7 +2,6 @@
 
 from datetime import timedelta
 import logging
-from typing import Any
 
 from aiokarakeep import (
     KarakeepApiError,
@@ -10,6 +9,7 @@ from aiokarakeep import (
     KarakeepClient,
     KarakeepConnectionError,
     KarakeepInvalidResponseError,
+    KarakeepStats,
 )
 
 from homeassistant.config_entries import ConfigEntry
@@ -21,16 +21,18 @@ from .const import DEFAULT_SCAN_INTERVAL, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
+type KarakeepConfigEntry = ConfigEntry[KarakeepDataUpdateCoordinator]
 
-class KarakeepDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
+
+class KarakeepDataUpdateCoordinator(DataUpdateCoordinator[KarakeepStats]):
     """Class to manage fetching Karakeep data."""
 
-    config_entry: ConfigEntry
+    config_entry: KarakeepConfigEntry
 
     def __init__(
         self,
         hass: HomeAssistant,
-        entry: ConfigEntry,
+        entry: KarakeepConfigEntry,
         client: KarakeepClient,
     ) -> None:
         """Initialize the coordinator."""
@@ -44,7 +46,7 @@ class KarakeepDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             config_entry=entry,
         )
 
-    async def _async_update_data(self) -> dict[str, Any]:
+    async def _async_update_data(self) -> KarakeepStats:
         """Fetch data from Karakeep API."""
         try:
             return await self.client.async_get_stats()

--- a/homeassistant/components/karakeep/coordinator.py
+++ b/homeassistant/components/karakeep/coordinator.py
@@ -7,7 +7,6 @@ from aiokarakeep import (
     KarakeepAuthError,
     KarakeepClient,
     KarakeepConnectionError,
-    KarakeepError,
     KarakeepInvalidResponseError,
     KarakeepStats,
 )
@@ -48,11 +47,7 @@ class KarakeepDataUpdateCoordinator(DataUpdateCoordinator[KarakeepStats]):
 
     async def _async_setup(self) -> None:
         """Fetch the server version once during setup."""
-        # The version is optional and must never fail setup.
-        try:
-            self.version = await self.client.async_get_version()
-        except KarakeepError as err:
-            _LOGGER.debug("Could not fetch Karakeep version: %s", err)
+        self.version = await self.client.async_get_version()
 
     async def _async_update_data(self) -> KarakeepStats:
         """Fetch data from Karakeep API."""

--- a/homeassistant/components/karakeep/coordinator.py
+++ b/homeassistant/components/karakeep/coordinator.py
@@ -1,6 +1,5 @@
 """Data update coordinator for the Karakeep integration."""
 
-from dataclasses import dataclass
 import logging
 
 from aiokarakeep import (
@@ -25,18 +24,11 @@ _LOGGER = logging.getLogger(__name__)
 type KarakeepConfigEntry = ConfigEntry[KarakeepDataUpdateCoordinator]
 
 
-@dataclass
-class KarakeepData:
-    """Data fetched from Karakeep."""
-
-    stats: KarakeepStats
-    version: str | None
-
-
-class KarakeepDataUpdateCoordinator(DataUpdateCoordinator[KarakeepData]):
+class KarakeepDataUpdateCoordinator(DataUpdateCoordinator[KarakeepStats]):
     """Class to manage fetching Karakeep data."""
 
     config_entry: KarakeepConfigEntry
+    version: str | None = None
 
     def __init__(
         self,
@@ -55,22 +47,21 @@ class KarakeepDataUpdateCoordinator(DataUpdateCoordinator[KarakeepData]):
             config_entry=entry,
         )
 
-    async def _async_update_data(self) -> KarakeepData:
+    async def _async_setup(self) -> None:
+        """Fetch the server version once during setup."""
+        # The version is optional and must never fail setup.
+        try:
+            self.version = await self.client.async_get_version()
+        except KarakeepError as err:
+            _LOGGER.debug("Could not fetch Karakeep version: %s", err)
+
+    async def _async_update_data(self) -> KarakeepStats:
         """Fetch data from Karakeep API."""
         try:
-            stats = await self.client.async_get_stats()
+            return await self.client.async_get_stats()
         except KarakeepAuthError as err:
             raise ConfigEntryAuthFailed("Invalid Karakeep API token") from err
         except KarakeepConnectionError as err:
             raise UpdateFailed(f"Error communicating with Karakeep: {err}") from err
         except (KarakeepApiError, KarakeepInvalidResponseError) as err:
             raise UpdateFailed(f"Invalid response from Karakeep: {err}") from err
-
-        # The version is optional and must never fail the data update.
-        try:
-            version = await self.client.async_get_version()
-        except KarakeepError as err:
-            _LOGGER.debug("Could not fetch Karakeep version: %s", err)
-            version = None
-
-        return KarakeepData(stats=stats, version=version)

--- a/homeassistant/components/karakeep/coordinator.py
+++ b/homeassistant/components/karakeep/coordinator.py
@@ -49,7 +49,10 @@ class KarakeepDataUpdateCoordinator(DataUpdateCoordinator[KarakeepStats]):
     @override
     async def _async_setup(self) -> None:
         """Fetch the server version once during setup."""
-        self.version = await self.client.async_get_version()
+        try:
+            self.version = await self.client.async_get_version()
+        except (KarakeepApiError, KarakeepConnectionError) as err:
+            raise UpdateFailed(f"Error communicating with Karakeep: {err}") from err
 
     @override
     async def _async_update_data(self) -> KarakeepStats:

--- a/homeassistant/components/karakeep/coordinator.py
+++ b/homeassistant/components/karakeep/coordinator.py
@@ -1,6 +1,5 @@
 """Data update coordinator for the Karakeep integration."""
 
-from datetime import timedelta
 import logging
 
 from aiokarakeep import (
@@ -17,7 +16,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DEFAULT_SCAN_INTERVAL, DOMAIN
+from .const import DOMAIN, UPDATE_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -42,7 +41,7 @@ class KarakeepDataUpdateCoordinator(DataUpdateCoordinator[KarakeepStats]):
             hass,
             _LOGGER,
             name=DOMAIN,
-            update_interval=timedelta(seconds=DEFAULT_SCAN_INTERVAL),
+            update_interval=UPDATE_INTERVAL,
             config_entry=entry,
         )
 

--- a/homeassistant/components/karakeep/entity.py
+++ b/homeassistant/components/karakeep/entity.py
@@ -1,0 +1,26 @@
+"""Base entity for the Karakeep integration."""
+
+from homeassistant.const import CONF_URL
+from homeassistant.helpers.device_registry import DeviceEntryType
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import KarakeepDataUpdateCoordinator
+
+
+class KarakeepEntity(CoordinatorEntity[KarakeepDataUpdateCoordinator]):
+    """Base class for Karakeep entities."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: KarakeepDataUpdateCoordinator) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+        self._attr_device_info = {
+            "identifiers": {
+                (DOMAIN, coordinator.config_entry.data[CONF_URL]),
+            },
+            "name": "Karakeep",
+            "manufacturer": "Karakeep",
+            "entry_type": DeviceEntryType.SERVICE,
+        }

--- a/homeassistant/components/karakeep/entity.py
+++ b/homeassistant/components/karakeep/entity.py
@@ -18,7 +18,7 @@ class KarakeepEntity(CoordinatorEntity[KarakeepDataUpdateCoordinator]):
         super().__init__(coordinator)
         url = coordinator.config_entry.data[CONF_URL]
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, url)},
+            identifiers={(DOMAIN, coordinator.config_entry.entry_id)},
             name="Karakeep",
             manufacturer="Karakeep",
             entry_type=DeviceEntryType.SERVICE,

--- a/homeassistant/components/karakeep/entity.py
+++ b/homeassistant/components/karakeep/entity.py
@@ -1,7 +1,7 @@
 """Base entity for the Karakeep integration."""
 
 from homeassistant.const import CONF_URL
-from homeassistant.helpers.device_registry import DeviceEntryType
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
@@ -16,11 +16,11 @@ class KarakeepEntity(CoordinatorEntity[KarakeepDataUpdateCoordinator]):
     def __init__(self, coordinator: KarakeepDataUpdateCoordinator) -> None:
         """Initialize the entity."""
         super().__init__(coordinator)
-        self._attr_device_info = {
-            "identifiers": {
-                (DOMAIN, coordinator.config_entry.data[CONF_URL]),
-            },
-            "name": "Karakeep",
-            "manufacturer": "Karakeep",
-            "entry_type": DeviceEntryType.SERVICE,
-        }
+        url = coordinator.config_entry.data[CONF_URL]
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, url)},
+            name="Karakeep",
+            manufacturer="Karakeep",
+            entry_type=DeviceEntryType.SERVICE,
+            configuration_url=url,
+        )

--- a/homeassistant/components/karakeep/entity.py
+++ b/homeassistant/components/karakeep/entity.py
@@ -23,5 +23,5 @@ class KarakeepEntity(CoordinatorEntity[KarakeepDataUpdateCoordinator]):
             manufacturer="Karakeep",
             entry_type=DeviceEntryType.SERVICE,
             configuration_url=url,
-            sw_version=coordinator.data.version,
+            sw_version=coordinator.version,
         )

--- a/homeassistant/components/karakeep/entity.py
+++ b/homeassistant/components/karakeep/entity.py
@@ -19,7 +19,6 @@ class KarakeepEntity(CoordinatorEntity[KarakeepDataUpdateCoordinator]):
         url = coordinator.config_entry.data[CONF_URL]
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, coordinator.config_entry.entry_id)},
-            name="Karakeep",
             manufacturer="Karakeep",
             entry_type=DeviceEntryType.SERVICE,
             configuration_url=url,

--- a/homeassistant/components/karakeep/entity.py
+++ b/homeassistant/components/karakeep/entity.py
@@ -23,4 +23,5 @@ class KarakeepEntity(CoordinatorEntity[KarakeepDataUpdateCoordinator]):
             manufacturer="Karakeep",
             entry_type=DeviceEntryType.SERVICE,
             configuration_url=url,
+            sw_version=coordinator.data.version,
         )

--- a/homeassistant/components/karakeep/icons.json
+++ b/homeassistant/components/karakeep/icons.json
@@ -1,14 +1,14 @@
 {
   "entity": {
     "sensor": {
+      "archived": {
+        "default": "mdi:archive"
+      },
       "bookmarks": {
         "default": "mdi:bookmark"
       },
       "favorites": {
         "default": "mdi:star"
-      },
-      "archived": {
-        "default": "mdi:archive"
       },
       "highlights": {
         "default": "mdi:marker"

--- a/homeassistant/components/karakeep/icons.json
+++ b/homeassistant/components/karakeep/icons.json
@@ -1,0 +1,24 @@
+{
+  "entity": {
+    "sensor": {
+      "bookmarks": {
+        "default": "mdi:bookmark"
+      },
+      "favorites": {
+        "default": "mdi:star"
+      },
+      "archived": {
+        "default": "mdi:archive"
+      },
+      "highlights": {
+        "default": "mdi:marker"
+      },
+      "lists": {
+        "default": "mdi:format-list-bulleted"
+      },
+      "tags": {
+        "default": "mdi:tag"
+      }
+    }
+  }
+}

--- a/homeassistant/components/karakeep/manifest.json
+++ b/homeassistant/components/karakeep/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "service",
   "iot_class": "local_polling",
   "quality_scale": "bronze",
-  "requirements": ["aiokarakeep==0.1.0"]
+  "requirements": ["aiokarakeep==0.2.0"]
 }

--- a/homeassistant/components/karakeep/manifest.json
+++ b/homeassistant/components/karakeep/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "karakeep",
+  "name": "Karakeep",
+  "codeowners": ["@sli-cka"],
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/karakeep",
+  "integration_type": "service",
+  "iot_class": "local_polling",
+  "requirements": ["aiokarakeep==0.1.0"]
+}

--- a/homeassistant/components/karakeep/manifest.json
+++ b/homeassistant/components/karakeep/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "service",
   "iot_class": "local_polling",
   "quality_scale": "silver",
-  "requirements": ["aiokarakeep==0.2.0"]
+  "requirements": ["aiokarakeep==0.3.0"]
 }

--- a/homeassistant/components/karakeep/manifest.json
+++ b/homeassistant/components/karakeep/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://www.home-assistant.io/integrations/karakeep",
   "integration_type": "service",
   "iot_class": "local_polling",
-  "quality_scale": "bronze",
+  "quality_scale": "silver",
   "requirements": ["aiokarakeep==0.2.0"]
 }

--- a/homeassistant/components/karakeep/manifest.json
+++ b/homeassistant/components/karakeep/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://www.home-assistant.io/integrations/karakeep",
   "integration_type": "service",
   "iot_class": "local_polling",
-  "quality_scale": "silver",
+  "quality_scale": "bronze",
   "requirements": ["aiokarakeep==0.3.0"]
 }

--- a/homeassistant/components/karakeep/manifest.json
+++ b/homeassistant/components/karakeep/manifest.json
@@ -6,5 +6,6 @@
   "documentation": "https://www.home-assistant.io/integrations/karakeep",
   "integration_type": "service",
   "iot_class": "local_polling",
+  "quality_scale": "bronze",
   "requirements": ["aiokarakeep==0.1.0"]
 }

--- a/homeassistant/components/karakeep/quality_scale.yaml
+++ b/homeassistant/components/karakeep/quality_scale.yaml
@@ -38,7 +38,7 @@ rules:
   integration-owner: done
   log-when-unavailable: done
   parallel-updates: done
-  reauthentication-flow: done
+  reauthentication-flow: todo
   test-coverage: done
 
   # Gold

--- a/homeassistant/components/karakeep/quality_scale.yaml
+++ b/homeassistant/components/karakeep/quality_scale.yaml
@@ -12,9 +12,15 @@ rules:
   docs-actions:
     status: exempt
     comment: This integration does not have custom service actions.
+  docs-conditions:
+    status: exempt
+    comment: This integration does not have any conditions.
   docs-high-level-description: done
   docs-installation-instructions: done
   docs-removal-instructions: done
+  docs-triggers:
+    status: exempt
+    comment: This integration does not have any triggers.
   entity-event-setup:
     status: exempt
     comment: Entities do not subscribe to external events.

--- a/homeassistant/components/karakeep/quality_scale.yaml
+++ b/homeassistant/components/karakeep/quality_scale.yaml
@@ -6,7 +6,7 @@ rules:
   appropriate-polling: done
   brands: todo
   common-modules: done
-  config-flow-test-coverage: todo
+  config-flow-test-coverage: done
   config-flow: done
   dependency-transparency: done
   docs-actions:

--- a/homeassistant/components/karakeep/quality_scale.yaml
+++ b/homeassistant/components/karakeep/quality_scale.yaml
@@ -4,7 +4,7 @@ rules:
     status: exempt
     comment: This integration does not have custom service actions.
   appropriate-polling: done
-  brands: todo
+  brands: done
   common-modules: done
   config-flow-test-coverage: done
   config-flow: done
@@ -12,9 +12,9 @@ rules:
   docs-actions:
     status: exempt
     comment: This integration does not have custom service actions.
-  docs-high-level-description: todo
-  docs-installation-instructions: todo
-  docs-removal-instructions: todo
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
   entity-event-setup:
     status: exempt
     comment: Entities do not subscribe to external events.
@@ -38,7 +38,7 @@ rules:
   integration-owner: done
   log-when-unavailable: todo
   parallel-updates: todo
-  reauthentication-flow: todo
+  reauthentication-flow: done
   test-coverage: todo
 
   # Gold

--- a/homeassistant/components/karakeep/quality_scale.yaml
+++ b/homeassistant/components/karakeep/quality_scale.yaml
@@ -1,0 +1,78 @@
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: This integration does not have custom service actions.
+  appropriate-polling: done
+  brands: todo
+  common-modules: done
+  config-flow-test-coverage: todo
+  config-flow: done
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: This integration does not have custom service actions.
+  docs-high-level-description: todo
+  docs-installation-instructions: todo
+  docs-removal-instructions: todo
+  entity-event-setup:
+    status: exempt
+    comment: Entities do not subscribe to external events.
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions:
+    status: exempt
+    comment: This integration does not have custom service actions.
+  config-entry-unloading: done
+  docs-configuration-parameters:
+    status: exempt
+    comment: This integration has no options flow.
+  docs-installation-parameters: todo
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: todo
+  parallel-updates: todo
+  reauthentication-flow: todo
+  test-coverage: todo
+
+  # Gold
+  devices: done
+  diagnostics: todo
+  discovery-update-info:
+    status: exempt
+    comment: This integration does not use discovery.
+  discovery: todo
+  docs-data-update: todo
+  docs-examples: todo
+  docs-known-limitations: todo
+  docs-supported-devices: todo
+  docs-supported-functions: todo
+  docs-troubleshooting: todo
+  docs-use-cases: todo
+  dynamic-devices:
+    status: exempt
+    comment: Karakeep exposes one service device per config entry.
+  entity-category: todo
+  entity-device-class: todo
+  entity-disabled-by-default: todo
+  entity-translations: done
+  exception-translations:
+    status: exempt
+    comment: This integration does not raise translatable Home Assistant exceptions.
+  icon-translations: todo
+  reconfiguration-flow: todo
+  repair-issues: todo
+  stale-devices:
+    status: exempt
+    comment: Karakeep exposes one service device per config entry.
+
+  # Platinum
+  async-dependency: done
+  inject-websession: done
+  strict-typing: todo

--- a/homeassistant/components/karakeep/quality_scale.yaml
+++ b/homeassistant/components/karakeep/quality_scale.yaml
@@ -33,13 +33,13 @@ rules:
   docs-configuration-parameters:
     status: exempt
     comment: This integration has no options flow.
-  docs-installation-parameters: todo
+  docs-installation-parameters: done
   entity-unavailable: done
   integration-owner: done
-  log-when-unavailable: todo
+  log-when-unavailable: done
   parallel-updates: done
   reauthentication-flow: done
-  test-coverage: todo
+  test-coverage: done
 
   # Gold
   devices: done

--- a/homeassistant/components/karakeep/quality_scale.yaml
+++ b/homeassistant/components/karakeep/quality_scale.yaml
@@ -37,7 +37,7 @@ rules:
   entity-unavailable: done
   integration-owner: done
   log-when-unavailable: todo
-  parallel-updates: todo
+  parallel-updates: done
   reauthentication-flow: done
   test-coverage: todo
 
@@ -65,7 +65,7 @@ rules:
   exception-translations:
     status: exempt
     comment: This integration does not raise translatable Home Assistant exceptions.
-  icon-translations: todo
+  icon-translations: done
   reconfiguration-flow: todo
   repair-issues: todo
   stale-devices:

--- a/homeassistant/components/karakeep/sensor.py
+++ b/homeassistant/components/karakeep/sensor.py
@@ -1,70 +1,67 @@
 """Sensor platform for Karakeep."""
 
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+
+from aiokarakeep import KarakeepStats
 
 from homeassistant.components.sensor import (
     SensorEntity,
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import KarakeepConfigEntry
+from .coordinator import KarakeepConfigEntry
 from .entity import KarakeepEntity
+
+PARALLEL_UPDATES = 0
 
 
 @dataclass(frozen=True, kw_only=True)
 class KarakeepSensorEntityDescription(SensorEntityDescription):
     """Describes a Karakeep sensor."""
 
-    value_key: str
+    value_fn: Callable[[KarakeepStats], int]
 
 
 SENSOR_DESCRIPTIONS: tuple[KarakeepSensorEntityDescription, ...] = (
     KarakeepSensorEntityDescription(
         key="bookmarks",
         translation_key="bookmarks",
-        icon="mdi:bookmark",
         state_class=SensorStateClass.MEASUREMENT,
-        value_key="numBookmarks",
+        value_fn=lambda stats: stats.num_bookmarks,
     ),
     KarakeepSensorEntityDescription(
         key="favorites",
         translation_key="favorites",
-        icon="mdi:star",
         state_class=SensorStateClass.MEASUREMENT,
-        value_key="numFavorites",
+        value_fn=lambda stats: stats.num_favorites,
     ),
     KarakeepSensorEntityDescription(
         key="archived",
         translation_key="archived",
-        icon="mdi:archive",
         state_class=SensorStateClass.MEASUREMENT,
-        value_key="numArchived",
+        value_fn=lambda stats: stats.num_archived,
     ),
     KarakeepSensorEntityDescription(
         key="highlights",
         translation_key="highlights",
-        icon="mdi:marker",
         state_class=SensorStateClass.MEASUREMENT,
-        value_key="numHighlights",
+        value_fn=lambda stats: stats.num_highlights,
     ),
     KarakeepSensorEntityDescription(
         key="lists",
         translation_key="lists",
-        icon="mdi:format-list-bulleted",
         state_class=SensorStateClass.MEASUREMENT,
-        value_key="numLists",
+        value_fn=lambda stats: stats.num_lists,
     ),
     KarakeepSensorEntityDescription(
         key="tags",
         translation_key="tags",
-        icon="mdi:tag",
         state_class=SensorStateClass.MEASUREMENT,
-        value_key="numTags",
+        value_fn=lambda stats: stats.num_tags,
     ),
 )
 
@@ -93,10 +90,9 @@ class KarakeepStatSensor(KarakeepEntity, SensorEntity):
         """Initialize the sensor."""
         super().__init__(entry.runtime_data)
         self.entity_description = entity_description
-        self._attr_unique_id = f"{entry.data[CONF_URL]}_{entity_description.key}"
+        self._attr_unique_id = f"{entry.entry_id}_{entity_description.key}"
 
     @property
-    def native_value(self) -> int | None:
+    def native_value(self) -> int:
         """Return the state of the sensor."""
-        value: Any = self.coordinator.data.get(self.entity_description.value_key)
-        return value if isinstance(value, int) else None
+        return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/karakeep/sensor.py
+++ b/homeassistant/components/karakeep/sensor.py
@@ -95,4 +95,4 @@ class KarakeepStatSensor(KarakeepEntity, SensorEntity):
     @property
     def native_value(self) -> int:
         """Return the state of the sensor."""
-        return self.entity_description.value_fn(self.coordinator.data)
+        return self.entity_description.value_fn(self.coordinator.data.stats)

--- a/homeassistant/components/karakeep/sensor.py
+++ b/homeassistant/components/karakeep/sensor.py
@@ -1,0 +1,108 @@
+"""Sensor platform for Karakeep."""
+
+from dataclasses import dataclass
+from typing import Any
+
+from homeassistant.components.sensor import (
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.const import CONF_URL
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import KarakeepConfigEntry
+from .entity import KarakeepEntity
+
+
+@dataclass(frozen=True, kw_only=True)
+class KarakeepSensorEntityDescription(SensorEntityDescription):
+    """Describes a Karakeep sensor."""
+
+    value_key: str
+
+
+SENSOR_DESCRIPTIONS: tuple[KarakeepSensorEntityDescription, ...] = (
+    KarakeepSensorEntityDescription(
+        key="bookmarks",
+        translation_key="bookmarks",
+        icon="mdi:bookmark",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement="bookmarks",
+        value_key="numBookmarks",
+    ),
+    KarakeepSensorEntityDescription(
+        key="favorites",
+        translation_key="favorites",
+        icon="mdi:star",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement="favorites",
+        value_key="numFavorites",
+    ),
+    KarakeepSensorEntityDescription(
+        key="archived",
+        translation_key="archived",
+        icon="mdi:archive",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement="items",
+        value_key="numArchived",
+    ),
+    KarakeepSensorEntityDescription(
+        key="highlights",
+        translation_key="highlights",
+        icon="mdi:marker",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement="highlights",
+        value_key="numHighlights",
+    ),
+    KarakeepSensorEntityDescription(
+        key="lists",
+        translation_key="lists",
+        icon="mdi:format-list-bulleted",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement="lists",
+        value_key="numLists",
+    ),
+    KarakeepSensorEntityDescription(
+        key="tags",
+        translation_key="tags",
+        icon="mdi:tag",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement="tags",
+        value_key="numTags",
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: KarakeepConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Karakeep sensors based on a config entry."""
+    async_add_entities(
+        KarakeepStatSensor(entry, description) for description in SENSOR_DESCRIPTIONS
+    )
+
+
+class KarakeepStatSensor(KarakeepEntity, SensorEntity):
+    """Representation of a Karakeep statistic as a sensor entity."""
+
+    entity_description: KarakeepSensorEntityDescription
+
+    def __init__(
+        self,
+        entry: KarakeepConfigEntry,
+        entity_description: KarakeepSensorEntityDescription,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(entry.runtime_data)
+        self.entity_description = entity_description
+        self._attr_unique_id = f"{entry.data[CONF_URL]}_{entity_description.key}"
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the state of the sensor."""
+        value: Any = self.coordinator.data.get(self.entity_description.value_key)
+        return value if isinstance(value, int) else None

--- a/homeassistant/components/karakeep/sensor.py
+++ b/homeassistant/components/karakeep/sensor.py
@@ -95,4 +95,4 @@ class KarakeepStatSensor(KarakeepEntity, SensorEntity):
     @property
     def native_value(self) -> int:
         """Return the state of the sensor."""
-        return self.entity_description.value_fn(self.coordinator.data.stats)
+        return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/karakeep/sensor.py
+++ b/homeassistant/components/karakeep/sensor.py
@@ -10,7 +10,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import KarakeepConfigEntry
 from .entity import KarakeepEntity
@@ -29,7 +29,6 @@ SENSOR_DESCRIPTIONS: tuple[KarakeepSensorEntityDescription, ...] = (
         translation_key="bookmarks",
         icon="mdi:bookmark",
         state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement="bookmarks",
         value_key="numBookmarks",
     ),
     KarakeepSensorEntityDescription(
@@ -37,7 +36,6 @@ SENSOR_DESCRIPTIONS: tuple[KarakeepSensorEntityDescription, ...] = (
         translation_key="favorites",
         icon="mdi:star",
         state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement="favorites",
         value_key="numFavorites",
     ),
     KarakeepSensorEntityDescription(
@@ -45,7 +43,6 @@ SENSOR_DESCRIPTIONS: tuple[KarakeepSensorEntityDescription, ...] = (
         translation_key="archived",
         icon="mdi:archive",
         state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement="items",
         value_key="numArchived",
     ),
     KarakeepSensorEntityDescription(
@@ -53,7 +50,6 @@ SENSOR_DESCRIPTIONS: tuple[KarakeepSensorEntityDescription, ...] = (
         translation_key="highlights",
         icon="mdi:marker",
         state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement="highlights",
         value_key="numHighlights",
     ),
     KarakeepSensorEntityDescription(
@@ -61,7 +57,6 @@ SENSOR_DESCRIPTIONS: tuple[KarakeepSensorEntityDescription, ...] = (
         translation_key="lists",
         icon="mdi:format-list-bulleted",
         state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement="lists",
         value_key="numLists",
     ),
     KarakeepSensorEntityDescription(
@@ -69,7 +64,6 @@ SENSOR_DESCRIPTIONS: tuple[KarakeepSensorEntityDescription, ...] = (
         translation_key="tags",
         icon="mdi:tag",
         state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement="tags",
         value_key="numTags",
     ),
 )
@@ -78,7 +72,7 @@ SENSOR_DESCRIPTIONS: tuple[KarakeepSensorEntityDescription, ...] = (
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: KarakeepConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Karakeep sensors based on a config entry."""
     async_add_entities(

--- a/homeassistant/components/karakeep/sensor.py
+++ b/homeassistant/components/karakeep/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from aiokarakeep import KarakeepStats
 
@@ -93,6 +94,7 @@ class KarakeepStatSensor(KarakeepEntity, SensorEntity):
         self._attr_unique_id = f"{entry.entry_id}_{entity_description.key}"
 
     @property
+    @override
     def native_value(self) -> int:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/karakeep/strings.json
+++ b/homeassistant/components/karakeep/strings.json
@@ -1,8 +1,7 @@
 {
   "config": {
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]",
-      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]"
     },
     "error": {
       "api_error": "The Karakeep API returned an unexpected response.",
@@ -12,15 +11,6 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
-      "reauth_confirm": {
-        "data": {
-          "token": "API token"
-        },
-        "data_description": {
-          "token": "The API token used to connect to your Karakeep instance."
-        },
-        "description": "Enter a new API token for your Karakeep instance."
-      },
       "user": {
         "data": {
           "token": "API token",

--- a/homeassistant/components/karakeep/strings.json
+++ b/homeassistant/components/karakeep/strings.json
@@ -20,7 +20,7 @@
         "data_description": {
           "token": "The API token used to connect to your Karakeep instance.",
           "url": "The URL of your Karakeep instance, including http:// or https://.",
-          "verify_ssl": "Verify the SSL certificate of your Karakeep instance. Disable this option if you are using a self-signed certificate."
+          "verify_ssl": "Should SSL certificates be verified? This should be off for self-signed certificates."
         },
         "description": "Connect to your Karakeep instance."
       }

--- a/homeassistant/components/karakeep/strings.json
+++ b/homeassistant/components/karakeep/strings.json
@@ -23,11 +23,13 @@
       "user": {
         "data": {
           "token": "API token",
-          "url": "URL"
+          "url": "URL",
+          "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
         },
         "data_description": {
           "token": "The API token used to connect to your Karakeep instance.",
-          "url": "The URL of your Karakeep instance, including http:// or https://."
+          "url": "The URL of your Karakeep instance, including http:// or https://.",
+          "verify_ssl": "Verify the SSL certificate of your Karakeep instance. Disable this option if you are using a self-signed certificate."
         },
         "description": "Connect to your Karakeep instance."
       }

--- a/homeassistant/components/karakeep/strings.json
+++ b/homeassistant/components/karakeep/strings.json
@@ -1,0 +1,44 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]"
+    },
+    "error": {
+      "api_error": "The Karakeep API returned an unexpected response.",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "invalid_url_format": "Enter a valid URL including http:// or https://."
+    },
+    "step": {
+      "user": {
+        "data": {
+          "token": "API token",
+          "url": "URL"
+        },
+        "description": "Connect to your Karakeep instance."
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "archived": {
+        "name": "Archived"
+      },
+      "bookmarks": {
+        "name": "Bookmarks"
+      },
+      "favorites": {
+        "name": "Favorites"
+      },
+      "highlights": {
+        "name": "Highlights"
+      },
+      "lists": {
+        "name": "Lists"
+      },
+      "tags": {
+        "name": "Tags"
+      }
+    }
+  }
+}

--- a/homeassistant/components/karakeep/strings.json
+++ b/homeassistant/components/karakeep/strings.json
@@ -36,22 +36,28 @@
   "entity": {
     "sensor": {
       "archived": {
-        "name": "Archived"
+        "name": "Archived",
+        "unit_of_measurement": "items"
       },
       "bookmarks": {
-        "name": "Bookmarks"
+        "name": "Bookmarks",
+        "unit_of_measurement": "bookmarks"
       },
       "favorites": {
-        "name": "Favorites"
+        "name": "Favorites",
+        "unit_of_measurement": "favorites"
       },
       "highlights": {
-        "name": "Highlights"
+        "name": "Highlights",
+        "unit_of_measurement": "highlights"
       },
       "lists": {
-        "name": "Lists"
+        "name": "Lists",
+        "unit_of_measurement": "lists"
       },
       "tags": {
-        "name": "Tags"
+        "name": "Tags",
+        "unit_of_measurement": "tags"
       }
     }
   }

--- a/homeassistant/components/karakeep/strings.json
+++ b/homeassistant/components/karakeep/strings.json
@@ -8,7 +8,8 @@
       "api_error": "The Karakeep API returned an unexpected response.",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "invalid_url_format": "Enter a valid URL including http:// or https://."
+      "invalid_url_format": "Enter a valid URL including http:// or https://.",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
       "reauth_confirm": {

--- a/homeassistant/components/karakeep/strings.json
+++ b/homeassistant/components/karakeep/strings.json
@@ -1,7 +1,8 @@
 {
   "config": {
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     },
     "error": {
       "api_error": "The Karakeep API returned an unexpected response.",
@@ -10,10 +11,23 @@
       "invalid_url_format": "Enter a valid URL including http:// or https://."
     },
     "step": {
+      "reauth_confirm": {
+        "data": {
+          "token": "API token"
+        },
+        "data_description": {
+          "token": "The API token used to connect to your Karakeep instance."
+        },
+        "description": "Enter a new API token for your Karakeep instance."
+      },
       "user": {
         "data": {
           "token": "API token",
           "url": "URL"
+        },
+        "data_description": {
+          "token": "The API token used to connect to your Karakeep instance.",
+          "url": "The URL of your Karakeep instance, including http:// or https://."
         },
         "description": "Connect to your Karakeep instance."
       }

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -388,6 +388,7 @@ FLOWS = {
         "justnimbus",
         "jvc_projector",
         "kaleidescape",
+        "karakeep",
         "keenetic_ndms2",
         "kegtron",
         "keymitt_ble",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -3494,6 +3494,12 @@
       "config_flow": false,
       "iot_class": "local_polling"
     },
+    "karakeep": {
+      "name": "Karakeep",
+      "integration_type": "service",
+      "config_flow": true,
+      "iot_class": "local_polling"
+    },
     "keba": {
       "name": "Keba Charging Station",
       "integration_type": "hub",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -305,6 +305,9 @@ aioimaplib==2.0.1
 # homeassistant.components.immich
 aioimmich==0.16.1
 
+# homeassistant.components.karakeep
+aiokarakeep==0.1.0
+
 # homeassistant.components.apache_kafka
 aiokafka==0.10.0
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -305,11 +305,11 @@ aioimaplib==2.0.1
 # homeassistant.components.immich
 aioimmich==0.16.1
 
-# homeassistant.components.karakeep
-aiokarakeep==0.1.0
-
 # homeassistant.components.apache_kafka
 aiokafka==0.10.0
+
+# homeassistant.components.karakeep
+aiokarakeep==0.3.0
 
 # homeassistant.components.kef
 aiokef==0.2.16

--- a/tests/components/karakeep/__init__.py
+++ b/tests/components/karakeep/__init__.py
@@ -1,0 +1,13 @@
+"""Tests for the Karakeep integration."""
+
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def setup_integration(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
+    """Set up the Karakeep integration."""
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()

--- a/tests/components/karakeep/conftest.py
+++ b/tests/components/karakeep/conftest.py
@@ -53,4 +53,5 @@ def mock_config_entry() -> MockConfigEntry:
             CONF_TOKEN: TEST_TOKEN,
             CONF_VERIFY_SSL: False,
         },
+        entry_id="01KVCW3ET6GZ025S7ARE8D5M8W",
     )

--- a/tests/components/karakeep/conftest.py
+++ b/tests/components/karakeep/conftest.py
@@ -1,0 +1,55 @@
+"""Karakeep tests configuration."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant.components.karakeep.const import DOMAIN
+from homeassistant.const import CONF_TOKEN, CONF_URL
+
+from .const import TEST_STATS, TEST_TOKEN, TEST_URL
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.karakeep.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        yield mock_setup_entry
+
+
+@pytest.fixture
+def mock_karakeep_client() -> Generator[AsyncMock]:
+    """Mock a Karakeep client."""
+    with (
+        patch(
+            "homeassistant.components.karakeep.KarakeepClient",
+            autospec=True,
+        ) as mock_client,
+        patch(
+            "homeassistant.components.karakeep.config_flow.KarakeepClient",
+            new=mock_client,
+        ),
+    ):
+        client = mock_client.return_value
+        client.async_get_stats.return_value = TEST_STATS
+        yield client
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Mock a config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="Karakeep",
+        data={
+            CONF_URL: TEST_URL,
+            CONF_TOKEN: TEST_TOKEN,
+        },
+        unique_id=TEST_URL,
+    )

--- a/tests/components/karakeep/conftest.py
+++ b/tests/components/karakeep/conftest.py
@@ -8,7 +8,7 @@ import pytest
 from homeassistant.components.karakeep.const import DOMAIN
 from homeassistant.const import CONF_TOKEN, CONF_URL, CONF_VERIFY_SSL
 
-from .const import TEST_STATS, TEST_TOKEN, TEST_URL
+from .const import TEST_STATS, TEST_TOKEN, TEST_URL, TEST_VERSION
 
 from tests.common import MockConfigEntry
 
@@ -38,6 +38,7 @@ def mock_karakeep_client() -> Generator[AsyncMock]:
     ):
         client = mock_client.return_value
         client.async_get_stats.return_value = TEST_STATS
+        client.async_get_version.return_value = TEST_VERSION
         yield client
 
 

--- a/tests/components/karakeep/conftest.py
+++ b/tests/components/karakeep/conftest.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from homeassistant.components.karakeep.const import DOMAIN
-from homeassistant.const import CONF_TOKEN, CONF_URL
+from homeassistant.const import CONF_TOKEN, CONF_URL, CONF_VERIFY_SSL
 
 from .const import TEST_STATS, TEST_TOKEN, TEST_URL
 
@@ -50,6 +50,7 @@ def mock_config_entry() -> MockConfigEntry:
         data={
             CONF_URL: TEST_URL,
             CONF_TOKEN: TEST_TOKEN,
+            CONF_VERIFY_SSL: False,
         },
         unique_id=TEST_URL,
     )

--- a/tests/components/karakeep/conftest.py
+++ b/tests/components/karakeep/conftest.py
@@ -51,7 +51,7 @@ def mock_config_entry() -> MockConfigEntry:
         data={
             CONF_URL: TEST_URL,
             CONF_TOKEN: TEST_TOKEN,
-            CONF_VERIFY_SSL: False,
+            CONF_VERIFY_SSL: True,
         },
         entry_id="01KVCW3ET6GZ025S7ARE8D5M8W",
     )

--- a/tests/components/karakeep/conftest.py
+++ b/tests/components/karakeep/conftest.py
@@ -52,5 +52,4 @@ def mock_config_entry() -> MockConfigEntry:
             CONF_TOKEN: TEST_TOKEN,
             CONF_VERIFY_SSL: False,
         },
-        unique_id=TEST_URL,
     )

--- a/tests/components/karakeep/const.py
+++ b/tests/components/karakeep/const.py
@@ -1,13 +1,15 @@
 """Constants for Karakeep tests."""
 
-TEST_STATS = {
-    "numBookmarks": 10,
-    "numFavorites": 2,
-    "numArchived": 3,
-    "numHighlights": 4,
-    "numLists": 5,
-    "numTags": 6,
-}
+from aiokarakeep import KarakeepStats
+
+TEST_STATS = KarakeepStats(
+    num_bookmarks=10,
+    num_favorites=2,
+    num_archived=3,
+    num_highlights=4,
+    num_lists=5,
+    num_tags=6,
+)
 
 TEST_TOKEN = "test-token"
 TEST_URL = "https://karakeep.example.com"

--- a/tests/components/karakeep/const.py
+++ b/tests/components/karakeep/const.py
@@ -1,0 +1,13 @@
+"""Constants for Karakeep tests."""
+
+TEST_STATS = {
+    "numBookmarks": 10,
+    "numFavorites": 2,
+    "numArchived": 3,
+    "numHighlights": 4,
+    "numLists": 5,
+    "numTags": 6,
+}
+
+TEST_TOKEN = "test-token"
+TEST_URL = "https://karakeep.example.com"

--- a/tests/components/karakeep/const.py
+++ b/tests/components/karakeep/const.py
@@ -11,5 +11,6 @@ TEST_STATS = KarakeepStats(
     num_tags=6,
 )
 
+TEST_VERSION = "0.32.0"
 TEST_TOKEN = "test-token"
 TEST_URL = "https://karakeep.example.com"

--- a/tests/components/karakeep/snapshots/test_sensor.ambr
+++ b/tests/components/karakeep/snapshots/test_sensor.ambr
@@ -1,0 +1,325 @@
+# serializer version: 1
+# name: test_sensors[sensor.karakeep_archived-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.karakeep_archived',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Archived',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Archived',
+    'platform': 'karakeep',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'archived',
+    'unique_id': '01KVCW3ET6GZ025S7ARE8D5M8W_archived',
+    'unit_of_measurement': 'items',
+  })
+# ---
+# name: test_sensors[sensor.karakeep_archived-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Karakeep Archived',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'items',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.karakeep_archived',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '3',
+  })
+# ---
+# name: test_sensors[sensor.karakeep_bookmarks-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.karakeep_bookmarks',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Bookmarks',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Bookmarks',
+    'platform': 'karakeep',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'bookmarks',
+    'unique_id': '01KVCW3ET6GZ025S7ARE8D5M8W_bookmarks',
+    'unit_of_measurement': 'bookmarks',
+  })
+# ---
+# name: test_sensors[sensor.karakeep_bookmarks-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Karakeep Bookmarks',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'bookmarks',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.karakeep_bookmarks',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '10',
+  })
+# ---
+# name: test_sensors[sensor.karakeep_favorites-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.karakeep_favorites',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Favorites',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Favorites',
+    'platform': 'karakeep',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'favorites',
+    'unique_id': '01KVCW3ET6GZ025S7ARE8D5M8W_favorites',
+    'unit_of_measurement': 'favorites',
+  })
+# ---
+# name: test_sensors[sensor.karakeep_favorites-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Karakeep Favorites',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'favorites',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.karakeep_favorites',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2',
+  })
+# ---
+# name: test_sensors[sensor.karakeep_highlights-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.karakeep_highlights',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Highlights',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Highlights',
+    'platform': 'karakeep',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'highlights',
+    'unique_id': '01KVCW3ET6GZ025S7ARE8D5M8W_highlights',
+    'unit_of_measurement': 'highlights',
+  })
+# ---
+# name: test_sensors[sensor.karakeep_highlights-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Karakeep Highlights',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'highlights',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.karakeep_highlights',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '4',
+  })
+# ---
+# name: test_sensors[sensor.karakeep_lists-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.karakeep_lists',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Lists',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Lists',
+    'platform': 'karakeep',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'lists',
+    'unique_id': '01KVCW3ET6GZ025S7ARE8D5M8W_lists',
+    'unit_of_measurement': 'lists',
+  })
+# ---
+# name: test_sensors[sensor.karakeep_lists-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Karakeep Lists',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'lists',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.karakeep_lists',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '5',
+  })
+# ---
+# name: test_sensors[sensor.karakeep_tags-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.karakeep_tags',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Tags',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Tags',
+    'platform': 'karakeep',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'tags',
+    'unique_id': '01KVCW3ET6GZ025S7ARE8D5M8W_tags',
+    'unit_of_measurement': 'tags',
+  })
+# ---
+# name: test_sensors[sensor.karakeep_tags-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Karakeep Tags',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'tags',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.karakeep_tags',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '6',
+  })
+# ---

--- a/tests/components/karakeep/snapshots/test_sensor.ambr
+++ b/tests/components/karakeep/snapshots/test_sensor.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -41,9 +41,9 @@
 # name: test_sensors[sensor.karakeep_archived-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Karakeep Archived',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'items',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Karakeep Archived',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'items',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.karakeep_archived',
@@ -60,7 +60,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -95,9 +95,9 @@
 # name: test_sensors[sensor.karakeep_bookmarks-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Karakeep Bookmarks',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'bookmarks',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Karakeep Bookmarks',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'bookmarks',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.karakeep_bookmarks',
@@ -114,7 +114,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -149,9 +149,9 @@
 # name: test_sensors[sensor.karakeep_favorites-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Karakeep Favorites',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'favorites',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Karakeep Favorites',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'favorites',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.karakeep_favorites',
@@ -168,7 +168,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -203,9 +203,9 @@
 # name: test_sensors[sensor.karakeep_highlights-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Karakeep Highlights',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'highlights',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Karakeep Highlights',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'highlights',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.karakeep_highlights',
@@ -222,7 +222,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -257,9 +257,9 @@
 # name: test_sensors[sensor.karakeep_lists-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Karakeep Lists',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'lists',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Karakeep Lists',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'lists',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.karakeep_lists',
@@ -276,7 +276,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -311,9 +311,9 @@
 # name: test_sensors[sensor.karakeep_tags-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Karakeep Tags',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'tags',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Karakeep Tags',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'tags',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.karakeep_tags',

--- a/tests/components/karakeep/test_config_flow.py
+++ b/tests/components/karakeep/test_config_flow.py
@@ -7,7 +7,7 @@ import pytest
 
 from homeassistant.components.karakeep.const import DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
-from homeassistant.const import CONF_TOKEN, CONF_URL
+from homeassistant.const import CONF_TOKEN, CONF_URL, CONF_VERIFY_SSL
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -32,6 +32,7 @@ async def test_full_flow(hass: HomeAssistant, mock_karakeep_client: AsyncMock) -
         {
             CONF_URL: f"{TEST_URL}/",
             CONF_TOKEN: f" {TEST_TOKEN} ",
+            CONF_VERIFY_SSL: False,
         },
     )
     await hass.async_block_till_done()
@@ -41,6 +42,7 @@ async def test_full_flow(hass: HomeAssistant, mock_karakeep_client: AsyncMock) -
     assert result["data"] == {
         CONF_URL: TEST_URL,
         CONF_TOKEN: TEST_TOKEN,
+        CONF_VERIFY_SSL: False,
     }
     assert result["result"].unique_id == TEST_URL
     mock_karakeep_client.async_get_stats.assert_awaited_once()

--- a/tests/components/karakeep/test_config_flow.py
+++ b/tests/components/karakeep/test_config_flow.py
@@ -35,7 +35,6 @@ async def test_full_flow(hass: HomeAssistant, mock_karakeep_client: AsyncMock) -
             CONF_VERIFY_SSL: False,
         },
     )
-    await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "Karakeep"
@@ -48,7 +47,7 @@ async def test_full_flow(hass: HomeAssistant, mock_karakeep_client: AsyncMock) -
     mock_karakeep_client.async_get_stats.assert_awaited_once()
 
 
-@pytest.mark.usefixtures("mock_setup_entry")
+@pytest.mark.usefixtures("mock_setup_entry", "mock_karakeep_client")
 async def test_invalid_url(hass: HomeAssistant) -> None:
     """Test invalid URL errors."""
     result = await hass.config_entries.flow.async_init(
@@ -66,6 +65,21 @@ async def test_invalid_url(hass: HomeAssistant) -> None:
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "invalid_url_format"}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_URL: TEST_URL,
+            CONF_TOKEN: TEST_TOKEN,
+        },
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == {
+        CONF_URL: TEST_URL,
+        CONF_TOKEN: TEST_TOKEN,
+        CONF_VERIFY_SSL: False,
+    }
 
 
 @pytest.mark.parametrize(
@@ -112,7 +126,6 @@ async def test_flow_errors(
             CONF_TOKEN: TEST_TOKEN,
         },
     )
-    await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"] == {

--- a/tests/components/karakeep/test_config_flow.py
+++ b/tests/components/karakeep/test_config_flow.py
@@ -78,7 +78,7 @@ async def test_invalid_url(hass: HomeAssistant) -> None:
     assert result["data"] == {
         CONF_URL: TEST_URL,
         CONF_TOKEN: TEST_TOKEN,
-        CONF_VERIFY_SSL: False,
+        CONF_VERIFY_SSL: True,
     }
 
 
@@ -131,7 +131,7 @@ async def test_flow_errors(
     assert result["data"] == {
         CONF_URL: TEST_URL,
         CONF_TOKEN: TEST_TOKEN,
-        CONF_VERIFY_SSL: False,
+        CONF_VERIFY_SSL: True,
     }
 
 

--- a/tests/components/karakeep/test_config_flow.py
+++ b/tests/components/karakeep/test_config_flow.py
@@ -1,0 +1,128 @@
+"""Tests for the Karakeep config flow."""
+
+from unittest.mock import AsyncMock
+
+from aiokarakeep import KarakeepApiError, KarakeepAuthError, KarakeepConnectionError
+import pytest
+
+from homeassistant.components.karakeep.const import DOMAIN
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_TOKEN, CONF_URL
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from .const import TEST_TOKEN, TEST_URL
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_full_flow(hass: HomeAssistant, mock_karakeep_client: AsyncMock) -> None:
+    """Test the full user flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_URL: f"{TEST_URL}/",
+            CONF_TOKEN: f" {TEST_TOKEN} ",
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Karakeep"
+    assert result["data"] == {
+        CONF_URL: TEST_URL,
+        CONF_TOKEN: TEST_TOKEN,
+    }
+    assert result["result"].unique_id == TEST_URL
+    mock_karakeep_client.async_get_stats.assert_awaited_once()
+
+
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_invalid_url(hass: HomeAssistant) -> None:
+    """Test invalid URL errors."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_URL: "karakeep.example.com",
+            CONF_TOKEN: TEST_TOKEN,
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_url_format"}
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "error"),
+    [
+        (KarakeepAuthError("Invalid token", 401), "invalid_auth"),
+        (KarakeepConnectionError("Cannot connect"), "cannot_connect"),
+        (KarakeepApiError("API error", 500), "api_error"),
+    ],
+)
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_flow_errors(
+    hass: HomeAssistant,
+    mock_karakeep_client: AsyncMock,
+    side_effect: Exception,
+    error: str,
+) -> None:
+    """Test config flow errors."""
+    mock_karakeep_client.async_get_stats.side_effect = side_effect
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_URL: TEST_URL,
+            CONF_TOKEN: TEST_TOKEN,
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": error}
+
+
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_duplicate(
+    hass: HomeAssistant,
+    mock_karakeep_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test duplicate config flow aborts."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_URL: f"{TEST_URL}/",
+            CONF_TOKEN: TEST_TOKEN,
+        },
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    mock_karakeep_client.async_get_stats.assert_not_awaited()

--- a/tests/components/karakeep/test_config_flow.py
+++ b/tests/components/karakeep/test_config_flow.py
@@ -6,7 +6,7 @@ from aiokarakeep import KarakeepApiError, KarakeepAuthError, KarakeepConnectionE
 import pytest
 
 from homeassistant.components.karakeep.const import DOMAIN
-from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
+from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_TOKEN, CONF_URL, CONF_VERIFY_SSL
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -147,53 +147,3 @@ async def test_duplicate(
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     mock_karakeep_client.async_get_stats.assert_not_awaited()
-
-
-async def test_reauth(
-    hass: HomeAssistant,
-    mock_karakeep_client: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test reauthentication flow recovers from an error."""
-    mock_config_entry.add_to_hass(hass)
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={
-            "source": SOURCE_REAUTH,
-            "entry_id": mock_config_entry.entry_id,
-        },
-        data=mock_config_entry.data,
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reauth_confirm"
-
-    mock_karakeep_client.async_get_stats.side_effect = KarakeepAuthError(
-        "Invalid token", 401
-    )
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {
-            CONF_TOKEN: "bad-token",
-        },
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reauth_confirm"
-    assert result["errors"] == {"base": "invalid_auth"}
-
-    mock_karakeep_client.async_get_stats.side_effect = None
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {
-            CONF_TOKEN: "new-token",
-        },
-    )
-    await hass.async_block_till_done()
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "reauth_successful"
-    assert mock_config_entry.data[CONF_TOKEN] == "new-token"

--- a/tests/components/karakeep/test_config_flow.py
+++ b/tests/components/karakeep/test_config_flow.py
@@ -47,8 +47,9 @@ async def test_full_flow(hass: HomeAssistant, mock_karakeep_client: AsyncMock) -
     mock_karakeep_client.async_get_stats.assert_awaited_once()
 
 
+@pytest.mark.parametrize("invalid_url", ["karakeep.example.com", "http://["])
 @pytest.mark.usefixtures("mock_setup_entry", "mock_karakeep_client")
-async def test_invalid_url(hass: HomeAssistant) -> None:
+async def test_invalid_url(hass: HomeAssistant, invalid_url: str) -> None:
     """Test invalid URL errors."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -58,7 +59,7 @@ async def test_invalid_url(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            CONF_URL: "karakeep.example.com",
+            CONF_URL: invalid_url,
             CONF_TOKEN: TEST_TOKEN,
         },
     )

--- a/tests/components/karakeep/test_config_flow.py
+++ b/tests/components/karakeep/test_config_flow.py
@@ -44,7 +44,7 @@ async def test_full_flow(hass: HomeAssistant, mock_karakeep_client: AsyncMock) -
         CONF_TOKEN: TEST_TOKEN,
         CONF_VERIFY_SSL: False,
     }
-    assert result["result"].unique_id == TEST_URL
+    assert result["result"].unique_id is None
     mock_karakeep_client.async_get_stats.assert_awaited_once()
 
 
@@ -74,6 +74,7 @@ async def test_invalid_url(hass: HomeAssistant) -> None:
         (KarakeepAuthError("Invalid token", 401), "invalid_auth"),
         (KarakeepConnectionError("Cannot connect"), "cannot_connect"),
         (KarakeepApiError("API error", 500), "api_error"),
+        (Exception("Boom"), "unknown"),
     ],
 )
 @pytest.mark.usefixtures("mock_setup_entry")
@@ -101,6 +102,24 @@ async def test_flow_errors(
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": error}
+
+    mock_karakeep_client.async_get_stats.side_effect = None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_URL: TEST_URL,
+            CONF_TOKEN: TEST_TOKEN,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == {
+        CONF_URL: TEST_URL,
+        CONF_TOKEN: TEST_TOKEN,
+        CONF_VERIFY_SSL: False,
+    }
 
 
 @pytest.mark.usefixtures("mock_setup_entry")
@@ -135,7 +154,7 @@ async def test_reauth(
     mock_karakeep_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test reauthentication flow."""
+    """Test reauthentication flow recovers from an error."""
     mock_config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
@@ -150,6 +169,23 @@ async def test_reauth(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
 
+    mock_karakeep_client.async_get_stats.side_effect = KarakeepAuthError(
+        "Invalid token", 401
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_TOKEN: "bad-token",
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+    assert result["errors"] == {"base": "invalid_auth"}
+
+    mock_karakeep_client.async_get_stats.side_effect = None
+
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
@@ -161,4 +197,3 @@ async def test_reauth(
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
     assert mock_config_entry.data[CONF_TOKEN] == "new-token"
-    assert mock_karakeep_client.async_get_stats.await_count == 2

--- a/tests/components/karakeep/test_config_flow.py
+++ b/tests/components/karakeep/test_config_flow.py
@@ -6,7 +6,7 @@ from aiokarakeep import KarakeepApiError, KarakeepAuthError, KarakeepConnectionE
 import pytest
 
 from homeassistant.components.karakeep.const import DOMAIN
-from homeassistant.config_entries import SOURCE_USER
+from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
 from homeassistant.const import CONF_TOKEN, CONF_URL
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -126,3 +126,37 @@ async def test_duplicate(
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     mock_karakeep_client.async_get_stats.assert_not_awaited()
+
+
+async def test_reauth(
+    hass: HomeAssistant,
+    mock_karakeep_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reauthentication flow."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": SOURCE_REAUTH,
+            "entry_id": mock_config_entry.entry_id,
+        },
+        data=mock_config_entry.data,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_TOKEN: "new-token",
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert mock_config_entry.data[CONF_TOKEN] == "new-token"
+    assert mock_karakeep_client.async_get_stats.await_count == 2

--- a/tests/components/karakeep/test_init.py
+++ b/tests/components/karakeep/test_init.py
@@ -32,7 +32,7 @@ async def test_setup_entry(
         await setup_integration(hass, mock_config_entry)
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
-    mock_get_clientsession.assert_called_once_with(hass, False)
+    mock_get_clientsession.assert_called_once_with(hass, True)
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
     mock_karakeep_client.async_get_stats.assert_awaited_once()
 

--- a/tests/components/karakeep/test_init.py
+++ b/tests/components/karakeep/test_init.py
@@ -1,0 +1,71 @@
+"""Tests for the Karakeep integration setup."""
+
+from unittest.mock import AsyncMock
+
+from aiokarakeep import KarakeepAuthError, KarakeepConnectionError
+
+from homeassistant.components.karakeep.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry
+
+
+async def test_setup_entry(
+    hass: HomeAssistant,
+    mock_karakeep_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test setting up the integration."""
+    await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+    mock_karakeep_client.async_get_stats.assert_awaited_once()
+
+
+async def test_setup_entry_auth_failure(
+    hass: HomeAssistant,
+    mock_karakeep_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test setup fails on authentication errors."""
+    mock_karakeep_client.async_get_stats.side_effect = KarakeepAuthError(
+        "Invalid token",
+        401,
+    )
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+
+
+async def test_setup_entry_connection_failure(
+    hass: HomeAssistant,
+    mock_karakeep_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test setup retries on connection errors."""
+    mock_karakeep_client.async_get_stats.side_effect = KarakeepConnectionError(
+        "Cannot connect"
+    )
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_unload_entry(
+    hass: HomeAssistant,
+    mock_karakeep_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test unloading the integration."""
+    await setup_integration(hass, mock_config_entry)
+
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED

--- a/tests/components/karakeep/test_init.py
+++ b/tests/components/karakeep/test_init.py
@@ -2,7 +2,13 @@
 
 from unittest.mock import AsyncMock, patch
 
-from aiokarakeep import KarakeepAuthError, KarakeepConnectionError
+from aiokarakeep import (
+    KarakeepApiError,
+    KarakeepAuthError,
+    KarakeepConnectionError,
+    KarakeepInvalidResponseError,
+)
+import pytest
 
 from homeassistant.components.karakeep.const import DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
@@ -49,15 +55,22 @@ async def test_setup_entry_auth_failure(
     assert flows[0]["context"]["source"] == SOURCE_REAUTH
 
 
-async def test_setup_entry_connection_failure(
+@pytest.mark.parametrize(
+    "side_effect",
+    [
+        KarakeepConnectionError("Cannot connect"),
+        KarakeepApiError("API error", 500),
+        KarakeepInvalidResponseError("Invalid response"),
+    ],
+)
+async def test_setup_entry_update_failure(
     hass: HomeAssistant,
     mock_karakeep_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
+    side_effect: Exception,
 ) -> None:
-    """Test setup retries on connection errors."""
-    mock_karakeep_client.async_get_stats.side_effect = KarakeepConnectionError(
-        "Cannot connect"
-    )
+    """Test setup retries on update failures."""
+    mock_karakeep_client.async_get_stats.side_effect = side_effect
 
     await setup_integration(hass, mock_config_entry)
 

--- a/tests/components/karakeep/test_init.py
+++ b/tests/components/karakeep/test_init.py
@@ -6,6 +6,7 @@ from aiokarakeep import (
     KarakeepApiError,
     KarakeepAuthError,
     KarakeepConnectionError,
+    KarakeepError,
     KarakeepInvalidResponseError,
 )
 import pytest
@@ -13,6 +14,7 @@ import pytest
 from homeassistant.components.karakeep.const import DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 
 from . import setup_integration
 
@@ -75,6 +77,25 @@ async def test_setup_entry_update_failure(
     await setup_integration(hass, mock_config_entry)
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_setup_entry_version_unavailable(
+    hass: HomeAssistant,
+    mock_karakeep_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test setup succeeds without a version when the endpoint is unavailable."""
+    mock_karakeep_client.async_get_version.side_effect = KarakeepError("boom")
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, mock_config_entry.entry_id)}
+    )
+    assert device_entry is not None
+    assert device_entry.sw_version is None
 
 
 async def test_unload_entry(

--- a/tests/components/karakeep/test_init.py
+++ b/tests/components/karakeep/test_init.py
@@ -1,6 +1,6 @@
 """Tests for the Karakeep integration setup."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 from aiokarakeep import KarakeepAuthError, KarakeepConnectionError
 
@@ -19,9 +19,13 @@ async def test_setup_entry(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test setting up the integration."""
-    await setup_integration(hass, mock_config_entry)
+    with patch(
+        "homeassistant.components.karakeep.async_get_clientsession"
+    ) as mock_get_clientsession:
+        await setup_integration(hass, mock_config_entry)
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
+    mock_get_clientsession.assert_called_once_with(hass, False)
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
     mock_karakeep_client.async_get_stats.assert_awaited_once()
 

--- a/tests/components/karakeep/test_init.py
+++ b/tests/components/karakeep/test_init.py
@@ -6,7 +6,6 @@ from aiokarakeep import (
     KarakeepApiError,
     KarakeepAuthError,
     KarakeepConnectionError,
-    KarakeepError,
     KarakeepInvalidResponseError,
 )
 import pytest
@@ -68,7 +67,7 @@ async def test_setup_entry_version_unavailable(
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test setup succeeds without a version when the endpoint is unavailable."""
-    mock_karakeep_client.async_get_version.side_effect = KarakeepError("boom")
+    mock_karakeep_client.async_get_version.return_value = None
 
     await setup_integration(hass, mock_config_entry)
 

--- a/tests/components/karakeep/test_init.py
+++ b/tests/components/karakeep/test_init.py
@@ -60,6 +60,21 @@ async def test_setup_entry_update_failure(
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
+async def test_setup_entry_version_failure(
+    hass: HomeAssistant,
+    mock_karakeep_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test setup retries when the version fetch fails."""
+    mock_karakeep_client.async_get_version.side_effect = KarakeepConnectionError(
+        "Cannot connect"
+    )
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
 async def test_setup_entry_version_unavailable(
     hass: HomeAssistant,
     mock_karakeep_client: AsyncMock,

--- a/tests/components/karakeep/test_init.py
+++ b/tests/components/karakeep/test_init.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock
 from aiokarakeep import KarakeepAuthError, KarakeepConnectionError
 
 from homeassistant.components.karakeep.const import DOMAIN
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.core import HomeAssistant
 
 from . import setup_integration
@@ -40,6 +40,9 @@ async def test_setup_entry_auth_failure(
     await setup_integration(hass, mock_config_entry)
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+    flows = list(mock_config_entry.async_get_active_flows(hass, {SOURCE_REAUTH}))
+    assert len(flows) == 1
+    assert flows[0]["context"]["source"] == SOURCE_REAUTH
 
 
 async def test_setup_entry_connection_failure(

--- a/tests/components/karakeep/test_init.py
+++ b/tests/components/karakeep/test_init.py
@@ -12,7 +12,7 @@ from aiokarakeep import (
 import pytest
 
 from homeassistant.components.karakeep.const import DOMAIN
-from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
@@ -38,28 +38,10 @@ async def test_setup_entry(
     mock_karakeep_client.async_get_stats.assert_awaited_once()
 
 
-async def test_setup_entry_auth_failure(
-    hass: HomeAssistant,
-    mock_karakeep_client: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test setup fails on authentication errors."""
-    mock_karakeep_client.async_get_stats.side_effect = KarakeepAuthError(
-        "Invalid token",
-        401,
-    )
-
-    await setup_integration(hass, mock_config_entry)
-
-    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
-    flows = list(mock_config_entry.async_get_active_flows(hass, {SOURCE_REAUTH}))
-    assert len(flows) == 1
-    assert flows[0]["context"]["source"] == SOURCE_REAUTH
-
-
 @pytest.mark.parametrize(
     "side_effect",
     [
+        KarakeepAuthError("Invalid token", 401),
         KarakeepConnectionError("Cannot connect"),
         KarakeepApiError("API error", 500),
         KarakeepInvalidResponseError("Invalid response"),

--- a/tests/components/karakeep/test_sensor.py
+++ b/tests/components/karakeep/test_sensor.py
@@ -7,7 +7,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import setup_integration
-from .const import TEST_STATS, TEST_URL
+from .const import TEST_STATS
 
 from tests.common import MockConfigEntry
 
@@ -65,7 +65,7 @@ async def test_device_info(
     await setup_integration(hass, mock_config_entry)
 
     device_entry = device_registry.async_get_device(
-        identifiers={("karakeep", TEST_URL)}
+        identifiers={("karakeep", mock_config_entry.entry_id)}
     )
     assert device_entry is not None
     assert device_entry.name == "Karakeep"

--- a/tests/components/karakeep/test_sensor.py
+++ b/tests/components/karakeep/test_sensor.py
@@ -1,0 +1,72 @@
+"""Tests for the Karakeep sensor platform."""
+
+from unittest.mock import AsyncMock
+
+from homeassistant.const import CONF_URL, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from . import setup_integration
+from .const import TEST_STATS, TEST_URL
+
+from tests.common import MockConfigEntry
+
+
+async def test_sensors(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_karakeep_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test Karakeep sensors."""
+    await setup_integration(hass, mock_config_entry)
+
+    expected_states = {
+        "sensor.karakeep_archived": "3",
+        "sensor.karakeep_bookmarks": "10",
+        "sensor.karakeep_favorites": "2",
+        "sensor.karakeep_highlights": "4",
+        "sensor.karakeep_lists": "5",
+        "sensor.karakeep_tags": "6",
+    }
+
+    for entity_id, state in expected_states.items():
+        assert hass.states.get(entity_id).state == state
+        registry_entry = entity_registry.async_get(entity_id)
+        assert registry_entry is not None
+        assert registry_entry.unique_id == (
+            f"{mock_config_entry.data[CONF_URL]}_{entity_id.removeprefix('sensor.karakeep_')}"
+        )
+
+
+async def test_sensor_ignores_non_integer_values(
+    hass: HomeAssistant,
+    mock_karakeep_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test non-integer stat values render as unknown."""
+    mock_karakeep_client.async_get_stats.return_value = {
+        **TEST_STATS,
+        "numBookmarks": "10",
+    }
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert hass.states.get("sensor.karakeep_bookmarks").state == STATE_UNKNOWN
+
+
+async def test_device_info(
+    hass: HomeAssistant,
+    mock_karakeep_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test device registry entry."""
+    await setup_integration(hass, mock_config_entry)
+
+    device_entry = device_registry.async_get_device(
+        identifiers={("karakeep", TEST_URL)}
+    )
+    assert device_entry is not None
+    assert device_entry.name == "Karakeep"
+    assert device_entry.manufacturer == "Karakeep"

--- a/tests/components/karakeep/test_sensor.py
+++ b/tests/components/karakeep/test_sensor.py
@@ -1,41 +1,33 @@
 """Tests for the Karakeep sensor platform."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import setup_integration
 from .const import TEST_VERSION
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, snapshot_platform
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_sensors(
     hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
     mock_karakeep_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test Karakeep sensors."""
-    await setup_integration(hass, mock_config_entry)
+    with patch("homeassistant.components.karakeep.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, mock_config_entry)
 
-    expected_states = {
-        "sensor.karakeep_archived": "3",
-        "sensor.karakeep_bookmarks": "10",
-        "sensor.karakeep_favorites": "2",
-        "sensor.karakeep_highlights": "4",
-        "sensor.karakeep_lists": "5",
-        "sensor.karakeep_tags": "6",
-    }
-
-    for entity_id, state in expected_states.items():
-        assert hass.states.get(entity_id).state == state
-        registry_entry = entity_registry.async_get(entity_id)
-        assert registry_entry is not None
-        assert registry_entry.unique_id == (
-            f"{mock_config_entry.entry_id}_{entity_id.removeprefix('sensor.karakeep_')}"
-        )
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
 async def test_device_info(

--- a/tests/components/karakeep/test_sensor.py
+++ b/tests/components/karakeep/test_sensor.py
@@ -6,6 +6,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import setup_integration
+from .const import TEST_VERSION
 
 from tests.common import MockConfigEntry
 
@@ -52,3 +53,4 @@ async def test_device_info(
     assert device_entry is not None
     assert device_entry.name == "Karakeep"
     assert device_entry.manufacturer == "Karakeep"
+    assert device_entry.sw_version == TEST_VERSION

--- a/tests/components/karakeep/test_sensor.py
+++ b/tests/components/karakeep/test_sensor.py
@@ -2,12 +2,10 @@
 
 from unittest.mock import AsyncMock
 
-from homeassistant.const import CONF_URL, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import setup_integration
-from .const import TEST_STATS
 
 from tests.common import MockConfigEntry
 
@@ -35,24 +33,8 @@ async def test_sensors(
         registry_entry = entity_registry.async_get(entity_id)
         assert registry_entry is not None
         assert registry_entry.unique_id == (
-            f"{mock_config_entry.data[CONF_URL]}_{entity_id.removeprefix('sensor.karakeep_')}"
+            f"{mock_config_entry.entry_id}_{entity_id.removeprefix('sensor.karakeep_')}"
         )
-
-
-async def test_sensor_ignores_non_integer_values(
-    hass: HomeAssistant,
-    mock_karakeep_client: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test non-integer stat values render as unknown."""
-    mock_karakeep_client.async_get_stats.return_value = {
-        **TEST_STATS,
-        "numBookmarks": "10",
-    }
-
-    await setup_integration(hass, mock_config_entry)
-
-    assert hass.states.get("sensor.karakeep_bookmarks").state == STATE_UNKNOWN
 
 
 async def test_device_info(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds a new integration for [Karakeep](https://karakeep.app/), a self-hostable bookmarking and read-it-later service.
The integration connects to a Karakeep instance and exposes account statistics as sensors. 

For the first version of the integration, I included the following statistics sensors:
- Archived
- Bookmarks
- Favorites
- Highlights
- Lists
- Tags

<img width="1043" height="552" alt="grafik" src="https://github.com/user-attachments/assets/10765099-716c-412f-9349-eab40ce5d38a" />

- The Karakeep server version is exposed as the device software version when the instance is running `0.29.0`
  or later (endpoint was added in this version)
- Communication is handled by PyPI library [`aiokarakeep`](https://pypi.org/project/aiokarakeep/)



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/46337
- Link to developer documentation pull request: 
- Link to frontend pull request: 
- Link to brands PR: https://github.com/home-assistant/brands/pull/10561 

New dependency `aiokarakeep==0.3.0` (new addition, not an upgrade):
- PyPI: https://pypi.org/project/aiokarakeep/0.3.0/
- Source: https://github.com/sli-cka/aiokarakeep
- Changelog: https://github.com/sli-cka/aiokarakeep/blob/main/CHANGELOG.md

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
