### PR TITLE
Rename entity trigger and condition keys for consistency

### DIFF
--- a/homeassistant/components/battery/icons.json
+++ b/homeassistant/components/battery/icons.json
@@ -17,16 +17,16 @@
     }
   },
   "triggers": {
+    "became_low": {
+      "trigger": "mdi:battery-alert"
+    },
     "level_changed": {
       "trigger": "mdi:battery-unknown"
     },
     "level_crossed_threshold": {
       "trigger": "mdi:battery-alert"
     },
-    "low": {
-      "trigger": "mdi:battery-alert"
-    },
-    "not_low": {
+    "no_longer_low": {
       "trigger": "mdi:battery"
     },
     "started_charging": {

--- a/homeassistant/components/battery/strings.json
+++ b/homeassistant/components/battery/strings.json
@@ -74,6 +74,18 @@
   },
   "title": "Battery",
   "triggers": {
+    "became_low": {
+      "description": "Triggers after one or more batteries become low.",
+      "fields": {
+        "behavior": {
+          "name": "[%key:component::battery::common::trigger_behavior_name%]"
+        },
+        "for": {
+          "name": "[%key:component::battery::common::trigger_for_name%]"
+        }
+      },
+      "name": "Battery low"
+    },
     "level_changed": {
       "description": "Triggers after the battery level of one or more batteries changes.",
       "fields": {
@@ -98,19 +110,7 @@
       },
       "name": "Battery level crossed threshold"
     },
-    "low": {
-      "description": "Triggers after one or more batteries become low.",
-      "fields": {
-        "behavior": {
-          "name": "[%key:component::battery::common::trigger_behavior_name%]"
-        },
-        "for": {
-          "name": "[%key:component::battery::common::trigger_for_name%]"
-        }
-      },
-      "name": "Battery low"
-    },
-    "not_low": {
+    "no_longer_low": {
       "description": "Triggers after one or more batteries are no longer low.",
       "fields": {
         "behavior": {

--- a/homeassistant/components/battery/trigger.py
+++ b/homeassistant/components/battery/trigger.py
@@ -30,10 +30,10 @@ BATTERY_PERCENTAGE_DOMAIN_SPECS: dict[str, DomainSpec] = {
 }
 
 TRIGGERS: dict[str, type[Trigger]] = {
-    "low": make_entity_target_state_trigger(
+    "became_low": make_entity_target_state_trigger(
         BATTERY_LOW_DOMAIN_SPECS, STATE_ON, primary_entities_only=False
     ),
-    "not_low": make_entity_target_state_trigger(
+    "no_longer_low": make_entity_target_state_trigger(
         BATTERY_LOW_DOMAIN_SPECS, STATE_OFF, primary_entities_only=False
     ),
     "started_charging": make_entity_target_state_trigger(

--- a/homeassistant/components/battery/triggers.yaml
+++ b/homeassistant/components/battery/triggers.yaml
@@ -43,13 +43,13 @@
       device_class: battery
   primary_entities_only: false
 
-low:
+became_low:
   fields:
     behavior: *trigger_behavior
     for: *trigger_for
   target: *trigger_target_battery
 
-not_low:
+no_longer_low:
   fields:
     behavior: *trigger_behavior
     for: *trigger_for

--- a/homeassistant/components/climate/condition.py
+++ b/homeassistant/components/climate/condition.py
@@ -109,8 +109,8 @@ CONDITIONS: dict[str, type[Condition]] = {
     "is_heating": make_entity_state_condition(
         {DOMAIN: DomainSpec(value_source=ATTR_HVAC_ACTION)}, HVACAction.HEATING
     ),
-    "target_humidity": ClimateTargetHumidityCondition,
-    "target_temperature": ClimateTargetTemperatureCondition,
+    "is_target_humidity": ClimateTargetHumidityCondition,
+    "is_target_temperature": ClimateTargetTemperatureCondition,
 }
 
 

--- a/homeassistant/components/climate/conditions.yaml
+++ b/homeassistant/components/climate/conditions.yaml
@@ -63,7 +63,7 @@ is_hvac_mode:
             - unknown
           multiple: true
 
-target_humidity:
+is_target_humidity:
   target: *condition_climate_target
   fields:
     behavior: *condition_behavior
@@ -76,7 +76,7 @@ target_humidity:
           mode: is
           number: *humidity_threshold_number
 
-target_temperature:
+is_target_temperature:
   target: *condition_climate_target
   fields:
     behavior: *condition_behavior

--- a/homeassistant/components/climate/icons.json
+++ b/homeassistant/components/climate/icons.json
@@ -18,10 +18,10 @@
     "is_on": {
       "condition": "mdi:power-on"
     },
-    "target_humidity": {
+    "is_target_humidity": {
       "condition": "mdi:water-percent"
     },
-    "target_temperature": {
+    "is_target_temperature": {
       "condition": "mdi:thermometer"
     }
   },

--- a/homeassistant/components/climate/strings.json
+++ b/homeassistant/components/climate/strings.json
@@ -84,7 +84,7 @@
       },
       "name": "Thermostat is on"
     },
-    "target_humidity": {
+    "is_target_humidity": {
       "description": "Tests the humidity setpoint of one or more thermostats.",
       "fields": {
         "behavior": {
@@ -99,7 +99,7 @@
       },
       "name": "Thermostat target humidity"
     },
-    "target_temperature": {
+    "is_target_temperature": {
       "description": "Tests the temperature setpoint of one or more thermostats.",
       "fields": {
         "behavior": {

--- a/homeassistant/components/lawn_mower/icons.json
+++ b/homeassistant/components/lawn_mower/icons.json
@@ -33,14 +33,14 @@
     }
   },
   "triggers": {
-    "docked": {
-      "trigger": "mdi:home-import-outline"
-    },
     "errored": {
       "trigger": "mdi:alert-circle-outline"
     },
     "paused_mowing": {
       "trigger": "mdi:pause"
+    },
+    "returned_to_dock": {
+      "trigger": "mdi:home-import-outline"
     },
     "started_mowing": {
       "trigger": "mdi:play"

--- a/homeassistant/components/lawn_mower/strings.json
+++ b/homeassistant/components/lawn_mower/strings.json
@@ -95,18 +95,6 @@
   },
   "title": "Lawn mower",
   "triggers": {
-    "docked": {
-      "description": "Triggers after one or more lawn mowers have returned to dock.",
-      "fields": {
-        "behavior": {
-          "name": "[%key:component::lawn_mower::common::trigger_behavior_name%]"
-        },
-        "for": {
-          "name": "[%key:component::lawn_mower::common::trigger_for_name%]"
-        }
-      },
-      "name": "Lawn mower returned to dock"
-    },
     "errored": {
       "description": "Triggers after one or more lawn mowers encounter an error.",
       "fields": {
@@ -130,6 +118,18 @@
         }
       },
       "name": "Lawn mower paused mowing"
+    },
+    "returned_to_dock": {
+      "description": "Triggers after one or more lawn mowers have returned to dock.",
+      "fields": {
+        "behavior": {
+          "name": "[%key:component::lawn_mower::common::trigger_behavior_name%]"
+        },
+        "for": {
+          "name": "[%key:component::lawn_mower::common::trigger_for_name%]"
+        }
+      },
+      "name": "Lawn mower returned to dock"
     },
     "started_mowing": {
       "description": "Triggers after one or more lawn mowers start mowing.",

--- a/homeassistant/components/lawn_mower/trigger.py
+++ b/homeassistant/components/lawn_mower/trigger.py
@@ -6,7 +6,9 @@ from homeassistant.helpers.trigger import Trigger, make_entity_target_state_trig
 from .const import DOMAIN, LawnMowerActivity
 
 TRIGGERS: dict[str, type[Trigger]] = {
-    "docked": make_entity_target_state_trigger(DOMAIN, LawnMowerActivity.DOCKED),
+    "returned_to_dock": make_entity_target_state_trigger(
+        DOMAIN, LawnMowerActivity.DOCKED
+    ),
     "errored": make_entity_target_state_trigger(DOMAIN, LawnMowerActivity.ERROR),
     "paused_mowing": make_entity_target_state_trigger(DOMAIN, LawnMowerActivity.PAUSED),
     "started_mowing": make_entity_target_state_trigger(

--- a/homeassistant/components/lawn_mower/triggers.yaml
+++ b/homeassistant/components/lawn_mower/triggers.yaml
@@ -15,7 +15,7 @@
       selector:
         duration:
 
-docked: *trigger_common
+returned_to_dock: *trigger_common
 errored: *trigger_common
 paused_mowing: *trigger_common
 started_mowing: *trigger_common

--- a/homeassistant/components/schedule/icons.json
+++ b/homeassistant/components/schedule/icons.json
@@ -16,10 +16,10 @@
     }
   },
   "triggers": {
-    "turned_off": {
+    "block_ended": {
       "trigger": "mdi:calendar-blank"
     },
-    "turned_on": {
+    "block_started": {
       "trigger": "mdi:calendar-clock"
     }
   }

--- a/homeassistant/components/schedule/strings.json
+++ b/homeassistant/components/schedule/strings.json
@@ -64,7 +64,7 @@
   },
   "title": "Schedule",
   "triggers": {
-    "turned_off": {
+    "block_ended": {
       "description": "Triggers when a schedule block ends.",
       "fields": {
         "behavior": {
@@ -76,7 +76,7 @@
       },
       "name": "Schedule block ended"
     },
-    "turned_on": {
+    "block_started": {
       "description": "Triggers when a schedule block starts.",
       "fields": {
         "behavior": {

--- a/homeassistant/components/schedule/trigger.py
+++ b/homeassistant/components/schedule/trigger.py
@@ -30,8 +30,8 @@ class ScheduleBackToBackTrigger(EntityTransitionTriggerBase):
 
 
 TRIGGERS: dict[str, type[Trigger]] = {
-    "turned_on": ScheduleBackToBackTrigger,
-    "turned_off": make_entity_target_state_trigger(DOMAIN, STATE_OFF),
+    "block_started": ScheduleBackToBackTrigger,
+    "block_ended": make_entity_target_state_trigger(DOMAIN, STATE_OFF),
 }
 
 

--- a/homeassistant/components/schedule/triggers.yaml
+++ b/homeassistant/components/schedule/triggers.yaml
@@ -15,5 +15,5 @@
       selector:
         duration:
 
-turned_off: *trigger_common
-turned_on: *trigger_common
+block_ended: *trigger_common
+block_started: *trigger_common

--- a/homeassistant/components/timer/icons.json
+++ b/homeassistant/components/timer/icons.json
@@ -40,14 +40,14 @@
     "paused": {
       "trigger": "mdi:timer-pause"
     },
+    "remaining_time_reached": {
+      "trigger": "mdi:timer-alert-outline"
+    },
     "restarted": {
       "trigger": "mdi:timer-refresh"
     },
     "started": {
       "trigger": "mdi:timer-play"
-    },
-    "time_remaining": {
-      "trigger": "mdi:timer-alert-outline"
     }
   }
 }

--- a/homeassistant/components/timer/strings.json
+++ b/homeassistant/components/timer/strings.json
@@ -160,6 +160,15 @@
       },
       "name": "Timer paused"
     },
+    "remaining_time_reached": {
+      "description": "Triggers when one or more timers reach a specific remaining time.",
+      "fields": {
+        "remaining": {
+          "name": "Time remaining"
+        }
+      },
+      "name": "Timer time remaining"
+    },
     "restarted": {
       "description": "Triggers when one or more timers are restarted.",
       "fields": {
@@ -183,15 +192,6 @@
         }
       },
       "name": "Timer started"
-    },
-    "time_remaining": {
-      "description": "Triggers when one or more timers reach a specific remaining time.",
-      "fields": {
-        "remaining": {
-          "name": "Time remaining"
-        }
-      },
-      "name": "Timer time remaining"
     }
   }
 }

--- a/homeassistant/components/timer/trigger.py
+++ b/homeassistant/components/timer/trigger.py
@@ -180,7 +180,7 @@ TRIGGERS: dict[str, type[Trigger]] = {
     "started": make_entity_target_state_trigger(
         {DOMAIN: DomainSpec(value_source=ATTR_LAST_TRANSITION)}, "started"
     ),
-    "time_remaining": TimeRemainingTrigger,
+    "remaining_time_reached": TimeRemainingTrigger,
 }
 
 

--- a/homeassistant/components/timer/triggers.yaml
+++ b/homeassistant/components/timer/triggers.yaml
@@ -21,7 +21,7 @@ paused: *trigger_common
 restarted: *trigger_common
 started: *trigger_common
 
-time_remaining:
+remaining_time_reached:
   target:
     entity:
       domain: timer

--- a/homeassistant/components/update/icons.json
+++ b/homeassistant/components/update/icons.json
@@ -27,7 +27,7 @@
     }
   },
   "triggers": {
-    "update_became_available": {
+    "became_available": {
       "trigger": "mdi:package-up"
     }
   }

--- a/homeassistant/components/update/strings.json
+++ b/homeassistant/components/update/strings.json
@@ -113,7 +113,7 @@
   },
   "title": "Update",
   "triggers": {
-    "update_became_available": {
+    "became_available": {
       "description": "Triggers after one or more updates become available.",
       "fields": {
         "behavior": {

--- a/homeassistant/components/update/trigger.py
+++ b/homeassistant/components/update/trigger.py
@@ -7,7 +7,7 @@ from homeassistant.helpers.trigger import Trigger, make_entity_target_state_trig
 from .const import DOMAIN
 
 TRIGGERS: dict[str, type[Trigger]] = {
-    "update_became_available": make_entity_target_state_trigger(DOMAIN, STATE_ON),
+    "became_available": make_entity_target_state_trigger(DOMAIN, STATE_ON),
 }
 
 

--- a/homeassistant/components/update/triggers.yaml
+++ b/homeassistant/components/update/triggers.yaml
@@ -15,4 +15,4 @@
       selector:
         duration:
 
-update_became_available: *trigger_common
+became_available: *trigger_common

--- a/homeassistant/components/vacuum/icons.json
+++ b/homeassistant/components/vacuum/icons.json
@@ -63,14 +63,14 @@
     }
   },
   "triggers": {
-    "docked": {
-      "trigger": "mdi:home-outline"
-    },
     "errored": {
       "trigger": "mdi:alert-circle-outline"
     },
     "paused_cleaning": {
       "trigger": "mdi:pause"
+    },
+    "returned_to_dock": {
+      "trigger": "mdi:home-outline"
     },
     "started_cleaning": {
       "trigger": "mdi:play"

--- a/homeassistant/components/vacuum/strings.json
+++ b/homeassistant/components/vacuum/strings.json
@@ -190,18 +190,6 @@
   },
   "title": "Vacuum",
   "triggers": {
-    "docked": {
-      "description": "Triggers after one or more vacuums have returned to dock.",
-      "fields": {
-        "behavior": {
-          "name": "[%key:component::vacuum::common::trigger_behavior_name%]"
-        },
-        "for": {
-          "name": "[%key:component::vacuum::common::trigger_for_name%]"
-        }
-      },
-      "name": "Vacuum returned to dock"
-    },
     "errored": {
       "description": "Triggers after one or more vacuums encounter an error.",
       "fields": {
@@ -225,6 +213,18 @@
         }
       },
       "name": "Vacuum cleaner paused cleaning"
+    },
+    "returned_to_dock": {
+      "description": "Triggers after one or more vacuums have returned to dock.",
+      "fields": {
+        "behavior": {
+          "name": "[%key:component::vacuum::common::trigger_behavior_name%]"
+        },
+        "for": {
+          "name": "[%key:component::vacuum::common::trigger_for_name%]"
+        }
+      },
+      "name": "Vacuum returned to dock"
     },
     "started_cleaning": {
       "description": "Triggers after one or more vacuums start cleaning.",

--- a/homeassistant/components/vacuum/trigger.py
+++ b/homeassistant/components/vacuum/trigger.py
@@ -6,7 +6,7 @@ from homeassistant.helpers.trigger import Trigger, make_entity_target_state_trig
 from .const import DOMAIN, VacuumActivity
 
 TRIGGERS: dict[str, type[Trigger]] = {
-    "docked": make_entity_target_state_trigger(DOMAIN, VacuumActivity.DOCKED),
+    "returned_to_dock": make_entity_target_state_trigger(DOMAIN, VacuumActivity.DOCKED),
     "errored": make_entity_target_state_trigger(DOMAIN, VacuumActivity.ERROR),
     "paused_cleaning": make_entity_target_state_trigger(DOMAIN, VacuumActivity.PAUSED),
     "started_cleaning": make_entity_target_state_trigger(

--- a/homeassistant/components/vacuum/triggers.yaml
+++ b/homeassistant/components/vacuum/triggers.yaml
@@ -15,7 +15,7 @@
       selector:
         duration:
 
-docked: *trigger_common
+returned_to_dock: *trigger_common
 errored: *trigger_common
 paused_cleaning: *trigger_common
 started_cleaning: *trigger_common

--- a/tests/components/battery/test_trigger.py
+++ b/tests/components/battery/test_trigger.py
@@ -51,8 +51,8 @@ _LEVEL_CROSSED_THRESHOLD = {"threshold": {"type": "above", "value": {"number": 5
 @pytest.mark.parametrize(
     ("trigger_key", "base_options", "supports_behavior", "supports_duration"),
     [
-        ("battery.low", {}, True, True),
-        ("battery.not_low", {}, True, True),
+        ("battery.became_low", {}, True, True),
+        ("battery.no_longer_low", {}, True, True),
         ("battery.started_charging", {}, True, True),
         ("battery.stopped_charging", {}, True, True),
         ("battery.level_changed", _LEVEL_CHANGED_THRESHOLD, False, False),
@@ -84,14 +84,14 @@ async def test_battery_trigger_options_validation(
     ("trigger", "trigger_options", "states"),
     [
         *parametrize_trigger_states(
-            trigger="battery.low",
+            trigger="battery.became_low",
             target_states=[STATE_ON],
             other_states=[STATE_OFF],
             required_filter_attributes={ATTR_DEVICE_CLASS: "battery"},
             trigger_from_none=False,
         ),
         *parametrize_trigger_states(
-            trigger="battery.not_low",
+            trigger="battery.no_longer_low",
             target_states=[STATE_OFF],
             other_states=[STATE_ON],
             required_filter_attributes={ATTR_DEVICE_CLASS: "battery"},
@@ -144,14 +144,14 @@ async def test_battery_binary_sensor_trigger_behavior_each(
     ("trigger", "trigger_options", "states"),
     [
         *parametrize_trigger_states(
-            trigger="battery.low",
+            trigger="battery.became_low",
             target_states=[STATE_ON],
             other_states=[STATE_OFF],
             required_filter_attributes={ATTR_DEVICE_CLASS: "battery"},
             trigger_from_none=False,
         ),
         *parametrize_trigger_states(
-            trigger="battery.not_low",
+            trigger="battery.no_longer_low",
             target_states=[STATE_OFF],
             other_states=[STATE_ON],
             required_filter_attributes={ATTR_DEVICE_CLASS: "battery"},
@@ -204,14 +204,14 @@ async def test_battery_binary_sensor_trigger_behavior_first(
     ("trigger", "trigger_options", "states"),
     [
         *parametrize_trigger_states(
-            trigger="battery.low",
+            trigger="battery.became_low",
             target_states=[STATE_ON],
             other_states=[STATE_OFF],
             required_filter_attributes={ATTR_DEVICE_CLASS: "battery"},
             trigger_from_none=False,
         ),
         *parametrize_trigger_states(
-            trigger="battery.not_low",
+            trigger="battery.no_longer_low",
             target_states=[STATE_OFF],
             other_states=[STATE_ON],
             required_filter_attributes={ATTR_DEVICE_CLASS: "battery"},

--- a/tests/components/climate/test_condition.py
+++ b/tests/components/climate/test_condition.py
@@ -57,8 +57,8 @@ _TEMPERATURE_THRESHOLD = {
         ("climate.is_drying", {}, True, True),
         ("climate.is_heating", {}, True, True),
         ("climate.is_hvac_mode", {"hvac_mode": [HVACMode.HEAT]}, True, True),
-        ("climate.target_humidity", _HUMIDITY_THRESHOLD, True, True),
-        ("climate.target_temperature", _TEMPERATURE_THRESHOLD, True, True),
+        ("climate.is_target_humidity", _HUMIDITY_THRESHOLD, True, True),
+        ("climate.is_target_temperature", _TEMPERATURE_THRESHOLD, True, True),
     ],
 )
 async def test_climate_condition_options_validation(
@@ -314,13 +314,13 @@ async def test_climate_attribute_condition_behavior_all(
     ("condition", "condition_options", "states"),
     [
         *parametrize_numerical_attribute_condition_above_below_any(
-            "climate.target_humidity",
+            "climate.is_target_humidity",
             HVACMode.AUTO,
             ATTR_HUMIDITY,
             attribute_required=True,
         ),
         *parametrize_numerical_attribute_condition_above_below_any(
-            "climate.target_temperature",
+            "climate.is_target_temperature",
             HVACMode.AUTO,
             ATTR_TEMPERATURE,
             threshold_unit=UnitOfTemperature.CELSIUS,
@@ -359,13 +359,13 @@ async def test_climate_numerical_condition_behavior_any(
     ("condition", "condition_options", "states"),
     [
         *parametrize_numerical_attribute_condition_above_below_all(
-            "climate.target_humidity",
+            "climate.is_target_humidity",
             HVACMode.AUTO,
             ATTR_HUMIDITY,
             attribute_required=True,
         ),
         *parametrize_numerical_attribute_condition_above_below_all(
-            "climate.target_temperature",
+            "climate.is_target_temperature",
             HVACMode.AUTO,
             ATTR_TEMPERATURE,
             threshold_unit=UnitOfTemperature.CELSIUS,
@@ -404,7 +404,7 @@ async def test_climate_numerical_condition_unit_conversion(hass: HomeAssistant) 
 
     await assert_numerical_condition_unit_conversion(
         hass,
-        condition="climate.target_temperature",
+        condition="climate.is_target_temperature",
         entity_id="climate.test",
         pass_states=[{"state": HVACMode.AUTO, "attributes": {ATTR_TEMPERATURE: 25}}],
         fail_states=[

--- a/tests/components/common.py
+++ b/tests/components/common.py
@@ -374,7 +374,7 @@ def parametrize_condition_states_any(
     every other targeted entity has been set to the same state.
 
     Args:
-        condition: Condition key, e.g. `"climate.target_humidity"`.
+        condition: Condition key, e.g. `"climate.is_target_humidity"`.
         condition_options: Options dict passed to the condition (typically
             includes the `threshold` block); merged into each generated tuple.
         target_states: States the condition is expected to evaluate True
@@ -433,7 +433,7 @@ def parametrize_condition_states_all(
     every other targeted entity has been set to the same state.
 
     Args:
-        condition: Condition key, e.g. `"climate.target_humidity"`.
+        condition: Condition key, e.g. `"climate.is_target_humidity"`.
         condition_options: Options dict passed to the condition (typically
             includes the `threshold` block); merged into each generated tuple.
         target_states: States the condition is expected to evaluate True for
@@ -2136,7 +2136,7 @@ def parametrize_numerical_attribute_condition_above_below_any(
 
     Uses behavior=any. Generates state sequences for a condition
     that reads its tracked value from a state attribute
-    (e.g. `climate.target_humidity`). The condition
+    (e.g. `climate.is_target_humidity`). The condition
     is exercised across three threshold types in turn — "above", "below",
     "between" — and for each, the helper invokes
     `parametrize_condition_states_any` with target/other states populated
@@ -2149,7 +2149,7 @@ def parametrize_numerical_attribute_condition_above_below_any(
     `("condition", "condition_options", "states")`.
 
     Args:
-        condition: Condition key, e.g. `"climate.target_humidity"`.
+        condition: Condition key, e.g. `"climate.is_target_humidity"`.
         state: The `state.state` value to use for entities meant to match
             the condition (the attribute lives on top of this state).
         attribute: Name of the attribute the condition reads. The helper
@@ -2296,7 +2296,7 @@ def parametrize_numerical_attribute_condition_above_below_all(
     `("condition", "condition_options", "states")`.
 
     Args:
-        condition: Condition key, e.g. `"climate.target_humidity"`.
+        condition: Condition key, e.g. `"climate.is_target_humidity"`.
         state: The `state.state` value to use for entities meant to match
             the condition (the attribute lives on top of this state).
         attribute: Name of the attribute the condition reads. The helper
@@ -2511,7 +2511,7 @@ async def assert_numerical_condition_unit_conversion(
     entities whose unit_of_measurement is invalid (not convertible).
 
     Args:
-        condition: The condition key (e.g. "climate.target_temperature").
+        condition: The condition key (e.g. "climate.is_target_temperature").
         entity_id: The entity being evaluated by the condition.
         pass_states: Entity states that should make the condition pass.
         fail_states: Entity states that should make the condition fail.

--- a/tests/components/lawn_mower/test_trigger.py
+++ b/tests/components/lawn_mower/test_trigger.py
@@ -29,7 +29,7 @@ async def target_lawn_mowers(hass: HomeAssistant) -> dict[str, list[str]]:
 @pytest.mark.parametrize(
     ("trigger_key", "base_options", "supports_behavior", "supports_duration"),
     [
-        ("lawn_mower.docked", {}, True, True),
+        ("lawn_mower.returned_to_dock", {}, True, True),
         ("lawn_mower.errored", {}, True, True),
         ("lawn_mower.paused_mowing", {}, True, True),
         ("lawn_mower.started_mowing", {}, True, True),
@@ -61,7 +61,7 @@ async def test_lawn_mower_trigger_options_validation(
     ("trigger", "trigger_options", "states"),
     [
         *parametrize_trigger_states(
-            trigger="lawn_mower.docked",
+            trigger="lawn_mower.returned_to_dock",
             target_states=[LawnMowerActivity.DOCKED],
             other_states=other_states(LawnMowerActivity.DOCKED),
         ),
@@ -118,7 +118,7 @@ async def test_lawn_mower_state_trigger_behavior_each(
     ("trigger", "trigger_options", "states"),
     [
         *parametrize_trigger_states(
-            trigger="lawn_mower.docked",
+            trigger="lawn_mower.returned_to_dock",
             target_states=[LawnMowerActivity.DOCKED],
             other_states=other_states(LawnMowerActivity.DOCKED),
         ),
@@ -175,7 +175,7 @@ async def test_lawn_mower_state_trigger_behavior_first(
     ("trigger", "trigger_options", "states"),
     [
         *parametrize_trigger_states(
-            trigger="lawn_mower.docked",
+            trigger="lawn_mower.returned_to_dock",
             target_states=[LawnMowerActivity.DOCKED],
             other_states=other_states(LawnMowerActivity.DOCKED),
         ),

--- a/tests/components/schedule/test_trigger.py
+++ b/tests/components/schedule/test_trigger.py
@@ -39,8 +39,8 @@ async def target_schedules(hass: HomeAssistant) -> dict[str, list[str]]:
 @pytest.mark.parametrize(
     ("trigger_key", "base_options", "supports_behavior", "supports_duration"),
     [
-        ("schedule.turned_off", {}, True, True),
-        ("schedule.turned_on", {}, True, True),
+        ("schedule.block_ended", {}, True, True),
+        ("schedule.block_started", {}, True, True),
     ],
 )
 async def test_schedule_trigger_options_validation(
@@ -68,12 +68,12 @@ async def test_schedule_trigger_options_validation(
     ("trigger", "trigger_options", "states"),
     [
         *parametrize_trigger_states(
-            trigger="schedule.turned_off",
+            trigger="schedule.block_ended",
             target_states=[(STATE_OFF, {ATTR_NEXT_EVENT: "2022-08-30T13:20:00-07:00"})],
             other_states=[(STATE_ON, {ATTR_NEXT_EVENT: "2022-08-30T13:30:00-07:00"})],
         ),
         *parametrize_trigger_states(
-            trigger="schedule.turned_on",
+            trigger="schedule.block_started",
             target_states=[(STATE_ON, {ATTR_NEXT_EVENT: "2022-08-30T13:20:00-07:00"})],
             other_states=[(STATE_OFF, {ATTR_NEXT_EVENT: "2022-08-30T13:30:00-07:00"})],
         ),
@@ -110,12 +110,12 @@ async def test_schedule_state_trigger_behavior_each(
     ("trigger", "trigger_options", "states"),
     [
         *parametrize_trigger_states(
-            trigger="schedule.turned_off",
+            trigger="schedule.block_ended",
             target_states=[(STATE_OFF, {ATTR_NEXT_EVENT: "2022-08-30T13:20:00-07:00"})],
             other_states=[(STATE_ON, {ATTR_NEXT_EVENT: "2022-08-30T13:30:00-07:00"})],
         ),
         *parametrize_trigger_states(
-            trigger="schedule.turned_on",
+            trigger="schedule.block_started",
             target_states=[(STATE_ON, {ATTR_NEXT_EVENT: "2022-08-30T13:20:00-07:00"})],
             other_states=[(STATE_OFF, {ATTR_NEXT_EVENT: "2022-08-30T13:30:00-07:00"})],
         ),
@@ -152,12 +152,12 @@ async def test_schedule_state_trigger_behavior_first(
     ("trigger", "trigger_options", "states"),
     [
         *parametrize_trigger_states(
-            trigger="schedule.turned_off",
+            trigger="schedule.block_ended",
             target_states=[(STATE_OFF, {ATTR_NEXT_EVENT: "2022-08-30T13:20:00-07:00"})],
             other_states=[(STATE_ON, {ATTR_NEXT_EVENT: "2022-08-30T13:30:00-07:00"})],
         ),
         *parametrize_trigger_states(
-            trigger="schedule.turned_on",
+            trigger="schedule.block_started",
             target_states=[(STATE_ON, {ATTR_NEXT_EVENT: "2022-08-30T13:20:00-07:00"})],
             other_states=[(STATE_OFF, {ATTR_NEXT_EVENT: "2022-08-30T13:30:00-07:00"})],
         ),
@@ -214,7 +214,7 @@ async def test_schedule_state_trigger_back_to_back(
 
     await arm_trigger(
         hass,
-        "schedule.turned_on",
+        "schedule.block_started",
         {},
         {"entity_id": [entity_id]},
         calls,

--- a/tests/components/timer/test_trigger.py
+++ b/tests/components/timer/test_trigger.py
@@ -59,7 +59,7 @@ async def target_timers(hass: HomeAssistant) -> dict[str, list[str]]:
         ("timer.paused", {}, True, True),
         ("timer.restarted", {}, True, True),
         ("timer.started", {}, True, True),
-        ("timer.time_remaining", {"remaining": {"hours": 1}}, False, False),
+        ("timer.remaining_time_reached", {"remaining": {"hours": 1}}, False, False),
     ],
 )
 async def test_timer_trigger_options_validation(
@@ -266,7 +266,7 @@ async def _arm_time_remaining_trigger(
         hass,
         [
             {
-                CONF_PLATFORM: "timer.time_remaining",
+                CONF_PLATFORM: "timer.remaining_time_reached",
                 CONF_TARGET: target or {CONF_ENTITY_ID: entity_id},
                 CONF_OPTIONS: {"remaining": remaining},
             }
@@ -299,7 +299,7 @@ async def test_time_remaining_trigger_validation(hass: HomeAssistant) -> None:
         hass,
         [
             {
-                CONF_PLATFORM: "timer.time_remaining",
+                CONF_PLATFORM: "timer.remaining_time_reached",
                 CONF_TARGET: {CONF_ENTITY_ID: "timer.test"},
                 CONF_OPTIONS: {"remaining": {"seconds": 30}},
             }
@@ -312,7 +312,7 @@ async def test_time_remaining_trigger_validation(hass: HomeAssistant) -> None:
             hass,
             [
                 {
-                    CONF_PLATFORM: "timer.time_remaining",
+                    CONF_PLATFORM: "timer.remaining_time_reached",
                     CONF_TARGET: {CONF_ENTITY_ID: "timer.test"},
                     CONF_OPTIONS: {},
                 }

--- a/tests/components/update/test_trigger.py
+++ b/tests/components/update/test_trigger.py
@@ -29,7 +29,7 @@ async def target_updates(hass: HomeAssistant) -> dict[str, list[str]]:
 @pytest.mark.parametrize(
     ("trigger_key", "base_options", "supports_behavior", "supports_duration"),
     [
-        ("update.update_became_available", {}, True, True),
+        ("update.became_available", {}, True, True),
     ],
 )
 async def test_update_trigger_options_validation(
@@ -57,7 +57,7 @@ async def test_update_trigger_options_validation(
     ("trigger", "trigger_options", "states"),
     [
         *parametrize_trigger_states(
-            trigger="update.update_became_available",
+            trigger="update.became_available",
             target_states=[STATE_ON],
             other_states=[STATE_OFF],
         ),
@@ -94,7 +94,7 @@ async def test_update_state_trigger_behavior_each(
     ("trigger", "trigger_options", "states"),
     [
         *parametrize_trigger_states(
-            trigger="update.update_became_available",
+            trigger="update.became_available",
             target_states=[STATE_ON],
             other_states=[STATE_OFF],
         ),
@@ -131,7 +131,7 @@ async def test_update_state_trigger_behavior_first(
     ("trigger", "trigger_options", "states"),
     [
         *parametrize_trigger_states(
-            trigger="update.update_became_available",
+            trigger="update.became_available",
             target_states=[STATE_ON],
             other_states=[STATE_OFF],
         ),

--- a/tests/components/vacuum/test_trigger.py
+++ b/tests/components/vacuum/test_trigger.py
@@ -29,7 +29,7 @@ async def target_vacuums(hass: HomeAssistant) -> dict[str, list[str]]:
 @pytest.mark.parametrize(
     ("trigger_key", "base_options", "supports_behavior", "supports_duration"),
     [
-        ("vacuum.docked", {}, True, True),
+        ("vacuum.returned_to_dock", {}, True, True),
         ("vacuum.errored", {}, True, True),
         ("vacuum.paused_cleaning", {}, True, True),
         ("vacuum.started_cleaning", {}, True, True),
@@ -61,7 +61,7 @@ async def test_vacuum_trigger_options_validation(
     ("trigger", "trigger_options", "states"),
     [
         *parametrize_trigger_states(
-            trigger="vacuum.docked",
+            trigger="vacuum.returned_to_dock",
             target_states=[VacuumActivity.DOCKED],
             other_states=other_states(VacuumActivity.DOCKED),
         ),
@@ -118,7 +118,7 @@ async def test_vacuum_state_trigger_behavior_each(
     ("trigger", "trigger_options", "states"),
     [
         *parametrize_trigger_states(
-            trigger="vacuum.docked",
+            trigger="vacuum.returned_to_dock",
             target_states=[VacuumActivity.DOCKED],
             other_states=other_states(VacuumActivity.DOCKED),
         ),
@@ -175,7 +175,7 @@ async def test_vacuum_state_trigger_behavior_first(
     ("trigger", "trigger_options", "states"),
     [
         *parametrize_trigger_states(
-            trigger="vacuum.docked",
+            trigger="vacuum.returned_to_dock",
             target_states=[VacuumActivity.DOCKED],
             other_states=other_states(VacuumActivity.DOCKED),
         ),


### PR DESCRIPTION
## Breaking change

Several entity triggers and conditions, part of the new purpose-specific triggers and conditions, have been renamed so their keys are consistent across all domains. The old keys no longer work.

The following keys changed:

Triggers:
- `battery.low` is now `battery.became_low`
- `battery.not_low` is now `battery.no_longer_low`
- `lawn_mower.docked` is now `lawn_mower.returned_to_dock`
- `schedule.turned_off` is now `schedule.block_ended`
- `schedule.turned_on` is now `schedule.block_started`
- `timer.time_remaining` is now `timer.remaining_time_reached`
- `update.update_became_available` is now `update.became_available`
- `vacuum.docked` is now `vacuum.returned_to_dock`

Conditions:
- `climate.target_humidity` is now `climate.is_target_humidity`
- `climate.target_temperature` is now `climate.is_target_temperature`

If you have an automation or script that uses one of these triggers or conditions, it will no longer find it and that trigger or condition will stop working until updated.

To fix it, open the affected automation or script, re-select the trigger or condition (it now shows under its new name), and save. If you edit in YAML, replace the old key with the new one from the list above.

## Proposed change

Entity triggers and conditions use a consistent naming pattern, but a handful were out of line. Conditions are expected to carry the `is_` prefix (`is_on`, `is_cooling`, ...), yet the two climate value conditions were exposed as `target_humidity` and `target_temperature`. Several triggers were named after a state rather than the event (`battery.low`, `vacuum.docked`), repeated their domain (`update.update_became_available`), or used a noun phrase instead of an event (`timer.time_remaining`).

This renames the keys so every entity trigger and condition follows the same pattern. Only the keys change in this PR. Titles and descriptions are intentionally left untouched and will be handled in a separate, dedicated pass.

Research: https://docs.google.com/document/d/18ZsosVR0OAOwkoQV1wmQ4FNSw18KV7EbPl0eNVP2uzA/edit?tab=t.0#heading=h.vwrsknoq58h0
Changes: https://docs.google.com/spreadsheets/d/1ahVHTWEZhk2-pwToI_ovHDBXIxHDmVqzRG41bwHGhMc/edit?gid=560897381#gid=560897381

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
