### PR TITLE
Reword trigger descriptions for air quality entities

### DIFF
--- a/homeassistant/components/air_quality/strings.json
+++ b/homeassistant/components/air_quality/strings.json
@@ -279,7 +279,7 @@
   "title": "Air Quality",
   "triggers": {
     "co2_changed": {
-      "description": "Triggers after one or more carbon dioxide levels change.",
+      "description": "Triggers when one or more carbon dioxide levels change.",
       "fields": {
         "threshold": {
           "name": "[%key:component::air_quality::common::trigger_threshold_name%]"
@@ -288,7 +288,7 @@
       "name": "Carbon dioxide level changed"
     },
     "co2_crossed_threshold": {
-      "description": "Triggers after one or more carbon dioxide levels cross a threshold.",
+      "description": "Triggers when one or more carbon dioxide levels cross a threshold.",
       "fields": {
         "behavior": {
           "name": "[%key:component::air_quality::common::trigger_behavior_name%]"
@@ -303,7 +303,7 @@
       "name": "Carbon dioxide level crossed threshold"
     },
     "co_changed": {
-      "description": "Triggers after one or more carbon monoxide levels change.",
+      "description": "Triggers when one or more carbon monoxide levels change.",
       "fields": {
         "threshold": {
           "name": "[%key:component::air_quality::common::trigger_threshold_name%]"
@@ -312,7 +312,7 @@
       "name": "Carbon monoxide level changed"
     },
     "co_cleared": {
-      "description": "Triggers after one or more carbon monoxide sensors stop detecting carbon monoxide.",
+      "description": "Triggers when one or more carbon monoxide sensors stop detecting carbon monoxide.",
       "fields": {
         "behavior": {
           "name": "[%key:component::air_quality::common::trigger_behavior_name%]"
@@ -324,7 +324,7 @@
       "name": "Carbon monoxide cleared"
     },
     "co_crossed_threshold": {
-      "description": "Triggers after one or more carbon monoxide levels cross a threshold.",
+      "description": "Triggers when one or more carbon monoxide levels cross a threshold.",
       "fields": {
         "behavior": {
           "name": "[%key:component::air_quality::common::trigger_behavior_name%]"
@@ -339,7 +339,7 @@
       "name": "Carbon monoxide level crossed threshold"
     },
     "co_detected": {
-      "description": "Triggers after one or more carbon monoxide sensors start detecting carbon monoxide.",
+      "description": "Triggers when one or more carbon monoxide sensors start detecting carbon monoxide.",
       "fields": {
         "behavior": {
           "name": "[%key:component::air_quality::common::trigger_behavior_name%]"
@@ -351,7 +351,7 @@
       "name": "Carbon monoxide detected"
     },
     "gas_cleared": {
-      "description": "Triggers after one or more gas sensors stop detecting gas.",
+      "description": "Triggers when one or more gas sensors stop detecting gas.",
       "fields": {
         "behavior": {
           "name": "[%key:component::air_quality::common::trigger_behavior_name%]"
@@ -363,7 +363,7 @@
       "name": "Gas cleared"
     },
     "gas_detected": {
-      "description": "Triggers after one or more gas sensors start detecting gas.",
+      "description": "Triggers when one or more gas sensors start detecting gas.",
       "fields": {
         "behavior": {
           "name": "[%key:component::air_quality::common::trigger_behavior_name%]"
@@ -375,7 +375,7 @@
       "name": "Gas detected"
     },
     "n2o_changed": {
-      "description": "Triggers after one or more nitrous oxide levels change.",
+      "description": "Triggers when one or more nitrous oxide levels change.",
       "fields": {
         "threshold": {
           "name": "[%key:component::air_quality::common::trigger_threshold_name%]"
@@ -384,7 +384,7 @@
       "name": "Nitrous oxide level changed"
     },
     "n2o_crossed_threshold": {
-      "description": "Triggers after one or more nitrous oxide levels cross a threshold.",
+      "description": "Triggers when one or more nitrous oxide levels cross a threshold.",
       "fields": {
         "behavior": {
           "name": "[%key:component::air_quality::common::trigger_behavior_name%]"
@@ -399,7 +399,7 @@
       "name": "Nitrous oxide level crossed threshold"
     },
     "no2_changed": {
-      "description": "Triggers after one or more nitrogen dioxide levels change.",
+      "description": "Triggers when one or more nitrogen dioxide levels change.",
       "fields": {
         "threshold": {
           "name": "[%key:component::air_quality::common::trigger_threshold_name%]"
@@ -408,7 +408,7 @@
       "name": "Nitrogen dioxide level changed"
     },
     "no2_crossed_threshold": {
-      "description": "Triggers after one or more nitrogen dioxide levels cross a threshold.",
+      "description": "Triggers when one or more nitrogen dioxide levels cross a threshold.",
       "fields": {
         "behavior": {
           "name": "[%key:component::air_quality::common::trigger_behavior_name%]"
@@ -423,7 +423,7 @@
       "name": "Nitrogen dioxide level crossed threshold"
     },
     "no_changed": {
-      "description": "Triggers after one or more nitrogen monoxide levels change.",
+      "description": "Triggers when one or more nitrogen monoxide levels change.",
       "fields": {
         "threshold": {
           "name": "[%key:component::air_quality::common::trigger_threshold_name%]"
@@ -432,7 +432,7 @@
       "name": "Nitrogen monoxide level changed"
     },
     "no_crossed_threshold": {
-      "description": "Triggers after one or more nitrogen monoxide levels cross a threshold.",
+      "description": "Triggers when one or more nitrogen monoxide levels cross a threshold.",
       "fields": {
         "behavior": {
           "name": "[%key:component::air_quality::common::trigger_behavior_name%]"
@@ -447,7 +447,7 @@
       "name": "Nitrogen monoxide level crossed threshold"
     },
     "ozone_changed": {
-      "description": "Triggers after one or more ozone levels change.",
+      "description": "Triggers when one or more ozone levels change.",
       "fields": {
         "threshold": {
           "name": "[%key:component::air_quality::common::trigger_threshold_name%]"
@@ -456,7 +456,7 @@
       "name": "Ozone level changed"
     },
     "ozone_crossed_threshold": {
-      "description": "Triggers after one or more ozone levels cross a threshold.",
+      "description": "Triggers when one or more ozone levels cross a threshold.",
       "fields": {
         "behavior": {
           "name": "[%key:component::air_quality::common::trigger_behavior_name%]"
@@ -471,7 +471,7 @@
       "name": "Ozone level crossed threshold"
     },
     "pm10_changed": {
-      "description": "Triggers after one or more PM10 levels change.",
+      "description": "Triggers when one or more PM10 levels change.",
       "fields": {
         "threshold": {
           "name": "[%key:component::air_quality::common::trigger_threshold_name%]"
@@ -480,7 +480,7 @@
       "name": "PM10 level changed"
     },
     "pm10_crossed_threshold": {
-      "description": "Triggers after one or more PM10 levels cross a threshold.",
+      "description": "Triggers when one or more PM10 levels cross a threshold.",
       "fields": {
         "behavior": {
           "name": "[%key:component::air_quality::common::trigger_behavior_name%]"
@@ -495,7 +495,7 @@
       "name": "PM10 level crossed threshold"
     },
     "pm1_changed": {
-      "description": "Triggers after one or more PM1 levels change.",
+      "description": "Triggers when one or more PM1 levels change.",
       "fields": {
         "threshold": {
           "name": "[%key:component::air_quality::common::trigger_threshold_name%]"
@@ -504,7 +504,7 @@
       "name": "PM1 level changed"
     },
     "pm1_crossed_threshold": {
-      "description": "Triggers after one or more PM1 levels cross a threshold.",
+      "description": "Triggers when one or more PM1 levels cross a threshold.",
       "fields": {
         "behavior": {
           "name": "[%key:component::air_quality::common::trigger_behavior_name%]"
@@ -519,7 +519,7 @@
       "name": "PM1 level crossed threshold"
     },
     "pm25_changed": {
-      "description": "Triggers after one or more PM2.5 levels change.",
+      "description": "Triggers when one or more PM2.5 levels change.",
       "fields": {
         "threshold": {
           "name": "[%key:component::air_quality::common::trigger_threshold_name%]"
@@ -528,7 +528,7 @@
       "name": "PM2.5 level changed"
     },
     "pm25_crossed_threshold": {
-      "description": "Triggers after one or more PM2.5 levels cross a threshold.",
+      "description": "Triggers when one or more PM2.5 levels cross a threshold.",
       "fields": {
         "behavior": {
           "name": "[%key:component::air_quality::common::trigger_behavior_name%]"
@@ -543,7 +543,7 @@
       "name": "PM2.5 level crossed threshold"
     },
     "pm4_changed": {
-      "description": "Triggers after one or more PM4 levels change.",
+      "description": "Triggers when one or more PM4 levels change.",
       "fields": {
         "threshold": {
           "name": "[%key:component::air_quality::common::trigger_threshold_name%]"
@@ -552,7 +552,7 @@
       "name": "PM4 level changed"
     },
     "pm4_crossed_threshold": {
-      "description": "Triggers after one or more PM4 levels cross a threshold.",
+      "description": "Triggers when one or more PM4 levels cross a threshold.",
       "fields": {
         "behavior": {
           "name": "[%key:component::air_quality::common::trigger_behavior_name%]"
@@ -567,7 +567,7 @@
       "name": "PM4 level crossed threshold"
     },
     "smoke_cleared": {
-      "description": "Triggers after one or more smoke sensors stop detecting smoke.",
+      "description": "Triggers when one or more smoke sensors stop detecting smoke.",
       "fields": {
         "behavior": {
           "name": "[%key:component::air_quality::common::trigger_behavior_name%]"
@@ -579,7 +579,7 @@
       "name": "Smoke cleared"
     },
     "smoke_detected": {
-      "description": "Triggers after one or more smoke sensors start detecting smoke.",
+      "description": "Triggers when one or more smoke sensors start detecting smoke.",
       "fields": {
         "behavior": {
           "name": "[%key:component::air_quality::common::trigger_behavior_name%]"
@@ -591,7 +591,7 @@
       "name": "Smoke detected"
     },
     "so2_changed": {
-      "description": "Triggers after one or more sulphur dioxide levels change.",
+      "description": "Triggers when one or more sulphur dioxide levels change.",
       "fields": {
         "threshold": {
           "name": "[%key:component::air_quality::common::trigger_threshold_name%]"
@@ -600,7 +600,7 @@
       "name": "Sulphur dioxide level changed"
     },
     "so2_crossed_threshold": {
-      "description": "Triggers after one or more sulphur dioxide levels cross a threshold.",
+      "description": "Triggers when one or more sulphur dioxide levels cross a threshold.",
       "fields": {
         "behavior": {
           "name": "[%key:component::air_quality::common::trigger_behavior_name%]"
@@ -615,7 +615,7 @@
       "name": "Sulphur dioxide level crossed threshold"
     },
     "voc_changed": {
-      "description": "Triggers after one or more volatile organic compound levels change.",
+      "description": "Triggers when one or more volatile organic compound levels change.",
       "fields": {
         "threshold": {
           "name": "[%key:component::air_quality::common::trigger_threshold_name%]"
@@ -624,7 +624,7 @@
       "name": "Volatile organic compounds level changed"
     },
     "voc_crossed_threshold": {
-      "description": "Triggers after one or more volatile organic compounds levels cross a threshold.",
+      "description": "Triggers when one or more volatile organic compounds levels cross a threshold.",
       "fields": {
         "behavior": {
           "name": "[%key:component::air_quality::common::trigger_behavior_name%]"
@@ -639,7 +639,7 @@
       "name": "Volatile organic compounds level crossed threshold"
     },
     "voc_ratio_changed": {
-      "description": "Triggers after one or more volatile organic compound ratios change.",
+      "description": "Triggers when one or more volatile organic compound ratios change.",
       "fields": {
         "threshold": {
           "name": "[%key:component::air_quality::common::trigger_threshold_name%]"
@@ -648,7 +648,7 @@
       "name": "Volatile organic compounds ratio changed"
     },
     "voc_ratio_crossed_threshold": {
-      "description": "Triggers after one or more volatile organic compounds ratios cross a threshold.",
+      "description": "Triggers when one or more volatile organic compounds ratios cross a threshold.",
       "fields": {
         "behavior": {
           "name": "[%key:component::air_quality::common::trigger_behavior_name%]"


### PR DESCRIPTION
## Proposed change

Entity triggers should describe themselves consistently. For the air quality entities (air quality), this aligns their names and descriptions with that standard. Most changes reword trigger descriptions to open with "Triggers when" instead of "Triggers after", which reads more naturally and matches the other triggers. Only names and descriptions change; keys are untouched.

This is part of a wider effort to make the naming of triggers, conditions, and actions consistent across Home Assistant. The naming review and reasoning behind these changes is documented here: https://docs.google.com/document/d/18ZsosVR0OAOwkoQV1wmQ4FNSw18KV7EbPl0eNVP2uzA/edit?tab=t.0#heading=h.vwrsknoq58h0

The full sheet of proposed changes can be found here: https://docs.google.com/spreadsheets/d/1ahVHTWEZhk2-pwToI_ovHDBXIxHDmVqzRG41bwHGhMc/edit?gid=560897381#gid=560897381

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
