### PR TITLE
Bump dsmr-parser to 1.9.0

### DIFF
--- a/homeassistant/components/dsmr/manifest.json
+++ b/homeassistant/components/dsmr/manifest.json
@@ -8,5 +8,5 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["dsmr_parser"],
-  "requirements": ["dsmr-parser==1.7.0"]
+  "requirements": ["dsmr-parser==1.9.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -865,7 +865,7 @@ dremel3dpy==2.1.1
 dropmqttapi==1.0.3
 
 # homeassistant.components.dsmr
-dsmr-parser==1.7.0
+dsmr-parser==1.9.0
 
 # homeassistant.components.dwd_weather_warnings
 dwdwfsapi==1.0.7


### PR DESCRIPTION
## Proposed change

This PR bumps dsmr-parser to [v1.9.0](https://github.com/ndokter/dsmr_parser/releases/tag/v1.9.0).
Full diff: https://github.com/ndokter/dsmr_parser/compare/v1.7.0...v1.9.0

The release is mainly to (hopefully) address the below issue after the recent change to serialx:
- https://github.com/home-assistant/core/issues/173474
  (by PR https://github.com/ndokter/dsmr_parser/pull/187)

Do note that I don't have a compatible smart meter, so I couldn't verify this change with a physical device.

Looking through all the changes, nothing should break HA’s implementation. Maybe we can go with this for a patch release?

There appears to be [one user](https://github.com/home-assistant/core/issues/173474#issuecomment-4750851388) in the issue who at least confirmed nothing broke further but still reports elevated CPU usage, assuming the updated library was correctly installed (unknown).

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/173474
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
