### PR TITLE
goodwe: add battery charge/discharge current limit number entities

### DIFF
--- a/homeassistant/components/goodwe/number.py
+++ b/homeassistant/components/goodwe/number.py
@@ -1,7 +1,7 @@
 """GoodWe PV inverter numeric settings entities."""
 
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import logging
 
 from goodwe import Inverter, InverterError
@@ -11,13 +11,18 @@ from homeassistant.components.number import (
     NumberEntity,
     NumberEntityDescription,
 )
-from homeassistant.const import PERCENTAGE, EntityCategory, UnitOfPower
+from homeassistant.const import (
+    PERCENTAGE,
+    EntityCategory,
+    UnitOfElectricCurrent,
+    UnitOfPower,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN
-from .coordinator import GoodweConfigEntry
+from .coordinator import GoodweConfigEntry, GoodweUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,6 +34,9 @@ class GoodweNumberEntityDescription(NumberEntityDescription):
     getter: Callable[[Inverter], Awaitable[int]]
     setter: Callable[[Inverter, int], Awaitable[None]]
     filter: Callable[[Inverter], bool]
+    # Optional sensor id whose runtime value becomes native_max_value.
+    # Falls back to native_max_value from the description when not set or unavailable.
+    max_sensor_id: str | None = field(default=None)
 
 
 def _get_setting_unit(inverter: Inverter, setting: str) -> str:
@@ -79,6 +87,38 @@ NUMBERS = (
         setter=lambda inv, val: inv.set_ongrid_battery_dod(val),
         filter=lambda inv: True,
     ),
+    GoodweNumberEntityDescription(
+        key="battery_charge_current",
+        translation_key="battery_charge_current",
+        icon="mdi:battery-arrow-up",
+        entity_category=EntityCategory.CONFIG,
+        device_class=NumberDeviceClass.CURRENT,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        native_step=0.1,
+        native_min_value=0,
+        native_max_value=100,
+        max_sensor_id="battery_charge_limit",
+        getter=lambda inv: inv.read_setting("battery_charge_current"),
+        setter=lambda inv, val: inv.write_setting("battery_charge_current", val),
+        filter=lambda inv: "battery_charge_current" in {s.id_ for s in inv.settings()},
+    ),
+    GoodweNumberEntityDescription(
+        key="battery_discharge_current",
+        translation_key="battery_discharge_current",
+        icon="mdi:battery-arrow-down",
+        entity_category=EntityCategory.CONFIG,
+        device_class=NumberDeviceClass.CURRENT,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        native_step=0.1,
+        native_min_value=0,
+        native_max_value=100,
+        max_sensor_id="battery_discharge_limit",
+        getter=lambda inv: inv.read_setting("battery_discharge_current"),
+        setter=lambda inv, val: inv.write_setting("battery_discharge_current", val),
+        filter=lambda inv: (
+            "battery_discharge_current" in {s.id_ for s in inv.settings()}
+        ),
+    ),
 )
 
 
@@ -89,6 +129,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up the inverter select entities from a config entry."""
     inverter = config_entry.runtime_data.inverter
+    coordinator = config_entry.runtime_data.coordinator
     device_info = config_entry.runtime_data.device_info
 
     entities = []
@@ -102,7 +143,9 @@ async def async_setup_entry(
             continue
 
         entities.append(
-            InverterNumberEntity(device_info, description, inverter, current_value)
+            InverterNumberEntity(
+                coordinator, device_info, description, inverter, current_value
+            )
         )
 
     async_add_entities(entities)
@@ -117,6 +160,7 @@ class InverterNumberEntity(NumberEntity):
 
     def __init__(
         self,
+        coordinator: GoodweUpdateCoordinator,
         device_info: DeviceInfo,
         description: GoodweNumberEntityDescription,
         inverter: Inverter,
@@ -128,6 +172,17 @@ class InverterNumberEntity(NumberEntity):
         self._attr_device_info = device_info
         self._attr_native_value = float(current_value)
         self._inverter: Inverter = inverter
+        self._coordinator = coordinator
+
+    @property
+    def native_max_value(self) -> float:
+        """Return max value, using the BMS-reported limit when available."""
+        max_sensor_id = self.entity_description.max_sensor_id
+        if max_sensor_id is not None:
+            bms_limit = self._coordinator.sensor_value(max_sensor_id)
+            if bms_limit is not None and bms_limit > 0:
+                return float(bms_limit)
+        return self.entity_description.native_max_value or 100.0
 
     async def async_update(self) -> None:
         """Get the current value from inverter."""

--- a/homeassistant/components/goodwe/strings.json
+++ b/homeassistant/components/goodwe/strings.json
@@ -24,6 +24,12 @@
       }
     },
     "number": {
+      "battery_charge_current": {
+        "name": "Battery charge current limit"
+      },
+      "battery_discharge_current": {
+        "name": "Battery discharge current limit"
+      },
       "battery_discharge_depth": {
         "name": "Depth of discharge (on-grid)"
       },


### PR DESCRIPTION
## Proposed change

The GoodWe inverter integration is missing two writable number entities for battery current limits. The underlying goodwe library has exposed `battery_charge_current` (register 45353) and `battery_discharge_current` (register 45355) as writable settings since ET inverter support was added, but they were never wired up in the HA integration. Users have no way to see or adjust these limits from Home Assistant.

This PR adds both as `EntityCategory.CONFIG` number entities with `NumberDeviceClass.CURRENT` and step 0.1 A.

**Dynamic max value from BMS:** Rather than hardcoding an upper bound, the entities read `battery_charge_limit` and `battery_discharge_limit` from the runtime coordinator data (registers 37004/37005). These are reported directly by the battery BMS and reflect what the hardware actually supports — e.g. 105 A on a standard LV battery. The description's `native_max_value` (100 A) is used as a fallback when the coordinator has no data yet or no battery is connected.

A `filter` lambda guards each entity so it is only registered when the inverter firmware actually supports the setting (the library silently drops unsupported registers during `read_device_info`).

**Tested on:** GoodWe GW8000M-ES-C10 (ESC platform, single-phase, 8.8 kW). Live readback confirmed 40.0 A charge limit and 60.0 A discharge limit; BMS reports 105 A for both, which becomes the slider ceiling.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- The goodwe library datasheet reference for the ES Uniq series: [GoodWe ES Uniq Datasheet (PDF)](https://en.goodwe.com/Ftp/EN/Downloads/Datasheet/GW_ES-Uniq_Datasheet-EN.pdf)
- Related goodwe library bug-fix PR: https://github.com/marcelblijleven/goodwe/pull/138

## Checklist

- [x] The code change is tested and works locally
- [x] Local tests pass with `python -m pytest tests/components/goodwe/ -v` (no regressions)
- [ ] I have followed the [development checklist](https://developers.home-assistant.io/docs/development_checklist/)
- [ ] The code has been formatted using Ruff (`python -m ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works