### PR TITLE
Add override decorator to components H to I

### DIFF
--- a/homeassistant/components/habitica/binary_sensor.py
+++ b/homeassistant/components/habitica/binary_sensor.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
+from typing import override
 
 from habiticalib import ContentData, UserData
 
@@ -85,11 +86,13 @@ class HabiticaBinarySensorEntity(HabiticaBase, BinarySensorEntity):
     entity_description: HabiticaBinarySensorEntityDescription
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """If the binary sensor is on."""
         return self.entity_description.value_fn(self.coordinator.data.user)
 
     @property
+    @override
     def entity_picture(self) -> str | None:
         """Return the entity picture to use in the frontend, if any."""
         if entity_picture := self.entity_description.entity_picture(
@@ -117,6 +120,7 @@ class HabiticaPartyBinarySensorEntity(HabiticaPartyBase, BinarySensorEntity):
         super().__init__(coordinator, config_entry, self.entity_description, content)
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """If the binary sensor is on."""
         return self.coordinator.data.party.quest.active

--- a/homeassistant/components/habitica/button.py
+++ b/homeassistant/components/habitica/button.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Any
+from typing import Any, override
 
 from habiticalib import Habitica, HabiticaClass, Skill, TaskType
 
@@ -311,6 +311,7 @@ class HabiticaButton(HabiticaBase, ButtonEntity):
 
     entity_description: HabiticaButtonEntityDescription
 
+    @override
     async def async_press(self) -> None:
         """Handle the button press."""
 
@@ -318,6 +319,7 @@ class HabiticaButton(HabiticaBase, ButtonEntity):
         await self.coordinator.async_request_refresh()
 
     @property
+    @override
     def available(self) -> bool:
         """Is entity available."""
 
@@ -326,6 +328,7 @@ class HabiticaButton(HabiticaBase, ButtonEntity):
         )
 
     @property
+    @override
     def entity_picture(self) -> str | None:
         """Return the entity picture to use in the frontend, if any."""
         if entity_picture := self.entity_description.entity_picture:

--- a/homeassistant/components/habitica/calendar.py
+++ b/homeassistant/components/habitica/calendar.py
@@ -4,7 +4,7 @@ from abc import abstractmethod
 from dataclasses import asdict
 from datetime import date, datetime, timedelta
 from enum import StrEnum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 from uuid import UUID
 
 from dateutil.rrule import rrule
@@ -70,11 +70,13 @@ class HabiticaCalendarEntity(HabiticaBase, CalendarEntity):
         """Return events."""
 
     @property
+    @override
     def event(self) -> CalendarEvent | None:
         """Return the current or next upcoming event."""
 
         return next(iter(self.get_events(dt_util.now())), None)
 
+    @override
     async def async_get_events(
         self, hass: HomeAssistant, start_date: datetime, end_date: datetime
     ) -> list[CalendarEvent]:
@@ -109,6 +111,7 @@ class HabiticaTodosCalendarEntity(HabiticaCalendarEntity):
         translation_key=HabiticaCalendar.TODOS,
     )
 
+    @override
     def get_events(
         self, start_date: datetime, end_date: datetime | None = None
     ) -> list[CalendarEvent]:
@@ -180,6 +183,7 @@ class HabiticaDailiesCalendarEntity(HabiticaCalendarEntity):
             else recurrence
         ).date() + timedelta(days=1)
 
+    @override
     def get_events(
         self, start_date: datetime, end_date: datetime | None = None
     ) -> list[CalendarEvent]:
@@ -234,11 +238,13 @@ class HabiticaDailiesCalendarEntity(HabiticaCalendarEntity):
         )
 
     @property
+    @override
     def event(self) -> CalendarEvent | None:
         """Return the next upcoming event."""
         return next(iter(self.get_events(self.start_of_today)), None)
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, bool | None] | None:
         """Return entity specific state attributes."""
         return {
@@ -256,6 +262,7 @@ class HabiticaTodoRemindersCalendarEntity(HabiticaCalendarEntity):
         translation_key=HabiticaCalendar.TODO_REMINDERS,
     )
 
+    @override
     def get_events(
         self, start_date: datetime, end_date: datetime | None = None
     ) -> list[CalendarEvent]:
@@ -326,6 +333,7 @@ class HabiticaDailyRemindersCalendarEntity(HabiticaCalendarEntity):
             tzinfo=dt_util.DEFAULT_TIME_ZONE,
         )
 
+    @override
     def get_events(
         self, start_date: datetime, end_date: datetime | None = None
     ) -> list[CalendarEvent]:

--- a/homeassistant/components/habitica/config_flow.py
+++ b/homeassistant/components/habitica/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 from uuid import UUID
 
 from aiohttp import ClientError
@@ -139,6 +139,7 @@ _LOGGER = logging.getLogger(__name__)
 class HabiticaConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for habitica."""
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -389,6 +390,7 @@ class HabiticaConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @classmethod
     @callback
+    @override
     def async_get_supported_subentry_types(
         cls, config_entry: ConfigEntry
     ) -> dict[str, type[ConfigSubentryFlow]]:

--- a/homeassistant/components/habitica/coordinator.py
+++ b/homeassistant/components/habitica/coordinator.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 from io import BytesIO
 import logging
-from typing import Any
+from typing import Any, override
 from uuid import UUID
 
 from aiohttp import ClientError
@@ -88,6 +88,7 @@ class HabiticaBaseCoordinator[_DataT](DataUpdateCoordinator[_DataT]):
     async def _update_data(self) -> _DataT:
         """Fetch data."""
 
+    @override
     async def _async_update_data(self) -> _DataT:
         """Fetch the latest party data."""
 
@@ -116,6 +117,7 @@ class HabiticaDataUpdateCoordinator(HabiticaBaseCoordinator[HabiticaData]):
     _update_interval = timedelta(seconds=30)
     content: ContentData
 
+    @override
     async def _async_setup(self) -> None:
         """Set up Habitica integration."""
 
@@ -148,6 +150,7 @@ class HabiticaDataUpdateCoordinator(HabiticaBaseCoordinator[HabiticaData]):
                 translation_placeholders={"reason": str(e)},
             ) from e
 
+    @override
     async def _update_data(self) -> HabiticaData:
         """Fetch the latest data."""
 
@@ -204,6 +207,7 @@ class HabiticaPartyCoordinator(HabiticaBaseCoordinator[HabiticaPartyData]):
 
     _update_interval = timedelta(minutes=15)
 
+    @override
     async def _update_data(self) -> HabiticaPartyData:
         """Fetch the latest party data."""
 

--- a/homeassistant/components/habitica/entity.py
+++ b/homeassistant/components/habitica/entity.py
@@ -1,6 +1,6 @@
 """Base entity for Habitica."""
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 from uuid import UUID
 
 from habiticalib import ContentData, UserData
@@ -89,6 +89,7 @@ class HabiticaPartyMemberBase(HabiticaBase):
         super().__init__(coordinator, entity_description, subentry)
 
     @property
+    @override
     def user(self) -> UserData | None:
         """Return the user data of the party member."""
         if TYPE_CHECKING:
@@ -97,11 +98,13 @@ class HabiticaPartyMemberBase(HabiticaBase):
         return self.party_coordinator.data.members.get(UUID(self.subentry.unique_id))
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available."""
 
         return super().available and self.user is not None
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()

--- a/homeassistant/components/habitica/image.py
+++ b/homeassistant/components/habitica/image.py
@@ -1,7 +1,7 @@
 """Image platform for Habitica integration."""
 
 from enum import StrEnum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 from uuid import UUID
 
 from habiticalib import Avatar, ContentData, extract_avatar
@@ -93,6 +93,7 @@ class HabiticaImage(HabiticaBase, ImageEntity):
             assert self.user
         self._avatar = extract_avatar(self.user)
 
+    @override
     def _handle_coordinator_update(self) -> None:
         """Check if equipped gear and other things have changed.
 
@@ -106,6 +107,7 @@ class HabiticaImage(HabiticaBase, ImageEntity):
 
         return super()._handle_coordinator_update()
 
+    @override
     async def async_image(self) -> bytes | None:
         """Return cached bytes, otherwise generate new avatar."""
         if not self._cache and self._avatar:
@@ -154,6 +156,7 @@ class HabiticaPartyImage(HabiticaPartyBase, ImageEntity):
         self._attr_image_url = self.image_url
         self._attr_image_last_updated = dt_util.utcnow()
 
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
 
@@ -165,6 +168,7 @@ class HabiticaPartyImage(HabiticaPartyBase, ImageEntity):
         super()._handle_coordinator_update()
 
     @property
+    @override
     def image_url(self) -> str | None:
         """Return URL of image."""
         return (
@@ -173,6 +177,7 @@ class HabiticaPartyImage(HabiticaPartyBase, ImageEntity):
             else None
         )
 
+    @override
     async def _async_load_image_from_url(self, url: str) -> Image | None:
         """Load an image by url.
 

--- a/homeassistant/components/habitica/notify.py
+++ b/homeassistant/components/habitica/notify.py
@@ -2,7 +2,7 @@
 
 from abc import abstractmethod
 from enum import StrEnum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 from uuid import UUID
 
 from aiohttp import ClientError
@@ -104,6 +104,7 @@ class HabiticaBaseNotifyEntity(HabiticaBase, NotifyEntity):
     async def _send_message(self, message: str) -> None:
         """Send a Habitica message."""
 
+    @override
     async def async_send_message(self, message: str, title: str | None = None) -> None:
         """Send a message."""
         try:
@@ -166,6 +167,7 @@ class HabiticaPartyChatNotifyEntity(HabiticaBaseNotifyEntity):
         self.party = party
         super().__init__(coordinator)
 
+    @override
     async def _send_message(self, message: str) -> None:
         """Send a Habitica party chat message."""
 
@@ -192,6 +194,7 @@ class HabiticaPrivateMessageNotifyEntity(HabiticaBaseNotifyEntity):
         self.member = member
         super().__init__(coordinator)
 
+    @override
     async def _send_message(self, message: str) -> None:
         """Send a Habitica private message."""
         if TYPE_CHECKING:

--- a/homeassistant/components/habitica/sensor.py
+++ b/homeassistant/components/habitica/sensor.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
 import logging
-from typing import Any
+from typing import Any, override
 from uuid import UUID
 
 from habiticalib import ContentData, GroupData, HabiticaClass, TaskData, UserData, ha
@@ -439,6 +439,7 @@ class HabiticaSensor(HabiticaBase, SensorEntity):
     entity_description: HabiticaSensorEntityDescription
 
     @property
+    @override
     def native_value(self) -> StateType | datetime:
         """Return the state of the device."""
 
@@ -449,6 +450,7 @@ class HabiticaSensor(HabiticaBase, SensorEntity):
         )
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, float | None] | None:
         """Return entity specific state attributes."""
         if self.user is not None and (func := self.entity_description.attributes_fn):
@@ -456,6 +458,7 @@ class HabiticaSensor(HabiticaBase, SensorEntity):
         return None
 
     @property
+    @override
     def entity_picture(self) -> str | None:
         """Return the entity picture to use in the frontend, if any."""
         if (
@@ -492,6 +495,7 @@ class HabiticaPartySensor(HabiticaPartyBase, SensorEntity):
     entity_description: HabiticaPartySensorEntityDescription
 
     @property
+    @override
     def native_value(self) -> StateType | datetime:
         """Return the state of the device."""
 
@@ -500,6 +504,7 @@ class HabiticaPartySensor(HabiticaPartyBase, SensorEntity):
         )
 
     @property
+    @override
     def entity_picture(self) -> str | None:
         """Return the entity picture to use in the frontend, if any."""
         pic = self.entity_description.entity_picture
@@ -519,6 +524,7 @@ class HabiticaPartySensor(HabiticaPartyBase, SensorEntity):
         )
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return entity specific state attributes."""
         if func := self.entity_description.attributes_fn:

--- a/homeassistant/components/habitica/switch.py
+++ b/homeassistant/components/habitica/switch.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Any
+from typing import Any, override
 
 from habiticalib import Habitica
 
@@ -68,17 +68,20 @@ class HabiticaSwitch(HabiticaBase, SwitchEntity):
     entity_description: HabiticaSwitchEntityDescription
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return the state of the device."""
         return self.entity_description.is_on_fn(
             self.coordinator.data,
         )
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
 
         await self.coordinator.execute(self.entity_description.turn_on_fn)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
 

--- a/homeassistant/components/habitica/todo.py
+++ b/homeassistant/components/habitica/todo.py
@@ -3,7 +3,7 @@
 from enum import StrEnum
 import logging
 import math
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 from uuid import UUID
 
 from aiohttp import ClientError
@@ -74,6 +74,7 @@ class BaseHabiticaListEntity(HabiticaBase, TodoListEntity):
 
         super().__init__(coordinator, self.entity_description)
 
+    @override
     async def async_delete_todo_items(self, uids: list[str]) -> None:
         """Delete Habitica tasks."""
         if len(uids) > 1 and self.entity_description.key is HabiticaTodoList.TODOS:
@@ -110,6 +111,7 @@ class BaseHabiticaListEntity(HabiticaBase, TodoListEntity):
 
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_move_todo_item(
         self, uid: str, previous_uid: str | None = None
     ) -> None:
@@ -148,6 +150,7 @@ class BaseHabiticaListEntity(HabiticaBase, TodoListEntity):
                 translation_placeholders={"pos": str(pos)},
             ) from e
 
+    @override
     async def async_update_todo_item(self, item: TodoItem) -> None:
         """Update a Habitica todo."""
         refresh_required = False
@@ -257,6 +260,7 @@ class HabiticaTodosListEntity(BaseHabiticaListEntity):
     )
 
     @property
+    @override
     def todo_items(self) -> list[TodoItem]:
         """Return the todo items."""
 
@@ -287,6 +291,7 @@ class HabiticaTodosListEntity(BaseHabiticaListEntity):
             ),
         )
 
+    @override
     async def async_create_todo_item(self, item: TodoItem) -> None:
         """Create a Habitica todo."""
         if TYPE_CHECKING:
@@ -333,6 +338,7 @@ class HabiticaDailiesListEntity(BaseHabiticaListEntity):
     )
 
     @property
+    @override
     def todo_items(self) -> list[TodoItem]:
         """Return the dailies.
 

--- a/homeassistant/components/hanna/config_flow.py
+++ b/homeassistant/components/hanna/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Hanna Instruments integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from hanna_cloud import AuthenticationError, HannaCloudClient
 from requests.exceptions import ConnectionError as RequestsConnectionError, Timeout
@@ -23,6 +23,7 @@ class HannaConfigFlow(ConfigFlow, domain=DOMAIN):
         {vol.Required(CONF_EMAIL): str, vol.Required(CONF_PASSWORD): str}
     )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/hanna/coordinator.py
+++ b/homeassistant/components/hanna/coordinator.py
@@ -6,7 +6,7 @@ sensor data.
 
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from hanna_cloud import HannaCloudClient
 from requests.exceptions import RequestException
@@ -59,6 +59,7 @@ class HannaDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 return parameter["value"]
         return None
 
+    @override
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch latest sensor data from the Hanna API."""
         try:

--- a/homeassistant/components/hanna/sensor.py
+++ b/homeassistant/components/hanna/sensor.py
@@ -6,6 +6,7 @@ to fetch readings and updates them periodically.
 """
 
 import logging
+from typing import override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -99,6 +100,7 @@ class HannaSensor(HannaEntity, SensorEntity):
         self.entity_description = description
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the value reported by the sensor."""
         return self.coordinator.get_parameter_value(self.entity_description.key)

--- a/homeassistant/components/harman_kardon_avr/media_player.py
+++ b/homeassistant/components/harman_kardon_avr/media_player.py
@@ -1,5 +1,7 @@
 """Support for interface with an Harman/Kardon or JBL AVR."""
 
+from typing import override
+
 import hkavr
 import voluptuous as vol
 
@@ -81,33 +83,40 @@ class HkAvrDevice(MediaPlayerEntity):
         self._current_source = self._avr.current_source
 
     @property
+    @override
     def name(self):
         """Return the name of the device."""
         return self._name
 
     @property
+    @override
     def is_volume_muted(self):
         """Muted status not available."""
         return self._muted
 
     @property
+    @override
     def source(self):
         """Return the current input source."""
         return self._current_source
 
     @property
+    @override
     def source_list(self):
         """Available sources."""
         return self._source_list
 
+    @override
     def turn_on(self) -> None:
         """Turn the AVR on."""
         self._avr.power_on()
 
+    @override
     def turn_off(self) -> None:
         """Turn off the AVR."""
         self._avr.power_off()
 
+    @override
     def select_source(self, source: str) -> None:
         """Select input source."""
         return self._avr.select_source(source)
@@ -120,6 +129,7 @@ class HkAvrDevice(MediaPlayerEntity):
         """Volume down AVR."""
         return self._avr.volume_down()
 
+    @override
     def mute_volume(self, mute: bool) -> None:
         """Send mute command."""
         return self._avr.mute(mute)

--- a/homeassistant/components/harmony/config_flow.py
+++ b/homeassistant/components/harmony/config_flow.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from typing import Any
+from typing import Any, override
 from urllib.parse import urlparse
 
 from aioharmony.hubconnector_websocket import HubConnector
@@ -70,6 +70,7 @@ class HarmonyConfigFlow(ConfigFlow, domain=DOMAIN):
         """Initialize the Harmony config flow."""
         self.harmony_config: dict[str, Any] = {}
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -96,6 +97,7 @@ class HarmonyConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="user", data_schema=DATA_SCHEMA, errors=errors
         )
 
+    @override
     async def async_step_ssdp(
         self, discovery_info: SsdpServiceInfo
     ) -> ConfigFlowResult:
@@ -155,6 +157,7 @@ class HarmonyConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> OptionsFlowHandler:

--- a/homeassistant/components/harmony/entity.py
+++ b/homeassistant/components/harmony/entity.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 from datetime import datetime
 import logging
+from typing import override
 
 from homeassistant.core import callback
 from homeassistant.helpers.entity import Entity
@@ -28,6 +29,7 @@ class HarmonyEntity(Entity):
         self._attr_should_poll = False
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if we're connected to the Hub, otherwise False."""
         return self._data.available

--- a/homeassistant/components/harmony/remote.py
+++ b/homeassistant/components/harmony/remote.py
@@ -3,7 +3,7 @@
 from collections.abc import Iterable
 import json
 import logging
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -129,6 +129,7 @@ class HarmonyRemote(HarmonyEntity, RemoteEntity, RestoreEntity):
         self._activity_starting = None
         self.async_write_ha_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Complete the initialization."""
         await super().async_added_to_hass()
@@ -163,16 +164,19 @@ class HarmonyRemote(HarmonyEntity, RemoteEntity, RestoreEntity):
         self._last_activity = last_state.attributes[ATTR_LAST_ACTIVITY]
 
     @property
+    @override
     def current_activity(self):
         """Return the current activity."""
         return self._current_activity
 
     @property
+    @override
     def activity_list(self):
         """Return the available activities."""
         return self._data.activity_names
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Add platform specific attributes."""
         return {
@@ -182,6 +186,7 @@ class HarmonyRemote(HarmonyEntity, RemoteEntity, RestoreEntity):
         }
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return False if PowerOff is the current activity, otherwise True."""
         return self._current_activity not in [None, "PowerOff"]
@@ -210,6 +215,7 @@ class HarmonyRemote(HarmonyEntity, RemoteEntity, RestoreEntity):
         self.async_new_activity(self._data.current_activity)
         await self.hass.async_add_executor_job(self.write_config_file)
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Start an activity from the Harmony device."""
         _LOGGER.debug("%s: Turn On", self._data.name)
@@ -229,10 +235,12 @@ class HarmonyRemote(HarmonyEntity, RemoteEntity, RestoreEntity):
                 "%s: No activity specified with turn_on service", self._data.name
             )
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Start the PowerOff activity."""
         await self._data.async_power_off()
 
+    @override
     async def async_send_command(self, command: Iterable[str], **kwargs: Any) -> None:
         """Send a list of commands to one device."""
         _LOGGER.debug("%s: Send Command", self._data.name)

--- a/homeassistant/components/harmony/select.py
+++ b/homeassistant/components/harmony/select.py
@@ -1,6 +1,7 @@
 """Support for Harmony Hub select activities."""
 
 import logging
+from typing import override
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.core import HassJob, HomeAssistant, callback
@@ -38,11 +39,13 @@ class HarmonyActivitySelect(HarmonyEntity, SelectEntity):
         self._attr_device_info = self._data.device_info(DOMAIN)
 
     @property
+    @override
     def options(self) -> list[str]:
         """Return a set of selectable options."""
         return [TRANSLATABLE_POWER_OFF, *sorted(self._data.activity_names)]
 
     @property
+    @override
     def current_option(self) -> str | None:
         """Return the current activity."""
         _, activity_name = self._data.current_activity
@@ -50,6 +53,7 @@ class HarmonyActivitySelect(HarmonyEntity, SelectEntity):
             return TRANSLATABLE_POWER_OFF
         return activity_name
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Change the current activity."""
         if option == TRANSLATABLE_POWER_OFF:
@@ -57,6 +61,7 @@ class HarmonyActivitySelect(HarmonyEntity, SelectEntity):
             return
         await self._data.async_start_activity(option)
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Call when entity is added to hass."""
         activity_update_job = HassJob(self._async_activity_update)

--- a/homeassistant/components/hassio/backup.py
+++ b/homeassistant/components/hassio/backup.py
@@ -6,7 +6,7 @@ from contextlib import suppress
 import logging
 import os
 from pathlib import Path, PurePath
-from typing import Any, cast
+from typing import Any, cast, override
 from uuid import UUID
 
 from aiohasupervisor import SupervisorClient
@@ -161,6 +161,7 @@ class SupervisorBackupAgent(BackupAgent):
         self.name = self.unique_id = name
         self.location = location
 
+    @override
     async def async_download_backup(
         self,
         backup_id: str,
@@ -177,6 +178,7 @@ class SupervisorBackupAgent(BackupAgent):
         except SupervisorNotFoundError as err:
             raise BackupNotFound(f"Backup {backup_id} not found") from err
 
+    @override
     async def async_upload_backup(
         self,
         *,
@@ -216,6 +218,7 @@ class SupervisorBackupAgent(BackupAgent):
             upload_options,
         )
 
+    @override
     async def async_list_backups(self, **kwargs: Any) -> list[AgentBackup]:
         """List backups."""
         backup_list = await self._client.backups.list()
@@ -227,6 +230,7 @@ class SupervisorBackupAgent(BackupAgent):
             result.append(_backup_details_to_agent_backup(details, self.location))
         return result
 
+    @override
     async def async_get_backup(
         self,
         backup_id: str,
@@ -241,6 +245,7 @@ class SupervisorBackupAgent(BackupAgent):
             raise BackupNotFound(f"Backup {backup_id} not found")
         return _backup_details_to_agent_backup(details, self.location)
 
+    @override
     async def async_delete_backup(self, backup_id: str, **kwargs: Any) -> None:
         """Remove a backup."""
         try:
@@ -262,6 +267,7 @@ class SupervisorBackupReaderWriter(BackupReaderWriter):
         self._hass = hass
         self._client = get_supervisor_client(hass)
 
+    @override
     async def async_create_backup(
         self,
         *,
@@ -493,6 +499,7 @@ class SupervisorBackupReaderWriter(BackupReaderWriter):
             release_stream=remove_backup,
         )
 
+    @override
     async def async_receive_backup(
         self,
         *,
@@ -539,6 +546,7 @@ class SupervisorBackupReaderWriter(BackupReaderWriter):
             release_stream=remove_backup,
         )
 
+    @override
     async def async_restore_backup(
         self,
         backup_id: str,
@@ -637,6 +645,7 @@ class SupervisorBackupReaderWriter(BackupReaderWriter):
         finally:
             unsub()
 
+    @override
     async def async_resume_restore_progress_after_restart(
         self,
         *,
@@ -699,6 +708,7 @@ class SupervisorBackupReaderWriter(BackupReaderWriter):
             _LOGGER.debug("Could not get restore job %s: %s", restore_job_id, err)
             unsub()
 
+    @override
     async def async_validate_config(self, *, config: BackupConfig) -> None:
         """Validate backup config.
 

--- a/homeassistant/components/hassio/binary_sensor.py
+++ b/homeassistant/components/hassio/binary_sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from aiohasupervisor.models import AddonState
 from aiohasupervisor.models.mounts import MountState
@@ -98,6 +99,7 @@ class HassioAddonBinarySensor(HassioAddonEntity, BinarySensorEntity):
     entity_description: HassioAddonBinarySensorEntityDescription
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if the binary sensor is on."""
         return self.entity_description.value_fn(self)
@@ -109,6 +111,7 @@ class HassioMountBinarySensor(HassioMountEntity, BinarySensorEntity):
     entity_description: HassioMountBinarySensorEntityDescription
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if the binary sensor is on."""
         return self.entity_description.value_fn(self)

--- a/homeassistant/components/hassio/coordinator.py
+++ b/homeassistant/components/hassio/coordinator.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from collections.abc import Awaitable
 from dataclasses import dataclass
 import logging
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, cast, override
 
 from aiohasupervisor import SupervisorError, SupervisorNotFoundError
 from aiohasupervisor.models import (
@@ -491,6 +491,7 @@ class HassioStatsDataUpdateCoordinator(DataUpdateCoordinator[HassioStatsData]):
             lambda: defaultdict(set)
         )
 
+    @override
     async def _async_update_data(self) -> HassioStatsData:
         """Update stats data via library."""
         try:
@@ -611,6 +612,7 @@ class HassioAddOnDataUpdateCoordinator(DataUpdateCoordinator[HassioAddonData]):
         self.supervisor_client = get_supervisor_client(hass)
         self.jobs = jobs
 
+    @override
     async def _async_update_data(self) -> HassioAddonData:
         """Update data via library."""
         is_first_update = not self.data
@@ -723,6 +725,7 @@ class HassioAddOnDataUpdateCoordinator(DataUpdateCoordinator[HassioAddonData]):
 
         return _remove
 
+    @override
     async def _async_refresh(
         self,
         log_failures: bool = True,
@@ -812,6 +815,7 @@ class HassioMainDataUpdateCoordinator(DataUpdateCoordinator[HassioMainData]):
         ):
             self.config_entry.async_create_task(self.hass, self.async_request_refresh())
 
+    @override
     async def _async_update_data(self) -> HassioMainData:
         """Update data via library."""
         is_first_update = not self.data
@@ -915,6 +919,7 @@ class HassioMainDataUpdateCoordinator(DataUpdateCoordinator[HassioMainData]):
 
         return new_data
 
+    @override
     async def _async_refresh(
         self,
         log_failures: bool = True,
@@ -941,6 +946,7 @@ class HassioMainDataUpdateCoordinator(DataUpdateCoordinator[HassioMainData]):
             log_failures, raise_on_auth_failed, scheduled, raise_on_entry_error
         )
 
+    @override
     async def async_shutdown(self) -> None:
         """Shut down and clean up when config entry unloaded."""
         await super().async_shutdown()

--- a/homeassistant/components/hassio/entity.py
+++ b/homeassistant/components/hassio/entity.py
@@ -1,6 +1,7 @@
 """Base for Hass.io entities."""
 
 from collections.abc import Callable
+from typing import override
 
 from aiohasupervisor.models import CIFSMountResponse, HostInfo, NFSMountResponse, OSInfo
 from aiohasupervisor.models.base import ContainerStats
@@ -54,10 +55,12 @@ class HassioStatsEntity(CoordinatorEntity[HassioStatsDataUpdateCoordinator]):
         return self._stats
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available."""
         return super().available and self._stats is not None
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Subscribe to stats updates."""
         await super().async_added_to_hass()
@@ -105,10 +108,12 @@ class HassioAddonEntity(CoordinatorEntity[HassioAddOnDataUpdateCoordinator]):
         return data.addons[self._addon_slug]
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available."""
         return super().available and self._addon_slug in self.coordinator.data.addons
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Subscribe to addon info updates."""
         await super().async_added_to_hass()
@@ -136,6 +141,7 @@ class HassioOSEntity(CoordinatorEntity[HassioMainDataUpdateCoordinator]):
         self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, "OS")})
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available."""
         return super().available and self.coordinator.data.os is not None
@@ -232,6 +238,7 @@ class HassioMountEntity(CoordinatorEntity[HassioMainDataUpdateCoordinator]):
         return self._mount.name
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available."""
         return super().available and self.mount_name in self.coordinator.data.mounts

--- a/homeassistant/components/hassio/repairs.py
+++ b/homeassistant/components/hassio/repairs.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable, Coroutine
 from types import MethodType
-from typing import Any
+from typing import Any, override
 
 from aiohasupervisor import SupervisorError
 from aiohasupervisor.models import ContextType
@@ -163,6 +163,7 @@ class DockerConfigIssueRepairFlow(SupervisorIssueRepairFlow):
     """Handler for docker config issue fixing flow."""
 
     @property
+    @override
     def description_placeholders(self) -> dict[str, str] | None:
         """Get description placeholders for steps."""
         placeholders = {PLACEHOLDER_KEY_COMPONENTS: ""}
@@ -197,6 +198,7 @@ class AddonIssueRepairFlow(SupervisorIssueRepairFlow):
     """Handler for addon issue fixing flows."""
 
     @property
+    @override
     def description_placeholders(self) -> dict[str, str] | None:
         """Get description placeholders for steps."""
         placeholders: dict[str, str] = super().description_placeholders or {}
@@ -215,6 +217,7 @@ class DeprecatedAddonIssueRepairFlow(AddonIssueRepairFlow):
     """Handler for deprecated addon issue fixing flows."""
 
     @property
+    @override
     def description_placeholders(self) -> dict[str, str] | None:
         """Get description placeholders for steps."""
         placeholders: dict[str, str] = super().description_placeholders or {}

--- a/homeassistant/components/hassio/sensor.py
+++ b/homeassistant/components/hassio/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from aiohasupervisor.models.base import ContainerStats
 
@@ -258,6 +259,7 @@ class HassioAddonSensor(HassioAddonEntity, SensorEntity):
     entity_description: HassioAddonSensorEntityDescription
 
     @property
+    @override
     def native_value(self) -> str | None:
         """Return native value of entity."""
         return self.entity_description.value_fn(self)
@@ -269,6 +271,7 @@ class HassioStatsSensor(HassioStatsEntity, SensorEntity):
     entity_description: HassioStatsSensorEntityDescription
 
     @property
+    @override
     def native_value(self) -> float:
         """Return native value of entity."""
         return self.entity_description.value_fn(self)
@@ -280,6 +283,7 @@ class HassioOSSensor(HassioOSEntity, SensorEntity):
     entity_description: HassioOSSensorEntityDescription
 
     @property
+    @override
     def native_value(self) -> str | None:
         """Return native value of entity."""
         return self.entity_description.value_fn(self)
@@ -291,6 +295,7 @@ class HostSensor(HassioHostEntity, SensorEntity):
     entity_description: HassioHostSensorEntityDescription
 
     @property
+    @override
     def native_value(self) -> str | float | None:
         """Return native value of entity."""
         return self.entity_description.value_fn(self)

--- a/homeassistant/components/hassio/switch.py
+++ b/homeassistant/components/hassio/switch.py
@@ -1,7 +1,7 @@
 """Switch platform for Hass.io addons."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from aiohasupervisor import SupervisorError
 from aiohasupervisor.models import AddonState
@@ -49,6 +49,7 @@ class HassioAddonSwitch(HassioAddonEntity, SwitchEntity):
     """Switch for Hass.io add-ons."""
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if the add-on is on."""
         return (
@@ -57,6 +58,7 @@ class HassioAddonSwitch(HassioAddonEntity, SwitchEntity):
         )
 
     @property
+    @override
     def entity_picture(self) -> str | None:
         """Return the icon of the add-on if any."""
         if not self.available:
@@ -65,6 +67,7 @@ class HassioAddonSwitch(HassioAddonEntity, SwitchEntity):
             return f"/api/hassio/addons/{self._addon_slug}/icon"
         return None
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         supervisor_client = get_supervisor_client(self.hass)
@@ -75,6 +78,7 @@ class HassioAddonSwitch(HassioAddonEntity, SwitchEntity):
 
         await self.coordinator.force_addon_info_data_refresh(self._addon_slug)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         supervisor_client = get_supervisor_client(self.hass)

--- a/homeassistant/components/hassio/update.py
+++ b/homeassistant/components/hassio/update.py
@@ -1,7 +1,7 @@
 """Update platform for Supervisor."""
 
 import re
-from typing import Any
+from typing import Any, override
 
 from aiohasupervisor import SupervisorError
 from aiohasupervisor.models import Job
@@ -103,26 +103,31 @@ class SupervisorAddonUpdateEntity(HassioAddonEntity, UpdateEntity):
         return self.coordinator.data.addons[self._addon_slug]
 
     @property
+    @override
     def auto_update(self) -> bool:
         """Return true if auto-update is enabled for the add-on."""
         return self._addon_data.auto_update
 
     @property
+    @override
     def title(self) -> str | None:
         """Return the title of the update."""
         return self._addon_data.addon.name
 
     @property
+    @override
     def latest_version(self) -> str | None:
         """Latest version available for install."""
         return self._addon_data.addon.version_latest
 
     @property
+    @override
     def installed_version(self) -> str | None:
         """Version installed and in use."""
         return self._addon_data.addon.version
 
     @property
+    @override
     def in_progress(self) -> bool | None:
         """Return combined progress from the update job and refresh phase."""
         if self._update_ongoing:
@@ -130,6 +135,7 @@ class SupervisorAddonUpdateEntity(HassioAddonEntity, UpdateEntity):
         return self._attr_in_progress
 
     @property
+    @override
     def entity_picture(self) -> str | None:
         """Return the icon of the add-on if any."""
         if not self.available:
@@ -138,6 +144,7 @@ class SupervisorAddonUpdateEntity(HassioAddonEntity, UpdateEntity):
             return f"/api/hassio/addons/{self._addon_slug}/icon"
         return None
 
+    @override
     async def async_release_notes(self) -> str | None:
         """Return the release notes for the update."""
         if (
@@ -156,6 +163,7 @@ class SupervisorAddonUpdateEntity(HassioAddonEntity, UpdateEntity):
         match = regex_pattern.search(changelog)
         return match.group(0) if match else changelog
 
+    @override
     async def async_install(
         self,
         version: str | None = None,
@@ -181,6 +189,7 @@ class SupervisorAddonUpdateEntity(HassioAddonEntity, UpdateEntity):
         await self.coordinator.async_refresh()
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Clear the ongoing flag once the installed version has changed."""
         if (
@@ -202,6 +211,7 @@ class SupervisorAddonUpdateEntity(HassioAddonEntity, UpdateEntity):
             self._attr_update_percentage = None
         self.async_write_ha_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Subscribe to progress updates."""
         await super().async_added_to_hass()
@@ -227,23 +237,27 @@ class SupervisorOSUpdateEntity(HassioOSEntity, UpdateEntity):
     _attr_title = "Home Assistant Operating System"
 
     @property
+    @override
     def latest_version(self) -> str | None:
         """Return the latest version."""
         assert self.coordinator.data.os is not None
         return self.coordinator.data.os.version_latest
 
     @property
+    @override
     def installed_version(self) -> str | None:
         """Return the installed version."""
         assert self.coordinator.data.os is not None
         return self.coordinator.data.os.version
 
     @property
+    @override
     def entity_picture(self) -> str | None:
         """Return the icon of the entity."""
         return "/api/brands/integration/homeassistant/icon.png?placeholder=no"
 
     @property
+    @override
     def release_url(self) -> str | None:
         """URL to the full release notes of the latest version available."""
         version = AwesomeVersion(self.latest_version)
@@ -253,6 +267,7 @@ class SupervisorOSUpdateEntity(HassioOSEntity, UpdateEntity):
             f"https://github.com/home-assistant/operating-system/releases/tag/{version}"
         )
 
+    @override
     async def async_install(
         self, version: str | None, backup: bool, **kwargs: Any
     ) -> None:
@@ -279,6 +294,7 @@ class SupervisorSupervisorUpdateEntity(HassioSupervisorEntity, UpdateEntity):
     _version_before_update: str | None = None
 
     @property
+    @override
     def in_progress(self) -> bool | None:
         """Return combined progress from the update job and restart phase."""
         if self._update_ongoing:
@@ -286,21 +302,25 @@ class SupervisorSupervisorUpdateEntity(HassioSupervisorEntity, UpdateEntity):
         return self._attr_in_progress
 
     @property
+    @override
     def latest_version(self) -> str | None:
         """Return the latest version."""
         return self.coordinator.data.supervisor.version_latest
 
     @property
+    @override
     def installed_version(self) -> str:
         """Return the installed version."""
         return self.coordinator.data.supervisor.version
 
     @property
+    @override
     def auto_update(self) -> bool:
         """Return true if auto-update is enabled for supervisor."""
         return self.coordinator.data.supervisor.auto_update
 
     @property
+    @override
     def release_url(self) -> str | None:
         """URL to the full release notes of the latest version available."""
         version = AwesomeVersion(self.latest_version)
@@ -309,10 +329,12 @@ class SupervisorSupervisorUpdateEntity(HassioSupervisorEntity, UpdateEntity):
         return f"https://github.com/home-assistant/supervisor/releases/tag/{version}"
 
     @property
+    @override
     def entity_picture(self) -> str | None:
         """Return the icon of the entity."""
         return "/api/brands/integration/hassio/icon.png?placeholder=no"
 
+    @override
     async def async_install(
         self, version: str | None, backup: bool, **kwargs: Any
     ) -> None:
@@ -333,6 +355,7 @@ class SupervisorSupervisorUpdateEntity(HassioSupervisorEntity, UpdateEntity):
             ) from err
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Clear the ongoing flag once the installed version has changed."""
         if (
@@ -360,6 +383,7 @@ class SupervisorSupervisorUpdateEntity(HassioSupervisorEntity, UpdateEntity):
             self._attr_update_percentage = None
         self.async_write_ha_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Subscribe to progress updates."""
         await super().async_added_to_hass()
@@ -382,21 +406,25 @@ class SupervisorCoreUpdateEntity(HassioCoreEntity, UpdateEntity):
     _attr_title = "Home Assistant Core"
 
     @property
+    @override
     def latest_version(self) -> str | None:
         """Return the latest version."""
         return self.coordinator.data.core.version_latest
 
     @property
+    @override
     def installed_version(self) -> str | None:
         """Return the installed version."""
         return self.coordinator.data.core.version
 
     @property
+    @override
     def entity_picture(self) -> str | None:
         """Return the icon of the entity."""
         return "/api/brands/integration/homeassistant/icon.png?placeholder=no"
 
     @property
+    @override
     def release_url(self) -> str | None:
         """URL to the full release notes of the latest version available."""
         version = AwesomeVersion(self.latest_version)
@@ -405,6 +433,7 @@ class SupervisorCoreUpdateEntity(HassioCoreEntity, UpdateEntity):
         subdomain = "rc" if version.beta else "www"
         return f"https://{subdomain}.home-assistant.io/latest-release-notes/"
 
+    @override
     async def async_install(
         self, version: str | None, backup: bool, **kwargs: Any
     ) -> None:
@@ -424,6 +453,7 @@ class SupervisorCoreUpdateEntity(HassioCoreEntity, UpdateEntity):
             self._attr_update_percentage = None
         self.async_write_ha_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Subscribe to progress updates."""
         await super().async_added_to_hass()

--- a/homeassistant/components/haveibeenpwned/sensor.py
+++ b/homeassistant/components/haveibeenpwned/sensor.py
@@ -3,7 +3,7 @@
 from datetime import timedelta
 from http import HTTPStatus
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 import requests
 import voluptuous as vol
@@ -66,6 +66,7 @@ class HaveIBeenPwnedSensor(SensorEntity):
         self._attr_native_unit_of_measurement = "Breaches"
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the attributes of the sensor."""
         val: dict[str, Any] = {}
@@ -83,6 +84,7 @@ class HaveIBeenPwnedSensor(SensorEntity):
 
         return val
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Get initial data."""
         # To make sure we get initial data for the sensors ignoring the normal

--- a/homeassistant/components/hddtemp/sensor.py
+++ b/homeassistant/components/hddtemp/sensor.py
@@ -3,7 +3,7 @@
 from datetime import timedelta
 import logging
 import socket
-from typing import Any
+from typing import Any, override
 
 from telnetlib import Telnet  # pylint: disable=deprecated-module
 import voluptuous as vol
@@ -81,6 +81,7 @@ class HddTempSensor(SensorEntity):
         self._details = None
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return the state attributes of the sensor."""
         if self._details is not None:

--- a/homeassistant/components/hdfury/button.py
+++ b/homeassistant/components/hdfury/button.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from typing import override
 
 from hdfury import HDFuryAPI, HDFuryError
 
@@ -64,6 +65,7 @@ class HDFuryButton(HDFuryEntity, ButtonEntity):
 
     entity_description: HDFuryButtonEntityDescription
 
+    @override
     async def async_press(self) -> None:
         """Handle Button Press."""
 

--- a/homeassistant/components/hdfury/config_flow.py
+++ b/homeassistant/components/hdfury/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for HDFury Integration."""
 
-from typing import Any
+from typing import Any, override
 
 from hdfury import HDFuryAPI, HDFuryError
 import voluptuous as vol
@@ -20,6 +20,7 @@ class HDFuryConfigFlow(ConfigFlow, domain=DOMAIN):
         """Initialize the config flow."""
         self.data: dict[str, Any] = {}
 
+    @override
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:
@@ -57,6 +58,7 @@ class HDFuryConfigFlow(ConfigFlow, domain=DOMAIN):
             },
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/hdfury/coordinator.py
+++ b/homeassistant/components/hdfury/coordinator.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
-from typing import Final
+from typing import Final, override
 
 from hdfury import HDFuryAPI, HDFuryError
 
@@ -47,6 +47,7 @@ class HDFuryCoordinator(DataUpdateCoordinator[HDFuryData]):
         self.host: str = entry.data[CONF_HOST]
         self.client = HDFuryAPI(self.host, async_get_clientsession(hass))
 
+    @override
     async def _async_update_data(self) -> HDFuryData:
         """Fetch the latest device data."""
 

--- a/homeassistant/components/hdfury/number.py
+++ b/homeassistant/components/hdfury/number.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from typing import override
 
 from hdfury import HDFuryAPI, HDFuryError
 
@@ -106,11 +107,13 @@ class HDFuryNumber(HDFuryEntity, NumberEntity):
     entity_description: HDFuryNumberEntityDescription
 
     @property
+    @override
     def native_value(self) -> float:
         """Return the current number value."""
 
         return float(self.coordinator.data.config[self.entity_description.key])
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Set Number Value Event."""
 

--- a/homeassistant/components/hdfury/select.py
+++ b/homeassistant/components/hdfury/select.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from typing import override
 
 from hdfury import OPERATION_MODES, TX0_INPUT_PORTS, TX1_INPUT_PORTS, HDFuryError
 
@@ -92,11 +93,13 @@ class HDFurySelect(HDFuryEntity, SelectEntity):
     entity_description: HDFurySelectEntityDescription
 
     @property
+    @override
     def current_option(self) -> str:
         """Return the current option."""
 
         return self.coordinator.data.info[self.entity_description.key]
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Update the current option."""
 

--- a/homeassistant/components/hdfury/sensor.py
+++ b/homeassistant/components/hdfury/sensor.py
@@ -1,5 +1,7 @@
 """Sensor platform for HDFury Integration."""
 
+from typing import override
+
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
@@ -117,6 +119,7 @@ class HDFurySensor(HDFuryEntity, SensorEntity):
     entity_description: SensorEntityDescription
 
     @property
+    @override
     def native_value(self) -> str:
         """Set Sensor Value."""
 

--- a/homeassistant/components/hdfury/switch.py
+++ b/homeassistant/components/hdfury/switch.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from hdfury import HDFuryAPI, HDFuryError
 
@@ -156,11 +156,13 @@ class HDFurySwitch(HDFuryEntity, SwitchEntity):
     entity_description: HDFurySwitchEntityDescription
 
     @property
+    @override
     def is_on(self) -> bool:
         """Set Switch State."""
 
         return self.coordinator.data.config.get(self.entity_description.key) == "1"
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Handle Switch On Event."""
 
@@ -174,6 +176,7 @@ class HDFurySwitch(HDFuryEntity, SwitchEntity):
 
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Handle Switch Off Event."""
 

--- a/homeassistant/components/hdmi_cec/entity.py
+++ b/homeassistant/components/hdmi_cec/entity.py
@@ -1,6 +1,6 @@
 """Support for HDMI CEC."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.core import callback
 from homeassistant.helpers.entity import Entity
@@ -63,6 +63,7 @@ class CecEntity(Entity):
         self._attr_available = False
         self.async_write_ha_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register HDMI callbacks after initialization."""
         self._device.set_update_callback(self._update)
@@ -101,6 +102,7 @@ class CecEntity(Entity):
         return self._device.type
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         state_attr = {}

--- a/homeassistant/components/hdmi_cec/media_player.py
+++ b/homeassistant/components/hdmi_cec/media_player.py
@@ -1,6 +1,7 @@
 """Support for HDMI CEC devices as media players."""
 
 import logging
+from typing import override
 
 from pycec.commands import CecCommand, KeyPressCommand, KeyReleaseCommand
 from pycec.const import (
@@ -78,53 +79,63 @@ class CecPlayerEntity(CecEntity, MediaPlayerEntity):
         """Send playback status to CEC adapter."""
         self._device.send_command(CecCommand(key, dst=self._logical_address))
 
+    @override
     async def async_mute_volume(self, mute: bool) -> None:
         """Mute volume."""
         self.send_keypress(KEY_MUTE_TOGGLE)
 
+    @override
     async def async_media_previous_track(self) -> None:
         """Go to previous track."""
         self.send_keypress(KEY_BACKWARD)
 
+    @override
     async def async_turn_on(self) -> None:
         """Turn device on."""
         self._device.turn_on()
         self._attr_state = MediaPlayerState.ON
         self.async_write_ha_state()
 
+    @override
     async def async_turn_off(self) -> None:
         """Turn device off."""
         self._device.send_command(CecCommand(CMD_STANDBY, dst=self._logical_address))
         self._attr_state = MediaPlayerState.OFF
         self.async_write_ha_state()
 
+    @override
     async def async_media_stop(self) -> None:
         """Stop playback."""
         self.send_keypress(KEY_STOP)
         self._attr_state = MediaPlayerState.IDLE
         self.async_write_ha_state()
 
+    @override
     async def async_media_next_track(self) -> None:
         """Skip to next track."""
         self.send_keypress(KEY_FORWARD)
 
+    @override
     async def async_media_pause(self) -> None:
         """Pause playback."""
         self.send_keypress(KEY_PAUSE)
         self._attr_state = MediaPlayerState.PAUSED
         self.async_write_ha_state()
 
+    @override
     async def async_media_play(self) -> None:
         """Start playback."""
         self.send_keypress(KEY_PLAY)
         self._attr_state = MediaPlayerState.PLAYING
         self.async_write_ha_state()
 
+    @override
     async def async_volume_up(self) -> None:
         """Increase volume."""
         _LOGGER.debug("%s: volume up", self._logical_address)
         self.send_keypress(KEY_VOLUME_UP)
 
+    @override
     async def async_volume_down(self) -> None:
         """Decrease volume."""
         _LOGGER.debug("%s: volume down", self._logical_address)
@@ -148,6 +159,7 @@ class CecPlayerEntity(CecEntity, MediaPlayerEntity):
             _LOGGER.warning("Unknown state: %s", device.status)
 
     @property
+    @override
     def supported_features(self) -> MediaPlayerEntityFeature:
         """Flag media player features that are supported."""
         if self.type_id == TYPE_RECORDER or self.type == TYPE_PLAYBACK:

--- a/homeassistant/components/hdmi_cec/switch.py
+++ b/homeassistant/components/hdmi_cec/switch.py
@@ -1,7 +1,7 @@
 """Support for HDMI CEC devices as switches."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from pycec.commands import CecCommand
 from pycec.const import CMD_STANDBY, POWER_OFF, POWER_ON
@@ -43,12 +43,14 @@ class CecSwitchEntity(CecEntity, SwitchEntity):
         CecEntity.__init__(self, device, logical)
         self.entity_id = f"{SWITCH_DOMAIN}.hdmi_{hex(self._logical_address)[2:]}"
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn device on."""
         self._device.turn_on()
         self._attr_is_on = True
         self.async_write_ha_state()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn device off."""
         self._device.send_command(CecCommand(CMD_STANDBY, dst=self._logical_address))

--- a/homeassistant/components/heatmiser/climate.py
+++ b/homeassistant/components/heatmiser/climate.py
@@ -1,7 +1,7 @@
 """Support for the PRT Heatmiser thermostats using the V3 protocol."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from heatmiserv3 import connection, heatmiser
 import voluptuous as vol
@@ -89,6 +89,7 @@ class HeatmiserV3Thermostat(ClimateEntity):
         self.dcb = None
         self._attr_hvac_mode = HVACMode.HEAT
 
+    @override
     def set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:

--- a/homeassistant/components/hegel/config_flow.py
+++ b/homeassistant/components/hegel/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Hegel integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from hegel_ip_client import HegelClient
 from hegel_ip_client.exceptions import HegelConnectionError
@@ -41,6 +41,7 @@ class HegelConfigFlow(ConfigFlow, domain=DOMAIN):
         finally:
             await client.stop()
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -72,6 +73,7 @@ class HegelConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    @override
     async def async_step_ssdp(
         self, discovery_info: SsdpServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/hegel/media_player.py
+++ b/homeassistant/components/hegel/media_player.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 import contextlib
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from hegel_ip_client import (
     COMMANDS,
@@ -109,6 +109,7 @@ class HegelMediaPlayer(MediaPlayerEntity):
         self._push_task: asyncio.Task[None] | None = None
         self._push_handler: Callable[[str], None] | None = None
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Handle entity added to Home Assistant."""
         await super().async_added_to_hass()
@@ -211,6 +212,7 @@ class HegelMediaPlayer(MediaPlayerEntity):
         except (HegelConnectionError, OSError) as err:
             _LOGGER.warning("Connected watcher failed: %s", err)
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Handle entity removal from Home Assistant.
 
@@ -246,11 +248,13 @@ class HegelMediaPlayer(MediaPlayerEntity):
         self.async_write_ha_state()
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if the client is connected."""
         return self._client.is_connected()
 
     @property
+    @override
     def state(self) -> MediaPlayerState | None:
         """Return the current state of the media player."""
         power = self._state.get("power")
@@ -259,6 +263,7 @@ class HegelMediaPlayer(MediaPlayerEntity):
         return MediaPlayerState.ON if power else MediaPlayerState.OFF
 
     @property
+    @override
     def volume_level(self) -> float | None:
         """Return the volume level."""
         volume = self._state.get("volume")
@@ -267,21 +272,25 @@ class HegelMediaPlayer(MediaPlayerEntity):
         return float(volume)
 
     @property
+    @override
     def is_volume_muted(self) -> bool | None:
         """Return whether volume is muted."""
         return bool(self._state.get("mute", False))
 
     @property
+    @override
     def source(self) -> str | None:
         """Return the current input source."""
         idx = self._state.get("input")
         return self._source_map.get(idx, f"Input {idx}") if idx else None
 
     @property
+    @override
     def source_list(self) -> list[str] | None:
         """Return the list of available input sources."""
         return [self._source_map[k] for k in sorted(self._source_map.keys())] or None
 
+    @override
     async def async_turn_on(self) -> None:
         """Turn on the media player."""
         try:
@@ -289,6 +298,7 @@ class HegelMediaPlayer(MediaPlayerEntity):
         except (HegelConnectionError, TimeoutError, OSError) as err:
             raise HomeAssistantError(f"Failed to turn on: {err}") from err
 
+    @override
     async def async_turn_off(self) -> None:
         """Turn off the media player."""
         try:
@@ -296,6 +306,7 @@ class HegelMediaPlayer(MediaPlayerEntity):
         except (HegelConnectionError, TimeoutError, OSError) as err:
             raise HomeAssistantError(f"Failed to turn off: {err}") from err
 
+    @override
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""
         vol = max(0.0, min(volume, 1.0))
@@ -305,6 +316,7 @@ class HegelMediaPlayer(MediaPlayerEntity):
         except (HegelConnectionError, TimeoutError, OSError) as err:
             raise HomeAssistantError(f"Failed to set volume: {err}") from err
 
+    @override
     async def async_mute_volume(self, mute: bool) -> None:
         """Mute or unmute the volume."""
         try:
@@ -314,6 +326,7 @@ class HegelMediaPlayer(MediaPlayerEntity):
         except (HegelConnectionError, TimeoutError, OSError) as err:
             raise HomeAssistantError(f"Failed to set mute: {err}") from err
 
+    @override
     async def async_volume_up(self) -> None:
         """Increase volume."""
         try:
@@ -321,6 +334,7 @@ class HegelMediaPlayer(MediaPlayerEntity):
         except (HegelConnectionError, TimeoutError, OSError) as err:
             raise HomeAssistantError(f"Failed to increase volume: {err}") from err
 
+    @override
     async def async_volume_down(self) -> None:
         """Decrease volume."""
         try:
@@ -328,6 +342,7 @@ class HegelMediaPlayer(MediaPlayerEntity):
         except (HegelConnectionError, TimeoutError, OSError) as err:
             raise HomeAssistantError(f"Failed to decrease volume: {err}") from err
 
+    @override
     async def async_select_source(self, source: str) -> None:
         """Select input source."""
         inv = {v: k for k, v in self._source_map.items()}

--- a/homeassistant/components/helty/button.py
+++ b/homeassistant/components/helty/button.py
@@ -1,5 +1,7 @@
 """Button platform for the Helty Flow integration."""
 
+from typing import override
+
 from pyhelty import HeltyError
 
 from homeassistant.components.button import ButtonEntity
@@ -35,6 +37,7 @@ class HeltyResetFilterButton(HeltyEntity, ButtonEntity):
         super().__init__(coordinator)
         self._attr_unique_id = f"{self._device_id}_reset_filter"
 
+    @override
     async def async_press(self) -> None:
         """Reset the filter-life counter."""
         try:

--- a/homeassistant/components/helty/config_flow.py
+++ b/homeassistant/components/helty/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for the Helty Flow integration."""
 
-from typing import Any
+from typing import Any, override
 
 from pyhelty import HeltyClient, HeltyConnectionError, HeltyError
 import voluptuous as vol
@@ -16,6 +16,7 @@ STEP_USER_DATA_SCHEMA = vol.Schema({vol.Required(CONF_HOST): str})
 class HeltyConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Helty Flow."""
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/helty/coordinator.py
+++ b/homeassistant/components/helty/coordinator.py
@@ -1,6 +1,7 @@
 """DataUpdateCoordinator for the Helty Flow integration."""
 
 import logging
+from typing import override
 
 from pyhelty import HeltyClient, HeltyConnectionError, HeltyData, HeltyError
 
@@ -36,6 +37,7 @@ class HeltyDataUpdateCoordinator(DataUpdateCoordinator[HeltyData]):
         )
         self.client = client
 
+    @override
     async def _async_update_data(self) -> HeltyData:
         try:
             return await self.client.async_get_data()

--- a/homeassistant/components/helty/fan.py
+++ b/homeassistant/components/helty/fan.py
@@ -1,6 +1,6 @@
 """Fan platform for the Helty Flow integration."""
 
-from typing import Any
+from typing import Any, override
 
 from pyhelty import FanMode, HeltyError
 
@@ -69,11 +69,13 @@ class HeltyFan(HeltyEntity, FanEntity):
         return self.coordinator.data.fan_mode
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return whether the fan is running."""
         return self._mode is not FanMode.OFF
 
     @property
+    @override
     def percentage(self) -> int | None:
         """Return the current speed as a percentage, or None when on a preset."""
         if self._mode in ORDERED_SPEEDS:
@@ -81,10 +83,12 @@ class HeltyFan(HeltyEntity, FanEntity):
         return None
 
     @property
+    @override
     def preset_mode(self) -> str | None:
         """Return the active preset, or None when running on a discrete speed."""
         return MODE_TO_PRESET.get(self._mode)
 
+    @override
     async def async_set_percentage(self, percentage: int) -> None:
         """Set a discrete fan speed from a percentage."""
         if percentage == 0:
@@ -94,10 +98,12 @@ class HeltyFan(HeltyEntity, FanEntity):
             percentage_to_ordered_list_item(ORDERED_SPEEDS, percentage)
         )
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set a preset mode."""
         await self._async_set_mode(PRESET_TO_MODE[preset_mode])
 
+    @override
     async def async_turn_on(
         self,
         percentage: int | None = None,
@@ -112,6 +118,7 @@ class HeltyFan(HeltyEntity, FanEntity):
         else:
             await self._async_set_mode(FanMode.LOW)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the fan off."""
         await self._async_set_mode(FanMode.OFF)

--- a/homeassistant/components/helty/sensor.py
+++ b/homeassistant/components/helty/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from pyhelty import HeltyData
 
@@ -82,6 +83,7 @@ class HeltySensor(HeltyEntity, SensorEntity):
         self._attr_unique_id = f"{self._device_id}_{description.key}"
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the current sensor reading."""
         return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/heos/config_flow.py
+++ b/homeassistant/components/heos/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 from urllib.parse import urlparse
 
 from pyheos import (
@@ -137,10 +137,12 @@ class HeosFlowHandler(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(config_entry: HeosConfigEntry) -> OptionsFlow:
         """Create the options flow."""
         return HeosOptionsFlowHandler()
 
+    @override
     async def async_step_ssdp(
         self, discovery_info: SsdpServiceInfo
     ) -> ConfigFlowResult:
@@ -154,6 +156,7 @@ class HeosFlowHandler(ConfigFlow, domain=DOMAIN):
 
         return await self._async_handle_discovered(hostname)
 
+    @override
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:
@@ -173,6 +176,7 @@ class HeosFlowHandler(ConfigFlow, domain=DOMAIN):
         self._set_confirm_only()
         return self.async_show_form(step_id="confirm_discovery")
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/heos/coordinator.py
+++ b/homeassistant/components/heos/coordinator.py
@@ -9,7 +9,7 @@ entity-specific updates within the entity class itself.
 
 from collections.abc import Callable, Sequence
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyheos import (
     Credentials,
@@ -125,6 +125,7 @@ class HeosCoordinator(DataUpdateCoordinator[None]):
         self.heos.add_on_connected(self._async_on_reconnected)
         self.heos.add_on_controller_event(self._async_on_controller_event)
 
+    @override
     async def async_shutdown(self) -> None:
         """Disconnect all callbacks and disconnect from the device."""
         # Removes all connected through heos.add_on_*
@@ -133,6 +134,7 @@ class HeosCoordinator(DataUpdateCoordinator[None]):
         await self.heos.disconnect()
         await super().async_shutdown()
 
+    @override
     def async_add_listener(
         self, update_callback: CALLBACK_TYPE, context: Any = None
     ) -> Callable[[], None]:

--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from functools import reduce, wraps
 import logging
 from operator import ior
-from typing import Any, Final
+from typing import Any, Final, override
 
 from pyheos import (
     AddCriteriaType,
@@ -192,6 +192,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         self._handle_coordinator_update()
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self._update_attributes()
@@ -238,6 +239,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
                 | MediaPlayerEntityFeature.SHUFFLE_SET
             )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Device added to hass."""
         # Update state when attributes of the player change
@@ -252,41 +254,49 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         return {"queue": [dataclasses.asdict(item) for item in queue]}
 
     @catch_action_error("clear playlist")
+    @override
     async def async_clear_playlist(self) -> None:
         """Clear players playlist."""
         await self._player.clear_queue()
 
     @catch_action_error("pause")
+    @override
     async def async_media_pause(self) -> None:
         """Send pause command."""
         await self._player.pause()
 
     @catch_action_error("play")
+    @override
     async def async_media_play(self) -> None:
         """Send play command."""
         await self._player.play()
 
     @catch_action_error("move to previous track")
+    @override
     async def async_media_previous_track(self) -> None:
         """Send previous track command."""
         await self._player.play_previous()
 
     @catch_action_error("move to next track")
+    @override
     async def async_media_next_track(self) -> None:
         """Send next track command."""
         await self._player.play_next()
 
     @catch_action_error("stop")
+    @override
     async def async_media_stop(self) -> None:
         """Send stop command."""
         await self._player.stop()
 
     @catch_action_error("set mute")
+    @override
     async def async_mute_volume(self, mute: bool) -> None:
         """Mute the volume."""
         await self._player.set_mute(mute)
 
     @catch_action_error("play media")
+    @override
     async def async_play_media(
         self, media_type: MediaType | str, media_id: str, **kwargs: Any
     ) -> None:
@@ -363,6 +373,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         raise ValueError(f"Unsupported media type '{media_type}'")
 
     @catch_action_error("select source")
+    @override
     async def async_select_source(self, source: str) -> None:
         """Select input source."""
         # Favorite
@@ -382,6 +393,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         )
 
     @catch_action_error("set repeat")
+    @override
     async def async_set_repeat(self, repeat: RepeatMode) -> None:
         """Set repeat mode."""
         await self._player.set_play_mode(
@@ -389,11 +401,13 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         )
 
     @catch_action_error("set shuffle")
+    @override
     async def async_set_shuffle(self, shuffle: bool) -> None:
         """Enable/disable shuffle mode."""
         await self._player.set_play_mode(self._player.repeat, shuffle)
 
     @catch_action_error("set volume level")
+    @override
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""
         await self._player.set_volume(int(volume * 100))
@@ -434,6 +448,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         await self.coordinator.heos.group_volume_up(self._player.group_id)
 
     @catch_action_error("join players")
+    @override
     async def async_join_players(self, group_members: list[str]) -> None:
         """Join `group_members` as a player group with the current player."""
         player_ids: list[int] = [self._player.player_id]
@@ -459,6 +474,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         await self.coordinator.heos.set_group(player_ids)
 
     @catch_action_error("unjoin player")
+    @override
     async def async_unjoin_player(self) -> None:
         """Remove this player from any group."""
         for group in self.coordinator.heos.groups.values():
@@ -486,11 +502,13 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         await self._player.move_queue_item(queue_ids, destination_position)
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if the device is available."""
         return self._player.available
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Get additional attribute about the state."""
         return {
@@ -502,26 +520,31 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         }
 
     @property
+    @override
     def is_volume_muted(self) -> bool:
         """Boolean if volume is currently muted."""
         return self._player.is_muted
 
     @property
+    @override
     def media_album_name(self) -> str | None:
         """Album name of current playing media, music track only."""
         return self._player.now_playing_media.album
 
     @property
+    @override
     def media_artist(self) -> str | None:
         """Artist of current playing media, music track only."""
         return self._player.now_playing_media.artist
 
     @property
+    @override
     def media_content_id(self) -> str | None:
         """Content ID of current playing media."""
         return self._player.now_playing_media.media_id
 
     @property
+    @override
     def media_duration(self) -> int | None:
         """Duration of current playing media in seconds."""
         duration = self._player.now_playing_media.duration
@@ -530,6 +553,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         return None
 
     @property
+    @override
     def media_position(self) -> int | None:
         """Position of current playing media in seconds."""
         # Some media doesn't have duration but reports position, return None
@@ -540,6 +564,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         return None
 
     @property
+    @override
     def media_position_updated_at(self) -> datetime | None:
         """When was the position of the current playing media valid."""
         # Some media doesn't have duration but reports position, return None
@@ -548,6 +573,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         return self._media_position_updated_at
 
     @property
+    @override
     def media_image_url(self) -> str | None:
         """Image url of current playing media."""
         # May be an empty string, if so, return None
@@ -555,21 +581,25 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         return image_url or None
 
     @property
+    @override
     def media_title(self) -> str | None:
         """Title of current playing media."""
         return self._player.now_playing_media.song
 
     @property
+    @override
     def shuffle(self) -> bool:
         """Boolean if shuffle is enabled."""
         return self._player.shuffle
 
     @property
+    @override
     def state(self) -> MediaPlayerState:
         """State of the player."""
         return PLAY_STATE_TO_STATE[self._player.state]
 
     @property
+    @override
     def volume_level(self) -> float:
         """Volume level of the media player (0..1)."""
         return self._player.volume / 100
@@ -632,6 +662,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             content_filter=lambda item: item.media_content_type.startswith("audio/"),
         )
 
+    @override
     async def async_browse_media(
         self,
         media_content_type: MediaType | str | None = None,

--- a/homeassistant/components/here_travel_time/config_flow.py
+++ b/homeassistant/components/here_travel_time/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from here_routing import (
     HERERoutingApi,
@@ -113,12 +113,14 @@ class HERETravelTimeConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> HERETravelTimeOptionsFlow:
         """Get the options flow."""
         return HERETravelTimeOptionsFlow()
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/here_travel_time/coordinator.py
+++ b/homeassistant/components/here_travel_time/coordinator.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, time, timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 import here_routing
 from here_routing import (
@@ -80,6 +80,7 @@ class HERERoutingDataUpdateCoordinator(DataUpdateCoordinator[HERETravelTimeData]
         )
         self._api = HERERoutingApi(api_key)
 
+    @override
     async def _async_update_data(self) -> HERETravelTimeData:
         """Get the latest data from the HERE Routing API."""
         params = prepare_parameters(self.hass, self.config_entry)
@@ -204,6 +205,7 @@ class HERETransitDataUpdateCoordinator(
         )
         self._api = HERETransitApi(api_key)
 
+    @override
     async def _async_update_data(self) -> HERETravelTimeData | None:
         """Get the latest data from the HERE Routing API."""
         params = prepare_parameters(self.hass, self.config_entry)

--- a/homeassistant/components/here_travel_time/sensor.py
+++ b/homeassistant/components/here_travel_time/sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 from datetime import timedelta
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.sensor import (
     RestoreSensor,
@@ -135,12 +135,14 @@ class HERETravelTimeSensor(
         if restored_data := await self.async_get_last_sensor_data():
             self._attr_native_value = restored_data.native_value
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Wait for start so origin and destination entities can be resolved."""
         await self._async_restore_state()
         await super().async_added_to_hass()
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         if self.coordinator.data is not None:
@@ -150,6 +152,7 @@ class HERETravelTimeSensor(
             self.async_write_ha_state()
 
     @property
+    @override
     def attribution(self) -> str | None:
         """Return the attribution."""
         if self.coordinator.data is not None:
@@ -177,6 +180,7 @@ class OriginSensor(HERETravelTimeSensor):
         super().__init__(unique_id_prefix, name, sensor_description, coordinator)
 
     @property
+    @override
     def extra_state_attributes(self) -> Mapping[str, Any] | None:
         """GPS coordinates."""
         if self.coordinator.data is not None:
@@ -206,6 +210,7 @@ class DestinationSensor(HERETravelTimeSensor):
         super().__init__(unique_id_prefix, name, sensor_description, coordinator)
 
     @property
+    @override
     def extra_state_attributes(self) -> Mapping[str, Any] | None:
         """GPS coordinates."""
         if self.coordinator.data is not None:

--- a/homeassistant/components/hikvision/binary_sensor.py
+++ b/homeassistant/components/hikvision/binary_sensor.py
@@ -1,7 +1,7 @@
 """Support for Hikvision event stream events represented as binary sensors."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -293,16 +293,19 @@ class HikvisionBinarySensor(HikvisionEntity, BinarySensorEntity):
         return self._camera.fetch_attributes(self._sensor_type, self._channel)
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if sensor is on."""
         return self._get_sensor_attributes()[0]
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         attrs = self._get_sensor_attributes()
         return {ATTR_LAST_TRIP_TIME: attrs[3]}
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register callback when entity is added."""
         await super().async_added_to_hass()

--- a/homeassistant/components/hikvision/camera.py
+++ b/homeassistant/components/hikvision/camera.py
@@ -1,5 +1,7 @@
 """Support for Hikvision cameras."""
 
+from typing import override
+
 from pyhik.hikvision import VideoChannel
 
 from homeassistant.components.camera import Camera, CameraEntityFeature
@@ -59,6 +61,7 @@ class HikvisionCamera(HikvisionEntity, Camera):
         # Build unique ID (unique per platform per integration)
         self._attr_unique_id = f"{self._data.device_id}_{channel.id}"
 
+    @override
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
@@ -72,6 +75,7 @@ class HikvisionCamera(HikvisionEntity, Camera):
                 f"Error getting image from {self._video_channel.name}: {err}"
             ) from err
 
+    @override
     async def stream_source(self) -> str | None:
         """Return the stream source URL."""
         return self._camera.get_stream_url(self._channel)

--- a/homeassistant/components/hikvision/config_flow.py
+++ b/homeassistant/components/hikvision/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Hikvision integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyhik.hikvision import HikCamera
 import requests
@@ -29,6 +29,7 @@ class HikvisionConfigFlow(ConfigFlow, domain=DOMAIN):
     VERSION = 1
     MINOR_VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/hikvisioncam/switch.py
+++ b/homeassistant/components/hikvisioncam/switch.py
@@ -1,7 +1,7 @@
 """Support turning on/off motion detection on Hikvision cameras."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 import hikvision.api
 from hikvision.error import HikvisionError, MissingParamError
@@ -79,11 +79,13 @@ class HikvisionMotionSwitch(SwitchEntity):
         self._hikvision_cam = hikvision_cam
         self._attr_is_on = False
 
+    @override
     def turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
         _LOGGING.info("Turning on Motion Detection ")
         self._hikvision_cam.enable_motion_detection()
 
+    @override
     def turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
         _LOGGING.info("Turning off Motion Detection ")

--- a/homeassistant/components/hisense_aehw4a1/climate.py
+++ b/homeassistant/components/hisense_aehw4a1/climate.py
@@ -2,7 +2,7 @@
 # pylint: disable=home-assistant-use-runtime-data  # Uses legacy hass.data[DOMAIN] pattern
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyaehw4a1.aehw4a1 import AehW4a1
 import pyaehw4a1.exceptions
@@ -225,6 +225,7 @@ class ClimateAehW4a1(ClimateEntity):
             self._attr_target_temperature = None
             self._attr_preset_mode = None
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperatures."""
         if self._on != "1":
@@ -241,6 +242,7 @@ class ClimateAehW4a1(ClimateEntity):
             else:
                 await self._device.command(f"temp_{int(temp)}_F")
 
+    @override
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new fan mode."""
         if self._on != "1":
@@ -256,6 +258,7 @@ class ClimateAehW4a1(ClimateEntity):
             )
             await self._device.command(HA_FAN_MODES_TO_AC[fan_mode])
 
+    @override
     async def async_set_swing_mode(self, swing_mode: str) -> None:
         """Set new target swing operation."""
         if self._on != "1":
@@ -293,6 +296,7 @@ class ClimateAehW4a1(ClimateEntity):
             if swing_act in (SWING_OFF, SWING_VERTICAL):
                 await self._device.command("hor_swing")
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
         if self._on != "1":
@@ -333,6 +337,7 @@ class ClimateAehW4a1(ClimateEntity):
                 await self._device.command(HA_STATE_TO_AC[self._previous_state])
             self._previous_state = None
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new operation mode."""
         _LOGGER.debug(
@@ -345,11 +350,13 @@ class ClimateAehW4a1(ClimateEntity):
             if self._on != "1":
                 await self.async_turn_on()
 
+    @override
     async def async_turn_on(self) -> None:
         """Turn on."""
         _LOGGER.debug("Turning %s on", self._attr_unique_id)
         await self._device.command("on")
 
+    @override
     async def async_turn_off(self) -> None:
         """Turn off."""
         _LOGGER.debug("Turning %s off", self._attr_unique_id)

--- a/homeassistant/components/history_stats/config_flow.py
+++ b/homeassistant/components/history_stats/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 from datetime import timedelta
-from typing import Any, cast
+from typing import Any, cast, override
 
 import voluptuous as vol
 
@@ -195,11 +195,13 @@ class HistoryStatsConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
     options_flow = OPTIONS_FLOW
     options_flow_reloads = True
 
+    @override
     def async_config_entry_title(self, options: Mapping[str, Any]) -> str:
         """Return config entry title."""
         return cast(str, options[CONF_NAME])
 
     @staticmethod
+    @override
     async def async_setup_preview(hass: HomeAssistant) -> None:
         """Set up preview WS API."""
         websocket_api.async_register_command(hass, ws_start_preview)

--- a/homeassistant/components/history_stats/coordinator.py
+++ b/homeassistant/components/history_stats/coordinator.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import (
@@ -98,6 +98,7 @@ class HistoryStatsUpdateCoordinator(DataUpdateCoordinator[HistoryStatsState]):
         """Process an update from an event."""
         self.async_set_updated_data(await self._history_stats.async_update(event))
 
+    @override
     async def _async_update_data(self) -> HistoryStatsState:
         """Fetch update the history stats state."""
         try:
@@ -105,6 +106,7 @@ class HistoryStatsUpdateCoordinator(DataUpdateCoordinator[HistoryStatsState]):
         except (TemplateError, TypeError, ValueError) as ex:
             raise UpdateFailed(ex) from ex
 
+    @override
     async def async_refresh(self) -> None:
         """Refresh data and log errors."""
         log_failures = not self._preview

--- a/homeassistant/components/history_stats/sensor.py
+++ b/homeassistant/components/history_stats/sensor.py
@@ -3,7 +3,7 @@
 from abc import abstractmethod
 from collections.abc import Callable, Mapping
 import datetime
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -196,11 +196,13 @@ class HistoryStatsSensorBase(
         super().__init__(coordinator)
         self._attr_name = name
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Entity has been added to hass."""
         await super().async_added_to_hass()
         self.async_on_remove(self.coordinator.async_setup_state_listener())
 
+    @override
     def _handle_coordinator_update(self) -> None:
         """Set attrs from value and count."""
         self._process_update()
@@ -246,6 +248,7 @@ class HistoryStatsSensor(HistoryStatsSensorBase):
             self._attr_suggested_display_precision = 2
 
     @callback
+    @override
     def _process_update(self) -> None:
         """Process an update from the coordinator."""
         state = self.coordinator.data

--- a/homeassistant/components/hitron_coda/device_tracker.py
+++ b/homeassistant/components/hitron_coda/device_tracker.py
@@ -3,6 +3,7 @@
 from collections import namedtuple
 from http import HTTPStatus
 import logging
+from typing import override
 
 import requests
 import voluptuous as vol
@@ -65,12 +66,14 @@ class HitronCODADeviceScanner(DeviceScanner):
 
         self.success_init = self._update_info()
 
+    @override
     def scan_devices(self):
         """Scan for new devices and return a list with found device IDs."""
         self._update_info()
 
         return [device.mac for device in self.last_results]
 
+    @override
     def get_device_name(self, device):
         """Return the name of the device with the given MAC address."""
         return next(

--- a/homeassistant/components/hive/climate.py
+++ b/homeassistant/components/hive/climate.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from apyhiveapi import Hive
 import voluptuous as vol
@@ -104,12 +104,14 @@ class HiveClimateEntity(HiveEntity, ClimateEntity):
         self._attr_temperature_unit = TEMP_UNIT[hive_device["temperatureunit"]]
 
     @refresh_system
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         new_mode = HASS_TO_HIVE_STATE[hvac_mode]
         await self.hive.heating.setMode(self.device, new_mode)
 
     @refresh_system
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         new_temperature = kwargs.get(ATTR_TEMPERATURE)
@@ -117,6 +119,7 @@ class HiveClimateEntity(HiveEntity, ClimateEntity):
             await self.hive.heating.setTargetTemperature(self.device, new_temperature)
 
     @refresh_system
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
         if preset_mode == PRESET_NONE and self.preset_mode == PRESET_BOOST:

--- a/homeassistant/components/hive/config_flow.py
+++ b/homeassistant/components/hive/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from apyhiveapi import Auth
 from apyhiveapi.helper.hive_exceptions import (
@@ -41,6 +41,7 @@ class HiveFlowHandler(ConfigFlow, domain=DOMAIN):
         self.device_registration: bool = False
         self.device_name = "Home Assistant"
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -197,6 +198,7 @@ class HiveFlowHandler(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: HiveConfigEntry,
     ) -> HiveOptionsFlowHandler:

--- a/homeassistant/components/hive/entity.py
+++ b/homeassistant/components/hive/entity.py
@@ -1,6 +1,6 @@
 """Support for the Hive devices and services."""
 
-from typing import Any
+from typing import Any, override
 
 from apyhiveapi import Hive
 
@@ -30,6 +30,7 @@ class HiveEntity(Entity):
         )
         self.attributes: dict[str, Any] = {}
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to Home Assistant."""
         self.async_on_remove(

--- a/homeassistant/components/hive/light.py
+++ b/homeassistant/components/hive/light.py
@@ -1,7 +1,7 @@
 """Support for Hive light devices."""
 
 from datetime import timedelta
-from typing import Any
+from typing import Any, override
 
 from apyhiveapi import Hive
 
@@ -58,6 +58,7 @@ class HiveDeviceLight(HiveEntity, LightEntity):
             self._attr_color_mode = ColorMode.UNKNOWN
 
     @refresh_system
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Instruct the light to turn on."""
         new_brightness = None
@@ -82,6 +83,7 @@ class HiveDeviceLight(HiveEntity, LightEntity):
         )
 
     @refresh_system
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Instruct the light to turn off."""
         await self.hive.light.turnOff(self.device)

--- a/homeassistant/components/hive/switch.py
+++ b/homeassistant/components/hive/switch.py
@@ -1,7 +1,7 @@
 """Support for the Hive switches."""
 
 from datetime import timedelta
-from typing import Any
+from typing import Any, override
 
 from apyhiveapi import Hive
 
@@ -64,11 +64,13 @@ class HiveSwitch(HiveEntity, SwitchEntity):
         self.entity_description = entity_description
 
     @refresh_system
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         await self.hive.switch.turnOn(self.device)
 
     @refresh_system
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
         await self.hive.switch.turnOff(self.device)

--- a/homeassistant/components/hive/water_heater.py
+++ b/homeassistant/components/hive/water_heater.py
@@ -1,7 +1,7 @@
 """Support for hive water heaters."""
 
 from datetime import timedelta
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -80,16 +80,19 @@ class HiveWaterHeater(HiveEntity, WaterHeaterEntity):
     _attr_operation_list = SUPPORT_WATER_HEATER
 
     @refresh_system
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on hotwater."""
         await self.hive.hotwater.setMode(self.device, "MANUAL")
 
     @refresh_system
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn on hotwater."""
         await self.hive.hotwater.setMode(self.device, "OFF")
 
     @refresh_system
+    @override
     async def async_set_operation_mode(self, operation_mode: str) -> None:
         """Set operation mode."""
         new_mode = HASS_TO_HIVE_STATE[operation_mode]

--- a/homeassistant/components/hko/config_flow.py
+++ b/homeassistant/components/hko/config_flow.py
@@ -2,7 +2,7 @@
 
 from asyncio import timeout
 import logging
-from typing import Any
+from typing import Any, override
 
 from hko import HKO, LOCATIONS, HKOError
 import voluptuous as vol
@@ -36,6 +36,7 @@ class HKOConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/hko/coordinator.py
+++ b/homeassistant/components/hko/coordinator.py
@@ -3,7 +3,7 @@
 from asyncio import timeout
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from aiohttp import ClientSession
 from hko import HKO, HKOError
@@ -94,6 +94,7 @@ class HKOUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             update_interval=timedelta(minutes=15),
         )
 
+    @override
     async def _async_update_data(self) -> dict[str, Any]:
         """Update data via HKO library."""
         try:

--- a/homeassistant/components/hko/weather.py
+++ b/homeassistant/components/hko/weather.py
@@ -1,5 +1,7 @@
 """Support for the HKO service."""
 
+from typing import override
+
 from homeassistant.components.weather import (
     Forecast,
     WeatherEntity,
@@ -55,20 +57,24 @@ class HKOEntity(CoordinatorEntity[HKOUpdateCoordinator], WeatherEntity):
         )
 
     @property
+    @override
     def condition(self) -> str:
         """Return the current condition."""
         return self.coordinator.data[API_FORECAST][0][API_CONDITION]
 
     @property
+    @override
     def native_temperature(self) -> int:
         """Return the temperature."""
         return self.coordinator.data[API_CURRENT][API_TEMPERATURE]
 
     @property
+    @override
     def humidity(self) -> int:
         """Return the humidity."""
         return self.coordinator.data[API_CURRENT][API_HUMIDITY]
 
+    @override
     async def async_forecast_daily(self) -> list[Forecast] | None:
         """Return the forecast data."""
         return self.coordinator.data[API_FORECAST]

--- a/homeassistant/components/hlk_sw16/config_flow.py
+++ b/homeassistant/components/hlk_sw16/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for HLK-SW16."""
 
 import asyncio
-from typing import Any
+from typing import Any, override
 
 from hlk_sw16 import create_hlk_sw16_connection
 from hlk_sw16.protocol import SW16Client
@@ -75,6 +75,7 @@ class SW16FlowHandler(ConfigFlow, domain=DOMAIN):
         """Handle import."""
         return await self.async_step_user(import_data)
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/hlk_sw16/entity.py
+++ b/homeassistant/components/hlk_sw16/entity.py
@@ -1,6 +1,7 @@
 """Support for HLK-SW16 relay switches."""
 
 import logging
+from typing import override
 
 from hlk_sw16.protocol import SW16Client
 
@@ -37,6 +38,7 @@ class SW16Entity(Entity):
         self.async_write_ha_state()
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available."""
         return bool(self._client.is_connected)
@@ -46,6 +48,7 @@ class SW16Entity(Entity):
         """Update availability state."""
         self.async_write_ha_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register update callback."""
         self._client.register_status_callback(

--- a/homeassistant/components/hlk_sw16/switch.py
+++ b/homeassistant/components/hlk_sw16/switch.py
@@ -1,6 +1,6 @@
 """Support for HLK-SW16 switches."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant
@@ -36,14 +36,17 @@ class SW16Switch(SW16Entity, SwitchEntity):
     """Representation of a HLK-SW16 switch."""
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if device is on."""
         return self._is_on
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
         await self._client.turn_on(self._device_port)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
         await self._client.turn_off(self._device_port)

--- a/homeassistant/components/holiday/calendar.py
+++ b/homeassistant/components/holiday/calendar.py
@@ -1,6 +1,7 @@
 """Holiday Calendar."""
 
 from datetime import datetime, timedelta
+from typing import override
 
 from holidays import PUBLIC, HolidayBase, country_holidays
 
@@ -147,10 +148,12 @@ class HolidayCalendarEntity(CalendarEntity):
         self._update_state_and_setup_listener()
         self.async_write_ha_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Set up first update."""
         self._update_state_and_setup_listener()
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Cancel listener when removing."""
         await super().async_will_remove_from_hass()
@@ -179,10 +182,12 @@ class HolidayCalendarEntity(CalendarEntity):
         )
 
     @property
+    @override
     def event(self) -> CalendarEvent | None:
         """Return the next upcoming event."""
         return self._attr_event
 
+    @override
     async def async_get_events(
         self, hass: HomeAssistant, start_date: datetime, end_date: datetime
     ) -> list[CalendarEvent]:

--- a/homeassistant/components/holiday/config_flow.py
+++ b/homeassistant/components/holiday/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for Holiday integration."""
 
-from typing import Any
+from typing import Any, override
 
 from babel import Locale, UnknownLocaleError
 from holidays import PUBLIC, country_holidays, list_supported_countries
@@ -111,10 +111,12 @@ class HolidayConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(config_entry: ConfigEntry) -> HolidayOptionsFlowHandler:
         """Get the options flow for this handler."""
         return HolidayOptionsFlowHandler()
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/home_connect/api.py
+++ b/homeassistant/components/home_connect/api.py
@@ -1,6 +1,6 @@
 """API for Home Connect bound to HASS OAuth."""
 
-from typing import cast
+from typing import cast, override
 
 from aiohomeconnect.client import AbstractAuth
 from aiohomeconnect.const import API_ENDPOINT
@@ -23,6 +23,7 @@ class AsyncConfigEntryAuth(AbstractAuth):
         super().__init__(get_async_client(hass), host=API_ENDPOINT)
         self.session = oauth_session
 
+    @override
     async def async_get_access_token(self) -> str:
         """Return a valid access token."""
         await self.session.async_ensure_token_valid()

--- a/homeassistant/components/home_connect/binary_sensor.py
+++ b/homeassistant/components/home_connect/binary_sensor.py
@@ -1,7 +1,7 @@
 """Provides a binary sensor for Home Connect."""
 
 from dataclasses import dataclass
-from typing import cast
+from typing import cast, override
 
 from aiohomeconnect.model import EventKey, StatusKey
 
@@ -180,6 +180,7 @@ class HomeConnectBinarySensor(HomeConnectEntity, BinarySensorEntity):
 
     entity_description: HomeConnectBinarySensorEntityDescription
 
+    @override
     def update_native_value(self) -> None:
         """Set the native value of the binary sensor."""
         status = self.appliance.status[cast(StatusKey, self.bsh_key)].value
@@ -196,11 +197,13 @@ class HomeConnectConnectivityBinarySensor(HomeConnectEntity, BinarySensorEntity)
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
+    @override
     def update_native_value(self) -> None:
         """Set the native value of the binary sensor."""
         self._attr_is_on = self.appliance.info.connected
 
     @property
+    @override
     def available(self) -> bool:
         """Return the availability."""
         return self.coordinator.last_update_success

--- a/homeassistant/components/home_connect/button.py
+++ b/homeassistant/components/home_connect/button.py
@@ -1,5 +1,7 @@
 """Provides button entities for Home Connect."""
 
+from typing import override
+
 from aiohomeconnect.model import CommandKey
 from aiohomeconnect.model.error import HomeConnectError
 
@@ -87,6 +89,7 @@ class HomeConnectButtonEntity(HomeConnectEntity, ButtonEntity):
         """Initialize the entity."""
         super().__init__(appliance_coordinator, desc, context_override=True)
 
+    @override
     def update_native_value(self) -> None:
         """Set the value of the entity."""
 
@@ -96,6 +99,7 @@ class HomeConnectCommandButtonEntity(HomeConnectButtonEntity):
 
     entity_description: HomeConnectCommandButtonEntityDescription
 
+    @override
     async def async_press(self) -> None:
         """Press the button."""
         try:
@@ -128,6 +132,7 @@ class HomeConnectStopProgramButtonEntity(HomeConnectButtonEntity):
             ),
         )
 
+    @override
     async def async_press(self) -> None:
         """Press the button."""
         try:

--- a/homeassistant/components/home_connect/climate.py
+++ b/homeassistant/components/home_connect/climate.py
@@ -1,7 +1,7 @@
 """Provides climate entities for Home Connect."""
 
 import logging
-from typing import Any, cast
+from typing import Any, cast, override
 
 from aiohomeconnect.model import EventKey, OptionKey, ProgramKey, SettingKey
 from aiohomeconnect.model.error import HomeConnectError
@@ -127,6 +127,7 @@ class HomeConnectAirConditioningEntity(HomeConnectEntity, ClimateEntity):
         )
 
     @property
+    @override
     def hvac_modes(self) -> list[HVACMode]:
         """Return the list of available hvac operation modes."""
         hvac_modes = [
@@ -144,6 +145,7 @@ class HomeConnectAirConditioningEntity(HomeConnectEntity, ClimateEntity):
         return hvac_modes
 
     @property
+    @override
     def preset_modes(self) -> list[str] | None:
         """Return a list of available preset modes."""
         active_clean = (
@@ -156,6 +158,7 @@ class HomeConnectAirConditioningEntity(HomeConnectEntity, ClimateEntity):
         )
 
     @property
+    @override
     def supported_features(self) -> ClimateEntityFeature:
         """Return the list of supported features."""
         features = ClimateEntityFeature(0)
@@ -177,6 +180,7 @@ class HomeConnectAirConditioningEntity(HomeConnectEntity, ClimateEntity):
             "Updated %s (fan mode), new state: %s", self.entity_id, self.fan_mode
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()
@@ -199,6 +203,7 @@ class HomeConnectAirConditioningEntity(HomeConnectEntity, ClimateEntity):
             )
         )
 
+    @override
     def update_native_value(self) -> None:
         """Set the HVAC Mode and preset mode values."""
         event = self.appliance.events.get(EventKey.BSH_COMMON_ROOT_ACTIVE_PROGRAM)
@@ -221,6 +226,7 @@ class HomeConnectAirConditioningEntity(HomeConnectEntity, ClimateEntity):
         )
 
     @property
+    @override
     def fan_mode(self) -> str | None:
         """Return the fan setting."""
         option_value = None
@@ -235,6 +241,7 @@ class HomeConnectAirConditioningEntity(HomeConnectEntity, ClimateEntity):
         )
 
     @property
+    @override
     def fan_modes(self) -> list[str] | None:
         """Return the list of available fan modes."""
         if (
@@ -257,6 +264,7 @@ class HomeConnectAirConditioningEntity(HomeConnectEntity, ClimateEntity):
             return list(FAN_MODES_OPTIONS.keys())
         return None
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Switch the device on."""
         try:
@@ -275,6 +283,7 @@ class HomeConnectAirConditioningEntity(HomeConnectEntity, ClimateEntity):
                 },
             ) from err
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Switch the device off."""
         try:
@@ -310,6 +319,7 @@ class HomeConnectAirConditioningEntity(HomeConnectEntity, ClimateEntity):
             ) from err
         _LOGGER.debug("Updated %s, new state: %s", self.entity_id, self.state)
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         if hvac_mode is HVACMode.OFF:
@@ -317,10 +327,12 @@ class HomeConnectAirConditioningEntity(HomeConnectEntity, ClimateEntity):
         else:
             await self._set_program(HVAC_MODES_PROGRAMS_MAP[hvac_mode])
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
         await self._set_program(PRESET_MODES_PROGRAMS_MAP[preset_mode])
 
+    @override
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""
         await super().async_set_option_with_key(

--- a/homeassistant/components/home_connect/config_flow.py
+++ b/homeassistant/components/home_connect/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 import jwt
 import voluptuous as vol
@@ -24,6 +24,7 @@ class OAuth2FlowHandler(
     MINOR_VERSION = 3
 
     @property
+    @override
     def logger(self) -> logging.Logger:
         """Return logger."""
         return logging.getLogger(__name__)
@@ -45,6 +46,7 @@ class OAuth2FlowHandler(
             )
         return await self.async_step_user()
 
+    @override
     async def async_oauth_create_entry(self, data: dict) -> ConfigFlowResult:
         """Create an oauth config entry or update existing entry for reauth."""
         await self.async_set_unique_id(
@@ -60,6 +62,7 @@ class OAuth2FlowHandler(
         self._abort_if_unique_id_configured()
         return await super().async_oauth_create_entry(data)
 
+    @override
     async def async_step_dhcp(
         self, discovery_info: DhcpServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/home_connect/coordinator.py
+++ b/homeassistant/components/home_connect/coordinator.py
@@ -4,6 +4,7 @@ from asyncio import sleep as asyncio_sleep
 from collections.abc import Callable
 from dataclasses import dataclass
 import logging
+from typing import override
 
 from aiohomeconnect.client import Client as HomeConnectClient
 from aiohomeconnect.model import (
@@ -392,6 +393,7 @@ class HomeConnectApplianceCoordinator(DataUpdateCoordinator[HomeConnectAppliance
         for listener, _ in self._listeners.values():
             listener()
 
+    @override
     async def _async_update_data(self) -> HomeConnectApplianceData:
         """Fetch data from Home Connect."""
         while True:

--- a/homeassistant/components/home_connect/entity.py
+++ b/homeassistant/components/home_connect/entity.py
@@ -5,7 +5,7 @@ from collections.abc import Callable, Coroutine
 import contextlib
 from datetime import datetime
 import logging
-from typing import Any, Concatenate, cast
+from typing import Any, Concatenate, cast, override
 
 from aiohomeconnect.model import EventKey, OptionKey
 from aiohomeconnect.model.error import (
@@ -58,6 +58,7 @@ class HomeConnectEntity(CoordinatorEntity[HomeConnectApplianceCoordinator]):
         """Set the value of the entity."""
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self.update_native_value()
@@ -70,6 +71,7 @@ class HomeConnectEntity(CoordinatorEntity[HomeConnectApplianceCoordinator]):
         return self.entity_description.key
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available.
 
@@ -107,6 +109,7 @@ class HomeConnectOptionEntity(HomeConnectEntity):
     """Class for entities that represents program options."""
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available."""
         return super().available and self.bsh_key in self.appliance.options
@@ -123,6 +126,7 @@ class HomeConnectOptionEntity(HomeConnectEntity):
         await super().async_set_option_with_key(self.bsh_key, value)
 
     @property
+    @override
     def bsh_key(self) -> OptionKey:
         """Return the BSH key."""
         return cast(OptionKey, self.entity_description.key)

--- a/homeassistant/components/home_connect/fan.py
+++ b/homeassistant/components/home_connect/fan.py
@@ -1,7 +1,7 @@
 """Provides fan entities for Home Connect."""
 
 import logging
-from typing import cast
+from typing import cast, override
 
 from aiohomeconnect.model import EventKey, OptionKey
 
@@ -110,6 +110,7 @@ class HomeConnectAirConditioningFanEntity(HomeConnectEntity, FanEntity):
             "Updated %s (fan mode), new state: %s", self.entity_id, self.preset_mode
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()
@@ -120,6 +121,7 @@ class HomeConnectAirConditioningFanEntity(HomeConnectEntity, FanEntity):
             )
         )
 
+    @override
     def update_native_value(self) -> None:
         """Set the speed percentage and speed mode values."""
         option_value = None
@@ -130,6 +132,7 @@ class HomeConnectAirConditioningFanEntity(HomeConnectEntity, FanEntity):
         )
 
     @property
+    @override
     def supported_features(self) -> FanEntityFeature:
         """Return the supported features for this fan entity."""
         features = FanEntityFeature(0)
@@ -179,6 +182,7 @@ class HomeConnectAirConditioningFanEntity(HomeConnectEntity, FanEntity):
                 if value in self._original_speed_modes_keys
             ]
 
+    @override
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed of the fan, as a percentage."""
         await super().async_set_option_with_key(
@@ -191,6 +195,7 @@ class HomeConnectAirConditioningFanEntity(HomeConnectEntity, FanEntity):
             percentage,
         )
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new target fan mode."""
         await super().async_set_option_with_key(
@@ -202,6 +207,7 @@ class HomeConnectAirConditioningFanEntity(HomeConnectEntity, FanEntity):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available."""
         return super().available and any(

--- a/homeassistant/components/home_connect/light.py
+++ b/homeassistant/components/home_connect/light.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 import logging
-from typing import Any, cast
+from typing import Any, cast, override
 
 from aiohomeconnect.model import EventKey, SettingKey
 from aiohomeconnect.model.error import HomeConnectError
@@ -141,6 +141,7 @@ class HomeConnectLight(HomeConnectEntity, LightEntity):
                 self._attr_color_mode = ColorMode.HS
                 self._attr_supported_color_modes = {ColorMode.HS, ColorMode.RGB}
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Switch the light on, change brightness, change color."""
         try:
@@ -251,6 +252,7 @@ class HomeConnectLight(HomeConnectEntity, LightEntity):
                     },
                 ) from err
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Switch the light off."""
         try:
@@ -269,6 +271,7 @@ class HomeConnectLight(HomeConnectEntity, LightEntity):
                 },
             ) from err
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register listener."""
         await super().async_added_to_hass()
@@ -285,6 +288,7 @@ class HomeConnectLight(HomeConnectEntity, LightEntity):
                 )
             )
 
+    @override
     def update_native_value(self) -> None:
         """Update the light's status."""
         self._attr_is_on = self.appliance.settings[SettingKey(self.bsh_key)].value

--- a/homeassistant/components/home_connect/number.py
+++ b/homeassistant/components/home_connect/number.py
@@ -1,7 +1,7 @@
 """Provides number entities for Home Connect."""
 
 import logging
-from typing import cast
+from typing import cast, override
 
 from aiohomeconnect.model import GetSetting, OptionKey, SettingKey
 from aiohomeconnect.model.error import HomeConnectError
@@ -165,6 +165,7 @@ async def async_setup_entry(
 class HomeConnectNumberEntity(HomeConnectEntity, NumberEntity):
     """Number setting class for Home Connect."""
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Set the native value of the entity."""
         _LOGGER.debug(
@@ -221,11 +222,13 @@ class HomeConnectNumberEntity(HomeConnectEntity, NumberEntity):
         else:
             self._attr_native_step = 0.1 if setting.type == "Double" else 1
 
+    @override
     def update_native_value(self) -> None:
         """Update status when an event for the entity is received."""
         data = self.appliance.settings[cast(SettingKey, self.bsh_key)]
         self._attr_native_value = cast(float, data.value)
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()
@@ -243,10 +246,12 @@ class HomeConnectNumberEntity(HomeConnectEntity, NumberEntity):
 class HomeConnectOptionNumberEntity(HomeConnectOptionEntity, NumberEntity):
     """Number option class for Home Connect."""
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Set the native value of the entity."""
         await self.async_set_option(value)
 
+    @override
     def update_native_value(self) -> None:
         """Set the value of the entity."""
         self._attr_native_value = cast(float | None, self.option_value)

--- a/homeassistant/components/home_connect/select.py
+++ b/homeassistant/components/home_connect/select.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 import logging
-from typing import Any, cast
+from typing import Any, cast, override
 
 from aiohomeconnect.client import Client as HomeConnectClient
 from aiohomeconnect.model import EventKey, OptionKey, ProgramKey, SettingKey
@@ -420,6 +420,7 @@ class HomeConnectProgramSelectEntity(HomeConnectEntity, SelectEntity):
         self.set_options()
         self.async_write_ha_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()
@@ -430,6 +431,7 @@ class HomeConnectProgramSelectEntity(HomeConnectEntity, SelectEntity):
             )
         )
 
+    @override
     def update_native_value(self) -> None:
         """Set the program value."""
         event = self.appliance.events.get(cast(EventKey, self.bsh_key))
@@ -452,6 +454,7 @@ class HomeConnectProgramSelectEntity(HomeConnectEntity, SelectEntity):
             PROGRAMS_TRANSLATION_KEYS_MAP.get(program_key) if program_key else None
         )
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Select new program."""
         program_key = TRANSLATION_KEYS_PROGRAMS_MAP[option]
@@ -490,6 +493,7 @@ class HomeConnectSelectEntity(HomeConnectEntity, SelectEntity):
             desc,
         )
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Select new option."""
         value = self.entity_description.translation_key_values[option]
@@ -511,6 +515,7 @@ class HomeConnectSelectEntity(HomeConnectEntity, SelectEntity):
                 },
             ) from err
 
+    @override
     def update_native_value(self) -> None:
         """Set the value of the entity."""
         data = self.appliance.settings[cast(SettingKey, self.bsh_key)]
@@ -518,6 +523,7 @@ class HomeConnectSelectEntity(HomeConnectEntity, SelectEntity):
             data.value
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()
@@ -565,12 +571,14 @@ class HomeConnectSelectOptionEntity(HomeConnectOptionEntity, SelectEntity):
             desc,
         )
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Select new option."""
         await self.async_set_option(
             self.entity_description.translation_key_values[option]
         )
 
+    @override
     def update_native_value(self) -> None:
         """Set the value of the entity."""
         self._attr_current_option = (

--- a/homeassistant/components/home_connect/sensor.py
+++ b/homeassistant/components/home_connect/sensor.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
-from typing import cast
+from typing import cast, override
 
 from aiohomeconnect.model import EventKey, StatusKey
 
@@ -554,6 +554,7 @@ class HomeConnectSensor(HomeConnectEntity, SensorEntity):
 
     entity_description: HomeConnectSensorEntityDescription
 
+    @override
     def update_native_value(self) -> None:
         """Set the value of the sensor."""
         status = self.appliance.status[cast(StatusKey, self.bsh_key)].value
@@ -577,6 +578,7 @@ class HomeConnectSensor(HomeConnectEntity, SensorEntity):
             case _:
                 self._attr_native_value = status
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()
@@ -602,6 +604,7 @@ class HomeConnectSensor(HomeConnectEntity, SensorEntity):
 class HomeConnectProgramSensor(HomeConnectSensor):
     """Sensor class for Home Connect running program information."""
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register listener."""
         await super().async_added_to_hass()
@@ -632,6 +635,7 @@ class HomeConnectProgramSensor(HomeConnectSensor):
         ]
 
     @property
+    @override
     def available(self) -> bool:
         """Return true if the sensor is available."""
         # These sensors are only available if the program is
@@ -639,6 +643,7 @@ class HomeConnectProgramSensor(HomeConnectSensor):
         # report erroneous values.
         return super().available and self.program_running
 
+    @override
     def update_native_value(self) -> None:
         """Update the program sensor's status."""
         event = self.appliance.events.get(cast(EventKey, self.bsh_key))
@@ -651,6 +656,7 @@ class HomeConnectEventSensor(HomeConnectSensor):
 
     _attr_entity_registry_enabled_default = False
 
+    @override
     def update_native_value(self) -> None:
         """Update the sensor's status."""
         event = self.appliance.events.get(cast(EventKey, self.bsh_key))

--- a/homeassistant/components/home_connect/switch.py
+++ b/homeassistant/components/home_connect/switch.py
@@ -1,7 +1,7 @@
 """Provides a switch for Home Connect."""
 
 import logging
-from typing import Any, cast
+from typing import Any, cast, override
 
 from aiohomeconnect.model import OptionKey, SettingKey
 from aiohomeconnect.model.error import HomeConnectError
@@ -218,6 +218,7 @@ async def async_setup_entry(
 class HomeConnectSwitch(HomeConnectEntity, SwitchEntity):
     """Generic switch class for Home Connect Binary Settings."""
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on setting."""
         try:
@@ -238,6 +239,7 @@ class HomeConnectSwitch(HomeConnectEntity, SwitchEntity):
                 },
             ) from err
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off setting."""
         try:
@@ -258,6 +260,7 @@ class HomeConnectSwitch(HomeConnectEntity, SwitchEntity):
                 },
             ) from err
 
+    @override
     def update_native_value(self) -> None:
         """Update the switch's status."""
         self._attr_is_on = self.appliance.settings[SettingKey(self.bsh_key)].value
@@ -268,6 +271,7 @@ class HomeConnectPowerSwitch(HomeConnectEntity, SwitchEntity):
 
     power_off_state: str | None | UndefinedType = UNDEFINED
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Switch the device on."""
         try:
@@ -287,6 +291,7 @@ class HomeConnectPowerSwitch(HomeConnectEntity, SwitchEntity):
                 },
             ) from err
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Switch the device off."""
         if self.power_off_state is UNDEFINED:
@@ -324,6 +329,7 @@ class HomeConnectPowerSwitch(HomeConnectEntity, SwitchEntity):
                 },
             ) from err
 
+    @override
     def update_native_value(self) -> None:
         """Set the value of the entity."""
         power_state = self.appliance.settings[SettingKey.BSH_COMMON_POWER_STATE]
@@ -372,14 +378,17 @@ class HomeConnectPowerSwitch(HomeConnectEntity, SwitchEntity):
 class HomeConnectSwitchOptionEntity(HomeConnectOptionEntity, SwitchEntity):
     """Switch option class for Home Connect."""
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the option."""
         await self.async_set_option(True)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the option."""
         await self.async_set_option(False)
 
+    @override
     def update_native_value(self) -> None:
         """Set the value of the entity."""
         self._attr_is_on = cast(bool | None, self.option_value)

--- a/homeassistant/components/homeassistant/scene.py
+++ b/homeassistant/components/homeassistant/scene.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping, ValuesView
 import logging
-from typing import Any, NamedTuple, cast
+from typing import Any, NamedTuple, cast, override
 
 import voluptuous as vol
 
@@ -340,21 +340,25 @@ class HomeAssistantScene(Scene):
         self.from_service = from_service
 
     @property
+    @override
     def name(self) -> str:
         """Return the name of the scene."""
         return self.scene_config.name
 
     @property
+    @override
     def icon(self) -> str | None:
         """Return the icon of the scene."""
         return self.scene_config.icon
 
     @property
+    @override
     def unique_id(self) -> str | None:
         """Return unique ID."""
         return self.scene_config.id
 
     @property
+    @override
     def extra_state_attributes(self) -> Mapping[str, Any]:
         """Return the scene state attributes."""
         attributes: dict[str, Any] = {ATTR_ENTITY_ID: list(self.scene_config.states)}
@@ -362,6 +366,7 @@ class HomeAssistantScene(Scene):
             attributes[CONF_ID] = unique_id
         return attributes
 
+    @override
     async def async_activate(self, **kwargs: Any) -> None:
         """Activate scene. Try to get entities into requested state."""
         await async_reproduce_state(

--- a/homeassistant/components/homeassistant_alerts/coordinator.py
+++ b/homeassistant/components/homeassistant_alerts/coordinator.py
@@ -2,6 +2,7 @@
 
 import dataclasses
 import logging
+from typing import override
 
 from awesomeversion import AwesomeVersion, AwesomeVersionStrategy
 
@@ -50,6 +51,7 @@ class AlertUpdateCoordinator(DataUpdateCoordinator[dict[str, IntegrationAlert]])
         )
         self.supervisor = is_hassio(self.hass)
 
+    @override
     async def _async_update_data(self) -> dict[str, IntegrationAlert]:
         response = await async_get_clientsession(self.hass).get(
             "https://alerts.home-assistant.io/alerts.json",

--- a/homeassistant/components/homeassistant_connect_zbt2/config_flow.py
+++ b/homeassistant/components/homeassistant_connect_zbt2/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for the Home Assistant Connect ZBT-2 integration."""
 
 import logging
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol, override
 
 from universal_silabs_flasher.flasher import Zbt2Flasher
 
@@ -119,12 +119,14 @@ class HomeAssistantConnectZBT2ConfigFlow(
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> OptionsFlow:
         """Return the options flow."""
         return HomeAssistantConnectZBT2OptionsFlowHandler(config_entry)
 
+    @override
     async def async_step_usb(self, discovery_info: UsbServiceInfo) -> ConfigFlowResult:
         """Handle usb discovery."""
         discovery_info.device = await self.hass.async_add_executor_job(
@@ -163,6 +165,7 @@ class HomeAssistantConnectZBT2ConfigFlow(
 
         return self._async_flow_finished()
 
+    @override
     def _async_flow_finished(self) -> ConfigFlowResult:
         """Create the config entry."""
         assert self._usb_info is not None
@@ -207,6 +210,7 @@ class HomeAssistantConnectZBT2OptionsFlowHandler(
         # Regenerate the translation placeholders
         self._get_translation_placeholders()
 
+    @override
     def _async_flow_finished(self) -> ConfigFlowResult:
         """Create the config entry."""
         assert self._probed_firmware_info is not None

--- a/homeassistant/components/homeassistant_connect_zbt2/update.py
+++ b/homeassistant/components/homeassistant_connect_zbt2/update.py
@@ -1,6 +1,7 @@
 """Home Assistant Connect ZBT-2 firmware update entity."""
 
 import logging
+from typing import override
 
 from universal_silabs_flasher.flasher import Zbt2Flasher
 
@@ -166,6 +167,7 @@ class FirmwareUpdateEntity(BaseFirmwareUpdateEntity):
                 source="homeassistant_connect_zbt2",
             )
 
+    @override
     def _update_attributes(self) -> None:
         """Recompute the attributes of the entity."""
         super()._update_attributes()
@@ -181,6 +183,7 @@ class FirmwareUpdateEntity(BaseFirmwareUpdateEntity):
         )
 
     @callback
+    @override
     def _firmware_info_callback(self, firmware_info: FirmwareInfo) -> None:
         """Handle updated firmware info being pushed by an integration."""
         self.hass.config_entries.async_update_entry(

--- a/homeassistant/components/homeassistant_green/config_flow.py
+++ b/homeassistant/components/homeassistant_green/config_flow.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -42,6 +42,7 @@ class HomeAssistantGreenConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> HomeAssistantGreenOptionsFlow:

--- a/homeassistant/components/homeassistant_hardware/coordinator.py
+++ b/homeassistant/components/homeassistant_hardware/coordinator.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import logging
+from typing import override
 
 from aiohttp import ClientSession
 from ha_silabs_firmware_client import (
@@ -42,6 +43,7 @@ class FirmwareUpdateCoordinator(DataUpdateCoordinator[FirmwareManifest]):
 
         self.client = FirmwareUpdateClient(url, session)
 
+    @override
     async def _async_update_data(self) -> FirmwareManifest:
         try:
             return await self.client.async_update_data()

--- a/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
+++ b/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 import asyncio
 from enum import StrEnum
 import logging
-from typing import Any
+from typing import Any, override
 
 from aiohttp import ClientError
 from ha_silabs_firmware_client import FirmwareUpdateClient, ManifestMissing
@@ -641,6 +641,7 @@ class BaseFirmwareConfigFlow(BaseFirmwareInstallFlow, ConfigFlow):
     @staticmethod
     @callback
     @abstractmethod
+    @override
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> OptionsFlow:
@@ -664,6 +665,7 @@ class BaseFirmwareConfigFlow(BaseFirmwareInstallFlow, ConfigFlow):
         return await self.async_step_pick_firmware()
 
     @callback
+    @override
     def _continue_zha_flow(self, zha_result: ConfigFlowResult) -> ConfigFlowResult:
         """Continue the ZHA flow."""
         next_flow_id = zha_result["flow_id"]
@@ -701,6 +703,7 @@ class BaseFirmwareOptionsFlow(BaseFirmwareInstallFlow, OptionsFlow):
         """Manage the options flow."""
         return await self.async_step_pick_firmware()
 
+    @override
     async def async_step_pick_firmware_zigbee(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -718,6 +721,7 @@ class BaseFirmwareOptionsFlow(BaseFirmwareInstallFlow, OptionsFlow):
 
         return await super().async_step_pick_firmware_zigbee(user_input)
 
+    @override
     async def async_step_pick_firmware_thread(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -737,6 +741,7 @@ class BaseFirmwareOptionsFlow(BaseFirmwareInstallFlow, OptionsFlow):
         return await super().async_step_pick_firmware_thread(user_input)
 
     @callback
+    @override
     def _continue_zha_flow(self, zha_result: ConfigFlowResult) -> ConfigFlowResult:
         """Continue the ZHA flow."""
         # The options flow cannot return a next_flow yet, so we just finish here.

--- a/homeassistant/components/homeassistant_hardware/switch.py
+++ b/homeassistant/components/homeassistant_hardware/switch.py
@@ -1,7 +1,7 @@
 """Home Assistant Hardware base beta firmware switch entity."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
@@ -30,6 +30,7 @@ class BaseBetaFirmwareSwitch(SwitchEntity, RestoreEntity):
         self._coordinator = coordinator
         self._config_entry = config_entry
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Handle entity which will be added to hass."""
         await super().async_added_to_hass()
@@ -44,12 +45,14 @@ class BaseBetaFirmwareSwitch(SwitchEntity, RestoreEntity):
         # Apply the restored state to the coordinator
         await self._update_coordinator_prerelease()
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on beta firmware updates."""
         self._attr_is_on = True
         self.async_write_ha_state()
         await self._update_coordinator_prerelease()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off beta firmware updates."""
         self._attr_is_on = False

--- a/homeassistant/components/homeassistant_hardware/update.py
+++ b/homeassistant/components/homeassistant_hardware/update.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 import logging
-from typing import Any, cast
+from typing import Any, cast, override
 
 from aiohasupervisor import SupervisorError
 from aiohasupervisor.models import RaspberryPiFirmwareInfo
@@ -60,6 +60,7 @@ class FirmwareUpdateExtraStoredData(ExtraStoredData):
 
     firmware_manifest: FirmwareManifest | None = None
 
+    @override
     def as_dict(self) -> dict[str, Any]:
         """Return a dict representation of the extra data."""
         return {
@@ -132,6 +133,7 @@ class BaseFirmwareUpdateEntity(
 
         return remove_callback
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Handle entity which will be added."""
         await super().async_added_to_hass()
@@ -163,6 +165,7 @@ class BaseFirmwareUpdateEntity(
             await self.coordinator.async_request_refresh()
 
     @property
+    @override
     def extra_restore_state_data(self) -> FirmwareUpdateExtraStoredData:
         """Return state data to be restored."""
         return FirmwareUpdateExtraStoredData(firmware_manifest=self._latest_manifest)
@@ -243,6 +246,7 @@ class BaseFirmwareUpdateEntity(
             self._attr_release_url = str(self._latest_manifest.html_url)
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self._latest_manifest = self.coordinator.data
@@ -263,6 +267,7 @@ class BaseFirmwareUpdateEntity(
             self._attr_update_percentage = None
             self.async_write_ha_state()
 
+    @override
     async def async_install(
         self, version: str | None, backup: bool, **kwargs: Any
     ) -> None:
@@ -330,6 +335,7 @@ class RaspberryPiFirmwareUpdateEntity(UpdateEntity):
         self._board = board
 
     @property
+    @override
     def installed_version(self) -> str | None:
         """Composite installed firmware version.
 
@@ -343,15 +349,18 @@ class RaspberryPiFirmwareUpdateEntity(UpdateEntity):
         return humanize_rpi_firmware_version(self._firmware.current_version)
 
     @property
+    @override
     def latest_version(self) -> str | None:
         """Composite available firmware version."""
         return humanize_rpi_firmware_version(self._firmware.latest_version)
 
     @property
+    @override
     def release_url(self) -> str | None:
         """Return the EEPROM release notes for this board's SoC."""
         return rpi_firmware_release_url(self._board)
 
+    @override
     async def async_release_notes(self) -> str | None:
         """Return the pre-install warning and reboot notice as ha-alert boxes."""
         return (
@@ -366,6 +375,7 @@ class RaspberryPiFirmwareUpdateEntity(UpdateEntity):
             "</ha-alert>\n"
         )
 
+    @override
     async def async_install(
         self, version: str | None, backup: bool, **kwargs: Any
     ) -> None:

--- a/homeassistant/components/homeassistant_sky_connect/config_flow.py
+++ b/homeassistant/components/homeassistant_sky_connect/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for the Home Assistant SkyConnect integration."""
 
 import logging
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol, override
 
 from universal_silabs_flasher.flasher import Zbt1Flasher
 
@@ -79,6 +79,7 @@ class SkyConnectFirmwareMixin(ConfigEntryBaseFlow, FirmwareInstallFlowProtocol):
     ZIGBEE_BAUDRATE = 115200
     _flasher_cls = Zbt1Flasher
 
+    @override
     def _get_translation_placeholders(self) -> dict[str, str]:
         """Shared translation placeholders."""
         placeholders = {
@@ -136,6 +137,7 @@ class HomeAssistantSkyConnectConfigFlow(
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> OptionsFlow:
@@ -147,6 +149,7 @@ class HomeAssistantSkyConnectConfigFlow(
 
         return HomeAssistantSkyConnectOptionsFlowHandler(config_entry)
 
+    @override
     async def async_step_usb(self, discovery_info: UsbServiceInfo) -> ConfigFlowResult:
         """Handle usb discovery."""
         if await self.async_set_unique_id(discovery_info.serial_number):
@@ -190,6 +193,7 @@ class HomeAssistantSkyConnectConfigFlow(
 
         return self._async_flow_finished()
 
+    @override
     def _async_flow_finished(self) -> ConfigFlowResult:
         """Create the config entry."""
         assert self._usb_info is not None
@@ -217,6 +221,7 @@ class HomeAssistantSkyConnectMultiPanOptionsFlowHandler(
 ):
     """Multi-PAN options flow for Home Assistant SkyConnect."""
 
+    @override
     async def _async_serial_port_settings(
         self,
     ) -> silabs_multiprotocol_addon.SerialPortSettings:
@@ -227,6 +232,7 @@ class HomeAssistantSkyConnectMultiPanOptionsFlowHandler(
             flow_control=True,
         )
 
+    @override
     async def _async_zha_physical_discovery(self) -> dict[str, Any]:
         """Return ZHA discovery data when multiprotocol FW is not used.
 
@@ -240,27 +246,33 @@ class HomeAssistantSkyConnectMultiPanOptionsFlowHandler(
         """Return the hardware variant."""
         return get_hardware_variant(self.config_entry)
 
+    @override
     def _zha_name(self) -> str:
         """Return the ZHA name."""
         return f"{self._hw_variant.short_name} Multiprotocol"
 
+    @override
     def _hardware_name(self) -> str:
         """Return the name of the hardware."""
         return self._hw_variant.full_name
 
+    @override
     def _firmware_update_url(self) -> str:
         """Return the firmware update manifest URL."""
         return NABU_CASA_FIRMWARE_RELEASES_URL
 
+    @override
     def _zigbee_firmware_type(self) -> str:
         """Return the zigbee firmware type identifier."""
         return "skyconnect_zigbee_ncp"
 
     @property
+    @override
     def _flasher_cls(self) -> type:
         """Return the hardware-specific flasher class."""
         return Zbt1Flasher  # type: ignore[no-any-return]
 
+    @override
     async def async_step_flashing_complete(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -305,6 +317,7 @@ class HomeAssistantSkyConnectOptionsFlowHandler(
         # Regenerate the translation placeholders
         self._get_translation_placeholders()
 
+    @override
     def _async_flow_finished(self) -> ConfigFlowResult:
         """Create the config entry."""
         assert self._probed_firmware_info is not None

--- a/homeassistant/components/homeassistant_sky_connect/repairs.py
+++ b/homeassistant/components/homeassistant_sky_connect/repairs.py
@@ -1,6 +1,6 @@
 """Repairs for the Home Assistant SkyConnect integration."""
 
-from typing import Any, cast
+from typing import Any, cast, override
 
 from homeassistant.components.homeassistant_hardware.repair_helpers import (
     ISSUE_MULTI_PAN_MIGRATION,
@@ -27,6 +27,7 @@ class SkyConnectMultiPanMigrationRepairFlow(
         HomeAssistantSkyConnectMultiPanOptionsFlowHandler.__init__(self, config_entry)
         self._repair_config_entry = config_entry
 
+    @override
     async def async_step_init(  # type: ignore[override]
         self, user_input: dict[str, Any] | None = None
     ) -> RepairsFlowResult:

--- a/homeassistant/components/homeassistant_sky_connect/update.py
+++ b/homeassistant/components/homeassistant_sky_connect/update.py
@@ -1,6 +1,7 @@
 """Home Assistant SkyConnect firmware update entity."""
 
 import logging
+from typing import override
 
 from universal_silabs_flasher.flasher import Zbt1Flasher
 
@@ -187,6 +188,7 @@ class FirmwareUpdateEntity(BaseFirmwareUpdateEntity):
                 source="homeassistant_sky_connect",
             )
 
+    @override
     def _update_attributes(self) -> None:
         """Recompute the attributes of the entity."""
         super()._update_attributes()
@@ -202,6 +204,7 @@ class FirmwareUpdateEntity(BaseFirmwareUpdateEntity):
         )
 
     @callback
+    @override
     def _firmware_info_callback(self, firmware_info: FirmwareInfo) -> None:
         """Handle updated firmware info being pushed by an integration."""
         self.hass.config_entries.async_update_entry(

--- a/homeassistant/components/homeassistant_yellow/config_flow.py
+++ b/homeassistant/components/homeassistant_yellow/config_flow.py
@@ -3,7 +3,7 @@
 from abc import ABC, abstractmethod
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Any, Protocol, final
+from typing import TYPE_CHECKING, Any, Protocol, final, override
 
 from universal_silabs_flasher.flasher import YellowFlasher
 import voluptuous as vol
@@ -126,6 +126,7 @@ class HomeAssistantYellowConfigFlow(
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> OptionsFlow:
@@ -164,6 +165,7 @@ class HomeAssistantYellowConfigFlow(
 
         return self._async_flow_finished()
 
+    @override
     def _async_flow_finished(self) -> ConfigFlowResult:
         """Create the config entry."""
         return self.async_create_entry(
@@ -275,6 +277,7 @@ class HomeAssistantYellowMultiPanOptionsFlowHandler(
 ):
     """Handle a multi-PAN options flow for Home Assistant Yellow."""
 
+    @override
     async def async_step_main_menu(self, _: None = None) -> ConfigFlowResult:
         """Show the main menu."""
         return self.async_show_menu(
@@ -293,6 +296,7 @@ class HomeAssistantYellowMultiPanOptionsFlowHandler(
             self, user_input
         )
 
+    @override
     async def _async_serial_port_settings(
         self,
     ) -> MultiprotocolSerialPortSettings:
@@ -303,6 +307,7 @@ class HomeAssistantYellowMultiPanOptionsFlowHandler(
             flow_control=True,
         )
 
+    @override
     async def _async_zha_physical_discovery(self) -> dict[str, Any]:
         """Return ZHA discovery data when multiprotocol FW is not used.
 
@@ -311,27 +316,33 @@ class HomeAssistantYellowMultiPanOptionsFlowHandler(
         """
         return {"hw": ZHA_HW_DISCOVERY_DATA}
 
+    @override
     def _zha_name(self) -> str:
         """Return the ZHA name."""
         return "Yellow Multiprotocol"
 
+    @override
     def _hardware_name(self) -> str:
         """Return the name of the hardware."""
         return BOARD_NAME
 
+    @override
     def _firmware_update_url(self) -> str:
         """Return the firmware update manifest URL."""
         return NABU_CASA_FIRMWARE_RELEASES_URL
 
+    @override
     def _zigbee_firmware_type(self) -> str:
         """Return the zigbee firmware type identifier."""
         return "yellow_zigbee_ncp"
 
     @property
+    @override
     def _flasher_cls(self) -> type:
         """Return the hardware-specific flasher class."""
         return YellowFlasher  # type: ignore[no-any-return]
 
+    @override
     async def async_step_flashing_complete(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -372,6 +383,7 @@ class HomeAssistantYellowOptionsFlowHandler(
         # Regenerate the translation placeholders
         self._get_translation_placeholders()
 
+    @override
     async def async_step_main_menu(self, _: None = None) -> ConfigFlowResult:
         """Show the main menu."""
         return self.async_show_menu(
@@ -388,6 +400,7 @@ class HomeAssistantYellowOptionsFlowHandler(
         """Handle firmware configuration settings."""
         return await super().async_step_pick_firmware()
 
+    @override
     def _async_flow_finished(self) -> ConfigFlowResult:
         """Create the config entry."""
         assert self._probed_firmware_info is not None

--- a/homeassistant/components/homeassistant_yellow/repairs.py
+++ b/homeassistant/components/homeassistant_yellow/repairs.py
@@ -1,6 +1,6 @@
 """Repairs for the Home Assistant Yellow integration."""
 
-from typing import cast
+from typing import cast, override
 
 from homeassistant.components.homeassistant_hardware.repair_helpers import (
     ISSUE_MULTI_PAN_MIGRATION,
@@ -27,6 +27,7 @@ class YellowMultiPanMigrationRepairFlow(
         HomeAssistantYellowMultiPanOptionsFlowHandler.__init__(self, hass, config_entry)
         self._repair_config_entry = config_entry
 
+    @override
     async def async_step_main_menu(  # type: ignore[override]
         self, _: None = None
     ) -> RepairsFlowResult:

--- a/homeassistant/components/homeassistant_yellow/update.py
+++ b/homeassistant/components/homeassistant_yellow/update.py
@@ -1,6 +1,7 @@
 """Home Assistant Yellow firmware update entity."""
 
 import logging
+from typing import override
 
 from aiohasupervisor import SupervisorError
 from universal_silabs_flasher.flasher import YellowFlasher
@@ -208,6 +209,7 @@ class FirmwareUpdateEntity(BaseFirmwareUpdateEntity):
             )
 
     @callback
+    @override
     def _firmware_info_callback(self, firmware_info: FirmwareInfo) -> None:
         """Handle updated firmware info being pushed by an integration."""
         self.hass.config_entries.async_update_entry(

--- a/homeassistant/components/homee/alarm_control_panel.py
+++ b/homeassistant/components/homee/alarm_control_panel.py
@@ -1,6 +1,7 @@
 """The Homee alarm control panel platform."""
 
 from dataclasses import dataclass
+from typing import override
 
 from pyHomee.const import AttributeChangedBy, AttributeType
 from pyHomee.model import HomeeAttribute, HomeeNode
@@ -104,11 +105,13 @@ class HomeeAlarmPanel(HomeeEntity, AlarmControlPanelEntity):
         self._attr_translation_key = description.key
 
     @property
+    @override
     def alarm_state(self) -> AlarmControlPanelState:
         """Return current state."""
         return self.entity_description.state_list[int(self._attribute.current_value)]
 
     @property
+    @override
     def changed_by(self) -> str:
         """Return by whom or what the entity was last changed."""
         changed_by_name = get_name_for_enum(
@@ -123,6 +126,7 @@ class HomeeAlarmPanel(HomeeEntity, AlarmControlPanelEntity):
                 self.entity_description.state_list.index(state)
             )
 
+    @override
     async def async_alarm_disarm(self, code: str | None = None) -> None:
         """Send disarm command."""
         # Since disarm is always present in the UI, we raise an error.
@@ -131,18 +135,22 @@ class HomeeAlarmPanel(HomeeEntity, AlarmControlPanelEntity):
             translation_key="disarm_not_supported",
         )
 
+    @override
     async def async_alarm_arm_home(self, code: str | None = None) -> None:
         """Send arm home command."""
         await self._async_set_alarm_state(AlarmControlPanelState.ARMED_HOME)
 
+    @override
     async def async_alarm_arm_night(self, code: str | None = None) -> None:
         """Send arm night command."""
         await self._async_set_alarm_state(AlarmControlPanelState.ARMED_NIGHT)
 
+    @override
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command."""
         await self._async_set_alarm_state(AlarmControlPanelState.ARMED_AWAY)
 
+    @override
     async def async_alarm_arm_vacation(self, code: str | None = None) -> None:
         """Send arm vacation command."""
         await self._async_set_alarm_state(AlarmControlPanelState.ARMED_VACATION)

--- a/homeassistant/components/homee/binary_sensor.py
+++ b/homeassistant/components/homee/binary_sensor.py
@@ -1,5 +1,7 @@
 """The Homee binary sensor platform."""
 
+from typing import override
+
 from pyHomee.const import AttributeType
 from pyHomee.model import HomeeAttribute, HomeeNode
 
@@ -197,6 +199,7 @@ class HomeeBinarySensor(HomeeEntity, BinarySensorEntity):
         self._attr_translation_key = description.key
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if the binary sensor is on."""
         return bool(self._attribute.current_value)

--- a/homeassistant/components/homee/button.py
+++ b/homeassistant/components/homee/button.py
@@ -1,5 +1,7 @@
 """The homee button platform."""
 
+from typing import override
+
 from pyHomee.const import AttributeType
 from pyHomee.model import HomeeAttribute, HomeeNode
 
@@ -85,6 +87,7 @@ class HomeeButton(HomeeEntity, ButtonEntity):
             self._attr_translation_key = f"{description.key}_instance"
             self._attr_translation_placeholders = {"instance": str(attribute.instance)}
 
+    @override
     async def async_press(self) -> None:
         """Handle the button press."""
         await self.async_set_homee_value(1)

--- a/homeassistant/components/homee/climate.py
+++ b/homeassistant/components/homee/climate.py
@@ -1,6 +1,6 @@
 """The Homee climate platform."""
 
-from typing import Any
+from typing import Any, override
 
 from pyHomee.const import AttributeType, NodeProfile
 from pyHomee.model import HomeeNode
@@ -88,6 +88,7 @@ class HomeeClimate(HomeeNodeEntity, ClimateEntity):
         )
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode:
         """Return the hvac operation mode."""
         if ClimateEntityFeature.TURN_OFF in self.supported_features and (
@@ -99,6 +100,7 @@ class HomeeClimate(HomeeNodeEntity, ClimateEntity):
         return HVACMode.HEAT
 
     @property
+    @override
     def hvac_action(self) -> HVACAction:
         """Return the hvac action."""
         if (
@@ -118,6 +120,7 @@ class HomeeClimate(HomeeNodeEntity, ClimateEntity):
         return HVACAction.HEATING
 
     @property
+    @override
     def preset_mode(self) -> str:
         """Return the present preset mode."""
         if (
@@ -133,6 +136,7 @@ class HomeeClimate(HomeeNodeEntity, ClimateEntity):
         return PRESET_NONE
 
     @property
+    @override
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
         if self._temperature is not None:
@@ -140,23 +144,27 @@ class HomeeClimate(HomeeNodeEntity, ClimateEntity):
         return None
 
     @property
+    @override
     def target_temperature(self) -> float:
         """Return the temperature we try to reach."""
         assert self._target_temp is not None
         return self._target_temp.current_value
 
     @property
+    @override
     def min_temp(self) -> float:
         """Return the lowest settable target temperature."""
         assert self._target_temp is not None
         return self._target_temp.minimum
 
     @property
+    @override
     def max_temp(self) -> float:
         """Return the lowest settable target temperature."""
         assert self._target_temp is not None
         return self._target_temp.maximum
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         # Currently only HEAT and OFF are supported.
@@ -166,6 +174,7 @@ class HomeeClimate(HomeeNodeEntity, ClimateEntity):
             (hvac_mode == HVACMode.HEAT) + self._heating_mode.minimum,
         )
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new target preset mode."""
         assert self._heating_mode is not None and self._attr_preset_modes is not None
@@ -174,6 +183,7 @@ class HomeeClimate(HomeeNodeEntity, ClimateEntity):
             self._attr_preset_modes.index(preset_mode) + self._heating_mode.minimum + 1,
         )
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         assert self._target_temp is not None
@@ -182,6 +192,7 @@ class HomeeClimate(HomeeNodeEntity, ClimateEntity):
                 self._target_temp, kwargs[ATTR_TEMPERATURE]
             )
 
+    @override
     async def async_turn_on(self) -> None:
         """Turn the entity on."""
         assert self._heating_mode is not None
@@ -189,6 +200,7 @@ class HomeeClimate(HomeeNodeEntity, ClimateEntity):
             self._heating_mode, 1 + self._heating_mode.minimum
         )
 
+    @override
     async def async_turn_off(self) -> None:
         """Turn the entity on."""
         assert self._heating_mode is not None

--- a/homeassistant/components/homee/config_flow.py
+++ b/homeassistant/components/homee/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyHomee import (
     Homee,
@@ -81,6 +81,7 @@ class HomeeConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return errors
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -107,6 +108,7 @@ class HomeeConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    @override
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/homee/cover.py
+++ b/homeassistant/components/homee/cover.py
@@ -2,7 +2,7 @@
 
 from enum import Enum
 import logging
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, cast, override
 
 from pyHomee.const import AttributeType, NodeProfile
 from pyHomee.model import HomeeAttribute, HomeeNode
@@ -166,6 +166,7 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
         )
 
     @property
+    @override
     def current_cover_position(self) -> int | None:
         """Return the cover's position."""
         # Translate the homee position values to HA's 0-100 scale
@@ -182,6 +183,7 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
         return None
 
     @property
+    @override
     def current_cover_tilt_position(self) -> int | None:
         """Return the cover's tilt position."""
         # Translate the homee position values to HA's 0-100 scale
@@ -200,6 +202,7 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
         return None
 
     @property
+    @override
     def is_opening(self) -> bool | None:
         """Return the opening status of the cover."""
         if self._open_close_attribute is not None:
@@ -212,6 +215,7 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
         return None
 
     @property
+    @override
     def is_closing(self) -> bool | None:
         """Return the closing status of the cover."""
         if self._open_close_attribute is not None:
@@ -224,6 +228,7 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
         return None
 
     @property
+    @override
     def is_closed(self) -> bool:
         """Return if the cover is closed."""
         if (
@@ -248,6 +253,7 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
 
         return attribute.get_value() == attribute.minimum
 
+    @override
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
         assert self._open_close_attribute is not None
@@ -260,6 +266,7 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
                 self._open_close_attribute, HomeeCoverState.CLOSED
             )
 
+    @override
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close cover."""
         assert self._open_close_attribute is not None
@@ -272,6 +279,7 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
                 self._open_close_attribute, HomeeCoverState.OPEN
             )
 
+    @override
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
         if CoverEntityFeature.SET_POSITION in self.supported_features:
@@ -287,6 +295,7 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
 
                 await self.async_set_homee_value(attribute, homee_position)
 
+    @override
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
         if self._open_close_attribute is not None:
@@ -294,6 +303,7 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
                 self._open_close_attribute, HomeeCoverState.STOPPED
             )
 
+    @override
     async def async_open_cover_tilt(self, **kwargs: Any) -> None:
         """Open the cover tilt."""
         if (
@@ -306,6 +316,7 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
             else:
                 await self.async_set_homee_value(slat_attribute, HomeeSlatState.CLOSED)
 
+    @override
     async def async_close_cover_tilt(self, **kwargs: Any) -> None:
         """Close the cover tilt."""
         if (
@@ -318,6 +329,7 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
             else:
                 await self.async_set_homee_value(slat_attribute, HomeeSlatState.OPEN)
 
+    @override
     async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
         """Stop the cover tilt."""
         if (
@@ -327,6 +339,7 @@ class HomeeCover(HomeeNodeEntity, CoverEntity):
         ) is not None:
             await self.async_set_homee_value(slat_attribute, HomeeSlatState.STOPPED)
 
+    @override
     async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
         """Move the cover tilt to a specific position."""
         if CoverEntityFeature.SET_TILT_POSITION in self.supported_features:

--- a/homeassistant/components/homee/entity.py
+++ b/homeassistant/components/homee/entity.py
@@ -1,5 +1,7 @@
 """Base Entities for Homee integration."""
 
+from typing import override
+
 from pyHomee.const import AttributeState, AttributeType, NodeProfile, NodeState
 from pyHomee.model import HomeeAttribute, HomeeNode
 from websockets.exceptions import ConnectionClosed
@@ -47,6 +49,7 @@ class HomeeEntity(Entity):
 
         self._host_connected = entry.runtime_data.connected
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Add the homee attribute entity to home assistant."""
         self.async_on_remove(
@@ -59,6 +62,7 @@ class HomeeEntity(Entity):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return the availability of the underlying node."""
         return (self._attribute.state == AttributeState.NORMAL) and self._host_connected
@@ -115,6 +119,7 @@ class HomeeNodeEntity(Entity):
 
         self._host_connected = entry.runtime_data.connected
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Add the homee binary sensor device to home assistant."""
         self.async_on_remove(self._node.add_on_changed_listener(self._on_node_updated))
@@ -125,6 +130,7 @@ class HomeeNodeEntity(Entity):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return the availability of the underlying node."""
         return self._node.state == NodeState.AVAILABLE and self._host_connected

--- a/homeassistant/components/homee/event.py
+++ b/homeassistant/components/homee/event.py
@@ -1,5 +1,7 @@
 """The homee event platform."""
 
+from typing import override
+
 from pyHomee.const import AttributeType, NodeProfile
 from pyHomee.model import HomeeAttribute, HomeeNode
 
@@ -94,6 +96,7 @@ class HomeeEvent(HomeeEntity, EventEntity):
             self._attr_translation_key = f"{self._attr_translation_key}_instance"
             self._attr_translation_placeholders = {"instance": str(attribute.instance)}
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Add the homee event entity to home assistant."""
         await super().async_added_to_hass()

--- a/homeassistant/components/homee/fan.py
+++ b/homeassistant/components/homee/fan.py
@@ -1,7 +1,7 @@
 """The Homee fan platform."""
 
 import math
-from typing import Any, cast
+from typing import Any, cast, override
 
 from pyHomee.const import AttributeType, NodeProfile
 from pyHomee.model import HomeeAttribute, HomeeNode
@@ -67,6 +67,7 @@ class HomeeFan(HomeeNodeEntity, FanEntity):
         )
 
     @property
+    @override
     def supported_features(self) -> FanEntityFeature:
         """Return the supported features based on preset_mode."""
         features = FanEntityFeature.PRESET_MODE
@@ -81,11 +82,13 @@ class HomeeFan(HomeeNodeEntity, FanEntity):
         return features
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if the entity is on."""
         return self.percentage > 0
 
     @property
+    @override
     def percentage(self) -> int:
         """Return the current speed percentage."""
         return ranged_value_to_percentage(
@@ -93,10 +96,12 @@ class HomeeFan(HomeeNodeEntity, FanEntity):
         )
 
     @property
+    @override
     def preset_mode(self) -> str:
         """Return the mode from the float state."""
         return self._attr_preset_modes[int(self._mode_attribute.current_value)]
 
+    @override
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed percentage of the fan."""
         await self.async_set_homee_value(
@@ -104,16 +109,19 @@ class HomeeFan(HomeeNodeEntity, FanEntity):
             math.ceil(percentage_to_ranged_value(self.speed_range, percentage)),
         )
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode of the fan."""
         await self.async_set_homee_value(
             self._mode_attribute, self._attr_preset_modes.index(preset_mode)
         )
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the fan off."""
         await self.async_set_homee_value(self._speed_attribute, 0)
 
+    @override
     async def async_turn_on(
         self,
         percentage: int | None = None,

--- a/homeassistant/components/homee/light.py
+++ b/homeassistant/components/homee/light.py
@@ -1,6 +1,6 @@
 """The Homee light platform."""
 
-from typing import Any
+from typing import Any, override
 
 from pyHomee.const import AttributeType
 from pyHomee.model import HomeeAttribute, HomeeNode
@@ -152,6 +152,7 @@ class HomeeLight(HomeeNodeEntity, LightEntity):
         )
 
     @property
+    @override
     def brightness(self) -> int:
         """Return the brightness of the light."""
         assert self._dimmer_attr is not None
@@ -161,6 +162,7 @@ class HomeeLight(HomeeNodeEntity, LightEntity):
         )
 
     @property
+    @override
     def hs_color(self) -> tuple[float, float] | None:
         """Return the color of the light."""
         assert self._col_attr is not None
@@ -168,16 +170,19 @@ class HomeeLight(HomeeNodeEntity, LightEntity):
         return color_RGB_to_hs(*rgb)
 
     @property
+    @override
     def color_temp_kelvin(self) -> int:
         """Return the color temperature of the light."""
         assert self._temp_attr is not None
         return int(self._temp_attr.current_value)
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if light is on."""
         return bool(self._on_off_attr.current_value)
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Instruct the light to turn on."""
         if ATTR_BRIGHTNESS in kwargs and self._dimmer_attr is not None:
@@ -204,6 +209,7 @@ class HomeeLight(HomeeNodeEntity, LightEntity):
                     rgb_list_to_decimal(color_hs_to_RGB(*color)),
                 )
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Instruct the light to turn off."""
         await self.async_set_homee_value(self._on_off_attr, 0)

--- a/homeassistant/components/homee/lock.py
+++ b/homeassistant/components/homee/lock.py
@@ -1,6 +1,6 @@
 """The Homee lock platform."""
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from pyHomee.const import AttributeChangedBy, AttributeType
 from pyHomee.model import HomeeAttribute, HomeeNode
@@ -71,11 +71,13 @@ class HomeeLock(HomeeEntity, LockEntity):
             self._attr_supported_features = LockEntityFeature.OPEN
 
     @property
+    @override
     def is_locked(self) -> bool:
         """Return if lock is locked."""
         return self._attribute.current_value == LOCK_STATE_LOCKED
 
     @property
+    @override
     def is_open(self) -> bool:
         """Return if lock is open (unlatched)."""
         # Require target_value too, so mid-transition away from "open" resolves
@@ -87,6 +89,7 @@ class HomeeLock(HomeeEntity, LockEntity):
         )
 
     @property
+    @override
     def is_locking(self) -> bool:
         """Return if lock is locking."""
         return (
@@ -95,6 +98,7 @@ class HomeeLock(HomeeEntity, LockEntity):
         )
 
     @property
+    @override
     def is_unlocking(self) -> bool:
         """Return if lock is unlocking."""
         return (
@@ -103,6 +107,7 @@ class HomeeLock(HomeeEntity, LockEntity):
         )
 
     @property
+    @override
     def is_opening(self) -> bool:
         """Return if lock is opening (unlatching)."""
         return (
@@ -112,6 +117,7 @@ class HomeeLock(HomeeEntity, LockEntity):
         )
 
     @property
+    @override
     def changed_by(self) -> str:
         """Return by whom or what the lock was last changed."""
         changed_id = str(self._attribute.changed_by_id)
@@ -129,14 +135,17 @@ class HomeeLock(HomeeEntity, LockEntity):
 
         return f"{changed_by_name}-{changed_id}"
 
+    @override
     async def async_lock(self, **kwargs: Any) -> None:
         """Lock specified lock. A code to lock the lock with may be specified."""
         await self.async_set_homee_value(LOCK_STATE_LOCKED)
 
+    @override
     async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock specified lock. A code to unlock the lock with may be specified."""
         await self.async_set_homee_value(LOCK_STATE_UNLOCKED)
 
+    @override
     async def async_open(self, **kwargs: Any) -> None:
         """Open (unlatch) the lock."""
         if TYPE_CHECKING:

--- a/homeassistant/components/homee/number.py
+++ b/homeassistant/components/homee/number.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from pyHomee.const import AttributeType
 from pyHomee.model import HomeeAttribute, HomeeNode
@@ -185,15 +186,18 @@ class HomeeNumber(HomeeEntity, NumberEntity):
         self._attr_native_step = description.native_step or attribute.step_value
 
     @property
+    @override
     def available(self) -> bool:
         """Return the availability of the entity."""
         return super().available and self._attribute.editable
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the native value of the number."""
         return self.entity_description.native_value_fn(self._attribute.current_value)
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Set the selected value."""
         await self.async_set_homee_value(

--- a/homeassistant/components/homee/select.py
+++ b/homeassistant/components/homee/select.py
@@ -1,5 +1,7 @@
 """The Homee select platform."""
 
+from typing import override
+
 from pyHomee.const import AttributeType
 from pyHomee.model import HomeeAttribute, HomeeNode
 
@@ -69,10 +71,12 @@ class HomeeSelect(HomeeEntity, SelectEntity):
         self._attr_translation_key = description.key
 
     @property
+    @override
     def current_option(self) -> str:
         """Return the current selected option."""
         return self.options[int(self._attribute.current_value)]
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         await self.async_set_homee_value(self.options.index(option))

--- a/homeassistant/components/homee/sensor.py
+++ b/homeassistant/components/homee/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from pyHomee.const import AttributeType, NodeState
 from pyHomee.model import HomeeAttribute, HomeeNode
@@ -341,11 +342,13 @@ class HomeeSensor(HomeeEntity, SensorEntity):
         )
 
     @property
+    @override
     def native_value(self) -> float | str | None:
         """Return the native value of the sensor."""
         return self.entity_description.value_fn(self._attribute)
 
     @property
+    @override
     def native_unit_of_measurement(self) -> str | None:
         """Return the native unit of the sensor."""
         return self.entity_description.native_unit_of_measurement_fn(
@@ -371,6 +374,7 @@ class HomeeNodeSensor(HomeeNodeEntity, SensorEntity):
         self._attr_unique_id = f"{self._attr_unique_id}-{description.key}"
 
     @property
+    @override
     def native_value(self) -> str | None:
         """Return the sensors value."""
         return self.entity_description.value_fn(self._node)

--- a/homeassistant/components/homee/siren.py
+++ b/homeassistant/components/homee/siren.py
@@ -1,6 +1,6 @@
 """The homee siren platform."""
 
-from typing import Any
+from typing import Any, override
 
 from pyHomee.const import AttributeType
 from pyHomee.model import HomeeNode
@@ -47,14 +47,17 @@ class HomeeSiren(HomeeEntity, SirenEntity):
     _attr_supported_features = SirenEntityFeature.TURN_ON | SirenEntityFeature.TURN_OFF
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return the state of the siren."""
         return self._attribute.current_value == 1.0
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the siren on."""
         await self.async_set_homee_value(1)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the siren off."""
         await self.async_set_homee_value(0)

--- a/homeassistant/components/homee/switch.py
+++ b/homeassistant/components/homee/switch.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from pyHomee.const import AttributeType, NodeProfile
 from pyHomee.model import HomeeAttribute, HomeeNode
@@ -128,19 +128,23 @@ class HomeeSwitch(HomeeEntity, SwitchEntity):
             self._attr_translation_placeholders = {"instance": str(attribute.instance)}
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return True if entity is on."""
         return bool(self._attribute.current_value)
 
     @property
+    @override
     def device_class(self) -> SwitchDeviceClass:
         """Return the device class of the switch."""
         return self.entity_description.device_class_fn(self._attribute, self._entry)
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         await self.async_set_homee_value(1)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         await self.async_set_homee_value(0)
@@ -171,6 +175,7 @@ class HomeegramSwitch(SwitchEntity):
             homeegram
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Add the Homeegram entity to home assistant."""
         self.async_on_remove(
@@ -183,19 +188,23 @@ class HomeegramSwitch(SwitchEntity):
         )
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return True if homeegram is executing."""
         return bool(self._homeegram.play)
 
     @property
+    @override
     def available(self) -> bool:
         """Return the availability of the homeegram based on host availability."""
         return bool(self._homeegram.active) and self._host_connected
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Trigger Homeegram on switching on."""
         await self._entry.runtime_data.play_homeegram(self._homeegram.id)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turning off homeegrams is not supported."""
         raise ServiceValidationError(

--- a/homeassistant/components/homee/valve.py
+++ b/homeassistant/components/homee/valve.py
@@ -1,5 +1,7 @@
 """The Homee valve platform."""
 
+from typing import override
+
 from pyHomee.const import AttributeType
 from pyHomee.model import HomeeAttribute, HomeeNode
 
@@ -67,6 +69,7 @@ class HomeeValve(HomeeEntity, ValveEntity):
         self._attr_translation_key = description.key
 
     @property
+    @override
     def supported_features(self) -> ValveEntityFeature:
         """Return the supported features."""
         if self._attribute.editable:
@@ -74,20 +77,24 @@ class HomeeValve(HomeeEntity, ValveEntity):
         return ValveEntityFeature(0)
 
     @property
+    @override
     def current_valve_position(self) -> int | None:
         """Return the current valve position."""
         return int(self._attribute.current_value)
 
     @property
+    @override
     def is_closing(self) -> bool:
         """Return if the valve is closing."""
         return self._attribute.target_value < self._attribute.current_value
 
     @property
+    @override
     def is_opening(self) -> bool:
         """Return if the valve is opening."""
         return self._attribute.target_value > self._attribute.current_value
 
+    @override
     async def async_set_valve_position(self, position: int) -> None:
         """Move the valve to a specific position."""
         await self.async_set_homee_value(position)

--- a/homeassistant/components/homekit/config_flow.py
+++ b/homeassistant/components/homekit/config_flow.py
@@ -6,7 +6,7 @@ from operator import itemgetter
 import random
 import re
 import string
-from typing import Any, Final, TypedDict
+from typing import Any, Final, TypedDict, override
 
 import voluptuous as vol
 
@@ -208,6 +208,7 @@ class HomeKitConfigFlow(ConfigFlow, domain=DOMAIN):
         """Initialize config flow."""
         self.hk_data: dict[str, Any] = {}
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -358,6 +359,7 @@ class HomeKitConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> OptionsFlowHandler:

--- a/homeassistant/components/homekit/doorbell.py
+++ b/homeassistant/components/homekit/doorbell.py
@@ -1,7 +1,7 @@
 """Extend the doorbell functions."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyhap.util import callback as pyhap_callback
 
@@ -70,6 +70,7 @@ class HomeDoorbellAccessory(HomeAccessory):
 
     @ha_callback
     @pyhap_callback  # type: ignore[untyped-decorator]
+    @override
     def run(self) -> None:
         """Handle doorbell event."""
         if self._char_doorbell_detected:

--- a/homeassistant/components/homekit/iidmanager.py
+++ b/homeassistant/components/homekit/iidmanager.py
@@ -6,6 +6,7 @@ be stable between reboots and upgrades.
 This module generates and stores them in a HA storage.
 """
 
+from typing import override
 from uuid import UUID
 
 from pyhap.util import uuid_to_hap_type
@@ -30,6 +31,7 @@ ACCESSORY_INFORMATION_SERVICE = "3E"
 class IIDStorage(Store):
     """Storage class for IIDManager."""
 
+    @override
     async def _async_migrate_func(
         self,
         old_major_version: int,

--- a/homeassistant/components/homekit/type_air_purifiers.py
+++ b/homeassistant/components/homekit/type_air_purifiers.py
@@ -1,7 +1,7 @@
 """Class to hold all air purifier accessories."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyhap.characteristic import Characteristic
 from pyhap.const import CATEGORY_AIR_PURIFIER
@@ -88,6 +88,7 @@ class AirPurifier(Fan):
                     self.auto_preset = preset
                     break
 
+    @override
     def create_services(self) -> Service:
         """Create and configure the primary service for this accessory."""
         self.chars.append(CHAR_ACTIVE)
@@ -214,12 +215,14 @@ class AirPurifier(Fan):
 
         return serv_air_purifier
 
+    @override
     def should_add_preset_mode_switch(self, preset_mode: str) -> bool:
         """Check if a preset mode switch should be added."""
         return preset_mode.lower() != "auto"
 
     @callback
     @pyhap_callback  # type: ignore[untyped-decorator]
+    @override
     def run(self) -> None:
         """Handle accessory driver started event.
 
@@ -449,6 +452,7 @@ class AirPurifier(Fan):
         self.char_filter_change_indication.set_value(current_change_indicator)
 
     @callback
+    @override
     def async_update_state(self, new_state: State) -> None:
         """Update fan after state change."""
         super().async_update_state(new_state)
@@ -472,6 +476,7 @@ class AirPurifier(Fan):
                 else TARGET_STATE_MANUAL
             )
 
+    @override
     def set_chars(self, char_values: dict[str, Any]) -> None:
         """Handle automatic mode after state change."""
         super().set_chars(char_values)

--- a/homeassistant/components/homekit/type_cameras.py
+++ b/homeassistant/components/homekit/type_cameras.py
@@ -3,7 +3,7 @@
 import asyncio
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from haffmpeg.core import FFMPEG_STDERR, HAFFmpeg
 from homekit_audio_proxy import AudioProxy
@@ -232,6 +232,7 @@ class Camera(HomeDoorbellAccessory, PyhapCamera):  # type: ignore[misc]
 
     @pyhap_callback  # type: ignore[untyped-decorator]
     @callback
+    @override
     def run(self) -> None:
         """Handle accessory driver started event.
 
@@ -297,6 +298,7 @@ class Camera(HomeDoorbellAccessory, PyhapCamera):  # type: ignore[misc]
         )
 
     @callback
+    @override
     def async_update_state(self, new_state: State | None) -> None:
         """Handle state change to update HomeKit value."""
 
@@ -461,6 +463,7 @@ class Camera(HomeDoorbellAccessory, PyhapCamera):  # type: ignore[misc]
         self.sessions[session_id].pop(FFMPEG_LOGGER).cancel()
 
     @callback
+    @override
     def async_stop(self) -> None:
         """Stop any streams when the accessory is stopped."""
         for session_info in self.sessions.values():

--- a/homeassistant/components/homekit/type_covers.py
+++ b/homeassistant/components/homekit/type_covers.py
@@ -1,7 +1,7 @@
 """Class to hold all cover accessories."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyhap.const import (
     CATEGORY_DOOR,
@@ -128,6 +128,7 @@ class GarageDoorOpener(HomeAccessory):
 
     @callback
     @pyhap_callback  # type: ignore[untyped-decorator]
+    @override
     def run(self) -> None:
         """Handle accessory driver started event.
 
@@ -185,6 +186,7 @@ class GarageDoorOpener(HomeAccessory):
             self.async_call_service(COVER_DOMAIN, SERVICE_CLOSE_COVER, params)
 
     @callback
+    @override
     def async_update_state(self, new_state: State) -> None:
         """Update cover state after state changed."""
         hass_state: CoverState = new_state.state  # type: ignore[assignment]
@@ -263,6 +265,7 @@ class OpeningDeviceBase(HomeAccessory):
         )
 
     @callback
+    @override
     def async_update_state(self, new_state: State) -> None:
         """Update cover position and tilt after state changed."""
         # update tilt
@@ -324,6 +327,7 @@ class OpeningDevice(OpeningDeviceBase, HomeAccessory):
         self.async_call_service(COVER_DOMAIN, SERVICE_SET_COVER_POSITION, params, value)
 
     @callback
+    @override
     def async_update_state(self, new_state: State) -> None:
         """Update cover position and tilt after state changed."""
         current_position = new_state.attributes.get(ATTR_CURRENT_POSITION)
@@ -426,6 +430,7 @@ class WindowCoveringBasic(OpeningDeviceBase, HomeAccessory):
         self.char_target_position.set_value(position)
 
     @callback
+    @override
     def async_update_state(self, new_state: State) -> None:
         """Update cover position after state changed."""
         position_mapping = {CoverState.OPEN: 100, CoverState.CLOSED: 0}

--- a/homeassistant/components/homekit/type_fans.py
+++ b/homeassistant/components/homekit/type_fans.py
@@ -1,7 +1,7 @@
 """Class to hold all fan accessories."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyhap.const import CATEGORY_FAN
 from pyhap.service import Service
@@ -255,6 +255,7 @@ class Fan(HomeAccessory):
         self.async_call_service(FAN_DOMAIN, SERVICE_SET_PERCENTAGE, params, value)
 
     @callback
+    @override
     def async_update_state(self, new_state: State) -> None:
         """Update fan after state change."""
         # Handle State

--- a/homeassistant/components/homekit/type_humidifiers.py
+++ b/homeassistant/components/homekit/type_humidifiers.py
@@ -1,7 +1,7 @@
 """Class to hold all thermostat accessories."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyhap.const import CATEGORY_HUMIDIFIER
 from pyhap.util import callback as pyhap_callback
@@ -179,6 +179,7 @@ class HumidifierDehumidifier(HomeAccessory):
 
     @callback
     @pyhap_callback  # type: ignore[untyped-decorator]
+    @override
     def run(self) -> None:
         """Handle accessory driver started event.
 
@@ -294,6 +295,7 @@ class HumidifierDehumidifier(HomeAccessory):
         return min_humidity, max_humidity
 
     @callback
+    @override
     def async_update_state(self, new_state: State) -> None:
         """Update state without rechecking the device features."""
         is_active = new_state.state == STATE_ON

--- a/homeassistant/components/homekit/type_lights.py
+++ b/homeassistant/components/homekit/type_lights.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyhap.const import CATEGORY_LIGHTBULB
 
@@ -244,6 +244,7 @@ class Light(HomeAccessory):
         self.async_call_service(LIGHT_DOMAIN, service, params, ", ".join(events))
 
     @callback
+    @override
     def async_update_state(self, new_state: State) -> None:
         """Update light after state change."""
         # Handle State

--- a/homeassistant/components/homekit/type_locks.py
+++ b/homeassistant/components/homekit/type_locks.py
@@ -1,7 +1,7 @@
 """Class to hold all lock accessories."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyhap.const import CATEGORY_DOOR_LOCK
 
@@ -91,6 +91,7 @@ class Lock(HomeDoorbellAccessory):
         self.async_call_service(LOCK_DOMAIN, service, params)
 
     @callback
+    @override
     def async_update_state(self, new_state: State) -> None:
         """Update lock after state changed."""
         hass_state = new_state.state

--- a/homeassistant/components/homekit/type_media_players.py
+++ b/homeassistant/components/homekit/type_media_players.py
@@ -1,7 +1,7 @@
 """Class to hold all media player accessories."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyhap.characteristic import Characteristic
 from pyhap.const import CATEGORY_SWITCH
@@ -211,6 +211,7 @@ class MediaPlayer(HomeAccessory):
         self.async_call_service(MEDIA_PLAYER_DOMAIN, SERVICE_VOLUME_MUTE, params)
 
     @callback
+    @override
     def async_update_state(self, new_state: State) -> None:
         """Update switch state after state changed."""
         current_state = new_state.state
@@ -312,6 +313,7 @@ class TelevisionMediaPlayer(RemoteInputSelectAccessory):
 
         self.async_update_state(state)
 
+    @override
     def set_on_off(self, value: bool) -> None:
         """Move switch state to value if call came from HomeKit."""
         _LOGGER.debug('%s: Set switch state for "on_off" to %s', self.entity_id, value)
@@ -340,6 +342,7 @@ class TelevisionMediaPlayer(RemoteInputSelectAccessory):
         params = {ATTR_ENTITY_ID: self.entity_id}
         self.async_call_service(MEDIA_PLAYER_DOMAIN, service, params)
 
+    @override
     def set_input_source(self, value: int) -> None:
         """Send input set value if call came from HomeKit."""
         _LOGGER.debug("%s: Set current input to %s", self.entity_id, value)
@@ -347,6 +350,7 @@ class TelevisionMediaPlayer(RemoteInputSelectAccessory):
         params = {ATTR_ENTITY_ID: self.entity_id, ATTR_INPUT_SOURCE: source_name}
         self.async_call_service(MEDIA_PLAYER_DOMAIN, SERVICE_SELECT_SOURCE, params)
 
+    @override
     def set_remote_key(self, value: int) -> None:
         """Send remote key value if call came from HomeKit."""
         _LOGGER.debug("%s: Set remote key to %s", self.entity_id, value)
@@ -376,6 +380,7 @@ class TelevisionMediaPlayer(RemoteInputSelectAccessory):
         )
 
     @callback
+    @override
     def async_update_state(self, new_state: State) -> None:
         """Update Television state after state changed."""
         current_state = new_state.state

--- a/homeassistant/components/homekit/type_remotes.py
+++ b/homeassistant/components/homekit/type_remotes.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractmethod
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyhap.const import CATEGORY_TELEVISION
 
@@ -232,6 +232,7 @@ class ActivityRemote(RemoteInputSelectAccessory):
         assert state
         self.async_update_state(state)
 
+    @override
     def set_on_off(self, value: bool) -> None:
         """Move switch state to value if call came from HomeKit."""
         _LOGGER.debug('%s: Set switch state for "on_off" to %s', self.entity_id, value)
@@ -239,6 +240,7 @@ class ActivityRemote(RemoteInputSelectAccessory):
         params = {ATTR_ENTITY_ID: self.entity_id}
         self.async_call_service(REMOTE_DOMAIN, service, params)
 
+    @override
     def set_input_source(self, value: int) -> None:
         """Send input set value if call came from HomeKit."""
         _LOGGER.debug("%s: Set current input to %s", self.entity_id, value)
@@ -246,6 +248,7 @@ class ActivityRemote(RemoteInputSelectAccessory):
         params = {ATTR_ENTITY_ID: self.entity_id, ATTR_ACTIVITY: source}
         self.async_call_service(REMOTE_DOMAIN, SERVICE_TURN_ON, params)
 
+    @override
     def set_remote_key(self, value: int) -> None:
         """Send remote key value if call came from HomeKit."""
         _LOGGER.debug("%s: Set remote key to %s", self.entity_id, value)
@@ -258,6 +261,7 @@ class ActivityRemote(RemoteInputSelectAccessory):
         )
 
     @callback
+    @override
     def async_update_state(self, new_state: State) -> None:
         """Update Television remote state after state changed."""
         current_state = new_state.state

--- a/homeassistant/components/homekit/type_security_systems.py
+++ b/homeassistant/components/homekit/type_security_systems.py
@@ -1,7 +1,7 @@
 """Class to hold all alarm control panel accessories."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyhap.const import CATEGORY_ALARM_SYSTEM
 
@@ -152,6 +152,7 @@ class SecuritySystem(HomeAccessory):
         self.async_call_service(ALARM_CONTROL_PANEL_DOMAIN, service, params)
 
     @callback
+    @override
     def async_update_state(self, new_state: State) -> None:
         """Update security state after state changed."""
         hass_state: str | AlarmControlPanelState = new_state.state

--- a/homeassistant/components/homekit/type_sensors.py
+++ b/homeassistant/components/homekit/type_sensors.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 import logging
-from typing import Any, NamedTuple
+from typing import Any, NamedTuple, override
 
 from pyhap.const import CATEGORY_SENSOR
 from pyhap.service import Service
@@ -127,6 +127,7 @@ class TemperatureSensor(HomeAccessory):
         self.async_update_state(state)
 
     @callback
+    @override
     def async_update_state(self, new_state: State) -> None:
         """Update temperature after state changed."""
         unit = new_state.attributes.get(
@@ -158,6 +159,7 @@ class HumiditySensor(HomeAccessory):
         self.async_update_state(state)
 
     @callback
+    @override
     def async_update_state(self, new_state: State) -> None:
         """Update accessory after state change."""
         if (humidity := convert_to_float(new_state.state)) is not None:
@@ -191,6 +193,7 @@ class AirQualitySensor(HomeAccessory):
         )
 
     @callback
+    @override
     def async_update_state(self, new_state: State) -> None:
         """Update accessory after state change."""
         if (density := convert_to_float(new_state.state)) is not None:
@@ -206,6 +209,7 @@ class AirQualitySensor(HomeAccessory):
 class PM10Sensor(AirQualitySensor):
     """Generate a PM10Sensor accessory as PM 10 sensor."""
 
+    @override
     def create_services(self) -> None:
         """Override the init function for PM 10 Sensor."""
         serv_air_quality = self.add_preload_service(
@@ -215,6 +219,7 @@ class PM10Sensor(AirQualitySensor):
         self.char_density = serv_air_quality.configure_char(CHAR_PM10_DENSITY, value=0)
 
     @callback
+    @override
     def async_update_state(self, new_state: State) -> None:
         """Update accessory after state change."""
         density = convert_to_float(new_state.state)
@@ -233,6 +238,7 @@ class PM10Sensor(AirQualitySensor):
 class PM25Sensor(AirQualitySensor):
     """Generate a PM25Sensor accessory as PM 2.5 sensor."""
 
+    @override
     def create_services(self) -> None:
         """Override the init function for PM 2.5 Sensor."""
         serv_air_quality = self.add_preload_service(
@@ -242,6 +248,7 @@ class PM25Sensor(AirQualitySensor):
         self.char_density = serv_air_quality.configure_char(CHAR_PM25_DENSITY, value=0)
 
     @callback
+    @override
     def async_update_state(self, new_state: State) -> None:
         """Update accessory after state change."""
         density = convert_to_float(new_state.state)
@@ -260,6 +267,7 @@ class PM25Sensor(AirQualitySensor):
 class NitrogenDioxideSensor(AirQualitySensor):
     """Generate a NitrogenDioxideSensor accessory as NO2 sensor."""
 
+    @override
     def create_services(self) -> None:
         """Override the init function for PM 2.5 Sensor."""
         serv_air_quality = self.add_preload_service(
@@ -271,6 +279,7 @@ class NitrogenDioxideSensor(AirQualitySensor):
         )
 
     @callback
+    @override
     def async_update_state(self, new_state: State) -> None:
         """Update accessory after state change."""
         density = convert_to_float(new_state.state)
@@ -292,6 +301,7 @@ class VolatileOrganicCompoundsSensor(AirQualitySensor):
     Sensor entity must return VOC in μg/m3.
     """
 
+    @override
     def create_services(self) -> None:
         """Override the init function for VOC Sensor."""
         serv_air_quality: Service = self.add_preload_service(
@@ -308,6 +318,7 @@ class VolatileOrganicCompoundsSensor(AirQualitySensor):
         )
 
     @callback
+    @override
     def async_update_state(self, new_state: State) -> None:
         """Update accessory after state change."""
         density = convert_to_float(new_state.state)
@@ -351,6 +362,7 @@ class CarbonMonoxideSensor(HomeAccessory):
         self.async_update_state(state)
 
     @callback
+    @override
     def async_update_state(self, new_state: State) -> None:
         """Update accessory after state change."""
         if (value := convert_to_float(new_state.state)) is not None:
@@ -391,6 +403,7 @@ class CarbonDioxideSensor(HomeAccessory):
         self.async_update_state(state)
 
     @callback
+    @override
     def async_update_state(self, new_state: State) -> None:
         """Update accessory after state change."""
         if (value := convert_to_float(new_state.state)) is not None:
@@ -420,6 +433,7 @@ class LightSensor(HomeAccessory):
         self.async_update_state(state)
 
     @callback
+    @override
     def async_update_state(self, new_state: State) -> None:
         """Update accessory after state change."""
         if (luminance := convert_to_float(new_state.state)) is not None:
@@ -454,6 +468,7 @@ class BinarySensor(HomeAccessory):
         self.async_update_state(state)
 
     @callback
+    @override
     def async_update_state(self, new_state: State) -> None:
         """Update accessory after state change."""
         state = new_state.state

--- a/homeassistant/components/homekit/type_switches.py
+++ b/homeassistant/components/homekit/type_switches.py
@@ -1,7 +1,7 @@
 """Class to hold all switch accessories."""
 
 import logging
-from typing import Any, Final, NamedTuple
+from typing import Any, Final, NamedTuple, override
 
 from pyhap.characteristic import Characteristic
 from pyhap.const import (
@@ -144,6 +144,7 @@ class Outlet(HomeAccessory):
         self.async_call_service(SWITCH_DOMAIN, service, params)
 
     @callback
+    @override
     def async_update_state(self, new_state: State) -> None:
         """Update switch state after state changed."""
         current_state = new_state.state == STATE_ON
@@ -205,6 +206,7 @@ class Switch(HomeAccessory):
             async_call_later(self.hass, ACTIVATE_ONLY_RESET_SECONDS, self.reset_switch)
 
     @callback
+    @override
     def async_update_state(self, new_state: State) -> None:
         """Update switch state after state changed."""
         self.activate_only = self.is_activate(new_state)
@@ -223,6 +225,7 @@ class Switch(HomeAccessory):
 class Vacuum(Switch):
     """Generate a Switch accessory."""
 
+    @override
     def set_state(self, value: bool) -> None:
         """Move switch state to value if call came from HomeKit."""
         _LOGGER.debug("%s: Set switch state to %s", self.entity_id, value)
@@ -243,6 +246,7 @@ class Vacuum(Switch):
         )
 
     @callback
+    @override
     def async_update_state(self, new_state: State) -> None:
         """Update switch state after state changed."""
         current_state = new_state.state in (VacuumActivity.CLEANING, STATE_ON)
@@ -254,6 +258,7 @@ class Vacuum(Switch):
 class LawnMower(Switch):
     """Generate a Switch accessory."""
 
+    @override
     def set_state(self, value: bool) -> None:
         """Move switch state to value if call came from HomeKit."""
         _LOGGER.debug("%s: Set switch state to %s", self.entity_id, value)
@@ -266,6 +271,7 @@ class LawnMower(Switch):
         )
 
     @callback
+    @override
     def async_update_state(self, new_state: State) -> None:
         """Update switch state after state changed."""
         current_state = new_state.state in (LawnMowerActivity.MOWING, STATE_ON)
@@ -375,6 +381,7 @@ class ValveBase(HomeAccessory):
         self.async_call_service(self.domain, service, params)
 
     @callback
+    @override
     def async_update_state(self, new_state: State) -> None:
         """Update switch state after state changed."""
         current_state = 1 if new_state.state in self.open_states else 0
@@ -546,6 +553,7 @@ class SelectSwitch(HomeAccessory):
         self.async_call_service(self.domain, SERVICE_SELECT_OPTION, params)
 
     @callback
+    @override
     def async_update_state(self, new_state: State) -> None:
         """Update switch state after state changed."""
         current_option = cleanup_name_for_homekit(new_state.state)

--- a/homeassistant/components/homekit/type_thermostats.py
+++ b/homeassistant/components/homekit/type_thermostats.py
@@ -1,7 +1,7 @@
 """Class to hold all thermostat accessories."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyhap.const import CATEGORY_THERMOSTAT
 
@@ -620,6 +620,7 @@ class Thermostat(HomeAccessory):
         )
 
     @callback
+    @override
     def async_update_state(self, new_state: State) -> None:
         """Update state without rechecking the device features."""
         attributes = new_state.attributes
@@ -874,6 +875,7 @@ class WaterHeater(HomeAccessory):
         )
 
     @callback
+    @override
     def async_update_state(self, new_state: State) -> None:
         """Update water_heater state after state change."""
         # Update current and target temperature

--- a/homeassistant/components/homekit/type_triggers.py
+++ b/homeassistant/components/homekit/type_triggers.py
@@ -1,7 +1,7 @@
 """Class to hold all sensor accessories."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyhap.const import CATEGORY_SENSOR
 from pyhap.util import callback as pyhap_callback
@@ -108,6 +108,7 @@ class DeviceTriggerAccessory(HomeAccessory):
 
     @pyhap_callback  # type: ignore[untyped-decorator]
     @callback
+    @override
     def run(self) -> None:
         """Run the accessory."""
         # Triggers have not entities so we do not call super().run()
@@ -130,12 +131,14 @@ class DeviceTriggerAccessory(HomeAccessory):
         self.triggers[idx].set_value(0)
 
     @callback
+    @override
     def async_stop(self) -> None:
         """Handle accessory driver stop event."""
         self._remove_triggers_if_configured()
         super().async_stop()
 
     @property
+    @override
     def available(self) -> bool:
         """Return available."""
         return True

--- a/homeassistant/components/homekit_controller/alarm_control_panel.py
+++ b/homeassistant/components/homekit_controller/alarm_control_panel.py
@@ -1,6 +1,6 @@
 """Support for Homekit Alarm Control Panel."""
 
-from typing import Any
+from typing import Any, override
 
 from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.services import Service, ServicesTypes
@@ -69,6 +69,7 @@ class HomeKitAlarmControlPanelEntity(HomeKitEntity, AlarmControlPanelEntity):
     )
     _attr_code_arm_required = False
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity cares about."""
         return [
@@ -78,24 +79,29 @@ class HomeKitAlarmControlPanelEntity(HomeKitEntity, AlarmControlPanelEntity):
         ]
 
     @property
+    @override
     def alarm_state(self) -> AlarmControlPanelState:
         """Return the state of the device."""
         return CURRENT_STATE_MAP[
             self.service.value(CharacteristicsTypes.SECURITY_SYSTEM_STATE_CURRENT)
         ]
 
+    @override
     async def async_alarm_disarm(self, code: str | None = None) -> None:
         """Send disarm command."""
         await self.set_alarm_state(AlarmControlPanelState.DISARMED, code)
 
+    @override
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm command."""
         await self.set_alarm_state(AlarmControlPanelState.ARMED_AWAY, code)
 
+    @override
     async def async_alarm_arm_home(self, code: str | None = None) -> None:
         """Send stay command."""
         await self.set_alarm_state(AlarmControlPanelState.ARMED_HOME, code)
 
+    @override
     async def async_alarm_arm_night(self, code: str | None = None) -> None:
         """Send night command."""
         await self.set_alarm_state(AlarmControlPanelState.ARMED_NIGHT, code)
@@ -109,6 +115,7 @@ class HomeKitAlarmControlPanelEntity(HomeKitEntity, AlarmControlPanelEntity):
         )
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return the optional state attributes."""
         battery_level = self.service.value(CharacteristicsTypes.BATTERY_LEVEL)

--- a/homeassistant/components/homekit_controller/binary_sensor.py
+++ b/homeassistant/components/homekit_controller/binary_sensor.py
@@ -1,5 +1,7 @@
 """Support for Homekit motion sensors."""
 
+from typing import override
+
 from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.services import Service, ServicesTypes
 
@@ -22,11 +24,13 @@ class HomeKitMotionSensor(HomeKitEntity, BinarySensorEntity):
 
     _attr_device_class = BinarySensorDeviceClass.MOTION
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity is tracking."""
         return [CharacteristicsTypes.MOTION_DETECTED]
 
     @property
+    @override
     def is_on(self) -> bool:
         """Has motion been detected."""
         return self.service.value(CharacteristicsTypes.MOTION_DETECTED) is True
@@ -37,11 +41,13 @@ class HomeKitContactSensor(HomeKitEntity, BinarySensorEntity):
 
     _attr_device_class = BinarySensorDeviceClass.OPENING
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity is tracking."""
         return [CharacteristicsTypes.CONTACT_STATE]
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if the binary sensor is on/open."""
         return self.service.value(CharacteristicsTypes.CONTACT_STATE) == 1
@@ -52,11 +58,13 @@ class HomeKitSmokeSensor(HomeKitEntity, BinarySensorEntity):
 
     _attr_device_class = BinarySensorDeviceClass.SMOKE
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity is tracking."""
         return [CharacteristicsTypes.SMOKE_DETECTED]
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if smoke is currently detected."""
         return self.service.value(CharacteristicsTypes.SMOKE_DETECTED) == 1
@@ -67,11 +75,13 @@ class HomeKitCarbonMonoxideSensor(HomeKitEntity, BinarySensorEntity):
 
     _attr_device_class = BinarySensorDeviceClass.CO
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity is tracking."""
         return [CharacteristicsTypes.CARBON_MONOXIDE_DETECTED]
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if CO is currently detected."""
         return self.service.value(CharacteristicsTypes.CARBON_MONOXIDE_DETECTED) == 1
@@ -82,11 +92,13 @@ class HomeKitOccupancySensor(HomeKitEntity, BinarySensorEntity):
 
     _attr_device_class = BinarySensorDeviceClass.OCCUPANCY
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity is tracking."""
         return [CharacteristicsTypes.OCCUPANCY_DETECTED]
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if occupancy is currently detected."""
         return self.service.value(CharacteristicsTypes.OCCUPANCY_DETECTED) == 1
@@ -97,11 +109,13 @@ class HomeKitLeakSensor(HomeKitEntity, BinarySensorEntity):
 
     _attr_device_class = BinarySensorDeviceClass.MOISTURE
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity is tracking."""
         return [CharacteristicsTypes.LEAK_DETECTED]
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if a leak is detected from the binary sensor."""
         return self.service.value(CharacteristicsTypes.LEAK_DETECTED) == 1
@@ -113,11 +127,13 @@ class HomeKitBatteryLowSensor(HomeKitEntity, BinarySensorEntity):
     _attr_device_class = BinarySensorDeviceClass.BATTERY
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity is tracking."""
         return [CharacteristicsTypes.STATUS_LO_BATT]
 
     @property
+    @override
     def name(self) -> str:
         """Return the name of the sensor."""
         if name := self.accessory.name:
@@ -125,6 +141,7 @@ class HomeKitBatteryLowSensor(HomeKitEntity, BinarySensorEntity):
         return "Low Battery"
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if low battery is detected from the binary sensor."""
         return self.service.value(CharacteristicsTypes.STATUS_LO_BATT) == 1

--- a/homeassistant/components/homekit_controller/button.py
+++ b/homeassistant/components/homekit_controller/button.py
@@ -7,6 +7,7 @@ characteristics that don't map to a Home Assistant feature.
 from collections.abc import Callable
 from dataclasses import dataclass
 import logging
+from typing import override
 
 from aiohomekit.model.characteristics import Characteristic, CharacteristicsTypes
 
@@ -119,17 +120,20 @@ class HomeKitButton(BaseHomeKitButton):
         self.entity_description = description
         super().__init__(conn, info, char)
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity is tracking."""
         return [self._char.type]
 
     @property
+    @override
     def name(self) -> str:
         """Return the name of the device if any."""
         if name := self.accessory.name:
             return f"{name} {self.entity_description.name}"
         return f"{self.entity_description.name}"
 
+    @override
     async def async_press(self) -> None:
         """Press the button."""
         key = self.entity_description.key
@@ -140,11 +144,13 @@ class HomeKitButton(BaseHomeKitButton):
 class HomeKitEcobeeClearHoldButton(BaseHomeKitButton):
     """Representation of a Button control for Ecobee clear hold request."""
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity is tracking."""
         return []
 
     @property
+    @override
     def name(self) -> str:
         """Return the name of the device if any."""
         prefix = ""
@@ -152,6 +158,7 @@ class HomeKitEcobeeClearHoldButton(BaseHomeKitButton):
             prefix = name
         return f"{prefix} Clear Hold"
 
+    @override
     async def async_press(self) -> None:
         """Press the button."""
         key = self._char.type
@@ -171,11 +178,13 @@ class HomeKitProvisionPreferredThreadCredentials(BaseHomeKitButton):
 
     _attr_entity_category = EntityCategory.CONFIG
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity is tracking."""
         return []
 
     @property
+    @override
     def name(self) -> str:
         """Return the name of the device if any."""
         prefix = ""
@@ -183,6 +192,7 @@ class HomeKitProvisionPreferredThreadCredentials(BaseHomeKitButton):
             prefix = name
         return f"{prefix} Provision Preferred Thread Credentials"
 
+    @override
     async def async_press(self) -> None:
         """Press the button."""
         await self._accessory.async_thread_provision()

--- a/homeassistant/components/homekit_controller/camera.py
+++ b/homeassistant/components/homekit_controller/camera.py
@@ -1,5 +1,7 @@
 """Support for Homekit cameras."""
 
+from typing import override
+
 from aiohomekit.model import Accessory
 from aiohomekit.model.services import ServicesTypes
 
@@ -19,10 +21,12 @@ class HomeKitCamera(AccessoryEntity, Camera):
 
     # content_type = "image/jpeg"
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity is tracking."""
         return []
 
+    @override
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:

--- a/homeassistant/components/homekit_controller/climate.py
+++ b/homeassistant/components/homekit_controller/climate.py
@@ -1,7 +1,7 @@
 """Support for Homekit climate devices."""
 
 import logging
-from typing import Any, Final
+from typing import Any, Final, override
 
 from aiohomekit.model.characteristics import (
     ActivationStateValues,
@@ -136,11 +136,13 @@ class HomeKitBaseClimateEntity(HomeKitEntity, ClimateEntity):
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
 
     @callback
+    @override
     def _async_reconfigure(self) -> None:
         """Reconfigure entity."""
         self._async_clear_property_cache(("supported_features", "fan_modes"))
         super()._async_reconfigure()
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity cares about."""
         return [
@@ -149,11 +151,13 @@ class HomeKitBaseClimateEntity(HomeKitEntity, ClimateEntity):
         ]
 
     @property
+    @override
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
         return self.service.value(CharacteristicsTypes.TEMPERATURE_CURRENT)
 
     @cached_property
+    @override
     def fan_modes(self) -> list[str] | None:
         """Return the available fan modes."""
         if self.service.has(CharacteristicsTypes.FAN_STATE_TARGET):
@@ -161,11 +165,13 @@ class HomeKitBaseClimateEntity(HomeKitEntity, ClimateEntity):
         return None
 
     @property
+    @override
     def fan_mode(self) -> str | None:
         """Return the current fan mode."""
         fan_mode = self.service.value(CharacteristicsTypes.FAN_STATE_TARGET)
         return FAN_AUTO if fan_mode else FAN_ON
 
+    @override
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Turn fan to manual/auto."""
         await self.async_put_characteristics(
@@ -173,6 +179,7 @@ class HomeKitBaseClimateEntity(HomeKitEntity, ClimateEntity):
         )
 
     @cached_property
+    @override
     def supported_features(self) -> ClimateEntityFeature:
         """Return the list of supported features."""
         features = ClimateEntityFeature.TURN_OFF | ClimateEntityFeature.TURN_ON
@@ -187,11 +194,13 @@ class HomeKitHeaterCoolerEntity(HomeKitBaseClimateEntity):
     """Representation of a Homekit climate device."""
 
     @callback
+    @override
     def _async_reconfigure(self) -> None:
         """Reconfigure entity."""
         self._async_clear_property_cache(("hvac_modes", "swing_modes"))
         super()._async_reconfigure()
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity cares about."""
         return [
@@ -212,11 +221,13 @@ class HomeKitHeaterCoolerEntity(HomeKitBaseClimateEntity):
         )
 
     @cached_property
+    @override
     def fan_modes(self) -> list[str]:
         """Return the available fan modes."""
         return [FAN_OFF, FAN_LOW, FAN_MEDIUM, FAN_HIGH]
 
     @property
+    @override
     def fan_mode(self) -> str | None:
         """Return the current fan mode."""
         speed_range = self._get_rotation_speed_range()
@@ -232,6 +243,7 @@ class HomeKitHeaterCoolerEntity(HomeKitBaseClimateEntity):
             return FAN_LOW
         return FAN_OFF
 
+    @override
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""
         rotation = HASS_FAN_MODE_TO_HOMEKIT_ROTATION.get(fan_mode, 0)
@@ -241,6 +253,7 @@ class HomeKitHeaterCoolerEntity(HomeKitBaseClimateEntity):
             {CharacteristicsTypes.ROTATION_SPEED: speed}
         )
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         temp = kwargs.get(ATTR_TEMPERATURE)
@@ -265,6 +278,7 @@ class HomeKitHeaterCoolerEntity(HomeKitBaseClimateEntity):
                 hvac_mode,
             )
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target operation mode."""
         if hvac_mode == HVACMode.OFF:
@@ -292,6 +306,7 @@ class HomeKitHeaterCoolerEntity(HomeKitBaseClimateEntity):
         )
 
     @property
+    @override
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
         state = self.service.value(CharacteristicsTypes.TARGET_HEATER_COOLER_STATE)
@@ -306,6 +321,7 @@ class HomeKitHeaterCoolerEntity(HomeKitBaseClimateEntity):
         return None
 
     @property
+    @override
     def target_temperature_step(self) -> float:
         """Return the supported step of target temperature."""
         state = self.service.value(CharacteristicsTypes.TARGET_HEATER_COOLER_STATE)
@@ -326,6 +342,7 @@ class HomeKitHeaterCoolerEntity(HomeKitBaseClimateEntity):
         return DEFAULT_MIN_STEP
 
     @property
+    @override
     def min_temp(self) -> float:
         """Return the minimum target temp."""
         state = self.service.value(CharacteristicsTypes.TARGET_HEATER_COOLER_STATE)
@@ -350,6 +367,7 @@ class HomeKitHeaterCoolerEntity(HomeKitBaseClimateEntity):
         return super().min_temp
 
     @property
+    @override
     def max_temp(self) -> float:
         """Return the maximum target temp."""
         state = self.service.value(CharacteristicsTypes.TARGET_HEATER_COOLER_STATE)
@@ -374,6 +392,7 @@ class HomeKitHeaterCoolerEntity(HomeKitBaseClimateEntity):
         return super().max_temp
 
     @property
+    @override
     def hvac_action(self) -> HVACAction | None:
         """Return the current running hvac operation."""
         # This characteristic describes the current mode of a device,
@@ -388,6 +407,7 @@ class HomeKitHeaterCoolerEntity(HomeKitBaseClimateEntity):
         return CURRENT_HEATER_COOLER_STATE_HOMEKIT_TO_HASS.get(value)
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode:
         """Return hvac operation ie. heat, cool mode."""
         # This characteristic describes the target mode
@@ -403,6 +423,7 @@ class HomeKitHeaterCoolerEntity(HomeKitBaseClimateEntity):
         return TARGET_HEATER_COOLER_STATE_HOMEKIT_TO_HASS[value]
 
     @cached_property
+    @override
     def hvac_modes(self) -> list[HVACMode]:
         """Return the list of available hvac operation modes."""
         valid_values = clamp_enum_to_char(
@@ -416,6 +437,7 @@ class HomeKitHeaterCoolerEntity(HomeKitBaseClimateEntity):
         return modes
 
     @property
+    @override
     def swing_mode(self) -> str:
         """Return the swing setting.
 
@@ -425,6 +447,7 @@ class HomeKitHeaterCoolerEntity(HomeKitBaseClimateEntity):
         return SWING_MODE_HOMEKIT_TO_HASS[value]
 
     @cached_property
+    @override
     def swing_modes(self) -> list[str]:
         """Return the list of available swing modes.
 
@@ -436,6 +459,7 @@ class HomeKitHeaterCoolerEntity(HomeKitBaseClimateEntity):
         )
         return [SWING_MODE_HOMEKIT_TO_HASS[mode] for mode in valid_values]
 
+    @override
     async def async_set_swing_mode(self, swing_mode: str) -> None:
         """Set new target swing operation."""
         await self.async_put_characteristics(
@@ -443,6 +467,7 @@ class HomeKitHeaterCoolerEntity(HomeKitBaseClimateEntity):
         )
 
     @cached_property
+    @override
     def supported_features(self) -> ClimateEntityFeature:
         """Return the list of supported features."""
         features = super().supported_features
@@ -466,11 +491,13 @@ class HomeKitClimateEntity(HomeKitBaseClimateEntity):
     """Representation of a Homekit climate device."""
 
     @callback
+    @override
     def _async_reconfigure(self) -> None:
         """Reconfigure entity."""
         self._async_clear_property_cache(("hvac_modes",))
         super()._async_reconfigure()
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity cares about."""
         return [
@@ -485,6 +512,7 @@ class HomeKitClimateEntity(HomeKitBaseClimateEntity):
             CharacteristicsTypes.FAN_STATE_CURRENT,
         ]
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         chars: dict[str, Any] = {}
@@ -524,12 +552,14 @@ class HomeKitClimateEntity(HomeKitBaseClimateEntity):
 
         await self.async_put_characteristics(chars)
 
+    @override
     async def async_set_humidity(self, humidity: int) -> None:
         """Set new target humidity."""
         await self.async_put_characteristics(
             {CharacteristicsTypes.RELATIVE_HUMIDITY_TARGET: humidity}
         )
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target operation mode."""
         await self.async_put_characteristics(
@@ -541,6 +571,7 @@ class HomeKitClimateEntity(HomeKitBaseClimateEntity):
         )
 
     @property
+    @override
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
         value = self.service.value(CharacteristicsTypes.HEATING_COOLING_TARGET)
@@ -553,6 +584,7 @@ class HomeKitClimateEntity(HomeKitBaseClimateEntity):
         return None
 
     @property
+    @override
     def target_temperature_high(self) -> float | None:
         """Return the highbound target temperature we try to reach."""
         value = self.service.value(CharacteristicsTypes.HEATING_COOLING_TARGET)
@@ -565,6 +597,7 @@ class HomeKitClimateEntity(HomeKitBaseClimateEntity):
         return None
 
     @property
+    @override
     def target_temperature_low(self) -> float | None:
         """Return the lowbound target temperature we try to reach."""
         value = self.service.value(CharacteristicsTypes.HEATING_COOLING_TARGET)
@@ -577,6 +610,7 @@ class HomeKitClimateEntity(HomeKitBaseClimateEntity):
         return None
 
     @property
+    @override
     def min_temp(self) -> float:
         """Return the minimum target temp."""
         value = self.service.value(CharacteristicsTypes.HEATING_COOLING_TARGET)
@@ -599,6 +633,7 @@ class HomeKitClimateEntity(HomeKitBaseClimateEntity):
         return super().min_temp
 
     @property
+    @override
     def max_temp(self) -> float:
         """Return the maximum target temp."""
         value = self.service.value(CharacteristicsTypes.HEATING_COOLING_TARGET)
@@ -621,16 +656,19 @@ class HomeKitClimateEntity(HomeKitBaseClimateEntity):
         return super().max_temp
 
     @property
+    @override
     def current_humidity(self) -> int:
         """Return the current humidity."""
         return self.service.value(CharacteristicsTypes.RELATIVE_HUMIDITY_CURRENT)
 
     @property
+    @override
     def target_humidity(self) -> int:
         """Return the humidity we try to reach."""
         return self.service.value(CharacteristicsTypes.RELATIVE_HUMIDITY_TARGET)
 
     @property
+    @override
     def min_humidity(self) -> float:
         """Return the minimum humidity."""
         min_humidity = self.service[
@@ -641,6 +679,7 @@ class HomeKitClimateEntity(HomeKitBaseClimateEntity):
         return super().min_humidity
 
     @property
+    @override
     def max_humidity(self) -> float:
         """Return the maximum humidity."""
         max_humidity = self.service[
@@ -651,6 +690,7 @@ class HomeKitClimateEntity(HomeKitBaseClimateEntity):
         return super().max_humidity
 
     @property
+    @override
     def hvac_action(self) -> HVACAction | None:
         """Return the current running hvac operation."""
         # This characteristic describes the current mode of a device,
@@ -680,6 +720,7 @@ class HomeKitClimateEntity(HomeKitBaseClimateEntity):
         return current_hass_value
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode:
         """Return hvac operation ie. heat, cool mode."""
         # This characteristic describes the target mode
@@ -690,6 +731,7 @@ class HomeKitClimateEntity(HomeKitBaseClimateEntity):
         return MODE_HOMEKIT_TO_HASS[value]
 
     @cached_property
+    @override
     def hvac_modes(self) -> list[HVACMode]:
         """Return the list of available hvac operation modes."""
         valid_values = clamp_enum_to_char(
@@ -699,6 +741,7 @@ class HomeKitClimateEntity(HomeKitBaseClimateEntity):
         return [MODE_HOMEKIT_TO_HASS[mode] for mode in valid_values]
 
     @cached_property
+    @override
     def supported_features(self) -> ClimateEntityFeature:
         """Return the list of supported features."""
         features = super().supported_features

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -2,7 +2,7 @@
 
 import logging
 import re
-from typing import TYPE_CHECKING, Any, Self, cast
+from typing import TYPE_CHECKING, Any, Self, cast, override
 
 import aiohomekit
 from aiohomekit import Controller, const as aiohomekit_const
@@ -119,6 +119,7 @@ class HomekitControllerFlowHandler(ConfigFlow, domain=DOMAIN):
         """Create the controller."""
         self.controller = await async_get_controller(self.hass)
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -190,6 +191,7 @@ class HomekitControllerFlowHandler(ConfigFlow, domain=DOMAIN):
 
         return False
 
+    @override
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:
@@ -334,6 +336,7 @@ class HomekitControllerFlowHandler(ConfigFlow, domain=DOMAIN):
         # pairing code)
         return self._async_step_pair_show_form()
 
+    @override
     def is_matching(self, other_flow: Self) -> bool:
         """Return True if other_flow is matching this flow."""
         if other_flow.context.get("unique_id") == self.hkid and not other_flow.pairing:
@@ -346,6 +349,7 @@ class HomekitControllerFlowHandler(ConfigFlow, domain=DOMAIN):
                 return True
         return False
 
+    @override
     async def async_step_bluetooth(
         self, discovery_info: bluetooth.BluetoothServiceInfoBleak
     ) -> ConfigFlowResult:

--- a/homeassistant/components/homekit_controller/cover.py
+++ b/homeassistant/components/homekit_controller/cover.py
@@ -1,6 +1,6 @@
 """Support for Homekit covers."""
 
-from typing import Any
+from typing import Any, override
 
 from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.services import Service, ServicesTypes
@@ -76,6 +76,7 @@ class HomeKitGarageDoorCover(HomeKitEntity, CoverEntity):
     _attr_device_class = CoverDeviceClass.GARAGE
     _attr_supported_features = CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity cares about."""
         return [
@@ -91,24 +92,29 @@ class HomeKitGarageDoorCover(HomeKitEntity, CoverEntity):
         return CURRENT_GARAGE_STATE_MAP[value]
 
     @property
+    @override
     def is_closed(self) -> bool:
         """Return true if cover is closed, else False."""
         return self._state == CoverState.CLOSED
 
     @property
+    @override
     def is_closing(self) -> bool:
         """Return if the cover is closing or not."""
         return self._state == CoverState.CLOSING
 
     @property
+    @override
     def is_opening(self) -> bool:
         """Return if the cover is opening or not."""
         return self._state == CoverState.OPENING
 
+    @override
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Send open command."""
         await self.set_door_state(CoverState.OPEN)
 
+    @override
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Send close command."""
         await self.set_door_state(CoverState.CLOSED)
@@ -120,6 +126,7 @@ class HomeKitGarageDoorCover(HomeKitEntity, CoverEntity):
         )
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the optional state attributes."""
         obstruction_detected = self.service.value(
@@ -132,11 +139,13 @@ class HomeKitWindowCover(HomeKitEntity, CoverEntity):
     """Representation of a HomeKit Window or Window Covering."""
 
     @callback
+    @override
     def _async_reconfigure(self) -> None:
         """Reconfigure entity."""
         self._async_clear_property_cache(("supported_features",))
         super()._async_reconfigure()
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity cares about."""
         return [
@@ -152,6 +161,7 @@ class HomeKitWindowCover(HomeKitEntity, CoverEntity):
         ]
 
     @cached_property
+    @override
     def supported_features(self) -> CoverEntityFeature:
         """Flag supported features."""
         features = (
@@ -175,16 +185,19 @@ class HomeKitWindowCover(HomeKitEntity, CoverEntity):
         return features
 
     @property
+    @override
     def current_cover_position(self) -> int:
         """Return the current position of cover."""
         return self.service.value(CharacteristicsTypes.POSITION_CURRENT)
 
     @property
+    @override
     def is_closed(self) -> bool:
         """Return true if cover is closed, else False."""
         return self.current_cover_position == 0
 
     @property
+    @override
     def is_closing(self) -> bool:
         """Return if the cover is closing or not."""
         value = self.service.value(CharacteristicsTypes.POSITION_STATE)
@@ -192,6 +205,7 @@ class HomeKitWindowCover(HomeKitEntity, CoverEntity):
         return state == CoverState.CLOSING
 
     @property
+    @override
     def is_opening(self) -> bool:
         """Return if the cover is opening or not."""
         value = self.service.value(CharacteristicsTypes.POSITION_STATE)
@@ -213,6 +227,7 @@ class HomeKitWindowCover(HomeKitEntity, CoverEntity):
         )
 
     @property
+    @override
     def current_cover_tilt_position(self) -> int | None:
         """Return current position of cover tilt."""
         if self.is_vertical_tilt:
@@ -243,18 +258,22 @@ class HomeKitWindowCover(HomeKitEntity, CoverEntity):
         # normal scale
         return abs(int(100 / total_range * (tilt_position - min_value)))
 
+    @override
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Send hold command."""
         await self.async_put_characteristics({CharacteristicsTypes.POSITION_HOLD: 1})
 
+    @override
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Send open command."""
         await self.async_set_cover_position(position=100)
 
+    @override
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Send close command."""
         await self.async_set_cover_position(position=0)
 
+    @override
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Send position command."""
         position = kwargs[ATTR_POSITION]
@@ -262,6 +281,7 @@ class HomeKitWindowCover(HomeKitEntity, CoverEntity):
             {CharacteristicsTypes.POSITION_TARGET: position}
         )
 
+    @override
     async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
         """Move the cover tilt to a specific position."""
         tilt_position = kwargs[ATTR_TILT_POSITION]
@@ -293,6 +313,7 @@ class HomeKitWindowCover(HomeKitEntity, CoverEntity):
         await self.async_put_characteristics({char.type: tilt_position})
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the optional state attributes."""
         obstruction_detected = self.service.value(

--- a/homeassistant/components/homekit_controller/entity.py
+++ b/homeassistant/components/homekit_controller/entity.py
@@ -1,6 +1,6 @@
 """Homekit Controller entities."""
 
-from typing import Any
+from typing import Any, override
 
 from aiohomekit.model.characteristics import (
     EVENT_CHARACTERISTICS,
@@ -87,6 +87,7 @@ class HomeKitEntity(Entity):
         self._async_subscribe_chars()
         self.async_write_ha_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Entity added to hass."""
         self._async_subscribe_chars()
@@ -97,6 +98,7 @@ class HomeKitEntity(Entity):
             self._accessory.async_subscribe_availability(self._async_write_ha_state)
         )
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Prepare to be removed from hass."""
         self._async_unsubscribe_chars()
@@ -206,6 +208,7 @@ class HomeKitEntity(Entity):
         return None
 
     @property
+    @override
     def name(self) -> str | None:
         """Return the name of the device if any."""
         accessory_name = self.accessory.name
@@ -226,6 +229,7 @@ class HomeKitEntity(Entity):
         return accessory_name
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available."""
         all_iids = self.all_iids
@@ -235,6 +239,7 @@ class HomeKitEntity(Entity):
         return self._accessory.available
 
     @property
+    @override
     def device_info(self) -> DeviceInfo:
         """Return the device info."""
         return self._accessory.device_info_for_accessory(self.accessory)
@@ -257,6 +262,7 @@ class AccessoryEntity(HomeKitEntity):
         self._attr_unique_id = f"{accessory.unique_id}_{self._aid}"
 
     @property
+    @override
     def old_unique_id(self) -> str:
         """Return the old ID of this device."""
         serial = self.accessory_info.value(CharacteristicsTypes.SERIAL_NUMBER)
@@ -292,6 +298,7 @@ class BaseCharacteristicEntity(HomeKitEntity):
         return False
 
     @callback
+    @override
     def _async_config_changed(self) -> None:
         """Handle accessory discovery changes."""
         if (
@@ -319,6 +326,7 @@ class CharacteristicEntity(BaseCharacteristicEntity):
         )
 
     @property
+    @override
     def old_unique_id(self) -> str:
         """Return the old ID of this device."""
         serial = self.accessory_info.value(CharacteristicsTypes.SERIAL_NUMBER)

--- a/homeassistant/components/homekit_controller/event.py
+++ b/homeassistant/components/homekit_controller/event.py
@@ -1,5 +1,7 @@
 """Support for Homekit motion sensors."""
 
+from typing import override
+
 from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.characteristics.const import InputEventValues
 from aiohomekit.model.services import Service, ServicesTypes
@@ -56,10 +58,12 @@ class HomeKitEventEntity(BaseCharacteristicEntity, EventEntity):
             for v in clamp_enum_to_char(InputEventValues, self._char)
         ]
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity cares about."""
         return [CharacteristicsTypes.INPUT_EVENT]
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Entity added to hass."""
         await super().async_added_to_hass()

--- a/homeassistant/components/homekit_controller/fan.py
+++ b/homeassistant/components/homekit_controller/fan.py
@@ -1,6 +1,6 @@
 """Support for Homekit fans."""
 
-from typing import Any
+from typing import Any, override
 
 from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.characteristics.const import (
@@ -51,6 +51,7 @@ class BaseHomeKitFan(HomeKitEntity, FanEntity):
     preset_automatic_value: int = TargetFanStateValues.AUTOMATIC
 
     @callback
+    @override
     def _async_reconfigure(self) -> None:
         """Reconfigure entity."""
         self._async_clear_property_cache(
@@ -65,6 +66,7 @@ class BaseHomeKitFan(HomeKitEntity, FanEntity):
         )
         super()._async_reconfigure()
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity cares about."""
         types = [
@@ -78,6 +80,7 @@ class BaseHomeKitFan(HomeKitEntity, FanEntity):
         return types
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if device is on."""
         return self.service.value(self.on_characteristic) == 1
@@ -100,6 +103,7 @@ class BaseHomeKitFan(HomeKitEntity, FanEntity):
         return round(self.service[CharacteristicsTypes.ROTATION_SPEED].maxValue or 100)
 
     @property
+    @override
     def percentage(self) -> int:
         """Return the current speed percentage."""
         if not self.is_on:
@@ -110,18 +114,21 @@ class BaseHomeKitFan(HomeKitEntity, FanEntity):
         )
 
     @property
+    @override
     def current_direction(self) -> str:
         """Return the current direction of the fan."""
         direction = self.service.value(CharacteristicsTypes.ROTATION_DIRECTION)
         return HK_DIRECTION_TO_HA[direction]
 
     @property
+    @override
     def oscillating(self) -> bool:
         """Return whether or not the fan is currently oscillating."""
         oscillating = self.service.value(CharacteristicsTypes.SWING_MODE)
         return oscillating == 1
 
     @cached_property
+    @override
     def supported_features(self) -> FanEntityFeature:
         """Flag supported features."""
         features = FanEntityFeature.TURN_OFF | FanEntityFeature.TURN_ON
@@ -141,6 +148,7 @@ class BaseHomeKitFan(HomeKitEntity, FanEntity):
         return features
 
     @cached_property
+    @override
     def speed_count(self) -> int:
         """Speed count for the fan."""
         return round(
@@ -149,11 +157,13 @@ class BaseHomeKitFan(HomeKitEntity, FanEntity):
         )
 
     @cached_property
+    @override
     def preset_modes(self) -> list[str]:
         """Return the preset modes."""
         return [PRESET_AUTO] if self.service.has(self.preset_char) else []
 
     @property
+    @override
     def preset_mode(self) -> str | None:
         """Return the current preset mode."""
         if (
@@ -163,6 +173,7 @@ class BaseHomeKitFan(HomeKitEntity, FanEntity):
             return PRESET_AUTO
         return None
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode of the fan."""
         if self.service.has(self.preset_char):
@@ -174,12 +185,14 @@ class BaseHomeKitFan(HomeKitEntity, FanEntity):
                 }
             )
 
+    @override
     async def async_set_direction(self, direction: str) -> None:
         """Set the direction of the fan."""
         await self.async_put_characteristics(
             {CharacteristicsTypes.ROTATION_DIRECTION: DIRECTION_TO_HK[direction]}
         )
 
+    @override
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed of the fan."""
         if percentage == 0:
@@ -197,12 +210,14 @@ class BaseHomeKitFan(HomeKitEntity, FanEntity):
 
         await self.async_put_characteristics(characteristics)
 
+    @override
     async def async_oscillate(self, oscillating: bool) -> None:
         """Oscillate the fan."""
         await self.async_put_characteristics(
             {CharacteristicsTypes.SWING_MODE: 1 if oscillating else 0}
         )
 
+    @override
     async def async_turn_on(
         self,
         percentage: int | None = None,
@@ -230,6 +245,7 @@ class BaseHomeKitFan(HomeKitEntity, FanEntity):
         if characteristics:
             await self.async_put_characteristics(characteristics)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the specified fan off."""
         await self.async_put_characteristics({self.on_characteristic: False})

--- a/homeassistant/components/homekit_controller/humidifier.py
+++ b/homeassistant/components/homekit_controller/humidifier.py
@@ -1,6 +1,6 @@
 """Support for HomeKit Controller humidifier."""
 
-from typing import Any
+from typing import Any, override
 
 from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.services import Service, ServicesTypes
@@ -48,17 +48,20 @@ class HomeKitBaseHumidifier(HomeKitEntity, HumidifierEntity):
     _on_mode_value = 1
 
     @callback
+    @override
     def _async_reconfigure(self) -> None:
         """Reconfigure entity."""
         self._async_clear_property_cache(("max_humidity", "min_humidity"))
         super()._async_reconfigure()
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if device is on."""
         return self.service.value(CharacteristicsTypes.ACTIVE)
 
     @property
+    @override
     def mode(self) -> str | None:
         """Return the current mode, e.g., home, auto, baby.
 
@@ -70,37 +73,45 @@ class HomeKitBaseHumidifier(HomeKitEntity, HumidifierEntity):
         return MODE_AUTO if mode == 1 else MODE_NORMAL
 
     @property
+    @override
     def current_humidity(self) -> int | None:
         """Return the current humidity."""
         return self.service.value(CharacteristicsTypes.RELATIVE_HUMIDITY_CURRENT)
 
     @property
+    @override
     def target_humidity(self) -> int | None:
         """Return the humidity we try to reach."""
         return self.service.value(self._humidity_char)
 
     @cached_property
+    @override
     def min_humidity(self) -> int:
         """Return the minimum humidity."""
         return int(self.service[self._humidity_char].minValue or DEFAULT_MIN_HUMIDITY)
 
     @cached_property
+    @override
     def max_humidity(self) -> int:
         """Return the maximum humidity."""
         return int(self.service[self._humidity_char].maxValue or DEFAULT_MAX_HUMIDITY)
 
+    @override
     async def async_set_humidity(self, humidity: int) -> None:
         """Set new target humidity."""
         await self.async_put_characteristics({self._humidity_char: humidity})
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the specified valve on."""
         await self.async_put_characteristics({CharacteristicsTypes.ACTIVE: True})
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the specified valve off."""
         await self.async_put_characteristics({CharacteristicsTypes.ACTIVE: False})
 
+    @override
     async def async_set_mode(self, mode: str) -> None:
         """Set new mode."""
         if mode == MODE_AUTO:
@@ -120,6 +131,7 @@ class HomeKitBaseHumidifier(HomeKitEntity, HumidifierEntity):
                 }
             )
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity cares about."""
         return [
@@ -148,6 +160,7 @@ class HomeKitDehumidifier(HomeKitBaseHumidifier):
         super().__init__(accessory, devinfo)
         self._attr_unique_id = f"{accessory.unique_id}_{self._iid}_{self.device_class}"
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity cares about."""
         return [
@@ -156,6 +169,7 @@ class HomeKitDehumidifier(HomeKitBaseHumidifier):
         ]
 
     @property
+    @override
     def old_unique_id(self) -> str:
         """Return the old ID of this device."""
         serial = self.accessory_info.value(CharacteristicsTypes.SERIAL_NUMBER)

--- a/homeassistant/components/homekit_controller/light.py
+++ b/homeassistant/components/homekit_controller/light.py
@@ -1,6 +1,6 @@
 """Support for Homekit lights."""
 
-from typing import Any
+from typing import Any, override
 
 from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.services import Service, ServicesTypes
@@ -57,6 +57,7 @@ class HomeKitLight(HomeKitEntity, LightEntity):
     _attr_min_color_temp_kelvin = DEFAULT_MIN_KELVIN
 
     @callback
+    @override
     def _async_reconfigure(self) -> None:
         """Reconfigure entity."""
         self._async_clear_property_cache(
@@ -69,6 +70,7 @@ class HomeKitLight(HomeKitEntity, LightEntity):
         )
         super()._async_reconfigure()
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity cares about."""
         return [
@@ -80,16 +82,19 @@ class HomeKitLight(HomeKitEntity, LightEntity):
         ]
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if device is on."""
         return self.service.value(CharacteristicsTypes.ON)
 
     @property
+    @override
     def brightness(self) -> int:
         """Return the brightness of this light between 0..255."""
         return self.service.value(CharacteristicsTypes.BRIGHTNESS) * 255 / 100
 
     @property
+    @override
     def hs_color(self) -> tuple[float, float]:
         """Return the color property."""
         return (
@@ -98,6 +103,7 @@ class HomeKitLight(HomeKitEntity, LightEntity):
         )
 
     @cached_property
+    @override
     def max_color_temp_kelvin(self) -> int:
         """Return the coldest color_temp_kelvin that this light supports."""
         if not self.service.has(CharacteristicsTypes.COLOR_TEMPERATURE):
@@ -110,6 +116,7 @@ class HomeKitLight(HomeKitEntity, LightEntity):
         )
 
     @cached_property
+    @override
     def min_color_temp_kelvin(self) -> int:
         """Return the warmest color_temp_kelvin that this light supports."""
         if not self.service.has(CharacteristicsTypes.COLOR_TEMPERATURE):
@@ -122,6 +129,7 @@ class HomeKitLight(HomeKitEntity, LightEntity):
         )
 
     @property
+    @override
     def color_temp_kelvin(self) -> int:
         """Return the color temperature value in Kelvin."""
         return color_util.color_temperature_mired_to_kelvin(
@@ -129,6 +137,7 @@ class HomeKitLight(HomeKitEntity, LightEntity):
         )
 
     @property
+    @override
     def color_mode(self) -> ColorMode:
         """Return the color mode of the light."""
         # aiohomekit does not keep track of the light's color mode, report
@@ -147,6 +156,7 @@ class HomeKitLight(HomeKitEntity, LightEntity):
         return ColorMode.ONOFF
 
     @cached_property
+    @override
     def supported_color_modes(self) -> set[ColorMode]:
         """Flag supported color modes."""
         color_modes: set[ColorMode] = set()
@@ -168,6 +178,7 @@ class HomeKitLight(HomeKitEntity, LightEntity):
 
         return color_modes
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the specified light on."""
         hs_color = kwargs.get(ATTR_HS_COLOR)
@@ -208,6 +219,7 @@ class HomeKitLight(HomeKitEntity, LightEntity):
 
         await self.async_put_characteristics(characteristics)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the specified light off."""
         await self.async_put_characteristics({CharacteristicsTypes.ON: False})

--- a/homeassistant/components/homekit_controller/lock.py
+++ b/homeassistant/components/homekit_controller/lock.py
@@ -1,6 +1,6 @@
 """Support for HomeKit Controller locks."""
 
-from typing import Any
+from typing import Any, override
 
 from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.services import Service, ServicesTypes
@@ -54,6 +54,7 @@ async def async_setup_entry(
 class HomeKitLock(HomeKitEntity, LockEntity):
     """Representation of a HomeKit Controller Lock."""
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity cares about."""
         return [
@@ -63,6 +64,7 @@ class HomeKitLock(HomeKitEntity, LockEntity):
         ]
 
     @property
+    @override
     def is_locked(self) -> bool | None:
         """Return true if device is locked."""
         value = self.service.value(CharacteristicsTypes.LOCK_MECHANISM_CURRENT_STATE)
@@ -71,6 +73,7 @@ class HomeKitLock(HomeKitEntity, LockEntity):
         return CURRENT_STATE_MAP[value] == LockState.LOCKED
 
     @property
+    @override
     def is_locking(self) -> bool:
         """Return true if device is locking."""
         current_value = self.service.value(
@@ -85,6 +88,7 @@ class HomeKitLock(HomeKitEntity, LockEntity):
         )
 
     @property
+    @override
     def is_unlocking(self) -> bool:
         """Return true if device is unlocking."""
         current_value = self.service.value(
@@ -99,15 +103,18 @@ class HomeKitLock(HomeKitEntity, LockEntity):
         )
 
     @property
+    @override
     def is_jammed(self) -> bool:
         """Return true if device is jammed."""
         value = self.service.value(CharacteristicsTypes.LOCK_MECHANISM_CURRENT_STATE)
         return CURRENT_STATE_MAP[value] == LockState.JAMMED
 
+    @override
     async def async_lock(self, **kwargs: Any) -> None:
         """Lock the device."""
         await self._set_lock_state(LockState.LOCKED)
 
+    @override
     async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock the device."""
         await self._set_lock_state(LockState.UNLOCKED)
@@ -123,6 +130,7 @@ class HomeKitLock(HomeKitEntity, LockEntity):
         await self._accessory.async_request_update()
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the optional state attributes."""
         attributes = {}

--- a/homeassistant/components/homekit_controller/media_player.py
+++ b/homeassistant/components/homekit_controller/media_player.py
@@ -1,6 +1,7 @@
 """Support for HomeKit Controller Televisions."""
 
 import logging
+from typing import override
 
 from aiohomekit.model.characteristics import (
     CharacteristicsTypes,
@@ -65,6 +66,7 @@ class HomeKitTelevision(HomeKitEntity, MediaPlayerEntity):
 
     _attr_device_class = MediaPlayerDeviceClass.TV
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity cares about."""
         return [
@@ -79,6 +81,7 @@ class HomeKitTelevision(HomeKitEntity, MediaPlayerEntity):
         ]
 
     @property
+    @override
     def supported_features(self) -> MediaPlayerEntityFeature:
         """Flag media player features that are supported."""
         features = MediaPlayerEntityFeature.TURN_OFF | MediaPlayerEntityFeature.TURN_ON
@@ -126,6 +129,7 @@ class HomeKitTelevision(HomeKitEntity, MediaPlayerEntity):
         )
 
     @property
+    @override
     def source_list(self) -> list[str]:
         """List of all input sources for this television."""
         sources = []
@@ -144,6 +148,7 @@ class HomeKitTelevision(HomeKitEntity, MediaPlayerEntity):
         return sources
 
     @property
+    @override
     def source(self) -> str | None:
         """Name of the current input source."""
         active_identifier = self.service.value(CharacteristicsTypes.ACTIVE_IDENTIFIER)
@@ -163,6 +168,7 @@ class HomeKitTelevision(HomeKitEntity, MediaPlayerEntity):
         return char.value
 
     @property
+    @override
     def state(self) -> MediaPlayerState:
         """State of the tv."""
         active = self.service.value(CharacteristicsTypes.ACTIVE)
@@ -175,14 +181,17 @@ class HomeKitTelevision(HomeKitEntity, MediaPlayerEntity):
 
         return MediaPlayerState.ON
 
+    @override
     async def async_turn_on(self) -> None:
         """Turn the tv on."""
         await self.async_put_characteristics({CharacteristicsTypes.ACTIVE: 1})
 
+    @override
     async def async_turn_off(self) -> None:
         """Turn the tv off."""
         await self.async_put_characteristics({CharacteristicsTypes.ACTIVE: 0})
 
+    @override
     async def async_media_play(self) -> None:
         """Send play command."""
         if self.state == MediaPlayerState.PLAYING:
@@ -198,6 +207,7 @@ class HomeKitTelevision(HomeKitEntity, MediaPlayerEntity):
                 {CharacteristicsTypes.REMOTE_KEY: RemoteKeyValues.PLAY_PAUSE}
             )
 
+    @override
     async def async_media_pause(self) -> None:
         """Send pause command."""
         if self.state == MediaPlayerState.PAUSED:
@@ -213,6 +223,7 @@ class HomeKitTelevision(HomeKitEntity, MediaPlayerEntity):
                 {CharacteristicsTypes.REMOTE_KEY: RemoteKeyValues.PLAY_PAUSE}
             )
 
+    @override
     async def async_media_stop(self) -> None:
         """Send stop command."""
         if self.state == MediaPlayerState.IDLE:
@@ -224,6 +235,7 @@ class HomeKitTelevision(HomeKitEntity, MediaPlayerEntity):
                 {CharacteristicsTypes.TARGET_MEDIA_STATE: TargetMediaStateValues.STOP}
             )
 
+    @override
     async def async_select_source(self, source: str) -> None:
         """Switch to a different media source."""
         this_accessory = self._accessory.entity_map.aid(self._aid)

--- a/homeassistant/components/homekit_controller/number.py
+++ b/homeassistant/components/homekit_controller/number.py
@@ -4,6 +4,8 @@ These are mostly used where a HomeKit accessory exposes additional non-standard
 characteristics that don't map to a Home Assistant feature.
 """
 
+from typing import override
+
 from aiohomekit.model.characteristics import Characteristic, CharacteristicsTypes
 
 from homeassistant.components.number import (
@@ -110,36 +112,43 @@ class HomeKitNumber(CharacteristicEntity, NumberEntity):
         super().__init__(conn, info, char)
 
     @property
+    @override
     def name(self) -> str:
         """Return the name of the device if any."""
         if name := self.accessory.name:
             return f"{name} {self.entity_description.name}"
         return f"{self.entity_description.name}"
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity is tracking."""
         return [self._char.type]
 
     @property
+    @override
     def native_min_value(self) -> float:
         """Return the minimum value."""
         return self._char.minValue or DEFAULT_MIN_VALUE
 
     @property
+    @override
     def native_max_value(self) -> float:
         """Return the maximum value."""
         return self._char.maxValue or DEFAULT_MAX_VALUE
 
     @property
+    @override
     def native_step(self) -> float:
         """Return the increment/decrement step."""
         return self._char.minStep or DEFAULT_STEP
 
     @property
+    @override
     def native_value(self) -> float:
         """Return the current characteristic value."""
         return self._char.value
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Set the characteristic to this value."""
         await self.async_put_characteristics(

--- a/homeassistant/components/homekit_controller/select.py
+++ b/homeassistant/components/homekit_controller/select.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 from enum import IntEnum
+from typing import override
 
 from aiohomekit.model.characteristics import Characteristic, CharacteristicsTypes
 from aiohomekit.model.characteristics.const import (
@@ -88,11 +89,13 @@ class HomeKitSelect(BaseHomeKitSelect):
 
         super().__init__(conn, info, char)
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity cares about."""
         return [self._char.type]
 
     @property
+    @override
     def name(self) -> str | None:
         """Return the name of the device if any."""
         if name := self.accessory.name:
@@ -100,10 +103,12 @@ class HomeKitSelect(BaseHomeKitSelect):
         return self.entity_description.name
 
     @property
+    @override
     def current_option(self) -> str | None:
         """Return the current selected option."""
         return self._enum_to_choice.get(self._char.value)
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Set the current option."""
         await self.async_put_characteristics(
@@ -118,12 +123,14 @@ class EcobeeModeSelect(BaseHomeKitSelect):
     _attr_translation_key = "ecobee_mode"
 
     @property
+    @override
     def name(self) -> str:
         """Return the name of the device if any."""
         if name := super().name:
             return f"{name} Current Mode"
         return "Current Mode"
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity cares about."""
         return [
@@ -131,10 +138,12 @@ class EcobeeModeSelect(BaseHomeKitSelect):
         ]
 
     @property
+    @override
     def current_option(self) -> str | None:
         """Return the current selected option."""
         return _ECOBEE_MODE_TO_TEXT.get(self._char.value)
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Set the current mode."""
         option_int = _ECOBEE_MODE_TO_NUMBERS[option]

--- a/homeassistant/components/homekit_controller/sensor.py
+++ b/homeassistant/components/homekit_controller/sensor.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import IntEnum
+from typing import override
 
 from aiohomekit.model import Accessory, Transport
 from aiohomekit.model.characteristics import Characteristic, CharacteristicsTypes
@@ -390,6 +391,7 @@ class HomeKitSensor(HomeKitEntity, SensorEntity):
     _attr_state_class = SensorStateClass.MEASUREMENT
 
     @property
+    @override
     def name(self) -> str | None:
         """Return the name of the device."""
         full_name = super().name
@@ -409,16 +411,19 @@ class HomeKitHumiditySensor(HomeKitSensor):
     _attr_device_class = SensorDeviceClass.HUMIDITY
     _attr_native_unit_of_measurement = PERCENTAGE
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity is tracking."""
         return [CharacteristicsTypes.RELATIVE_HUMIDITY_CURRENT]
 
     @property
+    @override
     def default_name(self) -> str:
         """Return the default name of the device."""
         return "Humidity"
 
     @property
+    @override
     def native_value(self) -> float:
         """Return the current humidity."""
         return self.service.value(CharacteristicsTypes.RELATIVE_HUMIDITY_CURRENT)
@@ -430,16 +435,19 @@ class HomeKitTemperatureSensor(HomeKitSensor):
     _attr_device_class = SensorDeviceClass.TEMPERATURE
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity is tracking."""
         return [CharacteristicsTypes.TEMPERATURE_CURRENT]
 
     @property
+    @override
     def default_name(self) -> str:
         """Return the default name of the device."""
         return "Temperature"
 
     @property
+    @override
     def native_value(self) -> float:
         """Return the current temperature in Celsius."""
         return self.service.value(CharacteristicsTypes.TEMPERATURE_CURRENT)
@@ -451,16 +459,19 @@ class HomeKitLightSensor(HomeKitSensor):
     _attr_device_class = SensorDeviceClass.ILLUMINANCE
     _attr_native_unit_of_measurement = LIGHT_LUX
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity is tracking."""
         return [CharacteristicsTypes.LIGHT_LEVEL_CURRENT]
 
     @property
+    @override
     def default_name(self) -> str:
         """Return the default name of the device."""
         return "Light Level"
 
     @property
+    @override
     def native_value(self) -> int:
         """Return the current light level in lux."""
         return self.service.value(CharacteristicsTypes.LIGHT_LEVEL_CURRENT)
@@ -472,16 +483,19 @@ class HomeKitCarbonDioxideSensor(HomeKitSensor):
     _attr_device_class = SensorDeviceClass.CO2
     _attr_native_unit_of_measurement = CONCENTRATION_PARTS_PER_MILLION
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity is tracking."""
         return [CharacteristicsTypes.CARBON_DIOXIDE_LEVEL]
 
     @property
+    @override
     def default_name(self) -> str:
         """Return the default name of the device."""
         return "Carbon Dioxide"
 
     @property
+    @override
     def native_value(self) -> int:
         """Return the current CO2 level in ppm."""
         return self.service.value(CharacteristicsTypes.CARBON_DIOXIDE_LEVEL)
@@ -494,6 +508,7 @@ class HomeKitBatterySensor(HomeKitSensor):
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity is tracking."""
         return [
@@ -503,11 +518,13 @@ class HomeKitBatterySensor(HomeKitSensor):
         ]
 
     @property
+    @override
     def default_name(self) -> str:
         """Return the default name of the device."""
         return "Battery"
 
     @property
+    @override
     def icon(self) -> str:
         """Return the sensor icon."""
         native_value = self.native_value
@@ -545,6 +562,7 @@ class HomeKitBatterySensor(HomeKitSensor):
         return self.service.value(CharacteristicsTypes.CHARGING_STATE) == 1
 
     @property
+    @override
     def native_value(self) -> int:
         """Return the current battery level percentage."""
         return self.service.value(CharacteristicsTypes.BATTERY_LEVEL)
@@ -575,11 +593,13 @@ class SimpleSensor(CharacteristicEntity, SensorEntity):
             self._attr_options = list(self.entity_description.enum.values())
         super().__init__(conn, info, char)
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity is tracking."""
         return [self._char.type]
 
     @property
+    @override
     def name(self) -> str:
         """Return the name of the device if any."""
         if name := self.accessory.name:
@@ -587,6 +607,7 @@ class SimpleSensor(CharacteristicEntity, SensorEntity):
         return f"{self.entity_description.name}"
 
     @property
+    @override
     def native_value(self) -> str | int | float:
         """Return the current sensor value."""
         if self.entity_description.enum:
@@ -625,28 +646,33 @@ class RSSISensor(HomeKitEntity, SensorEntity):
         super().__init__(accessory, devinfo)
         self._attr_unique_id = f"{accessory.unique_id}_rssi"
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity cares about."""
         return []
 
     @property
+    @override
     def available(self) -> bool:
         """Return if the bluetooth device is available."""
         address = self._accessory.pairing_data["AccessoryAddress"]
         return async_ble_device_from_address(self.hass, address) is not None
 
     @property
+    @override
     def name(self) -> str:
         """Return the name of the sensor."""
         return "Signal strength"
 
     @property
+    @override
     def old_unique_id(self) -> str:
         """Return the old ID of this device."""
         serial = self.accessory_info.value(CharacteristicsTypes.SERIAL_NUMBER)
         return f"homekit-{serial}-rssi"
 
     @property
+    @override
     def native_value(self) -> int | None:
         """Return the current rssi value."""
         address = self._accessory.pairing_data["AccessoryAddress"]

--- a/homeassistant/components/homekit_controller/switch.py
+++ b/homeassistant/components/homekit_controller/switch.py
@@ -1,7 +1,7 @@
 """Support for Homekit switches."""
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from aiohomekit.model.characteristics import (
     Characteristic,
@@ -82,24 +82,29 @@ SWITCH_ENTITIES: dict[str, DeclarativeSwitchEntityDescription] = {
 class HomeKitSwitch(HomeKitEntity, SwitchEntity):
     """Representation of a Homekit switch."""
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity cares about."""
         return [CharacteristicsTypes.ON, CharacteristicsTypes.OUTLET_IN_USE]
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if device is on."""
         return self.service.value(CharacteristicsTypes.ON)
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the specified switch on."""
         await self.async_put_characteristics({CharacteristicsTypes.ON: True})
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the specified switch off."""
         await self.async_put_characteristics({CharacteristicsTypes.ON: False})
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return the optional state attributes."""
         outlet_in_use = self.service.value(CharacteristicsTypes.OUTLET_IN_USE)
@@ -111,19 +116,23 @@ class HomeKitSwitch(HomeKitEntity, SwitchEntity):
 class HomeKitFaucet(HomeKitEntity, SwitchEntity):
     """Representation of a Homekit faucet."""
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity cares about."""
         return [CharacteristicsTypes.ACTIVE]
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if device is on."""
         return self.service.value(CharacteristicsTypes.ACTIVE)
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the specified faucet on."""
         await self.async_put_characteristics({CharacteristicsTypes.ACTIVE: True})
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the specified faucet off."""
         await self.async_put_characteristics({CharacteristicsTypes.ACTIVE: False})
@@ -134,6 +143,7 @@ class HomeKitValve(HomeKitEntity, SwitchEntity):
 
     _attr_translation_key = "valve"
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity cares about."""
         return [
@@ -143,20 +153,24 @@ class HomeKitValve(HomeKitEntity, SwitchEntity):
             CharacteristicsTypes.REMAINING_DURATION,
         ]
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the specified valve on."""
         await self.async_put_characteristics({CharacteristicsTypes.ACTIVE: True})
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the specified valve off."""
         await self.async_put_characteristics({CharacteristicsTypes.ACTIVE: False})
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if device is on."""
         return self.service.value(CharacteristicsTypes.ACTIVE)
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the optional state attributes."""
         attrs = {}
@@ -191,27 +205,32 @@ class DeclarativeCharacteristicSwitch(CharacteristicEntity, SwitchEntity):
         super().__init__(conn, info, char)
 
     @property
+    @override
     def name(self) -> str:
         """Return the name of the device if any."""
         if name := self.accessory.name:
             return f"{name} {self.entity_description.name}"
         return f"{self.entity_description.name}"
 
+    @override
     def get_characteristic_types(self) -> list[str]:
         """Define the homekit characteristics the entity cares about."""
         return [self._char.type]
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if device is on."""
         return self._char.value == self.entity_description.true_value
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the specified switch on."""
         await self.async_put_characteristics(
             {self._char.type: self.entity_description.true_value}
         )
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the specified switch off."""
         await self.async_put_characteristics(

--- a/homeassistant/components/homematic/binary_sensor.py
+++ b/homeassistant/components/homematic/binary_sensor.py
@@ -1,5 +1,7 @@
 """Support for HomeMatic binary sensors."""
 
+from typing import override
+
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
@@ -57,6 +59,7 @@ class HMBinarySensor(HMDevice, BinarySensorEntity):
     """Representation of a binary HomeMatic device."""
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if switch is on."""
         if not self.available:
@@ -64,6 +67,7 @@ class HMBinarySensor(HMDevice, BinarySensorEntity):
         return bool(self._hm_get_state())
 
     @property
+    @override
     def device_class(self) -> BinarySensorDeviceClass | None:
         """Return the class of this sensor from DEVICE_CLASSES."""
         # If state is MOTION (Only RemoteMotion working)
@@ -71,6 +75,7 @@ class HMBinarySensor(HMDevice, BinarySensorEntity):
             return BinarySensorDeviceClass.MOTION
         return SENSOR_TYPES_CLASS.get(self._hmdevice.__class__.__name__)
 
+    @override
     def _init_data_struct(self) -> None:
         """Generate the data dictionary (self._data) from metadata."""
         # Add state to data struct
@@ -84,10 +89,12 @@ class HMBatterySensor(HMDevice, BinarySensorEntity):
     _attr_device_class = BinarySensorDeviceClass.BATTERY
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return True if battery is low."""
         return bool(self._hm_get_state())
 
+    @override
     def _init_data_struct(self) -> None:
         """Generate the data dictionary (self._data) from metadata."""
         # Add state to data struct

--- a/homeassistant/components/homematic/climate.py
+++ b/homeassistant/components/homematic/climate.py
@@ -1,6 +1,6 @@
 """Support for Homematic thermostats."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.climate import (
     PRESET_BOOST,
@@ -68,6 +68,7 @@ class HMThermostat(HMDevice, ClimateEntity):
     _state: str
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode:
         """Return hvac operation ie. heat, cool mode.
 
@@ -86,6 +87,7 @@ class HMThermostat(HMDevice, ClimateEntity):
         return HVACMode.HEAT
 
     @property
+    @override
     def hvac_modes(self) -> list[HVACMode]:
         """Return the list of available hvac operation modes.
 
@@ -96,6 +98,7 @@ class HMThermostat(HMDevice, ClimateEntity):
         return [HVACMode.HEAT, HVACMode.OFF]
 
     @property
+    @override
     def preset_mode(self) -> str:
         """Return the current preset mode, e.g., home, away, temp."""
         if self._data.get("BOOST_MODE", False):
@@ -113,6 +116,7 @@ class HMThermostat(HMDevice, ClimateEntity):
         return mode
 
     @property
+    @override
     def preset_modes(self) -> list[str]:
         """Return a list of available preset modes."""
         return [
@@ -122,6 +126,7 @@ class HMThermostat(HMDevice, ClimateEntity):
         ]
 
     @property
+    @override
     def current_humidity(self) -> float | None:
         """Return the current humidity."""
         for node in HM_HUMI_MAP:
@@ -130,6 +135,7 @@ class HMThermostat(HMDevice, ClimateEntity):
         return None
 
     @property
+    @override
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
         for node in HM_TEMP_MAP:
@@ -138,10 +144,12 @@ class HMThermostat(HMDevice, ClimateEntity):
         return None
 
     @property
+    @override
     def target_temperature(self) -> float | None:
         """Return the target temperature."""
         return self._data.get(self._state)
 
+    @override
     def set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
@@ -149,6 +157,7 @@ class HMThermostat(HMDevice, ClimateEntity):
 
         self._hmdevice.writeNodeData(self._state, float(temperature))
 
+    @override
     def set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         if hvac_mode == HVACMode.AUTO:
@@ -158,6 +167,7 @@ class HMThermostat(HMDevice, ClimateEntity):
         elif hvac_mode == HVACMode.OFF:
             self._hmdevice.turnoff()
 
+    @override
     def set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
         if preset_mode == PRESET_BOOST:
@@ -176,6 +186,7 @@ class HMThermostat(HMDevice, ClimateEntity):
         # Homematic
         return self._data.get("CONTROL_MODE")
 
+    @override
     def _init_data_struct(self) -> None:
         """Generate a data dict (self._data) from the Homematic metadata."""
         self._state = next(iter(self._hmdevice.WRITENODE.keys()))

--- a/homeassistant/components/homematic/cover.py
+++ b/homeassistant/components/homematic/cover.py
@@ -1,6 +1,6 @@
 """Support for  HomeMatic covers."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.cover import (
     ATTR_POSITION,
@@ -42,6 +42,7 @@ class HMCover(HMDevice, CoverEntity):
     """Representation a HomeMatic Cover."""
 
     @property
+    @override
     def current_cover_position(self) -> int | None:
         """Return current position of cover.
 
@@ -49,6 +50,7 @@ class HMCover(HMDevice, CoverEntity):
         """
         return int(self._hm_get_state() * 100)
 
+    @override
     def set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
         if ATTR_POSITION in kwargs:
@@ -58,24 +60,29 @@ class HMCover(HMDevice, CoverEntity):
             self._hmdevice.set_level(level, self._channel)
 
     @property
+    @override
     def is_closed(self) -> bool | None:
         """Return whether the cover is closed."""
         if self.current_cover_position is not None:
             return self.current_cover_position == 0
         return None
 
+    @override
     def open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
         self._hmdevice.move_up(self._channel)
 
+    @override
     def close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
         self._hmdevice.move_down(self._channel)
 
+    @override
     def stop_cover(self, **kwargs: Any) -> None:
         """Stop the device if in motion."""
         self._hmdevice.stop(self._channel)
 
+    @override
     def _init_data_struct(self) -> None:
         """Generate a data dictionary (self._data) from metadata."""
         self._state = "LEVEL"
@@ -84,6 +91,7 @@ class HMCover(HMDevice, CoverEntity):
             self._data.update({"LEVEL_2": None})
 
     @property
+    @override
     def current_cover_tilt_position(self) -> int | None:
         """Return current position of cover tilt.
 
@@ -93,6 +101,7 @@ class HMCover(HMDevice, CoverEntity):
             return None
         return int(position * 100)
 
+    @override
     def set_cover_tilt_position(self, **kwargs: Any) -> None:
         """Move the cover tilt to a specific position."""
         if "LEVEL_2" in self._data and ATTR_TILT_POSITION in kwargs:
@@ -101,16 +110,19 @@ class HMCover(HMDevice, CoverEntity):
             level = position / 100.0
             self._hmdevice.set_cover_tilt_position(level, self._channel)
 
+    @override
     def open_cover_tilt(self, **kwargs: Any) -> None:
         """Open the cover tilt."""
         if "LEVEL_2" in self._data:
             self._hmdevice.open_slats()
 
+    @override
     def close_cover_tilt(self, **kwargs: Any) -> None:
         """Close the cover tilt."""
         if "LEVEL_2" in self._data:
             self._hmdevice.close_slats()
 
+    @override
     def stop_cover_tilt(self, **kwargs: Any) -> None:
         """Stop cover tilt."""
         if "LEVEL_2" in self._data:
@@ -126,6 +138,7 @@ class HMGarage(HMCover):
     _attr_device_class = CoverDeviceClass.GARAGE
 
     @property
+    @override
     def current_cover_position(self) -> None:
         """Return current position of cover.
 
@@ -135,10 +148,12 @@ class HMGarage(HMCover):
         return None
 
     @property
+    @override
     def is_closed(self) -> bool:
         """Return whether the cover is closed."""
         return self._hmdevice.is_closed(self._hm_get_state())
 
+    @override
     def _init_data_struct(self) -> None:
         """Generate a data dictionary (self._data) from metadata."""
         self._state = "DOOR_STATE"

--- a/homeassistant/components/homematic/entity.py
+++ b/homeassistant/components/homematic/entity.py
@@ -3,7 +3,7 @@
 from abc import abstractmethod
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyhomematic import HMConnection
 from pyhomematic.devicetypes.generic import HMGeneric
@@ -63,11 +63,13 @@ class HMDevice(Entity):
         if self._state:
             self._state = self._state.upper()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Load data init callbacks."""
         self._subscribe_homematic_events()
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return device specific state attributes."""
         # Static attributes
@@ -216,21 +218,25 @@ class HMHub(Entity):
         self.hass.add_job(self._update_variables, None)
 
     @property
+    @override
     def name(self) -> str:
         """Return the name of the device."""
         return self._name
 
     @property
+    @override
     def state(self) -> int | None:
         """Return the state of the entity."""
         return self._state
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         return self._variables.copy()
 
     @property
+    @override
     def icon(self) -> str:
         """Return the icon to use in the frontend, if any."""
         return "mdi:gradient-vertical"

--- a/homeassistant/components/homematic/light.py
+++ b/homeassistant/components/homematic/light.py
@@ -1,6 +1,6 @@
 """Support for Homematic lights."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -49,6 +49,7 @@ class HMLight(HMDevice, LightEntity):
     _attr_max_color_temp_kelvin = 6500  # 153 Mireds
 
     @property
+    @override
     def brightness(self) -> int | None:
         """Return the brightness of this light between 0..255."""
         # Is dimmer?
@@ -57,6 +58,7 @@ class HMLight(HMDevice, LightEntity):
         return None
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if light is on."""
         try:
@@ -65,6 +67,7 @@ class HMLight(HMDevice, LightEntity):
             return False
 
     @property
+    @override
     def color_mode(self) -> ColorMode:
         """Return the color mode of the light."""
         if "COLOR" in self._hmdevice.WRITENODE:
@@ -74,6 +77,7 @@ class HMLight(HMDevice, LightEntity):
         return ColorMode.BRIGHTNESS
 
     @property
+    @override
     def supported_color_modes(self) -> set[ColorMode]:
         """Flag supported color modes."""
         color_modes: set[ColorMode] = set()
@@ -88,6 +92,7 @@ class HMLight(HMDevice, LightEntity):
         return color_modes
 
     @property
+    @override
     def supported_features(self) -> LightEntityFeature:
         """Flag supported features."""
         features = LightEntityFeature.TRANSITION
@@ -96,6 +101,7 @@ class HMLight(HMDevice, LightEntity):
         return features
 
     @property
+    @override
     def hs_color(self) -> tuple[float, float] | None:
         """Return the hue and saturation color value [float, float]."""
         if ColorMode.HS not in self.supported_color_modes:
@@ -104,6 +110,7 @@ class HMLight(HMDevice, LightEntity):
         return hue * 360.0, sat * 100.0
 
     @property
+    @override
     def color_temp_kelvin(self) -> int | None:
         """Return the color temperature value in Kelvin."""
         if ColorMode.COLOR_TEMP not in self.supported_color_modes:
@@ -114,6 +121,7 @@ class HMLight(HMDevice, LightEntity):
         )
 
     @property
+    @override
     def effect_list(self) -> list[str] | None:
         """Return the list of supported effects."""
         if not self.supported_features & LightEntityFeature.EFFECT:
@@ -121,12 +129,14 @@ class HMLight(HMDevice, LightEntity):
         return self._hmdevice.get_effect_list()
 
     @property
+    @override
     def effect(self) -> str | None:
         """Return the current color change program of the light."""
         if not self.supported_features & LightEntityFeature.EFFECT:
             return None
         return self._hmdevice.get_effect()
 
+    @override
     def turn_on(self, **kwargs: Any) -> None:
         """Turn the light on and/or change color or color effect settings."""
         if ATTR_TRANSITION in kwargs:
@@ -157,6 +167,7 @@ class HMLight(HMDevice, LightEntity):
         if ATTR_EFFECT in kwargs:
             self._hmdevice.set_effect(kwargs[ATTR_EFFECT])
 
+    @override
     def turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
         if ATTR_TRANSITION in kwargs:
@@ -164,6 +175,7 @@ class HMLight(HMDevice, LightEntity):
 
         self._hmdevice.off(self._channel)
 
+    @override
     def _init_data_struct(self) -> None:
         """Generate a data dict (self._data) from the Homematic metadata."""
         # Use LEVEL

--- a/homeassistant/components/homematic/lock.py
+++ b/homeassistant/components/homematic/lock.py
@@ -1,6 +1,6 @@
 """Support for Homematic locks."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.lock import LockEntity, LockEntityFeature
 from homeassistant.core import HomeAssistant
@@ -30,22 +30,27 @@ class HMLock(HMDevice, LockEntity):
     _attr_supported_features = LockEntityFeature.OPEN
 
     @property
+    @override
     def is_locked(self) -> bool:
         """Return true if the lock is locked."""
         return not bool(self._hm_get_state())
 
+    @override
     def lock(self, **kwargs: Any) -> None:
         """Lock the lock."""
         self._hmdevice.lock()
 
+    @override
     def unlock(self, **kwargs: Any) -> None:
         """Unlock the lock."""
         self._hmdevice.unlock()
 
+    @override
     def open(self, **kwargs: Any) -> None:
         """Open the door latch."""
         self._hmdevice.open()
 
+    @override
     def _init_data_struct(self) -> None:
         """Generate the data dictionary (self._data) from metadata."""
         self._state = "STATE"

--- a/homeassistant/components/homematic/notify.py
+++ b/homeassistant/components/homematic/notify.py
@@ -1,6 +1,6 @@
 """Notification support for Homematic."""
 
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -60,6 +60,7 @@ class HomematicNotificationService(BaseNotificationService):
         self.hass = hass
         self.data = data
 
+    @override
     def send_message(self, message: str = "", **kwargs: Any) -> None:
         """Send a notification to the device."""
         data = {**self.data, **kwargs.get(ATTR_DATA, {})}

--- a/homeassistant/components/homematic/sensor.py
+++ b/homeassistant/components/homematic/sensor.py
@@ -2,6 +2,7 @@
 
 from copy import copy
 import logging
+from typing import override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -324,6 +325,7 @@ class HMSensor(HMDevice, SensorEntity):
     """Representation of a HomeMatic sensor."""
 
     @property
+    @override
     def native_value(self):
         """Return the state of the sensor."""
         # Does a cast exist for this class?
@@ -334,6 +336,7 @@ class HMSensor(HMDevice, SensorEntity):
         # No cast, return original value
         return self._hm_get_state()
 
+    @override
     def _init_data_struct(self) -> None:
         """Generate a data dictionary (self._data) from metadata."""
         if self._state:

--- a/homeassistant/components/homematic/switch.py
+++ b/homeassistant/components/homematic/switch.py
@@ -1,6 +1,6 @@
 """Support for HomeMatic switches."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant
@@ -33,6 +33,7 @@ class HMSwitch(HMDevice, SwitchEntity):
     """Representation of a HomeMatic switch."""
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return True if switch is on."""
         try:
@@ -51,14 +52,17 @@ class HMSwitch(HMDevice, SwitchEntity):
 
         return None
 
+    @override
     def turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         self._hmdevice.on(self._channel)
 
+    @override
     def turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         self._hmdevice.off(self._channel)
 
+    @override
     def _init_data_struct(self) -> None:
         """Generate the data dictionary (self._data) from metadata."""
         self._state = "STATE"

--- a/homeassistant/components/homematicip_cloud/alarm_control_panel.py
+++ b/homeassistant/components/homematicip_cloud/alarm_control_panel.py
@@ -1,6 +1,7 @@
 """Support for HomematicIP Cloud alarm control panel."""
 
 import logging
+from typing import override
 
 from homematicip.functionalHomes import SecurityAndAlarmHome
 
@@ -47,6 +48,7 @@ class HomematicipAlarmControlPanelEntity(AlarmControlPanelEntity):
         self._home: AsyncHome = hap.home
 
     @property
+    @override
     def device_info(self) -> DeviceInfo:
         """Return device specific attributes."""
         return DeviceInfo(
@@ -58,6 +60,7 @@ class HomematicipAlarmControlPanelEntity(AlarmControlPanelEntity):
         )
 
     @property
+    @override
     def alarm_state(self) -> AlarmControlPanelState:
         """Return the state of the alarm control panel."""
         # check for triggered alarm
@@ -78,18 +81,22 @@ class HomematicipAlarmControlPanelEntity(AlarmControlPanelEntity):
     def _security_and_alarm(self) -> SecurityAndAlarmHome:
         return self._home.get_functionalHome(SecurityAndAlarmHome)
 
+    @override
     async def async_alarm_disarm(self, code: str | None = None) -> None:
         """Send disarm command."""
         await self._home.set_security_zones_activation_async(False, False)
 
+    @override
     async def async_alarm_arm_home(self, code: str | None = None) -> None:
         """Send arm home command."""
         await self._home.set_security_zones_activation_async(False, True)
 
+    @override
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command."""
         await self._home.set_security_zones_activation_async(True, True)
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
         self._home.on_update(self._async_device_changed)
@@ -111,6 +118,7 @@ class HomematicipAlarmControlPanelEntity(AlarmControlPanelEntity):
             )
 
     @property
+    @override
     def name(self) -> str:
         """Return the name of the generic entity."""
         name = CONST_ALARM_CONTROL_PANEL_NAME
@@ -119,11 +127,13 @@ class HomematicipAlarmControlPanelEntity(AlarmControlPanelEntity):
         return name
 
     @property
+    @override
     def available(self) -> bool:
         """Return if alarm control panel is available."""
         return self._home.connected
 
     @property
+    @override
     def unique_id(self) -> str:
         """Return a unique ID."""
         return f"{self._home.id}_{self._feature_id}"

--- a/homeassistant/components/homematicip_cloud/binary_sensor.py
+++ b/homeassistant/components/homematicip_cloud/binary_sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from homematicip.base.enums import (
     BinaryBehaviorType,
@@ -337,6 +337,7 @@ class HomematicipSimpleBinarySensor[_DeviceT: Device](
         self.entity_description = description
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return whether the binary sensor is on."""
         return self.entity_description.value_fn(self._device)
@@ -352,6 +353,7 @@ class HomematicipCloudConnectionSensor(HomematicipGenericEntity, BinarySensorEnt
         super().__init__(hap, hap.home, feature_id="cloud_connection")
 
     @property
+    @override
     def device_info(self) -> DeviceInfo:
         """Return device specific attributes."""
         # Merges into the existing HAP device registered in __init__.py.
@@ -366,6 +368,7 @@ class HomematicipCloudConnectionSensor(HomematicipGenericEntity, BinarySensorEnt
         )
 
     @property
+    @override
     def icon(self) -> str:
         """Return the icon of the access point entity."""
         return (
@@ -375,11 +378,13 @@ class HomematicipCloudConnectionSensor(HomematicipGenericEntity, BinarySensorEnt
         )
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if hap is connected to cloud."""
         return self._home.connected
 
     @property
+    @override
     def available(self) -> bool:
         """Sensor is always available."""
         return True
@@ -391,11 +396,13 @@ class HomematicipBaseActionSensor(HomematicipGenericEntity, BinarySensorEntity):
     _attr_device_class = BinarySensorDeviceClass.MOVING
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if acceleration is detected."""
         return self._device.accelerationSensorTriggered
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the acceleration sensor."""
         state_attr = super().extra_state_attributes
@@ -448,6 +455,7 @@ class HomematicipMultiContactInterface(HomematicipGenericEntity, BinarySensorEnt
         )
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if the contact interface is on/open."""
         channel = self.get_channel_or_raise()
@@ -479,6 +487,7 @@ class HomematicipShutterContact(HomematicipMultiContactInterface, BinarySensorEn
         self.has_additional_state = has_additional_state
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the Shutter Contact."""
         state_attr = super().extra_state_attributes
@@ -503,6 +512,7 @@ class HomematicipFullFlushLockControllerLocked(
         super().__init__(hap, device, post="Locked", feature_id="lock_locked")
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if the controlled lock is unlocked.
 
@@ -551,6 +561,7 @@ class HomematicipFullFlushLockControllerGlassBreak(
         super().__init__(hap, device, post="Glass break", feature_id="glass_break")
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if glass break has been detected."""
         channel = _get_channel_by_role(
@@ -571,11 +582,13 @@ class HomematicipStormSensor(HomematicipGenericEntity, BinarySensorEntity):
         super().__init__(hap, device, "Storm", feature_id="storm")
 
     @property
+    @override
     def icon(self) -> str:
         """Return the icon."""
         return "mdi:weather-windy" if self.is_on else "mdi:pinwheel-outline"
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true, if storm is detected."""
         return self._device.storm
@@ -591,11 +604,13 @@ class HomematicipSunshineSensor(HomematicipGenericEntity, BinarySensorEntity):
         super().__init__(hap, device, post="Sunshine", feature_id="sunshine")
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if sun is shining."""
         return self._device.sunshine
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the illuminance sensor."""
         state_attr = super().extra_state_attributes
@@ -625,6 +640,7 @@ class HomematicipSecurityZoneSensorGroup(HomematicipGenericEntity, BinarySensorE
         super().__init__(hap, device, post=post, feature_id=feature_id)
 
     @property
+    @override
     def available(self) -> bool:
         """Security-Group available."""
         # A security-group must be available, and should not be affected by
@@ -632,6 +648,7 @@ class HomematicipSecurityZoneSensorGroup(HomematicipGenericEntity, BinarySensorE
         return True
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the security zone group."""
         state_attr = super().extra_state_attributes
@@ -647,6 +664,7 @@ class HomematicipSecurityZoneSensorGroup(HomematicipGenericEntity, BinarySensorE
         return state_attr
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if security issue detected."""
         if (
@@ -675,6 +693,7 @@ class HomematicipSecuritySensorGroup(
         super().__init__(hap, device, post="Sensors", feature_id="security")
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the security group."""
         state_attr = super().extra_state_attributes
@@ -688,6 +707,7 @@ class HomematicipSecuritySensorGroup(
         return state_attr
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if safety issue detected."""
         if super().is_on:

--- a/homeassistant/components/homematicip_cloud/button.py
+++ b/homeassistant/components/homematicip_cloud/button.py
@@ -1,5 +1,7 @@
 """Support for HomematicIP Cloud button devices."""
 
+from typing import override
+
 from homematicip.device import WallMountedGarageDoorController
 
 from homeassistant.components.button import ButtonEntity
@@ -46,6 +48,7 @@ class HomematicipGarageDoorControllerButton(HomematicipGenericEntity, ButtonEnti
         super().__init__(hap, device, feature_id="garage_button")
         self._attr_icon = "mdi:arrow-up-down"
 
+    @override
     async def async_press(self) -> None:
         """Handle the button press."""
         await self._device.send_start_impulse_async()
@@ -61,6 +64,7 @@ class HomematicipFullFlushLockControllerButton(HomematicipGenericEntity, ButtonE
         )
         self._attr_icon = "mdi:door-open"
 
+    @override
     async def async_press(self) -> None:
         """Handle the button press."""
         await self._device.send_start_impulse_async()

--- a/homeassistant/components/homematicip_cloud/climate.py
+++ b/homeassistant/components/homematicip_cloud/climate.py
@@ -1,6 +1,6 @@
 """Support for HomematicIP Cloud climate devices."""
 
-from typing import Any
+from typing import Any, override
 
 from homematicip.base.enums import AbsenceType
 from homematicip.device import (
@@ -89,6 +89,7 @@ class HomematicipHeatingGroup(HomematicipGenericEntity, ClimateEntity):
             self._simple_heating = self._first_radiator_thermostat
 
     @property
+    @override
     def available(self) -> bool:
         """Heating group available.
 
@@ -100,6 +101,7 @@ class HomematicipHeatingGroup(HomematicipGenericEntity, ClimateEntity):
         return True
 
     @property
+    @override
     def device_info(self) -> DeviceInfo:
         """Return device specific attributes."""
         return DeviceInfo(
@@ -111,11 +113,13 @@ class HomematicipHeatingGroup(HomematicipGenericEntity, ClimateEntity):
         )
 
     @property
+    @override
     def target_temperature(self) -> float:
         """Return the temperature we try to reach."""
         return self._device.setPointTemperature
 
     @property
+    @override
     def current_temperature(self) -> float:
         """Return the current temperature."""
         if self._simple_heating:
@@ -123,11 +127,13 @@ class HomematicipHeatingGroup(HomematicipGenericEntity, ClimateEntity):
         return self._device.actualTemperature
 
     @property
+    @override
     def current_humidity(self) -> int:
         """Return the current humidity."""
         return self._device.humidity
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode:
         """Return hvac operation ie."""
         if self._disabled_by_cooling_mode and not self._has_switch:
@@ -140,6 +146,7 @@ class HomematicipHeatingGroup(HomematicipGenericEntity, ClimateEntity):
         return HVACMode.AUTO
 
     @property
+    @override
     def hvac_modes(self) -> list[HVACMode]:
         """Return the list of available hvac operation modes."""
         if self._disabled_by_cooling_mode and not self._has_switch:
@@ -150,6 +157,7 @@ class HomematicipHeatingGroup(HomematicipGenericEntity, ClimateEntity):
         return [HVACMode.AUTO, HVACMode.COOL]
 
     @property
+    @override
     def hvac_action(self) -> HVACAction | None:
         """Return the current hvac_action.
 
@@ -165,6 +173,7 @@ class HomematicipHeatingGroup(HomematicipGenericEntity, ClimateEntity):
         return None
 
     @property
+    @override
     def preset_mode(self) -> str | None:
         """Return the current preset mode."""
         if self._device.boostMode:
@@ -189,6 +198,7 @@ class HomematicipHeatingGroup(HomematicipGenericEntity, ClimateEntity):
         )
 
     @property
+    @override
     def preset_modes(self) -> list[str]:
         """Return a list of available preset modes incl. hmip profiles."""
         # Boost is only available if a radiator thermostat is in the room,
@@ -208,15 +218,18 @@ class HomematicipHeatingGroup(HomematicipGenericEntity, ClimateEntity):
         return presets
 
     @property
+    @override
     def min_temp(self) -> float:
         """Return the minimum temperature."""
         return self._device.minTemperature
 
     @property
+    @override
     def max_temp(self) -> float:
         """Return the maximum temperature."""
         return self._device.maxTemperature
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
@@ -225,6 +238,7 @@ class HomematicipHeatingGroup(HomematicipGenericEntity, ClimateEntity):
         if self.min_temp <= temperature <= self.max_temp:
             await self._device.set_point_temperature_async(temperature)
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
 
@@ -233,6 +247,7 @@ class HomematicipHeatingGroup(HomematicipGenericEntity, ClimateEntity):
         else:
             await self._device.set_control_mode_async(HMIP_MANUAL_CM)
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
         if self._device.boostMode and preset_mode != PRESET_BOOST:
@@ -248,6 +263,7 @@ class HomematicipHeatingGroup(HomematicipGenericEntity, ClimateEntity):
             await self._device.set_active_profile_async(profile_idx)
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the access point."""
         state_attr = super().extra_state_attributes

--- a/homeassistant/components/homematicip_cloud/config_flow.py
+++ b/homeassistant/components/homematicip_cloud/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow to configure the HomematicIP Cloud component."""
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -21,6 +21,7 @@ class HomematicipCloudFlowHandler(ConfigFlow, domain=DOMAIN):
     def __init__(self) -> None:
         """Initialize HomematicIP Cloud config flow."""
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/homematicip_cloud/cover.py
+++ b/homeassistant/components/homematicip_cloud/cover.py
@@ -1,6 +1,6 @@
 """Support for HomematicIP Cloud cover devices."""
 
-from typing import Any
+from typing import Any, override
 
 from homematicip.base.enums import DoorCommand, DoorState
 from homematicip.device import (
@@ -72,6 +72,7 @@ class HomematicipBlindModule(HomematicipGenericEntity, CoverEntity):
         super().__init__(hap, device, feature_id="blind")
 
     @property
+    @override
     def current_cover_position(self) -> int | None:
         """Return current position of cover."""
         if self._device.primaryShadingLevel is not None:
@@ -79,12 +80,14 @@ class HomematicipBlindModule(HomematicipGenericEntity, CoverEntity):
         return None
 
     @property
+    @override
     def current_cover_tilt_position(self) -> int | None:
         """Return current tilt position of cover."""
         if self._device.secondaryShadingLevel is not None:
             return int((1 - self._device.secondaryShadingLevel) * 100)
         return None
 
+    @override
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
         position = kwargs[ATTR_POSITION]
@@ -92,6 +95,7 @@ class HomematicipBlindModule(HomematicipGenericEntity, CoverEntity):
         level = 1 - position / 100.0
         await self._device.set_primary_shading_level_async(primaryShadingLevel=level)
 
+    @override
     async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific tilt position."""
         position = kwargs[ATTR_TILT_POSITION]
@@ -103,28 +107,33 @@ class HomematicipBlindModule(HomematicipGenericEntity, CoverEntity):
         )
 
     @property
+    @override
     def is_closed(self) -> bool | None:
         """Return if the cover is closed."""
         if self._device.primaryShadingLevel is not None:
             return self._device.primaryShadingLevel == HMIP_COVER_CLOSED
         return None
 
+    @override
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
         await self._device.set_primary_shading_level_async(
             primaryShadingLevel=HMIP_COVER_OPEN
         )
 
+    @override
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
         await self._device.set_primary_shading_level_async(
             primaryShadingLevel=HMIP_COVER_CLOSED
         )
 
+    @override
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the device if in motion."""
         await self._device.stop_async()
 
+    @override
     async def async_open_cover_tilt(self, **kwargs: Any) -> None:
         """Open the slats."""
         await self._device.set_secondary_shading_level_async(
@@ -132,6 +141,7 @@ class HomematicipBlindModule(HomematicipGenericEntity, CoverEntity):
             secondaryShadingLevel=HMIP_SLATS_OPEN,
         )
 
+    @override
     async def async_close_cover_tilt(self, **kwargs: Any) -> None:
         """Close the slats."""
         await self._device.set_secondary_shading_level_async(
@@ -139,6 +149,7 @@ class HomematicipBlindModule(HomematicipGenericEntity, CoverEntity):
             secondaryShadingLevel=HMIP_SLATS_CLOSED,
         )
 
+    @override
     async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
         """Stop the device if in motion."""
         await self._device.stop_async()
@@ -167,6 +178,7 @@ class HomematicipMultiCoverShutter(HomematicipGenericEntity, CoverEntity):
         )
 
     @property
+    @override
     def current_cover_position(self) -> int | None:
         """Return current position of cover."""
         if self._device.functionalChannels[self._channel].shutterLevel is not None:
@@ -175,6 +187,7 @@ class HomematicipMultiCoverShutter(HomematicipGenericEntity, CoverEntity):
             )
         return None
 
+    @override
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
         position = kwargs[ATTR_POSITION]
@@ -183,6 +196,7 @@ class HomematicipMultiCoverShutter(HomematicipGenericEntity, CoverEntity):
         await self._device.set_shutter_level_async(level, self._channel)
 
     @property
+    @override
     def is_closed(self) -> bool | None:
         """Return if the cover is closed."""
         if self._device.functionalChannels[self._channel].shutterLevel is not None:
@@ -192,14 +206,17 @@ class HomematicipMultiCoverShutter(HomematicipGenericEntity, CoverEntity):
             )
         return None
 
+    @override
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
         await self._device.set_shutter_level_async(HMIP_COVER_OPEN, self._channel)
 
+    @override
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
         await self._device.set_shutter_level_async(HMIP_COVER_CLOSED, self._channel)
 
+    @override
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the device if in motion."""
         await self._device.set_shutter_stop_async(self._channel)
@@ -233,6 +250,7 @@ class HomematicipMultiCoverSlats(HomematicipMultiCoverShutter, CoverEntity):
         )
 
     @property
+    @override
     def current_cover_tilt_position(self) -> int | None:
         """Return current tilt position of cover."""
         if self._device.functionalChannels[self._channel].slatsLevel is not None:
@@ -241,6 +259,7 @@ class HomematicipMultiCoverSlats(HomematicipMultiCoverShutter, CoverEntity):
             )
         return None
 
+    @override
     async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific tilt position."""
         position = kwargs[ATTR_TILT_POSITION]
@@ -250,18 +269,21 @@ class HomematicipMultiCoverSlats(HomematicipMultiCoverShutter, CoverEntity):
             slatsLevel=level, channelIndex=self._channel
         )
 
+    @override
     async def async_open_cover_tilt(self, **kwargs: Any) -> None:
         """Open the slats."""
         await self._device.set_slats_level_async(
             slatsLevel=HMIP_SLATS_OPEN, channelIndex=self._channel
         )
 
+    @override
     async def async_close_cover_tilt(self, **kwargs: Any) -> None:
         """Close the slats."""
         await self._device.set_slats_level_async(
             slatsLevel=HMIP_SLATS_CLOSED, channelIndex=self._channel
         )
 
+    @override
     async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
         """Stop the device if in motion."""
         await self._device.set_shutter_stop_async(self._channel)
@@ -285,6 +307,7 @@ class HomematicipGarageDoorModule(HomematicipGenericEntity, CoverEntity):
         super().__init__(hap, device, feature_id="garage_door")
 
     @property
+    @override
     def current_cover_position(self) -> int | None:
         """Return current position of cover."""
         door_state_to_position = {
@@ -296,21 +319,25 @@ class HomematicipGarageDoorModule(HomematicipGenericEntity, CoverEntity):
         return door_state_to_position.get(self._device.doorState)
 
     @property
+    @override
     def is_closed(self) -> bool | None:
         """Return if the cover is closed."""
         channel = self.get_channel_or_raise()
         return channel.doorState == DoorState.CLOSED
 
+    @override
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
         channel = self.get_channel_or_raise()
         await channel.async_send_door_command(DoorCommand.OPEN)
 
+    @override
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
         channel = self.get_channel_or_raise()
         await channel.async_send_door_command(DoorCommand.CLOSE)
 
+    @override
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
         channel = self.get_channel_or_raise()
@@ -331,6 +358,7 @@ class HomematicipCoverShutterGroup(HomematicipGenericEntity, CoverEntity):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Cover shutter group available.
 
@@ -342,6 +370,7 @@ class HomematicipCoverShutterGroup(HomematicipGenericEntity, CoverEntity):
         return True
 
     @property
+    @override
     def current_cover_position(self) -> int | None:
         """Return current position of cover."""
         if self._device.shutterLevel is not None:
@@ -349,6 +378,7 @@ class HomematicipCoverShutterGroup(HomematicipGenericEntity, CoverEntity):
         return None
 
     @property
+    @override
     def current_cover_tilt_position(self) -> int | None:
         """Return current tilt position of cover."""
         if self._device.slatsLevel is not None:
@@ -356,12 +386,14 @@ class HomematicipCoverShutterGroup(HomematicipGenericEntity, CoverEntity):
         return None
 
     @property
+    @override
     def is_closed(self) -> bool | None:
         """Return if the cover is closed."""
         if self._device.shutterLevel is not None:
             return self._device.shutterLevel == HMIP_COVER_CLOSED
         return None
 
+    @override
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
         position = kwargs[ATTR_POSITION]
@@ -369,6 +401,7 @@ class HomematicipCoverShutterGroup(HomematicipGenericEntity, CoverEntity):
         level = 1 - position / 100.0
         await self._device.set_shutter_level_async(level)
 
+    @override
     async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific tilt position."""
         position = kwargs[ATTR_TILT_POSITION]
@@ -376,26 +409,32 @@ class HomematicipCoverShutterGroup(HomematicipGenericEntity, CoverEntity):
         level = 1 - position / 100.0
         await self._device.set_slats_level_async(level)
 
+    @override
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
         await self._device.set_shutter_level_async(HMIP_COVER_OPEN)
 
+    @override
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
         await self._device.set_shutter_level_async(HMIP_COVER_CLOSED)
 
+    @override
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the group if in motion."""
         await self._device.set_shutter_stop_async()
 
+    @override
     async def async_open_cover_tilt(self, **kwargs: Any) -> None:
         """Open the slats."""
         await self._device.set_slats_level_async(HMIP_SLATS_OPEN)
 
+    @override
     async def async_close_cover_tilt(self, **kwargs: Any) -> None:
         """Close the slats."""
         await self._device.set_slats_level_async(HMIP_SLATS_CLOSED)
 
+    @override
     async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
         """Stop the group if in motion."""
         await self._device.set_shutter_stop_async()

--- a/homeassistant/components/homematicip_cloud/entity.py
+++ b/homeassistant/components/homematicip_cloud/entity.py
@@ -2,7 +2,7 @@
 
 import contextlib
 import logging
-from typing import Any
+from typing import Any, override
 
 from homematicip.base.functionalChannels import FunctionalChannel
 from homematicip.device import Device
@@ -129,6 +129,7 @@ class HomematicipGenericEntity(Entity):
             self._setup_entity_name()
 
     @property
+    @override
     def device_info(self) -> DeviceInfo | None:
         """Return device specific attributes."""
         # Only physical devices should be HA devices.
@@ -158,6 +159,7 @@ class HomematicipGenericEntity(Entity):
             )
         return None
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
         self._hap.hmip_device_by_entity_id[self.entity_id] = self._device
@@ -178,6 +180,7 @@ class HomematicipGenericEntity(Entity):
                 self._device.modelType,
             )
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Run when hmip device will be removed from hass."""
 
@@ -312,11 +315,13 @@ class HomematicipGenericEntity(Entity):
         # device_class or translation_key.
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return not self._device.unreach
 
     @property
+    @override
     def unique_id(self) -> str:
         """Return a unique ID."""
         if not isinstance(self._device, Device):
@@ -325,6 +330,7 @@ class HomematicipGenericEntity(Entity):
         return f"{self._device.id}_{channel_index}_{self._feature_id}"
 
     @property
+    @override
     def icon(self) -> str | None:
         """Return the icon."""
         for attr, icon in DEVICE_ATTRIBUTE_ICONS.items():
@@ -334,6 +340,7 @@ class HomematicipGenericEntity(Entity):
         return None
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the generic entity."""
         state_attr = {}

--- a/homeassistant/components/homematicip_cloud/event.py
+++ b/homeassistant/components/homematicip_cloud/event.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from homematicip.base.channel_event import ChannelEvent
 from homematicip.base.enums import FunctionalChannelType
@@ -104,6 +105,7 @@ class HomematicipChannelEvent(HomematicipGenericEntity, EventEntity):
         if description.is_multi_channel:
             self._attr_translation_placeholders = {"channel": str(channel.index)}
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
         await super().async_added_to_hass()

--- a/homeassistant/components/homematicip_cloud/light.py
+++ b/homeassistant/components/homematicip_cloud/light.py
@@ -1,7 +1,7 @@
 """Support for HomematicIP Cloud lights."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from homematicip.base.enums import (
     DeviceType,
@@ -127,14 +127,17 @@ class HomematicipLight(HomematicipGenericEntity, LightEntity):
         super().__init__(hap, device, feature_id="light")
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if light is on."""
         return self._device.on
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""
         await self._device.turn_on_async()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
         await self._device.turn_off_async()
@@ -159,6 +162,7 @@ class HomematicipColorLight(HomematicipGenericEntity, LightEntity):
         return channel.hue is not None and channel.saturationLevel is not None
 
     @property
+    @override
     def color_mode(self) -> ColorMode:
         """Return the color mode of the light."""
         if self._supports_color():
@@ -166,6 +170,7 @@ class HomematicipColorLight(HomematicipGenericEntity, LightEntity):
         return ColorMode.BRIGHTNESS
 
     @property
+    @override
     def supported_color_modes(self) -> set[ColorMode]:
         """Return the supported color modes."""
         if self._supports_color():
@@ -173,18 +178,21 @@ class HomematicipColorLight(HomematicipGenericEntity, LightEntity):
         return {ColorMode.BRIGHTNESS}
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if light is on."""
         channel = self.get_channel_or_raise()
         return channel.on
 
     @property
+    @override
     def brightness(self) -> int | None:
         """Return the current brightness."""
         channel = self.get_channel_or_raise()
         return int(channel.dimLevel * 255.0)
 
     @property
+    @override
     def hs_color(self) -> tuple[float, float] | None:
         """Return the hue and saturation color value [float, float]."""
         channel = self.get_channel_or_raise()
@@ -195,6 +203,7 @@ class HomematicipColorLight(HomematicipGenericEntity, LightEntity):
             channel.saturationLevel * 100.0,
         )
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""
         channel = self.get_channel_or_raise()
@@ -222,6 +231,7 @@ class HomematicipColorLight(HomematicipGenericEntity, LightEntity):
             hue=hue, saturation_level=saturation, dim_level=dim_level
         )
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
         channel = self.get_channel_or_raise()
@@ -255,18 +265,21 @@ class HomematicipMultiDimmer(HomematicipGenericEntity, LightEntity):
         )
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if dimmer is on."""
         func_channel = self._device.functionalChannels[self._channel]
         return func_channel.dimLevel is not None and func_channel.dimLevel > 0.0
 
     @property
+    @override
     def brightness(self) -> int:
         """Return the brightness of this light between 0..255."""
         return int(
             (self._device.functionalChannels[self._channel].dimLevel or 0.0) * 255
         )
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the dimmer on."""
         if ATTR_BRIGHTNESS in kwargs:
@@ -276,6 +289,7 @@ class HomematicipMultiDimmer(HomematicipGenericEntity, LightEntity):
         else:
             await self._device.set_dim_level_async(1, self._channel)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the dimmer off."""
         await self._device.set_dim_level_async(0, self._channel)
@@ -322,6 +336,7 @@ class HomematicipNotificationLight(HomematicipGenericEntity, LightEntity):
         return self._device.functionalChannels[self._channel]
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if light is on."""
         return (
@@ -330,17 +345,20 @@ class HomematicipNotificationLight(HomematicipGenericEntity, LightEntity):
         )
 
     @property
+    @override
     def brightness(self) -> int:
         """Return the brightness of this light between 0..255."""
         return int((self._func_channel.dimLevel or 0.0) * 255)
 
     @property
+    @override
     def hs_color(self) -> tuple[float, float]:
         """Return the hue and saturation color value [float, float]."""
         simple_rgb_color = self._func_channel.simpleRGBColorState
         return self._color_switcher.get(simple_rgb_color, (0.0, 0.0))
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the notification light sensor."""
         state_attr = super().extra_state_attributes
@@ -350,6 +368,7 @@ class HomematicipNotificationLight(HomematicipGenericEntity, LightEntity):
 
         return state_attr
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""
         # Use hs_color from kwargs,
@@ -378,6 +397,7 @@ class HomematicipNotificationLight(HomematicipGenericEntity, LightEntity):
             rampTime=transition,
         )
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
         simple_rgb_color = self._func_channel.simpleRGBColorState
@@ -409,20 +429,24 @@ class HomematicipNotificationLightV2(HomematicipNotificationLight, LightEntity):
         self._attr_supported_features |= LightEntityFeature.EFFECT
 
     @property
+    @override
     def effect_list(self) -> list[str] | None:
         """Return the list of supported effects."""
         return self._effect_list
 
     @property
+    @override
     def effect(self) -> str | None:
         """Return the current effect."""
         return self._func_channel.opticalSignalBehaviour
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if light is on."""
         return self._func_channel.on
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""
         # Use hs_color from kwargs,
@@ -447,6 +471,7 @@ class HomematicipNotificationLightV2(HomematicipNotificationLight, LightEntity):
             opticalSignalBehaviour=effect, rgb=simple_rgb_color, dimLevel=dim_level
         )
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
         await self._func_channel.async_turn_off()
@@ -527,18 +552,21 @@ class HomematicipOpticalSignalLight(HomematicipGenericEntity, LightEntity):
         )
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if light is on."""
         channel = self.get_channel_or_raise()
         return channel.on is True
 
     @property
+    @override
     def brightness(self) -> int:
         """Return the brightness of this light between 0..255."""
         channel = self.get_channel_or_raise()
         return int((channel.dimLevel or 0.0) * 255)
 
     @property
+    @override
     def hs_color(self) -> tuple[float, float]:
         """Return the hue and saturation color value [float, float]."""
         channel = self.get_channel_or_raise()
@@ -546,12 +574,14 @@ class HomematicipOpticalSignalLight(HomematicipGenericEntity, LightEntity):
         return self._color_switcher.get(simple_rgb_color, (0.0, 0.0))
 
     @property
+    @override
     def effect(self) -> str | None:
         """Return the current effect."""
         channel = self.get_channel_or_raise()
         return self._behaviour_to_effect.get(channel.opticalSignalBehaviour)
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the optical signal light."""
         state_attr = super().extra_state_attributes
@@ -562,6 +592,7 @@ class HomematicipOpticalSignalLight(HomematicipGenericEntity, LightEntity):
 
         return state_attr
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""
         # Use hs_color from kwargs, if not applicable use current hs_color.
@@ -592,6 +623,7 @@ class HomematicipOpticalSignalLight(HomematicipGenericEntity, LightEntity):
             dimLevel=dim_level,
         )
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
         channel = self.get_channel_or_raise()
@@ -638,21 +670,25 @@ class HomematicipCombinationSignallingLight(HomematicipGenericEntity, LightEntit
         return self._device.functionalChannels[self._channel]
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if light is on."""
         return self._func_channel.on
 
     @property
+    @override
     def brightness(self) -> int:
         """Return the brightness of this light between 0..255."""
         return int((self._func_channel.dimLevel or 0.0) * 255)
 
     @property
+    @override
     def hs_color(self) -> tuple[float, float]:
         """Return the hue and saturation color value [float, float]."""
         simple_rgb_color = self._func_channel.simpleRGBColorState
         return self._color_switcher.get(simple_rgb_color, (0.0, 0.0))
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""
         hs_color = kwargs.get(ATTR_HS_COLOR, self.hs_color)
@@ -673,6 +709,7 @@ class HomematicipCombinationSignallingLight(HomematicipGenericEntity, LightEntit
             dim_level=dim_level,
         )
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
         await self._func_channel.turn_off_async()

--- a/homeassistant/components/homematicip_cloud/lock.py
+++ b/homeassistant/components/homematicip_cloud/lock.py
@@ -1,7 +1,7 @@
 """Support for HomematicIP Cloud lock devices."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from homematicip.base.enums import LockState, MotorState
 from homematicip.device import DoorLockDrive
@@ -56,6 +56,7 @@ class HomematicipDoorLockDrive(HomematicipGenericEntity, LockEntity):
         super().__init__(hap, device, feature_id="lock")
 
     @property
+    @override
     def is_locked(self) -> bool | None:
         """Return true if device is locked."""
         return (
@@ -64,31 +65,37 @@ class HomematicipDoorLockDrive(HomematicipGenericEntity, LockEntity):
         )
 
     @property
+    @override
     def is_locking(self) -> bool:
         """Return true if device is locking."""
         return self._device.motorState == MotorState.CLOSING
 
     @property
+    @override
     def is_unlocking(self) -> bool:
         """Return true if device is unlocking."""
         return self._device.motorState == MotorState.OPENING
 
     @handle_errors
+    @override
     async def async_lock(self, **kwargs: Any) -> None:
         """Lock the device."""
         return await self._device.set_lock_state_async(LockState.LOCKED)
 
     @handle_errors
+    @override
     async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock the device."""
         return await self._device.set_lock_state_async(LockState.UNLOCKED)
 
     @handle_errors
+    @override
     async def async_open(self, **kwargs: Any) -> None:
         """Open the door latch."""
         return await self._device.set_lock_state_async(LockState.OPEN)
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the device."""
         return super().extra_state_attributes | {

--- a/homeassistant/components/homematicip_cloud/sensor.py
+++ b/homeassistant/components/homematicip_cloud/sensor.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, override
 
 from homematicip.base.enums import FunctionalChannelType, ValveState
 from homematicip.base.functionalChannels import (
@@ -396,6 +396,7 @@ class HomematicipWaterFlowSensor(HomematicipGenericEntity, SensorEntity):
         )
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the state."""
         channel = self.get_channel_or_raise()
@@ -429,6 +430,7 @@ class HomematicipWaterVolumeSensor(HomematicipGenericEntity, SensorEntity):
         self._attribute_name = attribute
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the state."""
         return getattr(self.functional_channel, self._attribute_name, None)
@@ -463,6 +465,7 @@ class HomematicipTiltAngleSensor(HomematicipGenericEntity, SensorEntity):
         super().__init__(hap, device, post="Tilt Angle", feature_id="tilt_angle")
 
     @property
+    @override
     def native_value(self) -> int | None:
         """Return the state."""
         return getattr(self.functional_channel, "absoluteAngle", None)
@@ -480,12 +483,14 @@ class HomematicipTiltStateSensor(HomematicipGenericEntity, SensorEntity):
         super().__init__(hap, device, post="Tilt State", feature_id="tilt_state")
 
     @property
+    @override
     def native_value(self) -> str | None:
         """Return the state."""
         tilt_state = getattr(self.functional_channel, "tiltState", None)
         return tilt_state.lower() if tilt_state is not None else None
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the tilt sensor."""
         state_attr = super().extra_state_attributes
@@ -515,6 +520,7 @@ class HomematicipWindowStateSensor(HomematicipGenericEntity, SensorEntity):
         super().__init__(hap, device, feature_id="window_state")
 
     @property
+    @override
     def native_value(self) -> str | None:
         """Return the state."""
         window_state = getattr(self._device, "windowState", None)
@@ -543,6 +549,7 @@ class HomematicipFloorTerminalBlockMechanicChannelValve(
         )
 
     @property
+    @override
     def icon(self) -> str | None:
         """Return the icon."""
         if super().icon:
@@ -557,6 +564,7 @@ class HomematicipFloorTerminalBlockMechanicChannelValve(
         return "mdi:heating-coil"
 
     @property
+    @override
     def native_value(self) -> int | None:
         """Return the floor terminal block valve position."""
         channel = next(
@@ -583,6 +591,7 @@ class HomematicipAccesspointDutyCycle(HomematicipGenericEntity, SensorEntity):
         )
 
     @property
+    @override
     def native_value(self) -> float:
         """Return the state of the access point."""
         return self._device.dutyCycleLevel
@@ -598,6 +607,7 @@ class HomematicipHeatingThermostat(HomematicipGenericEntity, SensorEntity):
         super().__init__(hap, device, post="Heating", feature_id="valve_position")
 
     @property
+    @override
     def icon(self) -> str | None:
         """Return the icon."""
         if super().icon:
@@ -607,6 +617,7 @@ class HomematicipHeatingThermostat(HomematicipGenericEntity, SensorEntity):
         return "mdi:radiator"
 
     @property
+    @override
     def native_value(self) -> int | None:
         """Return the state of the radiator valve."""
         if self._device.valveState != ValveState.ADAPTION_DONE:
@@ -626,6 +637,7 @@ class HomematicipHumiditySensor(HomematicipGenericEntity, SensorEntity):
         super().__init__(hap, device, post="Humidity", feature_id="humidity")
 
     @property
+    @override
     def native_value(self) -> int:
         """Return the state."""
         return self._device.humidity
@@ -643,6 +655,7 @@ class HomematicipTemperatureSensor(HomematicipGenericEntity, SensorEntity):
         super().__init__(hap, device, post="Temperature", feature_id="temperature")
 
     @property
+    @override
     def native_value(self) -> float:
         """Return the state."""
         if hasattr(self._device, "valveActualTemperature"):
@@ -651,6 +664,7 @@ class HomematicipTemperatureSensor(HomematicipGenericEntity, SensorEntity):
         return self._device.actualTemperature
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the windspeed sensor."""
         state_attr = super().extra_state_attributes
@@ -678,6 +692,7 @@ class HomematicipAbsoluteHumiditySensor(HomematicipGenericEntity, SensorEntity):
         )
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the state."""
         value = self._device.vaporAmount
@@ -699,6 +714,7 @@ class HomematicipIlluminanceSensor(HomematicipGenericEntity, SensorEntity):
         super().__init__(hap, device, post="Illuminance", feature_id="illuminance")
 
     @property
+    @override
     def native_value(self) -> float:
         """Return the state."""
         if hasattr(self._device, "averageIllumination"):
@@ -707,6 +723,7 @@ class HomematicipIlluminanceSensor(HomematicipGenericEntity, SensorEntity):
         return self._device.illumination
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the wind speed sensor."""
         state_attr = super().extra_state_attributes
@@ -730,6 +747,7 @@ class HomematicipPowerSensor(HomematicipGenericEntity, SensorEntity):
         super().__init__(hap, device, post="Power", feature_id="power")
 
     @property
+    @override
     def native_value(self) -> float:
         """Return the power consumption value."""
         return self._device.currentPowerConsumption
@@ -747,6 +765,7 @@ class HomematicipEnergySensor(HomematicipGenericEntity, SensorEntity):
         super().__init__(hap, device, post="Energy", feature_id="energy")
 
     @property
+    @override
     def native_value(self) -> float:
         """Return the energy counter value."""
         return self._device.energyCounter
@@ -764,11 +783,13 @@ class HomematicipWindspeedSensor(HomematicipGenericEntity, SensorEntity):
         super().__init__(hap, device, post="Windspeed", feature_id="wind_speed")
 
     @property
+    @override
     def native_value(self) -> float:
         """Return the wind speed value."""
         return self._device.windSpeed
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the wind speed sensor."""
         state_attr = super().extra_state_attributes
@@ -796,6 +817,7 @@ class HomematicipTodayRainSensor(HomematicipGenericEntity, SensorEntity):
         super().__init__(hap, device, post="Today Rain", feature_id="today_rain")
 
     @property
+    @override
     def native_value(self) -> float:
         """Return the today's rain value."""
         return round(self._device.todayRainCounter, 2)
@@ -818,6 +840,7 @@ class HomematicpTemperatureExternalSensorCh1(HomematicipGenericEntity, SensorEnt
         )
 
     @property
+    @override
     def native_value(self) -> float:
         """Return the state."""
         return self._device.temperatureExternalOne
@@ -840,6 +863,7 @@ class HomematicpTemperatureExternalSensorCh2(HomematicipGenericEntity, SensorEnt
         )
 
     @property
+    @override
     def native_value(self) -> float:
         """Return the state."""
         return self._device.temperatureExternalTwo
@@ -862,6 +886,7 @@ class HomematicpTemperatureExternalSensorDelta(HomematicipGenericEntity, SensorE
         )
 
     @property
+    @override
     def native_value(self) -> float:
         """Return the state."""
         return self._device.temperatureExternalDelta
@@ -893,6 +918,7 @@ class HmipEsiSensorEntity(HomematicipGenericEntity, SensorEntity):
         self._type_fn = type_fn
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the esi sensor."""
         state_attr = super().extra_state_attributes
@@ -901,6 +927,7 @@ class HmipEsiSensorEntity(HomematicipGenericEntity, SensorEntity):
         return state_attr
 
     @property
+    @override
     def native_value(self) -> str | None:
         """Return the state of the sensor."""
         return str(self._value_fn(self.functional_channel))
@@ -1066,11 +1093,13 @@ class HomematicipPassageDetectorDeltaCounter(HomematicipGenericEntity, SensorEnt
         super().__init__(hap, device, feature_id="passage_counter")
 
     @property
+    @override
     def native_value(self) -> int:
         """Return the passage detector delta counter value."""
         return self._device.leftRightCounterDelta
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the delta counter."""
         state_attr = super().extra_state_attributes
@@ -1098,11 +1127,13 @@ class HmipSmokeDetectorSensor(HomematicipGenericEntity, SensorEntity):
         self._sensor_unique_id = f"{device.id}_{description.key}"
 
     @property
+    @override
     def unique_id(self) -> str:
         """Return a unique ID."""
         return self._sensor_unique_id
 
     @property
+    @override
     def native_value(self) -> StateType | datetime:
         """Return the sensor value."""
         return self.entity_description.value_fn(self._device)
@@ -1127,6 +1158,7 @@ class HomematicipSoilMoistureSensor(HomematicipGenericEntity, SensorEntity):
         )
 
     @property
+    @override
     def native_value(self) -> int | None:
         """Return the state."""
         if self.functional_channel is None:
@@ -1153,6 +1185,7 @@ class HomematicipSoilTemperatureSensor(HomematicipGenericEntity, SensorEntity):
         )
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the state."""
         if self.functional_channel is None:

--- a/homeassistant/components/homematicip_cloud/siren.py
+++ b/homeassistant/components/homematicip_cloud/siren.py
@@ -1,7 +1,7 @@
 """Support for HomematicIP Cloud sirens."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from homematicip.base.functionalChannels import NotificationMp3SoundChannel
 from homematicip.device import CombinationSignallingDevice
@@ -72,10 +72,12 @@ class HomematicipMP3Siren(HomematicipGenericEntity, SirenEntity):
         return self._device.functionalChannels[self._channel]
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if siren is playing."""
         return self._func_channel.playingFileActive
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the siren on."""
         tone = kwargs.get(ATTR_TONE, 0)
@@ -86,6 +88,7 @@ class HomematicipMP3Siren(HomematicipGenericEntity, SirenEntity):
             sound_file=sound_file, volume_level=volume_level
         )
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the siren off."""
         await self._func_channel.stop_sound_async()

--- a/homeassistant/components/homematicip_cloud/switch.py
+++ b/homeassistant/components/homematicip_cloud/switch.py
@@ -1,6 +1,6 @@
 """Support for HomematicIP Cloud switches."""
 
-from typing import Any
+from typing import Any, override
 
 from homematicip.base.enums import DeviceType, FunctionalChannelType
 from homematicip.device import (
@@ -115,16 +115,19 @@ class HomematicipMultiSwitch(HomematicipGenericEntity, SwitchEntity):
         )
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if switch is on."""
         channel = self.get_channel_or_raise()
         return channel.on
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         channel = self.get_channel_or_raise()
         await channel.async_turn_on()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         channel = self.get_channel_or_raise()
@@ -150,11 +153,13 @@ class HomematicipGroupSwitch(HomematicipGenericEntity, SwitchEntity):
         super().__init__(hap, device, post, feature_id="switch")
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if group is on."""
         return self._device.on
 
     @property
+    @override
     def available(self) -> bool:
         """Switch-Group available."""
         # A switch-group must be available, and should not be affected by the
@@ -164,6 +169,7 @@ class HomematicipGroupSwitch(HomematicipGenericEntity, SwitchEntity):
         return True
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the switch-group."""
         state_attr = super().extra_state_attributes
@@ -173,10 +179,12 @@ class HomematicipGroupSwitch(HomematicipGenericEntity, SwitchEntity):
 
         return state_attr
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the group on."""
         await self._device.turn_on_async()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the group off."""
         await self._device.turn_off_async()

--- a/homeassistant/components/homematicip_cloud/valve.py
+++ b/homeassistant/components/homematicip_cloud/valve.py
@@ -1,5 +1,7 @@
 """Support for HomematicIP Cloud valve devices."""
 
+from typing import override
+
 from homematicip.base.functionalChannels import FunctionalChannelType
 from homematicip.device import Device
 
@@ -50,17 +52,20 @@ class HomematicipWateringValve(HomematicipGenericEntity, ValveEntity):
             feature_id="watering",
         )
 
+    @override
     async def async_open_valve(self) -> None:
         """Open the valve."""
         channel = self.get_channel_or_raise()
         await channel.set_watering_switch_state_async(True)
 
+    @override
     async def async_close_valve(self) -> None:
         """Close valve."""
         channel = self.get_channel_or_raise()
         await channel.set_watering_switch_state_async(False)
 
     @property
+    @override
     def is_closed(self) -> bool:
         """Return if the valve is closed."""
         channel = self.get_channel_or_raise()

--- a/homeassistant/components/homematicip_cloud/weather.py
+++ b/homeassistant/components/homematicip_cloud/weather.py
@@ -1,5 +1,7 @@
 """Support for HomematicIP Cloud weather devices."""
 
+from typing import override
+
 from homematicip.base.enums import WeatherCondition
 from homematicip.device import WeatherSensor, WeatherSensorPlus, WeatherSensorPro
 
@@ -75,21 +77,25 @@ class HomematicipWeatherSensor(HomematicipGenericEntity, WeatherEntity):
         super().__init__(hap, device, feature_id="weather")
 
     @property
+    @override
     def native_temperature(self) -> float:
         """Return the platform temperature."""
         return self._device.actualTemperature
 
     @property
+    @override
     def humidity(self) -> int:
         """Return the humidity."""
         return self._device.humidity
 
     @property
+    @override
     def native_wind_speed(self) -> float:
         """Return the wind speed."""
         return self._device.windSpeed
 
     @property
+    @override
     def condition(self) -> str:
         """Return the current condition."""
         if getattr(self._device, "raining", None):
@@ -105,6 +111,7 @@ class HomematicipWeatherSensorPro(HomematicipWeatherSensor):
     """Representation of the HomematicIP weather sensor pro."""
 
     @property
+    @override
     def wind_bearing(self) -> float:
         """Return the wind bearing."""
         return self._device.windDirection
@@ -124,36 +131,43 @@ class HomematicipHomeWeather(HomematicipGenericEntity, WeatherEntity):
         super().__init__(hap, hap.home, feature_id="home_weather")
 
     @property
+    @override
     def available(self) -> bool:
         """Return if weather entity is available."""
         return self._home.connected
 
     @property
+    @override
     def name(self) -> str:
         """Return the name of the sensor."""
         return f"Weather {self._home.location.city}"
 
     @property
+    @override
     def native_temperature(self) -> float:
         """Return the temperature."""
         return self._device.weather.temperature
 
     @property
+    @override
     def humidity(self) -> int:
         """Return the humidity."""
         return self._device.weather.humidity
 
     @property
+    @override
     def native_wind_speed(self) -> float:
         """Return the wind speed."""
         return round(self._device.weather.windSpeed, 1)
 
     @property
+    @override
     def wind_bearing(self) -> float:
         """Return the wind bearing."""
         return self._device.weather.windDirection
 
     @property
+    @override
     def condition(self) -> str | None:
         """Return the current condition."""
         return HOME_WEATHER_CONDITION.get(self._device.weather.weatherCondition)

--- a/homeassistant/components/homevolt/config_flow.py
+++ b/homeassistant/components/homevolt/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from homevolt import Homevolt, HomevoltAuthenticationError, HomevoltConnectionError
 import voluptuous as vol
@@ -54,6 +54,7 @@ class HomevoltConfigFlow(ConfigFlow, domain=DOMAIN):
             errors["base"] = "unknown"
         return errors
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -157,6 +158,7 @@ class HomevoltConfigFlow(ConfigFlow, domain=DOMAIN):
             description_placeholders={"host": self._host},
         )
 
+    @override
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/homevolt/coordinator.py
+++ b/homeassistant/components/homevolt/coordinator.py
@@ -1,6 +1,7 @@
 """Data update coordinator for Homevolt integration."""
 
 import logging
+from typing import override
 
 from homevolt import (
     Homevolt,
@@ -42,6 +43,7 @@ class HomevoltDataUpdateCoordinator(DataUpdateCoordinator[Homevolt]):
             config_entry=entry,
         )
 
+    @override
     async def _async_update_data(self) -> Homevolt:
         """Fetch data from the Homevolt API."""
         try:

--- a/homeassistant/components/homevolt/sensor.py
+++ b/homeassistant/components/homevolt/sensor.py
@@ -1,6 +1,7 @@
 """Support for Homevolt sensors."""
 
 import logging
+from typing import override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -324,11 +325,13 @@ class HomevoltSensor(HomevoltEntity, SensorEntity):
         self._sensor_key = sensor_key
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return super().available and self._sensor_key in self.coordinator.data.sensors
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the native value of the sensor."""
         return self.coordinator.data.sensors[self._sensor_key].value

--- a/homeassistant/components/homevolt/switch.py
+++ b/homeassistant/components/homevolt/switch.py
@@ -1,6 +1,6 @@
 """Support for Homevolt switch entities."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.const import EntityCategory
@@ -36,17 +36,20 @@ class HomevoltLocalModeSwitch(HomevoltEntity, SwitchEntity):
         super().__init__(coordinator, f"ems_{device_id}")
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if local mode is enabled."""
         return self.coordinator.client.local_mode_enabled
 
     @homevolt_exception_handler
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Enable local mode."""
         await self.coordinator.client.enable_local_mode()
         await self.coordinator.async_request_refresh()
 
     @homevolt_exception_handler
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Disable local mode."""
         await self.coordinator.client.disable_local_mode()

--- a/homeassistant/components/homewizard/button.py
+++ b/homeassistant/components/homewizard/button.py
@@ -1,5 +1,7 @@
 """Support for HomeWizard buttons."""
 
+from typing import override
+
 from homeassistant.components.button import ButtonDeviceClass, ButtonEntity
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
@@ -34,6 +36,7 @@ class HomeWizardIdentifyButton(HomeWizardEntity, ButtonEntity):
         self._attr_unique_id = f"{coordinator.config_entry.unique_id}_identify"
 
     @homewizard_exception_handler
+    @override
     async def async_press(self) -> None:
         """Identify the device."""
         await self.coordinator.api.identify()

--- a/homeassistant/components/homewizard/config_flow.py
+++ b/homeassistant/components/homewizard/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for HomeWizard."""
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, override
 
 from homewizard_energy import (
     HomeWizardEnergy,
@@ -42,6 +42,7 @@ class HomeWizardConfigFlow(ConfigFlow, domain=DOMAIN):
     product_type: str | None = None
     serial: str | None = None
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -117,6 +118,7 @@ class HomeWizardConfigFlow(ConfigFlow, domain=DOMAIN):
             data=data,
         )
 
+    @override
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:
@@ -141,6 +143,7 @@ class HomeWizardConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return await self.async_step_discovery_confirm()
 
+    @override
     async def async_step_dhcp(
         self, discovery_info: DhcpServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/homewizard/coordinator.py
+++ b/homeassistant/components/homewizard/coordinator.py
@@ -1,5 +1,7 @@
 """Update coordinator for HomeWizard."""
 
+from typing import override
+
 from homewizard_energy import HomeWizardEnergy
 from homewizard_energy.errors import DisabledError, RequestError, UnauthorizedError
 from homewizard_energy.models import Batteries, CombinedModels as DeviceResponseEntry
@@ -73,6 +75,7 @@ class HWEnergyDeviceUpdateCoordinator(DataUpdateCoordinator[DeviceResponseEntry]
         elif not battery_mode_cloud_issue_active and issue_exists:
             ir.async_delete_issue(self.hass, DOMAIN, issue_id)
 
+    @override
     async def _async_update_data(self) -> DeviceResponseEntry:
         """Fetch all device and sensor data from api."""
         try:

--- a/homeassistant/components/homewizard/number.py
+++ b/homeassistant/components/homewizard/number.py
@@ -1,5 +1,7 @@
 """Creates HomeWizard Number entities."""
 
+from typing import override
+
 from homeassistant.components.number import NumberEntity
 from homeassistant.const import PERCENTAGE, EntityCategory
 from homeassistant.core import HomeAssistant
@@ -40,17 +42,20 @@ class HWEnergyNumberEntity(HomeWizardEntity, NumberEntity):
         )
 
     @homewizard_exception_handler
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Set a new value."""
         await self.coordinator.api.system(status_led_brightness_pct=int(value))
         await self.coordinator.async_refresh()
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return super().available and self.coordinator.data.system is not None
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the current value."""
         if (

--- a/homeassistant/components/homewizard/select.py
+++ b/homeassistant/components/homewizard/select.py
@@ -1,5 +1,7 @@
 """Support for HomeWizard select platform."""
 
+from typing import override
+
 from homewizard_energy.models import Batteries
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
@@ -62,6 +64,7 @@ class HomeWizardBatteryModeSelectEntity(HomeWizardEntity, SelectEntity):
         self._attr_unique_id = f"{coordinator.config_entry.unique_id}_{description.key}"
 
     @property
+    @override
     def current_option(self) -> str | None:
         """Return the selected entity option to represent the entity state."""
         return (
@@ -71,6 +74,7 @@ class HomeWizardBatteryModeSelectEntity(HomeWizardEntity, SelectEntity):
         )
 
     @homewizard_exception_handler
+    @override
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         await self.coordinator.api.batteries(Batteries.Mode(option))

--- a/homeassistant/components/homewizard/sensor.py
+++ b/homeassistant/components/homewizard/sensor.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Final
+from typing import Final, override
 
 from homewizard_energy.const import Model
 from homewizard_energy.models import CombinedModels, ExternalDevice
@@ -803,11 +803,13 @@ class HomeWizardSensorEntity(HomeWizardEntity, SensorEntity):
             self._attr_entity_registry_enabled_default = False
 
     @property
+    @override
     def native_value(self) -> StateType | datetime | None:
         """Return the sensor value."""
         return self.entity_description.value_fn(self.coordinator.data)
 
     @property
+    @override
     def available(self) -> bool:
         """Return availability of meter."""
         return super().available and self.native_value is not None
@@ -842,6 +844,7 @@ class HomeWizardExternalSensorEntity(HomeWizardEntity, SensorEntity):
             )
 
     @property
+    @override
     def native_value(self) -> float | int | str | None:
         """Return the sensor value."""
         return self.device.value if self.device is not None else None
@@ -856,11 +859,13 @@ class HomeWizardExternalSensorEntity(HomeWizardEntity, SensorEntity):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return availability of meter."""
         return super().available and self.device is not None
 
     @property
+    @override
     def native_unit_of_measurement(self) -> str | None:
         """Return unit of measurement based on device unit."""
         if (device := self.device) is None:
@@ -873,6 +878,7 @@ class HomeWizardExternalSensorEntity(HomeWizardEntity, SensorEntity):
         return device.unit
 
     @property
+    @override
     def device_class(self) -> SensorDeviceClass | None:
         """Validate unit of measurement and set device class."""
         if (

--- a/homeassistant/components/homewizard/switch.py
+++ b/homeassistant/components/homewizard/switch.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from homewizard_energy import HomeWizardEnergy
 from homewizard_energy.models import CombinedModels as DeviceResponseEntry
@@ -93,6 +93,7 @@ class HomeWizardSwitchEntity(HomeWizardEntity, SwitchEntity):
         self._attr_unique_id = f"{coordinator.config_entry.unique_id}_{description.key}"
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return super().available and self.entity_description.available_fn(
@@ -100,17 +101,20 @@ class HomeWizardSwitchEntity(HomeWizardEntity, SwitchEntity):
         )
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return state of the switch."""
         return self.entity_description.is_on_fn(self.coordinator.data)
 
     @homewizard_exception_handler
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         await self.entity_description.set_fn(self.coordinator.api, True)
         await self.coordinator.async_refresh()
 
     @homewizard_exception_handler
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         await self.entity_description.set_fn(self.coordinator.api, False)

--- a/homeassistant/components/homeworks/binary_sensor.py
+++ b/homeassistant/components/homeworks/binary_sensor.py
@@ -1,7 +1,7 @@
 """Support for Lutron Homeworks binary sensors."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyhomeworks.pyhomeworks import HW_KEYPAD_LED_CHANGED, Homeworks
 
@@ -76,6 +76,7 @@ class HomeworksBinarySensor(HomeworksEntity, BinarySensorEntity):
         )
         self._keypad = keypad
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Call when entity is added to hass."""
         signal = f"homeworks_entity_{self._controller_id}_{self._addr}"

--- a/homeassistant/components/homeworks/button.py
+++ b/homeassistant/components/homeworks/button.py
@@ -1,6 +1,7 @@
 """Support for Lutron Homeworks buttons."""
 
 import asyncio
+from typing import override
 
 from pyhomeworks.pyhomeworks import Homeworks
 
@@ -67,6 +68,7 @@ class HomeworksButton(HomeworksEntity, ButtonEntity):
         )
         self._release_delay = release_delay
 
+    @override
     async def async_press(self) -> None:
         """Press the button."""
         await self.hass.async_add_executor_job(

--- a/homeassistant/components/homeworks/config_flow.py
+++ b/homeassistant/components/homeworks/config_flow.py
@@ -3,7 +3,7 @@
 
 from functools import partial
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyhomeworks import exceptions as hw_exceptions
 from pyhomeworks.pyhomeworks import Homeworks
@@ -624,6 +624,7 @@ class HomeworksConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -658,6 +659,7 @@ class HomeworksConfigFlowHandler(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(config_entry: ConfigEntry) -> SchemaOptionsFlowHandler:
         """Options flow handler for Lutron Homeworks."""
         return SchemaOptionsFlowHandler(config_entry, OPTIONS_FLOW)

--- a/homeassistant/components/homeworks/light.py
+++ b/homeassistant/components/homeworks/light.py
@@ -1,7 +1,7 @@
 """Support for Lutron Homeworks lights."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyhomeworks.pyhomeworks import HW_LIGHT_CHANGED, Homeworks
 
@@ -63,6 +63,7 @@ class HomeworksLight(HomeworksEntity, LightEntity):
         self._level = 0
         self._prev_level = 0
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Call when entity is added to hass."""
         signal = f"homeworks_entity_{self._controller_id}_{self._addr}"
@@ -72,6 +73,7 @@ class HomeworksLight(HomeworksEntity, LightEntity):
         )
         self._controller.request_dimmer_level(self._addr)
 
+    @override
     def turn_on(self, **kwargs: Any) -> None:
         """Turn on the light."""
         if ATTR_BRIGHTNESS in kwargs:
@@ -82,11 +84,13 @@ class HomeworksLight(HomeworksEntity, LightEntity):
             new_level = self._prev_level
         self._set_brightness(new_level)
 
+    @override
     def turn_off(self, **kwargs: Any) -> None:
         """Turn off the light."""
         self._set_brightness(0)
 
     @property
+    @override
     def brightness(self) -> int:
         """Control the brightness."""
         return self._level
@@ -98,6 +102,7 @@ class HomeworksLight(HomeworksEntity, LightEntity):
         )
 
     @property
+    @override
     def is_on(self) -> bool:
         """Is the light on/off."""
         return self._level != 0

--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -1,7 +1,7 @@
 """Support for Honeywell (US) Total Connect Comfort climate systems."""
 
 import datetime
-from typing import Any
+from typing import Any, override
 
 from aiohttp import ClientConnectionError
 from aiosomecomfort import (
@@ -234,6 +234,7 @@ class HoneywellUSThermostat(ClimateEntity):
         self._attr_supported_features |= ClimateEntityFeature.FAN_MODE
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the device specific state attributes."""
         data: dict[str, Any] = {}
@@ -244,6 +245,7 @@ class HoneywellUSThermostat(ClimateEntity):
         return data
 
     @property
+    @override
     def min_temp(self) -> float:
         """Return the minimum temperature."""
         if self.hvac_mode == HVACMode.COOL:
@@ -262,6 +264,7 @@ class HoneywellUSThermostat(ClimateEntity):
         )
 
     @property
+    @override
     def max_temp(self) -> float:
         """Return the maximum temperature."""
         if self.hvac_mode == HVACMode.COOL:
@@ -280,16 +283,19 @@ class HoneywellUSThermostat(ClimateEntity):
         )
 
     @property
+    @override
     def current_humidity(self) -> int | None:
         """Return the current humidity."""
         return self._device.current_humidity
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode | None:
         """Return hvac operation ie. heat, cool mode."""
         return HW_MODE_TO_HVAC_MODE.get(self._device.system_mode)
 
     @property
+    @override
     def hvac_action(self) -> HVACAction | None:
         """Return the current running hvac operation if supported."""
         if self.hvac_mode == HVACMode.OFF:
@@ -297,11 +303,13 @@ class HoneywellUSThermostat(ClimateEntity):
         return HW_MODE_TO_HA_HVAC_ACTION.get(self._device.equipment_output_status)
 
     @property
+    @override
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
         return self._device.current_temperature
 
     @property
+    @override
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
         if self.hvac_mode == HVACMode.COOL:
@@ -311,6 +319,7 @@ class HoneywellUSThermostat(ClimateEntity):
         return None
 
     @property
+    @override
     def target_temperature_high(self) -> float | None:
         """Return the highbound target temperature we try to reach."""
         if self.hvac_mode == HVACMode.HEAT_COOL:
@@ -318,6 +327,7 @@ class HoneywellUSThermostat(ClimateEntity):
         return None
 
     @property
+    @override
     def target_temperature_low(self) -> float | None:
         """Return the lowbound target temperature we try to reach."""
         if self.hvac_mode == HVACMode.HEAT_COOL:
@@ -325,6 +335,7 @@ class HoneywellUSThermostat(ClimateEntity):
         return None
 
     @property
+    @override
     def preset_mode(self) -> str | None:
         """Return the current preset mode, e.g., home, away, temp."""
         if self._away and self._is_hold():
@@ -339,6 +350,7 @@ class HoneywellUSThermostat(ClimateEntity):
         return PRESET_NONE
 
     @property
+    @override
     def fan_mode(self) -> str | None:
         """Return the fan setting."""
         return HW_FAN_MODE_TO_HA.get(self._device.fan_mode)
@@ -400,6 +412,7 @@ class HoneywellUSThermostat(ClimateEntity):
                 translation_placeholders={"temperature": temperature},
             ) from err
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         if {HVACMode.COOL, HVACMode.HEAT} & set(self._hvac_mode_map):
@@ -424,6 +437,7 @@ class HoneywellUSThermostat(ClimateEntity):
                     translation_placeholders={"temperature": str(temperature)},
                 ) from err
 
+    @override
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""
         try:
@@ -435,6 +449,7 @@ class HoneywellUSThermostat(ClimateEntity):
                 translation_key="fan_mode_failed",
             ) from err
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         try:
@@ -531,6 +546,7 @@ class HoneywellUSThermostat(ClimateEntity):
                 translation_key="stop_hold_failed",
             ) from err
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
         if preset_mode == PRESET_AWAY:

--- a/homeassistant/components/honeywell/config_flow.py
+++ b/homeassistant/components/honeywell/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow to configure the honeywell integration."""
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, override
 
 import aiosomecomfort
 import voluptuous as vol
@@ -80,6 +80,7 @@ class HoneywellConfigFlow(ConfigFlow, domain=DOMAIN):
             description_placeholders={"name": "Honeywell"},
         )
 
+    @override
     async def async_step_user(self, user_input=None) -> ConfigFlowResult:
         """Create config entry. Show the setup form to the user."""
         errors: dict[str, str] = {}
@@ -127,6 +128,7 @@ class HoneywellConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> HoneywellOptionsFlowHandler:

--- a/homeassistant/components/honeywell/humidifier.py
+++ b/homeassistant/components/honeywell/humidifier.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from aiosomecomfort.device import Device
 
@@ -107,28 +107,34 @@ class HoneywellHumidifier(HumidifierEntity):
         )
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return the device is on or off."""
         return self.entity_description.mode(self._device) != 0
 
     @property
+    @override
     def target_humidity(self) -> int | None:
         """Return the humidity we try to reach."""
         return self.entity_description.current_set_humidity(self._device)
 
     @property
+    @override
     def current_humidity(self) -> int | None:
         """Return the current humidity."""
         return self.entity_description.current_humidity(self._device)
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
         await self.entity_description.on(self._device)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
         await self.entity_description.off(self._device)
 
+    @override
     async def async_set_humidity(self, humidity: int) -> None:
         """Set new target humidity."""
         await self.entity_description.set_humidity(self._device, humidity)

--- a/homeassistant/components/honeywell/sensor.py
+++ b/homeassistant/components/honeywell/sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from aiosomecomfort.device import Device
 
@@ -112,6 +112,7 @@ class HoneywellSensor(SensorEntity):
         )
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the state."""
         return self.entity_description.value_fn(self._device)

--- a/homeassistant/components/honeywell/switch.py
+++ b/homeassistant/components/honeywell/switch.py
@@ -1,6 +1,6 @@
 """Support for Honeywell switches."""
 
-from typing import Any
+from typing import Any, override
 
 from aiosomecomfort import SomeComfortError
 from aiosomecomfort.device import Device as SomeComfortDevice
@@ -66,6 +66,7 @@ class HoneywellSwitch(SwitchEntity):
             manufacturer="Honeywell",
         )
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on if heat mode is enabled."""
         try:
@@ -75,6 +76,7 @@ class HoneywellSwitch(SwitchEntity):
                 translation_domain=DOMAIN, translation_key="switch_failed_on"
             ) from err
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off if on."""
         if self.is_on:
@@ -87,6 +89,7 @@ class HoneywellSwitch(SwitchEntity):
                 ) from err
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if Emergency heat is enabled."""
         return self._device.system_mode == "emheat"

--- a/homeassistant/components/honeywell_string_lights/config_flow.py
+++ b/homeassistant/components/honeywell_string_lights/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for the Honeywell String Lights integration."""
 
-from typing import Any
+from typing import Any, override
 
 from rf_protocols import RadioFrequencyCommand
 from rf_protocols.codes.honeywell.string_lights import CODES
@@ -19,6 +19,7 @@ class HoneywellStringLightsConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/honeywell_string_lights/entity.py
+++ b/homeassistant/components/honeywell_string_lights/entity.py
@@ -1,6 +1,7 @@
 """Common entity for Honeywell String Lights integration."""
 
 import logging
+from typing import override
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_UNAVAILABLE
@@ -30,6 +31,7 @@ class HoneywellStringLightsEntity(Entity):
             model="String Lights",
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Subscribe to transmitter entity state changes."""
         await super().async_added_to_hass()

--- a/homeassistant/components/honeywell_string_lights/light.py
+++ b/homeassistant/components/honeywell_string_lights/light.py
@@ -1,6 +1,6 @@
 """Light platform for Honeywell String Lights."""
 
-from typing import Any
+from typing import Any, override
 
 from rf_protocols.codes.honeywell.string_lights import CODES
 
@@ -35,18 +35,21 @@ class HoneywellStringLight(HoneywellStringLightsEntity, LightEntity, RestoreEnti
     _attr_name = None
     _attr_should_poll = False
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Restore last known state."""
         await super().async_added_to_hass()
         if (last_state := await self.async_get_last_state()) is not None:
             self._attr_is_on = last_state.state == STATE_ON
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the light."""
         await self._async_send_command("turn_on")
         self._attr_is_on = True
         self.async_write_ha_state()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the light."""
         await self._async_send_command("turn_off")

--- a/homeassistant/components/horizon/media_player.py
+++ b/homeassistant/components/horizon/media_player.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from horimote import Client, keys
 from horimote.exceptions import AuthenticationError
@@ -88,6 +88,7 @@ class HorizonDevice(MediaPlayerEntity):
         self._keys = remote_keys
 
     @property
+    @override
     def name(self):
         """Return the name of the remote."""
         return self._name
@@ -103,31 +104,37 @@ class HorizonDevice(MediaPlayerEntity):
         except OSError:
             self._attr_state = MediaPlayerState.OFF
 
+    @override
     def turn_on(self) -> None:
         """Turn the device on."""
         if self.state == MediaPlayerState.OFF:
             self._send_key(self._keys.POWER)
 
+    @override
     def turn_off(self) -> None:
         """Turn the device off."""
         if self.state != MediaPlayerState.OFF:
             self._send_key(self._keys.POWER)
 
+    @override
     def media_previous_track(self) -> None:
         """Channel down."""
         self._send_key(self._keys.CHAN_DOWN)
         self._attr_state = MediaPlayerState.PLAYING
 
+    @override
     def media_next_track(self) -> None:
         """Channel up."""
         self._send_key(self._keys.CHAN_UP)
         self._attr_state = MediaPlayerState.PLAYING
 
+    @override
     def media_play(self) -> None:
         """Send play command."""
         self._send_key(self._keys.PAUSE)
         self._attr_state = MediaPlayerState.PLAYING
 
+    @override
     def media_pause(self) -> None:
         """Send pause command."""
         self._send_key(self._keys.PAUSE)
@@ -141,6 +148,7 @@ class HorizonDevice(MediaPlayerEntity):
         else:
             self._attr_state = MediaPlayerState.PAUSED
 
+    @override
     def play_media(
         self, media_type: MediaType | str, media_id: str, **kwargs: Any
     ) -> None:

--- a/homeassistant/components/hr_energy_qube/binary_sensor.py
+++ b/homeassistant/components/hr_energy_qube/binary_sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -285,6 +285,7 @@ class QubeBinarySensor(QubeEntity, BinarySensorEntity):
         self._attr_unique_id = f"{entry.entry_id}-{description.key}"
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
         return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/hr_energy_qube/config_flow.py
+++ b/homeassistant/components/hr_energy_qube/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for Qube Heat Pump integration."""
 
-from typing import Any
+from typing import Any, override
 
 from python_qube_heatpump import QubeClient
 import voluptuous as vol
@@ -16,6 +16,7 @@ class QubeConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/hr_energy_qube/coordinator.py
+++ b/homeassistant/components/hr_energy_qube/coordinator.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from python_qube_heatpump import QubeClient
 from python_qube_heatpump.models import QubeState
@@ -43,6 +43,7 @@ class QubeCoordinator(DataUpdateCoordinator[QubeData]):
             config_entry=entry,
         )
 
+    @override
     async def _async_update_data(self) -> QubeData:
         """Fetch data from the device."""
         try:

--- a/homeassistant/components/hr_energy_qube/sensor.py
+++ b/homeassistant/components/hr_energy_qube/sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -272,6 +272,7 @@ class QubeSensor(QubeEntity, SensorEntity):
         self._attr_unique_id = f"{entry.entry_id}-{description.key}"
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return native value."""
         return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/hr_energy_qube/switch.py
+++ b/homeassistant/components/hr_energy_qube/switch.py
@@ -1,7 +1,7 @@
 """Switch platform for Qube Heat Pump."""
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.const import EntityCategory
@@ -79,6 +79,7 @@ class QubeSwitch(QubeEntity, SwitchEntity):
         self._attr_unique_id = f"{entry.entry_id}-{description.key}"
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return (
@@ -87,6 +88,7 @@ class QubeSwitch(QubeEntity, SwitchEntity):
         )
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if the switch is on."""
         return self.coordinator.data.switches.get(self.entity_description.register_key)
@@ -108,10 +110,12 @@ class QubeSwitch(QubeEntity, SwitchEntity):
             )
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         await self._async_write_switch(True)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         await self._async_write_switch(False)

--- a/homeassistant/components/hr_energy_qube/water_heater.py
+++ b/homeassistant/components/hr_energy_qube/water_heater.py
@@ -1,6 +1,6 @@
 """Water heater platform for Qube Heat Pump."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.water_heater import (
     STATE_HEAT_PUMP,
@@ -61,16 +61,19 @@ class QubeWaterHeater(QubeEntity, WaterHeaterEntity):
         self._attr_unique_id = entry.entry_id
 
     @property
+    @override
     def current_temperature(self) -> float | None:
         """Return the current DHW temperature."""
         return self.coordinator.data.state.temp_dhw
 
     @property
+    @override
     def target_temperature(self) -> float | None:
         """Return the target DHW temperature."""
         return self.coordinator.data.state.setpoint_dhw
 
     @property
+    @override
     def current_operation(self) -> str | None:
         """Return the current operation mode."""
         boost = self.coordinator.data.switches.get(DHW_BOOST_KEY)
@@ -80,6 +83,7 @@ class QubeWaterHeater(QubeEntity, WaterHeaterEntity):
             return STATE_PERFORMANCE
         return STATE_HEAT_PUMP
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set the target DHW temperature."""
         temperature = kwargs.get("temperature")
@@ -101,6 +105,7 @@ class QubeWaterHeater(QubeEntity, WaterHeaterEntity):
             )
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_set_operation_mode(self, operation_mode: str) -> None:
         """Set the operation mode."""
         boost = operation_mode == STATE_PERFORMANCE

--- a/homeassistant/components/html5/config_flow.py
+++ b/homeassistant/components/html5/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for the html5 component."""
 
 import binascii
-from typing import Any, cast
+from typing import Any, cast, override
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
@@ -66,6 +66,7 @@ class HTML5ConfigFlow(ConfigFlow, domain=DOMAIN):
             flow_result = self.async_create_entry(title="HTML5", data=config)
         return errors, flow_result
 
+    @override
     async def async_step_user(
         self: HTML5ConfigFlow, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/html5/entity.py
+++ b/homeassistant/components/html5/entity.py
@@ -1,6 +1,6 @@
 """Base entities for HTML5 integration."""
 
-from typing import NotRequired, TypedDict
+from typing import NotRequired, TypedDict, override
 
 from aiohttp import ClientSession
 
@@ -66,6 +66,7 @@ class HTML5Entity(Entity):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available."""
         return super().available and self.target in self.registrations

--- a/homeassistant/components/html5/event.py
+++ b/homeassistant/components/html5/event.py
@@ -1,6 +1,6 @@
 """Event platform for HTML5 integration."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.event import EventEntity
 from homeassistant.config_entries import ConfigEntry
@@ -57,6 +57,7 @@ class HTML5EventEntity(HTML5Entity, EventEntity):
             )
             self.async_write_ha_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register event callback."""
 

--- a/homeassistant/components/html5/notify.py
+++ b/homeassistant/components/html5/notify.py
@@ -6,7 +6,7 @@ from http import HTTPStatus
 import json
 import logging
 import time
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, cast, override
 from urllib.parse import urlparse
 import uuid
 import warnings
@@ -452,6 +452,7 @@ class HTML5NotificationService(BaseNotificationService):
         )
 
     @property
+    @override
     def targets(self) -> dict[str, str]:
         """Return a dictionary of registered targets."""
         return {registration: registration for registration in self.registrations}
@@ -470,6 +471,7 @@ class HTML5NotificationService(BaseNotificationService):
 
         await self._push_message(payload, **kwargs)
 
+    @override
     async def async_send_message(self, message: str = "", **kwargs: Any) -> None:
         """Send a message to a user."""
 
@@ -616,6 +618,7 @@ class HTML5NotifyEntity(HTML5Entity, NotifyEntity):
     _attr_supported_features = NotifyEntityFeature.TITLE
     _key = "device"
 
+    @override
     async def async_send_message(self, message: str, title: str | None = None) -> None:
         """Send a message to a device via notify.send_message action."""
         await self._webpush(

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import socket
 import ssl
 from tempfile import NamedTemporaryFile
-from typing import Any, Final, TypedDict, cast
+from typing import Any, Final, TypedDict, cast, override
 
 from aiohttp import web
 from aiohttp.abc import AbstractStreamWriter
@@ -336,6 +336,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 class HomeAssistantRequest(web.Request):
     """Home Assistant request object."""
 
+    @override
     async def json(self, *, loads: JSONDecoder = json_loads) -> Any:
         """Return body as JSON."""
         # json_loads is a wrapper around orjson.loads that handles
@@ -346,6 +347,7 @@ class HomeAssistantRequest(web.Request):
 class HomeAssistantApplication(web.Application):
     """Home Assistant application."""
 
+    @override
     def _make_request(
         self,
         message: RawRequestMessage,

--- a/homeassistant/components/http/static.py
+++ b/homeassistant/components/http/static.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Final
+from typing import Final, override
 
 from aiohttp.hdrs import CACHE_CONTROL, CONTENT_TYPE
 from aiohttp.web import FileResponse, Request, StreamResponse
@@ -21,6 +21,7 @@ _GUESSER = CONTENT_TYPES.guess_file_type
 class CachingStaticResource(StaticResource):
     """Static Resource handler that will add cache headers."""
 
+    @override
     async def _handle(self, request: Request) -> StreamResponse:
         """Wrap base handler to cache file path resolution and content type guess."""
         rel_url = request.match_info["filename"]

--- a/homeassistant/components/http/web_runner.py
+++ b/homeassistant/components/http/web_runner.py
@@ -4,6 +4,7 @@ import asyncio
 from pathlib import Path
 import socket
 from ssl import SSLContext
+from typing import override
 
 from aiohttp import web
 from yarl import URL
@@ -47,12 +48,14 @@ class HomeAssistantTCPSite(web.BaseSite):
         self._reuse_port = reuse_port
 
     @property
+    @override
     def name(self) -> str:
         """Return server URL."""
         scheme = "https" if self._ssl_context else "http"
         host = self._host[0] if isinstance(self._host, list) else "0.0.0.0"
         return str(URL.build(scheme=scheme, host=host, port=self._port))
 
+    @override
     async def start(self) -> None:
         """Start server."""
         await super().start()
@@ -94,6 +97,7 @@ class HomeAssistantUnixSite(web.BaseSite):
         self._path = path
 
     @property
+    @override
     def name(self) -> str:
         """Return server URL."""
         return f"http://unix:{self._path}:"
@@ -117,6 +121,7 @@ class HomeAssistantUnixSite(web.BaseSite):
             raise
         return sock
 
+    @override
     async def start(self) -> None:
         """Start server."""
         await super().start()

--- a/homeassistant/components/huawei_lte/binary_sensor.py
+++ b/homeassistant/components/huawei_lte/binary_sensor.py
@@ -1,7 +1,7 @@
 """Support for Huawei LTE binary sensors."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from huawei_lte_api.enums.cradle import ConnectionStatusEnum
 
@@ -56,9 +56,11 @@ class HuaweiLteBaseBinarySensor(HuaweiLteBaseEntityWithDevice, BinarySensorEntit
     _raw_state: str | None = None
 
     @property
+    @override
     def _device_unique_id(self) -> str:
         return f"{self.key}.{self.item}"
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Subscribe to needed data on add."""
         await super().async_added_to_hass()
@@ -66,6 +68,7 @@ class HuaweiLteBaseBinarySensor(HuaweiLteBaseEntityWithDevice, BinarySensorEntit
             f"{BINARY_SENSOR_DOMAIN}/{self.item}"
         )
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Unsubscribe from needed data on remove."""
         await super().async_will_remove_from_hass()
@@ -73,6 +76,7 @@ class HuaweiLteBaseBinarySensor(HuaweiLteBaseEntityWithDevice, BinarySensorEntit
             f"{BINARY_SENSOR_DOMAIN}/{self.item}"
         )
 
+    @override
     async def async_update(self) -> None:
         """Update state."""
         try:
@@ -108,6 +112,7 @@ class HuaweiLteMobileConnectionBinarySensor(HuaweiLteBaseBinarySensor):
     item = "ConnectionStatus"
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return whether the binary sensor is on."""
         return bool(
@@ -117,6 +122,7 @@ class HuaweiLteMobileConnectionBinarySensor(HuaweiLteBaseBinarySensor):
         )
 
     @property
+    @override
     def assumed_state(self) -> bool:
         """Return True if real state is assumed, not known."""
         return not self._raw_state or int(self._raw_state) not in (
@@ -126,6 +132,7 @@ class HuaweiLteMobileConnectionBinarySensor(HuaweiLteBaseBinarySensor):
         )
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Get additional attributes related to connection status."""
         attributes = {}
@@ -142,11 +149,13 @@ class HuaweiLteBaseWifiStatusBinarySensor(HuaweiLteBaseBinarySensor):
     _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return whether the binary sensor is on."""
         return self._raw_state is not None and int(self._raw_state) == 1
 
     @property
+    @override
     def assumed_state(self) -> bool:
         """Return True if real state is assumed, not known."""
         return self._raw_state is None
@@ -188,11 +197,13 @@ class HuaweiLteSmsStorageFullBinarySensor(HuaweiLteBaseBinarySensor):
     item = "SmsStorageFull"
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return whether the binary sensor is on."""
         return self._raw_state is not None and int(self._raw_state) != 0
 
     @property
+    @override
     def assumed_state(self) -> bool:
         """Return True if real state is assumed, not known."""
         return self._raw_state is None

--- a/homeassistant/components/huawei_lte/button.py
+++ b/homeassistant/components/huawei_lte/button.py
@@ -1,6 +1,7 @@
 """Huawei LTE buttons."""
 
 import logging
+from typing import override
 
 from huawei_lte_api.enums.device import ControlModeEnum
 
@@ -37,13 +38,16 @@ class BaseButton(HuaweiLteBaseEntityWithDevice, ButtonEntity):
     """Huawei LTE button base class."""
 
     @property
+    @override
     def _device_unique_id(self) -> str:
         """Return unique ID for entity within a router."""
         return f"button-{self.entity_description.key}"
 
+    @override
     async def async_update(self) -> None:
         """Update is not necessary for button entities."""
 
+    @override
     def press(self) -> None:
         """Press button."""
         if self.router.suspended:
@@ -71,6 +75,7 @@ class ClearTrafficStatisticsButton(BaseButton):
         entity_category=EntityCategory.CONFIG,
     )
 
+    @override
     def _press(self) -> str:
         """Call clear traffic statistics endpoint."""
         return self.router.client.monitoring.set_clear_traffic()
@@ -88,6 +93,7 @@ class RestartButton(BaseButton):
         entity_category=EntityCategory.CONFIG,
     )
 
+    @override
     def _press(self) -> str:
         """Call restart endpoint."""
         return self.router.client.device.set_control(ControlModeEnum.REBOOT)

--- a/homeassistant/components/huawei_lte/config_flow.py
+++ b/homeassistant/components/huawei_lte/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 from urllib.parse import urlparse
 
 from huawei_lte_api.Client import Client
@@ -69,6 +69,7 @@ class HuaweiLteConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: HuaweiLteConfigEntry,
     ) -> HuaweiLteOptionsFlow:
@@ -194,6 +195,7 @@ class HuaweiLteConfigFlow(ConfigFlow, domain=DOMAIN):
         except Exception:
             _LOGGER.exception("Disconnect error")
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -273,6 +275,7 @@ class HuaweiLteConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_create_entry(title=title, data=user_input)
 
+    @override
     async def async_step_ssdp(
         self, discovery_info: SsdpServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/huawei_lte/device_tracker.py
+++ b/homeassistant/components/huawei_lte/device_tracker.py
@@ -1,7 +1,7 @@
 """Support for device tracking of Huawei LTE routers."""
 
 import logging
-from typing import Any, cast
+from typing import Any, cast, override
 
 from homeassistant.components.device_tracker import (
     DOMAIN as DEVICE_TRACKER_DOMAIN,
@@ -165,39 +165,47 @@ class HuaweiLteScannerEntity(HuaweiLteBaseEntity, ScannerEntity):
         self._mac_address = mac_address
 
     @property
+    @override
     def name(self) -> str:
         """Return the name of the entity."""
         return self.hostname or self.mac_address
 
     @property
+    @override
     def _device_unique_id(self) -> str:
         return self.mac_address
 
     @property
+    @override
     def ip_address(self) -> str | None:
         """Return the primary ip address of the device."""
         return self._ip_address
 
     @property
+    @override
     def mac_address(self) -> str:
         """Return the mac address of the device."""
         return self._mac_address
 
     @property
+    @override
     def hostname(self) -> str | None:
         """Return hostname of the device."""
         return self._hostname
 
     @property
+    @override
     def is_connected(self) -> bool:
         """Get whether the entity is connected."""
         return self._is_connected
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Get additional attributes related to entity state."""
         return self._extra_state_attributes
 
+    @override
     async def async_update(self) -> None:
         """Update state."""
         if (hosts := _get_hosts(self.router)) is None:

--- a/homeassistant/components/huawei_lte/entity.py
+++ b/homeassistant/components/huawei_lte/entity.py
@@ -1,6 +1,7 @@
 """Support for Huawei LTE routers."""
 
 from datetime import timedelta
+from typing import override
 
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -29,11 +30,13 @@ class HuaweiLteBaseEntity(Entity):
         raise NotImplementedError
 
     @property
+    @override
     def unique_id(self) -> str:
         """Return unique ID for entity."""
         return f"{self.router.config_entry.unique_id}-{self._device_unique_id}"
 
     @property
+    @override
     def available(self) -> bool:
         """Return whether the entity is available."""
         return self._available
@@ -42,6 +45,7 @@ class HuaweiLteBaseEntity(Entity):
         """Update state."""
         raise NotImplementedError
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Connect to update signals."""
         self.async_on_remove(
@@ -58,6 +62,7 @@ class HuaweiLteBaseEntityWithDevice(HuaweiLteBaseEntity):
     """Base entity with device info."""
 
     @property
+    @override
     def device_info(self) -> DeviceInfo:
         """Get info for matching with parent router."""
         return DeviceInfo(

--- a/homeassistant/components/huawei_lte/notify.py
+++ b/homeassistant/components/huawei_lte/notify.py
@@ -1,7 +1,7 @@
 """Support for Huawei LTE router notifications."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from huawei_lte_api.exceptions import ResponseErrorException
 
@@ -42,6 +42,7 @@ class HuaweiLteSmsNotificationService(BaseNotificationService):
         self.router = router
         self.default_targets = default_targets
 
+    @override
     def send_message(self, message: str = "", **kwargs: Any) -> None:
         """Send message to target numbers."""
 

--- a/homeassistant/components/huawei_lte/select.py
+++ b/homeassistant/components/huawei_lte/select.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
 import logging
-from typing import Any
+from typing import Any, override
 
 from huawei_lte_api.enums.net import LTEBandEnum, NetworkBandEnum, NetworkModeEnum
 
@@ -91,29 +91,35 @@ class HuaweiLteSelectEntity(HuaweiLteBaseEntityWithDevice, SelectEntity):
         self.key = key
         self.item = item
 
+    @override
     def select_option(self, option: str) -> None:
         """Change the selected option."""
         self.entity_description.setter_fn(option)
 
     @property
+    @override
     def current_option(self) -> str | None:
         """Return current option."""
         return self._raw_state
 
     @property
+    @override
     def _device_unique_id(self) -> str:
         return f"{self.key}.{self.item}"
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Subscribe to needed data on add."""
         await super().async_added_to_hass()
         self.router.subscriptions[self.key].append(f"{SELECT_DOMAIN}/{self.item}")
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Unsubscribe from needed data on remove."""
         await super().async_will_remove_from_hass()
         self.router.subscriptions[self.key].remove(f"{SELECT_DOMAIN}/{self.item}")
 
+    @override
     async def async_update(self) -> None:
         """Update state."""
         try:

--- a/homeassistant/components/huawei_lte/sensor.py
+++ b/homeassistant/components/huawei_lte/sensor.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 import ipaddress
 import logging
 import re
+from typing import override
 
 from homeassistant.components.sensor import (
     DOMAIN as SENSOR_DOMAIN,
@@ -847,6 +848,7 @@ class HuaweiLteSensor(HuaweiLteBaseEntityWithDevice, SensorEntity):
         self.item = item
         self.entity_description = entity_description
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Subscribe to needed data on add."""
         await super().async_added_to_hass()
@@ -856,6 +858,7 @@ class HuaweiLteSensor(HuaweiLteBaseEntityWithDevice, SensorEntity):
                 f"{SENSOR_DOMAIN}/{self.entity_description.last_reset_item}"
             )
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Unsubscribe from needed data on remove."""
         await super().async_will_remove_from_hass()
@@ -866,20 +869,24 @@ class HuaweiLteSensor(HuaweiLteBaseEntityWithDevice, SensorEntity):
             )
 
     @property
+    @override
     def _device_unique_id(self) -> str:
         return f"{self.key}.{self.item}"
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return sensor state."""
         return self._state
 
     @property
+    @override
     def native_unit_of_measurement(self) -> str | None:
         """Return sensor's unit of measurement."""
         return self.entity_description.native_unit_of_measurement or self._unit
 
     @property
+    @override
     def icon(self) -> str | None:
         """Return icon for sensor."""
         if self.entity_description.icon_fn:
@@ -887,6 +894,7 @@ class HuaweiLteSensor(HuaweiLteBaseEntityWithDevice, SensorEntity):
         return super().icon
 
     @property
+    @override
     def device_class(self) -> SensorDeviceClass | None:
         """Return device class for sensor."""
         if self.entity_description.device_class_fn:
@@ -895,10 +903,12 @@ class HuaweiLteSensor(HuaweiLteBaseEntityWithDevice, SensorEntity):
         return super().device_class
 
     @property
+    @override
     def last_reset(self) -> datetime | None:
         """Return the time when the sensor was last reset, if any."""
         return self._last_reset
 
+    @override
     async def async_update(self) -> None:
         """Update state."""
         try:

--- a/homeassistant/components/huawei_lte/switch.py
+++ b/homeassistant/components/huawei_lte/switch.py
@@ -1,7 +1,7 @@
 """Support for Huawei LTE switches."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.switch import (
     DOMAIN as SWITCH_DOMAIN,
@@ -49,24 +49,29 @@ class HuaweiLteBaseSwitch(HuaweiLteBaseEntityWithDevice, SwitchEntity):
     def _turn(self, state: bool) -> None:
         raise NotImplementedError
 
+    @override
     def turn_on(self, **kwargs: Any) -> None:
         """Turn switch on."""
         self._turn(state=True)
 
+    @override
     def turn_off(self, **kwargs: Any) -> None:
         """Turn switch off."""
         self._turn(state=False)
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Subscribe to needed data on add."""
         await super().async_added_to_hass()
         self.router.subscriptions[self.key].append(f"{SWITCH_DOMAIN}/{self.item}")
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Unsubscribe from needed data on remove."""
         await super().async_will_remove_from_hass()
         self.router.subscriptions[self.key].remove(f"{SWITCH_DOMAIN}/{self.item}")
 
+    @override
     async def async_update(self) -> None:
         """Update state."""
         try:
@@ -88,14 +93,17 @@ class HuaweiLteMobileDataSwitch(HuaweiLteBaseSwitch):
     item = "dataswitch"
 
     @property
+    @override
     def _device_unique_id(self) -> str:
         return f"{self.key}.{self.item}"
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return whether the switch is on."""
         return self._raw_state == "1"
 
+    @override
     def _turn(self, state: bool) -> None:
         value = 1 if state else 0
         self.router.client.dial_up.set_mobile_dataswitch(dataswitch=value)
@@ -112,20 +120,24 @@ class HuaweiLteWifiGuestNetworkSwitch(HuaweiLteBaseSwitch):
     item = "WifiEnable"
 
     @property
+    @override
     def _device_unique_id(self) -> str:
         return f"{self.key}.{self.item}"
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return whether the switch is on."""
         return self._raw_state == "1"
 
+    @override
     def _turn(self, state: bool) -> None:
         self.router.client.wlan.wifi_guest_network_switch(state)
         self._raw_state = "1" if state else "0"
         self.schedule_update_ha_state()
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, str | None]:
         """Return the state attributes."""
         return {"ssid": self.router.data[self.key].get("WifiSsid")}

--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from typing import Any
+from typing import Any, override
 
 import aiohttp
 from aiohue import LinkButtonNotPressed, create_app_key
@@ -51,6 +51,7 @@ class HueFlowHandler(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: HueConfigEntry,
     ) -> HueV1OptionsFlowHandler | HueV2OptionsFlowHandler:
@@ -64,6 +65,7 @@ class HueFlowHandler(ConfigFlow, domain=DOMAIN):
         self.bridge: DiscoveredHueBridge | None = None
         self.discovered_bridges: dict[str, DiscoveredHueBridge] | None = None
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -225,6 +227,7 @@ class HueFlowHandler(ConfigFlow, domain=DOMAIN):
             },
         )
 
+    @override
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:
@@ -261,6 +264,7 @@ class HueFlowHandler(ConfigFlow, domain=DOMAIN):
 
         return await self.async_step_link()
 
+    @override
     async def async_step_homekit(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/hue/event.py
+++ b/homeassistant/components/hue/event.py
@@ -1,6 +1,6 @@
 """Hue event entities from Button resources."""
 
-from typing import Any
+from typing import Any, override
 
 from aiohue.v2 import HueBridgeV2
 from aiohue.v2.controllers.events import EventType
@@ -100,6 +100,7 @@ class HueButtonEventEntity(HueBaseEntity, EventEntity):
         }
 
     @callback
+    @override
     def _handle_event(
         self, event_type: EventType, resource: Button | BellButton
     ) -> None:
@@ -140,6 +141,7 @@ class HueRotaryEventEntity(HueBaseEntity, EventEntity):
     )
 
     @callback
+    @override
     def _handle_event(self, event_type: EventType, resource: RelativeRotary) -> None:
         """Handle status event for this resource (or it's parent)."""
         if event_type == EventType.RESOURCE_UPDATED and resource.id == self.resource.id:

--- a/homeassistant/components/hue/scene.py
+++ b/homeassistant/components/hue/scene.py
@@ -1,7 +1,7 @@
 """Support for scene platform for Hue scenes (V2 only)."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from aiohue.v2 import HueBridgeV2
 from aiohue.v2.controllers.events import EventType
@@ -114,6 +114,7 @@ class HueSceneEntityBase(HueBaseEntity, SceneEntity):
             identifiers={(DOMAIN, self.hue_group.id)},
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Call when entity is added."""
         await super().async_added_to_hass()
@@ -127,6 +128,7 @@ class HueSceneEntityBase(HueBaseEntity, SceneEntity):
         )
 
     @property
+    @override
     def name(self) -> str:
         """Return name of the scene."""
         return self.resource.metadata.name
@@ -152,6 +154,7 @@ class HueSceneEntity(HueSceneEntityBase):
             return True
         return False
 
+    @override
     async def async_activate(self, **kwargs: Any) -> None:
         """Activate Hue scene."""
         transition = normalize_hue_transition(kwargs.get(ATTR_TRANSITION))
@@ -178,6 +181,7 @@ class HueSceneEntity(HueSceneEntityBase):
         )
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return the optional state attributes."""
         brightness = None
@@ -211,6 +215,7 @@ class HueSmartSceneEntity(HueSceneEntityBase):
         """Return if this smart scene is currently active."""
         return self.resource.state == SmartSceneState.ACTIVE
 
+    @override
     async def async_activate(self, **kwargs: Any) -> None:
         """Activate Hue Smart scene."""
 
@@ -220,6 +225,7 @@ class HueSmartSceneEntity(HueSceneEntityBase):
         )
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return the optional state attributes."""
         res = {

--- a/homeassistant/components/hue/switch.py
+++ b/homeassistant/components/hue/switch.py
@@ -1,6 +1,6 @@
 """Support for switch platform for Hue resources (V2 only)."""
 
-from typing import Any
+from typing import Any, override
 
 from aiohue.v2 import HueBridgeV2
 from aiohue.v2.controllers.config import BehaviorInstance, BehaviorInstanceController
@@ -87,16 +87,19 @@ class HueResourceEnabledEntity(HueBaseEntity, SwitchEntity):
     )
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if the switch is on."""
         return self.resource.enabled
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         await self.bridge.async_request_call(
             self.controller.set_enabled, self.resource.id, enabled=True
         )
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         await self.bridge.async_request_call(
@@ -116,6 +119,7 @@ class HueBehaviorInstanceEnabledEntity(HueResourceEnabledEntity):
     )
 
     @property
+    @override
     def name(self) -> str:
         """Return name for this entity."""
         return f"Automation: {self.resource.metadata.name}"

--- a/homeassistant/components/hue/v1/binary_sensor.py
+++ b/homeassistant/components/hue/v1/binary_sensor.py
@@ -1,6 +1,6 @@
 """Hue binary sensor entities."""
 
-from typing import Any
+from typing import Any, override
 
 from aiohue.v1.sensors import TYPE_ZLL_PRESENCE
 
@@ -40,11 +40,13 @@ class HuePresence(GenericZLLSensor, BinarySensorEntity):
     _attr_device_class = BinarySensorDeviceClass.MOTION
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if the binary sensor is on."""
         return self.sensor.presence
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the device state attributes."""
         attributes = super().extra_state_attributes

--- a/homeassistant/components/hue/v1/light.py
+++ b/homeassistant/components/hue/v1/light.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 from functools import partial
 import logging
 import random
-from typing import Any
+from typing import Any, override
 
 import aiohue
 
@@ -377,6 +377,7 @@ class HueLight(CoordinatorEntity, LightEntity):
                 self.gamut = None
 
     @property
+    @override
     def unique_id(self):
         """Return the unique ID of this Hue light."""
         unique_id = self.light.uniqueid
@@ -391,11 +392,13 @@ class HueLight(CoordinatorEntity, LightEntity):
         return self.unique_id
 
     @property
+    @override
     def name(self):
         """Return the name of the Hue light."""
         return self.light.name
 
     @property
+    @override
     def brightness(self):
         """Return the brightness of this light between 0..255."""
         if self.is_group:
@@ -409,6 +412,7 @@ class HueLight(CoordinatorEntity, LightEntity):
         return hue_brightness_to_hass(bri)
 
     @property
+    @override
     def color_mode(self) -> ColorMode:
         """Return the color mode of the light."""
         if self._fixed_color_mode:
@@ -429,6 +433,7 @@ class HueLight(CoordinatorEntity, LightEntity):
         return self.light.state.get("colormode")
 
     @property
+    @override
     def hs_color(self):
         """Return the hs color value."""
         mode = self._color_mode
@@ -440,6 +445,7 @@ class HueLight(CoordinatorEntity, LightEntity):
         return None
 
     @property
+    @override
     def color_temp_kelvin(self) -> int | None:
         """Return the color temperature value in Kelvin."""
         # Don't return color temperature unless in color temperature mode
@@ -452,6 +458,7 @@ class HueLight(CoordinatorEntity, LightEntity):
         return color_util.color_temperature_mired_to_kelvin(ct) if ct else None
 
     @property
+    @override
     def max_color_temp_kelvin(self) -> int:
         """Return the coldest color_temp_kelvin that this light supports."""
         if self.is_group:
@@ -466,6 +473,7 @@ class HueLight(CoordinatorEntity, LightEntity):
         return color_util.color_temperature_mired_to_kelvin(min_mireds)
 
     @property
+    @override
     def min_color_temp_kelvin(self) -> int:
         """Return the warmest color_temp_kelvin that this light supports."""
         if self.is_group:
@@ -481,6 +489,7 @@ class HueLight(CoordinatorEntity, LightEntity):
         return color_util.color_temperature_mired_to_kelvin(max_mireds)
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if device is on."""
         if self.is_group:
@@ -488,6 +497,7 @@ class HueLight(CoordinatorEntity, LightEntity):
         return self.light.state["on"]
 
     @property
+    @override
     def available(self):
         """Return if light is available."""
         return self.coordinator.last_update_success and (
@@ -495,11 +505,13 @@ class HueLight(CoordinatorEntity, LightEntity):
         )
 
     @property
+    @override
     def effect(self):
         """Return the current effect."""
         return self.light.state.get("effect", None)
 
     @property
+    @override
     def effect_list(self):
         """Return the list of supported effects."""
         if self.is_osram:
@@ -507,6 +519,7 @@ class HueLight(CoordinatorEntity, LightEntity):
         return [EFFECT_COLORLOOP, EFFECT_RANDOM]
 
     @property
+    @override
     def device_info(self) -> DeviceInfo | None:
         """Return the device info."""
         if self.light.type in (
@@ -535,6 +548,7 @@ class HueLight(CoordinatorEntity, LightEntity):
             via_device=(DOMAIN, self.bridge.api.config.bridgeid),
         )
 
+    @override
     async def async_turn_on(self, **kwargs):
         """Turn the specified or all lights on."""
         command = {"on": True}
@@ -595,6 +609,7 @@ class HueLight(CoordinatorEntity, LightEntity):
 
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_turn_off(self, **kwargs):
         """Turn the specified or all lights off."""
         command = {"on": False}
@@ -621,6 +636,7 @@ class HueLight(CoordinatorEntity, LightEntity):
         await self.coordinator.async_request_refresh()
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the device state attributes."""
         if not self.is_group:

--- a/homeassistant/components/hue/v1/sensor.py
+++ b/homeassistant/components/hue/v1/sensor.py
@@ -1,6 +1,6 @@
 """Hue sensor entities."""
 
-from typing import Any
+from typing import Any, override
 
 from aiohue.v1.sensors import (
     TYPE_ZLL_LIGHTLEVEL,
@@ -53,6 +53,7 @@ class HueLightLevel(GenericHueGaugeSensorEntity):
     _attr_native_unit_of_measurement = LIGHT_LUX
 
     @property
+    @override
     def native_value(self):
         """Return the state of the device."""
         if self.sensor.lightlevel is None:
@@ -66,6 +67,7 @@ class HueLightLevel(GenericHueGaugeSensorEntity):
         return round(float(10 ** ((self.sensor.lightlevel - 1) / 10000)), 2)
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the device state attributes."""
         attributes = super().extra_state_attributes
@@ -90,6 +92,7 @@ class HueTemperature(GenericHueGaugeSensorEntity):
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
 
     @property
+    @override
     def native_value(self):
         """Return the state of the device."""
         if self.sensor.temperature is None:
@@ -108,11 +111,13 @@ class HueBattery(GenericHueSensor, SensorEntity):
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     @property
+    @override
     def unique_id(self):
         """Return a unique identifier for this device."""
         return f"{self.sensor.uniqueid}-battery"
 
     @property
+    @override
     def native_value(self):
         """Return the state of the battery."""
         return self.sensor.battery

--- a/homeassistant/components/hue/v1/sensor_base.py
+++ b/homeassistant/components/hue/v1/sensor_base.py
@@ -3,7 +3,7 @@
 import asyncio
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from aiohue import AiohueException, Unauthorized
 from aiohue.v1.sensors import TYPE_ZLL_PRESENCE
@@ -170,6 +170,7 @@ class GenericHueSensor(GenericHueDevice, entity.Entity):  # pylint: disable=home
     should_poll = False
 
     @property
+    @override
     def available(self):
         """Return if sensor is available."""
         return self.bridge.sensor_manager.coordinator.last_update_success and (
@@ -183,6 +184,7 @@ class GenericHueSensor(GenericHueDevice, entity.Entity):  # pylint: disable=home
         """Return the state class of this entity, from STATE_CLASSES, if any."""
         return SensorStateClass.MEASUREMENT
 
+    @override
     async def async_added_to_hass(self):
         """When entity is added to hass."""
         await super().async_added_to_hass()
@@ -204,6 +206,7 @@ class GenericZLLSensor(GenericHueSensor):
     """Representation of a Hue-brand, physical sensor."""
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the device state attributes."""
         return {"battery_level": self.sensor.battery}

--- a/homeassistant/components/hue/v1/sensor_device.py
+++ b/homeassistant/components/hue/v1/sensor_device.py
@@ -1,5 +1,7 @@
 """Support for the Philips Hue sensor devices."""
 
+from typing import override
+
 from homeassistant.helpers import entity
 from homeassistant.helpers.device_registry import DeviceInfo
 
@@ -30,11 +32,13 @@ class GenericHueDevice(entity.Entity):  # pylint: disable=home-assistant-enforce
         return self.unique_id[:23]
 
     @property
+    @override
     def unique_id(self):
         """Return the ID of this Hue sensor."""
         return self.sensor.uniqueid
 
     @property
+    @override
     def name(self):
         """Return a friendly name for the sensor."""
         return self._name
@@ -45,6 +49,7 @@ class GenericHueDevice(entity.Entity):  # pylint: disable=home-assistant-enforce
         return self.primary_sensor.raw.get("swupdate", {}).get("state")
 
     @property
+    @override
     def device_info(self) -> DeviceInfo:
         """Return the device info.
 

--- a/homeassistant/components/hue/v2/binary_sensor.py
+++ b/homeassistant/components/hue/v2/binary_sensor.py
@@ -1,6 +1,7 @@
 """Support for Hue binary sensors."""
 
 from functools import partial
+from typing import override
 
 from aiohue.v2 import HueBridgeV2
 from aiohue.v2.controllers.config import (
@@ -140,6 +141,7 @@ class HueMotionSensor(HueBaseEntity, BinarySensorEntity):
     )
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
         if not self.resource.enabled:
@@ -194,6 +196,7 @@ class HueMotionAwareSensor(HueMotionSensor):
     )
 
     @property
+    @override
     def name(self) -> str:
         """Return sensor name."""
         return self.controller.get_motion_area_configuration(self.resource.id).name
@@ -216,6 +219,7 @@ class HueMotionAwareSensor(HueMotionSensor):
             identifiers={(DOMAIN, self.hue_group.id)},
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Call when entity is added."""
         await super().async_added_to_hass()
@@ -239,11 +243,13 @@ class HueEntertainmentActiveSensor(HueBaseEntity, BinarySensorEntity):
     )
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
         return self.resource.status == EntertainmentStatus.ACTIVE
 
     @property
+    @override
     def name(self) -> str:
         """Return sensor name."""
         return self.resource.metadata.name
@@ -263,6 +269,7 @@ class HueContactSensor(HueBaseEntity, BinarySensorEntity):
     )
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
         if not self.resource.enabled:
@@ -286,6 +293,7 @@ class HueTamperSensor(HueBaseEntity, BinarySensorEntity):
     )
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
         if not self.resource.tamper_reports:

--- a/homeassistant/components/hue/v2/entity.py
+++ b/homeassistant/components/hue/v2/entity.py
@@ -1,6 +1,6 @@
 """Generic Hue Entity Model."""
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from aiohue.v2.controllers.base import BaseResourcesController
 from aiohue.v2.controllers.events import EventType
@@ -68,6 +68,7 @@ class HueBaseEntity(Entity):  # pylint: disable=home-assistant-enforce-class-mod
         self._ignore_availability = None
         self._last_state = None
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Call when entity is added."""
         self._check_availability()
@@ -100,6 +101,7 @@ class HueBaseEntity(Entity):  # pylint: disable=home-assistant-enforce-class-mod
             )
 
     @property
+    @override
     def available(self) -> bool:
         """Return entity availability."""
         # entities without a device attached should be always available

--- a/homeassistant/components/hue/v2/group.py
+++ b/homeassistant/components/hue/v2/group.py
@@ -1,7 +1,7 @@
 """Support for Hue groups (room/zone)."""
 
 import asyncio
-from typing import Any
+from typing import Any, override
 
 from aiohue.v2 import HueBridgeV2
 from aiohue.v2.controllers.events import EventType
@@ -112,6 +112,7 @@ class GroupedHueLight(HueBaseEntity, LightEntity):
         self._dynamic_mode_active = False
         self._update_values()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Call when entity is added."""
         await super().async_added_to_hass()
@@ -131,11 +132,13 @@ class GroupedHueLight(HueBaseEntity, LightEntity):
             )
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if light is on."""
         return self.resource.on.on
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return the optional state attributes."""
         scenes = {
@@ -156,6 +159,7 @@ class GroupedHueLight(HueBaseEntity, LightEntity):
             "dynamics": self._dynamic_mode_active,
         }
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the grouped_light on."""
         transition = normalize_hue_transition(kwargs.get(ATTR_TRANSITION))
@@ -194,6 +198,7 @@ class GroupedHueLight(HueBaseEntity, LightEntity):
             transition_time=transition,
         )
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
         transition = normalize_hue_transition(kwargs.get(ATTR_TRANSITION))
@@ -222,6 +227,7 @@ class GroupedHueLight(HueBaseEntity, LightEntity):
         )
 
     @callback
+    @override
     def on_update(self) -> None:
         """Call on update event."""
         self._update_values()

--- a/homeassistant/components/hue/v2/light.py
+++ b/homeassistant/components/hue/v2/light.py
@@ -1,7 +1,7 @@
 """Support for Hue lights."""
 
 from functools import partial
-from typing import Any
+from typing import Any, override
 
 from aiohue import HueBridgeV2
 from aiohue.v2.controllers.events import EventType
@@ -123,6 +123,7 @@ class HueLight(HueBaseEntity, LightEntity):
             self._attr_supported_features |= LightEntityFeature.EFFECT
 
     @property
+    @override
     def brightness(self) -> int | None:
         """Return the brightness of this light between 0..255."""
         if dimming := self.resource.dimming:
@@ -131,11 +132,13 @@ class HueLight(HueBaseEntity, LightEntity):
         return None
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if device is on (brightness above 0)."""
         return self.resource.on.on
 
     @property
+    @override
     def color_mode(self) -> ColorMode:
         """Return the color mode of the light."""
         if self._fixed_color_mode:
@@ -161,6 +164,7 @@ class HueLight(HueBaseEntity, LightEntity):
         return self._color_temp_active
 
     @property
+    @override
     def xy_color(self) -> tuple[float, float] | None:
         """Return the xy color."""
         if color := self.resource.color:
@@ -168,6 +172,7 @@ class HueLight(HueBaseEntity, LightEntity):
         return None
 
     @property
+    @override
     def color_temp_kelvin(self) -> int | None:
         """Return the color temperature value in Kelvin."""
         if color_temp := self.resource.color_temperature:
@@ -196,16 +201,19 @@ class HueLight(HueBaseEntity, LightEntity):
         return FALLBACK_MIN_MIREDS
 
     @property
+    @override
     def max_color_temp_kelvin(self) -> int:
         """Return the coldest color_temp_kelvin that this light supports."""
         return color_util.color_temperature_mired_to_kelvin(self.min_color_temp_mireds)
 
     @property
+    @override
     def min_color_temp_kelvin(self) -> int:
         """Return the warmest color_temp_kelvin that this light supports."""
         return color_util.color_temperature_mired_to_kelvin(self.max_color_temp_mireds)
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, str] | None:
         """Return the optional state attributes."""
         return {
@@ -214,6 +222,7 @@ class HueLight(HueBaseEntity, LightEntity):
         }
 
     @property
+    @override
     def effect(self) -> str | None:
         """Return the current effect."""
         if effects := self.resource.effects:
@@ -224,6 +233,7 @@ class HueLight(HueBaseEntity, LightEntity):
                 return timed_effects.status.value
         return EFFECT_OFF
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
         transition = normalize_hue_transition(kwargs.get(ATTR_TRANSITION))
@@ -303,6 +313,7 @@ class HueLight(HueBaseEntity, LightEntity):
             effect=effect,
         )
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
         transition = normalize_hue_transition(kwargs.get(ATTR_TRANSITION))

--- a/homeassistant/components/hue/v2/sensor.py
+++ b/homeassistant/components/hue/v2/sensor.py
@@ -1,7 +1,7 @@
 """Support for Hue sensors."""
 
 from functools import partial
-from typing import Any
+from typing import Any, override
 
 from aiohue.v2 import HueBridgeV2
 from aiohue.v2.controllers.events import EventType
@@ -148,6 +148,7 @@ class HueTemperatureSensor(HueSensorBase):
     )
 
     @property
+    @override
     def native_value(self) -> float:
         """Return the value reported by the sensor."""
         return round(self.resource.temperature.value, 1)
@@ -166,6 +167,7 @@ class HueLightLevelSensor(HueSensorBase):
     )
 
     @property
+    @override
     def native_value(self) -> int | None:
         """Return the value reported by the sensor."""
         if self.resource.light.value is None:
@@ -177,6 +179,7 @@ class HueLightLevelSensor(HueSensorBase):
         return int(10 ** ((self.resource.light.value - 1) / 10000))
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the optional state attributes."""
         return {
@@ -223,11 +226,13 @@ class HueBatterySensor(HueSensorBase):
     )
 
     @property
+    @override
     def native_value(self) -> int:
         """Return the value reported by the sensor."""
         return self.resource.power_state.battery_level
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the optional state attributes."""
         if self.resource.power_state.battery_state is None:
@@ -255,11 +260,13 @@ class HueZigbeeConnectivitySensor(HueSensorBase):
     )
 
     @property
+    @override
     def native_value(self) -> str:
         """Return the value reported by the sensor."""
         return self.resource.status.value
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the optional state attributes."""
         return {"mac_address": self.resource.mac_address}

--- a/homeassistant/components/hue_ble/config_flow.py
+++ b/homeassistant/components/hue_ble/config_flow.py
@@ -2,7 +2,7 @@
 
 from enum import Enum
 import logging
-from typing import Any
+from typing import Any, override
 
 from bleak.backends.scanner import AdvertisementData
 from HueBLE import ConnectionError, HueBleError, HueBleLight, PairingError
@@ -83,6 +83,7 @@ class HueBleConfigFlow(ConfigFlow, domain=DOMAIN):
         self._discovered_devices: dict[str, bluetooth.BluetoothServiceInfoBleak] = {}
         self._discovery_info: bluetooth.BluetoothServiceInfoBleak | None = None
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -130,6 +131,7 @@ class HueBleConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    @override
     async def async_step_bluetooth(
         self, discovery_info: bluetooth.BluetoothServiceInfoBleak
     ) -> ConfigFlowResult:

--- a/homeassistant/components/hue_ble/light.py
+++ b/homeassistant/components/hue_ble/light.py
@@ -1,7 +1,7 @@
 """Hue BLE light platform."""
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from HueBLE import HueBleLight
 
@@ -79,11 +79,13 @@ class HueBLELight(LightEntity):
         self._attr_supported_color_modes = get_available_color_modes(self._api)
         self._update_updatable_attributes()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Run when this Entity has been added to HA."""
 
         self._api.add_callback_on_state_changed(self._state_change_callback)
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Run when entity will be removed from HA."""
 
@@ -111,6 +113,7 @@ class HueBLELight(LightEntity):
         """Fetch latest state from light and make available via properties."""
         await self._api.poll_state()
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Set properties then turn the light on."""
 
@@ -134,6 +137,7 @@ class HueBLELight(LightEntity):
 
         await self._api.set_power(True)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn light off then set properties."""
 
@@ -141,6 +145,7 @@ class HueBLELight(LightEntity):
         await self._api.set_power(False)
 
     @property
+    @override
     def color_mode(self) -> ColorMode:
         """Color mode of the light."""
 

--- a/homeassistant/components/huisbaasje/config_flow.py
+++ b/homeassistant/components/huisbaasje/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for EnergyFlip integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from energyflip import EnergyFlip, EnergyFlipConnectionException, EnergyFlipException
 import voluptuous as vol
@@ -24,6 +24,7 @@ class EnergyFlipConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/huisbaasje/coordinator.py
+++ b/homeassistant/components/huisbaasje/coordinator.py
@@ -3,7 +3,7 @@
 import asyncio
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from energyflip import EnergyFlip, EnergyFlipException
 
@@ -52,6 +52,7 @@ class EnergyFlipUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]
 
         self._energyflip = energyflip
 
+    @override
     async def _async_update_data(self) -> dict[str, dict[str, Any]]:
         """Update the data by performing a request to EnergyFlip."""
         try:

--- a/homeassistant/components/huisbaasje/sensor.py
+++ b/homeassistant/components/huisbaasje/sensor.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 import logging
+from typing import override
 
 from energyflip.const import (
     SOURCE_TYPE_ELECTRICITY,
@@ -246,6 +247,7 @@ class EnergyFlipSensor(CoordinatorEntity[EnergyFlipUpdateCoordinator], SensorEnt
         )
 
     @property
+    @override
     def native_value(self) -> int | float | None:
         """Return the state of the sensor."""
         if (
@@ -257,6 +259,7 @@ class EnergyFlipSensor(CoordinatorEntity[EnergyFlipUpdateCoordinator], SensorEnt
         return None
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return bool(

--- a/homeassistant/components/humidifier/__init__.py
+++ b/homeassistant/components/humidifier/__init__.py
@@ -3,7 +3,7 @@
 from datetime import timedelta
 from enum import StrEnum
 import logging
-from typing import Any, final
+from typing import Any, final, override
 
 from propcache.api import cached_property
 import voluptuous as vol
@@ -167,6 +167,7 @@ class HumidifierEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_AT
     _attr_target_humidity_step: float | None = None
 
     @property
+    @override
     def capability_attributes(self) -> dict[str, Any]:
         """Return capability attributes."""
         data: dict[str, Any] = {
@@ -182,6 +183,7 @@ class HumidifierEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_AT
         return data
 
     @cached_property
+    @override
     def device_class(self) -> HumidifierDeviceClass | None:
         """Return the class of this entity."""
         if hasattr(self, "_attr_device_class"):
@@ -192,6 +194,7 @@ class HumidifierEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_AT
 
     @final
     @property
+    @override
     def state_attributes(self) -> dict[str, Any]:
         """Return the optional state attributes."""
         data: dict[str, Any] = {}
@@ -273,6 +276,7 @@ class HumidifierEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_AT
         return self._attr_max_humidity
 
     @cached_property
+    @override
     def supported_features(self) -> HumidifierEntityFeature:
         """Return the list of supported features."""
         return self._attr_supported_features

--- a/homeassistant/components/humidifier/condition.py
+++ b/homeassistant/components/humidifier/condition.py
@@ -1,6 +1,6 @@
 """Provides conditions for humidifiers."""
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 import voluptuous as vol
 
@@ -57,6 +57,7 @@ class IsTargetHumidityCondition(EntityNumericalConditionBase):
     _domain_specs = {DOMAIN: DomainSpec(value_source=ATTR_HUMIDITY)}
     _valid_unit = PERCENTAGE
 
+    @override
     def _should_include(self, state: State) -> bool:
         """Skip humidifier entities that do not expose a target humidity."""
         return (
@@ -78,6 +79,7 @@ class IsModeCondition(EntityStateConditionBase):
             assert config.options is not None
         self._states = set(config.options[CONF_MODE])
 
+    @override
     def entity_filter(self, entities: set[str]) -> set[str]:
         """Filter entities of this domain."""
         entities = super().entity_filter(entities)

--- a/homeassistant/components/humidifier/intent.py
+++ b/homeassistant/components/humidifier/intent.py
@@ -1,5 +1,7 @@
 """Intents for the humidifier integration."""
 
+from typing import override
+
 import voluptuous as vol
 
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_MODE, STATE_OFF
@@ -37,6 +39,7 @@ class HumidityHandler(intent.IntentHandler):
     }
     platforms = {DOMAIN}
 
+    @override
     async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
         """Handle the hass intent."""
         hass = intent_obj.hass
@@ -92,6 +95,7 @@ class SetModeHandler(intent.IntentHandler):
     }
     platforms = {DOMAIN}
 
+    @override
     async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
         """Handle the hass intent."""
         hass = intent_obj.hass

--- a/homeassistant/components/humidifier/trigger.py
+++ b/homeassistant/components/humidifier/trigger.py
@@ -1,5 +1,7 @@
 """Provides triggers for humidifiers."""
 
+from typing import override
+
 import voluptuous as vol
 
 from homeassistant.const import ATTR_MODE, CONF_MODE, CONF_OPTIONS, STATE_OFF, STATE_ON
@@ -46,6 +48,7 @@ class ModeChangedTrigger(EntityTargetStateTriggerBase):
         super().__init__(hass, config)
         self._to_states = set(self._options[CONF_MODE])
 
+    @override
     def entity_filter(self, entities: set[str]) -> set[str]:
         """Filter entities of this domain."""
         entities = super().entity_filter(entities)

--- a/homeassistant/components/humidity/condition.py
+++ b/homeassistant/components/humidity/condition.py
@@ -1,5 +1,7 @@
 """Provides conditions for humidity."""
 
+from typing import override
+
 from homeassistant.components.climate import (
     ATTR_CURRENT_HUMIDITY as CLIMATE_ATTR_CURRENT_HUMIDITY,
     DOMAIN as CLIMATE_DOMAIN,
@@ -38,6 +40,7 @@ class HumidityCondition(EntityNumericalConditionBase):
     _domain_specs = HUMIDITY_DOMAIN_SPECS
     _valid_unit = PERCENTAGE
 
+    @override
     def _should_include(self, state: State) -> bool:
         """Skip attribute-source entities that lack the humidity attribute.
 

--- a/homeassistant/components/humidity/trigger.py
+++ b/homeassistant/components/humidity/trigger.py
@@ -1,5 +1,7 @@
 """Provides triggers for humidity."""
 
+from typing import override
+
 from homeassistant.components.climate import (
     ATTR_CURRENT_HUMIDITY as CLIMATE_ATTR_CURRENT_HUMIDITY,
     DOMAIN as CLIMATE_DOMAIN,
@@ -44,6 +46,7 @@ class _HumidityTriggerMixin(EntityNumericalStateTriggerBase):
     _domain_specs = HUMIDITY_DOMAIN_SPECS
     _valid_unit = "%"
 
+    @override
     def _should_include(self, state: State) -> bool:
         """Skip attribute-source entities that lack the humidity attribute.
 

--- a/homeassistant/components/hunterdouglas_powerview/button.py
+++ b/homeassistant/components/hunterdouglas_powerview/button.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Final
+from typing import Any, Final, override
 
 from aiopvapi.helpers.constants import (
     ATTR_NAME,
@@ -111,6 +111,7 @@ class PowerviewShadeButton(ShadeEntity, ButtonEntity):
         self.entity_description: PowerviewButtonDescription = description
         self._attr_unique_id = f"{self._attr_unique_id}_{description.key}"
 
+    @override
     async def async_press(self) -> None:
         """Handle the button press."""
         async with self.coordinator.radio_operation_lock:

--- a/homeassistant/components/hunterdouglas_powerview/config_flow.py
+++ b/homeassistant/components/hunterdouglas_powerview/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Hunter Douglas PowerView integration."""
 
 import logging
-from typing import TYPE_CHECKING, Any, Self
+from typing import TYPE_CHECKING, Any, Self, override
 
 import voluptuous as vol
 
@@ -59,6 +59,7 @@ class PowerviewConfigFlow(ConfigFlow, domain=DOMAIN):
         self.discovered_name: str | None = None
         self.data_schema: dict = {vol.Required(CONF_HOST): str}
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -108,6 +109,7 @@ class PowerviewConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return info, None
 
+    @override
     async def async_step_dhcp(
         self, discovery_info: DhcpServiceInfo
     ) -> ConfigFlowResult:
@@ -116,6 +118,7 @@ class PowerviewConfigFlow(ConfigFlow, domain=DOMAIN):
         self.discovered_name = discovery_info.hostname
         return await self.async_step_discovery_confirm()
 
+    @override
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:
@@ -126,6 +129,7 @@ class PowerviewConfigFlow(ConfigFlow, domain=DOMAIN):
         self.discovered_name = name
         return await self.async_step_discovery_confirm()
 
+    @override
     async def async_step_homekit(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:
@@ -163,6 +167,7 @@ class PowerviewConfigFlow(ConfigFlow, domain=DOMAIN):
         }
         return await self.async_step_link()
 
+    @override
     def is_matching(self, other_flow: Self) -> bool:
         """Return True if other_flow is matching this flow."""
         return other_flow.discovered_ip == self.discovered_ip

--- a/homeassistant/components/hunterdouglas_powerview/coordinator.py
+++ b/homeassistant/components/hunterdouglas_powerview/coordinator.py
@@ -3,6 +3,7 @@
 import asyncio
 from datetime import timedelta
 import logging
+from typing import override
 
 from aiopvapi.helpers.aiorequest import PvApiMaintenance
 from aiopvapi.hub import Hub
@@ -41,6 +42,7 @@ class PowerviewShadeUpdateCoordinator(DataUpdateCoordinator[PowerviewShadeData])
             update_interval=timedelta(seconds=60),
         )
 
+    @override
     async def _async_update_data(self) -> PowerviewShadeData:
         """Fetch data from shade endpoint."""
 

--- a/homeassistant/components/hunterdouglas_powerview/cover.py
+++ b/homeassistant/components/hunterdouglas_powerview/cover.py
@@ -5,7 +5,7 @@ from dataclasses import replace
 from datetime import datetime, timedelta
 import logging
 from math import ceil
-from typing import Any
+from typing import Any, override
 
 from aiopvapi.helpers.constants import (
     ATTR_NAME,
@@ -114,6 +114,7 @@ class PowerViewShadeBase(ShadeEntity, CoverEntity):
         self._forced_resync: Callable[[], None] | None = None
 
     @property
+    @override
     def assumed_state(self) -> bool:
         """If the device is hard wired we are polling state.
 
@@ -124,6 +125,7 @@ class PowerViewShadeBase(ShadeEntity, CoverEntity):
         return not self._is_hard_wired
 
     @property
+    @override
     def should_poll(self) -> bool:
         """Only poll if the device is hard wired.
 
@@ -134,21 +136,25 @@ class PowerViewShadeBase(ShadeEntity, CoverEntity):
         return self._is_hard_wired
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if shade position data is available."""
         return super().available and self.positions.primary is not None
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, str]:
         """Return the state attributes."""
         return {STATE_ATTRIBUTE_ROOM_NAME: self._room_name}
 
     @property
+    @override
     def is_closed(self) -> bool:
         """Return if the cover is closed."""
         return self.positions.primary <= CLOSED_POSITION
 
     @property
+    @override
     def current_cover_position(self) -> int:
         """Return the current position of cover."""
         return self.positions.primary
@@ -168,6 +174,7 @@ class PowerViewShadeBase(ShadeEntity, CoverEntity):
         """Return the close position and required additional positions."""
         return replace(self._shade.close_position, velocity=self.positions.velocity)
 
+    @override
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
         self._async_schedule_update_for_transition(self.transition_steps)
@@ -176,6 +183,7 @@ class PowerViewShadeBase(ShadeEntity, CoverEntity):
         self._attr_is_closing = True
         self.async_write_ha_state()
 
+    @override
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
         self._async_schedule_update_for_transition(100 - self.transition_steps)
@@ -184,6 +192,7 @@ class PowerViewShadeBase(ShadeEntity, CoverEntity):
         self._attr_is_closing = False
         self.async_write_ha_state()
 
+    @override
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
         self._async_cancel_scheduled_transition_update()
@@ -196,6 +205,7 @@ class PowerViewShadeBase(ShadeEntity, CoverEntity):
         # no override required in base
         return target_hass_position
 
+    @override
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the shade to a specific position."""
         await self._async_set_cover_position(kwargs[ATTR_POSITION])
@@ -291,6 +301,7 @@ class PowerViewShadeBase(ShadeEntity, CoverEntity):
         await self.async_update()
         self.async_write_ha_state()
 
+    @override
     # pylint: disable-next=home-assistant-missing-super-call
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
@@ -298,6 +309,7 @@ class PowerViewShadeBase(ShadeEntity, CoverEntity):
             self.coordinator.async_add_listener(self._async_update_shade_from_group)
         )
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Cancel any pending refreshes."""
         self._async_cancel_scheduled_transition_update()
@@ -316,6 +328,7 @@ class PowerViewShadeBase(ShadeEntity, CoverEntity):
         self.data.update_from_group_data(self._shade.id)
         self.async_write_ha_state()
 
+    @override
     async def async_update(self) -> None:
         """Refresh shade position."""
         if self._update_in_progress:
@@ -362,11 +375,13 @@ class PowerViewShadeWithTiltBase(PowerViewShadeBase):
         self._max_tilt = self._shade.shade_limits.tilt_max
 
     @property
+    @override
     def current_cover_tilt_position(self) -> int:
         """Return the current cover tile position."""
         return self.positions.tilt
 
     @property
+    @override
     def transition_steps(self) -> int:
         """Return the steps to make a move."""
         return self.positions.primary + self.positions.tilt
@@ -383,18 +398,21 @@ class PowerViewShadeWithTiltBase(PowerViewShadeBase):
             self._shade.close_position_tilt, velocity=self.positions.velocity
         )
 
+    @override
     async def async_close_cover_tilt(self, **kwargs: Any) -> None:
         """Close the cover tilt."""
         self._async_schedule_update_for_transition(self.transition_steps)
         await self._async_execute_move(self.close_tilt_position)
         self.async_write_ha_state()
 
+    @override
     async def async_open_cover_tilt(self, **kwargs: Any) -> None:
         """Open the cover tilt."""
         self._async_schedule_update_for_transition(100 - self.transition_steps)
         await self._async_execute_move(self.open_tilt_position)
         self.async_write_ha_state()
 
+    @override
     async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
         """Move the tilt to a specific position."""
         await self._async_set_cover_tilt_position(kwargs[ATTR_TILT_POSITION])
@@ -411,6 +429,7 @@ class PowerViewShadeWithTiltBase(PowerViewShadeBase):
         self.async_write_ha_state()
 
     @callback
+    @override
     def _get_shade_move(self, target_hass_position: int) -> ShadePosition:
         """Return a ShadePosition."""
         return ShadePosition(
@@ -426,6 +445,7 @@ class PowerViewShadeWithTiltBase(PowerViewShadeBase):
             velocity=self.positions.velocity,
         )
 
+    @override
     async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
         """Stop the cover tilting."""
         await self.async_stop_cover()
@@ -443,21 +463,25 @@ class PowerViewShadeWithTiltOnClosed(PowerViewShadeWithTiltBase):
     _attr_name = None
 
     @property
+    @override
     def open_position(self) -> ShadePosition:
         """Return the open position and required additional positions."""
         return replace(self._shade.open_position, velocity=self.positions.velocity)
 
     @property
+    @override
     def close_position(self) -> ShadePosition:
         """Return the close position and required additional positions."""
         return replace(self._shade.close_position, velocity=self.positions.velocity)
 
     @property
+    @override
     def open_tilt_position(self) -> ShadePosition:
         """Return the open tilt position and required additional positions."""
         return replace(self._shade.open_position_tilt, velocity=self.positions.velocity)
 
     @property
+    @override
     def close_tilt_position(self) -> ShadePosition:
         """Return the close tilt position and required additional positions."""
         return replace(
@@ -475,6 +499,7 @@ class PowerViewShadeWithTiltAnywhere(PowerViewShadeWithTiltBase):
     """
 
     @callback
+    @override
     def _get_shade_move(self, target_hass_position: int) -> ShadePosition:
         """Return a ShadePosition."""
         return ShadePosition(
@@ -484,6 +509,7 @@ class PowerViewShadeWithTiltAnywhere(PowerViewShadeWithTiltBase):
         )
 
     @callback
+    @override
     def _get_shade_tilt(self, target_hass_tilt_position: int) -> ShadePosition:
         """Return a ShadePosition."""
         return ShadePosition(
@@ -521,22 +547,26 @@ class PowerViewShadeTiltOnly(PowerViewShadeWithTiltBase):
         self._max_tilt = self._shade.shade_limits.tilt_max
 
     @property
+    @override
     def current_cover_position(self) -> int:
         """Return the current position of cover."""
         # allows using parent class with no other alterations
         return CLOSED_POSITION
 
     @property
+    @override
     def transition_steps(self) -> int:
         """Return the steps to make a move."""
         return self.positions.tilt
 
     @property
+    @override
     def is_closed(self) -> bool:
         """Return if the cover is closed."""
         return self.positions.tilt <= CLOSED_POSITION
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if shade position data is available."""
         return super().available and self.positions.tilt is not None
@@ -555,16 +585,19 @@ class PowerViewShadeTopDown(PowerViewShadeBase):
     _attr_name = None
 
     @property
+    @override
     def current_cover_position(self) -> int:
         """Return the current position of cover."""
         # inverted positioning
         return MAX_POSITION - self.positions.primary
 
+    @override
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the shade to a specific position."""
         await self._async_set_cover_position(MAX_POSITION - kwargs[ATTR_POSITION])
 
     @property
+    @override
     def is_closed(self) -> bool:
         """Return if the cover is closed."""
         return (MAX_POSITION - self.positions.primary) <= CLOSED_POSITION
@@ -579,6 +612,7 @@ class PowerViewShadeDualRailBase(PowerViewShadeBase):
     """
 
     @property
+    @override
     def transition_steps(self) -> int:
         """Return the steps to make a move."""
         return self.positions.primary + self.positions.secondary
@@ -607,11 +641,13 @@ class PowerViewShadeTDBUBottom(PowerViewShadeDualRailBase):
         self._attr_unique_id = f"{self._attr_unique_id}_bottom"
 
     @callback
+    @override
     def _clamp_cover_limit(self, target_hass_position: int) -> int:
         """Don't allow a cover to go into an impossbile position."""
         return min(target_hass_position, (MAX_POSITION - self.positions.secondary))
 
     @callback
+    @override
     def _get_shade_move(self, target_hass_position: int) -> ShadePosition:
         """Return a ShadePosition."""
         return ShadePosition(
@@ -644,6 +680,7 @@ class PowerViewShadeTDBUTop(PowerViewShadeDualRailBase):
         self._attr_unique_id = f"{self._attr_unique_id}_top"
 
     @property
+    @override
     def should_poll(self) -> bool:
         """Certain shades create multiple entities.
 
@@ -653,18 +690,21 @@ class PowerViewShadeTDBUTop(PowerViewShadeDualRailBase):
         return False
 
     @property
+    @override
     def is_closed(self) -> bool:
         """Return if the cover is closed."""
         # top shade needs to check other motor
         return self.positions.secondary <= CLOSED_POSITION
 
     @property
+    @override
     def current_cover_position(self) -> int:
         """Return the current position of cover."""
         # these need to be inverted to report state correctly in HA
         return self.positions.secondary
 
     @property
+    @override
     def open_position(self) -> ShadePosition:
         """Return the open position and required additional positions."""
         # these shades share a class in parent API
@@ -676,11 +716,13 @@ class PowerViewShadeTDBUTop(PowerViewShadeDualRailBase):
         )
 
     @callback
+    @override
     def _clamp_cover_limit(self, target_hass_position: int) -> int:
         """Don't allow a cover to go into an impossbile position."""
         return min(target_hass_position, (MAX_POSITION - self.positions.primary))
 
     @callback
+    @override
     def _get_shade_move(self, target_hass_position: int) -> ShadePosition:
         """Return a ShadePosition."""
         return ShadePosition(
@@ -697,6 +739,7 @@ class PowerViewShadeDualOverlappedBase(PowerViewShadeBase):
     """
 
     @property
+    @override
     def transition_steps(self) -> int:
         """Return the steps to make a move."""
         # poskind 1 represents the second half of the shade in hass
@@ -710,6 +753,7 @@ class PowerViewShadeDualOverlappedBase(PowerViewShadeBase):
         return ceil(primary + secondary)
 
     @property
+    @override
     def open_position(self) -> ShadePosition:
         """Return the open position and required additional positions."""
         return ShadePosition(
@@ -718,6 +762,7 @@ class PowerViewShadeDualOverlappedBase(PowerViewShadeBase):
         )
 
     @property
+    @override
     def close_position(self) -> ShadePosition:
         """Return the open position and required additional positions."""
         return ShadePosition(
@@ -752,12 +797,14 @@ class PowerViewShadeDualOverlappedCombined(PowerViewShadeDualOverlappedBase):
         self._attr_unique_id = f"{self._attr_unique_id}_combined"
 
     @property
+    @override
     def is_closed(self) -> bool:
         """Return if the cover is closed."""
         # if rear shade is down it is closed
         return self.positions.secondary <= CLOSED_POSITION
 
     @property
+    @override
     def current_cover_position(self) -> int:
         """Return the current position of cover."""
         # if front is open return that (other positions are impossible)
@@ -769,6 +816,7 @@ class PowerViewShadeDualOverlappedCombined(PowerViewShadeDualOverlappedBase):
         return ceil(position)
 
     @callback
+    @override
     def _get_shade_move(self, target_hass_position: int) -> ShadePosition:
         """Return a ShadePosition."""
         # 0 - 50 represents the rear blockut shade
@@ -818,6 +866,7 @@ class PowerViewShadeDualOverlappedFront(PowerViewShadeDualOverlappedBase):
         self._attr_unique_id = f"{self._attr_unique_id}_front"
 
     @property
+    @override
     def should_poll(self) -> bool:
         """Certain shades create multiple entities.
 
@@ -827,6 +876,7 @@ class PowerViewShadeDualOverlappedFront(PowerViewShadeDualOverlappedBase):
         return False
 
     @callback
+    @override
     def _get_shade_move(self, target_hass_position: int) -> ShadePosition:
         """Return a ShadePosition."""
         return ShadePosition(
@@ -835,6 +885,7 @@ class PowerViewShadeDualOverlappedFront(PowerViewShadeDualOverlappedBase):
         )
 
     @property
+    @override
     def close_position(self) -> ShadePosition:
         """Return the close position and required additional positions."""
         return ShadePosition(
@@ -874,6 +925,7 @@ class PowerViewShadeDualOverlappedRear(PowerViewShadeDualOverlappedBase):
         self._attr_unique_id = f"{self._attr_unique_id}_rear"
 
     @property
+    @override
     def should_poll(self) -> bool:
         """Certain shades create multiple entities.
 
@@ -883,17 +935,20 @@ class PowerViewShadeDualOverlappedRear(PowerViewShadeDualOverlappedBase):
         return False
 
     @property
+    @override
     def is_closed(self) -> bool:
         """Return if the cover is closed."""
         # if rear shade is down it is closed
         return self.positions.secondary <= CLOSED_POSITION
 
     @property
+    @override
     def current_cover_position(self) -> int:
         """Return the current position of cover."""
         return self.positions.secondary
 
     @callback
+    @override
     def _get_shade_move(self, target_hass_position: int) -> ShadePosition:
         """Return a ShadePosition."""
         return ShadePosition(
@@ -902,6 +957,7 @@ class PowerViewShadeDualOverlappedRear(PowerViewShadeDualOverlappedBase):
         )
 
     @property
+    @override
     def open_position(self) -> ShadePosition:
         """Return the open position and required additional positions."""
         return ShadePosition(
@@ -928,6 +984,7 @@ class PowerViewShadeDualOverlappedCombinedTilt(
     """
 
     @property
+    @override
     def transition_steps(self) -> int:
         """Return the steps to make a move."""
         # poskind 1 represents the second half of the shade in hass

--- a/homeassistant/components/hunterdouglas_powerview/entity.py
+++ b/homeassistant/components/hunterdouglas_powerview/entity.py
@@ -1,6 +1,7 @@
 """The powerview integration base entity."""
 
 import logging
+from typing import override
 
 from aiopvapi.resources.shade import BaseShade, ShadePosition
 from aiopvapi.resources.shade_data import PowerviewShadeData
@@ -41,6 +42,7 @@ class HDEntity(CoordinatorEntity[PowerviewShadeUpdateCoordinator]):
         return self.coordinator.data
 
     @property
+    @override
     def device_info(self) -> DeviceInfo:
         """Return the device_info of the device."""
         return DeviceInfo(
@@ -78,6 +80,7 @@ class ShadeEntity(HDEntity):
         return self.data.get_shade_position(self._shade.id)
 
     @property
+    @override
     def device_info(self) -> DeviceInfo:
         """Return the device_info of the device."""
         return DeviceInfo(

--- a/homeassistant/components/hunterdouglas_powerview/number.py
+++ b/homeassistant/components/hunterdouglas_powerview/number.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Final
+from typing import Final, override
 
 from aiopvapi.helpers.constants import ATTR_NAME, MOTION_VELOCITY
 from aiopvapi.resources.shade import BaseShade, ShadePosition
@@ -95,12 +95,14 @@ class PowerViewNumber(ShadeEntity, RestoreNumber):
         self.entity_description = description
         self._attr_unique_id = f"{self._attr_unique_id}_{description.key}"
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
         self._attr_native_value = value
         self.entity_description.store_value_fn(self.coordinator, self._shade.id, value)
         self.async_write_ha_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Restore last state."""
         await super().async_added_to_hass()

--- a/homeassistant/components/hunterdouglas_powerview/scene.py
+++ b/homeassistant/components/hunterdouglas_powerview/scene.py
@@ -1,7 +1,7 @@
 """Support for Powerview scenes from a Powerview hub."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from aiopvapi.helpers.constants import ATTR_NAME
 from aiopvapi.resources.scene import Scene as PvScene
@@ -54,6 +54,7 @@ class PowerViewScene(HDEntity, Scene):
         self._attr_name = scene.name
         self._attr_extra_state_attributes = {STATE_ATTRIBUTE_ROOM_NAME: room_name}
 
+    @override
     async def async_activate(self, **kwargs: Any) -> None:
         """Activate scene. Try to get entities into requested state."""
         shades = await self._scene.activate()

--- a/homeassistant/components/hunterdouglas_powerview/select.py
+++ b/homeassistant/components/hunterdouglas_powerview/select.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
-from typing import Any, Final
+from typing import Any, Final, override
 
 from aiopvapi.helpers.constants import ATTR_NAME, FUNCTION_SET_POWER
 from aiopvapi.resources.shade import BaseShade
@@ -94,15 +94,18 @@ class PowerViewSelect(ShadeEntity, SelectEntity):
         self._attr_unique_id = f"{self._attr_unique_id}_{description.key}"
 
     @property
+    @override
     def current_option(self) -> str | None:
         """Return the selected entity option to represent the entity state."""
         return self.entity_description.current_fn(self._shade)
 
     @property
+    @override
     def options(self) -> list[str]:
         """Return a set of selectable options."""
         return self.entity_description.options_fn(self._shade)
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         await self.entity_description.select_fn(self._shade, option)

--- a/homeassistant/components/hunterdouglas_powerview/sensor.py
+++ b/homeassistant/components/hunterdouglas_powerview/sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Final
+from typing import Any, Final, override
 
 from aiopvapi.helpers.constants import ATTR_NAME
 from aiopvapi.resources.shade import BaseShade
@@ -122,20 +122,24 @@ class PowerViewSensor(ShadeEntity, SensorEntity):
         self._attr_unique_id = f"{self._attr_unique_id}_{description.key}"
 
     @property
+    @override
     def native_value(self) -> int:
         """Get the current value of the sensor."""
         return self.entity_description.native_value_fn(self._shade)
 
     @property
+    @override
     def native_unit_of_measurement(self) -> str | None:
         """Return native unit of measurement of sensor."""
         return self.entity_description.native_unit_fn(self._shade)
 
     @property
+    @override
     def device_class(self) -> SensorDeviceClass | None:
         """Return the class of this entity."""
         return self.entity_description.device_class_fn(self._shade)
 
+    @override
     # pylint: disable-next=home-assistant-missing-super-call
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
@@ -149,6 +153,7 @@ class PowerViewSensor(ShadeEntity, SensorEntity):
         self._shade.raw_data = self.data.get_raw_data(self._shade.id)
         self.async_write_ha_state()
 
+    @override
     async def async_update(self) -> None:
         """Refresh sensor entity."""
         async with self.coordinator.radio_operation_lock:

--- a/homeassistant/components/husqvarna_automower/api.py
+++ b/homeassistant/components/husqvarna_automower/api.py
@@ -1,7 +1,7 @@
 """API for Husqvarna Automower bound to Home Assistant OAuth."""
 
 import logging
-from typing import cast
+from typing import cast, override
 
 from aioautomower.auth import AbstractAuth
 from aioautomower.const import API_BASE_URL
@@ -25,6 +25,7 @@ class AsyncConfigEntryAuth(AbstractAuth):
         super().__init__(websession, API_BASE_URL)
         self._oauth_session = oauth_session
 
+    @override
     async def async_get_access_token(self) -> str:
         """Return a valid access token."""
         await self._oauth_session.async_ensure_token_valid()
@@ -39,6 +40,7 @@ class AsyncConfigFlowAuth(AbstractAuth):
         super().__init__(websession, API_BASE_URL)
         self.token: dict = token
 
+    @override
     async def async_get_access_token(self) -> str:
         """Return a valid access token."""
         return cast(str, self.token[CONF_ACCESS_TOKEN])

--- a/homeassistant/components/husqvarna_automower/binary_sensor.py
+++ b/homeassistant/components/husqvarna_automower/binary_sensor.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 import logging
+from typing import override
 
 from aioautomower.model import MowerActivities, MowerAttributes
 
@@ -80,6 +81,7 @@ class AutomowerBinarySensorEntity(AutomowerBaseEntity, BinarySensorEntity):
         self._attr_unique_id = f"{mower_id}_{description.key}"
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return the state of the binary sensor."""
         return self.entity_description.value_fn(self.mower_attributes)

--- a/homeassistant/components/husqvarna_automower/button.py
+++ b/homeassistant/components/husqvarna_automower/button.py
@@ -3,7 +3,7 @@
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 import logging
-from typing import Any
+from typing import Any, override
 
 from aioautomower.model import MowerAttributes
 from aioautomower.session import AutomowerSession
@@ -106,6 +106,7 @@ class AutomowerButtonEntity(AutomowerControlEntity, ButtonEntity):
         self._attr_unique_id = f"{mower_id}_{description.key}"
 
     @property
+    @override
     def available(self) -> bool:
         """Return the available attribute of the entity."""
         return super().available and self.entity_description.available_fn(
@@ -113,6 +114,7 @@ class AutomowerButtonEntity(AutomowerControlEntity, ButtonEntity):
         )
 
     @handle_sending_exception
+    @override
     async def async_press(self) -> None:
         """Send a command to the mower."""
         await self.entity_description.press_fn(self.coordinator.api, self.mower_id)

--- a/homeassistant/components/husqvarna_automower/calendar.py
+++ b/homeassistant/components/husqvarna_automower/calendar.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from aioautomower.model import make_name_string
 
@@ -68,6 +68,7 @@ class AutomowerCalendarEntity(AutomowerBaseEntity, CalendarEntity):
         return device_entry.name_by_user or device_entry.name
 
     @property
+    @override
     def event(self) -> CalendarEvent | None:
         """Return the current or next upcoming event."""
         if not self.available:
@@ -90,6 +91,7 @@ class AutomowerCalendarEntity(AutomowerBaseEntity, CalendarEntity):
             rrule=program_event.rrule_str,
         )
 
+    @override
     async def async_get_events(
         self, hass: HomeAssistant, start_date: datetime, end_date: datetime
     ) -> list[CalendarEvent]:

--- a/homeassistant/components/husqvarna_automower/config_flow.py
+++ b/homeassistant/components/husqvarna_automower/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from aioautomower.session import AutomowerSession
 from aioautomower.utils import structure_token
@@ -30,6 +30,7 @@ class HusqvarnaConfigFlowHandler(
     VERSION = 1
     DOMAIN = DOMAIN
 
+    @override
     async def async_oauth_create_entry(self, data: dict[str, Any]) -> ConfigFlowResult:
         """Create an entry for the flow."""
         token = data[CONF_TOKEN]
@@ -70,6 +71,7 @@ class HusqvarnaConfigFlowHandler(
         )
 
     @property
+    @override
     def logger(self) -> logging.Logger:
         """Return logger."""
         return logging.getLogger(__name__)

--- a/homeassistant/components/husqvarna_automower/coordinator.py
+++ b/homeassistant/components/husqvarna_automower/coordinator.py
@@ -68,6 +68,7 @@ class AutomowerDataUpdateCoordinator(DataUpdateCoordinator[MowerDictionary]):
         self._on_data_update()
         super().async_update_listeners()
 
+    @override
     async def _async_setup(self) -> None:
         """Initialize websocket connection and callbacks."""
         await self.api.connect()
@@ -85,6 +86,7 @@ class AutomowerDataUpdateCoordinator(DataUpdateCoordinator[MowerDictionary]):
 
         self.api.register_ws_ready_callback(start_watchdog)
 
+    @override
     async def _async_update_data(self) -> MowerDictionary:
         """Poll data from the API."""
         try:
@@ -143,6 +145,7 @@ class AutomowerDataUpdateCoordinator(DataUpdateCoordinator[MowerDictionary]):
         self.async_set_updated_data(ws_data)
 
     @callback
+    @override
     def async_set_updated_data(self, data: MowerDictionary) -> None:
         """Override DataUpdateCoordinator to preserve fixed polling interval.
 

--- a/homeassistant/components/husqvarna_automower/device_tracker.py
+++ b/homeassistant/components/husqvarna_automower/device_tracker.py
@@ -1,5 +1,7 @@
 """Creates the device tracker entity for the mower."""
 
+from typing import override
+
 from homeassistant.components.device_tracker import TrackerEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -46,11 +48,13 @@ class AutomowerDeviceTrackerEntity(AutomowerBaseEntity, TrackerEntity):
         self._attr_unique_id = mower_id
 
     @property
+    @override
     def latitude(self) -> float:
         """Return latitude value of the device."""
         return self.mower_attributes.positions[0].latitude
 
     @property
+    @override
     def longitude(self) -> float:
         """Return longitude value of the device."""
         return self.mower_attributes.positions[0].longitude

--- a/homeassistant/components/husqvarna_automower/entity.py
+++ b/homeassistant/components/husqvarna_automower/entity.py
@@ -4,7 +4,7 @@ import asyncio
 from collections.abc import Callable, Coroutine
 import functools
 import logging
-from typing import TYPE_CHECKING, Any, Concatenate, overload
+from typing import TYPE_CHECKING, Any, Concatenate, overload, override
 
 from aioautomower.exceptions import ApiError
 from aioautomower.model import MowerActivities, MowerAttributes, MowerStates, WorkArea
@@ -136,6 +136,7 @@ class AutomowerBaseEntity(CoordinatorEntity[AutomowerDataUpdateCoordinator]):
         return self.coordinator.data[self.mower_id]
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if the device is available."""
         return super().available and self.mower_id in self.coordinator.data
@@ -145,6 +146,7 @@ class AutomowerControlEntity(AutomowerBaseEntity):
     """Replies available when the mower is connected."""
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if the device is available."""
         return (
@@ -180,6 +182,7 @@ class WorkAreaAvailableEntity(AutomowerControlEntity):
         return self.work_areas[self.work_area_id]
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if the work area is available and the mower has no errors."""
         return super().available and self.work_area_id in self.work_areas

--- a/homeassistant/components/husqvarna_automower/event.py
+++ b/homeassistant/components/husqvarna_automower/event.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 import logging
+from typing import override
 
 from aioautomower.model import SingleMessageData
 
@@ -97,6 +98,7 @@ class AutomowerMessageEventEntity(AutomowerBaseEntity, EventEntity):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if the entity is available."""
         return self.websocket_alive and self.mower_id in self.coordinator.data
@@ -118,12 +120,14 @@ class AutomowerMessageEventEntity(AutomowerBaseEntity, EventEntity):
         )
         self.async_write_ha_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register callback when entity is added to hass."""
         await super().async_added_to_hass()
         self.coordinator.api.register_single_message_callback(self._handle)
         self.coordinator.websocket_callbacks.append(self._handle_websocket_update)
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Unregister WebSocket callback when entity is removed."""
         self.coordinator.api.unregister_single_message_callback(self._handle)

--- a/homeassistant/components/husqvarna_automower/lawn_mower.py
+++ b/homeassistant/components/husqvarna_automower/lawn_mower.py
@@ -1,7 +1,7 @@
 """Husqvarna Automower lawn mower entity."""
 
 from datetime import timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from aioautomower.model import MowerActivities, MowerStates, WorkArea
 
@@ -72,6 +72,7 @@ class AutomowerLawnMowerEntity(AutomowerBaseEntity, LawnMowerEntity):
         self._attr_unique_id = mower_id
 
     @property
+    @override
     def activity(self) -> LawnMowerActivity:
         """Return the state of the mower."""
         mower_attributes = self.mower_attributes
@@ -91,6 +92,7 @@ class AutomowerLawnMowerEntity(AutomowerBaseEntity, LawnMowerEntity):
         return LawnMowerActivity.ERROR
 
     @property
+    @override
     def available(self) -> bool:
         """Return the available attribute of the entity."""
         return (
@@ -103,16 +105,19 @@ class AutomowerLawnMowerEntity(AutomowerBaseEntity, LawnMowerEntity):
         return self.mower_attributes.work_areas
 
     @handle_sending_exception
+    @override
     async def async_start_mowing(self) -> None:
         """Resume schedule."""
         await self.coordinator.api.commands.resume_schedule(self.mower_id)
 
     @handle_sending_exception
+    @override
     async def async_pause(self) -> None:
         """Pauses the mower."""
         await self.coordinator.api.commands.pause_mowing(self.mower_id)
 
     @handle_sending_exception
+    @override
     async def async_dock(self) -> None:
         """Parks the mower until next schedule."""
         await self.coordinator.api.commands.park_until_next_schedule(self.mower_id)

--- a/homeassistant/components/husqvarna_automower/number.py
+++ b/homeassistant/components/husqvarna_automower/number.py
@@ -3,7 +3,7 @@
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from aioautomower.model import MowerAttributes, WorkArea
 from aioautomower.session import AutomowerSession
@@ -171,11 +171,13 @@ class AutomowerNumberEntity(AutomowerControlEntity, NumberEntity):
         self._attr_unique_id = f"{mower_id}_{description.key}"
 
     @property
+    @override
     def native_value(self) -> float:
         """Return the state of the number."""
         return self.entity_description.value_fn(self.mower_attributes)
 
     @handle_sending_exception()
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Change to new number value."""
         await self.entity_description.set_value_fn(
@@ -204,6 +206,7 @@ class WorkAreaNumberEntity(WorkAreaControlEntity, NumberEntity):
         }
 
     @property
+    @override
     def translation_key(self) -> str:
         """Return the translation key of the work area."""
         return self.entity_description.translation_key_fn(
@@ -211,11 +214,13 @@ class WorkAreaNumberEntity(WorkAreaControlEntity, NumberEntity):
         )
 
     @property
+    @override
     def native_value(self) -> float:
         """Return the state of the number."""
         return self.entity_description.value_fn(self.work_area_attributes)
 
     @handle_sending_exception(poll_after_sending=True)
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Change to new number value."""
         await self.entity_description.set_value_fn(

--- a/homeassistant/components/husqvarna_automower/select.py
+++ b/homeassistant/components/husqvarna_automower/select.py
@@ -1,7 +1,7 @@
 """Creates a select entity for the headlight of the mower."""
 
 import logging
-from typing import cast
+from typing import cast, override
 
 from aioautomower.model import HeadlightModes
 
@@ -63,11 +63,13 @@ class AutomowerSelectEntity(AutomowerControlEntity, SelectEntity):
         self._attr_unique_id = f"{mower_id}_headlight_mode"
 
     @property
+    @override
     def current_option(self) -> str:
         """Return the current option for the entity."""
         return cast(HeadlightModes, self.mower_attributes.settings.headlight.mode)
 
     @handle_sending_exception
+    @override
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         await self.coordinator.api.commands.set_headlight_mode(

--- a/homeassistant/components/husqvarna_automower/sensor.py
+++ b/homeassistant/components/husqvarna_automower/sensor.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime
 import logging
 from operator import attrgetter
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from aioautomower.model import (
     ExternalReasons,
@@ -443,21 +443,25 @@ class AutomowerSensorEntity(AutomowerBaseEntity, SensorEntity):
         self._attr_unique_id = f"{mower_id}_{description.key}"
 
     @property
+    @override
     def native_value(self) -> StateType | datetime:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.mower_attributes)
 
     @property
+    @override
     def options(self) -> list[str] | None:
         """Return the option of the sensor."""
         return self.entity_description.option_fn(self.mower_attributes)
 
     @property
+    @override
     def extra_state_attributes(self) -> Mapping[str, Any] | None:
         """Return the state attributes."""
         return self.entity_description.extra_state_attributes_fn(self.mower_attributes)
 
     @property
+    @override
     def available(self) -> bool:
         """Return the available attribute of the entity."""
         return super().available and self.native_value is not None
@@ -484,11 +488,13 @@ class WorkAreaSensorEntity(WorkAreaAvailableEntity, SensorEntity):
         }
 
     @property
+    @override
     def native_value(self) -> StateType | datetime:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.work_area_attributes)
 
     @property
+    @override
     def translation_key(self) -> str:
         """Return the translation key of the work area."""
         return self.entity_description.translation_key_fn(

--- a/homeassistant/components/husqvarna_automower/switch.py
+++ b/homeassistant/components/husqvarna_automower/switch.py
@@ -1,7 +1,7 @@
 """Creates a switch entity for the mower."""
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from aioautomower.model import MowerModes, StayOutZones, Zone
 
@@ -104,16 +104,19 @@ class AutomowerScheduleSwitchEntity(AutomowerControlEntity, SwitchEntity):
         self._attr_unique_id = f"{self.mower_id}_{self._attr_translation_key}"
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return the state of the switch."""
         return self.mower_attributes.mower.mode != MowerModes.HOME
 
     @handle_sending_exception
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         await self.coordinator.api.commands.park_until_further_notice(self.mower_id)
 
     @handle_sending_exception
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         await self.coordinator.api.commands.resume_schedule(self.mower_id)
@@ -152,16 +155,19 @@ class StayOutZoneSwitchEntity(AutomowerControlEntity, SwitchEntity):
         return self.stay_out_zones.zones[self.stay_out_zone_uid]
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return the state of the switch."""
         return self.stay_out_zone.enabled
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if the device is available and the zones are not `dirty`."""
         return super().available and not self.stay_out_zones.dirty
 
     @handle_sending_exception(poll_after_sending=True)
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         await self.coordinator.api.commands.switch_stay_out_zone(
@@ -169,6 +175,7 @@ class StayOutZoneSwitchEntity(AutomowerControlEntity, SwitchEntity):
         )
 
     @handle_sending_exception(poll_after_sending=True)
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         await self.coordinator.api.commands.switch_stay_out_zone(
@@ -198,11 +205,13 @@ class WorkAreaSwitchEntity(WorkAreaControlEntity, SwitchEntity):
             self._attr_name = self.work_area_attributes.name
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return the state of the switch."""
         return self.work_area_attributes.enabled
 
     @handle_sending_exception(poll_after_sending=True)
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         await self.coordinator.api.commands.workarea_settings(
@@ -210,6 +219,7 @@ class WorkAreaSwitchEntity(WorkAreaControlEntity, SwitchEntity):
         ).enabled(enabled=False)
 
     @handle_sending_exception(poll_after_sending=True)
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         await self.coordinator.api.commands.workarea_settings(

--- a/homeassistant/components/husqvarna_automower_ble/config_flow.py
+++ b/homeassistant/components/husqvarna_automower_ble/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import random
-from typing import Any
+from typing import Any, override
 
 from automower_ble.mower import Mower
 from automower_ble.protocol import ResponseResult
@@ -80,6 +80,7 @@ class HusqvarnaAutomowerBleConfigFlow(ConfigFlow, domain=DOMAIN):
         LOGGER.debug("Supported device: %s", manufacturer_data)
         return True
 
+    @override
     async def async_step_bluetooth(
         self, discovery_info: BluetoothServiceInfo
     ) -> ConfigFlowResult:
@@ -128,6 +129,7 @@ class HusqvarnaAutomowerBleConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/husqvarna_automower_ble/coordinator.py
+++ b/homeassistant/components/husqvarna_automower_ble/coordinator.py
@@ -1,7 +1,7 @@
 """Provides the DataUpdateCoordinator."""
 
 from datetime import timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from automower_ble.mower import Mower
 from automower_ble.protocol import ResponseResult
@@ -45,6 +45,7 @@ class HusqvarnaCoordinator(DataUpdateCoordinator[dict[str, str | int]]):
         self.model = model
         self.mower = mower
 
+    @override
     async def async_shutdown(self) -> None:
         """Shutdown coordinator and any connection."""
         LOGGER.debug("Shutdown")
@@ -67,6 +68,7 @@ class HusqvarnaCoordinator(DataUpdateCoordinator[dict[str, str | int]]):
             await close_stale_connections_by_address(self.address)
             raise UpdateFailed("Failed to connect") from err
 
+    @override
     async def _async_update_data(self) -> dict[str, str | int]:
         """Poll the device."""
         LOGGER.debug("Polling device")

--- a/homeassistant/components/husqvarna_automower_ble/entity.py
+++ b/homeassistant/components/husqvarna_automower_ble/entity.py
@@ -1,5 +1,7 @@
 """Provides the HusqvarnaAutomowerBleEntity."""
 
+from typing import override
+
 from homeassistant.helpers.device_registry import (
     CONNECTION_BLUETOOTH,
     DeviceInfo,
@@ -30,6 +32,7 @@ class HusqvarnaAutomowerBleEntity(CoordinatorEntity[HusqvarnaCoordinator]):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return super().available and self.coordinator.mower.is_connected()

--- a/homeassistant/components/husqvarna_automower_ble/lawn_mower.py
+++ b/homeassistant/components/husqvarna_automower_ble/lawn_mower.py
@@ -1,5 +1,7 @@
 """The Husqvarna Autoconnect Bluetooth lawn mower platform."""
 
+from typing import override
+
 from automower_ble.protocol import MowerActivity, MowerState, ResponseResult
 
 from homeassistant.components import bluetooth
@@ -93,6 +95,7 @@ class AutomowerLawnMower(HusqvarnaAutomowerBleEntity, LawnMowerEntity):
         return LawnMowerActivity.ERROR
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         LOGGER.debug("AutomowerLawnMower: _handle_coordinator_update")
@@ -101,6 +104,7 @@ class AutomowerLawnMower(HusqvarnaAutomowerBleEntity, LawnMowerEntity):
         self._attr_available = self._attr_activity is not None
         super()._handle_coordinator_update()
 
+    @override
     async def async_start_mowing(self) -> None:
         """Start mowing."""
         LOGGER.debug("Starting mower")
@@ -120,6 +124,7 @@ class AutomowerLawnMower(HusqvarnaAutomowerBleEntity, LawnMowerEntity):
         self._attr_activity = self._get_activity()
         self.async_write_ha_state()
 
+    @override
     async def async_dock(self) -> None:
         """Start docking."""
         LOGGER.debug("Start docking")
@@ -137,6 +142,7 @@ class AutomowerLawnMower(HusqvarnaAutomowerBleEntity, LawnMowerEntity):
         self._attr_activity = self._get_activity()
         self.async_write_ha_state()
 
+    @override
     async def async_pause(self) -> None:
         """Pause mower."""
         LOGGER.debug("Pausing mower")

--- a/homeassistant/components/husqvarna_automower_ble/sensor.py
+++ b/homeassistant/components/husqvarna_automower_ble/sensor.py
@@ -1,5 +1,7 @@
 """Support for sensor entities."""
 
+from typing import override
+
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -44,6 +46,7 @@ class HusqvarnaAutomowerBleSensor(HusqvarnaAutomowerBleDescriptorEntity, SensorE
     entity_description: SensorEntityDescription
 
     @property
+    @override
     def native_value(self) -> str | int:
         """Return the previously fetched value."""
         return self.coordinator.data[self.entity_description.key]

--- a/homeassistant/components/huum/binary_sensor.py
+++ b/homeassistant/components/huum/binary_sensor.py
@@ -1,5 +1,7 @@
 """Sensor for door state."""
 
+from typing import override
+
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
@@ -36,6 +38,7 @@ class HuumDoorSensor(HuumBaseEntity, BinarySensorEntity):
         self._attr_unique_id = f"{coordinator.config_entry.entry_id}_door"
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return the current value."""
         return not self.coordinator.data.door_closed

--- a/homeassistant/components/huum/climate.py
+++ b/homeassistant/components/huum/climate.py
@@ -1,6 +1,6 @@
 """Support for Huum wifi-enabled sauna."""
 
-from typing import Any
+from typing import Any, override
 
 from huum.const import SaunaStatus
 from huum.exceptions import SafetyException
@@ -51,6 +51,7 @@ class HuumDevice(HuumBaseEntity, ClimateEntity):
         self._attr_unique_id = coordinator.config_entry.entry_id
 
     @property
+    @override
     def min_temp(self) -> int:
         """Return configured minimal temperature."""
         sauna_config = self.coordinator.data.sauna_config
@@ -59,6 +60,7 @@ class HuumDevice(HuumBaseEntity, ClimateEntity):
         return sauna_config.min_temp or CONFIG_DEFAULT_MIN_TEMP
 
     @property
+    @override
     def max_temp(self) -> int:
         """Return configured maximum temperature."""
         sauna_config = self.coordinator.data.sauna_config
@@ -67,6 +69,7 @@ class HuumDevice(HuumBaseEntity, ClimateEntity):
         return sauna_config.max_temp or CONFIG_DEFAULT_MAX_TEMP
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode:
         """Return hvac operation ie. heat, cool mode."""
         if self.coordinator.data.status == SaunaStatus.ONLINE_HEATING:
@@ -74,15 +77,18 @@ class HuumDevice(HuumBaseEntity, ClimateEntity):
         return HVACMode.OFF
 
     @property
+    @override
     def current_temperature(self) -> int | None:
         """Return the current temperature."""
         return self.coordinator.data.temperature
 
     @property
+    @override
     def target_temperature(self) -> int:
         """Return the temperature we try to reach."""
         return self.coordinator.data.target_temperature or int(self.min_temp)
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set hvac mode."""
         if hvac_mode == HVACMode.HEAT:
@@ -94,6 +100,7 @@ class HuumDevice(HuumBaseEntity, ClimateEntity):
             await self.coordinator.huum.turn_off()
         await self.coordinator.async_refresh()
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         temperature = kwargs.get(ATTR_TEMPERATURE)

--- a/homeassistant/components/huum/config_flow.py
+++ b/homeassistant/components/huum/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from huum.exceptions import Forbidden, NotAuthenticated
 from huum.huum import Huum
@@ -29,6 +29,7 @@ class HuumConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/huum/coordinator.py
+++ b/homeassistant/components/huum/coordinator.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import logging
+from typing import override
 
 from huum.exceptions import Forbidden, NotAuthenticated
 from huum.huum import Huum
@@ -47,6 +48,7 @@ class HuumDataUpdateCoordinator(DataUpdateCoordinator[HuumStatusResponse]):
             session=async_get_clientsession(hass),
         )
 
+    @override
     async def _async_update_data(self) -> HuumStatusResponse:
         """Get the latest status data."""
 

--- a/homeassistant/components/huum/light.py
+++ b/homeassistant/components/huum/light.py
@@ -1,7 +1,7 @@
 """Control for light."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.light import ColorMode, LightEntity
 from homeassistant.core import HomeAssistant
@@ -43,15 +43,18 @@ class HuumLight(HuumBaseEntity, LightEntity):
         self._attr_unique_id = coordinator.config_entry.entry_id
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return the current light status."""
         return self.coordinator.data.light == 1
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn device on."""
         if not self.is_on:
             await self._toggle_light()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn device off."""
         if self.is_on:

--- a/homeassistant/components/huum/number.py
+++ b/homeassistant/components/huum/number.py
@@ -1,6 +1,7 @@
 """Control for steamer."""
 
 import logging
+from typing import override
 
 from huum.const import SaunaStatus
 
@@ -47,10 +48,12 @@ class HuumSteamer(HuumBaseEntity, NumberEntity):
         self._attr_unique_id = coordinator.config_entry.entry_id
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the current value."""
         return self.coordinator.data.humidity
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
         target_temperature = self.coordinator.data.target_temperature

--- a/homeassistant/components/huum/sensor.py
+++ b/homeassistant/components/huum/sensor.py
@@ -1,5 +1,7 @@
 """Sensor platform for Huum sauna integration."""
 
+from typing import override
+
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -37,6 +39,7 @@ class HuumTemperatureSensor(HuumBaseEntity, SensorEntity):
         self._attr_unique_id = f"{coordinator.config_entry.entry_id}_temperature"
 
     @property
+    @override
     def native_value(self) -> int | None:
         """Return the current temperature."""
         return self.coordinator.data.temperature

--- a/homeassistant/components/hvv_departures/binary_sensor.py
+++ b/homeassistant/components/hvv_departures/binary_sensor.py
@@ -3,7 +3,7 @@
 import asyncio
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from aiohttp import ClientConnectorError
 from pygti.exceptions import GTIError
@@ -167,11 +167,13 @@ class HvvDepartureBinarySensor(CoordinatorEntity, BinarySensorEntity):
         )
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return entity state."""
         return bool(self.coordinator.data[self.idx]["state"])
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return (
@@ -180,6 +182,7 @@ class HvvDepartureBinarySensor(CoordinatorEntity, BinarySensorEntity):
         )
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return the state attributes."""
         if not (

--- a/homeassistant/components/hvv_departures/config_flow.py
+++ b/homeassistant/components/hvv_departures/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for HVV integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from aiohttp import ClientConnectorError
 from pygti.auth import GTI_DEFAULT_HOST
@@ -57,6 +57,7 @@ class HVVDeparturesConfigFlow(ConfigFlow, domain=DOMAIN):
         """Initialize component."""
         self.stations: dict[str, Any] = {}
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -143,6 +144,7 @@ class HVVDeparturesConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: HVVConfigEntry,
     ) -> OptionsFlowHandler:

--- a/homeassistant/components/hydrawise/binary_sensor.py
+++ b/homeassistant/components/hydrawise/binary_sensor.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from datetime import datetime
+from typing import override
 
 from pydrawise import Controller, Zone
 import voluptuous as vol
@@ -150,11 +151,13 @@ class HydrawiseBinarySensor(HydrawiseEntity, BinarySensorEntity):
 
     entity_description: HydrawiseBinarySensorEntityDescription
 
+    @override
     def _update_attrs(self) -> None:
         """Update state attributes."""
         self._attr_is_on = self.entity_description.value_fn(self)
 
     @property
+    @override
     def available(self) -> bool:
         """Set the entity availability."""
         if self.entity_description.always_available:

--- a/homeassistant/components/hydrawise/config_flow.py
+++ b/homeassistant/components/hydrawise/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for the Hydrawise integration."""
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, override
 
 from aiohttp import ClientError
 from pydrawise import auth as pydrawise_auth, hybrid
@@ -31,6 +31,7 @@ class HydrawiseConfigFlow(ConfigFlow, domain=DOMAIN):
     VERSION = 1
     MINOR_VERSION = 2
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/hydrawise/coordinator.py
+++ b/homeassistant/components/hydrawise/coordinator.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
+from typing import override
 
 from pydrawise import HydrawiseBase
 from pydrawise.schema import Controller, ControllerWaterUseSummary, Sensor, User, Zone
@@ -88,6 +89,7 @@ class HydrawiseMainDataUpdateCoordinator(HydrawiseDataUpdateCoordinator):
         """Begin tracking zone and controller add/remove on updates."""
         self.async_add_listener(self._add_remove_zones)
 
+    @override
     async def _async_update_data(self) -> HydrawiseData:
         """Fetch the latest data from Hydrawise."""
         # Don't fetch zones. We'll fetch them for each controller later.
@@ -219,6 +221,7 @@ class HydrawiseWaterUseDataUpdateCoordinator(HydrawiseDataUpdateCoordinator):
         self.data.zone_id_to_controller = main_data.zone_id_to_controller
         self.data.sensors = main_data.sensors
 
+    @override
     async def _async_update_data(self) -> HydrawiseData:
         """Fetch the latest data from Hydrawise."""
         daily_water_summary: dict[int, ControllerWaterUseSummary] = {}

--- a/homeassistant/components/hydrawise/entity.py
+++ b/homeassistant/components/hydrawise/entity.py
@@ -1,5 +1,7 @@
 """Base classes for Hydrawise entities."""
 
+from typing import override
+
 from pydrawise.schema import Controller, Sensor, Zone
 
 from homeassistant.core import callback
@@ -65,6 +67,7 @@ class HydrawiseEntity(CoordinatorEntity[HydrawiseDataUpdateCoordinator]):
         return  # pragma: no cover
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Get the latest data and updates the state."""
         # Guard against updates arriving after the controller has been removed
@@ -76,6 +79,7 @@ class HydrawiseEntity(CoordinatorEntity[HydrawiseDataUpdateCoordinator]):
         super()._handle_coordinator_update()
 
     @property
+    @override
     def available(self) -> bool:
         """Set the entity availability."""
         return super().available and self.controller.online

--- a/homeassistant/components/hydrawise/sensor.py
+++ b/homeassistant/components/hydrawise/sensor.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Any
+from typing import Any, override
 
 from pydrawise.schema import Controller, ControllerWaterUseSummary, Zone
 
@@ -202,6 +202,7 @@ class HydrawiseSensor(HydrawiseEntity, SensorEntity):
     entity_description: HydrawiseSensorEntityDescription
 
     @property
+    @override
     def native_unit_of_measurement(self) -> str | None:
         """Return the unit_of_measurement of the sensor."""
         if self.entity_description.device_class != SensorDeviceClass.WATER:
@@ -213,6 +214,7 @@ class HydrawiseSensor(HydrawiseEntity, SensorEntity):
         )
 
     @property
+    @override
     def icon(self) -> str | None:
         """Icon of the entity based on the value."""
         if (
@@ -223,6 +225,7 @@ class HydrawiseSensor(HydrawiseEntity, SensorEntity):
             return "mdi:water-outline"
         return None
 
+    @override
     def _update_attrs(self) -> None:
         """Update state attributes."""
         self._attr_native_value = self.entity_description.value_fn(self)

--- a/homeassistant/components/hydrawise/switch.py
+++ b/homeassistant/components/hydrawise/switch.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable, Coroutine, Iterable
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Any
+from typing import Any, override
 
 from pydrawise import Controller, HydrawiseBase, Zone
 
@@ -89,18 +89,21 @@ class HydrawiseSwitch(HydrawiseEntity, SwitchEntity):
     entity_description: HydrawiseSwitchEntityDescription
     zone: Zone
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
         await self.entity_description.turn_on_fn(self.coordinator.api, self.zone)
         self._attr_is_on = True
         self.async_write_ha_state()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
         await self.entity_description.turn_off_fn(self.coordinator.api, self.zone)
         self._attr_is_on = False
         self.async_write_ha_state()
 
+    @override
     def _update_attrs(self) -> None:
         """Update state attributes."""
         self._attr_is_on = self.entity_description.value_fn(self.zone)

--- a/homeassistant/components/hydrawise/valve.py
+++ b/homeassistant/components/hydrawise/valve.py
@@ -1,7 +1,7 @@
 """Support for Hydrawise sprinkler valves."""
 
 from collections.abc import Iterable
-from typing import Any
+from typing import Any, override
 
 from pydrawise.schema import Controller, Zone
 
@@ -59,14 +59,17 @@ class HydrawiseValve(HydrawiseEntity, ValveEntity):
     _attr_supported_features = ValveEntityFeature.OPEN | ValveEntityFeature.CLOSE
     zone: Zone
 
+    @override
     async def async_open_valve(self, **kwargs: Any) -> None:
         """Open the valve."""
         await self.coordinator.api.start_zone(self.zone)
 
+    @override
     async def async_close_valve(self) -> None:
         """Close the valve."""
         await self.coordinator.api.stop_zone(self.zone)
 
+    @override
     def _update_attrs(self) -> None:
         """Update state attributes."""
         self._attr_is_closed = self.zone.scheduled_runs.current_run is None

--- a/homeassistant/components/hyperion/camera.py
+++ b/homeassistant/components/hyperion/camera.py
@@ -6,7 +6,7 @@ import binascii
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 import functools
-from typing import Any
+from typing import Any, override
 
 from aiohttp import web
 from hyperion import client
@@ -141,11 +141,13 @@ class HyperionCamera(Camera):
         )
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if the camera is on."""
         return self.available
 
     @property
+    @override
     def available(self) -> bool:
         """Return server availability."""
         return bool(self._client.has_loaded_state)
@@ -204,6 +206,7 @@ class HyperionCamera(Camera):
         finally:
             await self._stop_image_streaming_for_client()
 
+    @override
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
@@ -213,6 +216,7 @@ class HyperionCamera(Camera):
                 return await self._async_wait_for_camera_image()
         return None
 
+    @override
     async def handle_async_mjpeg_stream(
         self, request: web.Request
     ) -> web.StreamResponse | None:
@@ -227,6 +231,7 @@ class HyperionCamera(Camera):
                 )
         return None
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register callbacks when entity added to hass."""
         self.async_on_remove(
@@ -239,6 +244,7 @@ class HyperionCamera(Camera):
 
         self._client.add_callbacks(self._client_callbacks)
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Cleanup prior to hass removal."""
         self._client.remove_callbacks(self._client_callbacks)

--- a/homeassistant/components/hyperion/config_flow.py
+++ b/homeassistant/components/hyperion/config_flow.py
@@ -4,7 +4,7 @@ import asyncio
 from collections.abc import Mapping
 from contextlib import suppress
 import logging
-from typing import Any
+from typing import Any, override
 from urllib.parse import urlparse
 
 from hyperion import client, const
@@ -151,6 +151,7 @@ class HyperionConfigFlow(ConfigFlow, domain=DOMAIN):
                 return self.async_abort(reason="cannot_connect")
             return await self._advance_to_auth_step_if_necessary(hyperion_client)
 
+    @override
     async def async_step_ssdp(
         self, discovery_info: SsdpServiceInfo
     ) -> ConfigFlowResult:
@@ -223,6 +224,7 @@ class HyperionConfigFlow(ConfigFlow, domain=DOMAIN):
                 return self.async_abort(reason="cannot_connect")
             return await self._advance_to_auth_step_if_necessary(hyperion_client)
 
+    @override
     async def async_step_user(
         self,
         user_input: dict[str, Any] | None = None,
@@ -423,6 +425,7 @@ class HyperionConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> HyperionOptionsFlow:

--- a/homeassistant/components/hyperion/light.py
+++ b/homeassistant/components/hyperion/light.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable, Mapping, Sequence
 import functools
 import logging
-from typing import Any
+from typing import Any, override
 
 from hyperion import client, const
 
@@ -161,16 +161,19 @@ class HyperionLight(LightEntity):
         return get_hyperion_unique_id(server_id, instance_num, TYPE_HYPERION_LIGHT)
 
     @property
+    @override
     def brightness(self) -> int:
         """Return the brightness of this light between 0..255."""
         return self._brightness
 
     @property
+    @override
     def hs_color(self) -> tuple[float, float]:
         """Return last color value set."""
         return color_util.color_RGB_to_hs(*self._rgb_color)
 
     @property
+    @override
     def icon(self) -> str:
         """Return state specific icon."""
         if self.is_on:
@@ -179,16 +182,19 @@ class HyperionLight(LightEntity):
         return ICON_LIGHTBULB
 
     @property
+    @override
     def effect(self) -> str:
         """Return the current effect."""
         return self._effect
 
     @property
+    @override
     def effect_list(self) -> list[str]:
         """Return the list of supported effects."""
         return self._effect_list
 
     @property
+    @override
     def available(self) -> bool:
         """Return server availability."""
         return bool(self._client.has_loaded_state)
@@ -202,6 +208,7 @@ class HyperionLight(LightEntity):
         return self._options.get(key, defaults[key])
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if light is on.
 
@@ -210,6 +217,7 @@ class HyperionLight(LightEntity):
         """
         return self._get_priority_entry_that_dictates_state() is not None
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the light."""
         # == Get key parameters ==
@@ -263,6 +271,7 @@ class HyperionLight(LightEntity):
         ):
             return
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the light i.e. clear the configured priority."""
         if not await self._client.async_send_clear(
@@ -365,6 +374,7 @@ class HyperionLight(LightEntity):
         """Update client connection state."""
         self.async_write_ha_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register callbacks when entity added to hass."""
         self.async_on_remove(
@@ -380,6 +390,7 @@ class HyperionLight(LightEntity):
         # Load initial state.
         self._update_full_state()
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Cleanup prior to hass removal."""
         self._client.remove_callbacks(self._client_callbacks)

--- a/homeassistant/components/hyperion/sensor.py
+++ b/homeassistant/components/hyperion/sensor.py
@@ -1,7 +1,7 @@
 """Sensor platform for Hyperion."""
 
 import functools
-from typing import Any
+from typing import Any, override
 
 from hyperion import client
 from hyperion.const import (
@@ -128,10 +128,12 @@ class HyperionSensor(SensorEntity):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return server availability."""
         return bool(self._client.has_loaded_state)
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register callbacks when entity added to hass."""
         self.async_on_remove(
@@ -144,6 +146,7 @@ class HyperionSensor(SensorEntity):
 
         self._client.add_callbacks(self._client_callbacks)
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Cleanup prior to hass removal."""
         self._client.remove_callbacks(self._client_callbacks)

--- a/homeassistant/components/hyperion/switch.py
+++ b/homeassistant/components/hyperion/switch.py
@@ -1,7 +1,7 @@
 """Switch platform for Hyperion."""
 
 import functools
-from typing import Any
+from typing import Any, override
 
 from hyperion import client
 from hyperion.const import (
@@ -164,6 +164,7 @@ class HyperionComponentSwitch(SwitchEntity):
         )
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if the switch is on."""
         for component in self._client.components or []:
@@ -172,6 +173,7 @@ class HyperionComponentSwitch(SwitchEntity):
         return False
 
     @property
+    @override
     def available(self) -> bool:
         """Return server availability."""
         return bool(self._client.has_loaded_state)
@@ -187,10 +189,12 @@ class HyperionComponentSwitch(SwitchEntity):
             }
         )
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the switch."""
         await self._async_send_set_component(True)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the switch."""
         await self._async_send_set_component(False)
@@ -200,6 +204,7 @@ class HyperionComponentSwitch(SwitchEntity):
         """Update Hyperion components."""
         self.async_write_ha_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register callbacks when entity added to hass."""
         self.async_on_remove(
@@ -212,6 +217,7 @@ class HyperionComponentSwitch(SwitchEntity):
 
         self._client.add_callbacks(self._client_callbacks)
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Cleanup prior to hass removal."""
         self._client.remove_callbacks(self._client_callbacks)

--- a/homeassistant/components/hypontech/config_flow.py
+++ b/homeassistant/components/hypontech/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from hyponcloud import KNOWN_OEMS, AdminInfo, AuthenticationError, HyponCloud
 import voluptuous as vol
@@ -93,6 +93,7 @@ class HypontechConfigFlow(ConfigFlow, domain=DOMAIN):
             errors["base"] = "unknown"
         return None, errors
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/hypontech/coordinator.py
+++ b/homeassistant/components/hypontech/coordinator.py
@@ -3,6 +3,7 @@
 import asyncio
 from dataclasses import dataclass
 from datetime import timedelta
+from typing import override
 
 from hyponcloud import (
     KNOWN_OEMS,
@@ -65,6 +66,7 @@ class HypontechDataCoordinator(DataUpdateCoordinator[HypontechCoordinatorData]):
         self.account_id = account_id
         self.oem_name = OEM_NAMES[int(config_entry.data.get(CONF_OEM, DEFAULT_OEM))]
 
+    @override
     async def _async_update_data(self) -> HypontechCoordinatorData:
         try:
             overview = await self.api.get_overview()

--- a/homeassistant/components/hypontech/entity.py
+++ b/homeassistant/components/hypontech/entity.py
@@ -1,5 +1,7 @@
 """Base entity for the Hypontech Cloud integration."""
 
+from typing import override
+
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -45,6 +47,7 @@ class HypontechPlantEntity(CoordinatorEntity[HypontechDataCoordinator]):
         return self.coordinator.data.plants[self.plant_id]
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return super().available and self.plant_id in self.coordinator.data.plants

--- a/homeassistant/components/hypontech/sensor.py
+++ b/homeassistant/components/hypontech/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from hyponcloud import OverviewData, PlantData
 
@@ -183,6 +184,7 @@ class HypontechOverviewSensor(HypontechEntity, SensorEntity):
         self._attr_unique_id = f"{coordinator.account_id}_{description.key}"
 
     @property
+    @override
     def native_unit_of_measurement(self) -> str | None:
         """Return the unit of measurement."""
         if self.entity_description.unit_fn is not None:
@@ -190,6 +192,7 @@ class HypontechOverviewSensor(HypontechEntity, SensorEntity):
         return super().native_unit_of_measurement
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.coordinator.data.overview)
@@ -212,6 +215,7 @@ class HypontechPlantSensor(HypontechPlantEntity, SensorEntity):
         self._attr_unique_id = f"{plant_id}_{description.key}"
 
     @property
+    @override
     def native_unit_of_measurement(self) -> str | None:
         """Return the unit of measurement."""
         if self.entity_description.unit_fn is not None:
@@ -219,6 +223,7 @@ class HypontechPlantSensor(HypontechPlantEntity, SensorEntity):
         return super().native_unit_of_measurement
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.plant)

--- a/homeassistant/components/ialarm/alarm_control_panel.py
+++ b/homeassistant/components/ialarm/alarm_control_panel.py
@@ -1,5 +1,7 @@
 """Interfaces with iAlarm control panels."""
 
+from typing import override
+
 from homeassistant.components.alarm_control_panel import (
     AlarmControlPanelEntity,
     AlarmControlPanelEntityFeature,
@@ -48,18 +50,22 @@ class IAlarmPanel(
         self._attr_unique_id = coordinator.mac
 
     @property
+    @override
     def alarm_state(self) -> AlarmControlPanelState | None:
         """Return the state of the device."""
         return self.coordinator.state
 
+    @override
     def alarm_disarm(self, code: str | None = None) -> None:
         """Send disarm command."""
         self.coordinator.ialarm.disarm()
 
+    @override
     def alarm_arm_home(self, code: str | None = None) -> None:
         """Send arm home command."""
         self.coordinator.ialarm.arm_stay()
 
+    @override
     def alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command."""
         self.coordinator.ialarm.arm_away()

--- a/homeassistant/components/ialarm/config_flow.py
+++ b/homeassistant/components/ialarm/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Antifurto365 iAlarm integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyialarm import IAlarm
 import voluptuous as vol
@@ -32,6 +32,7 @@ class IAlarmConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/ialarm/coordinator.py
+++ b/homeassistant/components/ialarm/coordinator.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from typing import override
 
 from pyialarm import IAlarm
 
@@ -53,6 +54,7 @@ class IAlarmDataUpdateCoordinator(DataUpdateCoordinator[None]):
 
         self.state = IALARM_TO_HASS.get(status)
 
+    @override
     async def _async_update_data(self) -> None:
         """Fetch data from iAlarm."""
         try:

--- a/homeassistant/components/iammeter/sensor.py
+++ b/homeassistant/components/iammeter/sensor.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 import logging
+from typing import override
 
 from iammeter.client import IamMeter
 import voluptuous as vol
@@ -179,6 +180,7 @@ class IammeterSensor(update_coordinator.CoordinatorEntity, SensorEntity):
         )
 
     @property
+    @override
     def native_value(self):
         """Return the native sensor value."""
         raw_attr = self.coordinator.data.get(self.entity_description.key, None)

--- a/homeassistant/components/iaqualink/binary_sensor.py
+++ b/homeassistant/components/iaqualink/binary_sensor.py
@@ -1,5 +1,7 @@
 """Support for Aqualink temperature sensors."""
 
+from typing import override
+
 from iaqualink.device import AqualinkBinarySensor
 
 from homeassistant.components.binary_sensor import (
@@ -44,6 +46,7 @@ class HassAqualinkBinarySensor(
             self._attr_device_class = BinarySensorDeviceClass.COLD
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return whether the binary sensor is on or not."""
         return self.dev.is_on

--- a/homeassistant/components/iaqualink/climate.py
+++ b/homeassistant/components/iaqualink/climate.py
@@ -1,7 +1,7 @@
 """Support for Aqualink Thermostats."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from iaqualink.device import AqualinkThermostat
 from iaqualink.systems.iaqua.device import AqualinkState
@@ -64,6 +64,7 @@ class HassAqualinkThermostat(AqualinkEntity[AqualinkThermostat], ClimateEntity):
         self._attr_max_temp = dev.max_temperature
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode:
         """Return the current HVAC mode."""
         if self.dev.is_on is True:
@@ -71,6 +72,7 @@ class HassAqualinkThermostat(AqualinkEntity[AqualinkThermostat], ClimateEntity):
         return HVACMode.OFF
 
     @refresh_system
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Turn the underlying heater switch on or off."""
         if hvac_mode == HVACMode.HEAT:
@@ -85,6 +87,7 @@ class HassAqualinkThermostat(AqualinkEntity[AqualinkThermostat], ClimateEntity):
             _LOGGER.warning("Unknown operation mode: %s", hvac_mode)
 
     @property
+    @override
     def hvac_action(self) -> HVACAction:
         """Return the current HVAC action."""
         state = AqualinkState(self.dev._heater.state)  # noqa: SLF001
@@ -95,11 +98,13 @@ class HassAqualinkThermostat(AqualinkEntity[AqualinkThermostat], ClimateEntity):
         return HVACAction.OFF
 
     @property
+    @override
     def target_temperature(self) -> float:
         """Return the current target temperature."""
         return float(self.dev.state)
 
     @refresh_system
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         await await_or_reraise(
@@ -109,6 +114,7 @@ class HassAqualinkThermostat(AqualinkEntity[AqualinkThermostat], ClimateEntity):
         )
 
     @property
+    @override
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
         if self.dev.current_temperature != "":

--- a/homeassistant/components/iaqualink/config_flow.py
+++ b/homeassistant/components/iaqualink/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for iAquaLink."""
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, override
 
 import httpx
 from iaqualink.client import AqualinkClient
@@ -55,6 +55,7 @@ class AqualinkFlowHandler(ConfigFlow, domain=DOMAIN):
 
         return {}
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/iaqualink/coordinator.py
+++ b/homeassistant/components/iaqualink/coordinator.py
@@ -1,7 +1,7 @@
 """Data update coordinator for iaqualink."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 import httpx
 from iaqualink.exception import (
@@ -40,6 +40,7 @@ class AqualinkDataUpdateCoordinator(DataUpdateCoordinator[None]):
         )
         self.system = system
 
+    @override
     async def _async_update_data(self) -> None:
         """Refresh internal state for a system."""
         try:

--- a/homeassistant/components/iaqualink/entity.py
+++ b/homeassistant/components/iaqualink/entity.py
@@ -1,5 +1,7 @@
 """Component to embed Aqualink devices."""
 
+from typing import override
+
 from iaqualink.device import AqualinkDevice
 
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -39,6 +41,7 @@ class AqualinkEntity[AqualinkDeviceT: AqualinkDevice](
         )
 
     @property
+    @override
     def assumed_state(self) -> bool:
         """Return whether the state is based on actual reading from the device."""
         return self.dev.system.online in [False, None]

--- a/homeassistant/components/iaqualink/light.py
+++ b/homeassistant/components/iaqualink/light.py
@@ -1,6 +1,6 @@
 """Support for Aqualink pool lights."""
 
-from typing import Any
+from typing import Any, override
 
 from iaqualink.device import AqualinkLight
 
@@ -54,11 +54,13 @@ class HassAqualinkLight(AqualinkEntity[AqualinkLight], LightEntity):
         self._attr_supported_color_modes = {color_mode}
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return whether the light is on or off."""
         return self.dev.is_on
 
     @refresh_system
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the light.
 
@@ -84,6 +86,7 @@ class HassAqualinkLight(AqualinkEntity[AqualinkLight], LightEntity):
             )
 
     @refresh_system
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the light."""
         await await_or_reraise(
@@ -91,6 +94,7 @@ class HassAqualinkLight(AqualinkEntity[AqualinkLight], LightEntity):
         )
 
     @property
+    @override
     def brightness(self) -> int:
         """Return current brightness of the light.
 
@@ -99,6 +103,7 @@ class HassAqualinkLight(AqualinkEntity[AqualinkLight], LightEntity):
         return round(self.dev.brightness * 255 / 100)
 
     @property
+    @override
     def effect(self) -> str:
         """Return the current light effect if supported."""
         return self.dev.effect

--- a/homeassistant/components/iaqualink/sensor.py
+++ b/homeassistant/components/iaqualink/sensor.py
@@ -1,5 +1,7 @@
 """Support for Aqualink temperature sensors."""
 
+from typing import override
+
 from iaqualink.device import AqualinkSensor
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
@@ -45,6 +47,7 @@ class HassAqualinkSensor(AqualinkEntity[AqualinkSensor], SensorEntity):
         self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
 
     @property
+    @override
     def native_value(self) -> int | float | None:
         """Return the state of the sensor."""
         if self.dev.state == "":

--- a/homeassistant/components/iaqualink/switch.py
+++ b/homeassistant/components/iaqualink/switch.py
@@ -1,6 +1,6 @@
 """Support for Aqualink pool feature switches."""
 
-from typing import Any
+from typing import Any, override
 
 from iaqualink.device import AqualinkSwitch
 
@@ -49,11 +49,13 @@ class HassAqualinkSwitch(AqualinkEntity[AqualinkSwitch], SwitchEntity):
             self._attr_icon = "mdi:radiator"
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return whether the switch is on or not."""
         return self.dev.is_on
 
     @refresh_system
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the switch."""
         await await_or_reraise(
@@ -61,6 +63,7 @@ class HassAqualinkSwitch(AqualinkEntity[AqualinkSwitch], SwitchEntity):
         )
 
     @refresh_system
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the switch."""
         await await_or_reraise(

--- a/homeassistant/components/ibeacon/config_flow.py
+++ b/homeassistant/components/ibeacon/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for iBeacon Tracker integration."""
 
-from typing import Any
+from typing import Any, override
 from uuid import UUID
 
 import voluptuous as vol
@@ -24,6 +24,7 @@ class IBeaconConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -38,6 +39,7 @@ class IBeaconConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> OptionsFlow:

--- a/homeassistant/components/ibeacon/device_tracker.py
+++ b/homeassistant/components/ibeacon/device_tracker.py
@@ -1,5 +1,7 @@
 """Support for tracking iBeacon devices."""
 
+from typing import override
+
 from ibeacon_ble import iBeaconAdvertisement
 
 from homeassistant.components.device_tracker import BaseScannerEntity, SourceType
@@ -66,11 +68,13 @@ class IBeaconTrackerEntity(IBeaconEntity, BaseScannerEntity):
         self._active = True
 
     @property
+    @override
     def is_connected(self) -> bool:
         """Return true if the device is connected."""
         return self._active
 
     @callback
+    @override
     def _async_seen(
         self,
         ibeacon_advertisement: iBeaconAdvertisement,
@@ -81,6 +85,7 @@ class IBeaconTrackerEntity(IBeaconEntity, BaseScannerEntity):
         self.async_write_ha_state()
 
     @callback
+    @override
     def _async_unavailable(self) -> None:
         """Set unavailable."""
         self._active = False

--- a/homeassistant/components/ibeacon/entity.py
+++ b/homeassistant/components/ibeacon/entity.py
@@ -1,6 +1,7 @@
 """Support for iBeacon device sensors."""
 
 from abc import abstractmethod
+from typing import override
 
 from ibeacon_ble import iBeaconAdvertisement
 
@@ -36,6 +37,7 @@ class IBeaconEntity(Entity):
         )
 
     @property
+    @override
     def extra_state_attributes(
         self,
     ) -> dict[str, str | int]:
@@ -61,6 +63,7 @@ class IBeaconEntity(Entity):
     def _async_unavailable(self) -> None:
         """Set unavailable."""
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register state update callbacks."""
         await super().async_added_to_hass()

--- a/homeassistant/components/ibeacon/sensor.py
+++ b/homeassistant/components/ibeacon/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from ibeacon_ble import iBeaconAdvertisement
 
@@ -116,6 +117,7 @@ class IBeaconSensorEntity(IBeaconEntity, SensorEntity):
         self.entity_description = description
 
     @callback
+    @override
     def _async_seen(
         self,
         ibeacon_advertisement: iBeaconAdvertisement,
@@ -126,12 +128,14 @@ class IBeaconSensorEntity(IBeaconEntity, SensorEntity):
         self.async_write_ha_state()
 
     @callback
+    @override
     def _async_unavailable(self) -> None:
         """Update state."""
         self._attr_available = False
         self.async_write_ha_state()
 
     @property
+    @override
     def native_value(self) -> str | int | None:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self._ibeacon_advertisement)

--- a/homeassistant/components/icloud/config_flow.py
+++ b/homeassistant/components/icloud/config_flow.py
@@ -3,7 +3,7 @@
 from collections.abc import Mapping
 import logging
 import os
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from pyicloud import PyiCloudService
 from pyicloud.exceptions import (
@@ -162,6 +162,7 @@ class IcloudFlowHandler(ConfigFlow, domain=DOMAIN):
         await self.hass.config_entries.async_reload(entry.entry_id)
         return self.async_abort(reason="reauth_successful")
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/icloud/device_tracker.py
+++ b/homeassistant/components/icloud/device_tracker.py
@@ -1,6 +1,6 @@
 """Support for tracking for iCloud devices."""
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from homeassistant.components.device_tracker import TrackerEntity
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
@@ -67,6 +67,7 @@ class IcloudTrackerEntity(TrackerEntity):
         self._attr_unique_id = device.unique_id
 
     @property
+    @override
     def location_accuracy(self) -> float:
         """Return the location accuracy of the device."""
         if TYPE_CHECKING:
@@ -74,6 +75,7 @@ class IcloudTrackerEntity(TrackerEntity):
         return self._device.location[DEVICE_LOCATION_HORIZONTAL_ACCURACY]
 
     @property
+    @override
     def latitude(self) -> float:
         """Return latitude value of the device."""
         if TYPE_CHECKING:
@@ -81,6 +83,7 @@ class IcloudTrackerEntity(TrackerEntity):
         return self._device.location[DEVICE_LOCATION_LATITUDE]
 
     @property
+    @override
     def longitude(self) -> float:
         """Return longitude value of the device."""
         if TYPE_CHECKING:
@@ -88,16 +91,19 @@ class IcloudTrackerEntity(TrackerEntity):
         return self._device.location[DEVICE_LOCATION_LONGITUDE]
 
     @property
+    @override
     def icon(self) -> str:
         """Return the icon."""
         return icon_for_icloud_device(self._device)
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the device state attributes."""
         return self._device.extra_state_attributes
 
     @property
+    @override
     def device_info(self) -> DeviceInfo:
         """Return the device information."""
         return DeviceInfo(
@@ -108,12 +114,14 @@ class IcloudTrackerEntity(TrackerEntity):
             name=self._device.name,
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register state update callback."""
         self._unsub_dispatcher = async_dispatcher_connect(
             self.hass, self._account.signal_device_update, self.async_write_ha_state
         )
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Clean up after entity before removal."""
         if self._unsub_dispatcher:

--- a/homeassistant/components/icloud/media_source.py
+++ b/homeassistant/components/icloud/media_source.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 from dataclasses import dataclass
 import logging
 import threading
+from typing import override
 import urllib.parse
 
 from aiohttp import ClientTimeout, hdrs, web
@@ -280,6 +281,7 @@ class IcloudMediaSourceIdentifier:
             photo_id=photo_id,
         )
 
+    @override
     def __str__(self) -> str:
         """Return string representation of the identifier."""
         parts = [self.config_entry_id]
@@ -302,6 +304,7 @@ class IcloudMediaSource(MediaSource):
         super().__init__(DOMAIN)
         self._hass = hass
 
+    @override
     async def async_resolve_media(self, item: MediaSourceItem) -> PlayMedia:
         """Resolve a media item to a playable object."""
         if not self._hass.config_entries.async_loaded_entries(DOMAIN):
@@ -349,6 +352,7 @@ class IcloudMediaSource(MediaSource):
 
         return " / ".join(title_parts)
 
+    @override
     async def async_browse_media(
         self,
         item: MediaSourceItem,

--- a/homeassistant/components/icloud/sensor.py
+++ b/homeassistant/components/icloud/sensor.py
@@ -1,6 +1,6 @@
 """Support for iCloud sensors."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.const import PERCENTAGE
@@ -73,11 +73,13 @@ class IcloudDeviceBatterySensor(SensorEntity):
         )
 
     @property
+    @override
     def native_value(self) -> int | None:
         """Battery state percentage."""
         return self._device.battery_level
 
     @property
+    @override
     def icon(self) -> str:
         """Battery state icon handling."""
         return icon_for_battery_level(
@@ -86,16 +88,19 @@ class IcloudDeviceBatterySensor(SensorEntity):
         )
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return default attributes for the iCloud device entity."""
         return self._device.extra_state_attributes
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register state update callback."""
         self._unsub_dispatcher = async_dispatcher_connect(
             self.hass, self._account.signal_device_update, self.async_write_ha_state
         )
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Clean up after entity before removal."""
         if self._unsub_dispatcher:

--- a/homeassistant/components/idasen_desk/button.py
+++ b/homeassistant/components/idasen_desk/button.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 import logging
-from typing import Any, Final
+from typing import Any, Final, override
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.const import EntityCategory
@@ -65,6 +65,7 @@ class IdasenDeskButton(IdasenDeskEntity, ButtonEntity):
         super().__init__(f"{description.key}-{coordinator.address}", coordinator)
         self.entity_description = description
 
+    @override
     async def async_press(self) -> None:
         """Triggers the IdasenDesk button press service."""
         _LOGGER.debug(
@@ -75,6 +76,7 @@ class IdasenDeskButton(IdasenDeskEntity, ButtonEntity):
         await self.entity_description.press_action(self.coordinator)()
 
     @property
+    @override
     def available(self) -> bool:
         """Connect/disconnect buttons should always be available."""
         return True

--- a/homeassistant/components/idasen_desk/config_flow.py
+++ b/homeassistant/components/idasen_desk/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Idasen Desk integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from bleak.exc import BleakError
 from bluetooth_data_tools import human_readable_name
@@ -32,6 +32,7 @@ class IdasenDeskConfigFlow(ConfigFlow, domain=DOMAIN):
         self._discovery_info: BluetoothServiceInfoBleak | None = None
         self._discovered_devices: dict[str, BluetoothServiceInfoBleak] = {}
 
+    @override
     async def async_step_bluetooth(
         self, discovery_info: BluetoothServiceInfoBleak
     ) -> ConfigFlowResult:
@@ -46,6 +47,7 @@ class IdasenDeskConfigFlow(ConfigFlow, domain=DOMAIN):
         }
         return await self.async_step_user()
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/idasen_desk/cover.py
+++ b/homeassistant/components/idasen_desk/cover.py
@@ -1,6 +1,6 @@
 """Idasen Desk integration cover platform."""
 
-from typing import Any
+from typing import Any, override
 
 from bleak.exc import BleakError
 
@@ -46,10 +46,12 @@ class IdasenDeskCover(IdasenDeskEntity, CoverEntity):
         super().__init__(coordinator.address, coordinator)
 
     @property
+    @override
     def is_closed(self) -> bool:
         """Return if the cover is closed."""
         return self.current_cover_position == 0
 
+    @override
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
         try:
@@ -57,6 +59,7 @@ class IdasenDeskCover(IdasenDeskEntity, CoverEntity):
         except BleakError as err:
             raise HomeAssistantError("Failed to move down: Bluetooth error") from err
 
+    @override
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
         try:
@@ -64,6 +67,7 @@ class IdasenDeskCover(IdasenDeskEntity, CoverEntity):
         except BleakError as err:
             raise HomeAssistantError("Failed to move up: Bluetooth error") from err
 
+    @override
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
         try:
@@ -71,6 +75,7 @@ class IdasenDeskCover(IdasenDeskEntity, CoverEntity):
         except BleakError as err:
             raise HomeAssistantError("Failed to stop moving: Bluetooth error") from err
 
+    @override
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover shutter to a specific position."""
         try:
@@ -81,6 +86,7 @@ class IdasenDeskCover(IdasenDeskEntity, CoverEntity):
             ) from err
 
     @property
+    @override
     def current_cover_position(self) -> int | None:
         """Return the current cover position."""
         return self._desk.height_percent

--- a/homeassistant/components/idasen_desk/entity.py
+++ b/homeassistant/components/idasen_desk/entity.py
@@ -1,5 +1,7 @@
 """Base entity for Idasen Desk."""
 
+from typing import override
+
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -27,6 +29,7 @@ class IdasenDeskEntity(CoordinatorEntity[IdasenDeskCoordinator]):
         self._desk = coordinator.desk
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available."""
         return super().available and self._desk.is_connected is True

--- a/homeassistant/components/idasen_desk/sensor.py
+++ b/homeassistant/components/idasen_desk/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -66,6 +67,7 @@ class IdasenDeskSensor(IdasenDeskEntity, SensorEntity):
         self.entity_description = description
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the value reported by the sensor."""
         return self.entity_description.value_fn(self.coordinator)

--- a/homeassistant/components/idrive_e2/backup.py
+++ b/homeassistant/components/idrive_e2/backup.py
@@ -5,7 +5,7 @@ import functools
 import json
 import logging
 from time import time
-from typing import Any, cast
+from typing import Any, cast, override
 
 from aiobotocore.client import AioBaseClient as S3Client
 from botocore.exceptions import BotoCoreError
@@ -105,6 +105,7 @@ class IDriveE2BackupAgent(BackupAgent):
         self._cache_expiration = time()
 
     @handle_boto_errors
+    @override
     async def async_download_backup(
         self,
         backup_id: str,
@@ -123,6 +124,7 @@ class IDriveE2BackupAgent(BackupAgent):
         )
         return response["Body"].iter_chunks()
 
+    @override
     async def async_upload_backup(
         self,
         *,
@@ -285,6 +287,7 @@ class IDriveE2BackupAgent(BackupAgent):
             raise
 
     @handle_boto_errors
+    @override
     async def async_delete_backup(
         self,
         backup_id: str,
@@ -312,12 +315,14 @@ class IDriveE2BackupAgent(BackupAgent):
         self._cache_expiration = time()
 
     @handle_boto_errors
+    @override
     async def async_list_backups(self, **kwargs: Any) -> list[AgentBackup]:
         """List backups."""
         backups = await self._list_backups()
         return list(backups.values())
 
     @handle_boto_errors
+    @override
     async def async_get_backup(
         self,
         backup_id: str,

--- a/homeassistant/components/idrive_e2/config_flow.py
+++ b/homeassistant/components/idrive_e2/config_flow.py
@@ -1,7 +1,7 @@
 """IDrive e2 config flow."""
 
 import logging
-from typing import Any, cast
+from typing import Any, cast, override
 
 from aiobotocore.session import AioSession
 from botocore.exceptions import ClientError, ConnectionError
@@ -63,6 +63,7 @@ class IDriveE2ConfigFlow(ConfigFlow, domain=DOMAIN):
     _data: dict[str, str]
     _buckets: list[str]
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/ifttt/alarm_control_panel.py
+++ b/homeassistant/components/ifttt/alarm_control_panel.py
@@ -1,6 +1,7 @@
 """Support for alarm control panels that can be controlled through IFTTT."""
 
 import logging
+from typing import override
 
 import voluptuous as vol
 
@@ -151,6 +152,7 @@ class IFTTTAlarmPanel(AlarmControlPanelEntity):
         self._optimistic = optimistic
 
     @property
+    @override
     def code_format(self) -> CodeFormat | None:
         """Return one or more digits/characters."""
         if self._code is None:
@@ -159,24 +161,28 @@ class IFTTTAlarmPanel(AlarmControlPanelEntity):
             return CodeFormat.NUMBER
         return CodeFormat.TEXT
 
+    @override
     def alarm_disarm(self, code: str | None = None) -> None:
         """Send disarm command."""
         if not self._check_code(code):
             return
         self.set_alarm_state(self._event_disarm, AlarmControlPanelState.DISARMED)
 
+    @override
     def alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command."""
         if self._code_arm_required and not self._check_code(code):
             return
         self.set_alarm_state(self._event_away, AlarmControlPanelState.ARMED_AWAY)
 
+    @override
     def alarm_arm_home(self, code: str | None = None) -> None:
         """Send arm home command."""
         if self._code_arm_required and not self._check_code(code):
             return
         self.set_alarm_state(self._event_home, AlarmControlPanelState.ARMED_HOME)
 
+    @override
     def alarm_arm_night(self, code: str | None = None) -> None:
         """Send arm night command."""
         if self._code_arm_required and not self._check_code(code):

--- a/homeassistant/components/iglo/light.py
+++ b/homeassistant/components/iglo/light.py
@@ -1,6 +1,6 @@
 """Support for lights under the iGlo brand."""
 
-from typing import Any
+from typing import Any, override
 
 from iglo import Lamp
 from iglo.lamp import MODE_WHITE
@@ -61,16 +61,19 @@ class IGloLamp(LightEntity):
         self._lamp = Lamp(0, host, port)
 
     @property
+    @override
     def name(self):
         """Return the name of the light."""
         return self._name
 
     @property
+    @override
     def brightness(self) -> int:
         """Return the brightness of this light between 0..255."""
         return int((self._lamp.state()["brightness"] / 200.0) * 255)
 
     @property
+    @override
     def color_mode(self) -> ColorMode:
         """Return the color mode of the light."""
         if self._lamp.state()["mode"] == MODE_WHITE:
@@ -80,40 +83,48 @@ class IGloLamp(LightEntity):
         return ColorMode.HS
 
     @property
+    @override
     def color_temp_kelvin(self) -> int | None:
         """Return the color temperature value in Kelvin."""
         return self._lamp.state()["white"]
 
     @property
+    @override
     def max_color_temp_kelvin(self) -> int:
         """Return the coldest color_temp_kelvin that this light supports."""
         return self._lamp.max_kelvin
 
     @property
+    @override
     def min_color_temp_kelvin(self) -> int:
         """Return the warmest color_temp_kelvin that this light supports."""
         return self._lamp.min_kelvin
 
     @property
+    @override
     def hs_color(self) -> tuple[float, float]:
         """Return the hs value."""
         return color_util.color_RGB_to_hs(*self._lamp.state()["rgb"])
 
     @property
+    @override
     def effect(self) -> str:
         """Return the current effect."""
         return self._lamp.state()["effect"]
 
     @property
+    @override
     def effect_list(self) -> list[str]:
         """Return the list of supported effects."""
         return self._lamp.effect_list()
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if light is on."""
         return self._lamp.state()["on"]
 
+    @override
     def turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""
         if not self.is_on:
@@ -137,6 +148,7 @@ class IGloLamp(LightEntity):
             self._lamp.effect(effect)
             return
 
+    @override
     def turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
         self._lamp.switch(False)

--- a/homeassistant/components/igloohome/config_flow.py
+++ b/homeassistant/components/igloohome/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for igloohome integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from aiohttp import ClientError
 from igloohome_api import Auth as IgloohomeAuth, AuthException
@@ -26,6 +26,7 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
 class IgloohomeConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for igloohome."""
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/igloohome/lock.py
+++ b/homeassistant/components/igloohome/lock.py
@@ -1,7 +1,7 @@
 """Implementation of the lock platform."""
 
 from datetime import timedelta
-from typing import Any
+from typing import Any, override
 
 from aiohttp import ClientError
 from igloohome_api import (
@@ -64,6 +64,7 @@ class IgloohomeLockEntity(IgloohomeBaseEntity, LockEntity):
         )
         self.bridge_id = bridge_id
 
+    @override
     async def async_lock(self, **kwargs: Any) -> None:
         """Lock this lock."""
         try:
@@ -73,6 +74,7 @@ class IgloohomeLockEntity(IgloohomeBaseEntity, LockEntity):
         except (ApiException, ClientError) as err:
             raise HomeAssistantError from err
 
+    @override
     async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock this lock."""
         try:
@@ -82,6 +84,7 @@ class IgloohomeLockEntity(IgloohomeBaseEntity, LockEntity):
         except (ApiException, ClientError) as err:
             raise HomeAssistantError from err
 
+    @override
     async def async_open(self, **kwargs: Any) -> None:
         """Open (unlatch) this lock."""
         try:

--- a/homeassistant/components/ign_sismologia/geo_location.py
+++ b/homeassistant/components/ign_sismologia/geo_location.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from georss_ign_sismologia_client import (
     IgnSismologiaFeedEntry,
@@ -164,6 +164,7 @@ class IgnSismologiaLocationEvent(GeolocationEvent):
         self._remove_signal_delete: Callable[[], None]
         self._remove_signal_update: Callable[[], None]
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Call when entity is added to hass."""
         self._remove_signal_delete = async_dispatcher_connect(
@@ -209,6 +210,7 @@ class IgnSismologiaLocationEvent(GeolocationEvent):
         self._image_url = feed_entry.image_url
 
     @property
+    @override
     def name(self) -> str | None:
         """Return the name of the entity."""
         if self._magnitude and self._region:
@@ -220,6 +222,7 @@ class IgnSismologiaLocationEvent(GeolocationEvent):
         return self._title
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the device state attributes."""
         return {

--- a/homeassistant/components/ihc/binary_sensor.py
+++ b/homeassistant/components/ihc/binary_sensor.py
@@ -1,5 +1,7 @@
 """Support for IHC binary sensors."""
 
+from typing import override
+
 from ihcsdk.ihccontroller import IHCController
 
 from homeassistant.components.binary_sensor import (
@@ -68,6 +70,7 @@ class IHCBinarySensor(IHCEntity, BinarySensorEntity):
         self._attr_device_class = try_parse_enum(BinarySensorDeviceClass, sensor_type)
         self.inverting = inverting
 
+    @override
     def on_ihc_change(self, ihc_id, value):
         """IHC resource has changed."""
         if self.inverting:

--- a/homeassistant/components/ihc/entity.py
+++ b/homeassistant/components/ihc/entity.py
@@ -1,7 +1,7 @@
 """Implementation of a base class for all IHC devices."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from ihcsdk.ihccontroller import IHCController
 
@@ -56,22 +56,26 @@ class IHCEntity(Entity):
             self.ihc_note = ""
             self.ihc_position = ""
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Add callback for IHC changes."""
         _LOGGER.debug("Adding IHC entity notify event: %s", self.ihc_id)
         self.ihc_controller.add_notify_event(self.ihc_id, self.on_ihc_change, True)
 
     @property
+    @override
     def name(self):
         """Return the device name."""
         return self._name
 
     @property
+    @override
     def unique_id(self):
         """Return a unique ID."""
         return f"{self.controller_id}-{self.ihc_id}"
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         if not self.hass.data[DOMAIN][self.controller_id][CONF_INFO]:

--- a/homeassistant/components/ihc/light.py
+++ b/homeassistant/components/ihc/light.py
@@ -1,6 +1,6 @@
 """Support for IHC lights."""
 
-from typing import Any
+from typing import Any, override
 
 from ihcsdk.ihccontroller import IHCController
 
@@ -82,15 +82,18 @@ class IhcLight(IHCEntity, LightEntity):
         self._attr_supported_color_modes = {self._attr_color_mode}
 
     @property
+    @override
     def brightness(self) -> int:
         """Return the brightness of this light between 0..255."""
         return self._brightness
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if light is on."""
         return self._state
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""
         if ATTR_BRIGHTNESS in kwargs:
@@ -107,6 +110,7 @@ class IhcLight(IHCEntity, LightEntity):
         else:
             await async_set_bool(self.hass, self.ihc_controller, self.ihc_id, True)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
         if self._dimmable:
@@ -116,6 +120,7 @@ class IhcLight(IHCEntity, LightEntity):
         else:
             await async_set_bool(self.hass, self.ihc_controller, self.ihc_id, False)
 
+    @override
     def on_ihc_change(self, ihc_id, value):
         """Handle IHC notifications."""
         if isinstance(value, bool):

--- a/homeassistant/components/ihc/sensor.py
+++ b/homeassistant/components/ihc/sensor.py
@@ -1,5 +1,7 @@
 """Support for IHC sensors."""
 
+from typing import override
+
 from ihcsdk.ihccontroller import IHCController
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
@@ -54,6 +56,7 @@ class IHCSensor(IHCEntity, SensorEntity):
         if unit in TEMPERATURE_UNITS:
             self._attr_device_class = SensorDeviceClass.TEMPERATURE
 
+    @override
     def on_ihc_change(self, ihc_id, value):
         """Handle IHC resource change."""
         self._attr_native_value = value

--- a/homeassistant/components/ihc/switch.py
+++ b/homeassistant/components/ihc/switch.py
@@ -1,6 +1,6 @@
 """Support for IHC switches."""
 
-from typing import Any
+from typing import Any, override
 
 from ihcsdk.ihccontroller import IHCController
 
@@ -59,6 +59,7 @@ class IHCSwitch(IHCEntity, SwitchEntity):
         self._ihc_off_id = ihc_off_id
         self._ihc_on_id = ihc_on_id
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         if self._ihc_on_id:
@@ -66,6 +67,7 @@ class IHCSwitch(IHCEntity, SwitchEntity):
         else:
             await async_set_bool(self.hass, self.ihc_controller, self.ihc_id, True)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
         if self._ihc_off_id:
@@ -73,6 +75,7 @@ class IHCSwitch(IHCEntity, SwitchEntity):
         else:
             await async_set_bool(self.hass, self.ihc_controller, self.ihc_id, False)
 
+    @override
     def on_ihc_change(self, ihc_id, value):
         """Handle IHC resource change."""
         self._attr_is_on = value

--- a/homeassistant/components/image/__init__.py
+++ b/homeassistant/components/image/__init__.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta
 import logging
 import os
 from random import SystemRandom
-from typing import Final, final
+from typing import Final, final, override
 
 from aiohttp import hdrs, web
 import httpx
@@ -216,6 +216,7 @@ class ImageEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         return self._attr_content_type
 
     @property
+    @override
     def entity_picture(self) -> str | None:
         """Return a link to the image as entity picture."""
         if self._attr_entity_picture is not None:
@@ -292,6 +293,7 @@ class ImageEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
 
     @property
     @final
+    @override
     def state(self) -> str | None:
         """Return the state."""
         if self.image_last_updated is None:
@@ -300,6 +302,7 @@ class ImageEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
 
     @final
     @property
+    @override
     def state_attributes(self) -> dict[str, str | None]:
         """Return the state attributes."""
         return {"access_token": self.access_tokens[-1]}
@@ -468,6 +471,7 @@ class ImageStreamView(ImageView):
     url = "/api/image_proxy_stream/{entity_id}"
     name = "api:image:stream"
 
+    @override
     async def handle(
         self, request: web.Request, image_entity: ImageEntity
     ) -> web.StreamResponse:

--- a/homeassistant/components/image/media_source.py
+++ b/homeassistant/components/image/media_source.py
@@ -1,6 +1,6 @@
 """Expose images as media sources."""
 
-from typing import cast
+from typing import cast, override
 
 from homeassistant.components.media_player import BrowseError, MediaClass
 from homeassistant.components.media_source import (
@@ -31,6 +31,7 @@ class ImageMediaSource(MediaSource):
         super().__init__(DOMAIN)
         self.hass = hass
 
+    @override
     async def async_resolve_media(self, item: MediaSourceItem) -> PlayMedia:
         """Resolve media to a url."""
         image = self.hass.data[DATA_COMPONENT].get_entity(item.identifier)
@@ -42,6 +43,7 @@ class ImageMediaSource(MediaSource):
             f"/api/image_proxy_stream/{image.entity_id}", image.content_type
         )
 
+    @override
     async def async_browse_media(
         self,
         item: MediaSourceItem,

--- a/homeassistant/components/image_processing/__init__.py
+++ b/homeassistant/components/image_processing/__init__.py
@@ -4,7 +4,7 @@ import asyncio
 from datetime import timedelta
 from enum import StrEnum
 import logging
-from typing import Any, Final, TypedDict, final
+from typing import Any, Final, TypedDict, final, override
 
 import voluptuous as vol
 
@@ -153,6 +153,7 @@ class ImageProcessingEntity(Entity):
         return None
 
     @property
+    @override
     def device_class(self) -> ImageProcessingDeviceClass | None:
         """Return the class of this entity."""
         if hasattr(self, "_attr_device_class"):
@@ -203,6 +204,7 @@ class ImageProcessingFaceEntity(ImageProcessingEntity):
         self.total_faces = 0
 
     @property
+    @override
     def state(self) -> str | int | None:
         """Return the state of the entity."""
         confidence: float = 0
@@ -228,6 +230,7 @@ class ImageProcessingFaceEntity(ImageProcessingEntity):
 
     @final
     @property
+    @override
     def state_attributes(self) -> dict[str, Any]:
         """Return device specific state attributes."""
         return {ATTR_FACES: self.faces, ATTR_TOTAL_FACES: self.total_faces}

--- a/homeassistant/components/image_upload/__init__.py
+++ b/homeassistant/components/image_upload/__init__.py
@@ -5,7 +5,7 @@ import logging
 import pathlib
 import secrets
 import shutil
-from typing import Any
+from typing import Any, override
 
 from aiohttp import hdrs, web
 from aiohttp.web_request import FileField
@@ -73,6 +73,7 @@ class ImageStorageCollection(collection.DictStorageCollection):
         self.async_add_listener(self._change_listener)
         self.image_dir = image_dir
 
+    @override
     async def _process_create_data(self, data: dict[str, Any]) -> dict[str, Any]:
         """Validate the config is valid."""
         data = self.CREATE_SCHEMA(dict(data))
@@ -125,10 +126,12 @@ class ImageStorageCollection(collection.DictStorageCollection):
         return media_file.stat().st_size
 
     @callback
+    @override
     def _get_suggested_id(self, info: dict[str, Any]) -> str:
         """Suggest an ID based on the config."""
         return str(info[CONF_ID])
 
+    @override
     async def _update_data(
         self,
         item: dict[str, Any],
@@ -153,6 +156,7 @@ class ImageStorageCollection(collection.DictStorageCollection):
 class ImageUploadStorageCollectionWebsocket(collection.DictStorageCollectionWebsocket):
     """Class to expose storage collection management over websocket."""
 
+    @override
     async def ws_create_item(
         self, hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict
     ) -> None:

--- a/homeassistant/components/image_upload/media_source.py
+++ b/homeassistant/components/image_upload/media_source.py
@@ -1,6 +1,7 @@
 """Expose image_upload as media sources."""
 
 import pathlib
+from typing import override
 
 from propcache.api import cached_property
 
@@ -37,6 +38,7 @@ class ImageUploadMediaSource(MediaSource):
         """Return the image folder path."""
         return pathlib.Path(self.hass.config.path(FOLDER_IMAGE))
 
+    @override
     async def async_resolve_media(self, item: MediaSourceItem) -> PlayMedia:
         """Resolve media to a url."""
         image = self.hass.data[DOMAIN].data.get(item.identifier)
@@ -50,6 +52,7 @@ class ImageUploadMediaSource(MediaSource):
             path=self.image_folder / item.identifier / "original",
         )
 
+    @override
     async def async_browse_media(
         self,
         item: MediaSourceItem,

--- a/homeassistant/components/imap/config_flow.py
+++ b/homeassistant/components/imap/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import ssl
-from typing import Any
+from typing import Any, override
 
 from aioimaplib import AioImapException
 import voluptuous as vol
@@ -142,6 +142,7 @@ class IMAPConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -200,6 +201,7 @@ class IMAPConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: ImapConfigEntry,
     ) -> ImapOptionsFlow:

--- a/homeassistant/components/imap/coordinator.py
+++ b/homeassistant/components/imap/coordinator.py
@@ -8,7 +8,7 @@ from email.header import decode_header, make_header
 from email.message import Message
 from email.utils import parseaddr, parsedate_to_datetime
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from aioimaplib import AUTH, IMAP4_SSL, NONAUTH, SELECTED, AioImapException
 
@@ -437,6 +437,7 @@ class ImapPollingDataUpdateCoordinator(ImapDataUpdateCoordinator):
         )
         super().__init__(hass, imap_client, entry, timedelta(seconds=10))
 
+    @override
     async def _async_update_data(self) -> int | None:
         """Update the number of unread emails."""
         try:
@@ -483,11 +484,13 @@ class ImapPushDataUpdateCoordinator(ImapDataUpdateCoordinator):
         self._push_wait_task: asyncio.Task[None] | None = None
         self.number_of_messages: int | None = None
 
+    @override
     async def _async_update_data(self) -> int | None:
         """Update the number of unread emails."""
         await self.async_start()
         return self.number_of_messages
 
+    @override
     async def async_start(self) -> None:
         """Start coordinator."""
         self._push_wait_task = self.hass.async_create_background_task(
@@ -565,6 +568,7 @@ class ImapPushDataUpdateCoordinator(ImapDataUpdateCoordinator):
                     except AioImapException:
                         pass
 
+    @override
     async def shutdown(self, *_: Any) -> None:
         """Close resources."""
         if self._push_wait_task:

--- a/homeassistant/components/imap/sensor.py
+++ b/homeassistant/components/imap/sensor.py
@@ -1,5 +1,7 @@
 """IMAP sensor support."""
 
+from typing import override
+
 from homeassistant.components.sensor import (
     SensorEntity,
     SensorEntityDescription,
@@ -59,6 +61,7 @@ class ImapSensor(CoordinatorEntity[ImapDataUpdateCoordinator], SensorEntity):
         )
 
     @property
+    @override
     def native_value(self) -> int | None:
         """Return the number of emails found."""
         return self.coordinator.data

--- a/homeassistant/components/imeon_inverter/config_flow.py
+++ b/homeassistant/components/imeon_inverter/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Imeon integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 from urllib.parse import urlparse
 
 from imeon_inverter_api.inverter import Inverter
@@ -26,6 +26,7 @@ class ImeonInverterConfigFlow(ConfigFlow, domain=DOMAIN):
 
     _host: str | None = None
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -90,6 +91,7 @@ class ImeonInverterConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    @override
     async def async_step_ssdp(
         self, discovery_info: SsdpServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/imeon_inverter/coordinator.py
+++ b/homeassistant/components/imeon_inverter/coordinator.py
@@ -3,6 +3,7 @@
 from asyncio import timeout
 from datetime import timedelta
 import logging
+from typing import override
 
 from aiohttp import ClientError
 from imeon_inverter_api.inverter import Inverter
@@ -53,6 +54,7 @@ class InverterCoordinator(DataUpdateCoordinator[dict[str, str | float | int]]):
         """Return the inverter object."""
         return self._api
 
+    @override
     async def _async_setup(self) -> None:
         """Set up the coordinator."""
         async with timeout(TIMEOUT):
@@ -63,6 +65,7 @@ class InverterCoordinator(DataUpdateCoordinator[dict[str, str | float | int]]):
 
             await self._api.init()
 
+    @override
     async def _async_update_data(self) -> dict[str, str | float | int]:
         """Fetch and store newest data from API.
 

--- a/homeassistant/components/imeon_inverter/select.py
+++ b/homeassistant/components/imeon_inverter/select.py
@@ -3,6 +3,7 @@
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 import logging
+from typing import override
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
@@ -60,6 +61,7 @@ class InverterSelect(InverterEntity, SelectEntity):
     _attr_entity_category = EntityCategory.CONFIG
 
     @property
+    @override
     def current_option(self) -> str | None:
         """Return the state of the select."""
         value = self.coordinator.data.get(self.data_key)
@@ -67,6 +69,7 @@ class InverterSelect(InverterEntity, SelectEntity):
             return None
         return self.entity_description.values.get(value)
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         await self.entity_description.set_value_fn(self.coordinator.api, option)

--- a/homeassistant/components/imeon_inverter/sensor.py
+++ b/homeassistant/components/imeon_inverter/sensor.py
@@ -1,6 +1,7 @@
 """Imeon inverter sensor support."""
 
 import logging
+from typing import override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -455,6 +456,7 @@ class InverterSensor(InverterEntity, SensorEntity):
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     @property
+    @override
     def native_value(self) -> StateType | None:
         """Return the state of the entity."""
         return self.coordinator.data.get(self.data_key)

--- a/homeassistant/components/imgw_pib/config_flow.py
+++ b/homeassistant/components/imgw_pib/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for IMGW-PIB integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from aiohttp import ClientError
 from imgw_pib import ImgwPib
@@ -27,6 +27,7 @@ class ImgwPibFlowHandler(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/imgw_pib/coordinator.py
+++ b/homeassistant/components/imgw_pib/coordinator.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 import logging
+from typing import override
 
 from imgw_pib import ApiError, HydrologicalData, ImgwPib
 
@@ -56,6 +57,7 @@ class ImgwPibDataUpdateCoordinator(DataUpdateCoordinator[HydrologicalData]):
             update_interval=UPDATE_INTERVAL,
         )
 
+    @override
     async def _async_update_data(self) -> HydrologicalData:
         """Update data via internal method."""
         try:

--- a/homeassistant/components/imgw_pib/sensor.py
+++ b/homeassistant/components/imgw_pib/sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from imgw_pib.const import HYDROLOGICAL_ALERTS_MAP, NO_ALERT
 from imgw_pib.model import HydrologicalData
@@ -166,11 +166,13 @@ class ImgwPibSensorEntity(ImgwPibEntity, SensorEntity):
         self.entity_description = description
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the value reported by the sensor."""
         return self.entity_description.value(self.coordinator.data)
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return the state attributes."""
         if self.entity_description.attrs:

--- a/homeassistant/components/immich/config_flow.py
+++ b/homeassistant/components/immich/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from aioimmich import Immich
 from aioimmich.const import CONNECT_ERRORS
@@ -81,6 +81,7 @@ class ImmichConfigFlow(ConfigFlow, domain=DOMAIN):
     _name: str
     _current_data: Mapping[str, Any]
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/immich/coordinator.py
+++ b/homeassistant/components/immich/coordinator.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
+from typing import override
 
 from aioimmich import Immich
 from aioimmich.const import CONNECT_ERRORS
@@ -78,6 +79,7 @@ class ImmichDataUpdateCoordinator(DataUpdateCoordinator[ImmichData]):
             update_interval=timedelta(seconds=60),
         )
 
+    @override
     async def _async_setup(self) -> None:
         """Handle setup of the coordinator."""
         try:
@@ -96,6 +98,7 @@ class ImmichDataUpdateCoordinator(DataUpdateCoordinator[ImmichData]):
 
         self.is_admin = user_info.is_admin
 
+    @override
     async def _async_update_data(self) -> ImmichData:
         """Update data via internal method."""
         try:

--- a/homeassistant/components/immich/media_source.py
+++ b/homeassistant/components/immich/media_source.py
@@ -1,6 +1,7 @@
 """Immich as a media source."""
 
 from logging import getLogger
+from typing import override
 
 from aiohttp.web import HTTPNotFound, Request, Response, StreamResponse
 from aioimmich.assets.models import ImmichAsset
@@ -56,6 +57,7 @@ class ImmichMediaSource(MediaSource):
         super().__init__(DOMAIN)
         self.hass = hass
 
+    @override
     async def async_browse_media(
         self,
         item: MediaSourceItem,
@@ -323,6 +325,7 @@ class ImmichMediaSource(MediaSource):
 
         return ret
 
+    @override
     async def async_resolve_media(self, item: MediaSourceItem) -> PlayMedia:
         """Resolve media to a url."""
         try:

--- a/homeassistant/components/immich/sensor.py
+++ b/homeassistant/components/immich/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -148,6 +149,7 @@ class ImmichSensorEntity(ImmichEntity, SensorEntity):
         self.entity_description = description
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the value reported by the sensor."""
         return self.entity_description.value(self.coordinator.data)

--- a/homeassistant/components/immich/update.py
+++ b/homeassistant/components/immich/update.py
@@ -1,5 +1,7 @@
 """Update platform for the Immich integration."""
 
+from typing import override
+
 from homeassistant.components.update import UpdateEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -37,17 +39,20 @@ class ImmichUpdateEntity(ImmichEntity, UpdateEntity):
         self._attr_unique_id = f"{coordinator.config_entry.unique_id}_update"
 
     @property
+    @override
     def installed_version(self) -> str:
         """Current installed immich server version."""
         return self.coordinator.data.server_about.version
 
     @property
+    @override
     def latest_version(self) -> str | None:
         """Available new immich server version."""
         assert self.coordinator.data.server_version_check
         return self.coordinator.data.server_version_check.release_version
 
     @property
+    @override
     def release_url(self) -> str | None:
         """URL to the full release notes of the new immich server version."""
         return (

--- a/homeassistant/components/imou/button.py
+++ b/homeassistant/components/imou/button.py
@@ -1,5 +1,7 @@
 """Support for Imou button controls."""
 
+from typing import override
+
 from pyimouapi.exceptions import ImouException
 from pyimouapi.ha_device import ImouHaDevice
 
@@ -96,6 +98,7 @@ class ImouButton(ImouEntity, ButtonEntity):
             self._attr_device_class = device_class
             self._attr_translation_key = None
 
+    @override
     async def async_press(self) -> None:
         """Handle button press."""
         duration = PTZ_MOVE_DURATION_MS if self._entity_type in PTZ_BUTTON_TYPES else 0

--- a/homeassistant/components/imou/camera.py
+++ b/homeassistant/components/imou/camera.py
@@ -1,5 +1,7 @@
 """Support for Imou camera entities."""
 
+from typing import override
+
 from pyimouapi.const import PARAM_HD, PARAM_MOTION_DETECT, PARAM_STATE
 from pyimouapi.exceptions import ImouException
 from pyimouapi.ha_device import ImouHaDevice
@@ -73,6 +75,7 @@ class ImouCamera(ImouEntity, Camera):
         Camera.__init__(self)
         super().__init__(coordinator, entity_type, device)
 
+    @override
     async def stream_source(self) -> str | None:
         """Return the live stream URL from the Imou cloud."""
         try:
@@ -84,6 +87,7 @@ class ImouCamera(ImouEntity, Camera):
         except ImouException as err:
             raise HomeAssistantError(str(err)) from err
 
+    @override
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
@@ -97,6 +101,7 @@ class ImouCamera(ImouEntity, Camera):
             raise HomeAssistantError(str(err)) from err
 
     @property
+    @override
     def motion_detection_enabled(self) -> bool:
         """Return True when human and/or motion detection switch is on."""
         header = self.device.switches.get(PARAM_HEADER_DETECT)

--- a/homeassistant/components/imou/config_flow.py
+++ b/homeassistant/components/imou/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Imou."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyimouapi.exceptions import (
     ConnectFailedException,
@@ -30,6 +30,7 @@ class ImouConfigFlow(ConfigFlow, domain=DOMAIN):
     VERSION = 1
     MINOR_VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/imou/coordinator.py
+++ b/homeassistant/components/imou/coordinator.py
@@ -4,6 +4,7 @@ import asyncio
 from collections.abc import Callable
 from datetime import timedelta
 import logging
+from typing import override
 
 from pyimouapi.exceptions import ImouException
 from pyimouapi.ha_device import ImouHaDevice, ImouHaDeviceManager
@@ -61,6 +62,7 @@ class ImouDataUpdateCoordinator(DataUpdateCoordinator[None]):
         """Return the current device for device_key, if still on the account."""
         return self.devices_by_key.get(device_key)
 
+    @override
     async def _async_update_data(self) -> None:
         """Update coordinator data."""
         try:

--- a/homeassistant/components/imou/entity.py
+++ b/homeassistant/components/imou/entity.py
@@ -1,5 +1,7 @@
 """An abstract class common to all Imou entities."""
 
+from typing import override
+
 from pyimouapi.ha_device import DeviceStatus, ImouHaDevice
 
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -45,6 +47,7 @@ class ImouEntity(CoordinatorEntity[ImouDataUpdateCoordinator]):
         return self.coordinator.devices_by_key[self._device_key]
 
     @property
+    @override
     def available(self) -> bool:
         """Return if the entity is available."""
         if (

--- a/homeassistant/components/improv_ble/config_flow.py
+++ b/homeassistant/components/improv_ble/config_flow.py
@@ -5,7 +5,7 @@ from collections.abc import AsyncGenerator, Callable, Coroutine
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 import logging
-from typing import Any
+from typing import Any, override
 
 from bleak import BleakError
 from improv_ble_client import (
@@ -74,6 +74,7 @@ class ImprovBLEConfigFlow(ConfigFlow, domain=DOMAIN):
         # Populated by bluetooth, reauth_confirm and user steps
         self._discovery_info: bluetooth.BluetoothServiceInfoBleak | None = None
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -194,6 +195,7 @@ class ImprovBLEConfigFlow(ConfigFlow, domain=DOMAIN):
         self._remove_bluetooth_callback()
         self._remove_bluetooth_callback = None
 
+    @override
     async def async_step_bluetooth(
         self, discovery_info: bluetooth.BluetoothServiceInfoBleak
     ) -> ConfigFlowResult:
@@ -524,6 +526,7 @@ class ImprovBLEConfigFlow(ConfigFlow, domain=DOMAIN):
             raise AbortFlow("unknown") from err
 
     @callback
+    @override
     def async_remove(self) -> None:
         """Notification that the flow has been removed."""
         self._unregister_bluetooth_callback()

--- a/homeassistant/components/indevolt/binary_sensor.py
+++ b/homeassistant/components/indevolt/binary_sensor.py
@@ -1,7 +1,7 @@
 """Binary sensor platform for Indevolt integration."""
 
 from dataclasses import dataclass
-from typing import Final
+from typing import Final, override
 
 from indevolt_api import IndevoltBattery, IndevoltGrid, IndevoltSystem
 
@@ -139,6 +139,7 @@ class IndevoltBinarySensorEntity(IndevoltEntity, BinarySensorEntity):
         self._attr_unique_id = f"{self.serial_number}_{description.key}"
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return on/active state of the binary sensor."""
         raw_value = self.coordinator.data.get(self.entity_description.key)

--- a/homeassistant/components/indevolt/button.py
+++ b/homeassistant/components/indevolt/button.py
@@ -1,7 +1,7 @@
 """Button platform for Indevolt integration."""
 
 from dataclasses import dataclass
-from typing import Final
+from typing import Final, override
 
 from indevolt_api import IndevoltRealtimeAction
 
@@ -64,6 +64,7 @@ class IndevoltButtonEntity(IndevoltEntity, ButtonEntity):
         self.entity_description = description
         self._attr_unique_id = f"{self.serial_number}_{description.key}"
 
+    @override
     async def async_press(self) -> None:
         """Handle the button press."""
         await self.coordinator.async_realtime_action(IndevoltRealtimeAction.STOP)

--- a/homeassistant/components/indevolt/config_flow.py
+++ b/homeassistant/components/indevolt/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Indevolt integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from aiohttp import ClientError
 from indevolt_api import IndevoltAPI
@@ -30,6 +30,7 @@ class IndevoltConfigFlow(ConfigFlow, domain=DOMAIN):
         self._discovered_host: str | None = None
         self._discovered_device_data: dict[str, Any] | None = None
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -92,6 +93,7 @@ class IndevoltConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    @override
     async def async_step_dhcp(
         self, discovery_info: DhcpServiceInfo
     ) -> ConfigFlowResult:
@@ -114,6 +116,7 @@ class IndevoltConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return await self.async_step_zeroconf_confirm()
 
+    @override
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/indevolt/coordinator.py
+++ b/homeassistant/components/indevolt/coordinator.py
@@ -3,7 +3,7 @@
 from datetime import timedelta
 import itertools
 import logging
-from typing import Any, Final
+from typing import Any, Final, override
 
 from aiohttp import ClientError
 from indevolt_api import (
@@ -70,6 +70,7 @@ class IndevoltCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.device_model: str = entry.data[CONF_MODEL]
         self.generation: int = entry.data[CONF_GENERATION]
 
+    @override
     async def _async_setup(self) -> None:
         """Fetch device info once on boot."""
         try:
@@ -87,6 +88,7 @@ class IndevoltCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         raw_mac = device_data.get("mac")
         self.mac_address = format_mac(raw_mac) if raw_mac else None
 
+    @override
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch raw JSON data from the device."""
         data: dict[str, Any] = {}

--- a/homeassistant/components/indevolt/entity.py
+++ b/homeassistant/components/indevolt/entity.py
@@ -1,5 +1,7 @@
 """Base entity for Indevolt integration."""
 
+from typing import override
+
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -18,6 +20,7 @@ class IndevoltEntity(CoordinatorEntity[IndevoltCoordinator]):
         return self.coordinator.serial_number
 
     @property
+    @override
     def device_info(self) -> DeviceInfo:
         """Return device information for registry."""
         coordinator = self.coordinator

--- a/homeassistant/components/indevolt/number.py
+++ b/homeassistant/components/indevolt/number.py
@@ -1,7 +1,7 @@
 """Number platform for Indevolt integration."""
 
 from dataclasses import dataclass
-from typing import Final
+from typing import Final, override
 
 from indevolt_api import IndevoltConfig
 
@@ -119,6 +119,7 @@ class IndevoltNumberEntity(IndevoltEntity, NumberEntity):
         self._attr_unique_id = f"{self.serial_number}_{description.key}"
 
     @property
+    @override
     def native_value(self) -> int | None:
         """Return the current value of the entity."""
         raw_value = self.coordinator.data.get(self.entity_description.read_key)
@@ -127,6 +128,7 @@ class IndevoltNumberEntity(IndevoltEntity, NumberEntity):
 
         return int(raw_value)
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Set a new value for the entity."""
 

--- a/homeassistant/components/indevolt/select.py
+++ b/homeassistant/components/indevolt/select.py
@@ -1,7 +1,7 @@
 """Select platform for Indevolt integration."""
 
 from dataclasses import dataclass, field
-from typing import Final
+from typing import Final, override
 
 from indevolt_api import IndevoltConfig, IndevoltEnergyMode
 
@@ -81,6 +81,7 @@ class IndevoltSelectEntity(IndevoltEntity, SelectEntity):
         self._option_to_value = {v: k for k, v in description.value_to_option.items()}
 
     @property
+    @override
     def current_option(self) -> str | None:
         """Return the currently selected option."""
         raw_value = self.coordinator.data.get(self.entity_description.read_key)
@@ -90,6 +91,7 @@ class IndevoltSelectEntity(IndevoltEntity, SelectEntity):
         return self.entity_description.value_to_option.get(raw_value)
 
     @property
+    @override
     def available(self) -> bool:
         """Return False when the device is in a mode that cannot be selected."""
         if not super().available:
@@ -98,6 +100,7 @@ class IndevoltSelectEntity(IndevoltEntity, SelectEntity):
         raw_value = self.coordinator.data.get(self.entity_description.read_key)
         return raw_value not in self.entity_description.unavailable_values
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Select a new option."""
         value = self._option_to_value[option]

--- a/homeassistant/components/indevolt/sensor.py
+++ b/homeassistant/components/indevolt/sensor.py
@@ -1,7 +1,7 @@
 """Sensor platform for Indevolt integration."""
 
 from dataclasses import dataclass, field
-from typing import Final, cast
+from typing import Final, cast, override
 
 from indevolt_api import (
     IndevoltBattery,
@@ -938,6 +938,7 @@ class IndevoltSensorEntity(IndevoltEntity, SensorEntity):
             self._attr_options = sorted(set(description.state_mapping.values()))
 
     @property
+    @override
     def available(self) -> bool:
         """Return False for sensors in a non-applicable state."""
 
@@ -960,6 +961,7 @@ class IndevoltSensorEntity(IndevoltEntity, SensorEntity):
         return super().available
 
     @property
+    @override
     def native_value(self) -> str | int | float | None:
         """Return the current value of the sensor in its native unit."""
         raw_value = self.coordinator.data.get(self.entity_description.key)

--- a/homeassistant/components/indevolt/switch.py
+++ b/homeassistant/components/indevolt/switch.py
@@ -1,7 +1,7 @@
 """Switch platform for Indevolt integration."""
 
 from dataclasses import dataclass
-from typing import Any, Final
+from typing import Any, Final, override
 
 from indevolt_api import IndevoltConfig
 
@@ -97,6 +97,7 @@ class IndevoltSwitchEntity(IndevoltEntity, SwitchEntity):
         self._attr_unique_id = f"{self.serial_number}_{description.key}"
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if switch is on."""
         raw_value = self.coordinator.data.get(self.entity_description.read_key)
@@ -111,10 +112,12 @@ class IndevoltSwitchEntity(IndevoltEntity, SwitchEntity):
 
         return None
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         await self._async_toggle(1)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         await self._async_toggle(0)

--- a/homeassistant/components/inels/config_flow.py
+++ b/homeassistant/components/inels/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for iNELS."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components import mqtt
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
@@ -14,6 +14,7 @@ class INelsConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_mqtt(
         self, discovery_info: MqttServiceInfo
     ) -> ConfigFlowResult:
@@ -31,6 +32,7 @@ class INelsConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return await self.async_step_confirm_from_mqtt()
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/inels/entity.py
+++ b/homeassistant/components/inels/entity.py
@@ -1,5 +1,7 @@
 """Base class for iNELS components."""
 
+from typing import override
+
 from inelsmqtt.devices import Device
 
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -39,6 +41,7 @@ class InelsBaseEntity(Entity):
             sw_version=info.sw_version,
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Add subscription of the data listener."""
         # Register the HA callback
@@ -54,6 +57,7 @@ class InelsBaseEntity(Entity):
             self.schedule_update_ha_state()
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return self._device.is_available

--- a/homeassistant/components/inels/switch.py
+++ b/homeassistant/components/inels/switch.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from inelsmqtt.devices import Device
 from inelsmqtt.utils.common import Bit, Relay, SimpleRelay
@@ -118,11 +118,13 @@ class InelsSwitch(InelsBaseEntity, SwitchEntity):
             raise ServiceValidationError("Cannot operate switch with active alerts")
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return if switch is on."""
         current_state = self.entity_description.get_state_fn(self._device, self._index)
         return current_state.is_on
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Instruct the switch to turn off."""
         current_state = self.entity_description.get_state_fn(self._device, self._index)
@@ -130,6 +132,7 @@ class InelsSwitch(InelsBaseEntity, SwitchEntity):
         current_state.is_on = False
         await self._device.set_ha_value(self._device.state)
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Instruct the switch to turn on."""
         current_state = self.entity_description.get_state_fn(self._device, self._index)

--- a/homeassistant/components/influxdb/__init__.py
+++ b/homeassistant/components/influxdb/__init__.py
@@ -8,7 +8,7 @@ import math
 import queue
 import threading
 import time
-from typing import Any
+from typing import Any, override
 
 from influxdb import InfluxDBClient, exceptions
 from influxdb_client import InfluxDBClient as InfluxDBClientV2
@@ -666,6 +666,7 @@ class InfluxThread(threading.Thread):
                         _LOGGER.error(err)
                     self.write_errors += len(json)
 
+    @override
     def run(self):
         """Process incoming events."""
         while not self._shutdown:

--- a/homeassistant/components/influxdb/config_flow.py
+++ b/homeassistant/components/influxdb/config_flow.py
@@ -3,7 +3,7 @@
 import logging
 from pathlib import Path
 import shutil
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 from yarl import URL
@@ -164,6 +164,7 @@ async def _save_uploaded_cert_file(hass: HomeAssistant, uploaded_file_id: str) -
 class InfluxDBConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for InfluxDB."""
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/influxdb/sensor.py
+++ b/homeassistant/components/influxdb/sensor.py
@@ -2,7 +2,7 @@
 
 import datetime
 import logging
-from typing import Final
+from typing import Final, override
 
 import voluptuous as vol
 
@@ -219,16 +219,19 @@ class InfluxSensor(SensorEntity):
             )
 
     @property
+    @override
     def name(self):
         """Return the name of the sensor."""
         return self._name
 
     @property
+    @override
     def native_value(self):
         """Return the state of the sensor."""
         return self._state
 
     @property
+    @override
     def native_unit_of_measurement(self):
         """Return the unit of measurement of this entity, if any."""
         return self._unit_of_measurement

--- a/homeassistant/components/infrared/entity.py
+++ b/homeassistant/components/infrared/entity.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
 import logging
-from typing import final
+from typing import final, override
 
 from infrared_protocols.commands import Command as InfraredCommand
 from propcache.api import cached_property
@@ -51,6 +51,7 @@ class InfraredEmitterEntity(RestoreEntity):
 
     @property
     @final
+    @override
     def state(self) -> str | None:
         """Return the entity state."""
         return self.__last_command_sent
@@ -66,6 +67,7 @@ class InfraredEmitterEntity(RestoreEntity):
         self.async_write_ha_state()
 
     @final
+    @override
     async def async_internal_added_to_hass(self) -> None:
         """Call when the infrared entity is added to hass."""
         await super().async_internal_added_to_hass()
@@ -106,11 +108,13 @@ class InfraredReceiverEntity(RestoreEntity):
 
     @property
     @final
+    @override
     def state(self) -> str | None:
         """Return the entity state."""
         return self.__last_signal_received
 
     @final
+    @override
     async def async_internal_added_to_hass(self) -> None:
         """Call when the infrared entity is added to hass."""
         await super().async_internal_added_to_hass()

--- a/homeassistant/components/infrared/helpers.py
+++ b/homeassistant/components/infrared/helpers.py
@@ -156,6 +156,7 @@ class InfraredEmitterConsumerEntity(InfraredConsumerEntity):
     _attr_should_poll = False
     _infrared_emitter_entity_id: str
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Subscribe to infrared entity state changes."""
         await super().async_added_to_hass()
@@ -181,6 +182,7 @@ class InfraredReceiverConsumerEntity(InfraredConsumerEntity):
     _infrared_receiver_entity_id: str
     _remove_signal_subscription: CALLBACK_TYPE | None = None
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Subscribe to infrared entity state changes and receiver signals."""
         await super().async_added_to_hass()

--- a/homeassistant/components/inkbird/config_flow.py
+++ b/homeassistant/components/inkbird/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for inkbird ble integration."""
 
-from typing import Any
+from typing import Any, override
 
 from inkbird_ble import INKBIRDBluetoothDeviceData as DeviceData
 import voluptuous as vol
@@ -27,6 +27,7 @@ class INKBIRDConfigFlow(ConfigFlow, domain=DOMAIN):
         self._discovered_device: DeviceData | None = None
         self._discovered_devices: dict[str, tuple[str, str]] = {}
 
+    @override
     async def async_step_bluetooth(
         self, discovery_info: BluetoothServiceInfoBleak
     ) -> ConfigFlowResult:
@@ -62,6 +63,7 @@ class INKBIRDConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="bluetooth_confirm", description_placeholders=placeholders
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/inkbird/coordinator.py
+++ b/homeassistant/components/inkbird/coordinator.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from inkbird_ble import INKBIRDBluetoothDeviceData, SensorUpdate
 
@@ -98,6 +98,7 @@ class INKBIRDActiveBluetoothProcessorCoordinator(
         await self._data.async_start(service_info, service_info.device)
         self._entry.async_on_unload(self._data.async_stop)
 
+    @override
     async def _async_poll_data(
         self, last_service_info: BluetoothServiceInfoBleak
     ) -> SensorUpdate:

--- a/homeassistant/components/inkbird/sensor.py
+++ b/homeassistant/components/inkbird/sensor.py
@@ -1,5 +1,7 @@
 """Support for inkbird ble sensors."""
 
+from typing import override
+
 from inkbird_ble import DeviceClass, DeviceKey, SensorUpdate, Units
 
 from homeassistant.components.bluetooth.passive_update_processor import (
@@ -131,6 +133,7 @@ class INKBIRDBluetoothSensorEntity(
     """Representation of a inkbird ble sensor."""
 
     @property
+    @override
     def native_value(self) -> int | float | None:
         """Return the native value."""
         return self.processor.entity_data.get(self.entity_key)

--- a/homeassistant/components/input_boolean/__init__.py
+++ b/homeassistant/components/input_boolean/__init__.py
@@ -1,7 +1,7 @@
 """Support to keep track of user controlled booleans for within automation."""
 
 import logging
-from typing import Any, Self
+from typing import Any, Self, override
 
 import voluptuous as vol
 
@@ -63,15 +63,18 @@ class InputBooleanStorageCollection(collection.DictStorageCollection):
 
     CREATE_UPDATE_SCHEMA = vol.Schema(STORAGE_FIELDS)
 
+    @override
     async def _process_create_data(self, data: dict) -> dict:
         """Validate the config is valid."""
         return self.CREATE_UPDATE_SCHEMA(data)
 
     @callback
+    @override
     def _get_suggested_id(self, info: dict) -> str:
         """Suggest an ID based on the config."""
         return info[CONF_NAME]
 
+    @override
     async def _update_data(self, item: dict, update_data: dict) -> dict:
         """Return a new updated data object."""
         update_data = self.CREATE_UPDATE_SCHEMA(update_data)
@@ -155,6 +158,7 @@ class InputBoolean(collection.CollectionEntity, ToggleEntity, RestoreEntity):
         self._attr_unique_id = config[CONF_ID]
 
     @classmethod
+    @override
     def from_storage(cls, config: ConfigType) -> Self:
         """Return entity instance initialized from storage."""
         input_bool = cls(config)
@@ -162,6 +166,7 @@ class InputBoolean(collection.CollectionEntity, ToggleEntity, RestoreEntity):
         return input_bool
 
     @classmethod
+    @override
     def from_yaml(cls, config: ConfigType) -> Self:
         """Return entity instance initialized from yaml."""
         input_bool = cls(config)
@@ -170,20 +175,24 @@ class InputBoolean(collection.CollectionEntity, ToggleEntity, RestoreEntity):
         return input_bool
 
     @property
+    @override
     def name(self) -> str | None:
         """Return name of the boolean input."""
         return self._config.get(CONF_NAME)
 
     @property
+    @override
     def icon(self) -> str | None:
         """Return the icon to be used for this entity."""
         return self._config.get(CONF_ICON)
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, bool]:
         """Return the state attributes of the entity."""
         return {ATTR_EDITABLE: self.editable}
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Call when entity about to be added to hass."""
         # Don't restore if we got an initial value.
@@ -194,16 +203,19 @@ class InputBoolean(collection.CollectionEntity, ToggleEntity, RestoreEntity):
         state = await self.async_get_last_state()
         self._attr_is_on = state is not None and state.state == STATE_ON
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         self._attr_is_on = True
         self.async_write_ha_state()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         self._attr_is_on = False
         self.async_write_ha_state()
 
+    @override
     async def async_update_config(self, config: ConfigType) -> None:
         """Handle when the config is updated."""
         self._config = config

--- a/homeassistant/components/input_button/__init__.py
+++ b/homeassistant/components/input_button/__init__.py
@@ -1,7 +1,7 @@
 """Support to keep track of user controlled buttons which can be used in automations."""
 
 import logging
-from typing import Self, cast
+from typing import Self, cast, override
 
 import voluptuous as vol
 
@@ -55,15 +55,18 @@ class InputButtonStorageCollection(collection.DictStorageCollection):
 
     CREATE_UPDATE_SCHEMA = vol.Schema(STORAGE_FIELDS)
 
+    @override
     async def _process_create_data(self, data: dict) -> dict[str, str]:
         """Validate the config is valid."""
         return self.CREATE_UPDATE_SCHEMA(data)  # type: ignore[no-any-return]
 
     @callback
+    @override
     def _get_suggested_id(self, info: dict) -> str:
         """Suggest an ID based on the config."""
         return cast(str, info[CONF_NAME])
 
+    @override
     async def _update_data(self, item: dict, update_data: dict) -> dict:
         """Return a new updated data object."""
         update_data = self.CREATE_UPDATE_SCHEMA(update_data)
@@ -138,6 +141,7 @@ class InputButton(collection.CollectionEntity, ButtonEntity, RestoreEntity):
         self._attr_unique_id = config[CONF_ID]
 
     @classmethod
+    @override
     def from_storage(cls, config: ConfigType) -> Self:
         """Return entity instance initialized from storage."""
         button = cls(config)
@@ -145,6 +149,7 @@ class InputButton(collection.CollectionEntity, ButtonEntity, RestoreEntity):
         return button
 
     @classmethod
+    @override
     def from_yaml(cls, config: ConfigType) -> Self:
         """Return entity instance initialized from yaml."""
         button = cls(config)
@@ -153,20 +158,24 @@ class InputButton(collection.CollectionEntity, ButtonEntity, RestoreEntity):
         return button
 
     @property
+    @override
     def name(self) -> str | None:
         """Return name of the button."""
         return self._config.get(CONF_NAME)
 
     @property
+    @override
     def icon(self) -> str | None:
         """Return the icon to be used for this entity."""
         return self._config.get(CONF_ICON)
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, bool]:
         """Return the state attributes of the entity."""
         return {ATTR_EDITABLE: self.editable}
 
+    @override
     async def async_press(self) -> None:
         """Press the button.
 
@@ -174,6 +183,7 @@ class InputButton(collection.CollectionEntity, ButtonEntity, RestoreEntity):
         The input button itself doesn't trigger anything.
         """
 
+    @override
     async def async_update_config(self, config: ConfigType) -> None:
         """Handle when the config is updated."""
         self._config = config

--- a/homeassistant/components/input_datetime/__init__.py
+++ b/homeassistant/components/input_datetime/__init__.py
@@ -2,7 +2,7 @@
 
 import datetime as py_datetime
 import logging
-from typing import Any, Self
+from typing import Any, Self, override
 
 import voluptuous as vol
 
@@ -195,15 +195,18 @@ class DateTimeStorageCollection(collection.DictStorageCollection):
 
     CREATE_UPDATE_SCHEMA = vol.Schema(vol.All(STORAGE_FIELDS, has_date_or_time))
 
+    @override
     async def _process_create_data(self, data: dict) -> dict:
         """Validate the config is valid."""
         return self.CREATE_UPDATE_SCHEMA(data)
 
     @callback
+    @override
     def _get_suggested_id(self, info: dict) -> str:
         """Suggest an ID based on the config."""
         return info[CONF_NAME]
 
+    @override
     async def _update_data(self, item: dict, update_data: dict) -> dict:
         """Return a new updated data object."""
         update_data = self.CREATE_UPDATE_SCHEMA(update_data)
@@ -239,6 +242,7 @@ class InputDatetime(collection.CollectionEntity, RestoreEntity):
             )
 
     @classmethod
+    @override
     def from_storage(cls, config: ConfigType) -> Self:
         """Return entity instance initialized from storage."""
         input_dt = cls(config)
@@ -246,6 +250,7 @@ class InputDatetime(collection.CollectionEntity, RestoreEntity):
         return input_dt
 
     @classmethod
+    @override
     def from_yaml(cls, config: ConfigType) -> Self:
         """Return entity instance initialized from yaml."""
         input_dt = cls(config)
@@ -253,6 +258,7 @@ class InputDatetime(collection.CollectionEntity, RestoreEntity):
         input_dt.editable = False
         return input_dt
 
+    @override
     async def async_added_to_hass(self):
         """Run when entity about to be added."""
         await super().async_added_to_hass()
@@ -291,6 +297,7 @@ class InputDatetime(collection.CollectionEntity, RestoreEntity):
         )
 
     @property
+    @override
     def name(self):
         """Return the name of the select input."""
         return self._config.get(CONF_NAME)
@@ -306,11 +313,13 @@ class InputDatetime(collection.CollectionEntity, RestoreEntity):
         return self._config[CONF_HAS_TIME]
 
     @property
+    @override
     def icon(self) -> str | None:
         """Return the icon to be used for this entity."""
         return self._config.get(CONF_ICON)
 
     @property
+    @override
     def state(self):
         """Return the state of the component."""
         if self._current_datetime is None:
@@ -325,6 +334,7 @@ class InputDatetime(collection.CollectionEntity, RestoreEntity):
         return self._current_datetime.strftime(FMT_TIME)
 
     @property
+    @override
     def capability_attributes(self) -> dict[str, Any]:
         """Return the capability attributes."""
         return {
@@ -333,6 +343,7 @@ class InputDatetime(collection.CollectionEntity, RestoreEntity):
         }
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         attrs: dict[str, Any] = {
@@ -371,6 +382,7 @@ class InputDatetime(collection.CollectionEntity, RestoreEntity):
         return attrs
 
     @property
+    @override
     def unique_id(self) -> str | None:
         """Return unique id of the entity."""
         return self._config[CONF_ID]
@@ -405,6 +417,7 @@ class InputDatetime(collection.CollectionEntity, RestoreEntity):
         )
         self.async_write_ha_state()
 
+    @override
     async def async_update_config(self, config: ConfigType) -> None:
         """Handle when the config is updated."""
         self._config = config

--- a/homeassistant/components/input_number/__init__.py
+++ b/homeassistant/components/input_number/__init__.py
@@ -2,7 +2,7 @@
 
 from contextlib import suppress
 import logging
-from typing import Any, Self
+from typing import Any, Self, override
 
 import voluptuous as vol
 
@@ -164,15 +164,18 @@ class NumberStorageCollection(collection.DictStorageCollection):
 
     SCHEMA = vol.Schema(vol.All(STORAGE_FIELDS, _cv_input_number))
 
+    @override
     async def _process_create_data(self, data: dict) -> dict:
         """Validate the config is valid."""
         return self.SCHEMA(data)
 
     @callback
+    @override
     def _get_suggested_id(self, info: dict) -> str:
         """Suggest an ID based on the config."""
         return info[CONF_NAME]
 
+    @override
     async def _async_load_data(self) -> collection.SerializedStorageCollection | None:
         """Load the data.
 
@@ -189,6 +192,7 @@ class NumberStorageCollection(collection.DictStorageCollection):
 
         return data
 
+    @override
     async def _update_data(self, item: dict, update_data: dict) -> dict:
         """Return a new updated data object."""
         update_data = self.SCHEMA(update_data)
@@ -211,6 +215,7 @@ class InputNumber(collection.CollectionEntity, RestoreEntity):
         self._current_value: float | None = config.get(CONF_INITIAL)
 
     @classmethod
+    @override
     def from_storage(cls, config: ConfigType) -> Self:
         """Return entity instance initialized from storage."""
         input_num = cls(config)
@@ -218,6 +223,7 @@ class InputNumber(collection.CollectionEntity, RestoreEntity):
         return input_num
 
     @classmethod
+    @override
     def from_yaml(cls, config: ConfigType) -> Self:
         """Return entity instance initialized from yaml."""
         input_num = cls(config)
@@ -236,16 +242,19 @@ class InputNumber(collection.CollectionEntity, RestoreEntity):
         return self._config[CONF_MAX]
 
     @property
+    @override
     def name(self):
         """Return the name of the input slider."""
         return self._config.get(CONF_NAME)
 
     @property
+    @override
     def icon(self) -> str | None:
         """Return the icon to be used for this entity."""
         return self._config.get(CONF_ICON)
 
     @property
+    @override
     def state(self):
         """Return the state of the component."""
         return self._current_value
@@ -256,16 +265,19 @@ class InputNumber(collection.CollectionEntity, RestoreEntity):
         return self._config[CONF_STEP]
 
     @property
+    @override
     def unit_of_measurement(self):
         """Return the unit the value is expressed in."""
         return self._config.get(CONF_UNIT_OF_MEASUREMENT)
 
     @property
+    @override
     def unique_id(self) -> str | None:
         """Return unique id of the entity."""
         return self._config[CONF_ID]
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         return {
@@ -277,6 +289,7 @@ class InputNumber(collection.CollectionEntity, RestoreEntity):
             ATTR_MODE: self._config[CONF_MODE],
         }
 
+    @override
     async def async_added_to_hass(self):
         """Run when entity about to be added to hass."""
         await super().async_added_to_hass()
@@ -315,6 +328,7 @@ class InputNumber(collection.CollectionEntity, RestoreEntity):
         """Decrement value."""
         await self.async_set_value(max(self._current_value - self._step, self._minimum))
 
+    @override
     async def async_update_config(self, config: ConfigType) -> None:
         """Handle when the config is updated."""
         self._config = config

--- a/homeassistant/components/input_select/__init__.py
+++ b/homeassistant/components/input_select/__init__.py
@@ -1,7 +1,7 @@
 """Support to select an option from a list."""
 
 import logging
-from typing import Any, Self, cast
+from typing import Any, Self, cast, override
 
 import voluptuous as vol
 
@@ -115,6 +115,7 @@ RELOAD_SERVICE_SCHEMA = vol.Schema({})
 class InputSelectStore(Store):
     """Store entity registry data."""
 
+    @override
     async def _async_migrate_func(
         self, old_major_version: int, old_minor_version: int, old_data: dict[str, Any]
     ) -> dict[str, Any]:
@@ -224,15 +225,18 @@ class InputSelectStorageCollection(collection.DictStorageCollection):
 
     CREATE_UPDATE_SCHEMA = vol.Schema(vol.All(STORAGE_FIELDS, _cv_input_select))
 
+    @override
     async def _process_create_data(self, data: dict[str, Any]) -> dict[str, Any]:
         """Validate the config is valid."""
         return cast(dict[str, Any], self.CREATE_UPDATE_SCHEMA(data))
 
     @callback
+    @override
     def _get_suggested_id(self, info: dict[str, Any]) -> str:
         """Suggest an ID based on the config."""
         return cast(str, info[CONF_NAME])
 
+    @override
     async def _update_data(
         self, item: dict[str, Any], update_data: dict[str, Any]
     ) -> dict[str, Any]:
@@ -262,6 +266,7 @@ class InputSelect(collection.CollectionEntity, SelectEntity, RestoreEntity):
         self._attr_unique_id = config[CONF_ID]
 
     @classmethod
+    @override
     def from_storage(cls, config: ConfigType) -> Self:
         """Return entity instance initialized from storage."""
         input_select = cls(config)
@@ -269,6 +274,7 @@ class InputSelect(collection.CollectionEntity, SelectEntity, RestoreEntity):
         return input_select
 
     @classmethod
+    @override
     def from_yaml(cls, config: ConfigType) -> Self:
         """Return entity instance initialized from yaml."""
         input_select = cls(config)
@@ -276,6 +282,7 @@ class InputSelect(collection.CollectionEntity, SelectEntity, RestoreEntity):
         input_select.editable = False
         return input_select
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added."""
         await super().async_added_to_hass()
@@ -289,10 +296,12 @@ class InputSelect(collection.CollectionEntity, SelectEntity, RestoreEntity):
             self._attr_current_option = state.state
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, bool]:
         """Return the state attributes."""
         return {ATTR_EDITABLE: self.editable}
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Select new option."""
         if option not in self.options:
@@ -321,6 +330,7 @@ class InputSelect(collection.CollectionEntity, SelectEntity, RestoreEntity):
 
         self.async_write_ha_state()
 
+    @override
     async def async_update_config(self, config: ConfigType) -> None:
         """Handle when the config is updated."""
         self._attr_icon = config.get(CONF_ICON)

--- a/homeassistant/components/input_text/__init__.py
+++ b/homeassistant/components/input_text/__init__.py
@@ -1,7 +1,7 @@
 """Support to enter a value into a text box."""
 
 import logging
-from typing import Any, Self
+from typing import Any, Self, override
 
 import voluptuous as vol
 
@@ -167,15 +167,18 @@ class InputTextStorageCollection(collection.DictStorageCollection):
 
     CREATE_UPDATE_SCHEMA = vol.Schema(vol.All(STORAGE_FIELDS, _cv_input_text))
 
+    @override
     async def _process_create_data(self, data: dict[str, Any]) -> dict[str, Any]:
         """Validate the config is valid."""
         return self.CREATE_UPDATE_SCHEMA(data)  # type: ignore[no-any-return]
 
     @callback
+    @override
     def _get_suggested_id(self, info: dict[str, Any]) -> str:
         """Suggest an ID based on the config."""
         return info[CONF_NAME]  # type: ignore[no-any-return]
 
+    @override
     async def _update_data(
         self, item: dict[str, Any], update_data: dict[str, Any]
     ) -> dict[str, Any]:
@@ -201,6 +204,7 @@ class InputText(collection.CollectionEntity, RestoreEntity):
         self._current_value = config.get(CONF_INITIAL)
 
     @classmethod
+    @override
     def from_storage(cls, config: ConfigType) -> Self:
         """Return entity instance initialized from storage."""
         input_text: Self = cls(config)
@@ -208,6 +212,7 @@ class InputText(collection.CollectionEntity, RestoreEntity):
         return input_text
 
     @classmethod
+    @override
     def from_yaml(cls, config: ConfigType) -> Self:
         """Return entity instance initialized from yaml."""
         input_text: Self = cls(config)
@@ -216,11 +221,13 @@ class InputText(collection.CollectionEntity, RestoreEntity):
         return input_text
 
     @property
+    @override
     def name(self) -> str | None:
         """Return the name of the text input entity."""
         return self._config.get(CONF_NAME)
 
     @property
+    @override
     def icon(self) -> str | None:
         """Return the icon to be used for this entity."""
         return self._config.get(CONF_ICON)
@@ -236,21 +243,25 @@ class InputText(collection.CollectionEntity, RestoreEntity):
         return self._config[CONF_MIN]  # type: ignore[no-any-return]
 
     @property
+    @override
     def state(self) -> str | None:
         """Return the state of the component."""
         return self._current_value
 
     @property
+    @override
     def unit_of_measurement(self) -> str | None:
         """Return the unit the value is expressed in."""
         return self._config.get(CONF_UNIT_OF_MEASUREMENT)
 
     @property
+    @override
     def unique_id(self) -> str:
         """Return unique id for the entity."""
         return self._config[CONF_ID]  # type: ignore[no-any-return]
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         return {
@@ -261,6 +272,7 @@ class InputText(collection.CollectionEntity, RestoreEntity):
             ATTR_MODE: self._config[CONF_MODE],
         }
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
         await super().async_added_to_hass()
@@ -287,6 +299,7 @@ class InputText(collection.CollectionEntity, RestoreEntity):
         self._current_value = value
         self.async_write_ha_state()
 
+    @override
     async def async_update_config(self, config: ConfigType) -> None:
         """Handle when the config is updated."""
         self._config = config

--- a/homeassistant/components/insteon/binary_sensor.py
+++ b/homeassistant/components/insteon/binary_sensor.py
@@ -1,5 +1,7 @@
 """Support for INSTEON dimmers via PowerLinc Modem."""
 
+from typing import override
+
 from pyinsteon.groups import (
     CO_SENSOR,
     DOOR_SENSOR,
@@ -80,6 +82,7 @@ class InsteonBinarySensorEntity(InsteonEntity, BinarySensorEntity):
         self._attr_device_class = SENSOR_TYPES.get(self._insteon_device_group.name)
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return the boolean response if the node is on."""
         return bool(self._insteon_device_group.value)

--- a/homeassistant/components/insteon/climate.py
+++ b/homeassistant/components/insteon/climate.py
@@ -1,6 +1,6 @@
 """Support for Insteon thermostat."""
 
-from typing import Any
+from typing import Any, override
 
 from pyinsteon.config import CELSIUS
 from pyinsteon.constants import ThermostatMode
@@ -94,6 +94,7 @@ class InsteonClimateEntity(InsteonEntity, ClimateEntity):
     _attr_min_humidity = 1
 
     @property
+    @override
     def temperature_unit(self) -> str:
         """Return the unit of measurement."""
         if self._insteon_device.configuration[CELSIUS].value:
@@ -101,21 +102,25 @@ class InsteonClimateEntity(InsteonEntity, ClimateEntity):
         return UnitOfTemperature.FAHRENHEIT
 
     @property
+    @override
     def current_humidity(self) -> int | None:
         """Return the current humidity."""
         return self._insteon_device.groups[HUMIDITY].value
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode:
         """Return hvac operation ie. heat, cool mode."""
         return HVAC_MODES[self._insteon_device.groups[SYSTEM_MODE].value]
 
     @property
+    @override
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
         return self._insteon_device.groups[TEMPERATURE].value
 
     @property
+    @override
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
         if self._insteon_device.groups[SYSTEM_MODE].value == ThermostatMode.HEAT:
@@ -125,6 +130,7 @@ class InsteonClimateEntity(InsteonEntity, ClimateEntity):
         return None
 
     @property
+    @override
     def target_temperature_high(self) -> float | None:
         """Return the highbound target temperature we try to reach."""
         if self._insteon_device.groups[SYSTEM_MODE].value == ThermostatMode.AUTO:
@@ -132,6 +138,7 @@ class InsteonClimateEntity(InsteonEntity, ClimateEntity):
         return None
 
     @property
+    @override
     def target_temperature_low(self) -> float | None:
         """Return the lowbound target temperature we try to reach."""
         if self._insteon_device.groups[SYSTEM_MODE].value == ThermostatMode.AUTO:
@@ -139,11 +146,13 @@ class InsteonClimateEntity(InsteonEntity, ClimateEntity):
         return None
 
     @property
+    @override
     def fan_mode(self) -> str | None:
         """Return the fan setting."""
         return FAN_MODES[self._insteon_device.groups[FAN_MODE].value]
 
     @property
+    @override
     def target_humidity(self) -> int | None:
         """Return the humidity we try to reach."""
         high = self._insteon_device.groups[HUMIDITY_HIGH].value
@@ -152,6 +161,7 @@ class InsteonClimateEntity(InsteonEntity, ClimateEntity):
         return (high + low) / 2 if high and low else None
 
     @property
+    @override
     def hvac_action(self) -> HVACAction:
         """Return the current running hvac operation if supported.
 
@@ -166,6 +176,7 @@ class InsteonClimateEntity(InsteonEntity, ClimateEntity):
         return HVACAction.IDLE
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Provide attributes for display on device card."""
         attr = super().extra_state_attributes
@@ -177,6 +188,7 @@ class InsteonClimateEntity(InsteonEntity, ClimateEntity):
         attr["humidifier"] = humidifier
         return attr
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         target_temp = kwargs.get(ATTR_TEMPERATURE)
@@ -191,16 +203,19 @@ class InsteonClimateEntity(InsteonEntity, ClimateEntity):
             await self._insteon_device.async_set_heat_set_point(target_temp_low)
             await self._insteon_device.async_set_cool_set_point(target_temp_high)
 
+    @override
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""
         mode = list(FAN_MODES)[list(FAN_MODES.values()).index(fan_mode)]
         await self._insteon_device.async_set_mode(mode)
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         mode = list(HVAC_MODES)[list(HVAC_MODES.values()).index(hvac_mode)]
         await self._insteon_device.async_set_mode(mode)
 
+    @override
     async def async_set_humidity(self, humidity: int) -> None:
         """Set new humidity level."""
         change = humidity - (self.target_humidity or 0)
@@ -209,6 +224,7 @@ class InsteonClimateEntity(InsteonEntity, ClimateEntity):
         await self._insteon_device.async_set_humidity_low_set_point(low)
         await self._insteon_device.async_set_humidity_high_set_point(high)
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register INSTEON update events."""
         await super().async_added_to_hass()

--- a/homeassistant/components/insteon/config_flow.py
+++ b/homeassistant/components/insteon/config_flow.py
@@ -1,7 +1,7 @@
 """Test config flow for Insteon."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyinsteon import async_connect
 
@@ -55,6 +55,7 @@ class InsteonFlowHandler(ConfigFlow, domain=DOMAIN):
     _device_name: str
     discovered_conf: dict[str, str] = {}
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -129,6 +130,7 @@ class InsteonFlowHandler(ConfigFlow, domain=DOMAIN):
             step_id=step_id, data_schema=data_schema, errors=errors
         )
 
+    @override
     async def async_step_usb(self, discovery_info: UsbServiceInfo) -> ConfigFlowResult:
         """Handle USB discovery."""
         self._device_path = discovery_info.device
@@ -159,6 +161,7 @@ class InsteonFlowHandler(ConfigFlow, domain=DOMAIN):
             description_placeholders={CONF_NAME: self._device_name},
         )
 
+    @override
     async def async_step_dhcp(
         self, discovery_info: DhcpServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/insteon/cover.py
+++ b/homeassistant/components/insteon/cover.py
@@ -1,7 +1,7 @@
 """Support for Insteon covers via PowerLinc Modem."""
 
 import math
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.cover import (
     ATTR_POSITION,
@@ -53,6 +53,7 @@ class InsteonCoverEntity(InsteonEntity, CoverEntity):
     )
 
     @property
+    @override
     def current_cover_position(self) -> int:
         """Return the current cover position."""
         if self._insteon_device_group.value is not None:
@@ -62,18 +63,22 @@ class InsteonCoverEntity(InsteonEntity, CoverEntity):
         return math.ceil(pos * 100 / 255)
 
     @property
+    @override
     def is_closed(self) -> bool:
         """Return the boolean response if the node is on."""
         return bool(self.current_cover_position)
 
+    @override
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open cover."""
         await self._insteon_device.async_open()
 
+    @override
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close cover."""
         await self._insteon_device.async_close()
 
+    @override
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Set the cover position."""
         position = int(kwargs[ATTR_POSITION] * 255 / 100)

--- a/homeassistant/components/insteon/entity.py
+++ b/homeassistant/components/insteon/entity.py
@@ -2,7 +2,7 @@
 
 import functools
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyinsteon import devices
 
@@ -38,6 +38,7 @@ class InsteonEntity(Entity):
         self._insteon_device_group = device.groups[group]
         self._insteon_device = device
 
+    @override
     def __hash__(self):
         """Return the hash of the Insteon Entity."""
         return hash(self._insteon_device)
@@ -53,6 +54,7 @@ class InsteonEntity(Entity):
         return self._insteon_device_group.group
 
     @property
+    @override
     def unique_id(self) -> str:
         """Return a unique ID."""
         if self._insteon_device_group.group == 0x01:
@@ -62,6 +64,7 @@ class InsteonEntity(Entity):
         return uid
 
     @property
+    @override
     def name(self):
         """Return the name of the node (used for Entity_ID)."""
         # Set a base description
@@ -73,6 +76,7 @@ class InsteonEntity(Entity):
         return f"{description} {self._insteon_device.address}{extension}"
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Provide attributes for display on device card."""
         return {
@@ -81,6 +85,7 @@ class InsteonEntity(Entity):
         }
 
     @property
+    @override
     def device_info(self) -> DeviceInfo:
         """Return device information."""
         return DeviceInfo(
@@ -110,6 +115,7 @@ class InsteonEntity(Entity):
         )
         self.async_write_ha_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register INSTEON update events."""
         _LOGGER.debug(
@@ -138,6 +144,7 @@ class InsteonEntity(Entity):
             )
         )
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Unsubscribe to INSTEON update events."""
         _LOGGER.debug(

--- a/homeassistant/components/insteon/fan.py
+++ b/homeassistant/components/insteon/fan.py
@@ -1,7 +1,7 @@
 """Support for INSTEON fans via PowerLinc Modem."""
 
 import math
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.fan import FanEntity, FanEntityFeature
 from homeassistant.config_entries import ConfigEntry
@@ -56,12 +56,14 @@ class InsteonFanEntity(InsteonEntity, FanEntity):
     _attr_speed_count = 3
 
     @property
+    @override
     def percentage(self) -> int | None:
         """Return the current speed percentage."""
         if self._insteon_device_group.value is None:
             return None
         return ranged_value_to_percentage(SPEED_RANGE, self._insteon_device_group.value)
 
+    @override
     async def async_turn_on(
         self,
         percentage: int | None = None,
@@ -71,10 +73,12 @@ class InsteonFanEntity(InsteonEntity, FanEntity):
         """Turn on the fan."""
         await self.async_set_percentage(percentage or 67)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the fan."""
         await self._insteon_device.async_fan_off()
 
+    @override
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed percentage of the fan."""
         if percentage == 0:

--- a/homeassistant/components/insteon/light.py
+++ b/homeassistant/components/insteon/light.py
@@ -1,6 +1,6 @@
 """Support for Insteon lights via PowerLinc Modem."""
 
-from typing import Any
+from typing import Any, override
 
 from pyinsteon.config import ON_LEVEL
 from pyinsteon.device_types.device_base import Device as InsteonDevice
@@ -61,15 +61,18 @@ class InsteonDimmerEntity(InsteonEntity, LightEntity):
             self._attr_supported_color_modes = {ColorMode.ONOFF}
 
     @property
+    @override
     def brightness(self) -> int:
         """Return the brightness of this light between 0..255."""
         return self._insteon_device_group.value
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return the boolean response if the node is on."""
         return bool(self.brightness)
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn light on."""
         brightness: int | None = None
@@ -84,6 +87,7 @@ class InsteonDimmerEntity(InsteonEntity, LightEntity):
         else:
             await self._insteon_device.async_on(group=self._insteon_device_group.group)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn light off."""
         await self._insteon_device.async_off(self._insteon_device_group.group)

--- a/homeassistant/components/insteon/lock.py
+++ b/homeassistant/components/insteon/lock.py
@@ -1,6 +1,6 @@
 """Support for INSTEON locks."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.lock import LockEntity
 from homeassistant.config_entries import ConfigEntry
@@ -42,14 +42,17 @@ class InsteonLockEntity(InsteonEntity, LockEntity):
     """A Class for an Insteon lock entity."""
 
     @property
+    @override
     def is_locked(self) -> bool:
         """Return the boolean response if the node is on."""
         return bool(self._insteon_device_group.value)
 
+    @override
     async def async_lock(self, **kwargs: Any) -> None:
         """Lock the device."""
         await self._insteon_device.async_lock()
 
+    @override
     async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock the device."""
         await self._insteon_device.async_unlock()

--- a/homeassistant/components/insteon/switch.py
+++ b/homeassistant/components/insteon/switch.py
@@ -1,6 +1,6 @@
 """Support for INSTEON dimmers via PowerLinc Modem."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
@@ -46,14 +46,17 @@ class InsteonSwitchEntity(InsteonEntity, SwitchEntity):
     """A Class for an Insteon switch entity."""
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return the boolean response if the node is on."""
         return bool(self._insteon_device_group.value)
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn switch on."""
         await self._insteon_device.async_on(group=self._insteon_device_group.group)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn switch off."""
         await self._insteon_device.async_off(group=self._insteon_device_group.group)

--- a/homeassistant/components/integration/config_flow.py
+++ b/homeassistant/components/integration/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Integration - Riemann sum integral integration."""
 
 from collections.abc import Mapping
-from typing import Any, cast
+from typing import Any, cast, override
 
 import voluptuous as vol
 
@@ -151,6 +151,7 @@ class ConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
     options_flow = OPTIONS_FLOW
     options_flow_reloads = True
 
+    @override
     def async_config_entry_title(self, options: Mapping[str, Any]) -> str:
         """Return config entry title."""
         return cast(str, options["name"])

--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 from decimal import Decimal, InvalidOperation
 from enum import Enum
 import logging
-from typing import TYPE_CHECKING, Any, Final, Self
+from typing import TYPE_CHECKING, Any, Final, Self, override
 
 import voluptuous as vol
 
@@ -129,11 +129,13 @@ class _IntegrationMethod(ABC):
 
 
 class _Trapezoidal(_IntegrationMethod):
+    @override
     def calculate_area_with_two_states(
         self, elapsed_time: Decimal, left: Decimal, right: Decimal
     ) -> Decimal:
         return elapsed_time * (left + right) / 2
 
+    @override
     def validate_states(self, left: str, right: str) -> tuple[Decimal, Decimal] | None:
         if (left_dec := _decimal_state(left)) is None or (
             right_dec := _decimal_state(right)
@@ -143,11 +145,13 @@ class _Trapezoidal(_IntegrationMethod):
 
 
 class _Left(_IntegrationMethod):
+    @override
     def calculate_area_with_two_states(
         self, elapsed_time: Decimal, left: Decimal, right: Decimal
     ) -> Decimal:
         return self.calculate_area_with_one_state(elapsed_time, left)
 
+    @override
     def validate_states(self, left: str, right: str) -> tuple[Decimal, Decimal] | None:
         if (left_dec := _decimal_state(left)) is None:
             return None
@@ -155,11 +159,13 @@ class _Left(_IntegrationMethod):
 
 
 class _Right(_IntegrationMethod):
+    @override
     def calculate_area_with_two_states(
         self, elapsed_time: Decimal, left: Decimal, right: Decimal
     ) -> Decimal:
         return self.calculate_area_with_one_state(elapsed_time, right)
 
+    @override
     def validate_states(self, left: str, right: str) -> tuple[Decimal, Decimal] | None:
         if (right_dec := _decimal_state(right)) is None:
             return None
@@ -192,6 +198,7 @@ class IntegrationSensorExtraStoredData(SensorExtraStoredData):
     source_entity: str | None
     last_valid_state: Decimal | None
 
+    @override
     def as_dict(self) -> dict[str, Any]:
         """Return a dict representation of the utility sensor data."""
         data = super().as_dict()
@@ -202,6 +209,7 @@ class IntegrationSensorExtraStoredData(SensorExtraStoredData):
         return data
 
     @classmethod
+    @override
     def from_dict(cls, restored: dict[str, Any]) -> Self | None:
         """Initialize a stored sensor state from a dict."""
         extra = SensorExtraStoredData.from_dict(restored)
@@ -409,6 +417,7 @@ class IntegrationSensor(RestoreSensor):
         )
         self._last_valid_state = self._state
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Handle entity which will be added."""
         await super().async_added_to_hass()
@@ -624,6 +633,7 @@ class IntegrationSensor(RestoreSensor):
         self._max_sub_interval_exceeded_callback()
 
     @property
+    @override
     def native_value(self) -> Decimal | None:
         """Return the state of the sensor."""
         if isinstance(self._state, Decimal) and self._round_digits:
@@ -631,11 +641,13 @@ class IntegrationSensor(RestoreSensor):
         return self._state
 
     @property
+    @override
     def native_unit_of_measurement(self) -> str | None:
         """Return the unit the value is expressed in."""
         return self._unit_of_measurement
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, str] | None:
         """Return the state attributes of the sensor."""
         return {
@@ -643,6 +655,7 @@ class IntegrationSensor(RestoreSensor):
         }
 
     @property
+    @override
     def extra_restore_state_data(self) -> IntegrationSensorExtraStoredData:
         """Return sensor specific state data to be restored."""
         return IntegrationSensorExtraStoredData(
@@ -652,6 +665,7 @@ class IntegrationSensor(RestoreSensor):
             self._last_valid_state,
         )
 
+    @override
     async def async_get_last_sensor_data(
         self,
     ) -> IntegrationSensorExtraStoredData | None:

--- a/homeassistant/components/intelliclima/config_flow.py
+++ b/homeassistant/components/intelliclima/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for IntelliClima integration."""
 
-from typing import Any
+from typing import Any, override
 
 from pyintelliclima import IntelliClimaAPI, IntelliClimaAPIError, IntelliClimaAuthError
 import voluptuous as vol
@@ -24,6 +24,7 @@ class IntelliClimaConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/intelliclima/coordinator.py
+++ b/homeassistant/components/intelliclima/coordinator.py
@@ -1,5 +1,7 @@
 """DataUpdateCoordinator for IntelliClima."""
 
+from typing import override
+
 from pyintelliclima import IntelliClimaAPI, IntelliClimaAPIError, IntelliClimaDevices
 
 from homeassistant.config_entries import ConfigEntry
@@ -27,6 +29,7 @@ class IntelliClimaCoordinator(DataUpdateCoordinator[IntelliClimaDevices]):
         )
         self.api = api
 
+    @override
     async def _async_setup(self) -> None:
         """Set up the coordinator - called once during first refresh."""
         # Authenticate and get initial device list
@@ -35,6 +38,7 @@ class IntelliClimaCoordinator(DataUpdateCoordinator[IntelliClimaDevices]):
         except IntelliClimaAPIError as err:
             raise UpdateFailed(f"Failed to set up IntelliClima: {err}") from err
 
+    @override
     async def _async_update_data(self) -> IntelliClimaDevices:
         """Fetch data from API."""
         try:

--- a/homeassistant/components/intelliclima/entity.py
+++ b/homeassistant/components/intelliclima/entity.py
@@ -1,5 +1,7 @@
 """Platform for shared base classes for sensors."""
 
+from typing import override
+
 from pyintelliclima.intelliclima_types import IntelliClimaC800, IntelliClimaECO
 
 from homeassistant.const import ATTR_CONNECTIONS, ATTR_MODEL, ATTR_SW_VERSION
@@ -64,6 +66,7 @@ class IntelliClimaECOEntity(IntelliClimaEntity):
         return self.coordinator.data.ecocomfort2_devices[self._device_id]
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return (

--- a/homeassistant/components/intelliclima/fan.py
+++ b/homeassistant/components/intelliclima/fan.py
@@ -1,7 +1,7 @@
 """Fan platform for IntelliClima VMC."""
 
 import math
-from typing import Any
+from typing import Any, override
 
 from pyintelliclima.const import FanMode, FanSpeed
 from pyintelliclima.intelliclima_types import IntelliClimaECO
@@ -65,11 +65,13 @@ class IntelliClimaVMCFan(IntelliClimaECOEntity, FanEntity):
         self._attr_unique_id = device.id
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if fan is on."""
         return bool(self._device_data.mode_set != FanMode.off)
 
     @property
+    @override
     def percentage(self) -> int | None:
         """Return the current speed percentage."""
         device_data = self._device_data
@@ -80,11 +82,13 @@ class IntelliClimaVMCFan(IntelliClimaECOEntity, FanEntity):
         return ranged_value_to_percentage(self._speed_range, int(device_data.speed_set))
 
     @property
+    @override
     def speed_count(self) -> int:
         """Return the number of speeds the fan supports."""
         return int_states_in_range(self._speed_range)
 
     @property
+    @override
     def preset_mode(self) -> str | None:
         """Return the current preset mode."""
         device_data = self._device_data
@@ -99,6 +103,7 @@ class IntelliClimaVMCFan(IntelliClimaECOEntity, FanEntity):
 
         return None
 
+    @override
     async def async_turn_on(
         self,
         percentage: int | None = None,
@@ -113,15 +118,18 @@ class IntelliClimaVMCFan(IntelliClimaECOEntity, FanEntity):
         percentage = 25 if percentage == 0 else percentage
         await self.async_set_mode_speed(preset_mode=preset_mode, percentage=percentage)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the fan."""
         await self.coordinator.api.ecocomfort.turn_off(self._device_sn)
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed percentage."""
         await self.async_set_mode_speed(percentage=percentage)
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set preset mode."""
         await self.async_set_mode_speed(preset_mode=preset_mode)

--- a/homeassistant/components/intelliclima/select.py
+++ b/homeassistant/components/intelliclima/select.py
@@ -1,5 +1,7 @@
 """Select platform for IntelliClima VMC."""
 
+from typing import override
+
 from pyintelliclima.const import FanMode, FanSpeed
 from pyintelliclima.intelliclima_types import IntelliClimaECO
 
@@ -59,6 +61,7 @@ class IntelliClimaVMCFanModeSelect(IntelliClimaECOEntity, SelectEntity):
         self._attr_unique_id = f"{device.id}_fan_mode"
 
     @property
+    @override
     def current_option(self) -> str | None:
         """Return the current fan mode."""
         device_data = self._device_data
@@ -76,6 +79,7 @@ class IntelliClimaVMCFanModeSelect(IntelliClimaECOEntity, SelectEntity):
 
         return INTELLICLIMA_MODE_TO_FAN_MODE.get(device_data.mode_set)
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Set the fan mode."""
         device_data = self._device_data

--- a/homeassistant/components/intelliclima/sensor.py
+++ b/homeassistant/components/intelliclima/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from pyintelliclima.intelliclima_types import IntelliClimaECO
 
@@ -96,6 +97,7 @@ class IntelliClimaSensor(IntelliClimaECOEntity, SensorEntity):
         self._attr_unique_id = f"{device.id}_{description.key}"
 
     @property
+    @override
     def native_value(self) -> int | float | str | None:
         """Use this to get the correct value."""
         return self.entity_description.value_fn(self._device_data)

--- a/homeassistant/components/intellifire/binary_sensor.py
+++ b/homeassistant/components/intellifire/binary_sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -165,6 +166,7 @@ class IntellifireBinarySensor(IntellifireEntity, BinarySensorEntity):
     entity_description: IntellifireBinarySensorEntityDescription
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Use this to get the correct value."""
         return self.entity_description.value_fn(self.coordinator)

--- a/homeassistant/components/intellifire/climate.py
+++ b/homeassistant/components/intellifire/climate.py
@@ -1,6 +1,6 @@
 """Intellifire Climate Entities."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.climate import (
     ClimateEntity,
@@ -71,12 +71,14 @@ class IntellifireClimate(IntellifireEntity, ClimateEntity):
             self.last_temp = int(coordinator.data.thermostat_setpoint_c)
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode:
         """Return current hvac mode."""
         if self.coordinator.read_api.data.thermostat_on:
             return HVACMode.HEAT
         return HVACMode.OFF
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Turn on thermostat by setting a target temperature."""
         raw_target_temp = kwargs[ATTR_TEMPERATURE]
@@ -91,15 +93,18 @@ class IntellifireClimate(IntellifireEntity, ClimateEntity):
         )
 
     @property
+    @override
     def current_temperature(self) -> float:
         """Return the current temperature."""
         return float(self.coordinator.read_api.data.temperature_c)
 
     @property
+    @override
     def target_temperature(self) -> float:
         """Return target temperature."""
         return float(self.coordinator.read_api.data.thermostat_setpoint_c)
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set HVAC mode to normal or thermostat control."""
         LOGGER.debug(

--- a/homeassistant/components/intellifire/config_flow.py
+++ b/homeassistant/components/intellifire/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from aiohttp import ClientConnectionError
 from intellifire4py.cloud_interface import IntelliFireCloudInterface
@@ -97,6 +97,7 @@ class IntelliFireConfigFlow(ConfigFlow, domain=DOMAIN):
         # Define a cloud api interface we can use
         self.cloud_api_interface = IntelliFireCloudInterface()
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -251,6 +252,7 @@ class IntelliFireConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return await self.async_step_cloud_api()
 
+    @override
     async def async_step_dhcp(
         self, discovery_info: DhcpServiceInfo
     ) -> ConfigFlowResult:
@@ -277,6 +279,7 @@ class IntelliFireConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(config_entry: IntellifireConfigEntry) -> OptionsFlow:
         """Create the options flow."""
         return IntelliFireOptionsFlowHandler()

--- a/homeassistant/components/intellifire/coordinator.py
+++ b/homeassistant/components/intellifire/coordinator.py
@@ -1,6 +1,7 @@
 """The IntelliFire integration."""
 
 from datetime import timedelta
+from typing import override
 
 import aiohttp
 from intellifire4py import UnifiedFireplace
@@ -51,6 +52,7 @@ class IntellifireDataUpdateCoordinator(DataUpdateCoordinator[IntelliFirePollData
         """Return the control API."""
         return self.fireplace.control_api
 
+    @override
     async def _async_update_data(self) -> IntelliFirePollData:
         try:
             await self.fireplace.perform_poll()

--- a/homeassistant/components/intellifire/fan.py
+++ b/homeassistant/components/intellifire/fan.py
@@ -3,7 +3,7 @@
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 import math
-from typing import Any
+from typing import Any, override
 
 from intellifire4py.control import IntelliFireController
 from intellifire4py.model import IntelliFirePollData
@@ -80,11 +80,13 @@ class IntellifireFan(IntellifireEntity, FanEntity):
     )
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return on or off."""
         return self.entity_description.value_fn(self.coordinator.read_api.data) >= 1
 
     @property
+    @override
     def percentage(self) -> int | None:
         """Return fan percentage."""
         return ranged_value_to_percentage(
@@ -93,10 +95,12 @@ class IntellifireFan(IntellifireEntity, FanEntity):
         )
 
     @property
+    @override
     def speed_count(self) -> int:
         """Count of supported speeds."""
         return self.entity_description.speed_range[1]
 
+    @override
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed percentage of the fan."""
         # Calculate percentage steps
@@ -108,6 +112,7 @@ class IntellifireFan(IntellifireEntity, FanEntity):
         await self.entity_description.set_fn(self.coordinator.control_api, int_value)
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_turn_on(
         self,
         percentage: int | None = None,
@@ -126,6 +131,7 @@ class IntellifireFan(IntellifireEntity, FanEntity):
         await self.entity_description.set_fn(self.coordinator.control_api, int_value)
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the fan."""
         await self.entity_description.set_fn(self.coordinator.control_api, 0)

--- a/homeassistant/components/intellifire/light.py
+++ b/homeassistant/components/intellifire/light.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from intellifire4py.control import IntelliFireController
 from intellifire4py.model import IntelliFirePollData
@@ -54,15 +54,18 @@ class IntellifireLight(IntellifireEntity, LightEntity):
     _attr_supported_color_modes = {ColorMode.BRIGHTNESS}
 
     @property
+    @override
     def brightness(self) -> int:
         """Return the current brightness 0-255."""
         return 85 * self.entity_description.value_fn(self.coordinator.read_api.data)
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if light is on."""
         return self.entity_description.value_fn(self.coordinator.read_api.data) >= 1
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Instruct the light to turn on."""
         if ATTR_BRIGHTNESS in kwargs:
@@ -73,6 +76,7 @@ class IntellifireLight(IntellifireEntity, LightEntity):
         await self.entity_description.set_fn(self.coordinator.control_api, light_level)
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Instruct the light to turn off."""
         await self.entity_description.set_fn(self.coordinator.control_api, 0)

--- a/homeassistant/components/intellifire/number.py
+++ b/homeassistant/components/intellifire/number.py
@@ -1,6 +1,7 @@
 """Flame height number sensors."""
 
 from dataclasses import dataclass
+from typing import override
 
 from homeassistant.components.number import (
     NumberEntity,
@@ -55,11 +56,13 @@ class IntellifireFlameControlEntity(IntellifireEntity, NumberEntity):
         super().__init__(coordinator, description)
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the current Flame Height segment number value."""
         # UI uses 1-5 for flame height, backing lib uses 0-4
         return self.coordinator.read_api.data.flameheight + 1
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Slider change."""
         value_to_send: int = int(value) - 1

--- a/homeassistant/components/intellifire/sensor.py
+++ b/homeassistant/components/intellifire/sensor.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from typing import override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -172,6 +173,7 @@ class IntelliFireSensor(IntellifireEntity, SensorEntity):
     entity_description: IntellifireSensorEntityDescription
 
     @property
+    @override
     def native_value(self) -> int | str | datetime | float | None:
         """Return the state."""
         return self.entity_description.value_fn(self.coordinator)

--- a/homeassistant/components/intellifire/switch.py
+++ b/homeassistant/components/intellifire/switch.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.core import HomeAssistant
@@ -65,17 +65,20 @@ class IntellifireSwitch(IntellifireEntity, SwitchEntity):
 
     entity_description: IntellifireSwitchEntityDescription
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the switch."""
         await self.entity_description.on_fn(self.coordinator)
         await self.async_update_ha_state(force_refresh=True)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the switch."""
         await self.entity_description.off_fn(self.coordinator)
         await self.async_update_ha_state(force_refresh=True)
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return the on state."""
         return self.entity_description.value_fn(self.coordinator)

--- a/homeassistant/components/intent/__init__.py
+++ b/homeassistant/components/intent/__init__.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Collection
 import logging
-from typing import Any, Protocol
+from typing import Any, Protocol, override
 
 from aiohttp import web
 import voluptuous as vol
@@ -180,6 +180,7 @@ class IntentPlatformProtocol(Protocol):
 class OnOffIntentHandler(intent.ServiceIntentHandler):
     """Intent handler for on/off that also supports covers, valves, locks, etc."""
 
+    @override
     async def async_call_service(
         self, domain: str, service: str, intent_obj: intent.Intent, state: State
     ) -> None:
@@ -291,6 +292,7 @@ class GetStateIntentHandler(intent.IntentHandler):
         vol.Optional("preferred_floor_id"): cv.string,
     }
 
+    @override
     async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
         """Handle the hass intent."""
         hass = intent_obj.hass
@@ -411,6 +413,7 @@ class NevermindIntentHandler(intent.IntentHandler):
     intent_type = intent.INTENT_NEVERMIND
     description = "Cancels the current request and does nothing"
 
+    @override
     async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
         """Do nothing and produces an empty response."""
         return intent_obj.create_response()
@@ -431,6 +434,7 @@ class SetPositionIntentHandler(intent.DynamicServiceIntentHandler):
             device_classes={CoverDeviceClass, ValveDeviceClass},
         )
 
+    @override
     def get_domain_and_service(
         self, intent_obj: intent.Intent, state: State
     ) -> tuple[str, str]:
@@ -456,6 +460,7 @@ class StopMovingIntentHandler(intent.DynamicServiceIntentHandler):
             device_classes={CoverDeviceClass, ValveDeviceClass},
         )
 
+    @override
     def get_domain_and_service(
         self, intent_obj: intent.Intent, state: State
     ) -> tuple[str, str]:
@@ -475,6 +480,7 @@ class GetCurrentDateIntentHandler(intent.IntentHandler):
     intent_type = intent.INTENT_GET_CURRENT_DATE
     description = "Gets the current date"
 
+    @override
     async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
         response = intent_obj.create_response()
         response.async_set_speech_slots({"date": dt_util.now().date()})
@@ -487,6 +493,7 @@ class GetCurrentTimeIntentHandler(intent.IntentHandler):
     intent_type = intent.INTENT_GET_CURRENT_TIME
     description = "Gets the current time"
 
+    @override
     async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
         response = intent_obj.create_response()
         response.async_set_speech_slots({"time": dt_util.now().time()})
@@ -503,6 +510,7 @@ class RespondIntentHandler(intent.IntentHandler):
         vol.Optional("response"): cv.string,
     }
 
+    @override
     async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
         """Return the provided response, but take no action."""
         slots = self.async_validate_slots(intent_obj.slots)
@@ -528,6 +536,7 @@ class GetTemperatureIntent(intent.IntentHandler):
     }
     platforms = {CLIMATE_DOMAIN}
 
+    @override
     async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
         """Handle the intent."""
         hass = intent_obj.hass

--- a/homeassistant/components/intent/timers.py
+++ b/homeassistant/components/intent/timers.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 import logging
 import time
-from typing import Any
+from typing import Any, override
 
 from propcache.api import cached_property
 import voluptuous as vol
@@ -832,6 +832,7 @@ class StartTimerIntentHandler(intent.IntentHandler):
         vol.Optional("conversation_command"): cv.string,
     }
 
+    @override
     async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
         """Handle the intent."""
         hass = intent_obj.hass
@@ -940,6 +941,7 @@ class CancelTimerIntentHandler(intent.IntentHandler):
         vol.Optional("area"): cv.string,
     }
 
+    @override
     async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
         """Handle the intent."""
         hass = intent_obj.hass
@@ -960,6 +962,7 @@ class CancelAllTimersIntentHandler(intent.IntentHandler):
         vol.Optional("area"): cv.string,
     }
 
+    @override
     async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
         """Handle the intent."""
         hass = intent_obj.hass
@@ -993,6 +996,7 @@ class IncreaseTimerIntentHandler(intent.IntentHandler):
         vol.Optional("area"): cv.string,
     }
 
+    @override
     async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
         """Handle the intent."""
         hass = intent_obj.hass
@@ -1017,6 +1021,7 @@ class DecreaseTimerIntentHandler(intent.IntentHandler):
         vol.Optional("area"): cv.string,
     }
 
+    @override
     async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
         """Handle the intent."""
         hass = intent_obj.hass
@@ -1040,6 +1045,7 @@ class PauseTimerIntentHandler(intent.IntentHandler):
         vol.Optional("area"): cv.string,
     }
 
+    @override
     async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
         """Handle the intent."""
         hass = intent_obj.hass
@@ -1064,6 +1070,7 @@ class UnpauseTimerIntentHandler(intent.IntentHandler):
         vol.Optional("area"): cv.string,
     }
 
+    @override
     async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
         """Handle the intent."""
         hass = intent_obj.hass
@@ -1088,6 +1095,7 @@ class TimerStatusIntentHandler(intent.IntentHandler):
         vol.Optional("area"): cv.string,
     }
 
+    @override
     async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
         """Handle the intent."""
         hass = intent_obj.hass

--- a/homeassistant/components/intent_script/__init__.py
+++ b/homeassistant/components/intent_script/__init__.py
@@ -1,7 +1,7 @@
 """Handle intents with scripts."""
 
 import logging
-from typing import Any, TypedDict
+from typing import Any, TypedDict, override
 
 import voluptuous as vol
 
@@ -170,6 +170,7 @@ class ScriptIntentHandler(intent.IntentHandler):
         self.description = config.get(CONF_DESCRIPTION)
         self.platforms = config.get(CONF_PLATFORMS)
 
+    @override
     async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
         """Handle the intent."""
         speech: _IntentSpeechRepromptData | None = self.config.get(CONF_SPEECH)

--- a/homeassistant/components/intesishome/climate.py
+++ b/homeassistant/components/intesishome/climate.py
@@ -2,7 +2,7 @@
 
 import logging
 from random import randrange
-from typing import Any, NamedTuple
+from typing import Any, NamedTuple, override
 
 from pyintesishome import IHAuthenticationError, IHConnectionError, IntesisHome
 import voluptuous as vol
@@ -205,6 +205,7 @@ class IntesisAC(ClimateEntity):
                 ClimateEntityFeature.TURN_OFF | ClimateEntityFeature.TURN_ON
             )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Subscribe to event updates."""
         _LOGGER.debug("Added climate device with state: %s", repr(self._ih_device))
@@ -216,6 +217,7 @@ class IntesisAC(ClimateEntity):
             raise PlatformNotReady from ex
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the device specific state attributes."""
         attrs = {}
@@ -233,10 +235,12 @@ class IntesisAC(ClimateEntity):
         return attrs
 
     @property
+    @override
     def unique_id(self):
         """Return unique ID for this device."""
         return self._device_id
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         if hvac_mode := kwargs.get(ATTR_HVAC_MODE):
@@ -251,6 +255,7 @@ class IntesisAC(ClimateEntity):
         # flapping (API confirmation is slow)
         self.async_write_ha_state()
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set operation mode."""
         _LOGGER.debug("Setting %s to %s mode", self._device_type, hvac_mode)
@@ -279,6 +284,7 @@ class IntesisAC(ClimateEntity):
         self._hvac_mode = hvac_mode
         self.async_write_ha_state()
 
+    @override
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set fan mode (from quiet, low, medium, high, auto)."""
         await self._controller.set_fan_speed(self._device_id, fan_mode)
@@ -287,11 +293,13 @@ class IntesisAC(ClimateEntity):
         self._attr_fan_mode = fan_mode
         self.async_write_ha_state()
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set preset mode."""
         ih_preset_mode = MAP_PRESET_MODE_TO_IH.get(preset_mode)
         await self._controller.set_preset_mode(self._device_id, ih_preset_mode)
 
+    @override
     async def async_set_swing_mode(self, swing_mode: str) -> None:
         """Set the vertical vane."""
         if swing_settings := MAP_SWING_TO_IH.get(swing_mode):
@@ -339,11 +347,13 @@ class IntesisAC(ClimateEntity):
             self._device_id
         )
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Shutdown the controller when the device is being removed."""
         await self._controller.stop()
 
     @property
+    @override
     def icon(self) -> str | None:
         """Return the icon for the current state."""
         if self._power:
@@ -384,6 +394,7 @@ class IntesisAC(ClimateEntity):
             self.async_schedule_update_ha_state(True)
 
     @property
+    @override
     def swing_mode(self) -> str:
         """Return current swing mode."""
         if self._vvane == IH_SWING_SWING and self._hvane == IH_SWING_SWING:
@@ -397,11 +408,13 @@ class IntesisAC(ClimateEntity):
         return swing
 
     @property
+    @override
     def available(self) -> bool:
         """If the device hasn't been able to connect, mark as unavailable."""
         return self._connected or self._connected is None
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode:
         """Return the current mode of operation if unit is on."""
         if self._power:

--- a/homeassistant/components/iometer/binary_sensor.py
+++ b/homeassistant/components/iometer/binary_sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -82,6 +83,7 @@ class IOmeterBinarySensor(IOmeterEntity, BinarySensorEntity):
         self._attr_unique_id = f"{coordinator.identifier}_{description.key}"
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return the binary sensor state."""
         return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/iometer/config_flow.py
+++ b/homeassistant/components/iometer/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for the IOmeter integration."""
 
-from typing import Any, Final
+from typing import Any, Final, override
 
 from iometer import (
     IOmeterClient,
@@ -28,6 +28,7 @@ class IOMeterConfigFlow(ConfigFlow, domain=DOMAIN):
         self._host: str
         self._meter_number: str
 
+    @override
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:
@@ -68,6 +69,7 @@ class IOMeterConfigFlow(ConfigFlow, domain=DOMAIN):
             description_placeholders={"meter_number": self._meter_number},
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/iometer/coordinator.py
+++ b/homeassistant/components/iometer/coordinator.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
+from typing import override
 
 from iometer import IOmeterClient, IOmeterConnectionError, Reading, Status
 
@@ -56,6 +57,7 @@ class IOMeterCoordinator(DataUpdateCoordinator[IOmeterData]):
         self.client = client
         self.identifier = config_entry.entry_id
 
+    @override
     async def _async_update_data(self) -> IOmeterData:
         """Update data async."""
         try:

--- a/homeassistant/components/iometer/sensor.py
+++ b/homeassistant/components/iometer/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -161,6 +162,7 @@ class IOmeterSensor(IOmeterEntity, SensorEntity):
         self._attr_unique_id = f"{coordinator.identifier}_{description.key}"
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the sensor value."""
         return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/ios/notify.py
+++ b/homeassistant/components/ios/notify.py
@@ -2,7 +2,7 @@
 
 from http import HTTPStatus
 import logging
-from typing import Any
+from typing import Any, override
 
 import requests
 
@@ -71,10 +71,12 @@ class iOSNotificationService(BaseNotificationService):
         """Initialize the service."""
 
     @property
+    @override
     def targets(self) -> dict[str, str]:
         """Return a dictionary of registered targets."""
         return devices_with_push(self.hass)
 
+    @override
     def send_message(self, message: str = "", **kwargs: Any) -> None:
         """Send a message to the Lambda APNS gateway."""
         data: dict[str, Any] = {ATTR_MESSAGE: message}

--- a/homeassistant/components/ios/sensor.py
+++ b/homeassistant/components/ios/sensor.py
@@ -1,6 +1,6 @@
 """Support for Home Assistant iOS app sensors."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -95,6 +95,7 @@ class IOSSensor(SensorEntity):
         self._attr_unique_id = f"{description.key}_{device_id}"
 
     @property
+    @override
     def device_info(self) -> DeviceInfo:
         """Return information about the device."""
         return DeviceInfo(
@@ -111,6 +112,7 @@ class IOSSensor(SensorEntity):
         )
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the device state attributes."""
         device = self._device[ATTR_DEVICE]
@@ -124,6 +126,7 @@ class IOSSensor(SensorEntity):
         }
 
     @property
+    @override
     def icon(self) -> str:
         """Return the icon to use in the frontend, if any."""
         device_battery = self._device[ATTR_BATTERY]
@@ -155,6 +158,7 @@ class IOSSensor(SensorEntity):
         ]
         self.async_write_ha_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Handle addition to hass: register to dispatch."""
         self._attr_native_value = self._device[ATTR_BATTERY][

--- a/homeassistant/components/iotawatt/config_flow.py
+++ b/homeassistant/components/iotawatt/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for iotawatt integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from iotawattpy.iotawatt import Iotawatt
 import voluptuous as vol
@@ -49,6 +49,7 @@ class IOTaWattConfigFlow(ConfigFlow, domain=DOMAIN):
         """Initialize."""
         self._data: dict[str, Any] = {}
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/iotawatt/coordinator.py
+++ b/homeassistant/components/iotawatt/coordinator.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime, timedelta
 import logging
+from typing import override
 
 from iotawattpy.iotawatt import Iotawatt
 
@@ -54,6 +55,7 @@ class IotawattUpdater(DataUpdateCoordinator):
         if self._last_run is None or last_run > self._last_run:
             self._last_run = last_run
 
+    @override
     async def _async_update_data(self):
         """Fetch sensors from IoTaWatt device."""
         if self.api is None:

--- a/homeassistant/components/iotawatt/sensor.py
+++ b/homeassistant/components/iotawatt/sensor.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 import logging
+from typing import override
 
 from iotawattpy.sensor import Sensor
 
@@ -175,11 +176,13 @@ class IotaWattSensor(CoordinatorEntity[IotawattUpdater], SensorEntity):
         return self.coordinator.data["sensors"][self._key]
 
     @property
+    @override
     def name(self) -> str | None:
         """Return name of the entity."""
         return self._sensor_data.getName()
 
     @property
+    @override
     def device_info(self) -> dr.DeviceInfo:
         """Return device info."""
         return dr.DeviceInfo(
@@ -191,6 +194,7 @@ class IotaWattSensor(CoordinatorEntity[IotawattUpdater], SensorEntity):
         )
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         if self._key not in self.coordinator.data["sensors"]:
@@ -208,6 +212,7 @@ class IotaWattSensor(CoordinatorEntity[IotawattUpdater], SensorEntity):
         super()._handle_coordinator_update()
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, str]:
         """Return the extra state attributes of the entity."""
         data = self._sensor_data
@@ -218,6 +223,7 @@ class IotaWattSensor(CoordinatorEntity[IotawattUpdater], SensorEntity):
         return attrs
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
         if func := self.entity_description.value:

--- a/homeassistant/components/iotty/api.py
+++ b/homeassistant/components/iotty/api.py
@@ -1,6 +1,6 @@
 """API for iotty bound to Home Assistant OAuth."""
 
-from typing import Any
+from typing import Any, override
 
 from aiohttp import ClientSession
 from iottycloud.cloudapi import CloudApi
@@ -29,6 +29,7 @@ class IottyProxy(CloudApi):
         self._oauth_session = oauth_session
         self._hass = hass
 
+    @override
     async def async_get_access_token(self) -> Any:
         """Return a valid access token."""
         await self._oauth_session.async_ensure_token_valid()

--- a/homeassistant/components/iotty/config_flow.py
+++ b/homeassistant/components/iotty/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow for iotty."""
 
 import logging
+from typing import override
 
 from homeassistant.helpers import config_entry_oauth2_flow
 
@@ -15,6 +16,7 @@ class OAuth2FlowHandler(
     DOMAIN = DOMAIN
 
     @property
+    @override
     def logger(self) -> logging.Logger:
         """Return logger."""
         return logging.getLogger(__name__)

--- a/homeassistant/components/iotty/coordinator.py
+++ b/homeassistant/components/iotty/coordinator.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
+from typing import override
 
 from iottycloud.device import Device
 from iottycloud.shutter import Shutter
@@ -70,12 +71,14 @@ class IottyDataUpdateCoordinator(DataUpdateCoordinator[IottyData]):
         )
         self._device_registry = dr.async_get(hass)
 
+    @override
     async def _async_setup(self) -> None:
         """Get devices."""
         _LOGGER.debug("Fetching devices list from iottyCloud")
         self._devices = await self.iotty.get_devices()
         _LOGGER.debug("There are %d devices", len(self._devices))
 
+    @override
     async def _async_update_data(self) -> IottyData:
         """Fetch data from iottyCloud device."""
         _LOGGER.debug("Fetching devices status from iottyCloud")

--- a/homeassistant/components/iotty/cover.py
+++ b/homeassistant/components/iotty/cover.py
@@ -1,7 +1,7 @@
 """Implement a iotty Shutter Device."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from iottycloud.device import Device
 from iottycloud.shutter import Shutter, ShutterState
@@ -109,6 +109,7 @@ class IottyShutter(IottyEntity, CoverEntity):
         super().__init__(coordinator, iotty_cloud, iotty_device)
 
     @property
+    @override
     def current_cover_position(self) -> int | None:
         """Return the current position of the shutter.
 
@@ -117,6 +118,7 @@ class IottyShutter(IottyEntity, CoverEntity):
         return self._iotty_device.percentage
 
     @property
+    @override
     def is_closed(self) -> bool:
         """Return true if the Shutter is closed."""
         _LOGGER.debug(
@@ -131,20 +133,24 @@ class IottyShutter(IottyEntity, CoverEntity):
         )
 
     @property
+    @override
     def is_opening(self) -> bool:
         """Return true if the Shutter is opening."""
         return self._iotty_device.status is ShutterState.OPENING
 
     @property
+    @override
     def is_closing(self) -> bool:
         """Return true if the Shutter is closing."""
         return self._iotty_device.status is ShutterState.CLOSING
 
     @property
+    @override
     def supported_features(self) -> CoverEntityFeature:
         """Flag supported features."""
         return self._attr_supported_features
 
+    @override
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
         await self._iotty_cloud.command(
@@ -152,6 +158,7 @@ class IottyShutter(IottyEntity, CoverEntity):
         )
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close cover."""
         await self._iotty_cloud.command(
@@ -159,6 +166,7 @@ class IottyShutter(IottyEntity, CoverEntity):
         )
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
         percentage = kwargs[ATTR_POSITION]
@@ -169,6 +177,7 @@ class IottyShutter(IottyEntity, CoverEntity):
         )
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
         await self._iotty_cloud.command(
@@ -177,6 +186,7 @@ class IottyShutter(IottyEntity, CoverEntity):
         await self.coordinator.async_request_refresh()
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
 

--- a/homeassistant/components/iotty/switch.py
+++ b/homeassistant/components/iotty/switch.py
@@ -1,7 +1,7 @@
 """Implement a iotty Light Switch Device."""
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from iottycloud.lightswitch import LightSwitch
 from iottycloud.outlet import Outlet
@@ -157,6 +157,7 @@ class IottySwitch(IottyEntity, SwitchEntity):
         self._attr_device_class = entity_description.device_class
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if the Switch is on."""
         _LOGGER.debug(
@@ -166,12 +167,14 @@ class IottySwitch(IottyEntity, SwitchEntity):
         )
         return self._iotty_device.is_on
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the Switch on."""
         _LOGGER.debug("[%s] Turning on", self._iotty_device.device_id)
         await self._iotty_cloud.command(self._iotty_device.device_id, COMMAND_TURNON)
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the Switch off."""
         _LOGGER.debug("[%s] Turning off", self._iotty_device.device_id)
@@ -179,6 +182,7 @@ class IottySwitch(IottyEntity, SwitchEntity):
         await self.coordinator.async_request_refresh()
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
 

--- a/homeassistant/components/iperf3/sensor.py
+++ b/homeassistant/components/iperf3/sensor.py
@@ -1,6 +1,6 @@
 """Support for Iperf3 sensors."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
 from homeassistant.const import CONF_MONITORED_CONDITIONS
@@ -50,6 +50,7 @@ class Iperf3Sensor(RestoreEntity, SensorEntity):
         self._attr_name = f"{description.name} {iperf3_data.host}"
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         return {
@@ -59,6 +60,7 @@ class Iperf3Sensor(RestoreEntity, SensorEntity):
             ATTR_VERSION: self._iperf3_data.data[ATTR_VERSION],
         }
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Handle entity which will be added."""
         await super().async_added_to_hass()

--- a/homeassistant/components/ipma/config_flow.py
+++ b/homeassistant/components/ipma/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow to configure IPMA component."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyipma import IPMAException
 from pyipma.api import IPMA_API
@@ -23,6 +23,7 @@ class IpmaFlowHandler(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/ipma/weather.py
+++ b/homeassistant/components/ipma/weather.py
@@ -3,7 +3,7 @@
 import asyncio
 import contextlib
 import logging
-from typing import Literal
+from typing import Literal, override
 
 from pyipma.api import IPMA_API
 from pyipma.forecast import Forecast as IPMAForecast
@@ -131,6 +131,7 @@ class IPMAWeather(WeatherEntity, IPMADevice):
         return CONDITION_MAP.get(identifier)
 
     @property
+    @override
     def condition(self) -> str | None:
         """Return the current condition.
 
@@ -144,6 +145,7 @@ class IPMAWeather(WeatherEntity, IPMADevice):
         return self._condition_conversion(forecast[0].weather_type.id, None)
 
     @property
+    @override
     def native_temperature(self) -> float | None:
         """Return the current temperature."""
         if not self._observation:
@@ -152,6 +154,7 @@ class IPMAWeather(WeatherEntity, IPMADevice):
         return self._observation.temperature
 
     @property
+    @override
     def native_pressure(self) -> float | None:
         """Return the current pressure."""
         if not self._observation:
@@ -160,6 +163,7 @@ class IPMAWeather(WeatherEntity, IPMADevice):
         return self._observation.pressure
 
     @property
+    @override
     def humidity(self) -> float | None:
         """Return the name of the sensor."""
         if not self._observation:
@@ -168,6 +172,7 @@ class IPMAWeather(WeatherEntity, IPMADevice):
         return self._observation.humidity
 
     @property
+    @override
     def native_wind_speed(self) -> float | None:
         """Return the current windspeed."""
         if not self._observation:
@@ -176,6 +181,7 @@ class IPMAWeather(WeatherEntity, IPMADevice):
         return self._observation.wind_intensity_km
 
     @property
+    @override
     def wind_bearing(self) -> float | None:
         """Return the current wind bearing (degrees)."""
         if not self._observation:
@@ -215,11 +221,13 @@ class IPMAWeather(WeatherEntity, IPMADevice):
             async with asyncio.timeout(10):
                 await self._update_forecast(forecast_type, period, False)
 
+    @override
     async def async_forecast_daily(self) -> list[Forecast]:
         """Return the daily forecast in native units."""
         await self._try_update_forecast("daily", 24)
         return self._forecast(self._daily_forecast)
 
+    @override
     async def async_forecast_hourly(self) -> list[Forecast]:
         """Return the hourly forecast in native units."""
         await self._try_update_forecast("hourly", 1)

--- a/homeassistant/components/ipp/config_flow.py
+++ b/homeassistant/components/ipp/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow to configure the IPP integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyipp import (
     IPP,
@@ -61,6 +61,7 @@ class IPPFlowHandler(ConfigFlow, domain=DOMAIN):
         """Set up the instance."""
         self.discovery_info: dict[str, Any] = {}
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -100,6 +101,7 @@ class IPPFlowHandler(ConfigFlow, domain=DOMAIN):
 
         return self.async_create_entry(title=user_input[CONF_HOST], data=user_input)
 
+    @override
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/ipp/coordinator.py
+++ b/homeassistant/components/ipp/coordinator.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import logging
+from typing import override
 
 from pyipp import IPP, IPPError, Printer as IPPPrinter
 
@@ -45,6 +46,7 @@ class IPPDataUpdateCoordinator(DataUpdateCoordinator[IPPPrinter]):
             update_interval=SCAN_INTERVAL,
         )
 
+    @override
     async def _async_update_data(self) -> IPPPrinter:
         """Fetch data from IPP."""
         try:

--- a/homeassistant/components/ipp/sensor.py
+++ b/homeassistant/components/ipp/sensor.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any
+from typing import Any, override
 
 from pyipp import Marker, Printer
 
@@ -132,11 +132,13 @@ class IPPSensor(IPPEntity, SensorEntity):
     entity_description: IPPSensorEntityDescription
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the entity."""
         return self.entity_description.attributes_fn(self.coordinator.data)
 
     @property
+    @override
     def native_value(self) -> StateType | datetime:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/iqvia/config_flow.py
+++ b/homeassistant/components/iqvia/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow to configure the IQVIA component."""
 
-from typing import Any
+from typing import Any, override
 
 from pyiqvia import Client
 from pyiqvia.errors import InvalidZipError
@@ -21,6 +21,7 @@ class IqviaConfigFlow(ConfigFlow, domain=DOMAIN):
         """Initialize the config flow."""
         self.data_schema = vol.Schema({vol.Required(CONF_ZIP_CODE): str})
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/iqvia/coordinator.py
+++ b/homeassistant/components/iqvia/coordinator.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable, Coroutine
 from datetime import timedelta
-from typing import Any
+from typing import Any, override
 
 from pyiqvia.errors import IQVIAError
 
@@ -39,6 +39,7 @@ class IqviaUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         )
         self._update_method = update_method
 
+    @override
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from the API."""
         try:

--- a/homeassistant/components/iqvia/entity.py
+++ b/homeassistant/components/iqvia/entity.py
@@ -1,5 +1,7 @@
 """Support for IQVIA."""
 
+from typing import override
+
 from homeassistant.core import callback
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -28,6 +30,7 @@ class IQVIAEntity(CoordinatorEntity[IqviaUpdateCoordinator]):
         self.entity_description = description
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         if not self.coordinator.last_update_success:
@@ -36,6 +39,7 @@ class IQVIAEntity(CoordinatorEntity[IqviaUpdateCoordinator]):
         self.update_from_latest_data()
         self.async_write_ha_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
         await super().async_added_to_hass()

--- a/homeassistant/components/iqvia/sensor.py
+++ b/homeassistant/components/iqvia/sensor.py
@@ -1,7 +1,7 @@
 """Support for IQVIA sensors."""
 
 from statistics import mean
-from typing import Any, NamedTuple, cast
+from typing import Any, NamedTuple, cast, override
 
 import numpy as np
 
@@ -176,6 +176,7 @@ class ForecastSensor(IQVIAEntity, SensorEntity):
     """Define sensor related to forecast data."""
 
     @callback
+    @override
     def update_from_latest_data(self) -> None:
         """Update the sensor."""
         if not self.available:
@@ -221,6 +222,7 @@ class IndexSensor(IQVIAEntity, SensorEntity):
     """Define sensor related to indices."""
 
     @callback
+    @override
     def update_from_latest_data(self) -> None:
         """Update the sensor."""
         if not self.coordinator.last_update_success:

--- a/homeassistant/components/irish_rail_transport/sensor.py
+++ b/homeassistant/components/irish_rail_transport/sensor.py
@@ -1,7 +1,7 @@
 """Support for Irish Rail RTPI information."""
 
 from datetime import timedelta
-from typing import Any
+from typing import Any, override
 
 from pyirishrail.pyirishrail import IrishRailRTPI
 import voluptuous as vol
@@ -93,16 +93,19 @@ class IrishRailTransportSensor(SensorEntity):
         self._times = []
 
     @property
+    @override
     def name(self):
         """Return the name of the sensor."""
         return self._name
 
     @property
+    @override
     def native_value(self):
         """Return the state of the sensor."""
         return self._state
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return the state attributes."""
         if self._times:
@@ -129,6 +132,7 @@ class IrishRailTransportSensor(SensorEntity):
         return None
 
     @property
+    @override
     def native_unit_of_measurement(self):
         """Return the unit this state is expressed in."""
         return UnitOfTime.MINUTES

--- a/homeassistant/components/irm_kmi/config_flow.py
+++ b/homeassistant/components/irm_kmi/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow to set up IRM KMI integration via the UI."""
 
 import logging
+from typing import override
 
 from irm_kmi_api import IrmKmiApiClient, IrmKmiApiError
 import voluptuous as vol
@@ -45,10 +46,12 @@ class IrmKmiConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(_config_entry: IrmKmiConfigEntry) -> OptionsFlow:
         """Create the options flow."""
         return IrmKmiOptionFlow()
 
+    @override
     async def async_step_user(self, user_input: dict | None = None) -> ConfigFlowResult:
         """Define the user step of the configuration flow."""
         errors: dict = {}

--- a/homeassistant/components/irm_kmi/coordinator.py
+++ b/homeassistant/components/irm_kmi/coordinator.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import logging
+from typing import override
 
 from irm_kmi_api import IrmKmiApiClientHa, IrmKmiApiError
 
@@ -43,6 +44,7 @@ class IrmKmiCoordinator(TimestampDataUpdateCoordinator[ProcessedCoordinatorData]
         self._api = api_client
         self._location = entry.data[CONF_LOCATION]
 
+    @override
     async def _async_update_data(self) -> ProcessedCoordinatorData:
         """Fetch data from API endpoint.
 

--- a/homeassistant/components/irm_kmi/weather.py
+++ b/homeassistant/components/irm_kmi/weather.py
@@ -1,5 +1,7 @@
 """Support for IRM KMI weather."""
 
+from typing import override
+
 from irm_kmi_api import CurrentWeatherData
 
 from homeassistant.components.weather import (
@@ -58,6 +60,7 @@ class IrmKmiWeather(
         self._attr_unique_id = entry.data[CONF_UNIQUE_ID]
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available."""
         return super().available
@@ -68,48 +71,58 @@ class IrmKmiWeather(
         return self.coordinator.data.current_weather
 
     @property
+    @override
     def condition(self) -> str | None:
         """Return the current condition."""
         return self.current_weather.get("condition")
 
     @property
+    @override
     def native_temperature(self) -> float | None:
         """Return the temperature in native units."""
         return self.current_weather.get("temperature")
 
     @property
+    @override
     def native_wind_speed(self) -> float | None:
         """Return the wind speed in native units."""
         return self.current_weather.get("wind_speed")
 
     @property
+    @override
     def native_wind_gust_speed(self) -> float | None:
         """Return the wind gust speed in native units."""
         return self.current_weather.get("wind_gust_speed")
 
     @property
+    @override
     def wind_bearing(self) -> float | str | None:
         """Return the wind bearing."""
         return self.current_weather.get("wind_bearing")
 
     @property
+    @override
     def native_pressure(self) -> float | None:
         """Return the pressure in native units."""
         return self.current_weather.get("pressure")
 
     @property
+    @override
     def uv_index(self) -> float | None:
         """Return the UV index."""
         return self.current_weather.get("uv_index")
 
+    @override
     def _async_forecast_twice_daily(self) -> list[Forecast] | None:
         """Return the daily forecast in native units."""
         return self.coordinator.data.daily_forecast
 
+    @override
     def _async_forecast_daily(self) -> list[Forecast] | None:
         """Return the daily forecast in native units."""
         return self.daily_forecast()
 
+    @override
     def _async_forecast_hourly(self) -> list[Forecast] | None:
         """Return the hourly forecast in native units."""
         return self.coordinator.data.hourly_forecast

--- a/homeassistant/components/iron_os/binary_sensor.py
+++ b/homeassistant/components/iron_os/binary_sensor.py
@@ -1,6 +1,7 @@
 """Binary sensor platform for IronOS integration."""
 
 from enum import StrEnum
+from typing import override
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -47,6 +48,7 @@ class IronOSBinarySensorEntity(IronOSBaseEntity, BinarySensorEntity):
     coordinator: IronOSLiveDataCoordinator
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
         return self.coordinator.has_tip

--- a/homeassistant/components/iron_os/button.py
+++ b/homeassistant/components/iron_os/button.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 from enum import StrEnum
+from typing import override
 
 from pynecil import CharSetting
 
@@ -77,6 +78,7 @@ class IronOSButtonEntity(IronOSBaseEntity, ButtonEntity):
 
         self.settings = coordinators.settings
 
+    @override
     async def async_press(self) -> None:
         """Handle the button press."""
 

--- a/homeassistant/components/iron_os/config_flow.py
+++ b/homeassistant/components/iron_os/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for IronOS integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from bleak.exc import BleakError
 from habluetooth import BluetoothServiceInfoBleak
@@ -25,6 +25,7 @@ class IronOSConfigFlow(ConfigFlow, domain=DOMAIN):
         self._discovery_info: BluetoothServiceInfoBleak | None = None
         self._discovered_devices: dict[str, str] = {}
 
+    @override
     async def async_step_bluetooth(
         self, discovery_info: BluetoothServiceInfoBleak
     ) -> ConfigFlowResult:
@@ -70,6 +71,7 @@ class IronOSConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/iron_os/coordinator.py
+++ b/homeassistant/components/iron_os/coordinator.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 from enum import Enum
 import logging
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, cast, override
 
 from awesomeversion import AwesomeVersion
 from pynecil import (
@@ -77,6 +77,7 @@ class IronOSBaseCoordinator[_DataT](DataUpdateCoordinator[_DataT]):
         self.device = device
         self.v223_features = False
 
+    @override
     async def _async_setup(self) -> None:
         """Set up the coordinator."""
         try:
@@ -101,6 +102,7 @@ class IronOSLiveDataCoordinator(IronOSBaseCoordinator[LiveDataResponse]):
         super().__init__(hass, config_entry, device, SCAN_INTERVAL)
         self.device_info = DeviceInfoResponse()
 
+    @override
     async def _async_update_data(self) -> LiveDataResponse:
         """Fetch data from Device."""
 
@@ -161,6 +163,7 @@ class IronOSSettingsCoordinator(IronOSBaseCoordinator[SettingsDataResponse]):
         """Initialize IronOS coordinator."""
         super().__init__(hass, config_entry, device, SCAN_INTERVAL_SETTINGS)
 
+    @override
     async def _async_update_data(self) -> SettingsDataResponse:
         """Fetch data from Device."""
 
@@ -213,6 +216,7 @@ class IronOSFirmwareUpdateCoordinator(DataUpdateCoordinator[LatestRelease]):
         )
         self.github = github
 
+    @override
     async def _async_update_data(self) -> LatestRelease:
         """Fetch data from Github."""
 

--- a/homeassistant/components/iron_os/entity.py
+++ b/homeassistant/components/iron_os/entity.py
@@ -1,6 +1,6 @@
 """Base entity for IronOS integration."""
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
@@ -48,6 +48,7 @@ class IronOSBaseEntity(CoordinatorEntity[IronOSLiveDataCoordinator]):
             )
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return super().available and self.coordinator.device.is_connected

--- a/homeassistant/components/iron_os/number.py
+++ b/homeassistant/components/iron_os/number.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
+from typing import override
 
 from pynecil import CharSetting, LiveDataResponse, SettingsDataResponse, TempUnit
 
@@ -406,6 +407,7 @@ class IronOSNumberEntity(IronOSBaseEntity, NumberEntity):
 
         self.settings = coordinators.settings
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
         if raw_value_fn := self.entity_description.raw_value_fn:
@@ -414,12 +416,14 @@ class IronOSNumberEntity(IronOSBaseEntity, NumberEntity):
         await self.settings.write(self.entity_description.characteristic, value)
 
     @property
+    @override
     def native_value(self) -> float | int | None:
         """Return sensor state."""
         return self.entity_description.value_fn(
             self.coordinator.data, self.settings.data
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
 
@@ -436,6 +440,7 @@ class IronOSTemperatureNumberEntity(IronOSNumberEntity):
     """Implementation of a IronOS temperature number entity."""
 
     @property
+    @override
     def native_unit_of_measurement(self) -> str | None:
         """Return the unit of measurement of the sensor, if any."""
 
@@ -446,6 +451,7 @@ class IronOSTemperatureNumberEntity(IronOSNumberEntity):
         )
 
     @property
+    @override
     def native_min_value(self) -> float:
         """Return the minimum value."""
 
@@ -457,6 +463,7 @@ class IronOSTemperatureNumberEntity(IronOSNumberEntity):
         )
 
     @property
+    @override
     def native_max_value(self) -> float:
         """Return the maximum value."""
 
@@ -468,6 +475,7 @@ class IronOSTemperatureNumberEntity(IronOSNumberEntity):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available."""
         if (
@@ -482,6 +490,7 @@ class IronOSSetpointNumberEntity(IronOSTemperatureNumberEntity):
     """IronOS setpoint temperature entity."""
 
     @property
+    @override
     def native_max_value(self) -> float:
         """Return the maximum value."""
 

--- a/homeassistant/components/iron_os/select.py
+++ b/homeassistant/components/iron_os/select.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum, StrEnum
+from typing import override
 
 from pynecil import (
     AnimationSpeed,
@@ -210,11 +211,13 @@ class IronOSSelectEntity(IronOSBaseEntity, SelectEntity):
         self.settings = coordinators.settings
 
     @property
+    @override
     def current_option(self) -> str | None:
         """Return the selected entity option to represent the entity state."""
 
         return self.entity_description.value_fn(self.settings.data)
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
 
@@ -223,6 +226,7 @@ class IronOSSelectEntity(IronOSBaseEntity, SelectEntity):
             self.entity_description.raw_value_fn(option),
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
 

--- a/homeassistant/components/iron_os/sensor.py
+++ b/homeassistant/components/iron_os/sensor.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from enum import StrEnum
+from typing import override
 
 from pynecil import LiveDataResponse, OperatingMode, PowerSource
 
@@ -206,6 +207,7 @@ class IronOSSensorEntity(IronOSBaseEntity, SensorEntity):
     coordinator: IronOSLiveDataCoordinator
 
     @property
+    @override
     def native_value(self) -> StateType | datetime:
         """Return sensor state."""
         return self.entity_description.value_fn(

--- a/homeassistant/components/iron_os/switch.py
+++ b/homeassistant/components/iron_os/switch.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Any
+from typing import Any, override
 
 from pynecil import CharSetting, SettingsDataResponse, TempUnit
 
@@ -135,12 +135,14 @@ class IronOSSwitchEntity(IronOSBaseEntity, SwitchEntity):
         self.settings = coordinators.settings
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return the state of the device."""
         return self.entity_description.is_on_fn(
             self.settings.data,
         )
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         if self.entity_description.key is IronOSSwitch.BOOST:
@@ -153,10 +155,12 @@ class IronOSSwitchEntity(IronOSBaseEntity, SwitchEntity):
         else:
             await self.settings.write(self.entity_description.characteristic, True)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         await self.settings.write(self.entity_description.characteristic, False)
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
 

--- a/homeassistant/components/iron_os/update.py
+++ b/homeassistant/components/iron_os/update.py
@@ -1,5 +1,7 @@
 """Update platform for IronOS integration."""
 
+from typing import override
+
 from homeassistant.components.update import (
     ATTR_INSTALLED_VERSION,
     UpdateDeviceClass,
@@ -55,34 +57,40 @@ class IronOSUpdate(IronOSBaseEntity, UpdateEntity, RestoreEntity):
         super().__init__(coordinator, entity_description)
 
     @property
+    @override
     def installed_version(self) -> str | None:
         """IronOS version on the device."""
 
         return self.coordinator.device_info.build or self._attr_installed_version
 
     @property
+    @override
     def title(self) -> str | None:
         """Title of the IronOS release."""
 
         return f"IronOS {self.firmware_update.data.name}"
 
     @property
+    @override
     def release_url(self) -> str | None:
         """URL to the full release notes of the latest IronOS version available."""
 
         return self.firmware_update.data.html_url
 
     @property
+    @override
     def latest_version(self) -> str | None:
         """Latest IronOS version available for install."""
 
         return self.firmware_update.data.tag_name
 
+    @override
     async def async_release_notes(self) -> str | None:
         """Return the release notes."""
 
         return self.firmware_update.data.body
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass.
 
@@ -97,6 +105,7 @@ class IronOSUpdate(IronOSBaseEntity, UpdateEntity, RestoreEntity):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return (

--- a/homeassistant/components/iskra/config_flow.py
+++ b/homeassistant/components/iskra/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for iskra integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyiskra.adapters import Modbus, RestAPI
 from pyiskra.exceptions import (
@@ -117,6 +117,7 @@ class IskraConfigFlowFlow(ConfigFlow, domain=DOMAIN):
     host: str
     protocol: str
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/iskra/coordinator.py
+++ b/homeassistant/components/iskra/coordinator.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import logging
+from typing import override
 
 from pyiskra.devices import Device
 from pyiskra.exceptions import (
@@ -41,6 +42,7 @@ class IskraDataUpdateCoordinator(DataUpdateCoordinator[None]):
             update_interval=timedelta(seconds=60),
         )
 
+    @override
     async def _async_update_data(self) -> None:
         """Fetch data from Iskra device."""
         try:

--- a/homeassistant/components/iskra/sensor.py
+++ b/homeassistant/components/iskra/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass, replace
+from typing import override
 
 from pyiskra.devices import Device
 from pyiskra.helper import Counter, CounterType
@@ -279,6 +280,7 @@ class IskraSensor(IskraEntity, SensorEntity):
         self._attr_unique_id = f"{coordinator.device.serial}_{description.key}"
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the state of the sensor."""
         return self.entity_description.value_func(self.device)

--- a/homeassistant/components/islamic_prayer_times/config_flow.py
+++ b/homeassistant/components/islamic_prayer_times/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for Islamic Prayer Times integration."""
 
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -46,12 +46,14 @@ class IslamicPrayerFlowHandler(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> IslamicPrayerOptionsFlowHandler:
         """Get the options flow for this handler."""
         return IslamicPrayerOptionsFlowHandler()
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/islamic_prayer_times/coordinator.py
+++ b/homeassistant/components/islamic_prayer_times/coordinator.py
@@ -2,7 +2,7 @@
 
 from datetime import date, datetime, timedelta
 import logging
-from typing import Any, cast
+from typing import Any, cast, override
 
 from prayer_times_calculator_offline import PrayerTimesCalculator
 
@@ -112,6 +112,7 @@ class IslamicPrayerDataUpdateCoordinator(DataUpdateCoordinator[dict[str, datetim
         """Request update from coordinator."""
         await self.async_request_refresh()
 
+    @override
     async def _async_update_data(self) -> dict[str, datetime]:
         """Update sensors with new prayer times.
 

--- a/homeassistant/components/islamic_prayer_times/sensor.py
+++ b/homeassistant/components/islamic_prayer_times/sensor.py
@@ -1,6 +1,7 @@
 """Platform to retrieve Islamic prayer times information for Home Assistant."""
 
 from datetime import datetime
+from typing import override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -86,6 +87,7 @@ class IslamicPrayerTimeSensor(
         )
 
     @property
+    @override
     def native_value(self) -> datetime:
         """Return the state of the sensor."""
         return self.coordinator.data[self.entity_description.key]

--- a/homeassistant/components/israel_rail/config_flow.py
+++ b/homeassistant/components/israel_rail/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for israel rail."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from israelrailapi import TrainSchedule
 from israelrailapi.stations import STATIONS
@@ -29,6 +29,7 @@ class IsraelRailConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/israel_rail/coordinator.py
+++ b/homeassistant/components/israel_rail/coordinator.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 from datetime import datetime
 import logging
+from typing import override
 
 from israelrailapi import TrainSchedule
 from israelrailapi.api import TrainRoute
@@ -65,6 +66,7 @@ class IsraelRailDataUpdateCoordinator(DataUpdateCoordinator[list[DataConnection]
         self._start = start
         self._destination = destination
 
+    @override
     async def _async_update_data(self) -> list[DataConnection]:
         try:
             train_routes = await self.hass.async_add_executor_job(

--- a/homeassistant/components/israel_rail/sensor.py
+++ b/homeassistant/components/israel_rail/sensor.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -139,6 +139,7 @@ class IsraelRailEntitySensor(
         self._attr_unique_id = f"{unique_id}_{entity_description.key}"
 
     @property
+    @override
     def native_value(self) -> StateType | datetime:
         """Return the state of the sensor."""
         if self.entity_description.index >= len(self.coordinator.data):

--- a/homeassistant/components/iss/config_flow.py
+++ b/homeassistant/components/iss/config_flow.py
@@ -1,5 +1,7 @@
 """Config flow to configure iss component."""
 
+from typing import override
+
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult, OptionsFlow
@@ -17,12 +19,14 @@ class ISSConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: IssConfigEntry,
     ) -> OptionsFlowHandler:
         """Get the options flow for this handler."""
         return OptionsFlowHandler()
 
+    @override
     async def async_step_user(self, user_input=None) -> ConfigFlowResult:
         """Handle a flow initialized by the user."""
         if user_input is not None:

--- a/homeassistant/components/iss/coordinator.py
+++ b/homeassistant/components/iss/coordinator.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
+from typing import override
 
 import pyiss
 import requests
@@ -51,6 +52,7 @@ class IssDataUpdateCoordinator(DataUpdateCoordinator[IssData]):
             current_location=self.iss.current_location(),
         )
 
+    @override
     async def _async_update_data(self) -> IssData:
         """Fetch data from the ISS API, tolerating transient failures."""
         try:

--- a/homeassistant/components/iss/sensor.py
+++ b/homeassistant/components/iss/sensor.py
@@ -1,7 +1,7 @@
 """Support for iss sensor."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE, CONF_SHOW_ON_MAP
@@ -52,11 +52,13 @@ class IssSensor(CoordinatorEntity[IssDataUpdateCoordinator], SensorEntity):
         )
 
     @property
+    @override
     def native_value(self) -> int:
         """Return number of people in space."""
         return self.coordinator.data.number_of_people_in_space
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         attrs = {}

--- a/homeassistant/components/ista_ecotrend/config_flow.py
+++ b/homeassistant/components/ista_ecotrend/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from pyecotrend_ista import KeycloakError, LoginError, PyEcotrendIsta, ServerError
 import voluptuous as vol
@@ -40,6 +40,7 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
 class IstaConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for ista EcoTrend."""
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/ista_ecotrend/coordinator.py
+++ b/homeassistant/components/ista_ecotrend/coordinator.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyecotrend_ista import KeycloakError, LoginError, PyEcotrendIsta, ServerError
 
@@ -38,6 +38,7 @@ class IstaCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         )
         self.ista = ista
 
+    @override
     async def _async_setup(self) -> None:
         """Set up the ista EcoTrend coordinator."""
 
@@ -57,6 +58,7 @@ class IstaCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 },
             ) from e
 
+    @override
     async def _async_update_data(self):
         """Fetch ista EcoTrend data."""
 

--- a/homeassistant/components/ista_ecotrend/sensor.py
+++ b/homeassistant/components/ista_ecotrend/sensor.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 import datetime
 from enum import StrEnum
 import logging
+from typing import override
 
 from homeassistant.components.recorder.models import StatisticMeanType
 from homeassistant.components.recorder.models.statistics import (
@@ -199,6 +200,7 @@ class IstaSensor(CoordinatorEntity[IstaCoordinator], SensorEntity):
         )
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the state of the device."""
 
@@ -208,6 +210,7 @@ class IstaSensor(CoordinatorEntity[IstaCoordinator], SensorEntity):
             value_type=self.entity_description.value_type,
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When added to hass."""
         # Perform initial statistics import when sensor is
@@ -217,6 +220,7 @@ class IstaSensor(CoordinatorEntity[IstaCoordinator], SensorEntity):
         await self.update_statistics()
         await super().async_added_to_hass()
 
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle coordinator update."""
         asyncio.run_coroutine_threadsafe(self.update_statistics(), self.hass.loop)

--- a/homeassistant/components/isy994/binary_sensor.py
+++ b/homeassistant/components/isy994/binary_sensor.py
@@ -1,7 +1,7 @@
 """Support for ISY binary sensors."""
 
 from datetime import datetime, timedelta
-from typing import Any
+from typing import Any, override
 
 from pyisy.constants import (
     CMD_OFF,
@@ -252,6 +252,7 @@ class ISYBinarySensorEntity(ISYNodeEntity, BinarySensorEntity):
         self._attr_device_class = force_device_class
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Get whether the ISY binary sensor device is on."""
         if self._node.status == ISY_VALUE_UNKNOWN:
@@ -286,6 +287,7 @@ class ISYInsteonBinarySensorEntity(ISYBinarySensorEntity):
             self._computed_state = bool(self._node.status)
             self._status_was_unknown = False
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Subscribe to the node and subnode event emitters."""
         await super().async_added_to_hass()
@@ -369,6 +371,7 @@ class ISYInsteonBinarySensorEntity(ISYBinarySensorEntity):
             self._async_heartbeat()
 
     @callback
+    @override
     def async_on_update(self, event: NodeProperty) -> None:
         """Primary node status updates.
 
@@ -386,6 +389,7 @@ class ISYInsteonBinarySensorEntity(ISYBinarySensorEntity):
             self._async_heartbeat()
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Get whether the ISY binary sensor device is on.
 
@@ -439,6 +443,7 @@ class ISYBinarySensorHeartbeat(ISYNodeEntity, BinarySensorEntity, RestoreEntity)
         if self.state is None:
             self._computed_state = False
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Subscribe to the node and subnode event emitters."""
         await super().async_added_to_hass()
@@ -492,6 +497,7 @@ class ISYBinarySensorHeartbeat(ISYNodeEntity, BinarySensorEntity, RestoreEntity)
         )
 
     @callback
+    @override
     def async_on_update(self, event: object) -> None:
         """Ignore node status updates.
 
@@ -499,6 +505,7 @@ class ISYBinarySensorHeartbeat(ISYNodeEntity, BinarySensorEntity, RestoreEntity)
         """
 
     @property
+    @override
     def is_on(self) -> bool:
         """Get whether the ISY binary sensor device is on.
 
@@ -509,6 +516,7 @@ class ISYBinarySensorHeartbeat(ISYNodeEntity, BinarySensorEntity, RestoreEntity)
         return bool(self._computed_state)
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Get the state attributes for the device."""
         attr = super().extra_state_attributes
@@ -524,6 +532,7 @@ class ISYBinarySensorProgramEntity(ISYProgramEntity, BinarySensorEntity):
     """
 
     @property
+    @override
     def is_on(self) -> bool:
         """Get whether the ISY binary sensor device is on."""
         return bool(self._node.status)

--- a/homeassistant/components/isy994/button.py
+++ b/homeassistant/components/isy994/button.py
@@ -1,5 +1,7 @@
 """Representation of ISY/IoX buttons."""
 
+from typing import override
+
 from pyisy import ISY
 from pyisy.constants import (
     ATTR_ACTION,
@@ -106,10 +108,12 @@ class ISYNodeButtonEntity(ButtonEntity):
         self._availability_handler: EventListener | None = None
 
     @property
+    @override
     def available(self) -> bool:
         """Return entity availability."""
         return self._node_enabled
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Subscribe to the node change events."""
         # No status for NetworkResources or ISY Query buttons
@@ -135,6 +139,7 @@ class ISYNodeButtonEntity(ButtonEntity):
 class ISYNodeQueryButtonEntity(ISYNodeButtonEntity):
     """Representation of a device query button entity."""
 
+    @override
     async def async_press(self) -> None:
         """Press the button."""
         await self._node.query()
@@ -143,6 +148,7 @@ class ISYNodeQueryButtonEntity(ISYNodeButtonEntity):
 class ISYNodeBeepButtonEntity(ISYNodeButtonEntity):
     """Representation of a device beep button entity."""
 
+    @override
     async def async_press(self) -> None:
         """Press the button."""
         await self._node.beep()
@@ -153,6 +159,7 @@ class ISYNetworkResourceButtonEntity(ISYNodeButtonEntity):
 
     _attr_has_entity_name = False
 
+    @override
     async def async_press(self) -> None:
         """Press the button."""
         await self._node.run()

--- a/homeassistant/components/isy994/climate.py
+++ b/homeassistant/components/isy994/climate.py
@@ -1,6 +1,6 @@
 """Support for Insteon Thermostats via ISY Platform."""
 
-from typing import Any
+from typing import Any, override
 
 from pyisy.constants import (
     CMD_CLIMATE_FAN_SETTING,
@@ -95,6 +95,7 @@ class ISYThermostatEntity(ISYNodeEntity, ClimateEntity):
             self._uom = self._node.uom[0]
 
     @property
+    @override
     def temperature_unit(self) -> str:
         """Return the unit of measurement."""
         if not (uom := self._node.aux_properties.get(PROP_UOM)):
@@ -106,6 +107,7 @@ class ISYThermostatEntity(ISYNodeEntity, ClimateEntity):
         return UnitOfTemperature.FAHRENHEIT
 
     @property
+    @override
     def current_humidity(self) -> int | None:
         """Return the current humidity."""
         if not (humidity := self._node.aux_properties.get(PROP_HUMIDITY)):
@@ -115,6 +117,7 @@ class ISYThermostatEntity(ISYNodeEntity, ClimateEntity):
         return int(humidity.value)
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode:
         """Return hvac operation ie. heat, cool mode."""
         if not (hvac_mode := self._node.aux_properties.get(CMD_CLIMATE_MODE)):
@@ -135,6 +138,7 @@ class ISYThermostatEntity(ISYNodeEntity, ClimateEntity):
         )
 
     @property
+    @override
     def hvac_action(self) -> HVACAction | None:
         """Return the current running hvac operation if supported."""
         hvac_action = self._node.aux_properties.get(PROP_HEAT_COOL_STATE)
@@ -145,6 +149,7 @@ class ISYThermostatEntity(ISYNodeEntity, ClimateEntity):
         )
 
     @property
+    @override
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
         return convert_isy_value_to_hass(
@@ -152,6 +157,7 @@ class ISYThermostatEntity(ISYNodeEntity, ClimateEntity):
         )
 
     @property
+    @override
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
         if self.hvac_mode == HVACMode.COOL:
@@ -161,6 +167,7 @@ class ISYThermostatEntity(ISYNodeEntity, ClimateEntity):
         return None
 
     @property
+    @override
     def target_temperature_high(self) -> float | None:
         """Return the highbound target temperature we try to reach."""
         target = self._node.aux_properties.get(PROP_SETPOINT_COOL)
@@ -169,6 +176,7 @@ class ISYThermostatEntity(ISYNodeEntity, ClimateEntity):
         return convert_isy_value_to_hass(target.value, target.uom, target.prec, 1)
 
     @property
+    @override
     def target_temperature_low(self) -> float | None:
         """Return the lowbound target temperature we try to reach."""
         target = self._node.aux_properties.get(PROP_SETPOINT_HEAT)
@@ -177,6 +185,7 @@ class ISYThermostatEntity(ISYNodeEntity, ClimateEntity):
         return convert_isy_value_to_hass(target.value, target.uom, target.prec, 1)
 
     @property
+    @override
     def fan_mode(self) -> str:
         """Return the current fan mode ie. auto, on."""
         fan_mode = self._node.aux_properties.get(CMD_CLIMATE_FAN_SETTING)
@@ -184,6 +193,7 @@ class ISYThermostatEntity(ISYNodeEntity, ClimateEntity):
             return FAN_OFF
         return UOM_TO_STATES[UOM_FAN_MODES].get(fan_mode.value, FAN_OFF)
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         target_temp = kwargs.get(ATTR_TEMPERATURE)
@@ -200,12 +210,14 @@ class ISYThermostatEntity(ISYNodeEntity, ClimateEntity):
             await self._node.set_climate_setpoint_cool(int(target_temp_high))
         self.async_write_ha_state()
 
+    @override
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""
         _LOGGER.debug("Requested fan mode %s", fan_mode)
         await self._node.set_fan_mode(HA_FAN_TO_ISY.get(fan_mode))
         self.async_write_ha_state()
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         _LOGGER.debug("Requested operation mode %s", hvac_mode)

--- a/homeassistant/components/isy994/config_flow.py
+++ b/homeassistant/components/isy994/config_flow.py
@@ -3,7 +3,7 @@
 import asyncio
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 from urllib.parse import urlparse, urlunparse
 
 import aiohttp
@@ -150,12 +150,14 @@ class Isy994ConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: IsyConfigEntry,
     ) -> OptionsFlowHandler:
         """Get the options flow for this handler."""
         return OptionsFlowHandler()
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -227,6 +229,7 @@ class Isy994ConfigFlow(ConfigFlow, domain=DOMAIN):
             )
         raise AbortFlow("already_configured")
 
+    @override
     async def async_step_dhcp(
         self, discovery_info: DhcpServiceInfo
     ) -> ConfigFlowResult:
@@ -250,6 +253,7 @@ class Isy994ConfigFlow(ConfigFlow, domain=DOMAIN):
         self.context["title_placeholders"] = self.discovered_conf
         return await self.async_step_user()
 
+    @override
     async def async_step_ssdp(
         self, discovery_info: SsdpServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/isy994/cover.py
+++ b/homeassistant/components/isy994/cover.py
@@ -1,6 +1,6 @@
 """Support for ISY covers."""
 
-from typing import Any, cast
+from typing import Any, cast, override
 
 from pyisy.constants import ISY_VALUE_UNKNOWN
 
@@ -49,6 +49,7 @@ class ISYCoverEntity(ISYNodeEntity, CoverEntity):
     )
 
     @property
+    @override
     def current_cover_position(self) -> int | None:
         """Return the current cover position."""
         if self._node.status == ISY_VALUE_UNKNOWN:
@@ -58,22 +59,26 @@ class ISYCoverEntity(ISYNodeEntity, CoverEntity):
         return int(sorted((0, self._node.status, 100))[1])
 
     @property
+    @override
     def is_closed(self) -> bool | None:
         """Get whether the ISY cover device is closed."""
         if self._node.status == ISY_VALUE_UNKNOWN:
             return None
         return bool(self._node.status == 0)
 
+    @override
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Send the open cover command to the ISY cover device."""
         if not await self._node.turn_on():
             _LOGGER.error("Unable to open the cover")
 
+    @override
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Send the close cover command to the ISY cover device."""
         if not await self._node.turn_off():
             _LOGGER.error("Unable to close the cover")
 
+    @override
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
         position = kwargs[ATTR_POSITION]
@@ -87,15 +92,18 @@ class ISYCoverProgramEntity(ISYProgramEntity, CoverEntity):
     """Representation of an ISY cover program."""
 
     @property
+    @override
     def is_closed(self) -> bool:
         """Get whether the ISY cover program is closed."""
         return bool(self._node.status)
 
+    @override
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Send the open cover command to the ISY cover program."""
         if not await self._actions.run_then():
             _LOGGER.error("Unable to open the cover")
 
+    @override
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Send the close cover command to the ISY cover program."""
         if not await self._actions.run_else():

--- a/homeassistant/components/isy994/entity.py
+++ b/homeassistant/components/isy994/entity.py
@@ -1,6 +1,6 @@
 """Representation of ISYEntity Types."""
 
-from typing import Any, cast
+from typing import Any, cast, override
 
 from pyisy.constants import (
     ATTR_ACTION,
@@ -51,6 +51,7 @@ class ISYEntity(Entity):
         self._change_handler: EventListener | None = None
         self._control_handler: EventListener | None = None
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Subscribe to the node change events."""
         self._change_handler = self._node.status_events.subscribe(self.async_on_update)
@@ -99,11 +100,13 @@ class ISYNodeEntity(ISYEntity):
             self._attr_name = None
 
     @property
+    @override
     def available(self) -> bool:
         """Return entity availability."""
         return getattr(self._node, TAG_ENABLED, True)
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Get the state attributes for the device.
 
@@ -188,6 +191,7 @@ class ISYProgramEntity(ISYEntity):
         self._actions = actions
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Get the state attributes for the device."""
         attr = {}
@@ -240,6 +244,7 @@ class ISYAuxControlEntity(Entity):
         self._change_handler: EventListener = None
         self._availability_handler: EventListener = None
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Subscribe to the node control change events."""
         self._change_handler = self._node.control_events.subscribe(
@@ -262,6 +267,7 @@ class ISYAuxControlEntity(Entity):
         self.async_write_ha_state()
 
     @property
+    @override
     def available(self) -> bool:
         """Return entity availability."""
         return cast(bool, self._node.enabled)

--- a/homeassistant/components/isy994/fan.py
+++ b/homeassistant/components/isy994/fan.py
@@ -1,7 +1,7 @@
 """Support for ISY fans."""
 
 import math
-from typing import Any
+from typing import Any, override
 
 from pyisy.constants import ISY_VALUE_UNKNOWN, PROTO_INSTEON
 
@@ -53,6 +53,7 @@ class ISYFanEntity(ISYNodeEntity, FanEntity):
     )
 
     @property
+    @override
     def percentage(self) -> int | None:
         """Return the current speed percentage."""
         if self._node.status == ISY_VALUE_UNKNOWN:
@@ -60,6 +61,7 @@ class ISYFanEntity(ISYNodeEntity, FanEntity):
         return ranged_value_to_percentage(SPEED_RANGE, self._node.status)
 
     @property
+    @override
     def speed_count(self) -> int:
         """Return the number of speeds the fan supports."""
         if self._node.protocol == PROTO_INSTEON:
@@ -67,12 +69,14 @@ class ISYFanEntity(ISYNodeEntity, FanEntity):
         return int_states_in_range(SPEED_RANGE)
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Get if the fan is on."""
         if self._node.status == ISY_VALUE_UNKNOWN:
             return None
         return bool(self._node.status != 0)
 
+    @override
     async def async_set_percentage(self, percentage: int) -> None:
         """Set node to speed percentage for the ISY fan device."""
         if percentage == 0:
@@ -83,6 +87,7 @@ class ISYFanEntity(ISYNodeEntity, FanEntity):
 
         await self._node.turn_on(val=isy_speed)
 
+    @override
     async def async_turn_on(
         self,
         percentage: int | None = None,
@@ -92,6 +97,7 @@ class ISYFanEntity(ISYNodeEntity, FanEntity):
         """Send the turn on command to the ISY fan device."""
         await self.async_set_percentage(percentage or 67)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Send the turn off command to the ISY fan device."""
         await self._node.turn_off()
@@ -101,6 +107,7 @@ class ISYFanProgramEntity(ISYProgramEntity, FanEntity):
     """Representation of an ISY fan program."""
 
     @property
+    @override
     def percentage(self) -> int | None:
         """Return the current speed percentage."""
         if self._node.status == ISY_VALUE_UNKNOWN:
@@ -108,20 +115,24 @@ class ISYFanProgramEntity(ISYProgramEntity, FanEntity):
         return ranged_value_to_percentage(SPEED_RANGE, self._node.status)
 
     @property
+    @override
     def speed_count(self) -> int:
         """Return the number of speeds the fan supports."""
         return int_states_in_range(SPEED_RANGE)
 
     @property
+    @override
     def is_on(self) -> bool:
         """Get if the fan is on."""
         return bool(self._node.status != 0)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Send the turn on command to ISY fan program."""
         if not await self._actions.run_then():
             _LOGGER.error("Unable to turn off the fan")
 
+    @override
     async def async_turn_on(
         self,
         percentage: int | None = None,

--- a/homeassistant/components/isy994/light.py
+++ b/homeassistant/components/isy994/light.py
@@ -1,6 +1,6 @@
 """Support for ISY lights."""
 
-from typing import Any, cast
+from typing import Any, cast, override
 
 from pyisy.constants import ISY_VALUE_UNKNOWN
 from pyisy.helpers import NodeProperty
@@ -55,6 +55,7 @@ class ISYLightEntity(ISYNodeEntity, LightEntity, RestoreEntity):
         self._restore_light_state = restore_light_state
 
     @property
+    @override
     def is_on(self) -> bool:
         """Get whether the ISY light is on."""
         if self._node.status == ISY_VALUE_UNKNOWN:
@@ -62,6 +63,7 @@ class ISYLightEntity(ISYNodeEntity, LightEntity, RestoreEntity):
         return int(self._node.status) != 0
 
     @property
+    @override
     def brightness(self) -> int | None:
         """Get the brightness of the ISY light."""
         if self._node.status == ISY_VALUE_UNKNOWN:
@@ -71,6 +73,7 @@ class ISYLightEntity(ISYNodeEntity, LightEntity, RestoreEntity):
             return round(cast(float, self._node.status) * 255.0 / 100.0)
         return int(self._node.status)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Send the turn off command to the ISY light device."""
         self._last_brightness = self.brightness
@@ -78,6 +81,7 @@ class ISYLightEntity(ISYNodeEntity, LightEntity, RestoreEntity):
             _LOGGER.debug("Unable to turn off light")
 
     @callback
+    @override
     def async_on_update(self, event: NodeProperty) -> None:
         """Save brightness in the update event from the ISY Node."""
         if self._node.status not in (0, ISY_VALUE_UNKNOWN):
@@ -87,6 +91,7 @@ class ISYLightEntity(ISYNodeEntity, LightEntity, RestoreEntity):
                 self._last_brightness = self._node.status
         super().async_on_update(event)
 
+    @override
     async def async_turn_on(self, brightness: int | None = None, **kwargs: Any) -> None:
         """Send the turn on command to the ISY light device."""
         if self._restore_light_state and brightness is None and self._last_brightness:
@@ -98,12 +103,14 @@ class ISYLightEntity(ISYNodeEntity, LightEntity, RestoreEntity):
             _LOGGER.debug("Unable to turn on light")
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the light attributes."""
         attribs = super().extra_state_attributes
         attribs[ATTR_LAST_BRIGHTNESS] = self._last_brightness
         return attribs
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Restore last_brightness on restart."""
         await super().async_added_to_hass()

--- a/homeassistant/components/isy994/lock.py
+++ b/homeassistant/components/isy994/lock.py
@@ -1,6 +1,6 @@
 """Support for ISY locks."""
 
-from typing import Any
+from typing import Any, override
 
 from pyisy.constants import ISY_VALUE_UNKNOWN
 
@@ -68,17 +68,20 @@ class ISYLockEntity(ISYNodeEntity, LockEntity):
     """Representation of an ISY lock device."""
 
     @property
+    @override
     def is_locked(self) -> bool | None:
         """Get whether the lock is in locked state."""
         if self._node.status == ISY_VALUE_UNKNOWN:
             return None
         return VALUE_TO_STATE.get(self._node.status)
 
+    @override
     async def async_lock(self, **kwargs: Any) -> None:
         """Send the lock command to the ISY device."""
         if not await self._node.secure_lock():
             raise HomeAssistantError(f"Unable to lock device {self._node.address}")
 
+    @override
     async def async_unlock(self, **kwargs: Any) -> None:
         """Send the unlock command to the ISY device."""
         if not await self._node.secure_unlock():
@@ -103,15 +106,18 @@ class ISYLockProgramEntity(ISYProgramEntity, LockEntity):
     """Representation of a ISY lock program."""
 
     @property
+    @override
     def is_locked(self) -> bool:
         """Return true if the device is locked."""
         return bool(self._node.status)
 
+    @override
     async def async_lock(self, **kwargs: Any) -> None:
         """Lock the device."""
         if not await self._actions.run_then():
             raise HomeAssistantError(f"Unable to lock device {self._node.address}")
 
+    @override
     async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock the device."""
         if not await self._actions.run_else():

--- a/homeassistant/components/isy994/number.py
+++ b/homeassistant/components/isy994/number.py
@@ -1,7 +1,7 @@
 """Support for ISY number entities."""
 
 from dataclasses import replace
-from typing import Any
+from typing import Any, override
 
 from pyisy.constants import (
     ATTR_ACTION,
@@ -139,6 +139,7 @@ class ISYAuxControlNumberEntity(ISYAuxControlEntity, NumberEntity):
     _attr_mode = NumberMode.SLIDER
 
     @property
+    @override
     def native_value(self) -> float | int | None:
         """Return the state of the variable."""
         node_prop: NodeProperty = self._node.aux_properties[self._control]
@@ -152,6 +153,7 @@ class ISYAuxControlNumberEntity(ISYAuxControlEntity, NumberEntity):
             return ranged_value_to_percentage(ON_RANGE, node_prop.value)
         return int(node_prop.value)
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
         node_prop: NodeProperty = self._node.aux_properties[self._control]
@@ -201,6 +203,7 @@ class ISYVariableNumberEntity(NumberEntity):
         self._attr_unique_id = unique_id
         self._attr_device_info = device_info
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Subscribe to the node change events."""
         self._change_handler = self._node.status_events.subscribe(self.async_on_update)
@@ -211,6 +214,7 @@ class ISYVariableNumberEntity(NumberEntity):
         self.async_write_ha_state()
 
     @property
+    @override
     def native_value(self) -> float | int | None:
         """Return the state of the variable."""
         return convert_isy_value_to_hass(
@@ -220,12 +224,14 @@ class ISYVariableNumberEntity(NumberEntity):
         )
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Get the state attributes for the device."""
         return {
             "last_edited": self._node.last_edited,
         }
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Set new value."""
         if not await self._node.set_value(value, init=self._init_entity):
@@ -252,6 +258,7 @@ class ISYBacklightNumberEntity(ISYAuxControlEntity, RestoreNumber):
         self._memory_change_handler: EventListener | None = None
         self._attr_native_value = 0
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Load the last known state when added to hass."""
         await super().async_added_to_hass()
@@ -282,6 +289,7 @@ class ISYBacklightNumberEntity(ISYAuxControlEntity, RestoreNumber):
         self._attr_native_value = value
         self.async_write_ha_state()
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
 

--- a/homeassistant/components/isy994/select.py
+++ b/homeassistant/components/isy994/select.py
@@ -1,6 +1,6 @@
 """Support for ISY select entities."""
 
-from typing import cast
+from typing import cast, override
 
 from pyisy.constants import (
     ATTR_ACTION,
@@ -112,6 +112,7 @@ class ISYRampRateSelectEntity(ISYAuxControlEntity, SelectEntity):
     """Representation of a ISY/IoX Aux Control Ramp Rate Select entity."""
 
     @property
+    @override
     def current_option(self) -> str | None:
         """Return the selected entity option to represent the entity state."""
         node_prop: NodeProperty = self._node.aux_properties[self._control]
@@ -120,6 +121,7 @@ class ISYRampRateSelectEntity(ISYAuxControlEntity, SelectEntity):
 
         return RAMP_RATE_OPTIONS[int(node_prop.value)]
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
 
@@ -130,6 +132,7 @@ class ISYAuxControlIndexSelectEntity(ISYAuxControlEntity, SelectEntity):
     """Representation of a ISY/IoX Aux Control Index Select entity."""
 
     @property
+    @override
     def current_option(self) -> str | None:
         """Return the selected entity option to represent the entity state."""
         node_prop: NodeProperty = self._node.aux_properties[self._control]
@@ -140,6 +143,7 @@ class ISYAuxControlIndexSelectEntity(ISYAuxControlEntity, SelectEntity):
             return cast(str, options_dict.get(node_prop.value, node_prop.value))
         return cast(str, node_prop.formatted)
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         node_prop: NodeProperty = self._node.aux_properties[self._control]
@@ -167,6 +171,7 @@ class ISYBacklightSelectEntity(ISYAuxControlEntity, SelectEntity, RestoreEntity)
         self._memory_change_handler: EventListener | None = None
         self._attr_current_option = None
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Load the last known state when added to hass."""
         await super().async_added_to_hass()
@@ -196,6 +201,7 @@ class ISYBacklightSelectEntity(ISYAuxControlEntity, SelectEntity, RestoreEntity)
         self._attr_current_option = option
         self.async_write_ha_state()
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
 

--- a/homeassistant/components/isy994/sensor.py
+++ b/homeassistant/components/isy994/sensor.py
@@ -1,6 +1,6 @@
 """Support for ISY sensors."""
 
-from typing import Any, cast
+from typing import Any, cast, override
 
 from pyisy.constants import (
     ATTR_ACTION,
@@ -261,6 +261,7 @@ class ISYSensorEntity(ISYNodeEntity, SensorEntity):
         return UOM_FRIENDLY_NAME.get(uom)
 
     @property
+    @override
     def native_value(self) -> float | int | str | None:
         """Get the state of the ISY sensor device."""
         if self.target is None:
@@ -292,6 +293,7 @@ class ISYSensorEntity(ISYNodeEntity, SensorEntity):
         return value
 
     @property
+    @override
     def native_unit_of_measurement(self) -> str | None:
         """Get the Home Assistant unit of measurement for the device."""
         raw_units = self.raw_unit_of_measurement
@@ -349,6 +351,7 @@ class ISYAuxSensorEntity(ISYSensorEntity):
         self._attr_name = f"{node.name} {name.replace('_', ' ').title()}"
 
     @property
+    @override
     def target(self) -> Node | NodeProperty | None:
         """Return target for the sensor."""
         if self._control not in self._node.aux_properties:
@@ -357,10 +360,12 @@ class ISYAuxSensorEntity(ISYSensorEntity):
         return cast(NodeProperty, self._node.aux_properties[self._control])
 
     @property
+    @override
     def target_value(self) -> Any:
         """Return the target value."""
         return None if self.target is None else self.target.value
 
+    @override
     # pylint: disable-next=home-assistant-missing-super-call
     async def async_added_to_hass(self) -> None:
         """Subscribe to the node control change events.
@@ -381,11 +386,13 @@ class ISYAuxSensorEntity(ISYSensorEntity):
         )
 
     @callback
+    @override
     def async_on_update(self, event: NodeProperty | NodeChangedEvent) -> None:
         """Handle a control event from the ISY Node."""
         self.async_write_ha_state()
 
     @property
+    @override
     def available(self) -> bool:
         """Return entity availability."""
         return cast(bool, self._node.enabled)

--- a/homeassistant/components/isy994/switch.py
+++ b/homeassistant/components/isy994/switch.py
@@ -1,7 +1,7 @@
 """Support for ISY switches."""
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from pyisy.constants import (
     ATTR_ACTION,
@@ -84,23 +84,27 @@ class ISYSwitchEntity(ISYNodeEntity, SwitchEntity):
     """Representation of an ISY switch device."""
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Get whether the ISY device is in the on state."""
         if self._node.status == ISY_VALUE_UNKNOWN:
             return None
         return bool(self._node.status)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Send the turn off command to the ISY switch."""
         if not await self._node.turn_off():
             raise HomeAssistantError(f"Unable to turn off switch {self._node.address}")
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Send the turn on command to the ISY switch."""
         if not await self._node.turn_on():
             raise HomeAssistantError(f"Unable to turn on switch {self._node.address}")
 
     @property
+    @override
     def icon(self) -> str | None:
         """Get the icon for groups."""
         if hasattr(self._node, "protocol") and self._node.protocol == PROTO_GROUP:
@@ -114,10 +118,12 @@ class ISYSwitchProgramEntity(ISYProgramEntity, SwitchEntity):
     _attr_icon = "mdi:script-text-outline"  # Matches isy program icon
 
     @property
+    @override
     def is_on(self) -> bool:
         """Get whether the ISY switch program is on."""
         return bool(self._node.status)
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Send the turn on command to the ISY switch program."""
         if not await self._actions.run_then():
@@ -125,6 +131,7 @@ class ISYSwitchProgramEntity(ISYProgramEntity, SwitchEntity):
                 f"Unable to run 'then' clause on program switch {self._actions.address}"
             )
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Send the turn off command to the ISY switch program."""
         if not await self._actions.run_else():
@@ -155,6 +162,7 @@ class ISYEnableSwitchEntity(ISYAuxControlEntity, SwitchEntity):
         self._attr_name = description.name  # Override super
         self._change_handler: EventListener | None = None
 
+    @override
     # pylint: disable-next=home-assistant-missing-super-call
     async def async_added_to_hass(self) -> None:
         """Subscribe to the node control change events."""
@@ -168,25 +176,30 @@ class ISYEnableSwitchEntity(ISYAuxControlEntity, SwitchEntity):
         )
 
     @callback
+    @override
     def async_on_update(self, event: NodeChangedEvent, key: str) -> None:
         """Handle a control event from the ISY Node."""
         self.async_write_ha_state()
 
     @property
+    @override
     def available(self) -> bool:
         """Return entity availability."""
         return True  # Enable switch is always available
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Get whether the ISY device is in the on state."""
         return bool(self._node.enabled)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Send the turn off command to the ISY switch."""
         if not await self._node.disable():
             raise HomeAssistantError(f"Unable to disable device {self._node.address}")
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Send the turn on command to the ISY switch."""
         if not await self._node.enable():

--- a/homeassistant/components/itach/remote.py
+++ b/homeassistant/components/itach/remote.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Iterable
 import logging
-from typing import Any
+from typing import Any, override
 
 import pyitachip2ir
 import voluptuous as vol
@@ -132,18 +132,21 @@ class ITachIP2IRRemote(remote.RemoteEntity):
         self._attr_name = name or DEVICE_DEFAULT_NAME
         self._ir_count = ir_count or DEFAULT_IR_COUNT
 
+    @override
     def turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
         self._attr_is_on = True
         self.itachip2ir.send(self.name, "ON", self._ir_count)
         self.schedule_update_ha_state()
 
+    @override
     def turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
         self._attr_is_on = False
         self.itachip2ir.send(self.name, "OFF", self._ir_count)
         self.schedule_update_ha_state()
 
+    @override
     def send_command(self, command: Iterable[str], **kwargs: Any) -> None:
         """Send a command to one device."""
         num_repeats = kwargs.get(ATTR_NUM_REPEATS, DEFAULT_NUM_REPEATS)

--- a/homeassistant/components/itunes/media_player.py
+++ b/homeassistant/components/itunes/media_player.py
@@ -1,6 +1,6 @@
 """Support for interfacing to iTunes API."""
 
-from typing import Any
+from typing import Any, override
 
 import requests
 import voluptuous as vol
@@ -237,11 +237,13 @@ class ItunesDevice(MediaPlayerEntity):
         self.shuffled = _shuffle == "songs"
 
     @property
+    @override
     def name(self):
         """Return the name of the device."""
         return self._name
 
     @property
+    @override
     def state(self):
         """Return the state of the device."""
         if self.player_state == "offline" or self.player_state is None:
@@ -286,21 +288,25 @@ class ItunesDevice(MediaPlayerEntity):
             self._add_entities(new_devices)
 
     @property
+    @override
     def is_volume_muted(self):
         """Boolean if volume is currently muted."""
         return self.muted
 
     @property
+    @override
     def volume_level(self):
         """Volume level of the media player (0..1)."""
         return self.current_volume / 100.0
 
     @property
+    @override
     def media_content_id(self):
         """Content ID of current playing media."""
         return self.content_id
 
     @property
+    @override
     def media_image_url(self):
         """Image url of current playing media."""
         if (
@@ -320,65 +326,78 @@ class ItunesDevice(MediaPlayerEntity):
         )
 
     @property
+    @override
     def media_title(self):
         """Title of current playing media."""
         return self.current_title
 
     @property
+    @override
     def media_artist(self):
         """Artist of current playing media (Music track only)."""
         return self.current_artist
 
     @property
+    @override
     def media_album_name(self):
         """Album of current playing media (Music track only)."""
         return self.current_album
 
     @property
+    @override
     def media_playlist(self):
         """Title of the currently playing playlist."""
         return self.current_playlist
 
     @property
+    @override
     def shuffle(self):
         """Boolean if shuffle is enabled."""
         return self.shuffled
 
+    @override
     def set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""
         response = self.client.set_volume(int(volume * 100))
         self.update_state(response)
 
+    @override
     def mute_volume(self, mute: bool) -> None:
         """Mute (true) or unmute (false) media player."""
         response = self.client.set_muted(mute)
         self.update_state(response)
 
+    @override
     def set_shuffle(self, shuffle: bool) -> None:
         """Shuffle (true) or no shuffle (false) media player."""
         response = self.client.set_shuffle(shuffle)
         self.update_state(response)
 
+    @override
     def media_play(self) -> None:
         """Send media_play command to media player."""
         response = self.client.play()
         self.update_state(response)
 
+    @override
     def media_pause(self) -> None:
         """Send media_pause command to media player."""
         response = self.client.pause()
         self.update_state(response)
 
+    @override
     def media_next_track(self) -> None:
         """Send media_next command to media player."""
         response = self.client.next()
         self.update_state(response)
 
+    @override
     def media_previous_track(self) -> None:
         """Send media_previous command media player."""
         response = self.client.previous()
         self.update_state(response)
 
+    @override
     def play_media(
         self, media_type: MediaType | str, media_id: str, **kwargs: Any
     ) -> None:
@@ -387,6 +406,7 @@ class ItunesDevice(MediaPlayerEntity):
             response = self.client.play_playlist(media_id)
             self.update_state(response)
 
+    @override
     def turn_off(self) -> None:
         """Turn the media player off."""
         response = self.client.stop()
@@ -444,11 +464,13 @@ class AirPlayDevice(MediaPlayerEntity):
             self.supports_video = state_hash.get("supports_video", None)
 
     @property
+    @override
     def name(self):
         """Return the name of the device."""
         return self.device_name
 
     @property
+    @override
     def icon(self) -> str:
         """Return the icon to use in the frontend, if any."""
         if self.selected is True:
@@ -457,6 +479,7 @@ class AirPlayDevice(MediaPlayerEntity):
         return "mdi:volume-off"
 
     @property
+    @override
     def state(self) -> MediaPlayerState:
         """Return the state of the device."""
         if self.selected is True:
@@ -468,16 +491,19 @@ class AirPlayDevice(MediaPlayerEntity):
         """Retrieve latest state."""
 
     @property
+    @override
     def volume_level(self):
         """Return the volume."""
         return float(self.volume) / 100.0
 
+    @override
     def set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""
         volume = int(volume * 100)
         response = self.client.set_volume_airplay_device(self._id, volume)
         self.update_state(response)
 
+    @override
     def turn_on(self) -> None:
         """Select AirPlay."""
         self.update_state({"selected": True})
@@ -485,6 +511,7 @@ class AirPlayDevice(MediaPlayerEntity):
         response = self.client.toggle_airplay_device(self._id, True)
         self.update_state(response)
 
+    @override
     def turn_off(self) -> None:
         """Deselect AirPlay."""
         self.update_state({"selected": False})

--- a/homeassistant/components/ituran/binary_sensor.py
+++ b/homeassistant/components/ituran/binary_sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from pyituran import Vehicle
 
@@ -67,6 +68,7 @@ class IturanBinarySensor(IturanBaseEntity, BinarySensorEntity):
         self.entity_description = description
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if the binary sensor is on."""
         return self.entity_description.value_fn(self.vehicle)

--- a/homeassistant/components/ituran/config_flow.py
+++ b/homeassistant/components/ituran/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyituran import Ituran
 from pyituran.exceptions import IturanApiError, IturanAuthError
@@ -39,6 +39,7 @@ class IturanConfigFlow(ConfigFlow, domain=DOMAIN):
 
     _user_info: dict[str, Any]
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/ituran/coordinator.py
+++ b/homeassistant/components/ituran/coordinator.py
@@ -1,6 +1,7 @@
 """Coordinator for Ituran."""
 
 import logging
+from typing import override
 
 from pyituran import Ituran, Vehicle
 from pyituran.exceptions import IturanApiError, IturanAuthError
@@ -44,6 +45,7 @@ class IturanDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Vehicle]]):
             entry.data[CONF_MOBILE_ID],
         )
 
+    @override
     async def _async_update_data(self) -> dict[str, Vehicle]:
         """Fetch data from Ituran."""
 

--- a/homeassistant/components/ituran/device_tracker.py
+++ b/homeassistant/components/ituran/device_tracker.py
@@ -1,5 +1,7 @@
 """Device tracker for Ituran vehicles."""
 
+from typing import override
+
 from homeassistant.components.device_tracker import TrackerEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -37,11 +39,13 @@ class IturanDeviceTracker(IturanBaseEntity, TrackerEntity):
         super().__init__(coordinator, license_plate, "device_tracker")
 
     @property
+    @override
     def latitude(self) -> float | None:
         """Return latitude value of the device."""
         return self.vehicle.gps_coordinates[0]
 
     @property
+    @override
     def longitude(self) -> float | None:
         """Return longitude value of the device."""
         return self.vehicle.gps_coordinates[1]

--- a/homeassistant/components/ituran/entity.py
+++ b/homeassistant/components/ituran/entity.py
@@ -1,5 +1,7 @@
 """Base for all turan entities."""
 
+from typing import override
+
 from pyituran import Vehicle
 
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -35,6 +37,7 @@ class IturanBaseEntity(CoordinatorEntity[IturanDataUpdateCoordinator]):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if vehicle is still included in the account."""
         return super().available and self._license_plate in self.coordinator.data

--- a/homeassistant/components/ituran/sensor.py
+++ b/homeassistant/components/ituran/sensor.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
+from typing import override
 
 from pyituran import Vehicle
 
@@ -131,6 +132,7 @@ class IturanSensor(IturanBaseEntity, SensorEntity):
         self.entity_description = description
 
     @property
+    @override
     def native_value(self) -> StateType | datetime:
         """Return the state of the device."""
         return self.entity_description.value_fn(self.vehicle)

--- a/homeassistant/components/izone/climate.py
+++ b/homeassistant/components/izone/climate.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable, Mapping
 import logging
-from typing import Any, Concatenate
+from typing import Any, Concatenate, override
 
 from pizone import Controller, Zone
 import voluptuous as vol
@@ -199,6 +199,7 @@ class ControllerDevice(ClimateEntity):
         for zone in controller.zones:
             self.zones[zone] = ZoneDevice(self, zone)
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Call on adding to hass."""
 
@@ -269,6 +270,7 @@ class ControllerDevice(ClimateEntity):
                 zone.async_schedule_update_ha_state()
 
     @property
+    @override
     def extra_state_attributes(self) -> Mapping[str, Any]:
         """Return the optional state attributes."""
         return {
@@ -298,6 +300,7 @@ class ControllerDevice(ClimateEntity):
         }
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode:
         """Return current operation ie. heat, cool, idle."""
         if not self._controller.is_on:
@@ -311,6 +314,7 @@ class ControllerDevice(ClimateEntity):
 
     @property
     @_return_on_connection_error([])
+    @override
     def hvac_modes(self) -> list[HVACMode]:
         """Return the list of available operation modes."""
         if self._controller.free_air:
@@ -319,12 +323,14 @@ class ControllerDevice(ClimateEntity):
 
     @property
     @_return_on_connection_error(PRESET_NONE)
+    @override
     def preset_mode(self) -> str:
         """Eco mode is external air."""
         return PRESET_ECO if self._controller.free_air else PRESET_NONE
 
     @property
     @_return_on_connection_error([PRESET_NONE])
+    @override
     def preset_modes(self) -> list[str]:
         """Available preset modes, normal or eco."""
         if self._controller.free_air_enabled:
@@ -333,6 +339,7 @@ class ControllerDevice(ClimateEntity):
 
     @property
     @_return_on_connection_error()
+    @override
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
         if self._controller.mode == Controller.Mode.FREE_AIR:
@@ -369,6 +376,7 @@ class ControllerDevice(ClimateEntity):
 
     @property
     @_return_on_connection_error()
+    @override
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach.
 
@@ -384,23 +392,27 @@ class ControllerDevice(ClimateEntity):
         return self._controller.temp_supply
 
     @property
+    @override
     def fan_mode(self) -> str | None:
         """Return the fan setting."""
         return _IZONE_FAN_TO_HA[self._controller.fan]
 
     @property
+    @override
     def fan_modes(self) -> list[str] | None:
         """Return the list of available fan modes."""
         return list(self._fan_to_pizone)
 
     @property
     @_return_on_connection_error(0.0)
+    @override
     def min_temp(self) -> float:
         """Return the minimum temperature."""
         return self._controller.temp_min
 
     @property
     @_return_on_connection_error(50.0)
+    @override
     def max_temp(self) -> float:
         """Return the maximum temperature."""
         return self._controller.temp_max
@@ -414,6 +426,7 @@ class ControllerDevice(ClimateEntity):
         else:
             self.set_available(True)
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         if not self.supported_features & ClimateEntityFeature.TARGET_TEMPERATURE:
@@ -422,11 +435,13 @@ class ControllerDevice(ClimateEntity):
         if (temp := kwargs.get(ATTR_TEMPERATURE)) is not None:
             await self.wrap_and_catch(self._controller.set_temp_setpoint(temp))
 
+    @override
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""
         fan = self._fan_to_pizone[fan_mode]
         await self.wrap_and_catch(self._controller.set_fan(fan))
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target operation mode."""
         if hvac_mode == HVACMode.OFF:
@@ -439,12 +454,14 @@ class ControllerDevice(ClimateEntity):
         mode = self._state_to_pizone[hvac_mode]
         await self.wrap_and_catch(self._controller.set_mode(mode))
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode."""
         await self.wrap_and_catch(
             self._controller.set_free_air(preset_mode == PRESET_ECO)
         )
 
+    @override
     async def async_turn_on(self) -> None:
         """Turn the entity on."""
         await self.wrap_and_catch(self._controller.set_on(True))
@@ -492,6 +509,7 @@ class ZoneDevice(ClimateEntity):
             via_device=(DOMAIN, controller.unique_id),
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Call on adding to hass."""
 
@@ -524,12 +542,14 @@ class ZoneDevice(ClimateEntity):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available."""
         return self._controller.available
 
     @property
     @_return_on_connection_error(ClimateEntityFeature(0))
+    @override
     def supported_features(self) -> ClimateEntityFeature:
         """Return the list of supported features."""
         if self._zone.mode == Zone.Mode.AUTO:
@@ -537,6 +557,7 @@ class ZoneDevice(ClimateEntity):
         return self._attr_supported_features & ~ClimateEntityFeature.TARGET_TEMPERATURE
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode | None:
         """Return current operation ie. heat, cool, idle."""
         mode = self._zone.mode
@@ -546,16 +567,19 @@ class ZoneDevice(ClimateEntity):
         return None
 
     @property
+    @override
     def hvac_modes(self) -> list[HVACMode]:
         """Return the list of available operation modes."""
         return list(self._state_to_pizone)
 
     @property
+    @override
     def current_temperature(self) -> float:
         """Return the current temperature."""
         return self._zone.temp_current
 
     @property
+    @override
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
         if self._zone.type != Zone.Type.AUTO:
@@ -563,11 +587,13 @@ class ZoneDevice(ClimateEntity):
         return self._zone.temp_setpoint
 
     @property
+    @override
     def min_temp(self) -> float:
         """Return the minimum temperature."""
         return self._controller.min_temp
 
     @property
+    @override
     def max_temp(self) -> float:
         """Return the maximum temperature."""
         return self._controller.max_temp
@@ -596,6 +622,7 @@ class ZoneDevice(ClimateEntity):
         )
         self.async_write_ha_state()
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         if self._zone.mode != Zone.Mode.AUTO:
@@ -603,6 +630,7 @@ class ZoneDevice(ClimateEntity):
         if (temp := kwargs.get(ATTR_TEMPERATURE)) is not None:
             await self._controller.wrap_and_catch(self._zone.set_temp_setpoint(temp))
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target operation mode."""
         mode = self._state_to_pizone[hvac_mode]
@@ -614,6 +642,7 @@ class ZoneDevice(ClimateEntity):
         """Return true if on."""
         return self._zone.mode != Zone.Mode.CLOSE
 
+    @override
     async def async_turn_on(self) -> None:
         """Turn device on (open zone)."""
         if self._zone.type == Zone.Type.AUTO:
@@ -622,6 +651,7 @@ class ZoneDevice(ClimateEntity):
             await self._controller.wrap_and_catch(self._zone.set_mode(Zone.Mode.OPEN))
         self.async_write_ha_state()
 
+    @override
     async def async_turn_off(self) -> None:
         """Turn device off (close zone)."""
         await self._controller.wrap_and_catch(self._zone.set_mode(Zone.Mode.CLOSE))
@@ -633,6 +663,7 @@ class ZoneDevice(ClimateEntity):
         return self._zone.index
 
     @property
+    @override
     def extra_state_attributes(self) -> Mapping[str, Any]:
         """Return the optional state attributes."""
         return {


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In preparation to enable the mypy check for `@override` in https://github.com/home-assistant/core/pull/171853

To make it easier to review, you can get a simplified diff with only changed lines (no context), and check that only imports changed and `@override` lines added: `git show override_componets_h_i --unified=0 | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)'`

Or get a diff with only the non-decorator changes:

`git show override_componets_h_i --unified=0 | grep -E '^[+-]' | grep -vE '^(\+\+\+|---) ' | grep -vE '^[+-][[:space:]]*@override$' | grep -vE '^[+-]from typing import '`

To reproduce and double check this change, run the following:

```bash
# generate errors list:
python extract_override_errors.py homeassistant/components

# filter component range
grep -E 'components/[h-i]' explicit_override_errors.txt | sort -o explicit_override_errors.txt

# add override decorator and ruff it
python add_override_decorators.py explicit_override_errors.txt
```

The two scripts can be found in https://github.com/home-assistant/core/pull/171853


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
