### PR TITLE
Improve trigger wording for lawn mower and vacuum entities

### DIFF
--- a/homeassistant/components/lawn_mower/strings.json
+++ b/homeassistant/components/lawn_mower/strings.json
@@ -120,7 +120,7 @@
       "name": "Lawn mower paused mowing"
     },
     "returned_to_dock": {
-      "description": "Triggers when one or more lawn mowers return to dock.",
+      "description": "Triggers when one or more lawn mowers have returned to dock.",
       "fields": {
         "behavior": {
           "name": "[%key:component::lawn_mower::common::trigger_behavior_name%]"

--- a/homeassistant/components/lawn_mower/strings.json
+++ b/homeassistant/components/lawn_mower/strings.json
@@ -96,7 +96,7 @@
   "title": "Lawn mower",
   "triggers": {
     "errored": {
-      "description": "Triggers after one or more lawn mowers encounter an error.",
+      "description": "Triggers when one or more lawn mowers encounter an error.",
       "fields": {
         "behavior": {
           "name": "[%key:component::lawn_mower::common::trigger_behavior_name%]"
@@ -108,7 +108,7 @@
       "name": "Lawn mower encountered an error"
     },
     "paused_mowing": {
-      "description": "Triggers after one or more lawn mowers pause mowing.",
+      "description": "Triggers when one or more lawn mowers pause mowing.",
       "fields": {
         "behavior": {
           "name": "[%key:component::lawn_mower::common::trigger_behavior_name%]"
@@ -120,7 +120,7 @@
       "name": "Lawn mower paused mowing"
     },
     "returned_to_dock": {
-      "description": "Triggers after one or more lawn mowers have returned to dock.",
+      "description": "Triggers when one or more lawn mowers return to dock.",
       "fields": {
         "behavior": {
           "name": "[%key:component::lawn_mower::common::trigger_behavior_name%]"
@@ -132,7 +132,7 @@
       "name": "Lawn mower returned to dock"
     },
     "started_mowing": {
-      "description": "Triggers after one or more lawn mowers start mowing.",
+      "description": "Triggers when one or more lawn mowers start mowing.",
       "fields": {
         "behavior": {
           "name": "[%key:component::lawn_mower::common::trigger_behavior_name%]"
@@ -144,7 +144,7 @@
       "name": "Lawn mower started mowing"
     },
     "started_returning": {
-      "description": "Triggers after one or more lawn mowers start returning to dock.",
+      "description": "Triggers when one or more lawn mowers start returning to dock.",
       "fields": {
         "behavior": {
           "name": "[%key:component::lawn_mower::common::trigger_behavior_name%]"

--- a/homeassistant/components/vacuum/strings.json
+++ b/homeassistant/components/vacuum/strings.json
@@ -191,7 +191,7 @@
   "title": "Vacuum",
   "triggers": {
     "errored": {
-      "description": "Triggers after one or more vacuums encounter an error.",
+      "description": "Triggers when one or more vacuum cleaners encounter an error.",
       "fields": {
         "behavior": {
           "name": "[%key:component::vacuum::common::trigger_behavior_name%]"
@@ -200,10 +200,10 @@
           "name": "[%key:component::vacuum::common::trigger_for_name%]"
         }
       },
-      "name": "Vacuum encountered an error"
+      "name": "Vacuum cleaner encountered an error"
     },
     "paused_cleaning": {
-      "description": "Triggers after one or more vacuums pause cleaning.",
+      "description": "Triggers when one or more vacuum cleaners pause cleaning.",
       "fields": {
         "behavior": {
           "name": "[%key:component::vacuum::common::trigger_behavior_name%]"
@@ -215,7 +215,7 @@
       "name": "Vacuum cleaner paused cleaning"
     },
     "returned_to_dock": {
-      "description": "Triggers after one or more vacuums have returned to dock.",
+      "description": "Triggers when one or more vacuum cleaners return to dock.",
       "fields": {
         "behavior": {
           "name": "[%key:component::vacuum::common::trigger_behavior_name%]"
@@ -224,10 +224,10 @@
           "name": "[%key:component::vacuum::common::trigger_for_name%]"
         }
       },
-      "name": "Vacuum returned to dock"
+      "name": "Vacuum cleaner returned to dock"
     },
     "started_cleaning": {
-      "description": "Triggers after one or more vacuums start cleaning.",
+      "description": "Triggers when one or more vacuum cleaners start cleaning.",
       "fields": {
         "behavior": {
           "name": "[%key:component::vacuum::common::trigger_behavior_name%]"
@@ -239,7 +239,7 @@
       "name": "Vacuum cleaner started cleaning"
     },
     "started_returning": {
-      "description": "Triggers after one or more vacuums start returning to dock.",
+      "description": "Triggers when one or more vacuum cleaners start returning to dock.",
       "fields": {
         "behavior": {
           "name": "[%key:component::vacuum::common::trigger_behavior_name%]"

--- a/homeassistant/components/vacuum/strings.json
+++ b/homeassistant/components/vacuum/strings.json
@@ -215,7 +215,7 @@
       "name": "Vacuum cleaner paused cleaning"
     },
     "returned_to_dock": {
-      "description": "Triggers when one or more vacuum cleaners return to dock.",
+      "description": "Triggers when one or more vacuum cleaners have returned to dock.",
       "fields": {
         "behavior": {
           "name": "[%key:component::vacuum::common::trigger_behavior_name%]"


### PR DESCRIPTION
## Proposed change

Entity triggers should describe themselves consistently. For the lawn mower and vacuum entities (lawn mower, vacuum), this aligns their names and descriptions with that standard. Most changes reword trigger descriptions to open with "Triggers when" instead of "Triggers after", which reads more naturally and matches the other triggers. In addition, 2 name(s) are refined and 4 description(s) are reworded for clarity, exactly as listed in the linked sheet. Only names and descriptions change; keys are untouched.

This is part of a wider effort to make the naming of triggers, conditions, and actions consistent across Home Assistant. The naming review and reasoning behind these changes is documented here: https://docs.google.com/document/d/18ZsosVR0OAOwkoQV1wmQ4FNSw18KV7EbPl0eNVP2uzA/edit?tab=t.0#heading=h.vwrsknoq58h0

The full sheet of proposed changes can be found here: https://docs.google.com/spreadsheets/d/1ahVHTWEZhk2-pwToI_ovHDBXIxHDmVqzRG41bwHGhMc/edit?gid=560897381#gid=560897381

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
