### PR TITLE
Add Yale BLE auto-lock entities

### DIFF
--- a/homeassistant/components/yalexs_ble/__init__.py
+++ b/homeassistant/components/yalexs_ble/__init__.py
@@ -36,7 +36,9 @@ type YALEXSBLEConfigEntry = ConfigEntry[YaleXSBLEData]
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.LOCK,
+    Platform.SELECT,
     Platform.SENSOR,
+    Platform.SWITCH,
 ]
 
 

--- a/homeassistant/components/yalexs_ble/select.py
+++ b/homeassistant/components/yalexs_ble/select.py
@@ -1,0 +1,131 @@
+"""Support for Yale Access Bluetooth selects."""
+
+from __future__ import annotations
+
+from yalexs_ble import ConnectionInfo, LockInfo, LockState
+from yalexs_ble.const import AutoLockMode
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import YALEXSBLEConfigEntry
+from .entity import YALEXSBLEEntity
+from .models import YaleXSBLEData
+
+AUTO_LOCK_WHEN_OPTIONS = {
+    "instant": AutoLockMode.INSTANT,
+    "on_timer": AutoLockMode.TIMER,
+}
+
+TIMING_OPTIONS = {
+    "10_s": 10,
+    "30_s": 30,
+    "1_min": 60,
+    "1_min_30_s": 90,
+    "2_min": 120,
+    "2_min_30_s": 150,
+    "3_min": 180,
+    "4_min": 240,
+    "5_min": 300,
+    "10_min": 600,
+    "20_min": 1200,
+    "30_min": 1800,
+}
+
+TIMING_BY_DURATION = {duration: option for option, duration in TIMING_OPTIONS.items()}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: YALEXSBLEConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Yale Access Bluetooth selects."""
+    async_add_entities(
+        [
+            YaleXSBLEAutoLockWhenSelect(entry.runtime_data),
+            YaleXSBLEAutoLockTimingSelect(entry.runtime_data),
+            YaleXSBLERelockTimingSelect(entry.runtime_data),
+        ]
+    )
+
+
+class YaleXSBLEAutoLockWhenSelect(YALEXSBLEEntity, SelectEntity):
+    """Yale Access Bluetooth auto-lock when select."""
+
+    _attr_translation_key = "auto_lock_when"
+    _attr_options = list(AUTO_LOCK_WHEN_OPTIONS)
+
+    def __init__(self, data: YaleXSBLEData) -> None:
+        """Initialize the select."""
+        super().__init__(data)
+        self._attr_unique_id = f"{self._device.address}_auto_lock_when"
+
+    @callback
+    def _async_update_state(
+        self, new_state: LockState, lock_info: LockInfo, connection_info: ConnectionInfo
+    ) -> None:
+        """Update the state."""
+        if new_state.auto_lock is None or new_state.auto_lock.mode is AutoLockMode.OFF:
+            self._attr_current_option = None
+        elif new_state.auto_lock.mode is AutoLockMode.TIMER:
+            self._attr_current_option = "on_timer"
+        else:
+            self._attr_current_option = "instant"
+        super()._async_update_state(new_state, lock_info, connection_info)
+
+    async def async_select_option(self, option: str) -> None:
+        """Set the auto-lock mode."""
+        await self._device.set_auto_lock_mode(AUTO_LOCK_WHEN_OPTIONS[option])
+
+
+class YaleXSBLETimingSelect(YALEXSBLEEntity, SelectEntity):
+    """Base class for Yale Access Bluetooth timing selects."""
+
+    _attr_options = list(TIMING_OPTIONS)
+    _mode: AutoLockMode
+
+    def __init__(self, data: YaleXSBLEData) -> None:
+        """Initialize the select."""
+        super().__init__(data)
+
+    @callback
+    def _async_update_state(
+        self, new_state: LockState, lock_info: LockInfo, connection_info: ConnectionInfo
+    ) -> None:
+        """Update the state."""
+        self._attr_current_option = (
+            TIMING_BY_DURATION.get(new_state.auto_lock.duration)
+            if new_state.auto_lock and new_state.auto_lock.mode is self._mode
+            else None
+        )
+        super()._async_update_state(new_state, lock_info, connection_info)
+
+    async def async_select_option(self, option: str) -> None:
+        """Set the timing."""
+        await self._device.set_auto_lock_duration(TIMING_OPTIONS[option])
+
+
+class YaleXSBLEAutoLockTimingSelect(YaleXSBLETimingSelect):
+    """Yale Access Bluetooth auto-lock timing select."""
+
+    _attr_translation_key = "auto_lock_timing"
+    _mode = AutoLockMode.TIMER
+
+    def __init__(self, data: YaleXSBLEData) -> None:
+        """Initialize the select."""
+        super().__init__(data)
+        self._attr_unique_id = f"{self._device.address}_auto_lock_timing"
+
+
+class YaleXSBLERelockTimingSelect(YaleXSBLETimingSelect):
+    """Yale Access Bluetooth re-lock timing select."""
+
+    _attr_translation_key = "relock_timing"
+    _mode = AutoLockMode.INSTANT
+
+    def __init__(self, data: YaleXSBLEData) -> None:
+        """Initialize the select."""
+        super().__init__(data)
+        self._attr_unique_id = f"{self._device.address}_relock_timing"

--- a/homeassistant/components/yalexs_ble/strings.json
+++ b/homeassistant/components/yalexs_ble/strings.json
@@ -47,9 +47,57 @@
         "name": "Secure mode"
       }
     },
+    "select": {
+      "auto_lock_when": {
+        "name": "Auto-lock when",
+        "state": {
+          "instant": "Instant",
+          "on_timer": "On a timer"
+        }
+      },
+      "auto_lock_timing": {
+        "name": "Auto-lock timing",
+        "state": {
+          "10_s": "10 s",
+          "30_s": "30 s",
+          "1_min": "1 min",
+          "1_min_30_s": "1 min 30 s",
+          "2_min": "2 min",
+          "2_min_30_s": "2 min 30 s",
+          "3_min": "3 min",
+          "4_min": "4 min",
+          "5_min": "5 min",
+          "10_min": "10 min",
+          "20_min": "20 min",
+          "30_min": "30 min"
+        }
+      },
+      "relock_timing": {
+        "name": "Re-lock timing",
+        "state": {
+          "10_s": "10 s",
+          "30_s": "30 s",
+          "1_min": "1 min",
+          "1_min_30_s": "1 min 30 s",
+          "2_min": "2 min",
+          "2_min_30_s": "2 min 30 s",
+          "3_min": "3 min",
+          "4_min": "4 min",
+          "5_min": "5 min",
+          "10_min": "10 min",
+          "20_min": "20 min",
+          "30_min": "30 min"
+        }
+      }
+    },
     "sensor": {
       "battery_voltage": {
         "name": "Battery voltage"
+      }
+    },
+    "switch": {
+      "auto_lock": {
+        "name": "Auto-lock enabled"
       }
     }
   },

--- a/homeassistant/components/yalexs_ble/switch.py
+++ b/homeassistant/components/yalexs_ble/switch.py
@@ -1,0 +1,59 @@
+"""Support for Yale Access Bluetooth switches."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from yalexs_ble import ConnectionInfo, LockInfo, LockState
+from yalexs_ble.const import AutoLockMode
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import YALEXSBLEConfigEntry
+from .entity import YALEXSBLEEntity
+from .models import YaleXSBLEData
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: YALEXSBLEConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Yale Access Bluetooth switches."""
+    async_add_entities([YaleXSBLEAutoLockSwitch(entry.runtime_data)])
+
+
+class YaleXSBLEAutoLockSwitch(YALEXSBLEEntity, SwitchEntity):
+    """Yale Access Bluetooth auto-lock switch."""
+
+    _attr_translation_key = "auto_lock"
+
+    def __init__(self, data: YaleXSBLEData) -> None:
+        """Initialize the switch."""
+        super().__init__(data)
+        self._attr_unique_id = f"{self._device.address}_auto_lock"
+
+    @callback
+    def _async_update_state(
+        self, new_state: LockState, lock_info: LockInfo, connection_info: ConnectionInfo
+    ) -> None:
+        """Update the state."""
+        self._attr_is_on = (
+            None
+            if new_state.auto_lock is None
+            else new_state.auto_lock.mode is not AutoLockMode.OFF
+        )
+        super()._async_update_state(new_state, lock_info, connection_info)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn auto-lock on."""
+        mode = AutoLockMode.INSTANT
+        if self._device.auto_lock_prev and self._device.auto_lock_prev.mode:
+            mode = self._device.auto_lock_prev.mode
+        await self._device.set_auto_lock_mode(mode)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn auto-lock off."""
+        await self._device.set_auto_lock_duration(0)

--- a/tests/components/yalexs_ble/test_auto_lock_entities.py
+++ b/tests/components/yalexs_ble/test_auto_lock_entities.py
@@ -1,0 +1,134 @@
+"""Test Yale Access Bluetooth auto-lock entities."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from yalexs_ble.const import (
+    AutoLockMode,
+    AutoLockState,
+    ConnectionInfo,
+    DoorStatus,
+    LockInfo,
+    LockState,
+    LockStatus,
+)
+
+from homeassistant.components.yalexs_ble.models import YaleXSBLEData
+from homeassistant.components.yalexs_ble.select import (
+    YaleXSBLEAutoLockTimingSelect,
+    YaleXSBLEAutoLockWhenSelect,
+    YaleXSBLERelockTimingSelect,
+)
+from homeassistant.components.yalexs_ble.switch import YaleXSBLEAutoLockSwitch
+
+
+@pytest.fixture
+def lock() -> MagicMock:
+    """Return a mocked lock."""
+    lock = MagicMock()
+    lock.address = "AA:BB:CC:DD:EE:FF"
+    lock.lock_info = LockInfo("Yale", "L7002DT", "serial", "1.0")
+    lock.connection_info = ConnectionInfo(-60)
+    lock.lock_state = _lock_state(AutoLockState(AutoLockMode.INSTANT, 60))
+    lock.auto_lock_prev = None
+    lock.set_auto_lock_duration = AsyncMock()
+    lock.set_auto_lock_mode = AsyncMock()
+    return lock
+
+
+@pytest.fixture
+def data(lock: MagicMock) -> YaleXSBLEData:
+    """Return Yale XS BLE runtime data."""
+    return YaleXSBLEData("Ytterdorr", lock, False)
+
+
+def _lock_state(auto_lock: AutoLockState | None) -> LockState:
+    """Return a lock state with the given auto-lock state."""
+    return LockState(
+        LockStatus.LOCKED,
+        DoorStatus.CLOSED,
+        None,
+        None,
+        auto_lock,
+        None,
+    )
+
+
+def test_auto_lock_when_select_options(data: YaleXSBLEData) -> None:
+    """Test the auto-lock when select follows the lock auto-lock mode."""
+    entity = YaleXSBLEAutoLockWhenSelect(data)
+
+    assert entity.current_option == "instant"
+
+    entity._async_update_state(  # noqa: SLF001
+        _lock_state(AutoLockState(AutoLockMode.TIMER, 60)),
+        data.lock.lock_info,
+        data.lock.connection_info,
+    )
+    assert entity.current_option == "on_timer"
+
+    entity._async_update_state(  # noqa: SLF001
+        _lock_state(AutoLockState(AutoLockMode.OFF, 0)),
+        data.lock.lock_info,
+        data.lock.connection_info,
+    )
+    assert entity.current_option is None
+
+
+async def test_auto_lock_when_select_sets_mode(data: YaleXSBLEData) -> None:
+    """Test selecting when auto-lock should happen sets the mode."""
+    entity = YaleXSBLEAutoLockWhenSelect(data)
+
+    await entity.async_select_option("on_timer")
+
+    data.lock.set_auto_lock_mode.assert_awaited_once_with(AutoLockMode.TIMER)
+
+
+def test_timing_selects_follow_matching_auto_lock_mode(data: YaleXSBLEData) -> None:
+    """Test timing selects only show state for their matching auto-lock mode."""
+    auto_lock_timing = YaleXSBLEAutoLockTimingSelect(data)
+    relock_timing = YaleXSBLERelockTimingSelect(data)
+
+    assert auto_lock_timing.current_option is None
+    assert relock_timing.current_option == "1_min"
+
+    state = _lock_state(AutoLockState(AutoLockMode.TIMER, 90))
+    auto_lock_timing._async_update_state(  # noqa: SLF001
+        state, data.lock.lock_info, data.lock.connection_info
+    )
+    relock_timing._async_update_state(  # noqa: SLF001
+        state, data.lock.lock_info, data.lock.connection_info
+    )
+
+    assert auto_lock_timing.current_option == "1_min_30_s"
+    assert relock_timing.current_option is None
+
+
+async def test_timing_selects_set_duration(data: YaleXSBLEData) -> None:
+    """Test timing selects set the auto-lock duration."""
+    entity = YaleXSBLEAutoLockTimingSelect(data)
+
+    await entity.async_select_option("30_s")
+
+    data.lock.set_auto_lock_duration.assert_awaited_once_with(30)
+
+
+async def test_auto_lock_switch(data: YaleXSBLEData) -> None:
+    """Test auto-lock switch state and commands."""
+    entity = YaleXSBLEAutoLockSwitch(data)
+
+    assert entity.is_on is True
+
+    entity._async_update_state(  # noqa: SLF001
+        _lock_state(AutoLockState(AutoLockMode.OFF, 0)),
+        data.lock.lock_info,
+        data.lock.connection_info,
+    )
+    assert entity.is_on is False
+
+    await entity.async_turn_off()
+    data.lock.set_auto_lock_duration.assert_awaited_once_with(0)
+
+    data.lock.auto_lock_prev = AutoLockState(AutoLockMode.TIMER, 60)
+    await entity.async_turn_on()
+    data.lock.set_auto_lock_mode.assert_awaited_once_with(AutoLockMode.TIMER)


