### PR TITLE
Retry Overkiz setup on transient server unavailable errors

### DIFF
--- a/homeassistant/components/overkiz/__init__.py
+++ b/homeassistant/components/overkiz/__init__.py
@@ -18,6 +18,7 @@ from pyoverkiz.exceptions import (
     MaintenanceError,
     NoSuchTokenError,
     NotAuthenticatedError,
+    ServiceUnavailableError,
     TooManyRequestsError,
 )
 from pyoverkiz.models import Device, PersistedActionGroup
@@ -147,6 +148,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: OverkizDataConfigEntry) 
         raise ConfigEntryNotReady("Failed to connect") from exception
     except MaintenanceError as exception:
         raise ConfigEntryNotReady("Server is down for maintenance") from exception
+    except ServiceUnavailableError as exception:
+        raise ConfigEntryNotReady("Server is unavailable") from exception
 
     coordinator = OverkizDataUpdateCoordinator(
         hass,

--- a/tests/components/overkiz/test_init.py
+++ b/tests/components/overkiz/test_init.py
@@ -2,6 +2,9 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from pyoverkiz.exceptions import MaintenanceError, ServiceUnavailableError
+import pytest
+
 from homeassistant import config_entries
 from homeassistant.components.overkiz.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
@@ -137,6 +140,35 @@ async def test_setup_token_transient_error_retries(
     client.login.side_effect = OAuth2TokenRequestError(
         request_info=MagicMock(), domain=DOMAIN
     )
+
+    with patch(
+        "homeassistant.components.overkiz.create_rexel_client", return_value=client
+    ):
+        await hass.config_entries.async_setup(mock_rexel_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert mock_rexel_config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert not hass.config_entries.flow.async_progress()
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        ServiceUnavailableError("Server is unavailable"),
+        MaintenanceError("Server is down for maintenance"),
+    ],
+    ids=["service_unavailable", "maintenance"],
+)
+async def test_setup_server_unavailable_retries(
+    hass: HomeAssistant,
+    mock_rexel_config_entry: MockConfigEntry,
+    exception: Exception,
+) -> None:
+    """A transient server error during setup retries instead of failing."""
+    mock_rexel_config_entry.add_to_hass(hass)
+
+    client = AsyncMock()
+    client.login.side_effect = exception
 
     with patch(
         "homeassistant.components.overkiz.create_rexel_client", return_value=client

--- a/tests/components/overkiz/test_init.py
+++ b/tests/components/overkiz/test_init.py
@@ -2,7 +2,12 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from pyoverkiz.exceptions import MaintenanceError, ServiceUnavailableError
+from aiohttp import ClientError
+from pyoverkiz.exceptions import (
+    MaintenanceError,
+    ServiceUnavailableError,
+    TooManyRequestsError,
+)
 import pytest
 
 from homeassistant import config_entries
@@ -130,41 +135,31 @@ async def test_setup_token_reauth_error_starts_reauth(
     assert flows[0]["context"]["source"] == config_entries.SOURCE_REAUTH
 
 
-async def test_setup_token_transient_error_retries(
-    hass: HomeAssistant, mock_rexel_config_entry: MockConfigEntry
-) -> None:
-    """A recoverable token refresh failure retries setup."""
-    mock_rexel_config_entry.add_to_hass(hass)
-
-    client = AsyncMock()
-    client.login.side_effect = OAuth2TokenRequestError(
-        request_info=MagicMock(), domain=DOMAIN
-    )
-
-    with patch(
-        "homeassistant.components.overkiz.create_rexel_client", return_value=client
-    ):
-        await hass.config_entries.async_setup(mock_rexel_config_entry.entry_id)
-        await hass.async_block_till_done()
-
-    assert mock_rexel_config_entry.state is ConfigEntryState.SETUP_RETRY
-    assert not hass.config_entries.flow.async_progress()
-
-
 @pytest.mark.parametrize(
     "exception",
     [
-        ServiceUnavailableError("Server is unavailable"),
+        OAuth2TokenRequestError(request_info=MagicMock(), domain=DOMAIN),
+        TooManyRequestsError("Too many requests"),
         MaintenanceError("Server is down for maintenance"),
+        ServiceUnavailableError("Server is unavailable"),
+        TimeoutError("Timed out"),
+        ClientError("Connection error"),
     ],
-    ids=["service_unavailable", "maintenance"],
+    ids=[
+        "oauth2_token_request",
+        "too_many_requests",
+        "maintenance",
+        "service_unavailable",
+        "timeout",
+        "client_error",
+    ],
 )
-async def test_setup_server_unavailable_retries(
+async def test_setup_transient_error_retries(
     hass: HomeAssistant,
     mock_rexel_config_entry: MockConfigEntry,
     exception: Exception,
 ) -> None:
-    """A transient server error during setup retries instead of failing."""
+    """A recoverable error during setup retries instead of failing."""
     mock_rexel_config_entry.add_to_hass(hass)
 
     client = AsyncMock()


### PR DESCRIPTION
## Proposed change

Catch `ServiceUnavailableError` during setup and raise `ConfigEntryNotReady` so setup retries instead of crashing. pyoverkiz now raises this (parent of the already-handled `MaintenanceError`) for transient token-endpoint failures.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #160761
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
