### PR TITLE
Reword trigger descriptions for climate entities

### DIFF
--- a/homeassistant/components/climate/strings.json
+++ b/homeassistant/components/climate/strings.json
@@ -396,7 +396,7 @@
   "title": "Climate",
   "triggers": {
     "hvac_mode_changed": {
-      "description": "Triggers after the mode of one or more thermostats changes.",
+      "description": "Triggers when the mode of one or more thermostats changes.",
       "fields": {
         "behavior": {
           "name": "[%key:component::climate::common::trigger_behavior_name%]"
@@ -412,7 +412,7 @@
       "name": "Thermostat mode changed"
     },
     "started_cooling": {
-      "description": "Triggers after one or more thermostats start cooling.",
+      "description": "Triggers when one or more thermostats start cooling.",
       "fields": {
         "behavior": {
           "name": "[%key:component::climate::common::trigger_behavior_name%]"
@@ -424,7 +424,7 @@
       "name": "Thermostat started cooling"
     },
     "started_drying": {
-      "description": "Triggers after one or more thermostats start drying.",
+      "description": "Triggers when one or more thermostats start drying.",
       "fields": {
         "behavior": {
           "name": "[%key:component::climate::common::trigger_behavior_name%]"
@@ -436,7 +436,7 @@
       "name": "Thermostat started drying"
     },
     "started_heating": {
-      "description": "Triggers after one or more thermostats start heating.",
+      "description": "Triggers when one or more thermostats start heating.",
       "fields": {
         "behavior": {
           "name": "[%key:component::climate::common::trigger_behavior_name%]"
@@ -448,7 +448,7 @@
       "name": "Thermostat started heating"
     },
     "target_humidity_changed": {
-      "description": "Triggers after the humidity setpoint of one or more thermostats changes.",
+      "description": "Triggers when the humidity setpoint of one or more thermostats changes.",
       "fields": {
         "threshold": {
           "name": "[%key:component::climate::common::trigger_threshold_name%]"
@@ -457,7 +457,7 @@
       "name": "Thermostat target humidity changed"
     },
     "target_humidity_crossed_threshold": {
-      "description": "Triggers after the humidity setpoint of one or more thermostats crosses a threshold.",
+      "description": "Triggers when the humidity setpoint of one or more thermostats crosses a threshold.",
       "fields": {
         "behavior": {
           "name": "[%key:component::climate::common::trigger_behavior_name%]"
@@ -472,7 +472,7 @@
       "name": "Thermostat target humidity crossed threshold"
     },
     "target_temperature_changed": {
-      "description": "Triggers after the temperature setpoint of one or more thermostats changes.",
+      "description": "Triggers when the temperature setpoint of one or more thermostats changes.",
       "fields": {
         "threshold": {
           "name": "[%key:component::climate::common::trigger_threshold_name%]"
@@ -481,7 +481,7 @@
       "name": "Thermostat target temperature changed"
     },
     "target_temperature_crossed_threshold": {
-      "description": "Triggers after the temperature setpoint of one or more thermostats crosses a threshold.",
+      "description": "Triggers when the temperature setpoint of one or more thermostats crosses a threshold.",
       "fields": {
         "behavior": {
           "name": "[%key:component::climate::common::trigger_behavior_name%]"
@@ -496,7 +496,7 @@
       "name": "Thermostat target temperature crossed threshold"
     },
     "turned_off": {
-      "description": "Triggers after one or more thermostats turn off.",
+      "description": "Triggers when one or more thermostats turn off.",
       "fields": {
         "behavior": {
           "name": "[%key:component::climate::common::trigger_behavior_name%]"
@@ -508,7 +508,7 @@
       "name": "Thermostat turned off"
     },
     "turned_on": {
-      "description": "Triggers after one or more thermostats turn on, regardless of the mode.",
+      "description": "Triggers when one or more thermostats turn on, regardless of the mode.",
       "fields": {
         "behavior": {
           "name": "[%key:component::climate::common::trigger_behavior_name%]"

--- a/homeassistant/components/humidifier/strings.json
+++ b/homeassistant/components/humidifier/strings.json
@@ -211,7 +211,7 @@
   "title": "Humidifier",
   "triggers": {
     "mode_changed": {
-      "description": "Triggers after the operation mode of one or more humidifiers changes.",
+      "description": "Triggers when the operation mode of one or more humidifiers changes.",
       "fields": {
         "behavior": {
           "name": "[%key:component::humidifier::common::trigger_behavior_name%]"
@@ -227,7 +227,7 @@
       "name": "Humidifier mode changed"
     },
     "started_drying": {
-      "description": "Triggers after one or more humidifiers start drying.",
+      "description": "Triggers when one or more humidifiers start drying.",
       "fields": {
         "behavior": {
           "name": "[%key:component::humidifier::common::trigger_behavior_name%]"
@@ -239,7 +239,7 @@
       "name": "Humidifier started drying"
     },
     "started_humidifying": {
-      "description": "Triggers after one or more humidifiers start humidifying.",
+      "description": "Triggers when one or more humidifiers start humidifying.",
       "fields": {
         "behavior": {
           "name": "[%key:component::humidifier::common::trigger_behavior_name%]"
@@ -251,7 +251,7 @@
       "name": "Humidifier started humidifying"
     },
     "turned_off": {
-      "description": "Triggers after one or more humidifiers turn off.",
+      "description": "Triggers when one or more humidifiers turn off.",
       "fields": {
         "behavior": {
           "name": "[%key:component::humidifier::common::trigger_behavior_name%]"
@@ -263,7 +263,7 @@
       "name": "Humidifier turned off"
     },
     "turned_on": {
-      "description": "Triggers after one or more humidifiers turn on.",
+      "description": "Triggers when one or more humidifiers turn on.",
       "fields": {
         "behavior": {
           "name": "[%key:component::humidifier::common::trigger_behavior_name%]"

--- a/homeassistant/components/temperature/strings.json
+++ b/homeassistant/components/temperature/strings.json
@@ -27,7 +27,7 @@
   "title": "Temperature",
   "triggers": {
     "changed": {
-      "description": "Triggers after one or more temperatures change.",
+      "description": "Triggers when one or more temperatures change.",
       "fields": {
         "threshold": {
           "name": "[%key:component::temperature::common::trigger_threshold_name%]"
@@ -36,7 +36,7 @@
       "name": "Temperature changed"
     },
     "crossed_threshold": {
-      "description": "Triggers after one or more temperatures cross a threshold.",
+      "description": "Triggers when one or more temperatures cross a threshold.",
       "fields": {
         "behavior": {
           "name": "[%key:component::temperature::common::trigger_behavior_name%]"

--- a/homeassistant/components/water_heater/strings.json
+++ b/homeassistant/components/water_heater/strings.json
@@ -178,7 +178,7 @@
   "title": "Water heater",
   "triggers": {
     "operation_mode_changed": {
-      "description": "Triggers after the operation mode of one or more water heaters changes to a specific mode.",
+      "description": "Triggers when the operation mode of one or more water heaters changes to a specific mode.",
       "fields": {
         "behavior": {
           "name": "[%key:component::water_heater::common::trigger_behavior_name%]"
@@ -194,7 +194,7 @@
       "name": "Water heater operation mode changed"
     },
     "target_temperature_changed": {
-      "description": "Triggers after the temperature setpoint of one or more water heaters changes.",
+      "description": "Triggers when the temperature setpoint of one or more water heaters changes.",
       "fields": {
         "threshold": {
           "name": "[%key:component::water_heater::common::trigger_threshold_name%]"
@@ -203,7 +203,7 @@
       "name": "Water heater target temperature changed"
     },
     "target_temperature_crossed_threshold": {
-      "description": "Triggers after the temperature setpoint of one or more water heaters crosses a threshold.",
+      "description": "Triggers when the temperature setpoint of one or more water heaters crosses a threshold.",
       "fields": {
         "behavior": {
           "name": "[%key:component::water_heater::common::trigger_behavior_name%]"
@@ -218,7 +218,7 @@
       "name": "Water heater target temperature crossed threshold"
     },
     "turned_off": {
-      "description": "Triggers after one or more water heaters turn off.",
+      "description": "Triggers when one or more water heaters turn off.",
       "fields": {
         "behavior": {
           "name": "[%key:component::water_heater::common::trigger_behavior_name%]"
@@ -230,7 +230,7 @@
       "name": "Water heater turned off"
     },
     "turned_on": {
-      "description": "Triggers after one or more water heaters turn on, regardless of the operation mode.",
+      "description": "Triggers when one or more water heaters turn on, regardless of the operation mode.",
       "fields": {
         "behavior": {
           "name": "[%key:component::water_heater::common::trigger_behavior_name%]"


### PR DESCRIPTION
## Proposed change

Entity triggers should describe themselves consistently. For the climate entities (climate, humidifier, water heater, temperature), this aligns their names and descriptions with that standard. Most changes reword trigger descriptions to open with "Triggers when" instead of "Triggers after", which reads more naturally and matches the other triggers. Only names and descriptions change; keys are untouched.

This is part of a wider effort to make the naming of triggers, conditions, and actions consistent across Home Assistant. The naming review and reasoning behind these changes is documented here: https://docs.google.com/document/d/18ZsosVR0OAOwkoQV1wmQ4FNSw18KV7EbPl0eNVP2uzA/edit?tab=t.0#heading=h.vwrsknoq58h0

The full sheet of proposed changes can be found here: https://docs.google.com/spreadsheets/d/1ahVHTWEZhk2-pwToI_ovHDBXIxHDmVqzRG41bwHGhMc/edit?gid=560897381#gid=560897381

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
