### PR TITLE
Standardize  constants across entity platforms

### DIFF
--- a/homeassistant/components/battery/condition.py
+++ b/homeassistant/components/battery/condition.py
@@ -14,26 +14,28 @@ from homeassistant.helpers.condition import (
     make_entity_state_condition,
 )
 
-BATTERY_DOMAIN_SPECS = {
-    BINARY_SENSOR_DOMAIN: DomainSpec(device_class=BinarySensorDeviceClass.BATTERY)
+BATTERY_LOW_DOMAIN_SPECS: dict[str, DomainSpec] = {
+    BINARY_SENSOR_DOMAIN: DomainSpec(device_class=BinarySensorDeviceClass.BATTERY),
 }
-BATTERY_CHARGING_DOMAIN_SPECS = {
+
+BATTERY_CHARGING_DOMAIN_SPECS: dict[str, DomainSpec] = {
     BINARY_SENSOR_DOMAIN: DomainSpec(
         device_class=BinarySensorDeviceClass.BATTERY_CHARGING
-    )
+    ),
 }
-BATTERY_PERCENTAGE_DOMAIN_SPECS = {
+
+BATTERY_PERCENTAGE_DOMAIN_SPECS: dict[str, DomainSpec] = {
     SENSOR_DOMAIN: DomainSpec(device_class=SensorDeviceClass.BATTERY),
 }
 
 CONDITIONS: dict[str, type[Condition]] = {
     "is_low": make_entity_state_condition(
-        BATTERY_DOMAIN_SPECS,
+        BATTERY_LOW_DOMAIN_SPECS,
         STATE_ON,
         primary_entities_only=False,
     ),
     "is_not_low": make_entity_state_condition(
-        BATTERY_DOMAIN_SPECS,
+        BATTERY_LOW_DOMAIN_SPECS,
         STATE_OFF,
         primary_entities_only=False,
     ),

--- a/homeassistant/components/humidity/condition.py
+++ b/homeassistant/components/humidity/condition.py
@@ -18,7 +18,7 @@ from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.automation import DomainSpec
 from homeassistant.helpers.condition import Condition, EntityNumericalConditionBase
 
-HUMIDITY_DOMAIN_SPECS = {
+HUMIDITY_DOMAIN_SPECS: dict[str, DomainSpec] = {
     CLIMATE_DOMAIN: DomainSpec(
         value_source=CLIMATE_ATTR_CURRENT_HUMIDITY,
     ),

--- a/homeassistant/components/illuminance/condition.py
+++ b/homeassistant/components/illuminance/condition.py
@@ -14,10 +14,10 @@ from homeassistant.helpers.condition import (
     make_entity_state_condition,
 )
 
-ILLUMINANCE_DETECTED_DOMAIN_SPECS = {
-    BINARY_SENSOR_DOMAIN: DomainSpec(device_class=BinarySensorDeviceClass.LIGHT)
+ILLUMINANCE_DETECTED_DOMAIN_SPECS: dict[str, DomainSpec] = {
+    BINARY_SENSOR_DOMAIN: DomainSpec(device_class=BinarySensorDeviceClass.LIGHT),
 }
-ILLUMINANCE_VALUE_DOMAIN_SPECS = {
+ILLUMINANCE_VALUE_DOMAIN_SPECS: dict[str, DomainSpec] = {
     SENSOR_DOMAIN: DomainSpec(device_class=SensorDeviceClass.ILLUMINANCE),
 }
 

--- a/homeassistant/components/illuminance/trigger.py
+++ b/homeassistant/components/illuminance/trigger.py
@@ -15,24 +15,25 @@ from homeassistant.helpers.trigger import (
     make_entity_target_state_trigger,
 )
 
-ILLUMINANCE_DOMAIN_SPECS: dict[str, DomainSpec] = {
+ILLUMINANCE_DETECTED_DOMAIN_SPECS: dict[str, DomainSpec] = {
+    BINARY_SENSOR_DOMAIN: DomainSpec(device_class=BinarySensorDeviceClass.LIGHT),
+}
+ILLUMINANCE_VALUE_DOMAIN_SPECS: dict[str, DomainSpec] = {
     SENSOR_DOMAIN: DomainSpec(device_class=SensorDeviceClass.ILLUMINANCE),
 }
 
 TRIGGERS: dict[str, type[Trigger]] = {
     "detected": make_entity_target_state_trigger(
-        {BINARY_SENSOR_DOMAIN: DomainSpec(device_class=BinarySensorDeviceClass.LIGHT)},
-        STATE_ON,
+        ILLUMINANCE_DETECTED_DOMAIN_SPECS, STATE_ON
     ),
     "cleared": make_entity_target_state_trigger(
-        {BINARY_SENSOR_DOMAIN: DomainSpec(device_class=BinarySensorDeviceClass.LIGHT)},
-        STATE_OFF,
+        ILLUMINANCE_DETECTED_DOMAIN_SPECS, STATE_OFF
     ),
     "changed": make_entity_numerical_state_changed_trigger(
-        ILLUMINANCE_DOMAIN_SPECS, valid_unit=LIGHT_LUX
+        ILLUMINANCE_VALUE_DOMAIN_SPECS, valid_unit=LIGHT_LUX
     ),
     "crossed_threshold": make_entity_numerical_state_crossed_threshold_trigger(
-        ILLUMINANCE_DOMAIN_SPECS, valid_unit=LIGHT_LUX
+        ILLUMINANCE_VALUE_DOMAIN_SPECS, valid_unit=LIGHT_LUX
     ),
 }
 

--- a/homeassistant/components/light/condition.py
+++ b/homeassistant/components/light/condition.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.condition import (
 from . import ATTR_BRIGHTNESS
 from .const import DOMAIN
 
-BRIGHTNESS_DOMAIN_SPECS = {
+BRIGHTNESS_DOMAIN_SPECS: dict[str, DomainSpec] = {
     DOMAIN: DomainSpec(value_source=ATTR_BRIGHTNESS),
 }
 

--- a/homeassistant/components/light/trigger.py
+++ b/homeassistant/components/light/trigger.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.trigger import (
 from . import ATTR_BRIGHTNESS
 from .const import DOMAIN
 
-BRIGHTNESS_DOMAIN_SPECS = {
+BRIGHTNESS_DOMAIN_SPECS: dict[str, DomainSpec] = {
     DOMAIN: DomainSpec(value_source=ATTR_BRIGHTNESS),
 }
 

--- a/homeassistant/components/media_player/condition.py
+++ b/homeassistant/components/media_player/condition.py
@@ -15,6 +15,10 @@ from homeassistant.helpers.condition import (
 from . import ATTR_MEDIA_VOLUME_LEVEL, ATTR_MEDIA_VOLUME_MUTED
 from .const import DOMAIN, MediaPlayerState
 
+VOLUME_DOMAIN_SPECS: dict[str, DomainSpec] = {
+    DOMAIN: DomainSpec(value_source=ATTR_MEDIA_VOLUME_LEVEL),
+}
+
 
 class _MediaPlayerMutedConditionBase(EntityConditionBase):
     """Base class for media player is_muted/is_unmuted conditions."""
@@ -70,7 +74,7 @@ class MediaPlayerIsUnmutedCondition(_MediaPlayerMutedConditionBase):
 class MediaPlayerIsVolumeCondition(EntityNumericalConditionBase):
     """Condition for media player volume level with 0.0-1.0 to percentage conversion."""
 
-    _domain_specs = {DOMAIN: DomainSpec(value_source=ATTR_MEDIA_VOLUME_LEVEL)}
+    _domain_specs = VOLUME_DOMAIN_SPECS
     _valid_unit = "%"
 
     def _get_tracked_value(self, entity_state: State) -> Any:

--- a/homeassistant/components/media_player/trigger.py
+++ b/homeassistant/components/media_player/trigger.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.trigger import (
 from . import ATTR_MEDIA_VOLUME_LEVEL, ATTR_MEDIA_VOLUME_MUTED, MediaPlayerState
 from .const import DOMAIN
 
-VOLUME_DOMAIN_SPECS = {
+VOLUME_DOMAIN_SPECS: dict[str, DomainSpec] = {
     DOMAIN: DomainSpec(value_source=ATTR_MEDIA_VOLUME_LEVEL),
 }
 

--- a/homeassistant/components/moisture/condition.py
+++ b/homeassistant/components/moisture/condition.py
@@ -14,23 +14,21 @@ from homeassistant.helpers.condition import (
     make_entity_state_condition,
 )
 
-_MOISTURE_BINARY_DOMAIN_SPECS = {
-    BINARY_SENSOR_DOMAIN: DomainSpec(
-        device_class=BinarySensorDeviceClass.MOISTURE,
-    )
+MOISTURE_BINARY_DOMAIN_SPECS: dict[str, DomainSpec] = {
+    BINARY_SENSOR_DOMAIN: DomainSpec(device_class=BinarySensorDeviceClass.MOISTURE),
 }
 
-_MOISTURE_NUMERICAL_DOMAIN_SPECS = {
+MOISTURE_NUMERICAL_DOMAIN_SPECS: dict[str, DomainSpec] = {
     SENSOR_DOMAIN: DomainSpec(device_class=SensorDeviceClass.MOISTURE),
 }
 
 CONDITIONS: dict[str, type[Condition]] = {
-    "is_detected": make_entity_state_condition(_MOISTURE_BINARY_DOMAIN_SPECS, STATE_ON),
+    "is_detected": make_entity_state_condition(MOISTURE_BINARY_DOMAIN_SPECS, STATE_ON),
     "is_not_detected": make_entity_state_condition(
-        _MOISTURE_BINARY_DOMAIN_SPECS, STATE_OFF
+        MOISTURE_BINARY_DOMAIN_SPECS, STATE_OFF
     ),
     "is_value": make_entity_numerical_condition(
-        _MOISTURE_NUMERICAL_DOMAIN_SPECS, PERCENTAGE
+        MOISTURE_NUMERICAL_DOMAIN_SPECS, PERCENTAGE
     ),
 }
 

--- a/homeassistant/components/motion/condition.py
+++ b/homeassistant/components/motion/condition.py
@@ -9,14 +9,14 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.automation import DomainSpec
 from homeassistant.helpers.condition import Condition, make_entity_state_condition
 
-_MOTION_DOMAIN_SPECS = {
-    BINARY_SENSOR_DOMAIN: DomainSpec(device_class=BinarySensorDeviceClass.MOTION)
+MOTION_DOMAIN_SPECS: dict[str, DomainSpec] = {
+    BINARY_SENSOR_DOMAIN: DomainSpec(device_class=BinarySensorDeviceClass.MOTION),
 }
 
 
 CONDITIONS: dict[str, type[Condition]] = {
-    "is_detected": make_entity_state_condition(_MOTION_DOMAIN_SPECS, STATE_ON),
-    "is_not_detected": make_entity_state_condition(_MOTION_DOMAIN_SPECS, STATE_OFF),
+    "is_detected": make_entity_state_condition(MOTION_DOMAIN_SPECS, STATE_ON),
+    "is_not_detected": make_entity_state_condition(MOTION_DOMAIN_SPECS, STATE_OFF),
 }
 
 

--- a/homeassistant/components/motion/trigger.py
+++ b/homeassistant/components/motion/trigger.py
@@ -9,13 +9,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.automation import DomainSpec
 from homeassistant.helpers.trigger import Trigger, make_entity_target_state_trigger
 
-_MOTION_DOMAIN_SPECS = {
-    BINARY_SENSOR_DOMAIN: DomainSpec(device_class=BinarySensorDeviceClass.MOTION)
+MOTION_DOMAIN_SPECS: dict[str, DomainSpec] = {
+    BINARY_SENSOR_DOMAIN: DomainSpec(device_class=BinarySensorDeviceClass.MOTION),
 }
 
 TRIGGERS: dict[str, type[Trigger]] = {
-    "detected": make_entity_target_state_trigger(_MOTION_DOMAIN_SPECS, STATE_ON),
-    "cleared": make_entity_target_state_trigger(_MOTION_DOMAIN_SPECS, STATE_OFF),
+    "detected": make_entity_target_state_trigger(MOTION_DOMAIN_SPECS, STATE_ON),
+    "cleared": make_entity_target_state_trigger(MOTION_DOMAIN_SPECS, STATE_OFF),
 }
 
 

--- a/homeassistant/components/occupancy/condition.py
+++ b/homeassistant/components/occupancy/condition.py
@@ -9,14 +9,14 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.automation import DomainSpec
 from homeassistant.helpers.condition import Condition, make_entity_state_condition
 
-_OCCUPANCY_DOMAIN_SPECS = {
-    BINARY_SENSOR_DOMAIN: DomainSpec(device_class=BinarySensorDeviceClass.OCCUPANCY)
+OCCUPANCY_DOMAIN_SPECS: dict[str, DomainSpec] = {
+    BINARY_SENSOR_DOMAIN: DomainSpec(device_class=BinarySensorDeviceClass.OCCUPANCY),
 }
 
 
 CONDITIONS: dict[str, type[Condition]] = {
-    "is_detected": make_entity_state_condition(_OCCUPANCY_DOMAIN_SPECS, STATE_ON),
-    "is_not_detected": make_entity_state_condition(_OCCUPANCY_DOMAIN_SPECS, STATE_OFF),
+    "is_detected": make_entity_state_condition(OCCUPANCY_DOMAIN_SPECS, STATE_ON),
+    "is_not_detected": make_entity_state_condition(OCCUPANCY_DOMAIN_SPECS, STATE_OFF),
 }
 
 

--- a/homeassistant/components/occupancy/trigger.py
+++ b/homeassistant/components/occupancy/trigger.py
@@ -9,13 +9,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.automation import DomainSpec
 from homeassistant.helpers.trigger import Trigger, make_entity_target_state_trigger
 
-_OCCUPANCY_DOMAIN_SPECS = {
-    BINARY_SENSOR_DOMAIN: DomainSpec(device_class=BinarySensorDeviceClass.OCCUPANCY)
+OCCUPANCY_DOMAIN_SPECS: dict[str, DomainSpec] = {
+    BINARY_SENSOR_DOMAIN: DomainSpec(device_class=BinarySensorDeviceClass.OCCUPANCY),
 }
 
 TRIGGERS: dict[str, type[Trigger]] = {
-    "detected": make_entity_target_state_trigger(_OCCUPANCY_DOMAIN_SPECS, STATE_ON),
-    "cleared": make_entity_target_state_trigger(_OCCUPANCY_DOMAIN_SPECS, STATE_OFF),
+    "detected": make_entity_target_state_trigger(OCCUPANCY_DOMAIN_SPECS, STATE_ON),
+    "cleared": make_entity_target_state_trigger(OCCUPANCY_DOMAIN_SPECS, STATE_OFF),
 }
 
 

--- a/homeassistant/components/power/condition.py
+++ b/homeassistant/components/power/condition.py
@@ -10,7 +10,7 @@ from homeassistant.helpers.condition import (
 )
 from homeassistant.util.unit_conversion import PowerConverter
 
-POWER_DOMAIN_SPECS = {
+POWER_DOMAIN_SPECS: dict[str, DomainSpec] = {
     SENSOR_DOMAIN: DomainSpec(device_class=SensorDeviceClass.POWER),
 }
 

--- a/homeassistant/components/select/condition.py
+++ b/homeassistant/components/select/condition.py
@@ -28,7 +28,10 @@ IS_OPTION_SELECTED_SCHEMA = ENTITY_STATE_CONDITION_SCHEMA_ANY_ALL.extend(
     }
 )
 
-SELECT_DOMAIN_SPECS = {DOMAIN: DomainSpec(), INPUT_SELECT_DOMAIN: DomainSpec()}
+SELECT_DOMAIN_SPECS: dict[str, DomainSpec] = {
+    DOMAIN: DomainSpec(),
+    INPUT_SELECT_DOMAIN: DomainSpec(),
+}
 
 
 class IsOptionSelectedCondition(EntityStateConditionBase):

--- a/homeassistant/components/select/trigger.py
+++ b/homeassistant/components/select/trigger.py
@@ -11,11 +11,16 @@ from homeassistant.helpers.trigger import (
 
 from .const import DOMAIN
 
+SELECT_DOMAIN_SPECS: dict[str, DomainSpec] = {
+    DOMAIN: DomainSpec(),
+    INPUT_SELECT_DOMAIN: DomainSpec(),
+}
+
 
 class SelectionChangedTrigger(EntityTriggerBase):
     """Trigger for select entity when its selection changes."""
 
-    _domain_specs = {DOMAIN: DomainSpec(), INPUT_SELECT_DOMAIN: DomainSpec()}
+    _domain_specs = SELECT_DOMAIN_SPECS
     _schema = ENTITY_STATE_TRIGGER_SCHEMA
 
 

--- a/homeassistant/components/switch/condition.py
+++ b/homeassistant/components/switch/condition.py
@@ -8,7 +8,10 @@ from homeassistant.helpers.condition import Condition, make_entity_state_conditi
 
 from .const import DOMAIN
 
-SWITCH_DOMAIN_SPECS = {DOMAIN: DomainSpec(), INPUT_BOOLEAN_DOMAIN: DomainSpec()}
+SWITCH_DOMAIN_SPECS: dict[str, DomainSpec] = {
+    DOMAIN: DomainSpec(),
+    INPUT_BOOLEAN_DOMAIN: DomainSpec(),
+}
 
 CONDITIONS: dict[str, type[Condition]] = {
     "is_off": make_entity_state_condition(SWITCH_DOMAIN_SPECS, STATE_OFF),

--- a/homeassistant/components/switch/trigger.py
+++ b/homeassistant/components/switch/trigger.py
@@ -8,7 +8,10 @@ from homeassistant.helpers.trigger import Trigger, make_entity_target_state_trig
 
 from .const import DOMAIN
 
-SWITCH_DOMAIN_SPECS = {DOMAIN: DomainSpec(), INPUT_BOOLEAN_DOMAIN: DomainSpec()}
+SWITCH_DOMAIN_SPECS: dict[str, DomainSpec] = {
+    DOMAIN: DomainSpec(),
+    INPUT_BOOLEAN_DOMAIN: DomainSpec(),
+}
 
 TRIGGERS: dict[str, type[Trigger]] = {
     "turned_on": make_entity_target_state_trigger(SWITCH_DOMAIN_SPECS, STATE_ON),

--- a/homeassistant/components/temperature/condition.py
+++ b/homeassistant/components/temperature/condition.py
@@ -23,7 +23,7 @@ from homeassistant.helpers.condition import (
 )
 from homeassistant.util.unit_conversion import TemperatureConverter
 
-TEMPERATURE_DOMAIN_SPECS = {
+TEMPERATURE_DOMAIN_SPECS: dict[str, DomainSpec] = {
     CLIMATE_DOMAIN: DomainSpec(
         value_source=CLIMATE_ATTR_CURRENT_TEMPERATURE,
     ),

--- a/homeassistant/components/temperature/trigger.py
+++ b/homeassistant/components/temperature/trigger.py
@@ -25,7 +25,7 @@ from homeassistant.helpers.trigger import (
 )
 from homeassistant.util.unit_conversion import TemperatureConverter
 
-TEMPERATURE_DOMAIN_SPECS = {
+TEMPERATURE_DOMAIN_SPECS: dict[str, DomainSpec] = {
     CLIMATE_DOMAIN: DomainSpec(
         value_source=CLIMATE_ATTR_CURRENT_TEMPERATURE,
     ),

--- a/homeassistant/components/valve/condition.py
+++ b/homeassistant/components/valve/condition.py
@@ -7,7 +7,9 @@ from homeassistant.helpers.condition import Condition, make_entity_state_conditi
 from . import ATTR_IS_CLOSED
 from .const import DOMAIN
 
-VALVE_DOMAIN_SPECS = {DOMAIN: DomainSpec(value_source=ATTR_IS_CLOSED)}
+VALVE_DOMAIN_SPECS: dict[str, DomainSpec] = {
+    DOMAIN: DomainSpec(value_source=ATTR_IS_CLOSED),
+}
 
 CONDITIONS: dict[str, type[Condition]] = {
     "is_open": make_entity_state_condition(VALVE_DOMAIN_SPECS, False),

--- a/homeassistant/components/valve/trigger.py
+++ b/homeassistant/components/valve/trigger.py
@@ -6,7 +6,9 @@ from homeassistant.helpers.trigger import Trigger, make_entity_transition_trigge
 
 from . import ATTR_IS_CLOSED, DOMAIN
 
-VALVE_DOMAIN_SPECS = {DOMAIN: DomainSpec(value_source=ATTR_IS_CLOSED)}
+VALVE_DOMAIN_SPECS: dict[str, DomainSpec] = {
+    DOMAIN: DomainSpec(value_source=ATTR_IS_CLOSED),
+}
 
 
 TRIGGERS: dict[str, type[Trigger]] = {


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Standardizes the `*_DOMAIN_SPECS` constants across the entity condition and trigger platforms onto one convention: public names, `dict[str, DomainSpec]` annotations, and matching constant names between each integration's `condition.py` and `trigger.py`. Pure consistency cleanup with no behavior change.

If you prefer one PR per platform, I can close this one and open multiple ones.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
