### PR TITLE
Bump pymodbus to 3.13.1

### DIFF
--- a/homeassistant/components/modbus/manifest.json
+++ b/homeassistant/components/modbus/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/modbus",
   "iot_class": "local_polling",
   "loggers": ["pymodbus"],
-  "requirements": ["pymodbus==3.11.2"]
+  "requirements": ["pymodbus==3.13.1"]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -223,7 +223,7 @@ num2words==0.5.14
 # pymodbus does not follow SemVer, and it keeps getting
 # downgraded or upgraded by custom components
 # This ensures all use the same version
-pymodbus==3.11.2
+pymodbus==3.13.1
 
 # Pin pytest-rerunfailures to prevent accidental breaks
 pytest-rerunfailures==16.0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2373,7 +2373,7 @@ pymitv==1.4.3
 pymochad==0.2.0
 
 # homeassistant.components.modbus
-pymodbus==3.11.2
+pymodbus==3.13.1
 
 # homeassistant.components.monoprice
 pymonoprice==0.5

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -207,7 +207,7 @@ num2words==0.5.14
 # pymodbus does not follow SemVer, and it keeps getting
 # downgraded or upgraded by custom components
 # This ensures all use the same version
-pymodbus==3.11.2
+pymodbus==3.13.1
 
 # Pin pytest-rerunfailures to prevent accidental breaks
 pytest-rerunfailures==16.0.1


### PR DESCRIPTION
## Breaking change


## Proposed change
Bump `pymodbus` from **3.11.2** to **3.13.1**. (integration modbus)

This update primarily consists of bug fixes, internal refactoring, test improvements, and development tooling updates. There are no known breaking API changes in the patch releases included in this upgrade.

Relevant improvements for Home Assistant's Modbus integration include:

* Improved frame handling and parser robustness, including fixes for skipped frames, short frame handling, ASCII framing, and TLS MBAP validation.
* Multiple datastore and register handling fixes, including address bounds validation, register count calculation, and `ModbusContext` fixes.
* Removal of the legacy 3.5 character frame timing check, improving compatibility with some devices.
* Exception handling improvements, including correct handling of `ExceptionResponse` when no response is expected.
* Minor simulator/runtime fixes and serial timing improvements.
* Added Python 3.14 compatibility.
* Various type hint improvements and internal refactoring.

The remaining changes are documentation, CI, testing, simulator, and developer tooling updates that do not affect Home Assistant's runtime behavior.

This version bump should be a low-risk maintenance update while bringing in several Modbus protocol robustness fixes and Python 3.14 support.

https://github.com/pymodbus-dev/pymodbus/blob/dev/CHANGELOG.rst
https://github.com/pymodbus-dev/pymodbus/releases/tag/v3.13.1 (bug fixes and CI updates)

## Type of change

- [x ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
