### PR TITLE
Improve zone trigger and condition wording

### DIFF
--- a/homeassistant/components/zone/strings.json
+++ b/homeassistant/components/zone/strings.json
@@ -43,7 +43,7 @@
       "name": "Is not in zone"
     },
     "occupancy_is_detected": {
-      "description": "Tests if a zone is occupied.",
+      "description": "Tests if one or more zones are occupied.",
       "fields": {
         "for": {
           "name": "[%key:component::zone::common::condition_for_name%]"
@@ -56,7 +56,7 @@
       "name": "Zone occupancy is detected"
     },
     "occupancy_is_not_detected": {
-      "description": "Tests if a zone is empty.",
+      "description": "Tests if one or more zones are unoccupied.",
       "fields": {
         "for": {
           "name": "[%key:component::zone::common::condition_for_name%]"
@@ -90,7 +90,7 @@
           "name": "[%key:component::zone::common::trigger_zone_name%]"
         }
       },
-      "name": "Entered zone"
+      "name": "Zone entered"
     },
     "left": {
       "description": "Triggers when one or more persons or device trackers leave a zone.",
@@ -106,10 +106,10 @@
           "name": "[%key:component::zone::common::trigger_zone_name%]"
         }
       },
-      "name": "Left zone"
+      "name": "Zone left"
     },
     "occupancy_cleared": {
-      "description": "Triggers when a zone transitions from occupied to unoccupied.",
+      "description": "Triggers when one or more zones transition from occupied to unoccupied.",
       "fields": {
         "for": {
           "name": "[%key:component::zone::common::trigger_for_name%]"
@@ -122,7 +122,7 @@
       "name": "Zone occupancy cleared"
     },
     "occupancy_detected": {
-      "description": "Triggers when a zone transitions to an occupied state.",
+      "description": "Triggers when one or more zones become occupied.",
       "fields": {
         "for": {
           "name": "[%key:component::zone::common::trigger_for_name%]"


### PR DESCRIPTION
## Proposed change

Entity triggers and conditions should describe themselves consistently. For the zone entities (zone), this aligns their names and descriptions with that standard. Most changes reword trigger descriptions to open with "Triggers when" instead of "Triggers after", which reads more naturally and matches the other triggers. In addition, 2 name(s) are refined and 4 description(s) are reworded for clarity, exactly as listed in the linked sheet. Only names and descriptions change; keys are untouched.

This is part of a wider effort to make the naming of triggers, conditions, and actions consistent across Home Assistant. The naming review and reasoning behind these changes is documented here: https://docs.google.com/document/d/18ZsosVR0OAOwkoQV1wmQ4FNSw18KV7EbPl0eNVP2uzA/edit?tab=t.0#heading=h.vwrsknoq58h0

The full sheet of proposed changes can be found here: https://docs.google.com/spreadsheets/d/1ahVHTWEZhk2-pwToI_ovHDBXIxHDmVqzRG41bwHGhMc/edit?gid=560897381#gid=560897381

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
