### PR TITLE
Improve trigger and condition wording for scene, select, and to-do list entities

### DIFF
--- a/homeassistant/components/scene/strings.json
+++ b/homeassistant/components/scene/strings.json
@@ -62,7 +62,7 @@
   "title": "Scene",
   "triggers": {
     "activated": {
-      "description": "Triggers when a scene was activated",
+      "description": "Triggers when one or more scenes are activated.",
       "name": "Scene activated"
     }
   }

--- a/homeassistant/components/select/strings.json
+++ b/homeassistant/components/select/strings.json
@@ -14,7 +14,7 @@
           "name": "Option"
         }
       },
-      "name": "Option is selected"
+      "name": "Dropdown option is selected"
     }
   },
   "device_automation": {
@@ -97,8 +97,8 @@
   "title": "Select",
   "triggers": {
     "selection_changed": {
-      "description": "Triggers after the selected option of one or more dropdowns changes.",
-      "name": "Selection changed"
+      "description": "Triggers when the selected option of one or more dropdowns changes.",
+      "name": "Dropdown selection changed"
     }
   }
 }

--- a/homeassistant/components/todo/strings.json
+++ b/homeassistant/components/todo/strings.json
@@ -135,15 +135,15 @@
   "title": "To-do list",
   "triggers": {
     "item_added": {
-      "description": "Triggers when a to-do item is added to a list.",
+      "description": "Triggers when one or more to-do items are added to a list.",
       "name": "To-do item added"
     },
     "item_completed": {
-      "description": "Triggers when a to-do item is marked as done.",
+      "description": "Triggers when one or more to-do items are marked as done.",
       "name": "To-do item completed"
     },
     "item_removed": {
-      "description": "Triggers when a to-do item is removed from a list.",
+      "description": "Triggers when one or more to-do items are removed from a list.",
       "name": "To-do item removed"
     }
   }


### PR DESCRIPTION
## Breaking change


## Proposed change

Entity triggers and conditions should describe themselves consistently. For the scene, select, and to-do list entities (scene, select, todo), this aligns their names and descriptions with that standard. Most changes reword trigger descriptions to open with "Triggers when" instead of "Triggers after", which reads more naturally and matches the other triggers. In addition, 2 name(s) are refined and 4 description(s) are reworded for clarity, exactly as listed in the linked sheet. Only names and descriptions change; keys are untouched.

This is part of a wider effort to make the naming of triggers, conditions, and actions consistent across Home Assistant. The naming review and reasoning behind these changes is documented here: https://docs.google.com/document/d/18ZsosVR0OAOwkoQV1wmQ4FNSw18KV7EbPl0eNVP2uzA/edit?tab=t.0#heading=h.vwrsknoq58h0

The full sheet of proposed changes can be found here: https://docs.google.com/spreadsheets/d/1ahVHTWEZhk2-pwToI_ovHDBXIxHDmVqzRG41bwHGhMc/edit?gid=560897381#gid=560897381

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
