### PR TITLE
Fix singleton leaving a dangling Event when wrapped coroutine raises

### DIFF
--- a/homeassistant/helpers/singleton.py
+++ b/homeassistant/helpers/singleton.py
@@ -59,19 +59,28 @@ def singleton[_S, _T, _U](
         @functools.wraps(func)
         async def async_wrapped(hass: HomeAssistant) -> _T:
             if data_key not in hass.data:
-                evt = hass.data[data_key] = asyncio.Event()
-                result = await func(hass)
+                future: asyncio.Future[_T] = asyncio.get_running_loop().create_future()
+                hass.data[data_key] = future
+                try:
+                    result = await func(hass)
+                except BaseException as err:
+                    # Clear the key so a future call retries, and propagate the
+                    # failure to any waiters instead of leaving them hung.
+                    del hass.data[data_key]
+                    future.set_exception(err)
+                    # Retrieve so an unawaited future does not log the exception.
+                    future.exception()
+                    raise
                 hass.data[data_key] = result
-                evt.set()
+                future.set_result(result)
                 return cast(_T, result)
 
-            obj_or_evt = hass.data[data_key]
+            obj_or_future = hass.data[data_key]
 
-            if isinstance(obj_or_evt, asyncio.Event):
-                await obj_or_evt.wait()
-                return cast(_T, hass.data[data_key])
+            if isinstance(obj_or_future, asyncio.Future):
+                return cast(_T, await obj_or_future)
 
-            return cast(_T, obj_or_evt)
+            return cast(_T, obj_or_future)
 
         return async_wrapped
 

--- a/tests/helpers/test_singleton.py
+++ b/tests/helpers/test_singleton.py
@@ -1,5 +1,6 @@
 """Test singleton helper."""
 
+import asyncio
 from typing import Any
 from unittest.mock import Mock
 
@@ -45,3 +46,58 @@ def test_singleton(mock_hass: HomeAssistant, result: Any) -> None:
     assert result1 is result2
     assert "test_key" in mock_hass.data
     assert mock_hass.data["test_key"] is result1
+
+
+async def test_singleton_async_raises(mock_hass: HomeAssistant) -> None:
+    """Test the key is not poisoned when the wrapped coroutine raises."""
+    calls = 0
+
+    @singleton.singleton("test_key")
+    async def something(hass: HomeAssistant) -> Any:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise ValueError("boom")
+        return "result"
+
+    with pytest.raises(ValueError, match="boom"):
+        await something(mock_hass)
+
+    # The failure cleared the key, so a later call retries cleanly.
+    assert "test_key" not in mock_hass.data
+
+    assert await something(mock_hass) == "result"
+    assert mock_hass.data["test_key"] == "result"
+    assert calls == 2
+
+
+async def test_singleton_async_concurrent_raises(mock_hass: HomeAssistant) -> None:
+    """Test a concurrent caller wakes up when the in-flight call raises."""
+    release = asyncio.Event()
+    calls = 0
+
+    @singleton.singleton("test_key")
+    async def something(hass: HomeAssistant) -> Any:
+        nonlocal calls
+        calls += 1
+        await release.wait()
+        raise ValueError("boom")
+
+    # First caller installs the future and parks on release.wait().
+    task1 = asyncio.create_task(something(mock_hass))
+    await asyncio.sleep(0)
+    # Second caller finds the in-flight future and waits on it.
+    task2 = asyncio.create_task(something(mock_hass))
+    await asyncio.sleep(0)
+
+    release.set()
+
+    async with asyncio.timeout(1):
+        with pytest.raises(ValueError, match="boom"):
+            await task1
+        with pytest.raises(ValueError, match="boom"):
+            await task2
+
+    # Only the first caller ran the wrapped function; the waiter observed its error.
+    assert calls == 1
+    assert "test_key" not in mock_hass.data


### PR DESCRIPTION
## Proposed change

The `@singleton` decorator previously stored an `asyncio.Event` in `hass.data` while the wrapped coroutine ran, and only called `evt.set()` after the coroutine returned successfully.

If the wrapped coroutine raised, the `hass.data` key was left pointing at an `Event` that was never set. This poisoned the key permanently:

- Any concurrent caller already awaiting `evt.wait()` would hang forever.
- Every future caller would also find the dangling `Event` and hang forever, since the key was never cleared to allow a retry.

This change replaces the `Event` with an `asyncio.Future`:

- On success, the future resolves to the computed result.
- On any exception, the `hass.data` key is deleted so a later call retries cleanly, and the exception is propagated to any concurrent waiters via `future.set_exception()` (the exception is also retrieved so an unawaited future does not log it), before being re-raised to the original caller.

Concurrent waiters now simply `await` the future, receiving either the result or the exception.

Tests added in `tests/helpers/test_singleton.py` cover the raise-then-retry case and the concurrent-waiter case.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr