### PR TITLE
Reword trigger descriptions for lights, switches, and output entities

### DIFF
--- a/homeassistant/components/fan/strings.json
+++ b/homeassistant/components/fan/strings.json
@@ -198,7 +198,7 @@
   "title": "Fan",
   "triggers": {
     "turned_off": {
-      "description": "Triggers after one or more fans turn off.",
+      "description": "Triggers when one or more fans turn off.",
       "fields": {
         "behavior": {
           "name": "[%key:component::fan::common::trigger_behavior_name%]"
@@ -210,7 +210,7 @@
       "name": "Fan turned off"
     },
     "turned_on": {
-      "description": "Triggers after one or more fans turn on.",
+      "description": "Triggers when one or more fans turn on.",
       "fields": {
         "behavior": {
           "name": "[%key:component::fan::common::trigger_behavior_name%]"

--- a/homeassistant/components/light/strings.json
+++ b/homeassistant/components/light/strings.json
@@ -499,7 +499,7 @@
   "title": "Light",
   "triggers": {
     "brightness_changed": {
-      "description": "Triggers after the brightness of one or more lights changes.",
+      "description": "Triggers when the brightness of one or more lights changes.",
       "fields": {
         "threshold": {
           "name": "[%key:component::light::common::trigger_threshold_name%]"
@@ -508,7 +508,7 @@
       "name": "Light brightness changed"
     },
     "brightness_crossed_threshold": {
-      "description": "Triggers after the brightness of one or more lights crosses a threshold.",
+      "description": "Triggers when the brightness of one or more lights crosses a threshold.",
       "fields": {
         "behavior": {
           "name": "[%key:component::light::common::trigger_behavior_name%]"
@@ -523,7 +523,7 @@
       "name": "Light brightness crossed threshold"
     },
     "turned_off": {
-      "description": "Triggers after one or more lights turn off.",
+      "description": "Triggers when one or more lights turn off.",
       "fields": {
         "behavior": {
           "name": "[%key:component::light::common::trigger_behavior_name%]"
@@ -535,7 +535,7 @@
       "name": "Light turned off"
     },
     "turned_on": {
-      "description": "Triggers after one or more lights turn on.",
+      "description": "Triggers when one or more lights turn on.",
       "fields": {
         "behavior": {
           "name": "[%key:component::light::common::trigger_behavior_name%]"

--- a/homeassistant/components/lock/strings.json
+++ b/homeassistant/components/lock/strings.json
@@ -141,7 +141,7 @@
   "title": "Lock",
   "triggers": {
     "jammed": {
-      "description": "Triggers after one or more locks jam.",
+      "description": "Triggers when one or more locks jam.",
       "fields": {
         "behavior": {
           "name": "[%key:component::lock::common::trigger_behavior_name%]"
@@ -153,7 +153,7 @@
       "name": "Lock jammed"
     },
     "locked": {
-      "description": "Triggers after one or more locks lock.",
+      "description": "Triggers when one or more locks lock.",
       "fields": {
         "behavior": {
           "name": "[%key:component::lock::common::trigger_behavior_name%]"
@@ -165,7 +165,7 @@
       "name": "Lock locked"
     },
     "opened": {
-      "description": "Triggers after one or more locks open.",
+      "description": "Triggers when one or more locks open.",
       "fields": {
         "behavior": {
           "name": "[%key:component::lock::common::trigger_behavior_name%]"
@@ -177,7 +177,7 @@
       "name": "Lock opened"
     },
     "unlocked": {
-      "description": "Triggers after one or more locks unlock.",
+      "description": "Triggers when one or more locks unlock.",
       "fields": {
         "behavior": {
           "name": "[%key:component::lock::common::trigger_behavior_name%]"

--- a/homeassistant/components/siren/strings.json
+++ b/homeassistant/components/siren/strings.json
@@ -76,7 +76,7 @@
   "title": "Siren",
   "triggers": {
     "turned_off": {
-      "description": "Triggers after one or more sirens turn off.",
+      "description": "Triggers when one or more sirens turn off.",
       "fields": {
         "behavior": {
           "name": "[%key:component::siren::common::trigger_behavior_name%]"
@@ -88,7 +88,7 @@
       "name": "Siren turned off"
     },
     "turned_on": {
-      "description": "Triggers after one or more sirens turn on.",
+      "description": "Triggers when one or more sirens turn on.",
       "fields": {
         "behavior": {
           "name": "[%key:component::siren::common::trigger_behavior_name%]"

--- a/homeassistant/components/switch/strings.json
+++ b/homeassistant/components/switch/strings.json
@@ -90,7 +90,7 @@
   "title": "Switch",
   "triggers": {
     "turned_off": {
-      "description": "Triggers after one or more switches turn off.",
+      "description": "Triggers when one or more switches turn off.",
       "fields": {
         "behavior": {
           "name": "[%key:component::switch::common::trigger_behavior_name%]"
@@ -102,7 +102,7 @@
       "name": "Switch turned off"
     },
     "turned_on": {
-      "description": "Triggers after one or more switches turn on.",
+      "description": "Triggers when one or more switches turn on.",
       "fields": {
         "behavior": {
           "name": "[%key:component::switch::common::trigger_behavior_name%]"


### PR DESCRIPTION
## Breaking change


## Proposed change

Entity triggers should describe themselves consistently. For the light, switch, and output entities (light, switch, fan, siren, lock), this aligns their names and descriptions with that standard. Most changes reword trigger descriptions to open with "Triggers when" instead of "Triggers after", which reads more naturally and matches the other triggers. Only names and descriptions change; keys are untouched.

This is part of a wider effort to make the naming of triggers, conditions, and actions consistent across Home Assistant. The naming review and reasoning behind these changes is documented here: https://docs.google.com/document/d/18ZsosVR0OAOwkoQV1wmQ4FNSw18KV7EbPl0eNVP2uzA/edit?tab=t.0#heading=h.vwrsknoq58h0

The full sheet of proposed changes can be found here: https://docs.google.com/spreadsheets/d/1ahVHTWEZhk2-pwToI_ovHDBXIxHDmVqzRG41bwHGhMc/edit?gid=560897381#gid=560897381

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
