### PR TITLE
Fix blink 2fa auth flow

### DIFF
--- a/homeassistant/components/blink/config_flow.py
+++ b/homeassistant/components/blink/config_flow.py
@@ -34,11 +34,10 @@ async def validate_input(blink: Blink) -> None:
         raise InvalidAuth
 
 
-async def _send_blink_2fa_pin(blink: Blink, pin: str | None) -> bool:
+async def _send_blink_2fa_pin(blink: Blink, pin: str | None) -> None:
     """Send 2FA pin to blink servers."""
     if not await blink.send_2fa_code(pin):
         raise InvalidAuth
-    return True
 
 
 class BlinkConfigFlow(ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/blink/config_flow.py
+++ b/homeassistant/components/blink/config_flow.py
@@ -27,14 +27,17 @@ _LOGGER = logging.getLogger(__name__)
 async def validate_input(blink: Blink) -> None:
     """Validate the user input allows us to connect."""
     try:
-        await blink.start()
+        result = await blink.start()
     except (LoginError, TokenRefreshFailed) as err:
         raise InvalidAuth from err
+    if result is False:
+        raise InvalidAuth
 
 
 async def _send_blink_2fa_pin(blink: Blink, pin: str | None) -> bool:
     """Send 2FA pin to blink servers."""
-    await blink.send_2fa_code(pin)
+    if not await blink.send_2fa_code(pin):
+        raise InvalidAuth
     return True
 
 
@@ -103,6 +106,8 @@ class BlinkConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors["base"] = "cannot_connect"
             except TokenRefreshFailed:
                 errors["base"] = "invalid_access_token"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
             except Exception:
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"

--- a/tests/components/blink/test_config_flow.py
+++ b/tests/components/blink/test_config_flow.py
@@ -173,6 +173,44 @@ async def test_form_2fa_unknown_error(hass: HomeAssistant) -> None:
     assert result3["errors"] == {"base": "unknown"}
 
 
+async def test_form_2fa_wrong_pin(hass: HomeAssistant) -> None:
+    """Test we report invalid auth when send_2fa_code returns False."""
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.blink.config_flow.Blink.start",
+        side_effect=BlinkTwoFARequiredError,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"username": "blink@example.com", "password": "example"},
+        )
+
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["step_id"] == "2fa"
+
+    with (
+        patch("homeassistant.components.blink.config_flow.Blink.start"),
+        patch(
+            "homeassistant.components.blink.config_flow.Blink.send_2fa_code",
+            return_value=False,
+        ),
+        patch(
+            "homeassistant.components.blink.async_setup_entry",
+            return_value=True,
+        ),
+    ):
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"], {"pin": "1234"}
+        )
+
+    assert result3["type"] is FlowResultType.FORM
+    assert result3["errors"] == {"base": "invalid_auth"}
+
+
 async def test_form_invalid_auth(hass: HomeAssistant) -> None:
     """Test we handle invalid auth."""
     result = await hass.config_entries.flow.async_init(
@@ -182,6 +220,28 @@ async def test_form_invalid_auth(hass: HomeAssistant) -> None:
     with patch(
         "homeassistant.components.blink.config_flow.Blink.start",
         side_effect=LoginError,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"username": "blink@example.com", "password": "example"}
+        )
+
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["errors"] == {"base": "invalid_auth"}
+
+
+async def test_form_start_returns_false(hass: HomeAssistant) -> None:
+    """Test we handle auth failure when blink.start() returns False without raising.
+
+    blink.start() catches LoginError/TokenRefreshFailed internally and returns
+    False instead of re-raising, so validate_input must check the return value.
+    """
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.blink.config_flow.Blink.start",
+        return_value=False,
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], {"username": "blink@example.com", "password": "example"}


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Three related bugs allowed the Blink config flow to silently succeed even when authentication actually failed:

1. validate_input() only caught LoginError/TokenRefreshFailed as exceptions, but blink.start() catches those internally and returns False without re-raising. A failed OAuth login that didn't trigger 2FA would return False from blink.start(), pass through validate_input() unchecked, and create a broken config entry. Fix: check the return value and raise InvalidAuth when False.

2. _send_blink_2fa_pin() discarded the return value of blink.send_2fa_code() and always returned True. A wrong PIN or server rejection would silently create a config entry with no valid tokens. Fix: raise InvalidAuth when send_2fa_code() returns False.

3. async_step_2fa() had no handler for InvalidAuth, so the new raise from (2) would fall through to the generic "unknown" error. Fix: add an explicit InvalidAuth handler that shows "invalid_auth".

Fixes issue #173457 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #173457 


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
