### PR TITLE
Reword trigger descriptions for Assist, alarm, calendar, and update entities

### DIFF
--- a/homeassistant/components/alarm_control_panel/strings.json
+++ b/homeassistant/components/alarm_control_panel/strings.json
@@ -238,7 +238,7 @@
   "title": "Alarm control panel",
   "triggers": {
     "armed": {
-      "description": "Triggers after one or more alarms become armed, regardless of the mode.",
+      "description": "Triggers when one or more alarms become armed, regardless of the mode.",
       "fields": {
         "behavior": {
           "name": "[%key:component::alarm_control_panel::common::trigger_behavior_name%]"
@@ -250,7 +250,7 @@
       "name": "Alarm armed"
     },
     "armed_away": {
-      "description": "Triggers after one or more alarms become armed in away mode.",
+      "description": "Triggers when one or more alarms become armed in away mode.",
       "fields": {
         "behavior": {
           "name": "[%key:component::alarm_control_panel::common::trigger_behavior_name%]"
@@ -262,7 +262,7 @@
       "name": "Alarm armed away"
     },
     "armed_home": {
-      "description": "Triggers after one or more alarms become armed in home mode.",
+      "description": "Triggers when one or more alarms become armed in home mode.",
       "fields": {
         "behavior": {
           "name": "[%key:component::alarm_control_panel::common::trigger_behavior_name%]"
@@ -274,7 +274,7 @@
       "name": "Alarm armed home"
     },
     "armed_night": {
-      "description": "Triggers after one or more alarms become armed in night mode.",
+      "description": "Triggers when one or more alarms become armed in night mode.",
       "fields": {
         "behavior": {
           "name": "[%key:component::alarm_control_panel::common::trigger_behavior_name%]"
@@ -286,7 +286,7 @@
       "name": "Alarm armed night"
     },
     "armed_vacation": {
-      "description": "Triggers after one or more alarms become armed in vacation mode.",
+      "description": "Triggers when one or more alarms become armed in vacation mode.",
       "fields": {
         "behavior": {
           "name": "[%key:component::alarm_control_panel::common::trigger_behavior_name%]"
@@ -298,7 +298,7 @@
       "name": "Alarm armed vacation"
     },
     "disarmed": {
-      "description": "Triggers after one or more alarms become disarmed.",
+      "description": "Triggers when one or more alarms become disarmed.",
       "fields": {
         "behavior": {
           "name": "[%key:component::alarm_control_panel::common::trigger_behavior_name%]"
@@ -310,7 +310,7 @@
       "name": "Alarm disarmed"
     },
     "triggered": {
-      "description": "Triggers after one or more alarms become triggered.",
+      "description": "Triggers when one or more alarms become triggered.",
       "fields": {
         "behavior": {
           "name": "[%key:component::alarm_control_panel::common::trigger_behavior_name%]"

--- a/homeassistant/components/assist_satellite/strings.json
+++ b/homeassistant/components/assist_satellite/strings.json
@@ -157,7 +157,7 @@
   "title": "Assist satellite",
   "triggers": {
     "idle": {
-      "description": "Triggers after one or more Assist satellites become idle after having processed a command.",
+      "description": "Triggers when one or more Assist satellites become idle after having processed a command.",
       "fields": {
         "behavior": {
           "name": "[%key:component::assist_satellite::common::trigger_behavior_name%]"
@@ -169,7 +169,7 @@
       "name": "Satellite became idle"
     },
     "listening": {
-      "description": "Triggers after one or more Assist satellites start listening for a command from someone.",
+      "description": "Triggers when one or more Assist satellites start listening for a command from someone.",
       "fields": {
         "behavior": {
           "name": "[%key:component::assist_satellite::common::trigger_behavior_name%]"
@@ -181,7 +181,7 @@
       "name": "Satellite started listening"
     },
     "processing": {
-      "description": "Triggers after one or more Assist satellites start processing a command after having heard it.",
+      "description": "Triggers when one or more Assist satellites start processing a command after having heard it.",
       "fields": {
         "behavior": {
           "name": "[%key:component::assist_satellite::common::trigger_behavior_name%]"
@@ -193,7 +193,7 @@
       "name": "Satellite started processing"
     },
     "responding": {
-      "description": "Triggers after one or more Assist satellites start responding to a command after having processed it, or start announcing something.",
+      "description": "Triggers when one or more Assist satellites start responding to a command after having processed it, or start announcing something.",
       "fields": {
         "behavior": {
           "name": "[%key:component::assist_satellite::common::trigger_behavior_name%]"

--- a/homeassistant/components/calendar/strings.json
+++ b/homeassistant/components/calendar/strings.json
@@ -132,7 +132,7 @@
   "title": "Calendar",
   "triggers": {
     "event_ended": {
-      "description": "Triggers when a calendar event ends.",
+      "description": "Triggers when one or more calendar events end.",
       "fields": {
         "offset": {
           "description": "Offset from the end of the event.",
@@ -146,7 +146,7 @@
       "name": "Calendar event ended"
     },
     "event_started": {
-      "description": "Triggers when a calendar event starts.",
+      "description": "Triggers when one or more calendar events start.",
       "fields": {
         "offset": {
           "description": "Offset from the start of the event.",

--- a/homeassistant/components/update/strings.json
+++ b/homeassistant/components/update/strings.json
@@ -114,7 +114,7 @@
   "title": "Update",
   "triggers": {
     "became_available": {
-      "description": "Triggers after one or more updates become available.",
+      "description": "Triggers when one or more updates become available.",
       "fields": {
         "behavior": {
           "name": "[%key:component::update::common::trigger_behavior_name%]"


### PR DESCRIPTION
## Proposed change

Entity triggers should describe themselves consistently. For the Assist satellite, alarm, calendar, and update entities (assist satellite, alarm control panel, calendar, update), this aligns their names and descriptions with that standard. Most changes reword trigger descriptions to open with "Triggers when" instead of "Triggers after", which reads more naturally and matches the other triggers. In addition, 2 description(s) are reworded for clarity, exactly as listed in the linked sheet. Only names and descriptions change; keys are untouched.

This is part of a wider effort to make the naming of triggers, conditions, and actions consistent across Home Assistant. The naming review and reasoning behind these changes is documented here: https://docs.google.com/document/d/18ZsosVR0OAOwkoQV1wmQ4FNSw18KV7EbPl0eNVP2uzA/edit?tab=t.0#heading=h.vwrsknoq58h0

The full sheet of proposed changes can be found here: https://docs.google.com/spreadsheets/d/1ahVHTWEZhk2-pwToI_ovHDBXIxHDmVqzRG41bwHGhMc/edit?gid=560897381#gid=560897381

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