### PR DESCRIPTION
## Proposed change

Add auto-lock controls to the Yale Access Bluetooth integration using the existing yalexs-ble support. The entity model follows the Yale app behavior:

- switch entity for enabling/disabling auto-lock
- select entity for when auto-lock should happen: instant or on a timer
- select entity for auto-lock timing when timer mode is active
- select entity for re-lock timing when instant mode is active

The timing choices use the durations exposed by yalexs-ble: 10 s, 30 s, 1 min, 1 min 30 s, 2 min, 2 min 30 s, 3 min, 4 min, 5 min, 10 min, 20 min, and 30 min.

These entities are attached to the existing Yale BLE config entry/device and use the Home Assistant Bluetooth path, including Bluetooth proxies.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix
- [x] New integration feature
- [ ] Documentation

## Additional information

The upstream yalexs-ble requirement already exposes `set_auto_lock_duration` and `set_auto_lock_mode`. During local testing with a Yale Doorman, auto-lock reads showed that the library may first surface an ACK-like response before the actual setting notification, so a yalexs-ble follow-up may be needed before this can be marked ready for review.

## Checklist

- [ ] The code change is tested and works locally.
- [x] Local tests have been added or updated.

## Tests

- `python3 -m py_compile homeassistant/components/yalexs_ble/select.py homeassistant/components/yalexs_ble/switch.py`
- `PYTHONPATH=/Users/sebastian/src/yalexs-ble/src python3 -m py_compile tests/components/yalexs_ble/test_auto_lock_entities.py`
- `python3 -m json.tool homeassistant/components/yalexs_ble/strings.json >/dev/null`
- `git diff --check`

Full pytest/lint not run locally because this checkout does not have the Home Assistant test environment installed (`pytest`, `ruff`/`prek`, `pylint`, and runtime deps such as `bleak_retry_connector` are missing).
