### PR TITLE
Improve trigger wording for button, event, and helper entities

### DIFF
--- a/homeassistant/components/button/strings.json
+++ b/homeassistant/components/button/strings.json
@@ -30,7 +30,7 @@
   "title": "Button",
   "triggers": {
     "pressed": {
-      "description": "Triggers when a button was pressed",
+      "description": "Triggers when one or more buttons are pressed.",
       "name": "Button pressed"
     }
   }

--- a/homeassistant/components/counter/strings.json
+++ b/homeassistant/components/counter/strings.json
@@ -74,15 +74,15 @@
   "title": "Counter",
   "triggers": {
     "decremented": {
-      "description": "Triggers after one or more counters decrement.",
+      "description": "Triggers when one or more counters decrement.",
       "name": "Counter decremented"
     },
     "incremented": {
-      "description": "Triggers after one or more counters increment.",
+      "description": "Triggers when one or more counters increment.",
       "name": "Counter incremented"
     },
     "maximum_reached": {
-      "description": "Triggers after one or more counters reach their maximum value.",
+      "description": "Triggers when one or more counters reach their maximum value.",
       "fields": {
         "behavior": {
           "name": "[%key:component::counter::common::trigger_behavior_name%]"
@@ -94,7 +94,7 @@
       "name": "Counter reached maximum"
     },
     "minimum_reached": {
-      "description": "Triggers after one or more counters reach their minimum value.",
+      "description": "Triggers when one or more counters reach their minimum value.",
       "fields": {
         "behavior": {
           "name": "[%key:component::counter::common::trigger_behavior_name%]"
@@ -106,7 +106,7 @@
       "name": "Counter reached minimum"
     },
     "reset": {
-      "description": "Triggers after one or more counters are reset.",
+      "description": "Triggers when one or more counters are reset.",
       "fields": {
         "behavior": {
           "name": "[%key:component::counter::common::trigger_behavior_name%]"

--- a/homeassistant/components/event/strings.json
+++ b/homeassistant/components/event/strings.json
@@ -31,7 +31,7 @@
   "title": "Event",
   "triggers": {
     "received": {
-      "description": "Triggers after one or more event entities receive a matching event.",
+      "description": "Triggers when one or more event entities receive a matching event.",
       "fields": {
         "event_type": {
           "description": "The event types to trigger on.",

--- a/homeassistant/components/schedule/strings.json
+++ b/homeassistant/components/schedule/strings.json
@@ -65,7 +65,7 @@
   "title": "Schedule",
   "triggers": {
     "block_ended": {
-      "description": "Triggers when a schedule block ends.",
+      "description": "Triggers when one or more schedule blocks end.",
       "fields": {
         "behavior": {
           "name": "[%key:component::schedule::common::trigger_behavior_name%]"
@@ -77,7 +77,7 @@
       "name": "Schedule block ended"
     },
     "block_started": {
-      "description": "Triggers when a schedule block starts.",
+      "description": "Triggers when one or more schedule blocks start.",
       "fields": {
         "behavior": {
           "name": "[%key:component::schedule::common::trigger_behavior_name%]"

--- a/homeassistant/components/text/strings.json
+++ b/homeassistant/components/text/strings.json
@@ -67,7 +67,7 @@
   "title": "Text",
   "triggers": {
     "changed": {
-      "description": "Triggers after one or more texts change.",
+      "description": "Triggers when one or more texts change.",
       "name": "Text changed"
     }
   }

--- a/homeassistant/components/timer/strings.json
+++ b/homeassistant/components/timer/strings.json
@@ -167,7 +167,7 @@
           "name": "Time remaining"
         }
       },
-      "name": "Timer reached remaining time"
+      "name": "Timer remaining time reached"
     },
     "restarted": {
       "description": "Triggers when one or more timers are restarted.",

--- a/homeassistant/components/timer/strings.json
+++ b/homeassistant/components/timer/strings.json
@@ -167,7 +167,7 @@
           "name": "Time remaining"
         }
       },
-      "name": "Timer time remaining"
+      "name": "Timer reached remaining time"
     },
     "restarted": {
       "description": "Triggers when one or more timers are restarted.",


### PR DESCRIPTION
## Proposed change

Entity triggers should describe themselves consistently. For the helper entities (counter, text, button, event, schedule, timer), this aligns their names and descriptions with that standard. Most changes reword trigger descriptions to open with "Triggers when" instead of "Triggers after", which reads more naturally and matches the other triggers. In addition, 1 name(s) are refined and 3 description(s) are reworded for clarity, exactly as listed in the linked sheet. Only names and descriptions change; keys are untouched.

This is part of a wider effort to make the naming of triggers, conditions, and actions consistent across Home Assistant. The naming review and reasoning behind these changes is documented here: https://docs.google.com/document/d/18ZsosVR0OAOwkoQV1wmQ4FNSw18KV7EbPl0eNVP2uzA/edit?tab=t.0#heading=h.vwrsknoq58h0

The full sheet of proposed changes can be found here: https://docs.google.com/spreadsheets/d/1ahVHTWEZhk2-pwToI_ovHDBXIxHDmVqzRG41bwHGhMc/edit?gid=560897381#gid=560897381

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
