### PR TITLE
Bump pyanglianwater to 3.2.2

### DIFF
--- a/homeassistant/components/anglian_water/__init__.py
+++ b/homeassistant/components/anglian_water/__init__.py
@@ -4,6 +4,7 @@ from aiohttp import CookieJar
 from pyanglianwater import AnglianWater
 from pyanglianwater.auth import MSOB2CAuth
 from pyanglianwater.exceptions import (
+    ConsentRequiredError,
     ExpiredAccessTokenError,
     SelfAssertedError,
     SmartMeterUnavailableError,
@@ -40,7 +41,7 @@ async def async_setup_entry(
     )
     try:
         await auth.send_refresh_request()
-    except (ExpiredAccessTokenError, SelfAssertedError) as err:
+    except (ConsentRequiredError, ExpiredAccessTokenError, SelfAssertedError) as err:
         raise ConfigEntryAuthFailed from err
 
     _aw = AnglianWater(authenticator=auth)

--- a/homeassistant/components/anglian_water/config_flow.py
+++ b/homeassistant/components/anglian_water/config_flow.py
@@ -7,6 +7,7 @@ from aiohttp import CookieJar
 from pyanglianwater import AnglianWater
 from pyanglianwater.auth import MSOB2CAuth
 from pyanglianwater.exceptions import (
+    ConsentRequiredError,
     InvalidAccountIdError,
     SelfAssertedError,
     SmartMeterUnavailableError,
@@ -36,7 +37,7 @@ async def validate_credentials(auth: MSOB2CAuth) -> str | MSOB2CAuth:
     """Validate the provided credentials."""
     try:
         await auth.send_login_request()
-    except SelfAssertedError:
+    except ConsentRequiredError, SelfAssertedError:
         return "invalid_auth"
     except Exception:
         _LOGGER.exception("Unexpected exception")

--- a/homeassistant/components/anglian_water/coordinator.py
+++ b/homeassistant/components/anglian_water/coordinator.py
@@ -5,7 +5,11 @@ import logging
 from typing import Any
 
 from pyanglianwater import AnglianWater
-from pyanglianwater.exceptions import ExpiredAccessTokenError, UnknownEndpointError
+from pyanglianwater.exceptions import (
+    ConsentRequiredError,
+    ExpiredAccessTokenError,
+    UnknownEndpointError,
+)
 
 from homeassistant.components.recorder import get_instance
 from homeassistant.components.recorder.models import (
@@ -59,7 +63,11 @@ class AnglianWaterUpdateCoordinator(DataUpdateCoordinator[None]):
         try:
             await self.api.update(self.config_entry.data[CONF_ACCOUNT_NUMBER])
             await self._insert_statistics()
-        except (ExpiredAccessTokenError, UnknownEndpointError) as err:
+        except (
+            ConsentRequiredError,
+            ExpiredAccessTokenError,
+            UnknownEndpointError,
+        ) as err:
             raise UpdateFailed from err
 
     async def _insert_statistics(self) -> None:

--- a/homeassistant/components/anglian_water/manifest.json
+++ b/homeassistant/components/anglian_water/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["pyanglianwater"],
   "quality_scale": "bronze",
-  "requirements": ["pyanglianwater==3.1.2"]
+  "requirements": ["pyanglianwater==3.2.2"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2030,7 +2030,7 @@ pyairobotrest==0.3.0
 pyairvisual==2023.08.1
 
 # homeassistant.components.anglian_water
-pyanglianwater==3.1.2
+pyanglianwater==3.2.2
 
 # homeassistant.components.aprilaire
 pyaprilaire==0.9.1

--- a/tests/components/anglian_water/test_config_flow.py
+++ b/tests/components/anglian_water/test_config_flow.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock
 
 from pyanglianwater.exceptions import (
+    ConsentRequiredError,
     InvalidAccountIdError,
     SelfAssertedError,
     SmartMeterUnavailableError,
@@ -140,7 +141,11 @@ async def test_already_configured(
 
 @pytest.mark.parametrize(
     ("exception_type", "expected_error"),
-    [(SelfAssertedError, "invalid_auth"), (ValueError, "unknown")],
+    [
+        (SelfAssertedError, "invalid_auth"),
+        (ValueError, "unknown"),
+        (ConsentRequiredError, "invalid_auth"),
+    ],
 )
 async def test_auth_recover_exception(
     hass: HomeAssistant,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump pyanglianwater to 3.2.2 - also I needed to add some new `ConsentRequiredError` exception handling to maintain compatibility. I will enhance this further to offer a repair (if appropriate?), this exception generally means that the terms and conditions of the service has changed and therefore requires the user to login to Anglian Water directly to review and accept the new Ts&Cs.

This update also correctly handles the B2C error code "AADB2C90080" as a sign that full new login session is required (as the refresh token has expired), which means that the Python module should now handle this seemlessly in the background.

Please can we tag for next patch release?

Diff: https://github.com/pantherale0/pyanglianwater/compare/3.1.2...3.2.2
Release: https://github.com/pantherale0/pyanglianwater/releases/tag/3.2.2, https://github.com/pantherale0/pyanglianwater/releases/tag/3.2.1, https://github.com/pantherale0/pyanglianwater/releases/tag/3.2.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #174410 #173437
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
