### PR TITLE
Add fan timer timeout timestamp sensor to Nest integration

### DIFF
--- a/homeassistant/components/nest/sensor.py
+++ b/homeassistant/components/nest/sensor.py
@@ -57,7 +57,7 @@ class SensorBase(SensorEntity):
     """Representation of a dynamically updated Sensor."""
 
     _attr_should_poll = False
-    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_state_class: SensorStateClass | None = SensorStateClass.MEASUREMENT
     _attr_has_entity_name = True
 
     def __init__(self, device: Device) -> None:
@@ -115,16 +115,6 @@ class FanTimerSensor(SensorBase):
     _attr_device_class = SensorDeviceClass.TIMESTAMP
     _attr_state_class = None
     _attr_translation_key = "fan_timer_timeout"
-
-    @property
-    def available(self) -> bool:
-        """Return True if the entity is available and the timer is active."""
-        if not super().available:
-            return False
-
-        trait: FanTrait = self._device.traits[FanTrait.NAME]
-        # The sensor is available when a timer is actually running
-        return trait.timer_timeout is not None
 
     @property
     def native_value(self) -> datetime | None:

--- a/homeassistant/components/nest/sensor.py
+++ b/homeassistant/components/nest/sensor.py
@@ -1,9 +1,10 @@
 """Support for Google Nest SDM sensors."""
 
+from datetime import datetime
 import logging
 
 from google_nest_sdm.device import Device
-from google_nest_sdm.device_traits import HumidityTrait, TemperatureTrait
+from google_nest_sdm.device_traits import FanTrait, HumidityTrait, TemperatureTrait
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -42,6 +43,8 @@ async def async_setup_entry(
                 entities.append(TemperatureSensor(device))
             if HumidityTrait.NAME in device.traits:
                 entities.append(HumiditySensor(device))
+            if FanTrait.NAME in device.traits:
+                entities.append(FanTimerSensor(device))
         async_add_entities(entities)
 
     entry.runtime_data.register_devices_listener(devices_added)
@@ -101,3 +104,26 @@ class HumiditySensor(SensorBase):
         trait: HumidityTrait = self._device.traits[HumidityTrait.NAME]
         # Cast without loss of precision because the API always returns an integer.
         return int(trait.ambient_humidity_percent)
+
+
+class FanTimerSensor(SensorBase):
+    """Representation of the Fan Timer Timeout Sensor."""
+
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+    _attr_translation_key = "fan_timer_timeout"
+
+    @property
+    def available(self) -> bool:
+        """Return True if the entity is available and the timer is active."""
+        if not super().available:
+            return False
+
+        trait: FanTrait = self._device.traits[FanTrait.NAME]
+        # The sensor is available when a timer is actually running
+        return trait.timer_timeout is not None
+
+    @property
+    def native_value(self) -> datetime | None:
+        """Return the state of the sensor."""
+        trait: FanTrait = self._device.traits[FanTrait.NAME]
+        return trait.timer_timeout

--- a/homeassistant/components/nest/sensor.py
+++ b/homeassistant/components/nest/sensor.py
@@ -110,6 +110,7 @@ class FanTimerSensor(SensorBase):
     """Representation of the Fan Timer Timeout Sensor."""
 
     _attr_device_class = SensorDeviceClass.TIMESTAMP
+    _attr_state_class = None
     _attr_translation_key = "fan_timer_timeout"
 
     @property

--- a/homeassistant/components/nest/sensor.py
+++ b/homeassistant/components/nest/sensor.py
@@ -43,7 +43,10 @@ async def async_setup_entry(
                 entities.append(TemperatureSensor(device))
             if HumidityTrait.NAME in device.traits:
                 entities.append(HumiditySensor(device))
-            if FanTrait.NAME in device.traits:
+            if (
+                FanTrait.NAME in device.traits
+                and device.traits[FanTrait.NAME].timer_mode is not None
+            ):
                 entities.append(FanTimerSensor(device))
         async_add_entities(entities)
 

--- a/homeassistant/components/nest/sensor.py
+++ b/homeassistant/components/nest/sensor.py
@@ -64,7 +64,6 @@ class SensorBase(SensorEntity):
         """Initialize the sensor."""
         self._device = device
         self._device_info = NestDeviceInfo(device)
-        self._attr_unique_id = f"{device.name}-{self.device_class}"
         self._attr_device_info = self._device_info.device_info
 
     @property
@@ -85,6 +84,11 @@ class TemperatureSensor(SensorBase):
     _attr_device_class = SensorDeviceClass.TEMPERATURE
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
 
+    def __init__(self, device: Device) -> None:
+        """Initialize the sensor."""
+        super().__init__(device)
+        self._attr_unique_id = f"{device.name}-temperature"
+
     @property
     def native_value(self) -> float:
         """Return the state of the sensor."""
@@ -101,6 +105,11 @@ class HumiditySensor(SensorBase):
     _attr_device_class = SensorDeviceClass.HUMIDITY
     _attr_native_unit_of_measurement = PERCENTAGE
 
+    def __init__(self, device: Device) -> None:
+        """Initialize the sensor."""
+        super().__init__(device)
+        self._attr_unique_id = f"{device.name}-humidity"
+
     @property
     def native_value(self) -> int:
         """Return the state of the sensor."""
@@ -115,6 +124,11 @@ class FanTimerSensor(SensorBase):
     _attr_device_class = SensorDeviceClass.TIMESTAMP
     _attr_state_class = None
     _attr_translation_key = "fan_timer_timeout"
+
+    def __init__(self, device: Device) -> None:
+        """Initialize the sensor."""
+        super().__init__(device)
+        self._attr_unique_id = f"{device.name}-fan-timer"
 
     @property
     def native_value(self) -> datetime | None:

--- a/homeassistant/components/nest/strings.json
+++ b/homeassistant/components/nest/strings.json
@@ -130,6 +130,11 @@
           }
         }
       }
