### PR TITLE
Add tests for the Overkiz binary sensor platform

### DIFF
--- a/tests/components/overkiz/snapshots/test_binary_sensor.ambr
+++ b/tests/components/overkiz/snapshots/test_binary_sensor.ambr
@@ -1,0 +1,154 @@
+# serializer version: 1
+# name: test_binary_sensor_entities_snapshot[cloud_atlantic_cozytouch.json][binary_sensor.my_home_patio_water_heating_energy_demand_status-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.my_home_patio_water_heating_energy_demand_status',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Energy demand status',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.HEAT: 'heat'>,
+    'original_icon': None,
+    'original_name': 'Energy demand status',
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'io://1234-5678-5643/109286#1-io:OperatingModeCapabilitiesState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensor_entities_snapshot[cloud_atlantic_cozytouch.json][binary_sensor.my_home_patio_water_heating_energy_demand_status-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'heat',
+      'friendly_name': 'Patio Water Heating Energy demand status',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.my_home_patio_water_heating_energy_demand_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_binary_sensor_entities_snapshot[cloud_atlantic_cozytouch.json][binary_sensor.my_home_patio_water_heating_heating_status-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.my_home_patio_water_heating_heating_status',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Heating status',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.HEAT: 'heat'>,
+    'original_icon': None,
+    'original_name': 'Heating status',
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'io://1234-5678-5643/109286#1-core:HeatingStatusState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensor_entities_snapshot[cloud_atlantic_cozytouch.json][binary_sensor.my_home_patio_water_heating_heating_status-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'heat',
+      'friendly_name': 'Patio Water Heating Heating status',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.my_home_patio_water_heating_heating_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_binary_sensor_entities_snapshot[cloud_nexity_rail_din_europe.json][binary_sensor.maple_residence_living_room_smoke_detector_smoke-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.maple_residence_living_room_smoke_detector_smoke',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Smoke',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.SMOKE: 'smoke'>,
+    'original_icon': None,
+    'original_name': 'Smoke',
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'io://1234-5678-1698/8907539-core:SmokeState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensor_entities_snapshot[cloud_nexity_rail_din_europe.json][binary_sensor.maple_residence_living_room_smoke_detector_smoke-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'smoke',
+      'friendly_name': 'Living Room Smoke Detector Smoke',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.maple_residence_living_room_smoke_detector_smoke',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/overkiz/snapshots/test_binary_sensor.ambr
+++ b/tests/components/overkiz/snapshots/test_binary_sensor.ambr
@@ -152,3 +152,309 @@
     'state': 'off',
   })
 # ---
