### PR TITLE
Improve trigger and condition wording for numeric sensor entities

### DIFF
--- a/homeassistant/components/battery/strings.json
+++ b/homeassistant/components/battery/strings.json
@@ -75,7 +75,7 @@
   "title": "Battery",
   "triggers": {
     "became_low": {
-      "description": "Triggers after one or more batteries become low.",
+      "description": "Triggers when one or more batteries become low.",
       "fields": {
         "behavior": {
           "name": "[%key:component::battery::common::trigger_behavior_name%]"
@@ -84,10 +84,10 @@
           "name": "[%key:component::battery::common::trigger_for_name%]"
         }
       },
-      "name": "Battery low"
+      "name": "Battery became low"
     },
     "level_changed": {
-      "description": "Triggers after the battery level of one or more batteries changes.",
+      "description": "Triggers when the battery level of one or more batteries changes.",
       "fields": {
         "threshold": {
           "name": "[%key:component::battery::common::trigger_threshold_name%]"
@@ -96,7 +96,7 @@
       "name": "Battery level changed"
     },
     "level_crossed_threshold": {
-      "description": "Triggers after the battery level of one or more batteries crosses a threshold.",
+      "description": "Triggers when the battery level of one or more batteries crosses a threshold.",
       "fields": {
         "behavior": {
           "name": "[%key:component::battery::common::trigger_behavior_name%]"
@@ -111,7 +111,7 @@
       "name": "Battery level crossed threshold"
     },
     "no_longer_low": {
-      "description": "Triggers after one or more batteries are no longer low.",
+      "description": "Triggers when one or more batteries are no longer low.",
       "fields": {
         "behavior": {
           "name": "[%key:component::battery::common::trigger_behavior_name%]"
@@ -120,10 +120,10 @@
           "name": "[%key:component::battery::common::trigger_for_name%]"
         }
       },
-      "name": "Battery not low"
+      "name": "Battery no longer low"
     },
     "started_charging": {
-      "description": "Triggers after one or more batteries start charging.",
+      "description": "Triggers when one or more batteries start charging.",
       "fields": {
         "behavior": {
           "name": "[%key:component::battery::common::trigger_behavior_name%]"
@@ -135,7 +135,7 @@
       "name": "Battery started charging"
     },
     "stopped_charging": {
-      "description": "Triggers after one or more batteries stop charging.",
+      "description": "Triggers when one or more batteries stop charging.",
       "fields": {
         "behavior": {
           "name": "[%key:component::battery::common::trigger_behavior_name%]"

--- a/homeassistant/components/humidity/strings.json
+++ b/homeassistant/components/humidity/strings.json
@@ -9,7 +9,7 @@
   },
   "conditions": {
     "is_value": {
-      "description": "Tests if a relative humidity value is above a threshold, below a threshold, or in a range of values.",
+      "description": "Tests the relative humidity of one or more entities.",
       "fields": {
         "behavior": {
           "name": "[%key:component::humidity::common::condition_behavior_name%]"
@@ -27,7 +27,7 @@
   "title": "Humidity",
   "triggers": {
     "changed": {
-      "description": "Triggers after one or more relative humidity values change.",
+      "description": "Triggers when one or more relative humidity values change.",
       "fields": {
         "threshold": {
           "name": "[%key:component::humidity::common::trigger_threshold_name%]"
@@ -36,7 +36,7 @@
       "name": "Relative humidity changed"
     },
     "crossed_threshold": {
-      "description": "Triggers after one or more relative humidity values cross a threshold.",
+      "description": "Triggers when one or more relative humidity values cross a threshold.",
       "fields": {
         "behavior": {
           "name": "[%key:component::humidity::common::trigger_behavior_name%]"

--- a/homeassistant/components/illuminance/strings.json
+++ b/homeassistant/components/illuminance/strings.json
@@ -9,7 +9,7 @@
   },
   "conditions": {
     "is_detected": {
-      "description": "Tests if light is currently detected.",
+      "description": "Tests if one or more light sensors are detecting light.",
       "fields": {
         "behavior": {
           "name": "[%key:component::illuminance::common::condition_behavior_name%]"
@@ -18,10 +18,10 @@
           "name": "[%key:component::illuminance::common::condition_for_name%]"
         }
       },
-      "name": "Light is detected"
+      "name": "Light level is detected"
     },
     "is_not_detected": {
-      "description": "Tests if light is currently not detected.",
+      "description": "Tests if one or more light sensors are not detecting light.",
       "fields": {
         "behavior": {
           "name": "[%key:component::illuminance::common::condition_behavior_name%]"
@@ -30,10 +30,10 @@
           "name": "[%key:component::illuminance::common::condition_for_name%]"
         }
       },
-      "name": "Light is not detected"
+      "name": "Light level is not detected"
     },
     "is_value": {
-      "description": "Tests the illuminance value.",
+      "description": "Tests the illuminance of one or more entities.",
       "fields": {
         "behavior": {
           "name": "[%key:component::illuminance::common::condition_behavior_name%]"
@@ -51,7 +51,7 @@
   "title": "Illuminance",
   "triggers": {
     "changed": {
-      "description": "Triggers after one or more illuminance values change.",
+      "description": "Triggers when one or more illuminance values change.",
       "fields": {
         "threshold": {
           "name": "[%key:component::illuminance::common::trigger_threshold_name%]"
@@ -60,7 +60,7 @@
       "name": "Illuminance changed"
     },
     "cleared": {
-      "description": "Triggers after one or more light sensors stop detecting light.",
+      "description": "Triggers when one or more light sensors stop detecting light.",
       "fields": {
         "behavior": {
           "name": "[%key:component::illuminance::common::trigger_behavior_name%]"
@@ -69,10 +69,10 @@
           "name": "[%key:component::illuminance::common::trigger_for_name%]"
         }
       },
-      "name": "Light cleared"
+      "name": "Light level cleared"
     },
     "crossed_threshold": {
-      "description": "Triggers after one or more illuminance values cross a threshold.",
+      "description": "Triggers when one or more illuminance values cross a threshold.",
       "fields": {
         "behavior": {
           "name": "[%key:component::illuminance::common::trigger_behavior_name%]"
@@ -87,7 +87,7 @@
       "name": "Illuminance crossed threshold"
     },
     "detected": {
-      "description": "Triggers after one or more light sensors start detecting light.",
+      "description": "Triggers when one or more light sensors start detecting light.",
       "fields": {
         "behavior": {
           "name": "[%key:component::illuminance::common::trigger_behavior_name%]"
@@ -96,7 +96,7 @@
           "name": "[%key:component::illuminance::common::trigger_for_name%]"
         }
       },
-      "name": "Light detected"
+      "name": "Light level detected"
     }
   }
 }

--- a/homeassistant/components/power/strings.json
+++ b/homeassistant/components/power/strings.json
@@ -27,7 +27,7 @@
   "title": "Power",
   "triggers": {
     "changed": {
-      "description": "Triggers after one or more power values change.",
+      "description": "Triggers when one or more power values change.",
       "fields": {
         "threshold": {
           "name": "[%key:component::power::common::trigger_threshold_name%]"
@@ -36,7 +36,7 @@
       "name": "Power changed"
     },
     "crossed_threshold": {
-      "description": "Triggers after one or more power values cross a threshold.",
+      "description": "Triggers when one or more power values cross a threshold.",
       "fields": {
         "behavior": {
           "name": "[%key:component::power::common::trigger_behavior_name%]"


### PR DESCRIPTION
## Proposed change

Entity triggers and conditions should describe themselves consistently. For the numeric sensor entities (illuminance, power, humidity, battery), this aligns their names and descriptions with that standard. Most changes reword trigger descriptions to open with "Triggers when" instead of "Triggers after", which reads more naturally and matches the other triggers. In addition, 6 name(s) are refined and 2 description(s) are reworded for clarity, exactly as listed in the linked sheet. Only names and descriptions change; keys are untouched.

This is part of a wider effort to make the naming of triggers, conditions, and actions consistent across Home Assistant. The naming review and reasoning behind these changes is documented here: https://docs.google.com/document/d/18ZsosVR0OAOwkoQV1wmQ4FNSw18KV7EbPl0eNVP2uzA/edit?tab=t.0#heading=h.vwrsknoq58h0

The full sheet of proposed changes can be found here: https://docs.google.com/spreadsheets/d/1ahVHTWEZhk2-pwToI_ovHDBXIxHDmVqzRG41bwHGhMc/edit?gid=560897381#gid=560897381

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
