### PR TITLE
Fix UndefinedType._singleton leaking into Overkiz sub-device entity names

### DIFF
--- a/homeassistant/components/overkiz/entity.py
+++ b/homeassistant/components/overkiz/entity.py
@@ -130,9 +130,8 @@ class OverkizDescriptiveEntity(OverkizEntity):
         self._attr_unique_id = f"{super().unique_id}-{self.entity_description.key}"
 
         if self.device.identifier.is_sub_device:
-            # In case of sub device, use the provided label and append the name
-            # of the type of entity. Descriptions without a name (e.g. those
-            # relying on a translation_key) fall back to the label alone.
+            # Prefix the sub device label; fall back to the label alone when the
+            # description has no name (e.g. when it relies on a translation_key).
             if isinstance(description.name, str):
                 self._attr_name = f"{self.device.label} {description.name}"
             else:

--- a/homeassistant/components/overkiz/entity.py
+++ b/homeassistant/components/overkiz/entity.py
@@ -130,7 +130,6 @@ class OverkizDescriptiveEntity(OverkizEntity):
         self._attr_unique_id = f"{super().unique_id}-{self.entity_description.key}"
 
         if self.device.identifier.is_sub_device:
-            # Prefix the sub device label, or use it alone when the description is unnamed.
             if isinstance(description.name, str):
                 self._attr_name = f"{self.device.label} {description.name}"
             else:

--- a/homeassistant/components/overkiz/entity.py
+++ b/homeassistant/components/overkiz/entity.py
@@ -130,8 +130,12 @@ class OverkizDescriptiveEntity(OverkizEntity):
         self._attr_unique_id = f"{super().unique_id}-{self.entity_description.key}"
 
         if self.device.identifier.is_sub_device:
-            # In case of sub device, use the provided label
-            # and append the name of the type of entity
-            self._attr_name = f"{self.device.label} {description.name}"
+            # In case of sub device, use the provided label and append the name
+            # of the type of entity. Descriptions without a name (e.g. those
+            # relying on a translation_key) fall back to the label alone.
+            if isinstance(description.name, str):
+                self._attr_name = f"{self.device.label} {description.name}"
+            else:
+                self._attr_name = self.device.label
         elif isinstance(description.name, str):
             self._attr_name = description.name

--- a/homeassistant/components/overkiz/entity.py
+++ b/homeassistant/components/overkiz/entity.py
@@ -130,8 +130,7 @@ class OverkizDescriptiveEntity(OverkizEntity):
         self._attr_unique_id = f"{super().unique_id}-{self.entity_description.key}"
 
         if self.device.identifier.is_sub_device:
-            # Prefix the sub device label; fall back to the label alone when the
-            # description has no name (e.g. when it relies on a translation_key).
+            # Prefix the sub device label, or use it alone when the description is unnamed.
             if isinstance(description.name, str):
                 self._attr_name = f"{self.device.label} {description.name}"
             else:

--- a/tests/components/overkiz/snapshots/test_switch.ambr
+++ b/tests/components/overkiz/snapshots/test_switch.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_switch_entities_snapshot[cloud_somfy_myfox_europe.json][switch.hot_water_tank_undefinedtype_singleton-entry]
+# name: test_switch_entities_snapshot[cloud_somfy_myfox_europe.json][switch.hot_water_tank-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -13,7 +13,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': None,
-    'entity_id': 'switch.hot_water_tank_undefinedtype_singleton',
+    'entity_id': 'switch.hot_water_tank',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -21,12 +21,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Hot Water Tank UndefinedType._singleton',
+    'object_id_base': 'Hot Water Tank',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': 'mdi:water-boiler',
-    'original_name': 'Hot Water Tank UndefinedType._singleton',
+    'original_name': 'Hot Water Tank',
     'platform': 'overkiz',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -36,14 +36,14 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_switch_entities_snapshot[cloud_somfy_myfox_europe.json][switch.hot_water_tank_undefinedtype_singleton-state]
+# name: test_switch_entities_snapshot[cloud_somfy_myfox_europe.json][switch.hot_water_tank-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Hot Water Tank UndefinedType._singleton',
+      'friendly_name': 'Hot Water Tank',
       'icon': 'mdi:water-boiler',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.hot_water_tank_undefinedtype_singleton',
+    'entity_id': 'switch.hot_water_tank',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/overkiz/test_switch.py
+++ b/tests/components/overkiz/test_switch.py
@@ -52,12 +52,12 @@ MYFOX_CAMERA = FixtureDevice(
     "myfox://SOMFY_PROTECT-1234567890ABCDEF/jQ5ul40RVLnipT6JB8b3JK96tUsf14mR",
     "switch.outdoor_camera_camera_shutter",
 )
-# Bug: entity ID contains "undefinedtype_singleton" because the DomesticHotWaterTank
-# description has no name set, and the #7 suffix makes it a sub-device.
+# Sub-device (#7 suffix) whose DomesticHotWaterTank description has no name set,
+# so the entity name falls back to the device label alone.
 DOMESTIC_HOT_WATER_TANK = FixtureDevice(
     "setup/cloud_somfy_myfox_europe.json",
     "io://1234-5678-1202/6019143#7",
-    "switch.hot_water_tank_undefinedtype_singleton",
+    "switch.hot_water_tank",
 )
 
 


### PR DESCRIPTION
## Proposed change

Sub-device entities prefix the sub-device label onto the description's name via an f-string, without checking the name is a string. When a description has no name (it defaults to the `UNDEFINED` sentinel), the f-string rendered its repr, producing names like `IO (4000#7) UndefinedType._singleton`.

This guards the f-string like the sibling branch already does: with no name, the sub-device label is used on its own. The switch test that documented the bug and its snapshot are updated accordingly.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
