### PR TITLE
Fix ecobee active sensor reporting for custom presets and shared device names

### DIFF
--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -628,23 +628,31 @@ class Thermostat(ClimateEntity):
             if device.name == sensor_info["name"]
         ]
 
+    def _active_climate_name(self) -> str:
+        """Return the ecobee climate name of the active comfort setting.
+
+        ``preset_mode`` is the climate *name*, but ``_preset_modes`` is keyed by
+        climateRef, so the built-in presets are translated back to their ecobee
+        name. Holds that are not a comfort setting (temperature/vacation/
+        indefinite away) are not real climates; per ecobee they follow the Home
+        comfort setting's sensor participation, so fall back to "Home".
+        """
+        # https://support.ecobee.com/s/articles/SmartSensors-Sensor-Participation
+        preset_mode = self.preset_mode
+        if preset_mode is None:
+            return "Home"
+        mode = HASS_TO_ECOBEE_PRESET.get(preset_mode, preset_mode)
+        return mode if mode in self._preset_modes.values() else "Home"
+
     @property
     def active_sensors_in_preset_mode(self) -> list:
         """Return the currently active/participating sensors."""
-        # https://support.ecobee.com/s/articles/SmartSensors-Sensor-Participation
-        # During a manual hold, the ecobee will follow the Sensor Participation
-        # rules for the Home Comfort Settings
-        mode = self._preset_modes.get(self.preset_mode, "Home")
-        return self._sensors_in_preset_mode(mode)
+        return self._sensors_in_preset_mode(self._active_climate_name())
 
     @property
     def active_sensor_devices_in_preset_mode(self) -> list:
         """Return the currently active/participating sensor devices."""
-        # https://support.ecobee.com/s/articles/SmartSensors-Sensor-Participation
-        # During a manual hold, the ecobee will follow the Sensor Participation
-        # rules for the Home Comfort Settings
-        mode = self._preset_modes.get(self.preset_mode, "Home")
-        return self._sensor_devices_in_preset_mode(mode)
+        return self._sensor_devices_in_preset_mode(self._active_climate_name())
 
     def set_preset_mode(self, preset_mode: str) -> None:
         """Activate a preset."""

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -626,6 +626,7 @@ class Thermostat(ClimateEntity):
             for device in device_registry.devices.values()
             for sensor_info in sensors_info
             if device.name == sensor_info["name"]
+            and any(identifier[0] == DOMAIN for identifier in device.identifiers)
         ]
 
     def _active_climate_name(self) -> str:
@@ -937,6 +938,7 @@ class Thermostat(ClimateEntity):
                 for device in device_registry.devices.values()
                 for sensor_name in sensor_names
                 if device.name == sensor_name
+                and any(identifier[0] == DOMAIN for identifier in device.identifiers)
             ]
         )
 

--- a/tests/components/ecobee/test_climate.py
+++ b/tests/components/ecobee/test_climate.py
@@ -523,6 +523,40 @@ async def test_remote_sensor_ids_names(hass: HomeAssistant) -> None:
     assert sorted(name_by_user_list) == sorted(["Remote Sensor 1", "ecobee"])
 
 
+async def test_remote_sensors_ignore_non_ecobee_devices(hass: HomeAssistant) -> None:
+    """Devices from other integrations sharing a sensor's name are not matched.
+
+    Regression test: the remote-sensor device lookup matched by device name across
+    the whole registry, so a device from another integration that happened to share
+    an ecobee sensor's name was wrongly reported as a participating sensor.
+    """
+    await setup_platform(hass, [const.Platform.CLIMATE, const.Platform.SENSOR])
+    device_registry = dr.async_get(hass)
+
+    # A device from another integration that shares the ecobee sensor's name.
+    other_entry = MockConfigEntry(domain="other")
+    other_entry.add_to_hass(hass)
+    device_registry.async_get_or_create(
+        config_entry_id=other_entry.entry_id,
+        identifiers={("other", "collision")},
+        name="ecobee",
+    )
+
+    platform = hass.data[const.Platform.CLIMATE].entities
+    for entity in platform:
+        if entity.entity_id == "climate.ecobee":
+            thermostat = entity
+            break
+
+    assert thermostat is not None
+
+    name_by_user_list = [
+        item["name_by_user"] for item in thermostat.remote_sensor_ids_names
+    ]
+    # Only the two ecobee devices, not the colliding "other" device.
+    assert sorted(name_by_user_list) == sorted(["Remote Sensor 1", "ecobee"])
+
+
 async def test_set_sensors_used_in_climate(hass: HomeAssistant) -> None:
     """Test set sensors used in climate."""
     # Get device_id of remote sensor from the device registry.

