### PR TITLE
Add plug (outlet) support to Cync integration 

### DIFF
--- a/homeassistant/components/cync/__init__.py
+++ b/homeassistant/components/cync/__init__.py
@@ -17,7 +17,7 @@ from .const import (
 )
 from .coordinator import CyncConfigEntry, CyncCoordinator
 
-_PLATFORMS: list[Platform] = [Platform.LIGHT]
+_PLATFORMS: list[Platform] = [Platform.LIGHT, Platform.SWITCH]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: CyncConfigEntry) -> bool:

--- a/homeassistant/components/cync/switch.py
+++ b/homeassistant/components/cync/switch.py
@@ -1,0 +1,70 @@
+"""Support for Cync switch entities."""
+
+from typing import Any
+
+from pycync.devices.devices import CyncDevice
+from pycync.devices.device_types import DeviceType
+
+from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import CyncConfigEntry, CyncCoordinator
+from .entity import CyncBaseEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: CyncConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Cync switches from a config entry."""
+
+    coordinator = entry.runtime_data
+    cync = coordinator.cync
+
+    entities_to_add = []
+
+    for home in cync.get_homes():
+        for room in home.rooms:
+            room_plugs = [
+                CyncSwitchEntity(device, coordinator, room.name)
+                for device in room.devices
+                if device.device_type == DeviceType.PLUG
+            ]
+            entities_to_add.extend(room_plugs)
+
+            group_plugs = [
+                CyncSwitchEntity(device, coordinator, room.name)
+                for group in room.groups
+                for device in group.devices
+                if device.device_type == DeviceType.PLUG
+            ]
+            entities_to_add.extend(group_plugs)
+
+    async_add_entities(entities_to_add)
+
+
+class CyncSwitchEntity(CyncBaseEntity, SwitchEntity):
+    """Representation of a Cync plug."""
+
+    _attr_device_class = SwitchDeviceClass.OUTLET
+    _attr_name = None
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return None — pycync 0.5.0 does not track on/off state for plugs."""
+        return None
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on the plug."""
+        await self._device._command_client.set_power_state(self._device, True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off the plug."""
+        await self._device._command_client.set_power_state(self._device, False)
+
+    @property
+    def _device(self) -> CyncDevice:
+        """Fetch the reference to the backing Cync device for this plug."""
+        return self.coordinator.data[self._cync_device_id]

--- a/tests/components/cync/fixtures/home.json
+++ b/tests/components/cync/fixtures/home.json
@@ -9,6 +9,19 @@
       "groups": [],
       "devices": [
         {
+          "name": "Bedroom Plug",
+          "is_online": true,
+          "wifi_connected": true,
+          "device_id": 1201,
+          "mesh_device_id": 10004,
+          "home_id": 1000,
+          "device_type_id": 64,
+          "device_type": "PLUG",
+          "mac_address": "AABBCC112233",
+          "product_id": "product456",
+          "authorize_code": "efgh_code"
+        },
+        {
           "name": "Bedroom Lamp",
           "is_online": true,
           "wifi_connected": true,

--- a/tests/components/cync/snapshots/test_switch.ambr
+++ b/tests/components/cync/snapshots/test_switch.ambr
@@ -1,0 +1,52 @@
+# serializer version: 1
+# name: test_entities[switch.bedroom_bedroom_plug-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.bedroom_bedroom_plug',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': <SwitchDeviceClass.OUTLET: 'outlet'>,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'cync',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1000-1201',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[switch.bedroom_bedroom_plug-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'outlet',
+      'friendly_name': 'Bedroom Plug',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.bedroom_bedroom_plug',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/cync/test_light.py
+++ b/tests/components/cync/test_light.py
@@ -1,16 +1,26 @@
 """Tests for the Cync integration light platform."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from . import setup_integration
 
 from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.fixture(autouse=True)
+def light_platform_only():
+    """Limit platform setup to light only."""
+    with patch(
+        "homeassistant.components.cync._PLATFORMS", [Platform.LIGHT]
+    ):
+        yield
 
 
 async def test_entities(

--- a/tests/components/cync/test_light.py
+++ b/tests/components/cync/test_light.py
@@ -17,9 +17,7 @@ from tests.common import MockConfigEntry, snapshot_platform
 @pytest.fixture(autouse=True)
 def light_platform_only():
     """Limit platform setup to light only."""
-    with patch(
-        "homeassistant.components.cync._PLATFORMS", [Platform.LIGHT]
-    ):
+    with patch("homeassistant.components.cync._PLATFORMS", [Platform.LIGHT]):
         yield
 
 

--- a/tests/components/cync/test_switch.py
+++ b/tests/components/cync/test_switch.py
@@ -1,0 +1,72 @@
+"""Tests for the Cync integration switch platform."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+PLUG_DEVICE_ID = 1201
+PLUG_ENTITY_ID = "switch.bedroom_bedroom_plug"
+
+
+@pytest.fixture(autouse=True)
+def switch_platform_only():
+    """Limit platform setup to switch only."""
+    with patch(
+        "homeassistant.components.cync._PLATFORMS", [Platform.SWITCH]
+    ):
+        yield
+
+
+async def test_entities(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that switch attributes are properly set on setup."""
+
+    await setup_integration(hass, mock_config_entry)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    ("service", "expected_is_on"),
+    [
+        ("turn_on", True),
+        ("turn_off", False),
+    ],
+    ids=["turn_on", "turn_off"],
+)
+async def test_switch(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    service: str,
+    expected_is_on: bool,
+) -> None:
+    """Test that turning on/off the plug calls set_power_state with the correct value."""
+
+    await setup_integration(hass, mock_config_entry)
+
+    test_device = mock_config_entry.runtime_data.data.get(PLUG_DEVICE_ID)
+    mock_client = MagicMock()
+    mock_client.set_power_state = AsyncMock(name="set_power_state")
+    test_device._command_client = mock_client
+
+    await hass.services.async_call(
+        "switch",
+        service,
+        {"entity_id": PLUG_ENTITY_ID},
+        blocking=True,
+    )
+
+    mock_client.set_power_state.assert_called_once_with(test_device, expected_is_on)

--- a/tests/components/cync/test_switch.py
+++ b/tests/components/cync/test_switch.py
@@ -20,9 +20,7 @@ PLUG_ENTITY_ID = "switch.bedroom_bedroom_plug"
 @pytest.fixture(autouse=True)
 def switch_platform_only():
     """Limit platform setup to switch only."""
-    with patch(
-        "homeassistant.components.cync._PLATFORMS", [Platform.SWITCH]
-    ):
+    with patch("homeassistant.components.cync._PLATFORMS", [Platform.SWITCH]):
         yield
 
 


### PR DESCRIPTION
## Proposed change

Extends the Cync integration to expose smart plug/outlet devices as Home Assistant switch entities. Previously only light devices were supported; this adds the `switch` platform for devices with `DeviceType.PLUG` (pycync type IDs 64, 65, 66, 67, 68, 69, 111, 172 — PlugGen1 through SingleChipPlugTCOGen1).

Plugs are represented with `SwitchDeviceClass.OUTLET`. On/off control works via the existing `set_power_state` command in pycync's TCP client.

**Known limitation**: pycync 0.5.0 does not track on/off state for non-light `CyncDevice` instances (the packet parser only calls `update_state()` for `CyncLight`). Plug entities will report `unknown` state until a future pycync release adds plug state tracking.

## Type of change

- [x] New feature (which adds functionality to an existing integration)

## Additional information

- This PR is related to issue: #149848 (initial Cync integration)

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository] (https://github.com/home-assistant/home-assistant.io/pull/46338)

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr