### PR TITLE
Fix flaky test_thread_fails_raise

### DIFF
--- a/tests/util/test_thread.py
+++ b/tests/util/test_thread.py
@@ -37,20 +37,20 @@ async def test_thread_not_started(hass: HomeAssistant) -> None:
         test_thread.raise_exc(TimeoutError)
 
 
-async def test_thread_fails_raise(hass: HomeAssistant) -> None:
+async def test_thread_fails_raise() -> None:
     """Test throwing after already ended."""
 
-    finish_event = asyncio.Event()
-
-    def _do_nothing(*_):
-        run_callback_threadsafe(hass.loop, finish_event.set)
-
-    test_thread = ThreadWithException(target=_do_nothing)
+    test_thread = ThreadWithException(target=lambda *_: None)
     test_thread.start()
-    await asyncio.wait_for(finish_event.wait(), timeout=0.1)
     test_thread.join()
 
-    with pytest.raises(ValueError, match="Thread not found"):
+    # After the thread has ended, its id may still briefly resolve to a live
+    # thread state, so patch it to an id guaranteed not to exist to
+    # deterministically exercise the "Thread not found" path.
+    with (
+        patch.object(test_thread, "_ident", -1),
+        pytest.raises(ValueError, match="Thread not found"),
+    ):
         test_thread.raise_exc(ValueError)
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix the flaky `tests/util/test_thread.py::test_thread_fails_raise` test.

The test starts a thread, joins it, and then expects `raise_exc()` to raise `ValueError("Thread not found")`. That error is produced by `async_raise()` when `PyThreadState_SetAsyncExc` returns `0` (thread id not found).

The flakiness is a CPython teardown race: even after `Thread.join()` returns, the thread id can still briefly resolve to a live `PyThreadState`. When that happens `PyThreadState_SetAsyncExc` returns `1` instead of `0`, so no `ValueError` is raised and the test fails with `DID NOT RAISE`. This is more visible on Python 3.14.

The fix patches the thread id to one that is guaranteed not to exist before calling `raise_exc()`, so the "Thread not found" path is exercised deterministically regardless of teardown timing.

Example failure: https://github.com/home-assistant/core/actions/runs/27909952929/job/82585577379

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: flaky failure observed in https://github.com/home-assistant/core/actions/runs/27909952929/job/82585577379 (CI for #174364)
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