--- a/tests/components/ecobee/test_climate.py
+++ b/tests/components/ecobee/test_climate.py
@@ -477,6 +477,33 @@ async def test_active_sensor_devices_in_preset_mode(hass: HomeAssistant) -> None
     assert state.attributes.get("active_sensors") == ["ecobee"]
 
 
+async def test_active_sensors_in_preset_mode_for_custom_climate(
+    ecobee_fixture, thermostat
+) -> None:
+    """Custom comfort settings report their own sensors, not Home's.
+
+    Regression test: the active climate was looked up in a climateRef-keyed map
+    using the preset *name*. For the built-in presets the lowercased name equals
+    the climateRef, so they resolved; every custom comfort setting's name is never
+    a climateRef key, so it silently fell back to the Home comfort setting's
+    sensors.
+    """
+    # The active comfort setting is the custom "Climate1" (running hold on "c1").
+    assert thermostat.preset_mode == "Climate1"
+
+    # Give Climate1 a different sensor set than Home.
+    for climate in ecobee_fixture["program"]["climates"]:
+        if climate["climateRef"] == "c1":
+            climate["sensors"] = [{"name": "Ecobee"}, {"name": "Remote Sensor 1"}]
+        elif climate["climateRef"] == "home":
+            climate["sensors"] = [{"name": "Ecobee"}]
+
+    assert sorted(thermostat.active_sensors_in_preset_mode) == [
+        "Ecobee",
+        "Remote Sensor 1",
+    ]
+
+
 async def test_remote_sensor_ids_names(hass: HomeAssistant) -> None:
     """Test getting ids and names_by_user for thermostat."""
     await setup_platform(hass, [const.Platform.CLIMATE, const.Platform.SENSOR])


### PR DESCRIPTION
## Proposed change

This fixes two issues in how the ecobee climate entity reports the sensors participating in a comfort setting (`active_sensors_in_preset_mode`, `active_sensor_devices_in_preset_mode`, `remote_sensor_ids_names`, `remote_sensor_devices` — surfaced as the `active_sensors` / `available_sensors` state attributes).

**1. Custom comfort settings reported the Home comfort setting's sensors.**

`active_sensors_in_preset_mode` / `active_sensor_devices_in_preset_mode` looked the active climate up in `self._preset_modes` — which is keyed by the ecobee **climateRef** — using `self.preset_mode`, which is the climate **name**:

```python
self._preset_modes = {c["climateRef"]: c["name"] for c in climates}
mode = self._preset_modes.get(self.preset_mode, "Home")
```

For the built-in comfort settings the lowercased name equals the climateRef (`home`/`away`/`sleep`), so they resolve. A custom comfort setting's name is never a climateRef key, so the lookup fell through to the `"Home"` default and reported Home's sensors instead of the active custom comfort setting's. This adds an `_active_climate_name()` helper that translates the preset back to the ecobee climate name via the existing `HASS_TO_ECOBEE_PRESET` map, and only falls back to `"Home"` for presets that aren't real comfort settings (temperature / vacation / indefinite-away holds), preserving the documented "manual holds follow Home participation" behaviour for those.

**2. Sensor lists included devices from other integrations that shared a name.**

`remote_sensor_ids_names` and `_sensor_devices_in_preset_mode` matched ecobee sensor names against **every** device in the registry (`device.name == sensor_name`), with no scoping to ecobee. A device from another integration that happens to share an ecobee sensor's name (e.g. a network switch or air-quality sensor named after a room) was reported as a participating ecobee sensor. This requires the matched device to carry an `("ecobee", …)` identifier, mirroring what `set_sensors_used_in_climate` already does on the write side.

Verified against a running instance: a custom comfort setting now reports its own sensors (it previously reported Home's), and unrelated same-named devices from other integrations no longer appear in the sensor lists.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is not related to an open issue.

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
