### PR TITLE
Lazy media source platforms

### DIFF
--- a/homeassistant/components/ai_task/__init__.py
+++ b/homeassistant/components/ai_task/__init__.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import voluptuous as vol
 
+from homeassistant.components.media_source import local_source
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ENTITY_ID, CONF_DESCRIPTION, CONF_SELECTOR
 from homeassistant.core import (
@@ -34,6 +35,7 @@ from .const import (
 )
 from .entity import AITaskEntity
 from .http import async_setup as async_setup_http
+from .media_source import async_get_media_source
 from .task import (
     GenDataTask,
     GenDataTaskResult,
@@ -88,6 +90,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     hass.data[DATA_PREFERENCES] = AITaskPreferences(hass)
     await hass.data[DATA_PREFERENCES].async_load()
     async_setup_http(hass)
+    if hass.config.media_dirs:
+        source = await async_get_media_source(hass)
+        hass.http.register_view(local_source.LocalMediaView(hass, source))
     hass.services.async_register(
         DOMAIN,
         SERVICE_GENERATE_DATA,

--- a/homeassistant/components/ai_task/media_source.py
+++ b/homeassistant/components/ai_task/media_source.py
@@ -2,14 +2,16 @@
 
 from pathlib import Path
 
-from homeassistant.components.media_source import MediaSource, local_source
+from homeassistant.components.media_source import local_source
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.singleton import singleton
 
 from .const import DATA_MEDIA_SOURCE, DOMAIN, IMAGE_DIR
 
 
-async def async_get_media_source(hass: HomeAssistant) -> MediaSource:
+@singleton(DATA_MEDIA_SOURCE, async_=True)
+async def async_get_media_source(hass: HomeAssistant) -> local_source.LocalSource:
     """Set up local media source."""
     media_dirs = list(hass.config.media_dirs.values())
 
@@ -20,11 +22,10 @@ async def async_get_media_source(hass: HomeAssistant) -> MediaSource:
 
     media_dir = Path(media_dirs[0]) / DOMAIN / IMAGE_DIR
 
-    hass.data[DATA_MEDIA_SOURCE] = source = local_source.LocalSource(
+    return local_source.LocalSource(
         hass,
         DOMAIN,
         "AI generated images",
         {IMAGE_DIR: str(media_dir)},
         f"/{DOMAIN}",
     )
-    return source

--- a/homeassistant/components/media_source/__init__.py
+++ b/homeassistant/components/media_source/__init__.py
@@ -10,11 +10,11 @@ from homeassistant.helpers.typing import ConfigType
 
 from . import http, local_source
 from .const import (
+    DATA_LOCAL_SOURCE,
     DATA_MEDIA_SOURCE_PLATFORMS,
     DOMAIN,
     MEDIA_CLASS_MAP,
     MEDIA_MIME_TYPES,
-    MEDIA_SOURCE_DATA,
     URI_SCHEME,
     URI_SCHEME_REGEX,
 )
@@ -72,14 +72,13 @@ def generate_media_source_id(domain: str, identifier: str) -> str:
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the media_source component."""
-    hass.data[MEDIA_SOURCE_DATA] = {}
     hass.data[DATA_MEDIA_SOURCE_PLATFORMS] = LazyIntegrationPlatforms[MediaSource](
         hass, DOMAIN, _process_media_source_platform
     )
     http.async_setup(hass)
 
     # Local sources support
-    hass.data[MEDIA_SOURCE_DATA][DOMAIN] = await _process_media_source_platform(
+    hass.data[DATA_LOCAL_SOURCE] = await _process_media_source_platform(
         hass, DOMAIN, local_source
     )
     hass.http.register_view(local_source.UploadMediaView)

--- a/homeassistant/components/media_source/__init__.py
+++ b/homeassistant/components/media_source/__init__.py
@@ -78,9 +78,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     http.async_setup(hass)
 
     # Local sources support
-    hass.data[DATA_LOCAL_SOURCE] = await _process_media_source_platform(
-        hass, DOMAIN, local_source
-    )
+    source = await local_source.async_get_media_source(hass)
+    hass.data[DATA_LOCAL_SOURCE] = source
+    hass.http.register_view(local_source.LocalMediaView(hass, source))
     hass.http.register_view(local_source.UploadMediaView)
     websocket_api.async_register_command(hass, local_source.websocket_remove_media)
 
@@ -93,7 +93,4 @@ async def _process_media_source_platform(
     platform: MediaSourceProtocol,
 ) -> MediaSource:
     """Process a media source platform."""
-    source = await platform.async_get_media_source(hass)
-    if isinstance(source, local_source.LocalSource):
-        hass.http.register_view(local_source.LocalMediaView(hass, source))
-    return source
+    return await platform.async_get_media_source(hass)

--- a/homeassistant/components/media_source/__init__.py
+++ b/homeassistant/components/media_source/__init__.py
@@ -5,13 +5,12 @@ from typing import Protocol
 from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.integration_platform import (
-    async_process_integration_platforms,
-)
+from homeassistant.helpers.integration_platform import LazyIntegrationPlatforms
 from homeassistant.helpers.typing import ConfigType
 
 from . import http, local_source
 from .const import (
+    DATA_MEDIA_SOURCE_PLATFORMS,
     DOMAIN,
     MEDIA_CLASS_MAP,
     MEDIA_MIME_TYPES,
@@ -74,16 +73,18 @@ def generate_media_source_id(domain: str, identifier: str) -> str:
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the media_source component."""
     hass.data[MEDIA_SOURCE_DATA] = {}
+    hass.data[DATA_MEDIA_SOURCE_PLATFORMS] = LazyIntegrationPlatforms[MediaSource](
+        hass, DOMAIN, _process_media_source_platform
+    )
     http.async_setup(hass)
 
     # Local sources support
-    await _process_media_source_platform(hass, DOMAIN, local_source)
+    hass.data[MEDIA_SOURCE_DATA][DOMAIN] = await _process_media_source_platform(
+        hass, DOMAIN, local_source
+    )
     hass.http.register_view(local_source.UploadMediaView)
     websocket_api.async_register_command(hass, local_source.websocket_remove_media)
 
-    await async_process_integration_platforms(
-        hass, DOMAIN, _process_media_source_platform
-    )
     return True
 
 
@@ -91,9 +92,9 @@ async def _process_media_source_platform(
     hass: HomeAssistant,
     domain: str,
     platform: MediaSourceProtocol,
-) -> None:
+) -> MediaSource:
     """Process a media source platform."""
     source = await platform.async_get_media_source(hass)
-    hass.data[MEDIA_SOURCE_DATA][domain] = source
     if isinstance(source, local_source.LocalSource):
         hass.http.register_view(local_source.LocalMediaView(hass, source))
+    return source

--- a/homeassistant/components/media_source/const.py
+++ b/homeassistant/components/media_source/const.py
@@ -7,10 +7,17 @@ from homeassistant.components.media_player import MediaClass
 from homeassistant.util.hass_dict import HassKey
 
 if TYPE_CHECKING:
+    from homeassistant.helpers.integration_platform import LazyIntegrationPlatforms
+
     from .models import MediaSource
 
 DOMAIN = "media_source"
+# Eagerly loaded built-in sources (currently only the local source).
 MEDIA_SOURCE_DATA: HassKey[dict[str, MediaSource]] = HassKey(DOMAIN)
+# Lazily loaded media sources provided by other integrations.
+DATA_MEDIA_SOURCE_PLATFORMS: HassKey[LazyIntegrationPlatforms[MediaSource]] = HassKey(
+    "media_source_platforms"
+)
 MEDIA_MIME_TYPES = ("audio", "video", "image")
 MEDIA_CLASS_MAP = {
     "audio": MediaClass.MUSIC,

--- a/homeassistant/components/media_source/const.py
+++ b/homeassistant/components/media_source/const.py
@@ -12,9 +12,7 @@ if TYPE_CHECKING:
     from .models import MediaSource
 
 DOMAIN = "media_source"
-# Eagerly loaded built-in sources (currently only the local source).
-MEDIA_SOURCE_DATA: HassKey[dict[str, MediaSource]] = HassKey(DOMAIN)
-# Lazily loaded media sources provided by other integrations.
+DATA_LOCAL_SOURCE: HassKey[MediaSource] = HassKey("media_source_local_source")
 DATA_MEDIA_SOURCE_PLATFORMS: HassKey[LazyIntegrationPlatforms[MediaSource]] = HassKey(
     "media_source_platforms"
 )

--- a/homeassistant/components/media_source/helper.py
+++ b/homeassistant/components/media_source/helper.py
@@ -56,7 +56,7 @@ async def async_browse_media(
     content_filter: Callable[[BrowseMedia], bool] | None = None,
 ) -> BrowseMediaSource | RootBrowseMediaSource:
     """Return media player browse media results."""
-    if DOMAIN not in hass.data:
+    if DOMAIN not in hass.config.top_level_components:
         raise BrowseError("Media Source not loaded")
 
     try:
@@ -89,11 +89,12 @@ async def async_search_media(
     query: SearchMediaQuery,
 ) -> SearchMedia:
     """Return media searched in the media source."""
-    if DOMAIN not in hass.data:
+    if DOMAIN not in hass.config.top_level_components:
         raise BrowseError("Media Source not loaded")
 
     try:
-        return await _get_media_item(hass, media_content_id, None).async_search(query)
+        media_item = await _get_media_item(hass, media_content_id, None)
+        return await media_item.async_search(query)
     except NotImplementedError as err:
         raise BrowseError(
             translation_domain=DOMAIN,
@@ -117,7 +118,7 @@ async def async_resolve_media(
     target_media_player: str | None | UndefinedType = UNDEFINED,
 ) -> PlayMedia:
     """Get info to play media."""
-    if DOMAIN not in hass.data:
+    if DOMAIN not in hass.config.top_level_components:
         raise Unresolvable("Media Source not loaded")
 
     if target_media_player is UNDEFINED:

--- a/homeassistant/components/media_source/helper.py
+++ b/homeassistant/components/media_source/helper.py
@@ -8,17 +8,23 @@ from homeassistant.components.media_player import (
     SearchMedia,
     SearchMediaQuery,
 )
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.frame import report_usage
 from homeassistant.helpers.typing import UNDEFINED, UndefinedType
 
-from .const import DOMAIN, MEDIA_SOURCE_DATA
+from .const import DOMAIN
 from .error import UnknownMediaSource, Unresolvable
-from .models import BrowseMediaSource, MediaSourceItem, PlayMedia, RootBrowseMediaSource
+from .models import (
+    BrowseMediaSource,
+    MediaSourceItem,
+    PlayMedia,
+    RootBrowseMediaSource,
+    _async_get_media_source,
+    _async_get_media_sources,
+)
 
 
-@callback
-def _get_media_item(
+async def _get_media_item(
     hass: HomeAssistant, media_content_id: str | None, target_media_player: str | None
 ) -> MediaSourceItem:
     """Return media item."""
@@ -26,10 +32,14 @@ def _get_media_item(
         item = MediaSourceItem.from_uri(hass, media_content_id, target_media_player)
     else:
         # We default to our own domain if its only one registered
-        domain = None if len(hass.data[MEDIA_SOURCE_DATA]) > 1 else DOMAIN
+        sources = await _async_get_media_sources(hass)
+        domain = None if len(sources) > 1 else DOMAIN
         return MediaSourceItem(hass, domain, "", target_media_player)
 
-    if item.domain is not None and item.domain not in hass.data[MEDIA_SOURCE_DATA]:
+    if (
+        item.domain is not None
+        and await _async_get_media_source(hass, item.domain) is None
+    ):
         raise UnknownMediaSource(
             translation_domain=DOMAIN,
             translation_key="unknown_media_source",
@@ -50,7 +60,8 @@ async def async_browse_media(
         raise BrowseError("Media Source not loaded")
 
     try:
-        item = await _get_media_item(hass, media_content_id, None).async_browse()
+        media_item = await _get_media_item(hass, media_content_id, None)
+        item = await media_item.async_browse()
     except ValueError as err:
         raise BrowseError(
             translation_domain=DOMAIN,
@@ -117,7 +128,7 @@ async def async_resolve_media(
         target_media_player = None
 
     try:
-        item = _get_media_item(hass, media_content_id, target_media_player)
+        item = await _get_media_item(hass, media_content_id, target_media_player)
     except ValueError as err:
         raise Unresolvable(
             translation_domain=DOMAIN,

--- a/homeassistant/components/media_source/local_source.py
+++ b/homeassistant/components/media_source/local_source.py
@@ -24,7 +24,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util import raise_if_invalid_filename, raise_if_invalid_path
 
-from .const import DOMAIN, MEDIA_CLASS_MAP, MEDIA_MIME_TYPES, MEDIA_SOURCE_DATA
+from .const import DATA_LOCAL_SOURCE, DOMAIN, MEDIA_CLASS_MAP, MEDIA_MIME_TYPES
 from .error import Unresolvable
 from .models import BrowseMediaSource, MediaSource, MediaSourceItem, PlayMedia
 
@@ -446,7 +446,7 @@ class UploadMediaView(http.HomeAssistantView):
         if target_folder.domain != DOMAIN:
             raise web.HTTPBadRequest
 
-        source = cast(LocalSource, hass.data[MEDIA_SOURCE_DATA][target_folder.domain])
+        source = cast(LocalSource, hass.data[DATA_LOCAL_SOURCE])
         try:
             uploaded_media_source_id = await source.async_upload_media(
                 target_folder, data["file"]
@@ -491,7 +491,7 @@ async def websocket_remove_media(
         )
         return
 
-    source = cast(LocalSource, hass.data[MEDIA_SOURCE_DATA][item.domain])
+    source = cast(LocalSource, hass.data[DATA_LOCAL_SOURCE])
 
     try:
         await source.async_delete_media(item)

--- a/homeassistant/components/media_source/models.py
+++ b/homeassistant/components/media_source/models.py
@@ -10,13 +10,35 @@ from homeassistant.components.media_player import (
     SearchMedia,
     SearchMediaQuery,
 )
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.translation import async_get_cached_translations
 
-from .const import MEDIA_SOURCE_DATA, URI_SCHEME, URI_SCHEME_REGEX
+from .const import (
+    DATA_MEDIA_SOURCE_PLATFORMS,
+    MEDIA_SOURCE_DATA,
+    URI_SCHEME,
+    URI_SCHEME_REGEX,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+async def _async_get_media_sources(hass: HomeAssistant) -> dict[str, MediaSource]:
+    """Return all media sources, loading integration platforms on demand."""
+    eager_sources: dict[str, MediaSource] = hass.data[MEDIA_SOURCE_DATA]
+    sources = dict(eager_sources)
+    sources.update(await hass.data[DATA_MEDIA_SOURCE_PLATFORMS].async_get_platforms())
+    return sources
+
+
+async def _async_get_media_source(
+    hass: HomeAssistant, domain: str
+) -> MediaSource | None:
+    """Return the media source for a domain, loading it on demand."""
+    if (source := hass.data[MEDIA_SOURCE_DATA].get(domain)) is not None:
+        return source
+    return await hass.data[DATA_MEDIA_SOURCE_PLATFORMS].async_get_platform(domain)
 
 
 @dataclass(slots=True)
@@ -87,6 +109,7 @@ class MediaSourceItem:
                 can_expand=True,
                 children_media_class=MediaClass.APP,
             )
+            sources = await _async_get_media_sources(self.hass)
             base.children = sorted(
                 (
                     BrowseMediaSource(
@@ -99,13 +122,13 @@ class MediaSourceItem:
                         can_play=False,
                         can_expand=True,
                     )
-                    for source in self.hass.data[MEDIA_SOURCE_DATA].values()
+                    for source in sources.values()
                 ),
                 key=lambda item: item.title,
             )
             return base
 
-        return await self.async_media_source().async_browse_media(self)
+        return await (await self.async_media_source()).async_browse_media(self)
 
     async def async_search(self, query: SearchMediaQuery) -> SearchMedia:
         """Search this item."""
@@ -118,14 +141,16 @@ class MediaSourceItem:
 
     async def async_resolve(self) -> PlayMedia:
         """Resolve to playable item."""
-        return await self.async_media_source().async_resolve_media(self)
+        return await (await self.async_media_source()).async_resolve_media(self)
 
-    @callback
-    def async_media_source(self) -> MediaSource:
+    async def async_media_source(self) -> MediaSource:
         """Return media source that owns this item."""
         if TYPE_CHECKING:
             assert self.domain is not None
-        return self.hass.data[MEDIA_SOURCE_DATA][self.domain]
+        # Existence is validated by _get_media_item before browse/resolve.
+        source = await _async_get_media_source(self.hass, self.domain)
+        assert source is not None
+        return source
 
     @classmethod
     def from_uri(

--- a/homeassistant/components/media_source/models.py
+++ b/homeassistant/components/media_source/models.py
@@ -14,8 +14,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.translation import async_get_cached_translations
 
 from .const import (
+    DATA_LOCAL_SOURCE,
     DATA_MEDIA_SOURCE_PLATFORMS,
-    MEDIA_SOURCE_DATA,
+    DOMAIN,
     URI_SCHEME,
     URI_SCHEME_REGEX,
 )
@@ -26,8 +27,7 @@ if TYPE_CHECKING:
 
 async def _async_get_media_sources(hass: HomeAssistant) -> dict[str, MediaSource]:
     """Return all media sources, loading integration platforms on demand."""
-    eager_sources: dict[str, MediaSource] = hass.data[MEDIA_SOURCE_DATA]
-    sources = dict(eager_sources)
+    sources: dict[str, MediaSource] = {DOMAIN: hass.data[DATA_LOCAL_SOURCE]}
     sources.update(await hass.data[DATA_MEDIA_SOURCE_PLATFORMS].async_get_platforms())
     return sources
 
@@ -36,8 +36,8 @@ async def _async_get_media_source(
     hass: HomeAssistant, domain: str
 ) -> MediaSource | None:
     """Return the media source for a domain, loading it on demand."""
-    if (source := hass.data[MEDIA_SOURCE_DATA].get(domain)) is not None:
-        return source
+    if domain == DOMAIN:
+        return hass.data[DATA_LOCAL_SOURCE]
     return await hass.data[DATA_MEDIA_SOURCE_PLATFORMS].async_get_platform(domain)
 
 
@@ -137,7 +137,7 @@ class MediaSourceItem:
         if self.domain is None:
             raise NotImplementedError
 
-        return await self.async_media_source().async_search_media(self, query)
+        return await (await self._async_media_source()).async_search_media(self, query)
 
     async def async_resolve(self) -> PlayMedia:
         """Resolve to playable item."""

--- a/homeassistant/components/media_source/models.py
+++ b/homeassistant/components/media_source/models.py
@@ -128,7 +128,8 @@ class MediaSourceItem:
             )
             return base
 
-        return await (await self.async_media_source()).async_browse_media(self)
+        source = await self._async_media_source()
+        return await source.async_browse_media(self)
 
     async def async_search(self, query: SearchMediaQuery) -> SearchMedia:
         """Search this item."""
@@ -141,9 +142,10 @@ class MediaSourceItem:
 
     async def async_resolve(self) -> PlayMedia:
         """Resolve to playable item."""
-        return await (await self.async_media_source()).async_resolve_media(self)
+        source = await self._async_media_source()
+        return await source.async_resolve_media(self)
 
-    async def async_media_source(self) -> MediaSource:
+    async def _async_media_source(self) -> MediaSource:
         """Return media source that owns this item."""
         if TYPE_CHECKING:
             assert self.domain is not None

--- a/homeassistant/helpers/integration_platform.py
+++ b/homeassistant/helpers/integration_platform.py
@@ -266,7 +266,7 @@ async def _async_process_integration_platforms(
 
 
 # Any = platform.
-type ProcessPlatform[_R] = Callable[[HomeAssistant, str, Any], _R]
+type ProcessPlatform[_R] = Callable[[HomeAssistant, str, Any], _R | Awaitable[_R]]
 
 
 class LazyIntegrationPlatforms[_R]:
@@ -276,6 +276,8 @@ class LazyIntegrationPlatforms[_R]:
     platform for every loaded integration up front (and as integrations load),
     this only imports and processes the platform for an integration the first
     time it is requested, and only for integrations that are loaded.
+
+    The process callback may be a coroutine function; its result is awaited.
 
     The platform is intentionally not registered for preloading, since for a
     rarely used platform that would import it for every integration during
@@ -358,7 +360,10 @@ class LazyIntegrationPlatforms[_R]:
             result: _R | None = None
             if platform is not None:
                 try:
-                    result = self._process_platform(self._hass, domain, platform)
+                    processed = self._process_platform(self._hass, domain, platform)
+                    if isinstance(processed, Awaitable):
+                        processed = await processed
+                    result = processed
                 except Exception:
                     _LOGGER.exception(
                         "Error processing %s platform for %s",

--- a/tests/components/ai_task/test_media_source.py
+++ b/tests/components/ai_task/test_media_source.py
@@ -26,6 +26,9 @@ async def test_local_media_source(hass: HomeAssistant, init_components: None) ->
     )
     assert source.url_prefix == "/ai_task"
 
+
+async def test_media_source_no_media_dirs(hass: HomeAssistant) -> None:
+    """Test an error is raised when no media directories are configured."""
     hass.config.media_dirs = {}
 
     with pytest.raises(

--- a/tests/components/media_source/test_helper.py
+++ b/tests/components/media_source/test_helper.py
@@ -1,6 +1,6 @@
 """Test media source helpers."""
 
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -11,7 +11,7 @@ from homeassistant.components.media_player import (
     SearchMediaQuery,
 )
 from homeassistant.components.media_source import const, models
-from homeassistant.components.media_source.const import MEDIA_SOURCE_DATA
+from homeassistant.components.media_source.const import DATA_MEDIA_SOURCE_PLATFORMS
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -125,18 +125,18 @@ async def test_async_unresolve_media(hass: HomeAssistant) -> None:
         )
 
 
-async def test_browse_resolve_without_setup() -> None:
+async def test_browse_resolve_without_setup(hass: HomeAssistant) -> None:
     """Test browse and resolve work without being setup."""
     with pytest.raises(BrowseError):
-        await media_source.async_browse_media(Mock(data={}), None)
+        await media_source.async_browse_media(hass, None)
 
     with pytest.raises(BrowseError):
         await media_source.async_search_media(
-            Mock(data={}), None, SearchMediaQuery(search_query="test")
+            hass, None, SearchMediaQuery(search_query="test")
         )
 
     with pytest.raises(media_source.Unresolvable):
-        await media_source.async_resolve_media(Mock(data={}), None, None)
+        await media_source.async_resolve_media(hass, None, None)
 
 
 async def test_async_search_media(hass: HomeAssistant) -> None:
@@ -166,7 +166,11 @@ async def test_async_search_media(hass: HomeAssistant) -> None:
 
 async def test_async_search_media_not_supported(hass: HomeAssistant) -> None:
     """Test searching a source without search support raises a BrowseError."""
-    hass.data[MEDIA_SOURCE_DATA] = {"plain": models.MediaSource("plain")}
+    assert await async_setup_component(hass, media_source.DOMAIN, {})
+    await hass.async_block_till_done()
+    hass.data[DATA_MEDIA_SOURCE_PLATFORMS].async_get_platform = AsyncMock(
+        return_value=models.MediaSource("plain")
+    )
 
     with pytest.raises(BrowseError):
         await media_source.async_search_media(
@@ -178,10 +182,11 @@ async def test_async_search_media_not_supported(hass: HomeAssistant) -> None:
 
 async def test_async_search_media_root_not_supported(hass: HomeAssistant) -> None:
     """Test searching the aggregate root of multiple sources is not supported."""
-    hass.data[MEDIA_SOURCE_DATA] = {
-        "source_a": models.MediaSource("source_a"),
-        "source_b": models.MediaSource("source_b"),
-    }
+    assert await async_setup_component(hass, media_source.DOMAIN, {})
+    await hass.async_block_till_done()
+    hass.data[DATA_MEDIA_SOURCE_PLATFORMS].async_get_platforms = AsyncMock(
+        return_value={"source_a": models.MediaSource("source_a")}
+    )
 
     with pytest.raises(BrowseError):
         await media_source.async_search_media(

--- a/tests/helpers/test_integration_platform.py
+++ b/tests/helpers/test_integration_platform.py
@@ -471,3 +471,25 @@ async def test_lazy_integration_platforms_concurrent(hass: HomeAssistant) -> Non
     assert results == [loaded_platform, loaded_platform]
     # The platform was imported and processed exactly once.
     assert processed == ["loaded"]
+
+
+async def test_lazy_integration_platforms_async_process(hass: HomeAssistant) -> None:
+    """Test a coroutine process callback is awaited and its result cached."""
+    loaded_platform = Mock()
+    mock_platform(hass, "loaded.platform_to_check", loaded_platform)
+    hass.config.components.add("loaded")
+
+    processed: list[str] = []
+
+    async def _process_platform(hass: HomeAssistant, domain: str, platform: Any) -> Any:
+        processed.append(domain)
+        return platform
+
+    platforms = LazyIntegrationPlatforms(hass, "platform_to_check", _process_platform)
+
+    assert await platforms.async_get_platform("loaded") is loaded_platform
+    assert processed == ["loaded"]
+
+    # The awaited result is cached, so a subsequent request does not reprocess.
+    assert await platforms.async_get_platform("loaded") is loaded_platform
+    assert processed == ["loaded"]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Media source platforms are only needed when a user plays a media source item, or browses the media panel. Until then, we don't need to load the platforms.

LocalSource returned from get_media_source used to rely on a side-effect of being loaded that it would register the HTTP view. This was only leveraged by AI Task. We cannot rely on this, so now both media source and AI task will register their media source themselves with HTTP view.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