+# name: test_binary_sensor_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][binary_sensor.family_wing_fenetre_garage_contact-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.family_wing_fenetre_garage_contact',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Contact',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.DOOR: 'door'>,
+    'original_icon': None,
+    'original_name': 'Contact',
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'rtds://1234-1234-6233/394765-core:ContactState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensor_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][binary_sensor.family_wing_fenetre_garage_contact-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Fenêtre Garage Contact',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.family_wing_fenetre_garage_contact',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_binary_sensor_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][binary_sensor.family_wing_porte_contact-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.family_wing_porte_contact',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Contact',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.DOOR: 'door'>,
+    'original_icon': None,
+    'original_name': 'Contact',
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'rtds://1234-1234-6233/394781-core:ContactState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensor_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][binary_sensor.family_wing_porte_contact-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Porte Contact',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.family_wing_porte_contact',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_binary_sensor_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][binary_sensor.kids_room_kitchen_occupancy-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.kids_room_kitchen_occupancy',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Occupancy',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.OCCUPANCY: 'occupancy'>,
+    'original_icon': None,
+    'original_name': 'Occupancy',
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'rtds://1234-1234-6233/288316-core:OccupancyState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensor_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][binary_sensor.kids_room_kitchen_occupancy-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'occupancy',
+      'friendly_name': 'Kitchen Occupancy',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.kids_room_kitchen_occupancy',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_binary_sensor_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][binary_sensor.living_room_hallway_occupancy-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.living_room_hallway_occupancy',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Occupancy',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.OCCUPANCY: 'occupancy'>,
+    'original_icon': None,
+    'original_name': 'Occupancy',
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'rtds://1234-1234-6233/232949-core:OccupancyState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensor_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][binary_sensor.living_room_hallway_occupancy-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'occupancy',
+      'friendly_name': 'Hallway Occupancy',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.living_room_hallway_occupancy',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_binary_sensor_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][binary_sensor.upstairs_detecteur_fumee_smoke-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.upstairs_detecteur_fumee_smoke',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Smoke',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.SMOKE: 'smoke'>,
+    'original_icon': None,
+    'original_name': 'Smoke',
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'rtds://1234-1234-6233/711548-core:SmokeState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensor_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][binary_sensor.upstairs_detecteur_fumee_smoke-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'smoke',
+      'friendly_name': 'Détecteur Fumée Smoke',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.upstairs_detecteur_fumee_smoke',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_binary_sensor_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][binary_sensor.upstairs_entree_occupancy-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.upstairs_entree_occupancy',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Occupancy',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.OCCUPANCY: 'occupancy'>,
+    'original_icon': None,
+    'original_name': 'Occupancy',
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'rtds://1234-1234-6233/246258-core:OccupancyState',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensor_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][binary_sensor.upstairs_entree_occupancy-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'occupancy',
+      'friendly_name': 'Entrée Occupancy',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.upstairs_entree_occupancy',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/overkiz/test_binary_sensor.py
+++ b/tests/components/overkiz/test_binary_sensor.py
@@ -1,0 +1,162 @@
+"""Tests for the Overkiz binary sensor platform."""
+
+from collections.abc import Generator
+from pathlib import Path
+from unittest.mock import patch
+
+from freezegun.api import FrozenDateTimeFactory
+from pyoverkiz.enums import OverkizState
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .conftest import FixtureDevice, MockOverkizClient, SetupOverkizIntegration
+from .helpers import (
+    async_deliver_events,
+    device_state_changed_event,
+    device_unavailable_event,
+)
+
+from tests.common import snapshot_platform
+
+SMOKE_SENSOR = FixtureDevice(
+    "setup/cloud_nexity_rail_din_europe.json",
+    "io://1234-5678-1698/8907539",
+    "binary_sensor.maple_residence_living_room_smoke_detector_smoke",
+)
+HEATING_STATUS = FixtureDevice(
+    "setup/cloud_atlantic_cozytouch.json",
+    "io://1234-5678-5643/109286#1",
+    "binary_sensor.my_home_patio_water_heating_heating_status",
+)
+
+SNAPSHOT_FIXTURES = [
+    SMOKE_SENSOR,
+    HEATING_STATUS,
+]
+
+
+@pytest.fixture(autouse=True)
+def fixture_platforms() -> Generator[None]:
+    """Limit platforms to binary_sensor only."""
+    with patch("homeassistant.components.overkiz.PLATFORMS", [Platform.BINARY_SENSOR]):
+        yield
+
+
+@pytest.mark.parametrize(
+    "device",
+    SNAPSHOT_FIXTURES,
+    ids=[Path(device.fixture).name for device in SNAPSHOT_FIXTURES],
+)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_binary_sensor_entities_snapshot(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+    device: FixtureDevice,
+) -> None:
+    """Test representative real setups via snapshot."""
+    config_entry = await setup_overkiz_integration(fixture=device.fixture)
+
+    await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
+
+
+async def test_binary_sensor_smoke_state_update(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test event-driven state update for a smoke sensor (notDetected → detected)."""
+    await setup_overkiz_integration(fixture=SMOKE_SENSOR.fixture)
+
+    state = hass.states.get(SMOKE_SENSOR.entity_id)
+    assert state
+    assert state.state == STATE_OFF
+
+    await async_deliver_events(
+        hass,
+        freezer,
+        mock_client,
+        [
+            device_state_changed_event(
+                SMOKE_SENSOR.device_url,
+                [
+                    {
+                        "name": OverkizState.CORE_SMOKE.value,
+                        "type": 3,
+                        "value": "detected",
+                    },
+                ],
+            )
+        ],
+    )
+
+    state = hass.states.get(SMOKE_SENSOR.entity_id)
+    assert state
+    assert state.state == STATE_ON
+
+
+async def test_binary_sensor_heating_state_update(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test event-driven state update for a heating sensor (off → on)."""
+    await setup_overkiz_integration(fixture=HEATING_STATUS.fixture)
+
+    state = hass.states.get(HEATING_STATUS.entity_id)
+    assert state
+    assert state.state == STATE_OFF
+
+    await async_deliver_events(
+        hass,
+        freezer,
+        mock_client,
+        [
+            device_state_changed_event(
+                HEATING_STATUS.device_url,
+                [
+                    {
+                        "name": OverkizState.CORE_HEATING_STATUS.value,
+                        "type": 3,
+                        "value": "on",
+                    },
+                ],
+            )
+        ],
+    )
+
+    state = hass.states.get(HEATING_STATUS.entity_id)
+    assert state
+    assert state.state == STATE_ON
+
+
+async def test_binary_sensor_unavailability(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    mock_client: MockOverkizClient,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test binary sensor becomes unavailable when device goes offline."""
+    await setup_overkiz_integration(fixture=SMOKE_SENSOR.fixture)
+
+    state = hass.states.get(SMOKE_SENSOR.entity_id)
+    assert state
+    assert state.state != STATE_UNAVAILABLE
+
+    await async_deliver_events(
+        hass,
+        freezer,
+        mock_client,
+        [device_unavailable_event(SMOKE_SENSOR.device_url)],
+    )
+
+    state = hass.states.get(SMOKE_SENSOR.entity_id)
+    assert state
+    assert state.state == STATE_UNAVAILABLE

--- a/tests/components/overkiz/test_binary_sensor.py
+++ b/tests/components/overkiz/test_binary_sensor.py
@@ -32,7 +32,6 @@ HEATING_STATUS = FixtureDevice(
     "io://1234-5678-5643/109286#1",
     "binary_sensor.my_home_patio_water_heating_heating_status",
 )
-# Setup covering occupancy and contact sensors in addition to smoke.
 CONTACT_SENSOR = FixtureDevice(
     "setup/cloud_somfy_tahoma_v2_europe.json",
     "rtds://1234-1234-6233/394781",

--- a/tests/components/overkiz/test_binary_sensor.py
+++ b/tests/components/overkiz/test_binary_sensor.py
@@ -32,10 +32,17 @@ HEATING_STATUS = FixtureDevice(
     "io://1234-5678-5643/109286#1",
     "binary_sensor.my_home_patio_water_heating_heating_status",
 )
+# Setup covering occupancy and contact sensors in addition to smoke.
+CONTACT_SENSOR = FixtureDevice(
+    "setup/cloud_somfy_tahoma_v2_europe.json",
+    "rtds://1234-1234-6233/394781",
+    "binary_sensor.family_wing_porte_contact",
+)
 
 SNAPSHOT_FIXTURES = [
     SMOKE_SENSOR,
     HEATING_STATUS,
+    CONTACT_SENSOR,
 ]
 
 
@@ -97,42 +104,6 @@ async def test_binary_sensor_smoke_state_update(
     )
 
     state = hass.states.get(SMOKE_SENSOR.entity_id)
-    assert state
-    assert state.state == STATE_ON
-
-
-async def test_binary_sensor_heating_state_update(
-    hass: HomeAssistant,
-    setup_overkiz_integration: SetupOverkizIntegration,
-    mock_client: MockOverkizClient,
-    freezer: FrozenDateTimeFactory,
-) -> None:
-    """Test event-driven state update for a heating sensor (off → on)."""
-    await setup_overkiz_integration(fixture=HEATING_STATUS.fixture)
-
-    state = hass.states.get(HEATING_STATUS.entity_id)
-    assert state
-    assert state.state == STATE_OFF
-
-    await async_deliver_events(
-        hass,
-        freezer,
-        mock_client,
-        [
-            device_state_changed_event(
-                HEATING_STATUS.device_url,
-                [
-                    {
-                        "name": OverkizState.CORE_HEATING_STATUS.value,
-                        "type": 3,
-                        "value": "on",
-                    },
-                ],
-            )
-        ],
-    )
-
-    state = hass.states.get(HEATING_STATUS.entity_id)
     assert state
     assert state.state == STATE_ON
 


### PR DESCRIPTION
## Proposed change

Adds test coverage for the Overkiz `binary_sensor` platform, which had none.

- Snapshot tests across three real setups, covering smoke, heating status,
  energy demand, occupancy and contact sensors.
- Event-driven tests for a state update (`off → on`) and for going unavailable.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
