### PR TITLE
Reword trigger descriptions for presence and detection entities

### DIFF
--- a/homeassistant/components/doorbell/strings.json
+++ b/homeassistant/components/doorbell/strings.json
@@ -2,7 +2,7 @@
   "title": "Doorbell",
   "triggers": {
     "rang": {
-      "description": "Triggers after one or more doorbells rang.",
+      "description": "Triggers when one or more doorbells ring.",
       "name": "Doorbell rang"
     }
   }

--- a/homeassistant/components/moisture/strings.json
+++ b/homeassistant/components/moisture/strings.json
@@ -51,7 +51,7 @@
   "title": "Moisture",
   "triggers": {
     "changed": {
-      "description": "Triggers after one or more moisture content values change.",
+      "description": "Triggers when one or more moisture content values change.",
       "fields": {
         "threshold": {
           "name": "[%key:component::moisture::common::trigger_threshold_name%]"
@@ -60,7 +60,7 @@
       "name": "Moisture content changed"
     },
     "cleared": {
-      "description": "Triggers after one or more moisture sensors stop detecting moisture.",
+      "description": "Triggers when one or more moisture sensors stop detecting moisture.",
       "fields": {
         "behavior": {
           "name": "[%key:component::moisture::common::trigger_behavior_name%]"
@@ -72,7 +72,7 @@
       "name": "Moisture cleared"
     },
     "crossed_threshold": {
-      "description": "Triggers after one or more moisture content values cross a threshold.",
+      "description": "Triggers when one or more moisture content values cross a threshold.",
       "fields": {
         "behavior": {
           "name": "[%key:component::moisture::common::trigger_behavior_name%]"
@@ -87,7 +87,7 @@
       "name": "Moisture content crossed threshold"
     },
     "detected": {
-      "description": "Triggers after one or more moisture sensors start detecting moisture.",
+      "description": "Triggers when one or more moisture sensors start detecting moisture.",
       "fields": {
         "behavior": {
           "name": "[%key:component::moisture::common::trigger_behavior_name%]"

--- a/homeassistant/components/motion/strings.json
+++ b/homeassistant/components/motion/strings.json
@@ -34,7 +34,7 @@
   "title": "Motion",
   "triggers": {
     "cleared": {
-      "description": "Triggers after one or more motion sensors stop detecting motion.",
+      "description": "Triggers when one or more motion sensors stop detecting motion.",
       "fields": {
         "behavior": {
           "name": "[%key:component::motion::common::trigger_behavior_name%]"
@@ -46,7 +46,7 @@
       "name": "Motion cleared"
     },
     "detected": {
-      "description": "Triggers after one or more motion sensors start detecting motion.",
+      "description": "Triggers when one or more motion sensors start detecting motion.",
       "fields": {
         "behavior": {
           "name": "[%key:component::motion::common::trigger_behavior_name%]"

--- a/homeassistant/components/occupancy/strings.json
+++ b/homeassistant/components/occupancy/strings.json
@@ -34,7 +34,7 @@
   "title": "Occupancy",
   "triggers": {
     "cleared": {
-      "description": "Triggers after one or more occupancy sensors stop detecting occupancy.",
+      "description": "Triggers when one or more occupancy sensors stop detecting occupancy.",
       "fields": {
         "behavior": {
           "name": "[%key:component::occupancy::common::trigger_behavior_name%]"
@@ -46,7 +46,7 @@
       "name": "Occupancy cleared"
     },
     "detected": {
-      "description": "Triggers after one or more occupancy sensors start detecting occupancy.",
+      "description": "Triggers when one or more occupancy sensors start detecting occupancy.",
       "fields": {
         "behavior": {
           "name": "[%key:component::occupancy::common::trigger_behavior_name%]"


### PR DESCRIPTION
## Proposed change

Entity triggers should describe themselves consistently. For the presence and detection entities (motion, occupancy, moisture, doorbell), this aligns their names and descriptions with that standard. Most changes reword trigger descriptions to open with "Triggers when" instead of "Triggers after", which reads more naturally and matches the other triggers. In addition, 1 description(s) are reworded for clarity, exactly as listed in the linked sheet. Only names and descriptions change; keys are untouched.

This is part of a wider effort to make the naming of triggers, conditions, and actions consistent across Home Assistant. The naming review and reasoning behind these changes is documented here: https://docs.google.com/document/d/18ZsosVR0OAOwkoQV1wmQ4FNSw18KV7EbPl0eNVP2uzA/edit?tab=t.0#heading=h.vwrsknoq58h0

The full sheet of proposed changes can be found here: https://docs.google.com/spreadsheets/d/1ahVHTWEZhk2-pwToI_ovHDBXIxHDmVqzRG41bwHGhMc/edit?gid=560897381#gid=560897381

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
