### PR TITLE
Reword trigger descriptions for opening and closing entities

### DIFF
--- a/homeassistant/components/cover/strings.json
+++ b/homeassistant/components/cover/strings.json
@@ -267,7 +267,7 @@
   "title": "Cover",
   "triggers": {
     "awning_closed": {
-      "description": "Triggers after one or more awnings close.",
+      "description": "Triggers when one or more awnings close.",
       "fields": {
         "behavior": {
           "name": "[%key:component::cover::common::trigger_behavior_name%]"
@@ -279,7 +279,7 @@
       "name": "Awning closed"
     },
     "awning_opened": {
-      "description": "Triggers after one or more awnings open.",
+      "description": "Triggers when one or more awnings open.",
       "fields": {
         "behavior": {
           "name": "[%key:component::cover::common::trigger_behavior_name%]"
@@ -291,7 +291,7 @@
       "name": "Awning opened"
     },
     "blind_closed": {
-      "description": "Triggers after one or more blinds close.",
+      "description": "Triggers when one or more blinds close.",
       "fields": {
         "behavior": {
           "name": "[%key:component::cover::common::trigger_behavior_name%]"
@@ -303,7 +303,7 @@
       "name": "Blind closed"
     },
     "blind_opened": {
-      "description": "Triggers after one or more blinds open.",
+      "description": "Triggers when one or more blinds open.",
       "fields": {
         "behavior": {
           "name": "[%key:component::cover::common::trigger_behavior_name%]"
@@ -315,7 +315,7 @@
       "name": "Blind opened"
     },
     "curtain_closed": {
-      "description": "Triggers after one or more curtains close.",
+      "description": "Triggers when one or more curtains close.",
       "fields": {
         "behavior": {
           "name": "[%key:component::cover::common::trigger_behavior_name%]"
@@ -327,7 +327,7 @@
       "name": "Curtain closed"
     },
     "curtain_opened": {
-      "description": "Triggers after one or more curtains open.",
+      "description": "Triggers when one or more curtains open.",
       "fields": {
         "behavior": {
           "name": "[%key:component::cover::common::trigger_behavior_name%]"
@@ -339,7 +339,7 @@
       "name": "Curtain opened"
     },
     "shade_closed": {
-      "description": "Triggers after one or more shades close.",
+      "description": "Triggers when one or more shades close.",
       "fields": {
         "behavior": {
           "name": "[%key:component::cover::common::trigger_behavior_name%]"
@@ -351,7 +351,7 @@
       "name": "Shade closed"
     },
     "shade_opened": {
-      "description": "Triggers after one or more shades open.",
+      "description": "Triggers when one or more shades open.",
       "fields": {
         "behavior": {
           "name": "[%key:component::cover::common::trigger_behavior_name%]"
@@ -363,7 +363,7 @@
       "name": "Shade opened"
     },
     "shutter_closed": {
-      "description": "Triggers after one or more shutters close.",
+      "description": "Triggers when one or more shutters close.",
       "fields": {
         "behavior": {
           "name": "[%key:component::cover::common::trigger_behavior_name%]"
@@ -375,7 +375,7 @@
       "name": "Shutter closed"
     },
     "shutter_opened": {
-      "description": "Triggers after one or more shutters open.",
+      "description": "Triggers when one or more shutters open.",
       "fields": {
         "behavior": {
           "name": "[%key:component::cover::common::trigger_behavior_name%]"

--- a/homeassistant/components/door/strings.json
+++ b/homeassistant/components/door/strings.json
@@ -34,7 +34,7 @@
   "title": "Door",
   "triggers": {
     "closed": {
-      "description": "Triggers after one or more doors close.",
+      "description": "Triggers when one or more doors close.",
       "fields": {
         "behavior": {
           "name": "[%key:component::door::common::trigger_behavior_name%]"
@@ -46,7 +46,7 @@
       "name": "Door closed"
     },
     "opened": {
-      "description": "Triggers after one or more doors open.",
+      "description": "Triggers when one or more doors open.",
       "fields": {
         "behavior": {
           "name": "[%key:component::door::common::trigger_behavior_name%]"

--- a/homeassistant/components/garage_door/strings.json
+++ b/homeassistant/components/garage_door/strings.json
@@ -34,7 +34,7 @@
   "title": "Garage door",
   "triggers": {
     "closed": {
-      "description": "Triggers after one or more garage doors close.",
+      "description": "Triggers when one or more garage doors close.",
       "fields": {
         "behavior": {
           "name": "[%key:component::garage_door::common::trigger_behavior_name%]"
@@ -46,7 +46,7 @@
       "name": "Garage door closed"
     },
     "opened": {
-      "description": "Triggers after one or more garage doors open.",
+      "description": "Triggers when one or more garage doors open.",
       "fields": {
         "behavior": {
           "name": "[%key:component::garage_door::common::trigger_behavior_name%]"

--- a/homeassistant/components/gate/strings.json
+++ b/homeassistant/components/gate/strings.json
@@ -34,7 +34,7 @@
   "title": "Gate",
   "triggers": {
     "closed": {
-      "description": "Triggers after one or more gates close.",
+      "description": "Triggers when one or more gates close.",
       "fields": {
         "behavior": {
           "name": "[%key:component::gate::common::trigger_behavior_name%]"
@@ -46,7 +46,7 @@
       "name": "Gate closed"
     },
     "opened": {
-      "description": "Triggers after one or more gates open.",
+      "description": "Triggers when one or more gates open.",
       "fields": {
         "behavior": {
           "name": "[%key:component::gate::common::trigger_behavior_name%]"

--- a/homeassistant/components/valve/strings.json
+++ b/homeassistant/components/valve/strings.json
@@ -85,7 +85,7 @@
   "title": "Valve",
   "triggers": {
     "closed": {
-      "description": "Triggers after one or more valves close.",
+      "description": "Triggers when one or more valves close.",
       "fields": {
         "behavior": {
           "name": "[%key:component::valve::common::trigger_behavior_name%]"
@@ -97,7 +97,7 @@
       "name": "Valve closed"
     },
     "opened": {
-      "description": "Triggers after one or more valves open.",
+      "description": "Triggers when one or more valves open.",
       "fields": {
         "behavior": {
           "name": "[%key:component::valve::common::trigger_behavior_name%]"

--- a/homeassistant/components/window/strings.json
+++ b/homeassistant/components/window/strings.json
@@ -34,7 +34,7 @@
   "title": "Window",
   "triggers": {
     "closed": {
-      "description": "Triggers after one or more windows close.",
+      "description": "Triggers when one or more windows close.",
       "fields": {
         "behavior": {
           "name": "[%key:component::window::common::trigger_behavior_name%]"
@@ -46,7 +46,7 @@
       "name": "Window closed"
     },
     "opened": {
-      "description": "Triggers after one or more windows open.",
+      "description": "Triggers when one or more windows open.",
       "fields": {
         "behavior": {
           "name": "[%key:component::window::common::trigger_behavior_name%]"


### PR DESCRIPTION
## Proposed change

Entity trigger descriptions open with "Triggers when". The triggers for the opening and closing entities (cover, door, garage door, gate, valve, window) used "Triggers after", which is slightly less natural to read and inconsistent with the rest. This rewords those trigger descriptions to start with "Triggers when". Only the descriptions change. Keys and names are untouched.

This is part of a wider effort to make the naming of triggers, conditions, and actions consistent across Home Assistant. The naming review and reasoning behind these changes is documented here: https://docs.google.com/document/d/18ZsosVR0OAOwkoQV1wmQ4FNSw18KV7EbPl0eNVP2uzA/edit?tab=t.0#heading=h.vwrsknoq58h0

The full sheet of proposed changes can be found here: https://docs.google.com/spreadsheets/d/1ahVHTWEZhk2-pwToI_ovHDBXIxHDmVqzRG41bwHGhMc/edit?gid=560897381#gid=560897381

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
