### PR TITLE
Bump pyatv to 0.18.0

### DIFF
--- a/homeassistant/components/apple_tv/manifest.json
+++ b/homeassistant/components/apple_tv/manifest.json
@@ -8,7 +8,7 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "loggers": ["pyatv", "srptools"],
-  "requirements": ["pyatv==0.17.0"],
+  "requirements": ["pyatv==0.18.0"],
   "zeroconf": [
     "_mediaremotetv._tcp.local.",
     "_companion-link._tcp.local.",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2045,7 +2045,7 @@ pyatag==0.3.5.3
 pyatmo==9.4.0
 
 # homeassistant.components.apple_tv
-pyatv==0.17.0
+pyatv==0.18.0
 
 # homeassistant.components.aussie_broadband
 pyaussiebb==0.1.5


### PR DESCRIPTION
## Proposed change

Bumps the `apple_tv` integration's pyatv pin from 0.17.0 to 0.18.0.

pyatv 0.18.0 ("Willie", 2026-06-19) ships the Companion-protocol fixes needed for tvOS 26.x:

- sends `TVRCSessionStart` during connect, so power on/off and app/source commands work again
- never sends a null `_i` in `_systemInfo`, so the device pushes power-state events and the state correctly flips to off

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #166545
- This PR is related to issue: #170441 (already closed)
- Library changelog / release notes: https://github.com/postlund/pyatv/releases/tag/v0.18.0
- Relevant upstream library fixes: postlund/pyatv#2855, postlund/pyatv#2847

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
       Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
       Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
