### PR TITLE
Fix flaky KNX sensor validation test

### DIFF
--- a/tests/components/knx/test_sensor.py
+++ b/tests/components/knx/test_sensor.py
@@ -24,6 +24,7 @@ from tests.common import (
     async_fire_time_changed,
     mock_restore_cache_with_extra_data,
 )
+from tests.typing import WebSocketGenerator
 
 
 async def test_sensor(hass: HomeAssistant, knx: KNXTestKit) -> None:
@@ -334,17 +335,25 @@ async def test_sensor_ui_load(knx: KNXTestKit) -> None:
 async def test_sensor_ui_create_attribute_validation(
     hass: HomeAssistant,
     knx: KNXTestKit,
-    create_ui_entity: KnxEntityGenerator,
+    hass_ws_client: WebSocketGenerator,
     knx_config: dict[str, Any],
 ) -> None:
     """Test creating a sensor with invalid unit, state_class or device_class."""
     await knx.setup_integration()
-    with pytest.raises(AssertionError) as err:
-        await create_ui_entity(
-            platform=Platform.SENSOR,
-            entity_data={"name": "test"},
-            knx_data=knx_config,
-        )
-    assert "success" in err.value.args[0]
-    assert "error_base" in err.value.args[0]
-    assert "path" in err.value.args[0]
+    client = await hass_ws_client(hass)
+
+    await client.send_json_auto_id(
+        {
+            "type": "knx/create_entity",
+            "platform": Platform.SENSOR,
+            "data": {
+                "entity": {"name": "test"},
+                "knx": knx_config,
+            },
+        }
+    )
+    res = await client.receive_json()
+    assert res["success"], res
+    assert res["result"]["success"] is False
+    assert res["result"]["error_base"]
+    assert res["result"]["errors"][0]["path"]


### PR DESCRIPTION
## Breaking change

## Proposed change

`test_sensor_ui_create_attribute_validation` (in `tests/components/knx/test_sensor.py`) is flaky and fails consistently once pytest is bumped to 9.1.x (see #174371).

The test called the `create_ui_entity` helper, which on a validation failure raises `AssertionError` with the result dict as its message, then asserted on substrings of `err.value.args[0]`:

```python
assert "path" in err.value.args[0]
```

That string is pytest's `saferepr`-rendered assertion message, which is truncated (`...`) at a fixed size. The result dict's `error_base` field holds `str(vol.Invalid)`, built from a **hash-randomized set** of enum options, so depending on `PYTHONHASHSEED` the truncation point shifts and can drop the `'errors': [{'path': ...}]` part — flaky failures. pytest 9.1 shrank the truncation window, so it now fails on every seed.

The fix inspects the structured WebSocket result directly instead of a truncatable repr string, matching the pattern already used in `test_config_store.py`. Verified passing on both pytest 9.0.3 and 9.1.1 across the seeds that previously failed.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #174371
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
