### PR TITLE
Remove rdfurman from CODEOWNERS for honeywell component ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -781,8 +781,8 @@ CLAUDE.md @home-assistant/core
 /tests/components/homevolt/ @danielhiversen @liudger
 /homeassistant/components/homewizard/ @DCSBL
 /tests/components/homewizard/ @DCSBL
-/homeassistant/components/honeywell/ @rdfurman @mkmer
-/tests/components/honeywell/ @rdfurman @mkmer
+/homeassistant/components/honeywell/ @mkmer
+/tests/components/honeywell/ @mkmer
 /homeassistant/components/honeywell_string_lights/ @balloob
 /tests/components/honeywell_string_lights/ @balloob
 /homeassistant/components/hr_energy_qube/ @MattieGit


### PR DESCRIPTION
I'm no longer working on the honeywell component.