+    },
+    "sensor": {
+      "fan_timer_timeout": {
+        "name": "Fan timer timeout"
+      }
     }
   },
   "exceptions": {

--- a/tests/components/nest/test_sensor.py
+++ b/tests/components/nest/test_sensor.py
@@ -287,3 +287,57 @@ async def test_temperature_rounding(
 
     temperature = hass.states.get("sensor.my_sensor_temperature")
     assert temperature.state == "25.2"
+
+
+async def test_thermostat_fan_timer_sensor(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    create_device: CreateDevice,
+    setup_platform: PlatformSetup,
+) -> None:
+    """Test a thermostat with a fan timer sensor."""
+    create_device.create(
+        {
+            "sdm.devices.traits.Fan": {
+                "timerMode": "ON",
+                "timerTimeout": "2019-05-10T03:22:54Z",
+            },
+        }
+    )
+    await setup_platform()
+
+    fan_timer = hass.states.get("sensor.my_sensor_fan_timer_timeout")
+    assert fan_timer is not None
+    assert fan_timer.state == "2019-05-10T03:22:54+00:00"
+    assert fan_timer.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.TIMESTAMP
+    assert fan_timer.attributes.get(ATTR_FRIENDLY_NAME) == "My Sensor Fan timer timeout"
+
+    entry = entity_registry.async_get("sensor.my_sensor_fan_timer_timeout")
+    assert entry.unique_id == f"{DEVICE_ID}-timestamp"
+    assert entry.domain == "sensor"
+
+    device = device_registry.async_get(entry.device_id)
+    assert device.name == "My Sensor"
+    assert device.identifiers == {("nest", DEVICE_ID)}
+
+
+async def test_thermostat_fan_timer_sensor_not_active(
+    hass: HomeAssistant,
+    create_device: CreateDevice,
+    setup_platform: PlatformSetup,
+) -> None:
+    """Test a thermostat fan timer sensor when the timer is inactive."""
+    create_device.create(
+        {
+            "sdm.devices.traits.Fan": {
+                "timerMode": "OFF",
+            },
+        }
+    )
+    await setup_platform()
+
+    fan_timer = hass.states.get("sensor.my_sensor_fan_timer_timeout")
+    # When the timer is inactive, timer_timeout is None, rendering the sensor unavailable.
+    assert fan_timer is not None
+    assert fan_timer.state == STATE_UNAVAILABLE

--- a/tests/components/nest/test_sensor.py
+++ b/tests/components/nest/test_sensor.py
@@ -312,6 +312,7 @@ async def test_thermostat_fan_timer_sensor(
     assert fan_timer is not None
     assert fan_timer.state == "2019-05-10T03:22:54+00:00"
     assert fan_timer.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.TIMESTAMP
+    assert fan_timer.attributes.get(ATTR_STATE_CLASS) is None
     assert fan_timer.attributes.get(ATTR_FRIENDLY_NAME) == "My Sensor Fan timer timeout"
 
     entry = entity_registry.async_get("sensor.my_sensor_fan_timer_timeout")

--- a/tests/components/nest/test_sensor.py
+++ b/tests/components/nest/test_sensor.py
@@ -20,6 +20,7 @@ from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
     PERCENTAGE,
     STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
@@ -338,6 +339,6 @@ async def test_thermostat_fan_timer_sensor_not_active(
     await setup_platform()
 
     fan_timer = hass.states.get("sensor.my_sensor_fan_timer_timeout")
-    # When the timer is inactive, timer_timeout is None, rendering the sensor unavailable.
+    # When the timer is inactive, timer_timeout is None, rendering the sensor state unknown.
     assert fan_timer is not None
-    assert fan_timer.state == STATE_UNAVAILABLE
+    assert fan_timer.state == STATE_UNKNOWN

--- a/tests/components/nest/test_sensor.py
+++ b/tests/components/nest/test_sensor.py
@@ -316,7 +316,7 @@ async def test_thermostat_fan_timer_sensor(
     assert fan_timer.attributes.get(ATTR_FRIENDLY_NAME) == "My Sensor Fan timer timeout"
 
     entry = entity_registry.async_get("sensor.my_sensor_fan_timer_timeout")
-    assert entry.unique_id == f"{DEVICE_ID}-timestamp"
+    assert entry.unique_id == f"{DEVICE_ID}-fan-timer"
     assert entry.domain == "sensor"
 
     device = device_registry.async_get(entry.device_id)

--- a/tests/components/nest/test_sensor.py
+++ b/tests/components/nest/test_sensor.py
@@ -343,3 +343,21 @@ async def test_thermostat_fan_timer_sensor_not_active(
     # When the timer is inactive, timer_timeout is None, rendering the sensor state unknown.
     assert fan_timer is not None
     assert fan_timer.state == STATE_UNKNOWN
+
+
+async def test_thermostat_fan_timer_sensor_unsupported(
+    hass: HomeAssistant,
+    create_device: CreateDevice,
+    setup_platform: PlatformSetup,
+) -> None:
+    """Test that the fan timer sensor is not created if the Fan trait lacks timer support."""
+    create_device.create(
+        {
+            "sdm.devices.traits.Fan": {},
+        }
+    )
+    await setup_platform()
+
+    fan_timer = hass.states.get("sensor.my_sensor_fan_timer_timeout")
+    # The sensor should not be created when timer_mode is unsupported/None
+    assert fan_timer is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Introduce a new timestamp sensor, `FanTimerSensor`, mapping to the SDM API Fan trait's `timerTimeout` field. Guard the sensor's creation to only devices where `timer_mode` is supported. Represent an inactive fan timer as an unknown state (`STATE_UNKNOWN`).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/46348
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
