### PR TITLE
Add override decorator to components P to R

### DIFF
--- a/homeassistant/components/p1_monitor/config_flow.py
+++ b/homeassistant/components/p1_monitor/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for P1 Monitor integration."""
 
-from typing import Any
+from typing import Any, override
 
 from p1monitor import P1Monitor, P1MonitorError
 import voluptuous as vol
@@ -23,6 +23,7 @@ class P1MonitorFlowHandler(ConfigFlow, domain=DOMAIN):
 
     VERSION = 2
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/p1_monitor/coordinator.py
+++ b/homeassistant/components/p1_monitor/coordinator.py
@@ -1,6 +1,6 @@
 """Coordinator for the P1 Monitor integration."""
 
-from typing import TypedDict
+from typing import TypedDict, override
 
 from p1monitor import (
     P1Monitor,
@@ -66,6 +66,7 @@ class P1MonitorDataUpdateCoordinator(DataUpdateCoordinator[P1MonitorData]):
             session=async_get_clientsession(hass),
         )
 
+    @override
     async def _async_update_data(self) -> P1MonitorData:
         """Fetch data from P1 Monitor."""
         data: P1MonitorData = {

--- a/homeassistant/components/p1_monitor/sensor.py
+++ b/homeassistant/components/p1_monitor/sensor.py
@@ -1,6 +1,6 @@
 """Support for P1 Monitor sensors."""
 
-from typing import Literal
+from typing import Literal, override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -314,6 +314,7 @@ class P1MonitorSensorEntity(
         )
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
         value = getattr(

--- a/homeassistant/components/paj_gps/config_flow.py
+++ b/homeassistant/components/paj_gps/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for PAJ GPS Tracker integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from aiohttp import ClientError
 from pajgps_api import PajGpsApi
@@ -64,6 +64,7 @@ class PajGPSConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return None, auth
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/paj_gps/coordinator.py
+++ b/homeassistant/components/paj_gps/coordinator.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
+from typing import override
 
 from pajgps_api import PajGpsApi
 from pajgps_api.models.device import Device
@@ -72,6 +73,7 @@ class PajGpsCoordinator(DataUpdateCoordinator[PajGpsData]):
         """Return the user ID obtained from the login response."""
         return self._user_id
 
+    @override
     async def _async_setup(self) -> None:
         """Perform initial and first data refresh."""
         try:
@@ -82,6 +84,7 @@ class PajGpsCoordinator(DataUpdateCoordinator[PajGpsData]):
         except Exception as exc:
             raise ConfigEntryNotReady from exc
 
+    @override
     async def _async_update_data(self) -> PajGpsData:
         """Fetch device list and positions."""
         devices: dict[int, Device] = {}

--- a/homeassistant/components/paj_gps/device_tracker.py
+++ b/homeassistant/components/paj_gps/device_tracker.py
@@ -4,6 +4,7 @@ Reads position data from PajGpsCoordinator and exposes it as a TrackerEntity.
 """
 
 import logging
+from typing import override
 
 from homeassistant.components.device_tracker import TrackerEntity
 from homeassistant.core import HomeAssistant, callback
@@ -60,12 +61,14 @@ class PajGPSDeviceTracker(PajGpsEntity, TrackerEntity):
         self._attr_unique_id = f"{pajgps_coordinator.user_id}_{device_id}"
 
     @property
+    @override
     def latitude(self) -> float | None:
         """Return the latitude of the device."""
         tp = self.coordinator.data.positions.get(self._device_id)
         return float(tp.lat) if tp and tp.lat is not None else None
 
     @property
+    @override
     def longitude(self) -> float | None:
         """Return the longitude of the device."""
         tp = self.coordinator.data.positions.get(self._device_id)

--- a/homeassistant/components/paj_gps/entity.py
+++ b/homeassistant/components/paj_gps/entity.py
@@ -1,5 +1,7 @@
 """Base entity class for the PAJ GPS integration."""
 
+from typing import override
+
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -29,6 +31,7 @@ class PajGpsEntity(CoordinatorEntity[PajGpsCoordinator]):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return False when the device has been removed from the account."""
         return super().available and self._device_id in self.coordinator.data.devices

--- a/homeassistant/components/paj_gps/sensor.py
+++ b/homeassistant/components/paj_gps/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from typing import override
 
 from pajgps_api.models.trackpoint import TrackPoint
 
@@ -99,6 +100,7 @@ class PajGpsSensor(PajGpsEntity, SensorEntity):
         self._attr_unique_id = f"{coordinator.user_id}_{device_id}_{description.key}"
 
     @property
+    @override
     def native_value(self) -> int | None:
         """Return the sensor value from the latest trackpoint."""
         tp = self.coordinator.data.positions.get(self._device_id)

--- a/homeassistant/components/palazzetti/button.py
+++ b/homeassistant/components/palazzetti/button.py
@@ -1,5 +1,7 @@
 """Support for Palazzetti buttons."""
 
+from typing import override
+
 from pypalazzetti.exceptions import CommunicationError
 
 from homeassistant.components.button import ButtonEntity
@@ -37,6 +39,7 @@ class PalazzettiSilentButtonEntity(PalazzettiEntity, ButtonEntity):
         super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.config_entry.unique_id}-silent"
 
+    @override
     async def async_press(self) -> None:
         """Press the button."""
         try:

--- a/homeassistant/components/palazzetti/climate.py
+++ b/homeassistant/components/palazzetti/climate.py
@@ -1,6 +1,6 @@
 """Support for Palazzetti climates."""
 
-from typing import Any
+from typing import Any, override
 
 from pypalazzetti.exceptions import CommunicationError, ValidationError
 
@@ -62,11 +62,13 @@ class PalazzettiClimateEntity(PalazzettiEntity, ClimateEntity):
             self._attr_fan_modes.append(FAN_AUTO)
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode:
         """Return hvac operation ie. heat or off mode."""
         return HVACMode.HEAT if self.coordinator.client.is_on else HVACMode.OFF
 
     @property
+    @override
     def hvac_action(self) -> HVACAction:
         """Return hvac action ie. heating or idle."""
         return (
@@ -75,6 +77,7 @@ class PalazzettiClimateEntity(PalazzettiEntity, ClimateEntity):
             else HVACAction.IDLE
         )
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         try:
@@ -90,15 +93,18 @@ class PalazzettiClimateEntity(PalazzettiEntity, ClimateEntity):
         await self.coordinator.async_refresh()
 
     @property
+    @override
     def current_temperature(self) -> float | None:
         """Return current temperature."""
         return self.coordinator.client.room_temperature
 
     @property
+    @override
     def target_temperature(self) -> int | None:
         """Return the temperature."""
         return self.coordinator.client.target_temperature
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new temperature."""
         temperature = int(kwargs[ATTR_TEMPERATURE])
@@ -119,11 +125,13 @@ class PalazzettiClimateEntity(PalazzettiEntity, ClimateEntity):
         await self.coordinator.async_refresh()
 
     @property
+    @override
     def fan_mode(self) -> str | None:
         """Return the fan mode."""
         api_state = self.coordinator.client.current_fan_speed()
         return FAN_MODES[api_state]
 
+    @override
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new fan mode."""
         try:

--- a/homeassistant/components/palazzetti/config_flow.py
+++ b/homeassistant/components/palazzetti/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for Palazzetti."""
 
-from typing import Any
+from typing import Any, override
 
 from pypalazzetti.client import PalazzettiClient
 from pypalazzetti.exceptions import CommunicationError
@@ -19,6 +19,7 @@ class PalazzettiConfigFlow(ConfigFlow, domain=DOMAIN):
 
     _discovered_device: PalazzettiClient
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -52,6 +53,7 @@ class PalazzettiConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    @override
     async def async_step_dhcp(
         self, discovery_info: DhcpServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/palazzetti/coordinator.py
+++ b/homeassistant/components/palazzetti/coordinator.py
@@ -1,5 +1,7 @@
 """Helpers to help coordinate updates."""
 
+from typing import override
+
 from pypalazzetti.client import PalazzettiClient
 from pypalazzetti.exceptions import CommunicationError, ValidationError
 
@@ -34,6 +36,7 @@ class PalazzettiDataUpdateCoordinator(DataUpdateCoordinator[None]):
         )
         self.client = PalazzettiClient(self.config_entry.data[CONF_HOST])
 
+    @override
     async def _async_setup(self) -> None:
         try:
             await self.client.connect()
@@ -41,6 +44,7 @@ class PalazzettiDataUpdateCoordinator(DataUpdateCoordinator[None]):
         except (CommunicationError, ValidationError) as err:
             raise UpdateFailed(f"Error communicating with the API: {err}") from err
 
+    @override
     async def _async_update_data(self) -> None:
         """Fetch data from Palazzetti."""
         try:

--- a/homeassistant/components/palazzetti/entity.py
+++ b/homeassistant/components/palazzetti/entity.py
@@ -1,5 +1,7 @@
 """Base class for Palazzetti entities."""
 
+from typing import override
+
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -27,6 +29,7 @@ class PalazzettiEntity(CoordinatorEntity[PalazzettiDataUpdateCoordinator]):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Is the entity available."""
         return super().available and self.coordinator.client.connected

--- a/homeassistant/components/palazzetti/number.py
+++ b/homeassistant/components/palazzetti/number.py
@@ -1,5 +1,7 @@
 """Number platform for Palazzetti settings."""
 
+from typing import override
+
 from pypalazzetti.exceptions import CommunicationError, ValidationError
 from pypalazzetti.fan import FanType
 
@@ -51,10 +53,12 @@ class PalazzettiCombustionPowerEntity(PalazzettiEntity, NumberEntity):
         self._attr_unique_id = f"{coordinator.config_entry.unique_id}-combustion_power"
 
     @property
+    @override
     def native_value(self) -> float:
         """Return the state of the setting entity."""
         return self.coordinator.client.power_mode
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Update the setting."""
         try:
@@ -96,10 +100,12 @@ class PalazzettiFanEntity(PalazzettiEntity, NumberEntity):
         )
 
     @property
+    @override
     def native_value(self) -> float:
         """Return the state of the setting entity."""
         return self.coordinator.client.current_fan_speed(self.fan)
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Update the setting."""
         try:

--- a/homeassistant/components/palazzetti/sensor.py
+++ b/homeassistant/components/palazzetti/sensor.py
@@ -1,6 +1,7 @@
 """Support for Palazzetti sensors."""
 
 from dataclasses import dataclass
+from typing import override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -112,6 +113,7 @@ class PalazzettiSensor(PalazzettiEntity, SensorEntity):
         self._attr_unique_id = f"{coordinator.config_entry.unique_id}-{description.key}"
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the state value of the sensor."""
 

--- a/homeassistant/components/panasonic_bluray/media_player.py
+++ b/homeassistant/components/panasonic_bluray/media_player.py
@@ -1,6 +1,7 @@
 """Support for Panasonic Blu-ray players."""
 
 from datetime import timedelta
+from typing import override
 
 from panacotta import PanasonicBD
 import voluptuous as vol
@@ -89,6 +90,7 @@ class PanasonicBluRay(MediaPlayerEntity):
         self._attr_media_position_updated_at = utcnow()
         self._attr_media_duration = state[2]
 
+    @override
     def turn_off(self) -> None:
         """Instruct the device to turn standby.
 
@@ -102,6 +104,7 @@ class PanasonicBluRay(MediaPlayerEntity):
 
         self._attr_state = MediaPlayerState.OFF
 
+    @override
     def turn_on(self) -> None:
         """Wake the device back up from standby."""
         if self.state == MediaPlayerState.OFF:
@@ -109,14 +112,17 @@ class PanasonicBluRay(MediaPlayerEntity):
 
         self._attr_state = MediaPlayerState.IDLE
 
+    @override
     def media_play(self) -> None:
         """Send play command."""
         self._device.send_key("PLAYBACK")
 
+    @override
     def media_pause(self) -> None:
         """Send pause command."""
         self._device.send_key("PAUSE")
 
+    @override
     def media_stop(self) -> None:
         """Send stop command."""
         self._device.send_key("STOP")

--- a/homeassistant/components/panasonic_viera/config_flow.py
+++ b/homeassistant/components/panasonic_viera/config_flow.py
@@ -2,7 +2,7 @@
 
 from functools import partial
 import logging
-from typing import Any
+from typing import Any, override
 from urllib.error import URLError
 
 from panasonic_viera import TV_TYPE_ENCRYPTED, RemoteControl, SOAPError
@@ -44,6 +44,7 @@ class PanasonicVieraConfigFlow(ConfigFlow, domain=DOMAIN):
 
         self._remote: RemoteControl | None = None
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/panasonic_viera/media_player.py
+++ b/homeassistant/components/panasonic_viera/media_player.py
@@ -1,7 +1,7 @@
 """Media player support for Panasonic Viera TV."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from panasonic_viera import Keys
 
@@ -86,21 +86,25 @@ class PanasonicVieraTVEntity(MediaPlayerEntity):
             self._attr_name = name
 
     @property
+    @override
     def state(self) -> MediaPlayerState | None:
         """Return the state of the device."""
         return self._remote.state
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if the device is available."""
         return self._remote.available
 
     @property
+    @override
     def volume_level(self) -> float | None:
         """Volume level of the media player (0..1)."""
         return self._remote.volume
 
     @property
+    @override
     def is_volume_muted(self) -> bool | None:
         """Boolean if volume is currently muted."""
         return self._remote.muted
@@ -109,30 +113,37 @@ class PanasonicVieraTVEntity(MediaPlayerEntity):
         """Retrieve the latest data."""
         await self._remote.async_update()
 
+    @override
     async def async_turn_on(self) -> None:
         """Turn on the media player."""
         await self._remote.async_turn_on(context=self._context)
 
+    @override
     async def async_turn_off(self) -> None:
         """Turn off media player."""
         await self._remote.async_turn_off()
 
+    @override
     async def async_volume_up(self) -> None:
         """Volume up the media player."""
         await self._remote.async_send_key(Keys.VOLUME_UP)
 
+    @override
     async def async_volume_down(self) -> None:
         """Volume down media player."""
         await self._remote.async_send_key(Keys.VOLUME_DOWN)
 
+    @override
     async def async_mute_volume(self, mute: bool) -> None:
         """Send mute command."""
         await self._remote.async_set_mute(mute)
 
+    @override
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""
         await self._remote.async_set_volume(volume)
 
+    @override
     async def async_media_play_pause(self) -> None:
         """Simulate play pause media player."""
         if self._remote.playing:
@@ -142,28 +153,34 @@ class PanasonicVieraTVEntity(MediaPlayerEntity):
             await self._remote.async_send_key(Keys.PLAY)
             self._remote.playing = True
 
+    @override
     async def async_media_play(self) -> None:
         """Send play command."""
         await self._remote.async_send_key(Keys.PLAY)
         self._remote.playing = True
 
+    @override
     async def async_media_pause(self) -> None:
         """Send pause command."""
         await self._remote.async_send_key(Keys.PAUSE)
         self._remote.playing = False
 
+    @override
     async def async_media_stop(self) -> None:
         """Stop playback."""
         await self._remote.async_send_key(Keys.STOP)
 
+    @override
     async def async_media_next_track(self) -> None:
         """Send the fast forward command."""
         await self._remote.async_send_key(Keys.FAST_FORWARD)
 
+    @override
     async def async_media_previous_track(self) -> None:
         """Send the rewind command."""
         await self._remote.async_send_key(Keys.REWIND)
 
+    @override
     async def async_play_media(
         self, media_type: MediaType | str, media_id: str, **kwargs: Any
     ) -> None:
@@ -182,6 +199,7 @@ class PanasonicVieraTVEntity(MediaPlayerEntity):
         media_id = async_process_play_media_url(self.hass, media_id)
         await self._remote.async_play_media(media_type, media_id)
 
+    @override
     async def async_browse_media(
         self,
         media_content_type: MediaType | str | None = None,

--- a/homeassistant/components/panasonic_viera/remote.py
+++ b/homeassistant/components/panasonic_viera/remote.py
@@ -1,7 +1,7 @@
 """Remote control support for Panasonic Viera TV."""
 
 from collections.abc import Iterable
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.remote import RemoteEntity
 from homeassistant.const import ATTR_MANUFACTURER, CONF_NAME, STATE_ON
@@ -49,6 +49,7 @@ class PanasonicVieraRemoteEntity(RemoteEntity):
         self._device_info = device_info
 
     @property
+    @override
     def unique_id(self) -> str | None:
         """Return the unique ID of the device."""
         if self._device_info is None:
@@ -56,6 +57,7 @@ class PanasonicVieraRemoteEntity(RemoteEntity):
         return self._device_info[ATTR_UDN]
 
     @property
+    @override
     def device_info(self) -> DeviceInfo | None:
         """Return device specific attributes."""
         if self._device_info is None:
@@ -68,28 +70,34 @@ class PanasonicVieraRemoteEntity(RemoteEntity):
         )
 
     @property
+    @override
     def name(self) -> str:
         """Return the name of the device."""
         return self._name
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if the device is available."""
         return self._remote.available
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if device is on."""
         return self._remote.state == STATE_ON
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
         await self._remote.async_turn_on(context=self._context)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
         await self._remote.async_turn_off()
 
+    @override
     async def async_send_command(self, command: Iterable[str], **kwargs: Any) -> None:
         """Send a command to one device."""
         for cmd in command:

--- a/homeassistant/components/paperless_ngx/config_flow.py
+++ b/homeassistant/components/paperless_ngx/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for the Paperless-ngx integration."""
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, override
 
 from pypaperless import Paperless
 from pypaperless.exceptions import (
@@ -31,6 +31,7 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
 class PaperlessConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Paperless-ngx."""
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/paperless_ngx/coordinator.py
+++ b/homeassistant/components/paperless_ngx/coordinator.py
@@ -3,6 +3,7 @@
 from abc import abstractmethod
 from dataclasses import dataclass
 from datetime import timedelta
+from typing import override
 
 from pypaperless import Paperless
 from pypaperless.exceptions import (
@@ -58,6 +59,7 @@ class PaperlessCoordinator[DataT](DataUpdateCoordinator[DataT]):
             update_interval=update_interval,
         )
 
+    @override
     async def _async_update_data(self) -> DataT:
         """Update data via internal method."""
         try:
@@ -106,6 +108,7 @@ class PaperlessStatisticCoordinator(PaperlessCoordinator[Statistic]):
             update_interval=UPDATE_INTERVAL_STATISTICS,
         )
 
+    @override
     async def _async_update_data_internal(self) -> Statistic:
         """Fetch statistics data from API endpoint."""
         return await self.api.statistics()
@@ -129,6 +132,7 @@ class PaperlessStatusCoordinator(PaperlessCoordinator[Status]):
             update_interval=UPDATE_INTERVAL_STATUS,
         )
 
+    @override
     async def _async_update_data_internal(self) -> Status:
         """Fetch status data from API endpoint."""
         return await self.api.status()

--- a/homeassistant/components/paperless_ngx/sensor.py
+++ b/homeassistant/components/paperless_ngx/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from pypaperless.models import Statistic, Status
 from pypaperless.models.common import StatusType
@@ -286,6 +287,7 @@ class PaperlessSensor[CoordinatorT: PaperlessCoordinator](
     entity_description: PaperlessEntityDescription
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the current value of the sensor."""
         return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/paperless_ngx/update.py
+++ b/homeassistant/components/paperless_ngx/update.py
@@ -1,6 +1,7 @@
 """Update platform for Paperless-ngx."""
 
 from datetime import timedelta
+from typing import override
 
 from pypaperless.exceptions import PaperlessConnectionError
 
@@ -53,20 +54,24 @@ class PaperlessUpdate(PaperlessEntity[PaperlessStatusCoordinator], UpdateEntity)
     release_url = PAPERLESS_CHANGELOGS
 
     @property
+    @override
     def should_poll(self) -> bool:
         """Return True because we need to poll the latest version."""
         return True
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available."""
         return self._attr_available
 
     @property
+    @override
     def installed_version(self) -> str | None:
         """Return the installed version."""
         return self.coordinator.api.host_version
 
+    @override
     async def async_update(self) -> None:
         """Update the entity."""
         remote_version = None

--- a/homeassistant/components/peblar/binary_sensor.py
+++ b/homeassistant/components/peblar/binary_sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -70,6 +71,7 @@ class PeblarBinarySensorEntity(
     entity_description: PeblarBinarySensorEntityDescription
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return state of the binary sensor."""
         return self.entity_description.is_on_fn(self.coordinator.data)

--- a/homeassistant/components/peblar/button.py
+++ b/homeassistant/components/peblar/button.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from peblar import Peblar
 
@@ -72,6 +72,7 @@ class PeblarButtonEntity(
     entity_description: PeblarButtonEntityDescription
 
     @peblar_exception_handler
+    @override
     async def async_press(self) -> None:
         """Trigger button press on the Peblar device."""
         await self.entity_description.press_fn(self.coordinator.peblar)

--- a/homeassistant/components/peblar/config_flow.py
+++ b/homeassistant/components/peblar/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow to configure the Peblar integration."""
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, override
 
 from aiohttp import CookieJar
 from peblar import Peblar, PeblarAuthenticationError, PeblarConnectionError
@@ -27,6 +27,7 @@ class PeblarFlowHandler(ConfigFlow, domain=DOMAIN):
 
     _discovery_info: ZeroconfServiceInfo
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -125,6 +126,7 @@ class PeblarFlowHandler(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    @override
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/peblar/coordinator.py
+++ b/homeassistant/components/peblar/coordinator.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Any, Concatenate
+from typing import Any, Concatenate, override
 
 from peblar import (
     Peblar,
@@ -125,6 +125,7 @@ class PeblarVersionDataUpdateCoordinator(
         )
 
     @_coordinator_exception_handler
+    @override
     async def _async_update_data(self) -> PeblarVersionInformation:
         """Fetch data from the Peblar device."""
         return PeblarVersionInformation(
@@ -152,6 +153,7 @@ class PeblarDataUpdateCoordinator(DataUpdateCoordinator[PeblarData]):
         )
 
     @_coordinator_exception_handler
+    @override
     async def _async_update_data(self) -> PeblarData:
         """Fetch data from the Peblar device."""
         return PeblarData(
@@ -180,6 +182,7 @@ class PeblarUserConfigurationDataUpdateCoordinator(
         )
 
     @_coordinator_exception_handler
+    @override
     async def _async_update_data(self) -> PeblarUserConfiguration:
         """Fetch data from the Peblar device."""
         return await self.peblar.user_configuration()

--- a/homeassistant/components/peblar/number.py
+++ b/homeassistant/components/peblar/number.py
@@ -1,5 +1,7 @@
 """Support for Peblar numbers."""
 
+from typing import override
+
 from homeassistant.components.number import (
     NumberDeviceClass,
     NumberEntityDescription,
@@ -71,6 +73,7 @@ class PeblarChargeCurrentLimitNumberEntity(
         configuration = entry.runtime_data.user_configuration_coordinator.data
         self._attr_native_max_value = configuration.user_defined_charge_limit_current
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Load the last known state when adding this entity."""
         if (
@@ -90,6 +93,7 @@ class PeblarChargeCurrentLimitNumberEntity(
         self._handle_coordinator_update()
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle coordinator update.
 
@@ -112,6 +116,7 @@ class PeblarChargeCurrentLimitNumberEntity(
         super()._handle_coordinator_update()
 
     @peblar_exception_handler
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Change the current charging value."""
         # If charging is currently disabled (below 6 amps), just set the value

--- a/homeassistant/components/peblar/select.py
+++ b/homeassistant/components/peblar/select.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from peblar import Peblar, PeblarUserConfiguration, SmartChargingMode
 
@@ -69,11 +69,13 @@ class PeblarSelectEntity(
     entity_description: PeblarSelectEntityDescription
 
     @property
+    @override
     def current_option(self) -> str | None:
         """Return the selected entity option to represent the entity state."""
         return self.entity_description.current_fn(self.coordinator.data)
 
     @peblar_exception_handler
+    @override
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         await self.entity_description.select_fn(self.coordinator.peblar, option)

--- a/homeassistant/components/peblar/sensor.py
+++ b/homeassistant/components/peblar/sensor.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from typing import override
 
 from peblar import PeblarUserConfiguration
 
@@ -249,6 +250,7 @@ class PeblarSensorEntity(PeblarEntity[PeblarDataUpdateCoordinator], SensorEntity
     entity_description: PeblarSensorDescription
 
     @property
+    @override
     def native_value(self) -> datetime | int | str | None:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/peblar/switch.py
+++ b/homeassistant/components/peblar/switch.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from peblar import PeblarEVInterface
 
@@ -92,17 +92,20 @@ class PeblarSwitchEntity(
     entity_description: PeblarSwitchEntityDescription
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return state of the switch."""
         return self.entity_description.is_on_fn(self.coordinator.data)
 
     @peblar_exception_handler
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         await self.entity_description.set_fn(self.coordinator, True)
         await self.coordinator.async_request_refresh()
 
     @peblar_exception_handler
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         await self.entity_description.set_fn(self.coordinator, False)

--- a/homeassistant/components/peblar/update.py
+++ b/homeassistant/components/peblar/update.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from homeassistant.components.update import (
     UpdateDeviceClass,
@@ -74,11 +75,13 @@ class PeblarUpdateEntity(
     entity_description: PeblarUpdateEntityDescription
 
     @property
+    @override
     def installed_version(self) -> str | None:
         """Version currently installed and in use."""
         return self.entity_description.installed_fn(self.coordinator.data)
 
     @property
+    @override
     def latest_version(self) -> str | None:
         """Latest version available for install."""
         return self.entity_description.available_fn(self.coordinator.data)

--- a/homeassistant/components/peco/binary_sensor.py
+++ b/homeassistant/components/peco/binary_sensor.py
@@ -1,6 +1,6 @@
 """Binary sensor for PECO outage counter."""
 
-from typing import Final
+from typing import Final, override
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -46,6 +46,7 @@ class PecoBinarySensor(
         self._attr_unique_id = f"{phone_number}"
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return if the meter has power."""
         return self.coordinator.data

--- a/homeassistant/components/peco/config_flow.py
+++ b/homeassistant/components/peco/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for PECO Outage Counter integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from peco import (
     HttpError,
@@ -50,6 +50,7 @@ class PecoConfigFlow(ConfigFlow, domain=DOMAIN):
         except HttpError:
             self.meter_error = {"phone_number": "http_error", "type": "error"}
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/peco/coordinator.py
+++ b/homeassistant/components/peco/coordinator.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 from datetime import timedelta
+from typing import override
 
 from peco import (
     AlertResults,
@@ -57,6 +58,7 @@ class PecoOutageCoordinator(DataUpdateCoordinator[PECOCoordinatorData]):
         self._websession = async_get_clientsession(hass)
         self._county: str = entry.data[CONF_COUNTY]
 
+    @override
     async def _async_update_data(self) -> PECOCoordinatorData:
         """Fetch data from API."""
         try:
@@ -93,6 +95,7 @@ class PecoSmartMeterCoordinator(DataUpdateCoordinator[bool]):
         self._websession = async_get_clientsession(hass)
         self._phone_number = phone_number
 
+    @override
     async def _async_update_data(self) -> bool:
         """Fetch data from API."""
         try:

--- a/homeassistant/components/peco/sensor.py
+++ b/homeassistant/components/peco/sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Final
+from typing import Final, override
 
 from homeassistant.components.sensor import (
     SensorEntity,
@@ -103,11 +103,13 @@ class PecoSensor(CoordinatorEntity[PecoOutageCoordinator], SensorEntity):
         self.entity_description = description
 
     @property
+    @override
     def native_value(self) -> int | str:
         """Return the value of the sensor."""
         return self.entity_description.value_fn(self.coordinator.data)
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, str]:
         """Return state attributes for the sensor."""
         return self.entity_description.attribute_fn(self.coordinator.data)

--- a/homeassistant/components/pegel_online/config_flow.py
+++ b/homeassistant/components/pegel_online/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for PEGELONLINE."""
 
-from typing import Any
+from typing import Any, override
 
 from aiopegelonline import CONNECT_ERRORS, PegelOnline
 import voluptuous as vol
@@ -38,6 +38,7 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
         self._data: dict[str, Any] = {}
         self._stations: dict[str, str] = {}
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/pegel_online/coordinator.py
+++ b/homeassistant/components/pegel_online/coordinator.py
@@ -1,6 +1,7 @@
 """DataUpdateCoordinator for pegel_online."""
 
 import logging
+from typing import override
 
 from aiopegelonline import CONNECT_ERRORS, PegelOnline, Station, StationMeasurements
 
@@ -38,6 +39,7 @@ class PegelOnlineDataUpdateCoordinator(DataUpdateCoordinator[StationMeasurements
             update_interval=MIN_TIME_BETWEEN_UPDATES,
         )
 
+    @override
     async def _async_update_data(self) -> StationMeasurements:
         """Fetch data from API endpoint."""
         try:

--- a/homeassistant/components/pegel_online/sensor.py
+++ b/homeassistant/components/pegel_online/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from aiopegelonline.models import CurrentMeasurement, StationMeasurements
 
@@ -143,6 +144,7 @@ class PegelOnlineSensor(PegelOnlineEntity, SensorEntity):
         return measurement
 
     @property
+    @override
     def native_value(self) -> float:
         """Return the state of the device."""
         return self.measurement.value

--- a/homeassistant/components/pencom/switch.py
+++ b/homeassistant/components/pencom/switch.py
@@ -1,7 +1,7 @@
 """Pencom relay control."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from pencompy.pencompy import Pencompy
 import voluptuous as vol
@@ -82,10 +82,12 @@ class PencomRelay(SwitchEntity):
         self._addr = addr
         self._attr_name = name
 
+    @override
     def turn_on(self, **kwargs: Any) -> None:
         """Turn a relay on."""
         self._hub.set(self._board, self._addr, True)
 
+    @override
     def turn_off(self, **kwargs: Any) -> None:
         """Turn a relay off."""
         self._hub.set(self._board, self._addr, False)
@@ -95,6 +97,7 @@ class PencomRelay(SwitchEntity):
         self._attr_is_on = self._hub.get(self._board, self._addr)
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return supported attributes."""
         return {"board": self._board, "addr": self._addr}

--- a/homeassistant/components/permobil/binary_sensor.py
+++ b/homeassistant/components/permobil/binary_sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from mypermobil import BATTERY_CHARGING
 
@@ -56,11 +56,13 @@ class PermobilbinarySensor(PermobilEntity, BinarySensorEntity):
     entity_description: PermobilBinarySensorEntityDescription
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return True if the wheelchair is charging."""
         return self.entity_description.is_on_fn(self.coordinator.data)
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if the sensor has value."""
         return super().available and self.entity_description.available_fn(

--- a/homeassistant/components/permobil/config_flow.py
+++ b/homeassistant/components/permobil/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from mypermobil import (
     MyPermobil,
@@ -51,6 +51,7 @@ class PermobilConfigFlow(ConfigFlow, domain=DOMAIN):
         session = async_get_clientsession(hass)
         self.p_api = MyPermobil(APPLICATION, session=session)
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/permobil/coordinator.py
+++ b/homeassistant/components/permobil/coordinator.py
@@ -4,6 +4,7 @@ import asyncio
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
+from typing import override
 
 from mypermobil import MyPermobil, MyPermobilAPIException
 
@@ -43,6 +44,7 @@ class MyPermobilCoordinator(DataUpdateCoordinator[MyPermobilData]):
         )
         self.p_api = p_api
 
+    @override
     async def _async_update_data(self) -> MyPermobilData:
         """Fetch data from the 3 API endpoints."""
         try:

--- a/homeassistant/components/permobil/sensor.py
+++ b/homeassistant/components/permobil/sensor.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 import logging
-from typing import Any
+from typing import Any, override
 
 from mypermobil import (
     BATTERY_AMPERE_HOURS_LEFT,
@@ -198,6 +198,7 @@ class PermobilSensor(PermobilEntity, SensorEntity):
     entity_description: PermobilSensorEntityDescription
 
     @property
+    @override
     def native_unit_of_measurement(self) -> str | None:
         """Return the unit of measurement of the sensor."""
         if self.entity_description.key == "record_distance":
@@ -207,6 +208,7 @@ class PermobilSensor(PermobilEntity, SensorEntity):
         return self.entity_description.native_unit_of_measurement
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if the sensor has value."""
         return super().available and self.entity_description.available_fn(
@@ -214,6 +216,7 @@ class PermobilSensor(PermobilEntity, SensorEntity):
         )
 
     @property
+    @override
     def native_value(self) -> float | int:
         """Return the value of the sensor."""
         return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 import logging
-from typing import Any, Self
+from typing import Any, Self, override
 
 import voluptuous as vol
 
@@ -186,6 +186,7 @@ UPDATE_FIELDS: VolDictType = {
 class PersonStore(Store):
     """Person storage."""
 
+    @override
     async def _async_migrate_func(
         self, old_major_version: int, old_minor_version: int, old_data: dict[str, Any]
     ) -> dict[str, Any]:
@@ -212,6 +213,7 @@ class PersonStorageCollection(collection.DictStorageCollection):
         super().__init__(store, id_manager)
         self.yaml_collection = yaml_collection
 
+    @override
     async def _async_load_data(self) -> collection.SerializedStorageCollection | None:
         """Load the data.
 
@@ -229,6 +231,7 @@ class PersonStorageCollection(collection.DictStorageCollection):
 
         return data
 
+    @override
     async def async_load(self) -> None:
         """Load the Storage collection."""
         await super().async_load()
@@ -268,6 +271,7 @@ class PersonStorageCollection(collection.DictStorageCollection):
                 },
             )
 
+    @override
     async def _process_create_data(self, data: dict) -> dict:
         """Validate the config is valid."""
         data = self.CREATE_SCHEMA(data)
@@ -278,10 +282,12 @@ class PersonStorageCollection(collection.DictStorageCollection):
         return data
 
     @callback
+    @override
     def _get_suggested_id(self, info: dict[str, str]) -> str:
         """Suggest an ID based on the config."""
         return info[CONF_NAME]
 
+    @override
     async def _update_data(self, item: dict, update_data: dict) -> dict:
         """Return a new updated data object."""
         update_data = self.UPDATE_SCHEMA(update_data)
@@ -306,6 +312,7 @@ class PersonStorageCollection(collection.DictStorageCollection):
 class PersonStorageCollectionWebsocket(collection.DictStorageCollectionWebsocket):
     """Class to expose storage collection management over websocket."""
 
+    @override
     def ws_list_item(
         self,
         hass: HomeAssistant,
@@ -445,6 +452,7 @@ class Person(
         self.device_trackers = self._config[CONF_DEVICE_TRACKERS]
 
     @classmethod
+    @override
     def from_storage(cls, config: ConfigType) -> Self:
         """Return entity instance initialized from storage."""
         person = cls(config)
@@ -452,12 +460,14 @@ class Person(
         return person
 
     @classmethod
+    @override
     def from_yaml(cls, config: ConfigType) -> Self:
         """Return entity instance initialized from yaml."""
         person = cls(config)
         person.editable = False
         return person
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register device trackers."""
         await super().async_added_to_hass()
@@ -481,6 +491,7 @@ class Person(
             # as there are attributes that can already be set
             self._update_extra_state_attributes()
 
+    @override
     async def async_update_config(self, config: ConfigType) -> None:
         """Handle when the config is updated."""
         self._async_update_config(config)

--- a/homeassistant/components/pglab/config_flow.py
+++ b/homeassistant/components/pglab/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for PG LAB Electronics integration."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components import mqtt
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
@@ -14,6 +14,7 @@ class PGLabFlowHandler(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_mqtt(
         self, discovery_info: MqttServiceInfo
     ) -> ConfigFlowResult:
@@ -31,6 +32,7 @@ class PGLabFlowHandler(ConfigFlow, domain=DOMAIN):
 
         return await self.async_step_confirm_from_mqtt()
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/pglab/cover.py
+++ b/homeassistant/components/pglab/cover.py
@@ -1,6 +1,6 @@
 """PG LAB Electronics Cover."""
 
-from typing import Any
+from typing import Any, override
 
 from pypglab.device import Device as PyPGLabDevice
 from pypglab.shutter import Shutter as PyPGLabShutter
@@ -71,19 +71,23 @@ class PGLabCover(PGLabEntity, CoverEntity):
             CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE | CoverEntityFeature.STOP
         )
 
+    @override
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
         await self._shutter.open()
 
+    @override
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close cover."""
         await self._shutter.close()
 
+    @override
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
         await self._shutter.stop()
 
     @property
+    @override
     def is_closed(self) -> bool | None:
         """Return if cover is closed."""
         if not self._shutter.state:
@@ -91,6 +95,7 @@ class PGLabCover(PGLabEntity, CoverEntity):
         return self._shutter.state == PyPGLabShutter.STATE_CLOSED
 
     @property
+    @override
     def is_closing(self) -> bool | None:
         """Return if the cover is closing."""
         if not self._shutter.state:
@@ -98,6 +103,7 @@ class PGLabCover(PGLabEntity, CoverEntity):
         return self._shutter.state == PyPGLabShutter.STATE_CLOSING
 
     @property
+    @override
     def is_opening(self) -> bool | None:
         """Return if the cover is opening."""
         if not self._shutter.state:

--- a/homeassistant/components/pglab/entity.py
+++ b/homeassistant/components/pglab/entity.py
@@ -1,5 +1,7 @@
 """Entity for PG LAB Electronics."""
 
+from typing import override
+
 from pypglab.device import Device as PyPGLabDevice
 from pypglab.entity import Entity as PyPGLabEntity
 
@@ -40,6 +42,7 @@ class PGLabBaseEntity(Entity):
             connections={(CONNECTION_NETWORK_MAC, pglab_device.mac)},
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Update the device discovery info."""
 
@@ -72,6 +75,7 @@ class PGLabEntity(PGLabBaseEntity):
         self._id = pglab_entity.id
         self._entity: PyPGLabEntity = pglab_entity
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Subscribe pypglab entity to MQTT updates.
 
@@ -85,6 +89,7 @@ class PGLabEntity(PGLabBaseEntity):
         await self._entity.subscribe_topics()
         await super().async_added_to_hass()
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Unsubscribe when removed."""
 

--- a/homeassistant/components/pglab/sensor.py
+++ b/homeassistant/components/pglab/sensor.py
@@ -1,5 +1,7 @@
 """Sensor for PG LAB Electronics."""
 
+from typing import override
+
 from pypglab.const import SENSOR_REBOOT_TIME, SENSOR_TEMPERATURE, SENSOR_VOLTAGE
 from pypglab.device import Device as PyPGLabDevice
 
@@ -93,6 +95,7 @@ class PGLabSensor(PGLabSensorEntity, SensorEntity):
         self.entity_description = description
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Update attributes when the coordinator updates."""
 
@@ -102,6 +105,7 @@ class PGLabSensor(PGLabSensorEntity, SensorEntity):
         super()._handle_coordinator_update()
 
     @property
+    @override
     def available(self) -> bool:
         """Return PG LAB sensor availability."""
         return super().available and self.native_value is not None

--- a/homeassistant/components/pglab/switch.py
+++ b/homeassistant/components/pglab/switch.py
@@ -1,6 +1,6 @@
 """Switch for PG LAB Electronics."""
 
-from typing import Any
+from typing import Any, override
 
 from pypglab.device import Device as PyPGLabDevice
 from pypglab.relay import Relay as PyPGLabRelay
@@ -60,15 +60,18 @@ class PGLabSwitch(PGLabEntity, SwitchEntity):
 
         self._relay = pglab_relay
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
         await self._relay.turn_on()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
         await self._relay.turn_off()
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if device is on."""
         return self._relay.state

--- a/homeassistant/components/philips_js/binary_sensor.py
+++ b/homeassistant/components/philips_js/binary_sensor.py
@@ -1,6 +1,7 @@
 """Philips TV binary sensors."""
 
 from dataclasses import dataclass
+from typing import override
 
 from haphilipsjs import PhilipsTV
 
@@ -88,6 +89,7 @@ class PhilipsTVBinarySensorEntityRecordingType(PhilipsJsEntity, BinarySensorEnti
         super().__init__(coordinator)
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator.
 

--- a/homeassistant/components/philips_js/config_flow.py
+++ b/homeassistant/components/philips_js/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import platform
-from typing import Any
+from typing import Any, override
 
 from haphilipsjs import (
     DEFAULT_API_VERSION,
@@ -177,6 +177,7 @@ class PhilipsJSConfigFlow(ConfigFlow, domain=DOMAIN):
         self._current[CONF_API_VERSION] = entry_data[CONF_API_VERSION]
         return await self.async_step_user()
 
+    @override
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:
@@ -214,6 +215,7 @@ class PhilipsJSConfigFlow(ConfigFlow, domain=DOMAIN):
             description_placeholders={CONF_NAME: name},
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -236,6 +238,7 @@ class PhilipsJSConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> SchemaOptionsFlowHandler:

--- a/homeassistant/components/philips_js/coordinator.py
+++ b/homeassistant/components/philips_js/coordinator.py
@@ -3,6 +3,7 @@
 import asyncio
 from datetime import timedelta
 import logging
+from typing import override
 
 from haphilipsjs import (
     AutenticationFailure,
@@ -125,11 +126,13 @@ class PhilipsTVDataUpdateCoordinator(DataUpdateCoordinator[None]):
             self._notify_future = asyncio.create_task(self._notify_task())
 
     @callback
+    @override
     def _unschedule_refresh(self) -> None:
         """Remove data update."""
         super()._unschedule_refresh()
         self._async_notify_stop()
 
+    @override
     async def _async_update_data(self):
         """Fetch the latest data from the source."""
         try:

--- a/homeassistant/components/philips_js/light.py
+++ b/homeassistant/components/philips_js/light.py
@@ -1,7 +1,7 @@
 """Component to integrate ambilight for TVs exposing the Joint Space API."""
 
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any, cast, override
 
 from haphilipsjs import PhilipsTV
 from haphilipsjs.typing import AmbilightCurrentConfiguration
@@ -89,6 +89,7 @@ class AmbilightEffect:
             return AmbilightEffect(mode=EFFECT_EXPERT, style=style, algorithm=algorithm)
         return AmbilightEffect(mode=EFFECT_AUTO, style=style, algorithm=algorithm)
 
+    @override
     def __str__(self) -> str:
         """Get a string representation of the effect."""
         if self.mode == EFFECT_MODE:
@@ -201,6 +202,7 @@ class PhilipsTVLightEntity(PhilipsJsEntity, LightEntity):
         return AmbilightEffect(EFFECT_MODE, self._tv.ambilight_mode, None)
 
     @property
+    @override
     def color_mode(self) -> ColorMode:
         """Return the current color mode."""
         current = self._tv.ambilight_current_configuration
@@ -213,6 +215,7 @@ class PhilipsTVLightEntity(PhilipsJsEntity, LightEntity):
         return ColorMode.ONOFF
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return if the light is turned on."""
         if self._tv.on:
@@ -255,6 +258,7 @@ class PhilipsTVLightEntity(PhilipsJsEntity, LightEntity):
             self._attr_brightness = None
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self._update_from_coordinator()
@@ -324,6 +328,7 @@ class PhilipsTVLightEntity(PhilipsJsEntity, LightEntity):
         if await self._tv.setAmbilightCurrentConfiguration(config) is False:
             raise HomeAssistantError("Failed to set ambilight mode")
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the bulb on."""
         brightness = kwargs.get(ATTR_BRIGHTNESS, self.brightness)
@@ -365,6 +370,7 @@ class PhilipsTVLightEntity(PhilipsJsEntity, LightEntity):
         self._update_from_coordinator()
         self.async_write_ha_state()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn of ambilight."""
 
@@ -380,6 +386,7 @@ class PhilipsTVLightEntity(PhilipsJsEntity, LightEntity):
         self.async_write_ha_state()
 
     @property
+    @override
     def available(self) -> bool:
         """Return true if entity is available."""
         if not super().available:

--- a/homeassistant/components/philips_js/media_player.py
+++ b/homeassistant/components/philips_js/media_player.py
@@ -1,6 +1,6 @@
 """Media Player component to integrate TVs exposing the Joint Space API."""
 
-from typing import Any
+from typing import Any, override
 
 from haphilipsjs import ConnectionFailure
 
@@ -80,6 +80,7 @@ class PhilipsTVMediaPlayer(PhilipsJsEntity, MediaPlayerEntity):
         super().__init__(coordinator)
         self._update_from_coordinator()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Handle being added to hass."""
         await super().async_added_to_hass()
@@ -97,6 +98,7 @@ class PhilipsTVMediaPlayer(PhilipsJsEntity, MediaPlayerEntity):
         await self.coordinator.async_request_refresh()
 
     @property
+    @override
     def supported_features(self) -> MediaPlayerEntityFeature:
         """Flag media player features that are supported."""
         supports = SUPPORT_PHILIPS_JS
@@ -104,12 +106,14 @@ class PhilipsTVMediaPlayer(PhilipsJsEntity, MediaPlayerEntity):
             supports |= MediaPlayerEntityFeature.TURN_ON
         return supports
 
+    @override
     async def async_select_source(self, source: str) -> None:
         """Set the input source."""
         if source_id := _inverted(self._sources).get(source):
             await self._tv.setSource(source_id)
         await self._async_update_soon()
 
+    @override
     async def async_turn_on(self) -> None:
         """Turn on the device."""
         if self._tv.on and self._tv.powerstate:
@@ -119,6 +123,7 @@ class PhilipsTVMediaPlayer(PhilipsJsEntity, MediaPlayerEntity):
             await self._turn_on.async_run(self.hass, self._context)
         await self._async_update_soon()
 
+    @override
     async def async_turn_off(self) -> None:
         """Turn off the device."""
         if self._attr_state == MediaPlayerState.ON:
@@ -128,16 +133,19 @@ class PhilipsTVMediaPlayer(PhilipsJsEntity, MediaPlayerEntity):
         else:
             _LOGGER.debug("Ignoring turn off when already in expected state")
 
+    @override
     async def async_volume_up(self) -> None:
         """Send volume up command."""
         await self._tv.sendKey("VolumeUp")
         await self._async_update_soon()
 
+    @override
     async def async_volume_down(self) -> None:
         """Send volume down command."""
         await self._tv.sendKey("VolumeDown")
         await self._async_update_soon()
 
+    @override
     async def async_mute_volume(self, mute: bool) -> None:
         """Send mute command."""
         if self._tv.muted != mute:
@@ -146,11 +154,13 @@ class PhilipsTVMediaPlayer(PhilipsJsEntity, MediaPlayerEntity):
         else:
             _LOGGER.debug("Ignoring request when already in expected state")
 
+    @override
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""
         await self._tv.setVolume(volume, self._tv.muted)
         await self._async_update_soon()
 
+    @override
     async def async_media_previous_track(self) -> None:
         """Send rewind command."""
         if self._tv.channel_active:
@@ -159,6 +169,7 @@ class PhilipsTVMediaPlayer(PhilipsJsEntity, MediaPlayerEntity):
             await self._tv.sendKey("Previous")
         await self._async_update_soon()
 
+    @override
     async def async_media_next_track(self) -> None:
         """Send fast forward command."""
         if self._tv.channel_active:
@@ -167,6 +178,7 @@ class PhilipsTVMediaPlayer(PhilipsJsEntity, MediaPlayerEntity):
             await self._tv.sendKey("Next")
         await self._async_update_soon()
 
+    @override
     async def async_media_play_pause(self) -> None:
         """Send pause command to media player."""
         if self._tv.quirk_playpause_spacebar:
@@ -175,22 +187,26 @@ class PhilipsTVMediaPlayer(PhilipsJsEntity, MediaPlayerEntity):
             await self._tv.sendKey("PlayPause")
         await self._async_update_soon()
 
+    @override
     async def async_media_play(self) -> None:
         """Send pause command to media player."""
         await self._tv.sendKey("Play")
         await self._async_update_soon()
 
+    @override
     async def async_media_pause(self) -> None:
         """Send play command to media player."""
         await self._tv.sendKey("Pause")
         await self._async_update_soon()
 
+    @override
     async def async_media_stop(self) -> None:
         """Send play command to media player."""
         await self._tv.sendKey("Stop")
         await self._async_update_soon()
 
     @property
+    @override
     def media_image_url(self) -> str | None:
         """Image url of current playing media."""
         if self._attr_media_content_id and self._attr_media_content_type in (
@@ -220,6 +236,7 @@ class PhilipsTVMediaPlayer(PhilipsJsEntity, MediaPlayerEntity):
 
         raise HomeAssistantError(f"Unable to find channel {media_id}")
 
+    @override
     async def async_play_media(
         self, media_type: MediaType | str, media_id: str, **kwargs: Any
     ) -> None:
@@ -384,6 +401,7 @@ class PhilipsTVMediaPlayer(PhilipsJsEntity, MediaPlayerEntity):
             ],
         )
 
+    @override
     async def async_browse_media(
         self,
         media_content_type: MediaType | str | None = None,
@@ -407,6 +425,7 @@ class PhilipsTVMediaPlayer(PhilipsJsEntity, MediaPlayerEntity):
 
         raise BrowseError(f"Media not found: {media_content_type} / {media_content_id}")
 
+    @override
     async def async_get_browse_image(
         self,
         media_content_type: MediaType | str,
@@ -427,6 +446,7 @@ class PhilipsTVMediaPlayer(PhilipsJsEntity, MediaPlayerEntity):
             _LOGGER.warning("Failed to fetch image")
         return None, None
 
+    @override
     async def async_get_media_image(self) -> tuple[bytes | None, str | None]:
         """Serve album art. Returns (content, content_type)."""
         if self.media_content_type is None or self.media_content_id is None:
@@ -485,6 +505,7 @@ class PhilipsTVMediaPlayer(PhilipsJsEntity, MediaPlayerEntity):
         self._attr_assumed_state = True
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self._update_from_coordinator()

--- a/homeassistant/components/philips_js/remote.py
+++ b/homeassistant/components/philips_js/remote.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from collections.abc import Iterable
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.remote import (
     ATTR_DELAY_SECS,
@@ -45,6 +45,7 @@ class PhilipsTVRemote(PhilipsJsEntity, RemoteEntity):
         self._attr_unique_id = coordinator.unique_id
         self._turn_on = PluggableAction(self.async_write_ha_state)
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Handle being added to hass."""
         await super().async_added_to_hass()
@@ -57,12 +58,14 @@ class PhilipsTVRemote(PhilipsJsEntity, RemoteEntity):
             )
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if device is on."""
         return bool(
             self._tv.on and (self._tv.powerstate == "On" or self._tv.powerstate is None)
         )
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
         if self._tv.on and self._tv.powerstate:
@@ -71,6 +74,7 @@ class PhilipsTVRemote(PhilipsJsEntity, RemoteEntity):
             await self._turn_on.async_run(self.hass, self._context)
         self.async_write_ha_state()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
         if self._tv.on:
@@ -79,6 +83,7 @@ class PhilipsTVRemote(PhilipsJsEntity, RemoteEntity):
         else:
             LOGGER.debug("Tv was already turned off")
 
+    @override
     async def async_send_command(self, command: Iterable[str], **kwargs: Any) -> None:
         """Send a command to one device."""
         num_repeats = kwargs[ATTR_NUM_REPEATS]

--- a/homeassistant/components/philips_js/switch.py
+++ b/homeassistant/components/philips_js/switch.py
@@ -1,6 +1,6 @@
 """Philips TV menu switches."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant
@@ -43,6 +43,7 @@ class PhilipsTVScreenSwitch(PhilipsJsEntity, SwitchEntity):
         self._attr_unique_id = f"{coordinator.unique_id}_screenstate"
 
     @property
+    @override
     def available(self) -> bool:
         """Return true if entity is available."""
         if not super().available:
@@ -52,14 +53,17 @@ class PhilipsTVScreenSwitch(PhilipsJsEntity, SwitchEntity):
         return self.coordinator.api.powerstate == "On"
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return True if entity is on."""
         return self.coordinator.api.screenstate == "On"
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         await self.coordinator.api.setScreenState("On")
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         await self.coordinator.api.setScreenState("Off")
@@ -81,6 +85,7 @@ class PhilipsTVAmbilightHueSwitch(PhilipsJsEntity, SwitchEntity):
         self._attr_unique_id = f"{coordinator.unique_id}_ambi_hue"
 
     @property
+    @override
     def available(self) -> bool:
         """Return true if entity is available."""
         if not super().available:
@@ -90,15 +95,18 @@ class PhilipsTVAmbilightHueSwitch(PhilipsJsEntity, SwitchEntity):
         return self.coordinator.api.powerstate == "On"
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return True if entity is on."""
         return self.coordinator.api.huelamp_power == HUE_POWER_ON
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         await self.coordinator.api.setHueLampPower(HUE_POWER_ON)
         self.async_write_ha_state()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         await self.coordinator.api.setHueLampPower(HUE_POWER_OFF)

--- a/homeassistant/components/pi_hole/binary_sensor.py
+++ b/homeassistant/components/pi_hole/binary_sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from hole import Hole
 
@@ -78,12 +78,14 @@ class PiHoleBinarySensor(PiHoleEntity, BinarySensorEntity):
         self._attr_unique_id = f"{self._server_unique_id}/{description.key}"
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return if the service is on."""
 
         return self.entity_description.state_value(self.api)
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return the state attributes of the Pi-hole."""
         return self.entity_description.extra_value(self.api)

--- a/homeassistant/components/pi_hole/config_flow.py
+++ b/homeassistant/components/pi_hole/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from hole.exceptions import HoleError
 import voluptuous as vol
@@ -39,6 +39,7 @@ class PiHoleFlowHandler(ConfigFlow, domain=DOMAIN):
         """Initialize the config flow."""
         self._config: dict = {}
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/pi_hole/coordinator.py
+++ b/homeassistant/components/pi_hole/coordinator.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 import logging
+from typing import override
 
 from hole import HoleV5, HoleV6
 from hole.exceptions import HoleError
@@ -52,6 +53,7 @@ class PiHoleUpdateCoordinator(DataUpdateCoordinator[None]):
         self._name = config_entry.data[CONF_NAME]
         self._host = config_entry.data[CONF_HOST]
 
+    @override
     async def _async_update_data(self) -> None:
         """Fetch data from the Pi-hole API."""
         try:

--- a/homeassistant/components/pi_hole/entity.py
+++ b/homeassistant/components/pi_hole/entity.py
@@ -1,5 +1,7 @@
 """The pi_hole component."""
 
+from typing import override
+
 from hole import Hole
 
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -26,6 +28,7 @@ class PiHoleEntity(CoordinatorEntity[PiHoleUpdateCoordinator]):
         self._server_unique_id = server_unique_id
 
     @property
+    @override
     def device_info(self) -> DeviceInfo:
         """Return the device information of the entity."""
         if (

--- a/homeassistant/components/pi_hole/sensor.py
+++ b/homeassistant/components/pi_hole/sensor.py
@@ -1,7 +1,7 @@
 """Support for getting statistical data from a Pi-hole system."""
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, override
 
 from hole import Hole
 
@@ -157,6 +157,7 @@ class PiHoleSensor(PiHoleEntity, SensorEntity):
         self._attr_unique_id = f"{self._server_unique_id}/{description.key}"
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the state of the device."""
         return get_nested(self.api.data, self.entity_description.key)

--- a/homeassistant/components/pi_hole/switch.py
+++ b/homeassistant/components/pi_hole/switch.py
@@ -1,7 +1,7 @@
 """Support for turning on and off Pi-hole system."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from hole.exceptions import HoleError
 import voluptuous as vol
@@ -56,20 +56,24 @@ class PiHoleSwitch(PiHoleEntity, SwitchEntity):
     _attr_icon = "mdi:pi-hole"
 
     @property
+    @override
     def name(self) -> str:
         """Return the name of the switch."""
         return self._name
 
     @property
+    @override
     def unique_id(self) -> str:
         """Return the unique id of the switch."""
         return f"{self._server_unique_id}/Switch"
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return if the service is on."""
         return self.api.status == "enabled"  # type: ignore[no-any-return]
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the service."""
         try:
@@ -79,6 +83,7 @@ class PiHoleSwitch(PiHoleEntity, SwitchEntity):
         except HoleError as err:
             _LOGGER.error("Unable to enable Pi-hole: %s", err)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the service."""
         await self.async_disable()

--- a/homeassistant/components/pi_hole/update.py
+++ b/homeassistant/components/pi_hole/update.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from hole import Hole
 
@@ -102,6 +103,7 @@ class PiHoleUpdateEntity(PiHoleEntity, UpdateEntity):
         self._attr_title = description.title
 
     @property
+    @override
     def installed_version(self) -> str | None:
         """Version installed and in use."""
         if isinstance(self.api.versions, dict):
@@ -109,6 +111,7 @@ class PiHoleUpdateEntity(PiHoleEntity, UpdateEntity):
         return None
 
     @property
+    @override
     def latest_version(self) -> str | None:
         """Latest version available for install."""
         if isinstance(self.api.versions, dict):
@@ -118,6 +121,7 @@ class PiHoleUpdateEntity(PiHoleEntity, UpdateEntity):
         return None
 
     @property
+    @override
     def release_url(self) -> str | None:
         """URL to the full release notes of the latest version available."""
         if self.latest_version:

--- a/homeassistant/components/picnic/config_flow.py
+++ b/homeassistant/components/picnic/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from python_picnic_api2 import PicnicAPI
 from python_picnic_api2.session import (
@@ -78,6 +78,7 @@ class PicnicConfigFlow(ConfigFlow, domain=DOMAIN):
         """Perform the re-auth step upon an API authentication error."""
         return await self.async_step_user()
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/picnic/coordinator.py
+++ b/homeassistant/components/picnic/coordinator.py
@@ -5,6 +5,7 @@ from contextlib import suppress
 import copy
 from datetime import timedelta
 import logging
+from typing import override
 
 from python_picnic_api2 import PicnicAPI
 from python_picnic_api2.session import PicnicAuthError
@@ -44,6 +45,7 @@ class PicnicUpdateCoordinator(DataUpdateCoordinator):
             update_interval=timedelta(minutes=30),
         )
 
+    @override
     async def _async_update_data(self) -> dict:
         """Fetch data from API endpoint."""
         try:

--- a/homeassistant/components/picnic/sensor.py
+++ b/homeassistant/components/picnic/sensor.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Literal, cast
+from typing import Any, Literal, cast, override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -228,6 +228,7 @@ class PicnicSensor(SensorEntity, CoordinatorEntity[PicnicUpdateCoordinator]):
         )
 
     @property
+    @override
     def native_value(self) -> StateType | datetime:
         """Return the value reported by the sensor."""
         data_set = (

--- a/homeassistant/components/picnic/todo.py
+++ b/homeassistant/components/picnic/todo.py
@@ -1,7 +1,7 @@
 """Definition of Picnic shopping cart."""
 
 import logging
-from typing import cast
+from typing import cast, override
 
 from homeassistant.components.todo import (
     TodoItem,
@@ -56,6 +56,7 @@ class PicnicCart(TodoListEntity, CoordinatorEntity[PicnicUpdateCoordinator]):
         self._attr_unique_id = f"{config_entry.unique_id}-cart"
 
     @property
+    @override
     def todo_items(self) -> list[TodoItem] | None:
         """Get the current set of items in cart items."""
         if self.coordinator.data is None:
@@ -74,6 +75,7 @@ class PicnicCart(TodoListEntity, CoordinatorEntity[PicnicUpdateCoordinator]):
             for article in item["items"]
         ]
 
+    @override
     async def async_create_todo_item(self, item: TodoItem) -> None:
         """Add item to shopping cart."""
         product_id = await self.hass.async_add_executor_job(

--- a/homeassistant/components/picotts/config_flow.py
+++ b/homeassistant/components/picotts/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Pico TTS integration."""
 
 import shutil
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -18,6 +18,7 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
 class PicoTTSConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Pico TTS."""
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/picotts/tts.py
+++ b/homeassistant/components/picotts/tts.py
@@ -6,7 +6,7 @@ import os
 import shutil
 import subprocess
 import tempfile
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -81,6 +81,7 @@ class PicoTTSEntity(TextToSpeechEntity):
             name=f"Pico TTS {lang}",
         )
 
+    @override
     def get_tts_audio(
         self, message: str, language: str, options: dict[str, Any]
     ) -> TtsAudioType:
@@ -127,15 +128,18 @@ class PicoProvider(Provider):
         self.name = "PicoTTS"
 
     @property
+    @override
     def default_language(self) -> str:
         """Return the default language."""
         return self._lang
 
     @property
+    @override
     def supported_languages(self) -> list[str]:
         """Return list of supported languages."""
         return SUPPORT_LANGUAGES
 
+    @override
     def get_tts_audio(
         self, message: str, language: str, options: dict[str, Any]
     ) -> TtsAudioType:

--- a/homeassistant/components/pilight/entity.py
+++ b/homeassistant/components/pilight/entity.py
@@ -1,6 +1,6 @@
 """Base class for pilight."""
 
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -91,6 +91,7 @@ class PilightBaseDevice(RestoreEntity):
 
         self._brightness: int | None = 255
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Call when entity about to be added to hass."""
         await super().async_added_to_hass()

--- a/homeassistant/components/pilight/light.py
+++ b/homeassistant/components/pilight/light.py
@@ -1,6 +1,6 @@
 """Support for switching devices via Pilight to on and off."""
 
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -60,10 +60,12 @@ class PilightLight(PilightBaseDevice, LightEntity):
         self._dimlevel_max: int = config[CONF_DIMLEVEL_MAX]
 
     @property
+    @override
     def brightness(self) -> int | None:
         """Return the brightness."""
         return self._brightness
 
+    @override
     def turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on by calling pilight.send service with on code."""
         # Update brightness only if provided as an argument.

--- a/homeassistant/components/ping/binary_sensor.py
+++ b/homeassistant/components/ping/binary_sensor.py
@@ -1,5 +1,7 @@
 """Tracks the latency of a host by sending ICMP echo requests (ping)."""
 
+from typing import override
+
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
@@ -41,6 +43,7 @@ class PingBinarySensor(PingEntity, BinarySensorEntity):
             )
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if the binary sensor is on."""
         return self.coordinator.data.is_alive

--- a/homeassistant/components/ping/config_flow.py
+++ b/homeassistant/components/ping/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Ping (ICMP) integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -37,6 +37,7 @@ class PingConfigFlow(ConfigFlow, domain=DOMAIN):
     VERSION = 1
     MINOR_VERSION = 2
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -68,6 +69,7 @@ class PingConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> OptionsFlowHandler:

--- a/homeassistant/components/ping/coordinator.py
+++ b/homeassistant/components/ping/coordinator.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -48,6 +48,7 @@ class PingUpdateCoordinator(DataUpdateCoordinator[PingResult]):
             update_interval=timedelta(seconds=30),
         )
 
+    @override
     async def _async_update_data(self) -> PingResult:
         """Trigger ping check."""
         await self.ping.async_update()

--- a/homeassistant/components/ping/device_tracker.py
+++ b/homeassistant/components/ping/device_tracker.py
@@ -1,6 +1,7 @@
 """Tracks devices by sending a ICMP echo request (ping)."""
 
 from datetime import datetime, timedelta
+from typing import override
 
 from homeassistant.components.device_tracker import (
     CONF_CONSIDER_HOME,
@@ -56,16 +57,19 @@ class PingDeviceTracker(CoordinatorEntity[PingUpdateCoordinator], ScannerEntity)
             self.device_entry = device
 
     @property
+    @override
     def ip_address(self) -> str:
         """Return the primary ip address of the device."""
         return self.coordinator.data.ip_address
 
     @property
+    @override
     def unique_id(self) -> str:
         """Return a unique ID."""
         return self.config_entry.entry_id
 
     @property
+    @override
     def is_connected(self) -> bool:
         """Return true if ping returns is_alive or considered home."""
         if self.coordinator.data.is_alive:
@@ -77,6 +81,7 @@ class PingDeviceTracker(CoordinatorEntity[PingUpdateCoordinator], ScannerEntity)
         )
 
     @property
+    @override
     def entity_registry_enabled_default(self) -> bool:
         """Return if entity is enabled by default."""
         if CONF_IMPORTED_BY in self.config_entry.data:

--- a/homeassistant/components/ping/sensor.py
+++ b/homeassistant/components/ping/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -129,11 +130,13 @@ class PingSensor(PingEntity, SensorEntity):
         self.entity_description = description
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available."""
         return super().available and self.coordinator.data.is_alive
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the sensor state."""
         return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/pioneer/media_player.py
+++ b/homeassistant/components/pioneer/media_player.py
@@ -1,7 +1,7 @@
 """Support for Pioneer Network Receivers."""
 
 import logging
-from typing import Final
+from typing import Final, override
 
 import telnetlib  # pylint: disable=deprecated-module
 import voluptuous as vol
@@ -167,11 +167,13 @@ class PioneerDevice(MediaPlayerEntity):
         return True
 
     @property
+    @override
     def name(self):
         """Return the name of the device."""
         return self._name
 
     @property
+    @override
     def state(self) -> MediaPlayerState | None:
         """Return the state of the device."""
         if self._pwstate == "PWR2":
@@ -184,30 +186,36 @@ class PioneerDevice(MediaPlayerEntity):
         return None
 
     @property
+    @override
     def volume_level(self):
         """Volume level of the media player (0..1)."""
         return self._volume
 
     @property
+    @override
     def is_volume_muted(self):
         """Boolean if volume is currently muted."""
         return self._muted
 
     @property
+    @override
     def source(self):
         """Return the current input source."""
         return self._selected_source
 
     @property
+    @override
     def source_list(self):
         """List of available input sources."""
         return list(self._source_name_to_number)
 
     @property
+    @override
     def media_title(self):
         """Title of current playing media."""
         return self._selected_source
 
+    @override
     def turn_off(self) -> None:
         """Turn off media player."""
         self.telnet_command("PF")
@@ -220,19 +228,23 @@ class PioneerDevice(MediaPlayerEntity):
         """Volume down media player."""
         self.telnet_command("VD")
 
+    @override
     def set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""
         # 60dB max
         self.telnet_command(f"{round(volume * MAX_VOLUME):03}VL")
 
+    @override
     def mute_volume(self, mute: bool) -> None:
         """Mute (true) or unmute (false) media player."""
         self.telnet_command("MO" if mute else "MF")
 
+    @override
     def turn_on(self) -> None:
         """Turn the media player on."""
         self.telnet_command("PO")
 
+    @override
     def select_source(self, source: str) -> None:
         """Select input source."""
         self.telnet_command(f"{self._source_name_to_number.get(source)}FN")

--- a/homeassistant/components/pjlink/config_flow.py
+++ b/homeassistant/components/pjlink/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for the PJLink integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from pypjlink import Projector
 from pypjlink.projector import ProjectorError
@@ -38,6 +38,7 @@ class PJLinkConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/pjlink/media_player.py
+++ b/homeassistant/components/pjlink/media_player.py
@@ -1,6 +1,6 @@
 """Support for controlling projector via the PJLink protocol."""
 
-from typing import Any
+from typing import Any, override
 
 from pypjlink import MUTE_AUDIO, Projector
 from pypjlink.projector import ProjectorError
@@ -188,21 +188,25 @@ class PjLinkDevice(MediaPlayerEntity):
             else:
                 raise
 
+    @override
     def turn_off(self) -> None:
         """Turn projector off."""
         with self.projector() as projector:
             projector.set_power("off")
 
+    @override
     def turn_on(self) -> None:
         """Turn projector on."""
         with self.projector() as projector:
             projector.set_power("on")
 
+    @override
     def mute_volume(self, mute: bool) -> None:
         """Mute (true) of unmute (false) media player."""
         with self.projector() as projector:
             projector.set_mute(MUTE_AUDIO, mute)
 
+    @override
     def select_source(self, source: str) -> None:
         """Set the input source."""
         source = self._source_name_mapping[source]

--- a/homeassistant/components/plaato/binary_sensor.py
+++ b/homeassistant/components/plaato/binary_sensor.py
@@ -1,5 +1,7 @@
 """Support for Plaato Airlock sensors."""
 
+from typing import override
+
 from pyplaato.plaato import PlaatoKeg
 
 from homeassistant.components.binary_sensor import (
@@ -54,6 +56,7 @@ class PlaatoBinarySensor(PlaatoEntity, BinarySensorEntity):
             self._attr_device_class = BinarySensorDeviceClass.OPENING
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if the binary sensor is on."""
         if self._coordinator is not None:

--- a/homeassistant/components/plaato/config_flow.py
+++ b/homeassistant/components/plaato/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for Plaato."""
 
-from typing import Any
+from typing import Any, override
 
 from pyplaato.plaato import PlaatoDeviceType
 import voluptuous as vol
@@ -42,6 +42,7 @@ class PlaatoConfigFlow(ConfigFlow, domain=DOMAIN):
         """Initialize."""
         self._init_info: dict[str, Any] = {}
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -181,6 +182,7 @@ class PlaatoConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> PlaatoOptionsFlowHandler:

--- a/homeassistant/components/plaato/coordinator.py
+++ b/homeassistant/components/plaato/coordinator.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass, field
 from datetime import timedelta
 import logging
+from typing import override
 
 from pyplaato.models.device import PlaatoDevice
 from pyplaato.plaato import Plaato, PlaatoDeviceType
@@ -58,6 +59,7 @@ class PlaatoCoordinator(DataUpdateCoordinator[PlaatoDevice]):
             update_interval=update_interval,
         )
 
+    @override
     async def _async_update_data(self) -> PlaatoDevice:
         """Update data via library."""
         return await self.api.get_data(

--- a/homeassistant/components/plaato/entity.py
+++ b/homeassistant/components/plaato/entity.py
@@ -1,6 +1,6 @@
 """PlaatoEntity class."""
 
-from typing import Any, cast
+from typing import Any, cast, override
 
 from pyplaato.models.device import PlaatoDevice
 
@@ -61,6 +61,7 @@ class PlaatoEntity(entity.Entity):
         return self._entry_data.sensor_data
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return the state attributes of the monitored installation."""
         if self._attributes:
@@ -73,12 +74,14 @@ class PlaatoEntity(entity.Entity):
         return None
 
     @property
+    @override
     def available(self) -> bool:
         """Return if sensor is available."""
         if self._coordinator is not None:
             return self._coordinator.last_update_success
         return True
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         if self._coordinator is not None:

--- a/homeassistant/components/plaato/sensor.py
+++ b/homeassistant/components/plaato/sensor.py
@@ -1,5 +1,7 @@
 """Support for Plaato Airlock sensors."""
 
+from typing import override
+
 from pyplaato.models.device import PlaatoDevice
 from pyplaato.plaato import PlaatoKeg
 
@@ -81,11 +83,13 @@ class PlaatoSensor(PlaatoEntity, SensorEntity):
             self._attr_device_class = SensorDeviceClass.TEMPERATURE
 
     @property
+    @override
     def native_value(self) -> str | int | float | None:
         """Return the state of the sensor."""
         return self._sensor_data.sensors.get(self._sensor_type)
 
     @property
+    @override
     def native_unit_of_measurement(self) -> str | None:
         """Return the unit of measurement."""
         return self._sensor_data.get_unit_of_measurement(self._sensor_type)

--- a/homeassistant/components/plant/__init__.py
+++ b/homeassistant/components/plant/__init__.py
@@ -8,7 +8,7 @@ from collections import deque
 from contextlib import suppress
 from datetime import datetime, timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -286,6 +286,7 @@ class Plant(Entity):
                 return f"{sensor_name} high"
         return None
 
+    @override
     async def async_added_to_hass(self):
         """After being added to hass, load from history."""
         if "recorder" in self.hass.config.components:
@@ -336,16 +337,19 @@ class Plant(Entity):
         _LOGGER.debug("Initializing from database completed")
 
     @property
+    @override
     def name(self):
         """Return the name of the sensor."""
         return self._name
 
     @property
+    @override
     def state(self):
         """Return the state of the entity."""
         return self._state
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the attributes of the entity.
 

--- a/homeassistant/components/playstation_network/binary_sensor.py
+++ b/homeassistant/components/playstation_network/binary_sensor.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
+from typing import override
 
 from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
@@ -68,6 +69,7 @@ class PlaystationNetworkBinarySensorEntity(
     coordinator: PlaystationNetworkUserDataCoordinator
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return the state of the binary sensor."""
 

--- a/homeassistant/components/playstation_network/config_flow.py
+++ b/homeassistant/components/playstation_network/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from psnawp_api.core.psnawp_exceptions import (
     PSNAWPAuthenticationError,
@@ -44,12 +44,14 @@ class PlaystationNetworkConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @classmethod
     @callback
+    @override
     def async_get_supported_subentry_types(
         cls, config_entry: ConfigEntry
     ) -> dict[str, type[ConfigSubentryFlow]]:
         """Return subentries supported by this integration."""
         return {"friend": FriendSubentryFlowHandler}
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/playstation_network/coordinator.py
+++ b/homeassistant/components/playstation_network/coordinator.py
@@ -4,7 +4,7 @@ from abc import abstractmethod
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from psnawp_api.core.psnawp_exceptions import (
     PSNAWPAuthenticationError,
@@ -75,6 +75,7 @@ class PlayStationNetworkBaseCoordinator[_DataT](DataUpdateCoordinator[_DataT]):
     async def update_data(self) -> _DataT:
         """Update coordinator data."""
 
+    @override
     async def _async_update_data(self) -> _DataT:
         """Get the latest data from the PSN."""
         try:
@@ -98,6 +99,7 @@ class PlaystationNetworkUserDataCoordinator(
 
     _update_interval = timedelta(seconds=30)
 
+    @override
     async def _async_setup(self) -> None:
         """Set up the coordinator."""
 
@@ -114,6 +116,7 @@ class PlaystationNetworkUserDataCoordinator(
                 translation_key="update_failed",
             ) from error
 
+    @override
     async def update_data(self) -> PlaystationNetworkData:
         """Get the latest data from the PSN."""
         return await self.psn.get_data()
@@ -126,6 +129,7 @@ class PlaystationNetworkTrophyTitlesCoordinator(
 
     _update_interval = timedelta(days=1)
 
+    @override
     async def update_data(self) -> list[TrophyTitle]:
         """Update trophy titles data."""
         self.psn.trophy_titles = await self.hass.async_add_executor_job(
@@ -142,6 +146,7 @@ class PlaystationNetworkFriendlistCoordinator(
 
     _update_interval = timedelta(hours=3)
 
+    @override
     async def update_data(self) -> dict[str, User]:
         """Update trophy titles data."""
 
@@ -161,6 +166,7 @@ class PlaystationNetworkGroupsUpdateCoordinator(
 
     _update_interval = timedelta(hours=3)
 
+    @override
     async def update_data(self) -> dict[str, GroupDetails]:
         """Update groups data."""
         try:
@@ -221,6 +227,7 @@ class PlaystationNetworkFriendDataCoordinator(
 
         self.profile = self.user.profile()
 
+    @override
     async def _async_setup(self) -> None:
         """Set up the coordinator."""
 
@@ -272,6 +279,7 @@ class PlaystationNetworkFriendDataCoordinator(
             trophy_summary=trophy_summary,
         )
 
+    @override
     async def update_data(self) -> PlaystationNetworkData:
         """Update friend status data."""
         return await self.hass.async_add_executor_job(self._update_data)

--- a/homeassistant/components/playstation_network/image.py
+++ b/homeassistant/components/playstation_network/image.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from homeassistant.components.image import ImageEntity, ImageEntityDescription
 from homeassistant.config_entries import ConfigSubentry
@@ -128,6 +128,7 @@ class PlaystationNetworkImageBaseEntity(PlaystationNetworkServiceEntity, ImageEn
         self._attr_image_url = self.entity_description.image_url_fn(coordinator.data)
         self._attr_image_last_updated = dt_util.utcnow()
 
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         if TYPE_CHECKING:

--- a/homeassistant/components/playstation_network/media_player.py
+++ b/homeassistant/components/playstation_network/media_player.py
@@ -1,7 +1,7 @@
 """Media player entity for the PlayStation Network Integration."""
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from psnawp_api.models.trophies import PlatformType
 
@@ -115,6 +115,7 @@ class PsnMediaPlayerEntity(
         self.trophy_titles = trophy_titles
 
     @property
+    @override
     def state(self) -> MediaPlayerState:
         """Media Player state getter."""
         session = self.coordinator.data.active_sessions.get(self.key)
@@ -128,23 +129,27 @@ class PsnMediaPlayerEntity(
         return MediaPlayerState.OFF
 
     @property
+    @override
     def media_title(self) -> str | None:
         """Media title getter."""
         session = self.coordinator.data.active_sessions.get(self.key)
         return session.title_name if session else None
 
     @property
+    @override
     def media_content_id(self) -> str | None:
         """Content ID of current playing media."""
         session = self.coordinator.data.active_sessions.get(self.key)
         return session.title_id if session else None
 
     @property
+    @override
     def media_image_url(self) -> str | None:
         """Media image url getter."""
         session = self.coordinator.data.active_sessions.get(self.key)
         return session.media_image_url if session else None
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
 

--- a/homeassistant/components/playstation_network/notify.py
+++ b/homeassistant/components/playstation_network/notify.py
@@ -1,7 +1,7 @@
 """Notify platform for PlayStation Network."""
 
 from enum import StrEnum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from psnawp_api.core.psnawp_exceptions import (
     PSNAWPClientError,
@@ -117,6 +117,7 @@ class PlaystationNetworkNotifyBaseEntity(PlaystationNetworkServiceEntity, Notify
             assert self.psn_group
         self.psn_group.send_message(message)
 
+    @override
     def send_message(self, message: str, title: str | None = None) -> None:
         """Send a message."""
 
@@ -194,6 +195,7 @@ class PlaystationNetworkDirectMessageNotifyEntity(PlaystationNetworkNotifyBaseEn
 
         super().__init__(coordinator, self.entity_description)
 
+    @override
     def _send_message(self, message: str) -> None:
         if not self.psn_group:
             self.psn_group = self.coordinator.psn.psn.group(

--- a/homeassistant/components/playstation_network/sensor.py
+++ b/homeassistant/components/playstation_network/sensor.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
+from typing import override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -193,12 +194,14 @@ class PlaystationNetworkSensorBaseEntity(
     coordinator: PlayStationNetworkBaseCoordinator
 
     @property
+    @override
     def native_value(self) -> StateType | datetime:
         """Return the state of the sensor."""
 
         return self.entity_description.value_fn(self.coordinator.data)
 
     @property
+    @override
     def entity_picture(self) -> str | None:
         """Return the entity picture to use in the frontend, if any."""
         if self.entity_description.key is PlaystationNetworkSensor.ONLINE_ID and (
@@ -213,6 +216,7 @@ class PlaystationNetworkSensorBaseEntity(
         return super().entity_picture
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available."""
 

--- a/homeassistant/components/plex/button.py
+++ b/homeassistant/components/plex/button.py
@@ -1,5 +1,7 @@
 """Representation of Plex buttons."""
 
+from typing import override
+
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
@@ -41,6 +43,7 @@ class PlexScanClientsButton(ButtonEntity):
             manufacturer="Plex",
         )
 
+    @override
     async def async_press(self) -> None:
         """Press the button."""
         async_dispatcher_send(

--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -3,7 +3,7 @@
 from collections.abc import Mapping
 from copy import deepcopy
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from aiohttp import web_response
 import plexapi.exceptions
@@ -96,6 +96,7 @@ class PlexFlowHandler(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> PlexOptionsFlowHandler:
@@ -110,6 +111,7 @@ class PlexFlowHandler(ConfigFlow, domain=DOMAIN):
         self._manual = False
         self._reauth_config: dict[str, Any] | None = None
 
+    @override
     async def async_step_user(
         self,
         user_input: dict[str, Any] | None = None,
@@ -287,6 +289,7 @@ class PlexFlowHandler(ConfigFlow, domain=DOMAIN):
             errors={},
         )
 
+    @override
     async def async_step_integration_discovery(
         self, discovery_info: dict[str, Any]
     ) -> ConfigFlowResult:

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from functools import wraps
 import logging
-from typing import Any, Concatenate, cast
+from typing import Any, Concatenate, cast, override
 
 from plexapi.client import PlexClient
 import plexapi.exceptions
@@ -143,6 +143,7 @@ class PlexMediaPlayer(MediaPlayerEntity):
         # Initializes other attributes
         self.session = session
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Run when about to be added to hass."""
         _LOGGER.debug("Added %s [%s]", self.entity_id, self.unique_id)
@@ -290,12 +291,14 @@ class PlexMediaPlayer(MediaPlayerEntity):
 
     @property
     @needs_session
+    @override
     def media_content_id(self):
         """Return the content ID of current playing media."""
         return self.session.media_content_id
 
     @property
     @needs_session
+    @override
     def media_content_type(self):
         """Return the content type of current playing media."""
         return self.session.media_content_type
@@ -308,48 +311,56 @@ class PlexMediaPlayer(MediaPlayerEntity):
 
     @property
     @needs_session
+    @override
     def media_artist(self):
         """Return the artist of current playing media, music track only."""
         return self.session.media_artist
 
     @property
     @needs_session
+    @override
     def media_album_name(self):
         """Return the album name of current playing media, music track only."""
         return self.session.media_album_name
 
     @property
     @needs_session
+    @override
     def media_album_artist(self):
         """Return the album artist of current playing media, music only."""
         return self.session.media_album_artist
 
     @property
     @needs_session
+    @override
     def media_track(self):
         """Return the track number of current playing media, music only."""
         return self.session.media_track
 
     @property
     @needs_session
+    @override
     def media_duration(self):
         """Return the duration of current playing media in seconds."""
         return self.session.media_duration
 
     @property
     @needs_session
+    @override
     def media_position(self):
         """Return the duration of current playing media in seconds."""
         return self.session.media_position
 
     @property
     @needs_session
+    @override
     def media_position_updated_at(self):
         """When was the position of the current playing media valid."""
         return self.session.media_position_updated_at
 
     @property
     @needs_session
+    @override
     def media_image_url(self):
         """Return the image URL of current playing media."""
         return self.session.media_image_url
@@ -362,29 +373,34 @@ class PlexMediaPlayer(MediaPlayerEntity):
 
     @property
     @needs_session
+    @override
     def media_title(self):
         """Return the title of current playing media."""
         return self.session.media_title
 
     @property
     @needs_session
+    @override
     def media_season(self):
         """Return the season of current playing media (TV Show only)."""
         return self.session.media_season
 
     @property
     @needs_session
+    @override
     def media_series_title(self):
         """Return the title of the series of current playing media."""
         return self.session.media_series_title
 
     @property
     @needs_session
+    @override
     def media_episode(self):
         """Return the episode of current playing media (TV Show only)."""
         return self.session.media_episode
 
     @property
+    @override
     def supported_features(self) -> MediaPlayerEntityFeature:
         """Flag media player features that are supported."""
         if self.device and "playback" in self._device_protocol_capabilities:
@@ -405,6 +421,7 @@ class PlexMediaPlayer(MediaPlayerEntity):
             MediaPlayerEntityFeature.BROWSE_MEDIA | MediaPlayerEntityFeature.PLAY_MEDIA
         )
 
+    @override
     def set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""
         if self.device and "playback" in self._device_protocol_capabilities:
@@ -412,6 +429,7 @@ class PlexMediaPlayer(MediaPlayerEntity):
             self._volume_level = volume  # store since we can't retrieve
 
     @property
+    @override
     def volume_level(self):
         """Return the volume level of the client (0..1)."""
         if (
@@ -423,12 +441,14 @@ class PlexMediaPlayer(MediaPlayerEntity):
         return None
 
     @property
+    @override
     def is_volume_muted(self):
         """Return boolean if volume is currently muted."""
         if self._is_player_active and self.device:
             return self._volume_muted
         return None
 
+    @override
     def mute_volume(self, mute: bool) -> None:
         """Mute the volume.
 
@@ -446,36 +466,43 @@ class PlexMediaPlayer(MediaPlayerEntity):
         else:
             self.set_volume_level(self._previous_volume_level)
 
+    @override
     def media_play(self) -> None:
         """Send play command."""
         if self.device and "playback" in self._device_protocol_capabilities:
             self.device.play(self._active_media_plexapi_type)
 
+    @override
     def media_pause(self) -> None:
         """Send pause command."""
         if self.device and "playback" in self._device_protocol_capabilities:
             self.device.pause(self._active_media_plexapi_type)
 
+    @override
     def media_stop(self) -> None:
         """Send stop command."""
         if self.device and "playback" in self._device_protocol_capabilities:
             self.device.stop(self._active_media_plexapi_type)
 
+    @override
     def media_seek(self, position: float) -> None:
         """Send the seek command."""
         if self.device and "playback" in self._device_protocol_capabilities:
             self.device.seekTo(position * 1000, self._active_media_plexapi_type)
 
+    @override
     def media_next_track(self) -> None:
         """Send next track command."""
         if self.device and "playback" in self._device_protocol_capabilities:
             self.device.skipNext(self._active_media_plexapi_type)
 
+    @override
     def media_previous_track(self) -> None:
         """Send previous track command."""
         if self.device and "playback" in self._device_protocol_capabilities:
             self.device.skipPrevious(self._active_media_plexapi_type)
 
+    @override
     def play_media(
         self, media_type: MediaType | str, media_id: str, **kwargs: Any
     ) -> None:
@@ -498,6 +525,7 @@ class PlexMediaPlayer(MediaPlayerEntity):
             ) from exc
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the scene state attributes."""
         attributes = {}
@@ -514,6 +542,7 @@ class PlexMediaPlayer(MediaPlayerEntity):
         return attributes
 
     @property
+    @override
     def device_info(self) -> DeviceInfo | None:
         """Return a device description for device registry."""
         if self.machine_identifier is None:
@@ -540,6 +569,7 @@ class PlexMediaPlayer(MediaPlayerEntity):
             via_device=(DOMAIN, self.plex_server.machine_identifier),
         )
 
+    @override
     async def async_browse_media(
         self,
         media_content_type: MediaType | str | None = None,

--- a/homeassistant/components/plex/models.py
+++ b/homeassistant/components/plex/models.py
@@ -1,6 +1,7 @@
 """Models to represent various Plex objects used in the integration."""
 
 import logging
+from typing import override
 
 import plexapi.playqueue
 
@@ -60,6 +61,7 @@ class PlexSession:
 
         self.update_media(session)
 
+    @override
     def __repr__(self):
         """Return representation of the session."""
         return f"<{self.session_key}:{self.sensor_title}>"

--- a/homeassistant/components/plex/sensor.py
+++ b/homeassistant/components/plex/sensor.py
@@ -1,7 +1,7 @@
 """Support for Plex media server monitoring."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from plexapi.exceptions import NotFound
 import requests.exceptions
@@ -91,6 +91,7 @@ class PlexSensor(SensorEntity):
             function=self._async_refresh_sensor,
         ).async_call
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Run when about to be added to hass."""
         server_id = self._server.machine_identifier
@@ -109,11 +110,13 @@ class PlexSensor(SensorEntity):
         self.async_write_ha_state()
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         return self._server.sensor_attributes
 
     @property
+    @override
     def device_info(self) -> DeviceInfo | None:
         """Return a device description for device registry."""
         return DeviceInfo(
@@ -147,6 +150,7 @@ class PlexLibrarySectionSensor(SensorEntity):
         self._attr_name = f"{self.server_name} Library - {plex_library_section.title}"
         self._attr_unique_id = f"library-{self.server_id}-{plex_library_section.uuid}"
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Run when about to be added to hass."""
         self.async_on_remove(
@@ -203,6 +207,7 @@ class PlexLibrarySectionSensor(SensorEntity):
             self._attr_extra_state_attributes["last_added_timestamp"] = media.addedAt
 
     @property
+    @override
     def device_info(self) -> DeviceInfo | None:
         """Return a device description for device registry."""
         if self.unique_id is None:

--- a/homeassistant/components/plex/update.py
+++ b/homeassistant/components/plex/update.py
@@ -1,7 +1,7 @@
 """Representation of Plex updates."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from plexapi.exceptions import PlexApiException
 import requests.exceptions
@@ -64,10 +64,12 @@ class PlexUpdate(UpdateEntity):
         else:
             self._release_notes = None
 
+    @override
     def release_notes(self) -> str | None:
         """Return release notes for the available upgrade."""
         return self._release_notes
 
+    @override
     def install(self, version: str | None, backup: bool, **kwargs: Any) -> None:
         """Install an update."""
         try:
@@ -76,6 +78,7 @@ class PlexUpdate(UpdateEntity):
             raise HomeAssistantError(str(exc)) from exc
 
     @property
+    @override
     def device_info(self) -> DeviceInfo:
         """Return a device description for device registry."""
         return DeviceInfo(

--- a/homeassistant/components/plugwise/binary_sensor.py
+++ b/homeassistant/components/plugwise/binary_sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from plugwise.constants import BinarySensorType
 
@@ -123,11 +123,13 @@ class PlugwiseBinarySensorEntity(PlugwiseEntity, BinarySensorEntity):
         self._attr_unique_id = f"{device_id}-{description.key}"
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if the binary sensor is on."""
         return self.device["binary_sensors"][self.entity_description.key]
 
     @property
+    @override
     def extra_state_attributes(self) -> Mapping[str, Any] | None:
         """Return entity specific state attributes."""
         if self.entity_description.key != "plugwise_notification":

--- a/homeassistant/components/plugwise/button.py
+++ b/homeassistant/components/plugwise/button.py
@@ -1,5 +1,7 @@
 """Plugwise Button component for Home Assistant."""
 
+from typing import override
+
 from homeassistant.components.button import ButtonDeviceClass, ButtonEntity
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
@@ -45,6 +47,7 @@ class PlugwiseButtonEntity(PlugwiseEntity, ButtonEntity):
         self._attr_unique_id = f"{device_id}-reboot"
 
     @plugwise_command
+    @override
     async def async_press(self) -> None:
         """Triggers the Plugwise button press service."""
         await self.coordinator.api.reboot_gateway()

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -1,7 +1,7 @@
 """Plugwise Climate component for Home Assistant."""
 
 from dataclasses import asdict, dataclass
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.climate import (
     ATTR_HVAC_MODE,
@@ -43,6 +43,7 @@ class PlugwiseClimateExtraStoredData(ExtraStoredData):
     last_active_schedule: str | None
     previous_action_mode: str | None
 
+    @override
     def as_dict(self) -> dict[str, Any]:
         """Return a dict representation of the text data."""
         return asdict(self)
@@ -133,6 +134,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
             self.device["thermostat"]["resolution"], 0.1
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added."""
         await super().async_added_to_hass()
@@ -147,6 +149,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
             )
 
     @property
+    @override
     def extra_restore_state_data(self) -> PlugwiseClimateExtraStoredData:
         """Return text specific state data to be restored."""
         return PlugwiseClimateExtraStoredData(
@@ -155,11 +158,13 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
         )
 
     @property
+    @override
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
         return self.device["sensors"].get("temperature")
 
     @property
+    @override
     def target_temperature(self) -> float:
         """Return the temperature we try to reach.
 
@@ -169,6 +174,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
         return self.device["thermostat"]["setpoint"]
 
     @property
+    @override
     def target_temperature_high(self) -> float:
         """Return the temperature we try to reach in case of cooling.
 
@@ -177,6 +183,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
         return self.device["thermostat"]["setpoint_high"]
 
     @property
+    @override
     def target_temperature_low(self) -> float:
         """Return the heating temperature we try to reach in case of heating.
 
@@ -185,6 +192,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
         return self.device["thermostat"]["setpoint_low"]
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode:
         """Return HVAC operation ie. auto, cool, heat, heat_cool, or off mode."""
         if (
@@ -194,6 +202,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
         return HVACMode(mode)
 
     @property
+    @override
     def hvac_modes(self) -> list[HVACMode]:
         """Return a list of available HVACModes."""
         hvac_modes: list[HVACMode] = []
@@ -217,6 +226,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
         return hvac_modes
 
     @property
+    @override
     def hvac_action(self) -> HVACAction:
         """Return the current running hvac operation if supported."""
         # Keep track of the previous hvac_action mode.
@@ -235,11 +245,13 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
         return HVACAction.IDLE
 
     @property
+    @override
     def preset_mode(self) -> str | None:
         """Return the current preset mode."""
         return self.device.get("active_preset")
 
     @plugwise_command
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         data: dict[str, Any] = {}
@@ -267,6 +279,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
         return mode
 
     @plugwise_command
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set the HVAC mode (off, heat, cool, heat_cool, or auto/schedule)."""
         # Early exit if no mode change
@@ -316,6 +329,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
         await self._api.set_schedule_state(self._location, STATE_ON, desired_schedule)
 
     @plugwise_command
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode."""
         await self._api.set_preset(self._location, preset_mode)

--- a/homeassistant/components/plugwise/config_flow.py
+++ b/homeassistant/components/plugwise/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Plugwise integration."""
 
 import logging
-from typing import Any, Self
+from typing import Any, Self, override
 
 from plugwise import Smile
 from plugwise.exceptions import (
@@ -122,6 +122,7 @@ class PlugwiseConfigFlow(ConfigFlow, domain=DOMAIN):
     product: str = UNKNOWN_SMILE
     _username: str = DEFAULT_USERNAME
 
+    @override
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:
@@ -178,6 +179,7 @@ class PlugwiseConfigFlow(ConfigFlow, domain=DOMAIN):
         )
         return await self.async_step_user()
 
+    @override
     def is_matching(self, other_flow: Self) -> bool:
         """Return True if other_flow is matching this flow."""
         # This is an Anna, and there is already an Adam flow in progress
@@ -190,6 +192,7 @@ class PlugwiseConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return False
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/plugwise/coordinator.py
+++ b/homeassistant/components/plugwise/coordinator.py
@@ -1,5 +1,7 @@
 """DataUpdateCoordinator for Plugwise."""
 
+from typing import override
+
 from packaging.version import Version
 from plugwise import GwEntityData, Smile
 from plugwise.exceptions import (
@@ -79,6 +81,7 @@ class PlugwiseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, GwEntityData
         if self._connected and self.api.smile.type == "power":
             self.update_interval = P1_UPDATE_INTERVAL
 
+    @override
     async def _async_setup(self) -> None:
         """Initialize the update_data process."""
         device_reg = dr.async_get(self.hass)
@@ -92,6 +95,7 @@ class PlugwiseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, GwEntityData
             if identifier[0] == DOMAIN
         }
 
+    @override
     async def _async_update_data(self) -> dict[str, GwEntityData]:
         """Fetch data from Plugwise."""
         try:

--- a/homeassistant/components/plugwise/entity.py
+++ b/homeassistant/components/plugwise/entity.py
@@ -1,5 +1,7 @@
 """Generic Plugwise Entity Class."""
 
+from typing import override
+
 from plugwise import GwEntityData
 
 from homeassistant.const import ATTR_NAME, ATTR_VIA_DEVICE, CONF_HOST
@@ -69,6 +71,7 @@ class PlugwiseEntity(CoordinatorEntity[PlugwiseDataUpdateCoordinator]):
             )
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return (

--- a/homeassistant/components/plugwise/number.py
+++ b/homeassistant/components/plugwise/number.py
@@ -1,6 +1,7 @@
 """Number platform for Plugwise integration."""
 
 from dataclasses import dataclass
+from typing import override
 
 from homeassistant.components.number import (
     NumberDeviceClass,
@@ -103,11 +104,13 @@ class PlugwiseNumberEntity(PlugwiseEntity, NumberEntity):
         self._attr_native_step = native_step
 
     @property
+    @override
     def native_value(self) -> float:
         """Return the present setpoint value."""
         return self.device[self.entity_description.key]["setpoint"]
 
     @plugwise_command
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Change to the new setpoint value."""
         await self.coordinator.api.set_number(

--- a/homeassistant/components/plugwise/select.py
+++ b/homeassistant/components/plugwise/select.py
@@ -1,6 +1,7 @@
 """Plugwise Select component for Home Assistant."""
 
 from dataclasses import dataclass
+from typing import override
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.const import STATE_ON, EntityCategory
@@ -110,16 +111,19 @@ class PlugwiseSelectEntity(PlugwiseEntity, SelectEntity):
             self._location = location
 
     @property
+    @override
     def current_option(self) -> str | None:
         """Return the selected entity option to represent the entity state."""
         return self.device[self.entity_description.key]
 
     @property
+    @override
     def options(self) -> list[str]:
         """Return the available select-options."""
         return self.device[self.entity_description.options_key]
 
     @plugwise_command
+    @override
     async def async_select_option(self, option: str) -> None:
         """Change to the selected entity option.
 

--- a/homeassistant/components/plugwise/sensor.py
+++ b/homeassistant/components/plugwise/sensor.py
@@ -1,6 +1,7 @@
 """Plugwise Sensor component for Home Assistant."""
 
 from dataclasses import dataclass
+from typing import override
 
 from plugwise.constants import SensorType
 
@@ -440,6 +441,7 @@ class PlugwiseSensorEntity(PlugwiseEntity, SensorEntity):
         self.entity_description = description
 
     @property
+    @override
     def native_value(self) -> int | float:
         """Return the value reported by the sensor."""
         return self.device["sensors"][self.entity_description.key]

--- a/homeassistant/components/plugwise/switch.py
+++ b/homeassistant/components/plugwise/switch.py
@@ -1,7 +1,7 @@
 """Plugwise Switch component for HomeAssistant."""
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from plugwise.constants import SwitchType
 
@@ -95,11 +95,13 @@ class PlugwiseSwitchEntity(PlugwiseEntity, SwitchEntity):
         self.entity_description = description
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return True if entity is on."""
         return self.device["switches"][self.entity_description.key]
 
     @plugwise_command
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
         await self.coordinator.api.set_switch_state(
@@ -110,6 +112,7 @@ class PlugwiseSwitchEntity(PlugwiseEntity, SwitchEntity):
         )
 
     @plugwise_command
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
         await self.coordinator.api.set_switch_state(

--- a/homeassistant/components/pocketcasts/sensor.py
+++ b/homeassistant/components/pocketcasts/sensor.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import logging
+from typing import override
 
 from pycketcasts import pocketcasts
 import voluptuous as vol
@@ -57,11 +58,13 @@ class PocketCastsSensor(SensorEntity):
         self._state = None
 
     @property
+    @override
     def name(self):
         """Return the name of the sensor."""
         return SENSOR_NAME
 
     @property
+    @override
     def native_value(self):
         """Return the sensor state."""
         return self._state

--- a/homeassistant/components/point/alarm_control_panel.py
+++ b/homeassistant/components/point/alarm_control_panel.py
@@ -1,6 +1,7 @@
 """Support for Minut Point."""
 
 import logging
+from typing import override
 
 from pypoint import PointSession
 
@@ -65,6 +66,7 @@ class MinutPointAlarmControl(AlarmControlPanelEntity):
             name=self._attr_name,
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Call when entity is added to HOme Assistant."""
         await super().async_added_to_hass()
@@ -88,18 +90,21 @@ class MinutPointAlarmControl(AlarmControlPanelEntity):
         self.async_write_ha_state()
 
     @property
+    @override
     def alarm_state(self) -> AlarmControlPanelState:
         """Return state of the device."""
         return EVENT_MAP.get(
             self._home["alarm_status"], AlarmControlPanelState.ARMED_AWAY
         )
 
+    @override
     async def async_alarm_disarm(self, code: str | None = None) -> None:
         """Send disarm command."""
         status = await self._client.alarm_disarm(self._home_id)
         if status:
             self._home["alarm_status"] = "off"
 
+    @override
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command."""
         status = await self._client.alarm_arm(self._home_id)

--- a/homeassistant/components/point/binary_sensor.py
+++ b/homeassistant/components/point/binary_sensor.py
@@ -1,7 +1,7 @@
 """Support for Minut Point binary sensors."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from pypoint import EVENTS
 
@@ -79,6 +79,7 @@ class MinutPointBinarySensor(MinutPointEntity, BinarySensorEntity):
         self._attr_unique_id = f"point.{device_id}-{key}"  # pylint: disable=home-assistant-entity-unique-id-redundant-domain
         self._attr_icon = DEVICES[key].get("icon")
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Call when entity is added to HOme Assistant."""
         await super().async_added_to_hass()
@@ -86,6 +87,7 @@ class MinutPointBinarySensor(MinutPointEntity, BinarySensorEntity):
             async_dispatcher_connect(self.hass, SIGNAL_WEBHOOK, self._webhook_event)
         )
 
+    @override
     def _handle_coordinator_update(self) -> None:
         """Update the value of the sensor."""
         if self.device_class == BinarySensorDeviceClass.CONNECTIVITY:

--- a/homeassistant/components/point/config_flow.py
+++ b/homeassistant/components/point/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.webhook import async_generate_id
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlowResult
@@ -20,6 +20,7 @@ class OAuth2FlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):
     DOMAIN = DOMAIN
 
     @property
+    @override
     def logger(self) -> logging.Logger:
         """Return logger."""
         return logging.getLogger(__name__)
@@ -38,6 +39,7 @@ class OAuth2FlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):
             return self.async_show_form(step_id="reauth_confirm")
         return await self.async_step_user()
 
+    @override
     async def async_oauth_create_entry(self, data: dict[str, Any]) -> ConfigFlowResult:
         """Create an oauth config entry or update existing entry for reauth."""
         user_id = str(data[CONF_TOKEN]["user_id"])

--- a/homeassistant/components/point/coordinator.py
+++ b/homeassistant/components/point/coordinator.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from datetime import datetime
 import logging
-from typing import Any
+from typing import Any, override
 
 from pypoint import PointSession
 
@@ -43,6 +43,7 @@ class PointDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
         self.new_device_callbacks: list[Callable[[str], None]] = []
         self.data: dict[str, dict[str, Any]] = {}
 
+    @override
     async def _async_update_data(self) -> dict[str, dict[str, Any]]:
         if not await self.point.update():
             raise UpdateFailed("Failed to fetch data from Point")

--- a/homeassistant/components/point/entity.py
+++ b/homeassistant/components/point/entity.py
@@ -1,7 +1,7 @@
 """Support for Minut Point."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from pypoint import Device, PointSession
 
@@ -47,6 +47,7 @@ class MinutPointEntity(CoordinatorEntity[PointDataUpdateCoordinator]):
         return self.coordinator.point
 
     @property
+    @override
     def available(self) -> bool:
         """Return true if device is not offline."""
         return super().available and self.device_id in self.client.device_ids
@@ -57,6 +58,7 @@ class MinutPointEntity(CoordinatorEntity[PointDataUpdateCoordinator]):
         return self.client.device(self.device_id)
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return status of device."""
         attrs = self.device.device_status

--- a/homeassistant/components/point/sensor.py
+++ b/homeassistant/components/point/sensor.py
@@ -1,6 +1,7 @@
 """Support for Minut Point sensors."""
 
 import logging
+from typing import override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -80,6 +81,7 @@ class MinutPointSensor(MinutPointEntity, SensorEntity):
         self._attr_unique_id = f"point.{device_id}-{description.key}"  # pylint: disable=home-assistant-entity-unique-id-redundant-domain
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
         return self.coordinator.data[self.device_id].get(self.entity_description.key)

--- a/homeassistant/components/pooldose/binary_sensor.py
+++ b/homeassistant/components/pooldose/binary_sensor.py
@@ -1,7 +1,7 @@
 """Binary sensors for the Seko PoolDose integration."""
 
 import logging
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, cast, override
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -207,6 +207,7 @@ class PooldoseBinarySensor(PooldoseEntity, BinarySensorEntity):
     """Binary sensor entity for the Seko PoolDose Python API."""
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if the binary sensor is on."""
         data = cast(dict, self.get_data())

--- a/homeassistant/components/pooldose/config_flow.py
+++ b/homeassistant/components/pooldose/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for the Seko PoolDose integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from pooldose.client import PooldoseClient
 from pooldose.request_status import RequestStatus
@@ -65,6 +65,7 @@ class PooldoseConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return serial_number, None, None
 
+    @override
     async def async_step_dhcp(
         self, discovery_info: DhcpServiceInfo
     ) -> ConfigFlowResult:
@@ -108,6 +109,7 @@ class PooldoseConfigFlow(ConfigFlow, domain=DOMAIN):
             },
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/pooldose/coordinator.py
+++ b/homeassistant/components/pooldose/coordinator.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import logging
+from typing import override
 
 from pooldose.client import PooldoseClient
 from pooldose.request_status import RequestStatus
@@ -38,12 +39,14 @@ class PooldoseCoordinator(DataUpdateCoordinator[StructuredValuesDict]):
         )
         self.client = client
 
+    @override
     async def _async_setup(self) -> None:
         """Set up the coordinator."""
         # Update device info after successful connection
         self.device_info = self.client.device_info
         _LOGGER.debug("Device info: %s", self.device_info)
 
+    @override
     async def _async_update_data(self) -> StructuredValuesDict:
         """Fetch data from the PoolDose API."""
         try:

--- a/homeassistant/components/pooldose/entity.py
+++ b/homeassistant/components/pooldose/entity.py
@@ -1,7 +1,7 @@
 """Base entity for Seko Pooldose integration."""
 
 from collections.abc import Callable, Coroutine
-from typing import Any, Literal
+from typing import Any, Literal, override
 
 from pooldose.type_definitions import DeviceInfoDict, ValueDict
 
@@ -71,6 +71,7 @@ class PooldoseEntity(CoordinatorEntity[PooldoseCoordinator]):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return super().available and self.get_data() is not None

--- a/homeassistant/components/pooldose/number.py
+++ b/homeassistant/components/pooldose/number.py
@@ -1,7 +1,7 @@
 """Number entities for the Seko PoolDose integration."""
 
 import logging
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, cast, override
 
 from homeassistant.components.number import (
     NumberDeviceClass,
@@ -163,6 +163,7 @@ class PooldoseNumber(PooldoseEntity, NumberEntity):
         super().__init__(coordinator, serial_number, device_info, description, "number")
         self._async_update_attrs()
 
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self._async_update_attrs()
@@ -176,6 +177,7 @@ class PooldoseNumber(PooldoseEntity, NumberEntity):
         self._attr_native_max_value = data["max"]
         self._attr_native_step = data["step"]
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Set new value."""
         await self._async_perform_write(

--- a/homeassistant/components/pooldose/select.py
+++ b/homeassistant/components/pooldose/select.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 import logging
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, cast, override
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.const import EntityCategory, UnitOfVolume, UnitOfVolumeFlowRate
@@ -128,6 +128,7 @@ class PooldoseSelect(PooldoseEntity, SelectEntity):
         super().__init__(coordinator, serial_number, device_info, description, "select")
         self._async_update_attrs()
 
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self._async_update_attrs()
@@ -145,6 +146,7 @@ class PooldoseSelect(PooldoseEntity, SelectEntity):
         else:
             self._attr_current_option = api_value
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         # Convert Home Assistant unit to API value if unit conversion is enabled

--- a/homeassistant/components/pooldose/sensor.py
+++ b/homeassistant/components/pooldose/sensor.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -232,6 +232,7 @@ class PooldoseSensor(PooldoseEntity, SensorEntity):
     entity_description: PooldoseSensorEntityDescription
 
     @property
+    @override
     def native_value(self) -> float | int | str | None:
         """Return the current value of the sensor."""
         data = self.get_data()
@@ -240,6 +241,7 @@ class PooldoseSensor(PooldoseEntity, SensorEntity):
         return None
 
     @property
+    @override
     def native_unit_of_measurement(self) -> str | None:
         """Return the unit of measurement."""
         if (

--- a/homeassistant/components/pooldose/switch.py
+++ b/homeassistant/components/pooldose/switch.py
@@ -1,7 +1,7 @@
 """Switches for the Seko PoolDose integration."""
 
 import logging
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, cast, override
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.const import EntityCategory
@@ -72,6 +72,7 @@ class PooldoseSwitch(PooldoseEntity, SwitchEntity):
         super().__init__(coordinator, serial_number, device_info, description, "switch")
         self._async_update_attrs()
 
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self._async_update_attrs()
@@ -82,6 +83,7 @@ class PooldoseSwitch(PooldoseEntity, SwitchEntity):
         data = cast(dict, self.get_data())
         self._attr_is_on = cast(bool, data["value"])
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         await self._async_perform_write(
@@ -91,6 +93,7 @@ class PooldoseSwitch(PooldoseEntity, SwitchEntity):
         self._attr_is_on = True
         self.async_write_ha_state()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         await self._async_perform_write(

--- a/homeassistant/components/poolsense/binary_sensor.py
+++ b/homeassistant/components/poolsense/binary_sensor.py
@@ -1,5 +1,7 @@
 """Support for PoolSense binary sensors."""
 
+from typing import override
+
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
@@ -43,6 +45,7 @@ class PoolSenseBinarySensor(PoolSenseEntity, BinarySensorEntity):
     """Representation of PoolSense binary sensors."""
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if the binary sensor is on."""
         return self.coordinator.data[self.entity_description.key] == "red"

--- a/homeassistant/components/poolsense/config_flow.py
+++ b/homeassistant/components/poolsense/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for PoolSense integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from poolsense import PoolSense
 import voluptuous as vol
@@ -20,6 +20,7 @@ class PoolSenseConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/poolsense/coordinator.py
+++ b/homeassistant/components/poolsense/coordinator.py
@@ -3,6 +3,7 @@
 import asyncio
 from datetime import timedelta
 import logging
+from typing import override
 
 from poolsense import PoolSense
 from poolsense.exceptions import PoolSenseError
@@ -42,6 +43,7 @@ class PoolSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, StateType]]
         self.poolsense = poolsense
         self.email = self.config_entry.data[CONF_EMAIL]
 
+    @override
     async def _async_update_data(self) -> dict[str, StateType]:
         """Update data via library."""
         async with asyncio.timeout(10):

--- a/homeassistant/components/poolsense/sensor.py
+++ b/homeassistant/components/poolsense/sensor.py
@@ -1,5 +1,7 @@
 """Sensor platform for the PoolSense sensor."""
 
+from typing import override
+
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -77,6 +79,7 @@ class PoolSenseSensor(PoolSenseEntity, SensorEntity):
     """Sensor representing poolsense data."""
 
     @property
+    @override
     def native_value(self) -> StateType:
         """State of the sensor."""
         return self.coordinator.data[self.entity_description.key]

--- a/homeassistant/components/portainer/binary_sensor.py
+++ b/homeassistant/components/portainer/binary_sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from pyportainer import DockerContainerState, EndpointStatus, StackStatus
 
@@ -163,6 +164,7 @@ class PortainerEndpointSensor(PortainerEndpointEntity, BinarySensorEntity):
     entity_description: PortainerEndpointBinarySensorEntityDescription
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
         return self.entity_description.state_fn(self.coordinator.data[self.device_id])
@@ -174,6 +176,7 @@ class PortainerContainerSensor(PortainerContainerEntity, BinarySensorEntity):
     entity_description: PortainerContainerBinarySensorEntityDescription
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
         return self.entity_description.state_fn(self.container_data)
@@ -185,6 +188,7 @@ class PortainerStackSensor(PortainerStackEntity, BinarySensorEntity):
     entity_description: PortainerStackBinarySensorEntityDescription
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
         return self.entity_description.state_fn(self.stack_data)

--- a/homeassistant/components/portainer/button.py
+++ b/homeassistant/components/portainer/button.py
@@ -4,7 +4,7 @@ from abc import abstractmethod
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Any
+from typing import Any, override
 
 from pyportainer import Portainer
 from pyportainer.exceptions import (
@@ -193,6 +193,7 @@ class PortainerBaseButton(ButtonEntity):
     async def _async_press_call(self) -> None:
         """Abstract method used per Portainer button class."""
 
+    @override
     async def async_press(self) -> None:
         """Trigger the Portainer button press service."""
         try:
@@ -221,6 +222,7 @@ class PortainerEndpointButton(PortainerEndpointEntity, PortainerBaseButton):
 
     entity_description: PortainerButtonDescription
 
+    @override
     async def _async_press_call(self) -> None:
         """Call the endpoint button press action."""
         await self.entity_description.press_action(
@@ -233,6 +235,7 @@ class PortainerContainerButton(PortainerContainerEntity, PortainerBaseButton):
 
     entity_description: PortainerButtonDescription
 
+    @override
     async def _async_press_call(self) -> None:
         """Call the container button press action."""
         await self.entity_description.press_action(

--- a/homeassistant/components/portainer/config_flow.py
+++ b/homeassistant/components/portainer/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyportainer import (
     Portainer,
@@ -59,6 +59,7 @@ class PortainerConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 5
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/portainer/coordinator.py
+++ b/homeassistant/components/portainer/coordinator.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
+from typing import override
 
 from pyportainer import (
     DockerContainerState,
@@ -123,6 +124,7 @@ class PortainerBaseCoordinator[_DataT](DataUpdateCoordinator[_DataT]):
             Callable[[list[tuple[PortainerCoordinatorData, PortainerVolumeData]]], None]
         ] = []
 
+    @override
     async def _async_setup(self) -> None:
         """Set up the Portainer Data Update Coordinator."""
         try:
@@ -150,6 +152,7 @@ class PortainerBaseCoordinator[_DataT](DataUpdateCoordinator[_DataT]):
     async def update_data(self) -> _DataT:
         """Update coordinator data."""
 
+    @override
     async def _async_update_data(self) -> _DataT:
         """Fetch per coordinator specific data."""
         try:
@@ -183,6 +186,7 @@ class PortainerCoordinator(
     docker_disk_space: PortainerDockerDiskSpaceCoordinator | None = None
     _update_interval = DEFAULT_SCAN_INTERVAL
 
+    @override
     async def update_data(self) -> dict[int, PortainerCoordinatorData]:
         """Fetch data from Portainer API."""
         _LOGGER.debug(
@@ -440,6 +444,7 @@ class PortainerDockerDiskSpaceCoordinator(
     config_entry: PortainerConfigEntry
     _update_interval = DEFAULT_DF_SCAN_INTERVAL
 
+    @override
     async def update_data(self) -> dict[int, DockerSystemDF]:
         """Fetch Docker disk space data independently from Portainer API."""
         endpoints = await self.portainer.get_endpoints()

--- a/homeassistant/components/portainer/entity.py
+++ b/homeassistant/components/portainer/entity.py
@@ -1,5 +1,7 @@
 """Base class for Portainer entities."""
 
+from typing import override
+
 from yarl import URL
 
 from homeassistant.const import CONF_URL
@@ -65,6 +67,7 @@ class PortainerEndpointEntity(PortainerCoordinatorEntity):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return if the device is available."""
         return super().available and self.device_id in self.coordinator.data
@@ -124,6 +127,7 @@ class PortainerContainerEntity(PortainerCoordinatorEntity):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return if the device is available."""
         return (
@@ -181,6 +185,7 @@ class PortainerStackEntity(PortainerCoordinatorEntity):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return if the stack is available."""
         return (
@@ -232,6 +237,7 @@ class PortainerDockerSystemDiskSpaceEndpointEntity(
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return if the device is available."""
         return (
@@ -284,6 +290,7 @@ class PortainerVolumeEntity(PortainerCoordinatorEntity):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return if the volume is available."""
         return (

--- a/homeassistant/components/portainer/sensor.py
+++ b/homeassistant/components/portainer/sensor.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from itertools import chain
+from typing import override
 
 from pyportainer import StackType
 from pyportainer.models.docker import DockerSystemDF
@@ -473,6 +474,7 @@ class PortainerContainerSensor(PortainerContainerEntity, SensorEntity):
     entity_description: PortainerContainerSensorEntityDescription
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.container_data)
@@ -484,6 +486,7 @@ class PortainerEndpointSensor(PortainerEndpointEntity, SensorEntity):
     entity_description: PortainerEndpointSensorEntityDescription
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
         endpoint_data = self.coordinator.data[self._device_info.endpoint.id]
@@ -498,6 +501,7 @@ class PortainerDockerSystemDiskSpaceSensor(
     entity_description: PortainerDockerSystemDiskSpaceSensorEntityDescription
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
         endpoint_data = self.coordinator.data[self._device_info.endpoint.id]
@@ -510,6 +514,7 @@ class PortainerStackSensor(PortainerStackEntity, SensorEntity):
     entity_description: PortainerStackSensorEntityDescription
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.stack_data)
@@ -521,6 +526,7 @@ class PortainerVolumeSensor(PortainerVolumeEntity, SensorEntity):
     entity_description: PortainerVolumeSensorEntityDescription
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.volume_data)

--- a/homeassistant/components/portainer/switch.py
+++ b/homeassistant/components/portainer/switch.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from pyportainer import DockerContainerState, Portainer, StackStatus
 from pyportainer.exceptions import (
@@ -169,10 +169,12 @@ class PortainerContainerSwitch(PortainerContainerEntity, SwitchEntity):
     entity_description: PortainerSwitchEntityDescription
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return the state of the device."""
         return self.entity_description.is_on_fn(self.container_data)
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Start (turn on) the container."""
         await _perform_action(
@@ -182,6 +184,7 @@ class PortainerContainerSwitch(PortainerContainerEntity, SwitchEntity):
             ),
         )
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Stop (turn off) the container."""
         await _perform_action(
@@ -198,10 +201,12 @@ class PortainerStackSwitch(PortainerStackEntity, SwitchEntity):
     entity_description: PortainerStackSwitchEntityDescription
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return the state of the device."""
         return self.entity_description.is_on_fn(self.stack_data)
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Start (turn on) the stack."""
         await _perform_action(
@@ -211,6 +216,7 @@ class PortainerStackSwitch(PortainerStackEntity, SwitchEntity):
             ),
         )
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Stop (turn off) the stack."""
         await _perform_action(

--- a/homeassistant/components/powerfox/config_flow.py
+++ b/homeassistant/components/powerfox/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Powerfox integration."""
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, override
 
 from powerfox import Powerfox, PowerfoxAuthenticationError, PowerfoxConnectionError
 import voluptuous as vol
@@ -33,6 +33,7 @@ STEP_REAUTH_SCHEMA = vol.Schema(
 class PowerfoxConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Powerfox."""
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/powerfox/coordinator.py
+++ b/homeassistant/components/powerfox/coordinator.py
@@ -1,6 +1,7 @@
 """Coordinator for Powerfox integration."""
 
 from datetime import datetime
+from typing import override
 
 from powerfox import (
     Device,
@@ -50,6 +51,7 @@ class PowerfoxBaseCoordinator[T](DataUpdateCoordinator[T]):
         self.client = client
         self.device = device
 
+    @override
     async def _async_update_data(self) -> T:
         """Fetch data and normalize Powerfox errors."""
         try:
@@ -85,6 +87,7 @@ class PowerfoxBaseCoordinator[T](DataUpdateCoordinator[T]):
 class PowerfoxDataUpdateCoordinator(PowerfoxBaseCoordinator[Poweropti]):
     """Class to manage fetching Powerfox data from the API."""
 
+    @override
     async def _async_fetch_data(self) -> Poweropti:
         """Fetch live device data from the Powerfox API."""
         return await self.client.device(device_id=self.device.id)
@@ -93,6 +96,7 @@ class PowerfoxDataUpdateCoordinator(PowerfoxBaseCoordinator[Poweropti]):
 class PowerfoxReportDataUpdateCoordinator(PowerfoxBaseCoordinator[DeviceReport]):
     """Coordinator handling report data from the API."""
 
+    @override
     async def _async_fetch_data(self) -> DeviceReport:
         """Fetch report data from the Powerfox API."""
         local_now = datetime.now(  # pylint: disable=home-assistant-enforce-now

--- a/homeassistant/components/powerfox/sensor.py
+++ b/homeassistant/components/powerfox/sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from powerfox import Device, GasReport, HeatMeter, PowerMeter, WaterMeter
 
@@ -315,6 +315,7 @@ class PowerfoxSensorEntity(BasePowerfoxSensorEntity[PowerfoxDataUpdateCoordinato
     entity_description: PowerfoxSensorEntityDescription
 
     @property
+    @override
     def native_value(self) -> float | int | None:
         """Return the state of the entity."""
         return self.entity_description.value_fn(self.coordinator.data)
@@ -329,6 +330,7 @@ class PowerfoxGasSensorEntity(
     entity_description: PowerfoxReportSensorEntityDescription
 
     @property
+    @override
     def native_value(self) -> float | int | None:
         """Return the state of the entity."""
         gas_report = self.coordinator.data.gas

--- a/homeassistant/components/powerfox_local/config_flow.py
+++ b/homeassistant/components/powerfox_local/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Powerfox Local integration."""
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, override
 
 from powerfox import PowerfoxAuthenticationError, PowerfoxConnectionError, PowerfoxLocal
 import voluptuous as vol
@@ -39,6 +39,7 @@ class PowerfoxLocalConfigFlow(ConfigFlow, domain=DOMAIN):
     _api_key: str
     _device_id: str
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -73,6 +74,7 @@ class PowerfoxLocalConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    @override
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/powerfox_local/coordinator.py
+++ b/homeassistant/components/powerfox_local/coordinator.py
@@ -1,5 +1,7 @@
 """Coordinator for Powerfox Local integration."""
 
+from typing import override
+
 from powerfox import (
     LocalResponse,
     PowerfoxAuthenticationError,
@@ -40,6 +42,7 @@ class PowerfoxLocalDataUpdateCoordinator(DataUpdateCoordinator[LocalResponse]):
             update_interval=SCAN_INTERVAL,
         )
 
+    @override
     async def _async_update_data(self) -> LocalResponse:
         """Fetch data from the local poweropti."""
         try:

--- a/homeassistant/components/powerfox_local/sensor.py
+++ b/homeassistant/components/powerfox_local/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from powerfox import LocalResponse
 
@@ -105,6 +106,7 @@ class PowerfoxLocalSensorEntity(PowerfoxLocalEntity, SensorEntity):
         self._attr_unique_id = f"{coordinator.device_id}_{description.key}"
 
     @property
+    @override
     def native_value(self) -> float | int | None:
         """Return the state of the entity."""
         return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/powerwall/binary_sensor.py
+++ b/homeassistant/components/powerwall/binary_sensor.py
@@ -1,6 +1,6 @@
 """Support for powerwall binary sensors."""
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from tesla_powerwall import GridStatus, MeterType
 
@@ -55,11 +55,13 @@ class PowerWallRunningSensor(PowerWallEntity, BinarySensorEntity):
     _attr_device_class = BinarySensorDeviceClass.POWER
 
     @property
+    @override
     def unique_id(self) -> str:
         """Device Uniqueid."""
         return f"{self.base_unique_id}_running"
 
     @property
+    @override
     def is_on(self) -> bool:
         """Get the powerwall running state."""
         site_master = self.data.site_master
@@ -75,11 +77,13 @@ class PowerWallConnectedSensor(PowerWallEntity, BinarySensorEntity):
     _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
 
     @property
+    @override
     def unique_id(self) -> str:
         """Device Uniqueid."""
         return f"{self.base_unique_id}_connected_to_tesla"
 
     @property
+    @override
     def is_on(self) -> bool:
         """Get the powerwall connected to tesla state."""
         site_master = self.data.site_master
@@ -95,11 +99,13 @@ class PowerWallGridServicesActiveSensor(PowerWallEntity, BinarySensorEntity):
     _attr_device_class = BinarySensorDeviceClass.POWER
 
     @property
+    @override
     def unique_id(self) -> str:
         """Device Uniqueid."""
         return f"{self.base_unique_id}_grid_services_active"
 
     @property
+    @override
     def is_on(self) -> bool:
         """Grid services is active."""
         return self.data.grid_services_active
@@ -112,11 +118,13 @@ class PowerWallGridStatusSensor(PowerWallEntity, BinarySensorEntity):
     _attr_device_class = BinarySensorDeviceClass.POWER
 
     @property
+    @override
     def unique_id(self) -> str:
         """Device Uniqueid."""
         return f"{self.base_unique_id}_grid_status"
 
     @property
+    @override
     def is_on(self) -> bool:
         """Grid is online."""
         return self.data.grid_status in CONNECTED_GRID_STATUSES
@@ -128,6 +136,7 @@ class PowerWallChargingStatusSensor(PowerWallEntity, BinarySensorEntity):
     _attr_device_class = BinarySensorDeviceClass.BATTERY_CHARGING
 
     @property
+    @override
     def available(self) -> bool:
         """Powerwall is available."""
         # Return False if no battery is installed
@@ -137,11 +146,13 @@ class PowerWallChargingStatusSensor(PowerWallEntity, BinarySensorEntity):
         )
 
     @property
+    @override
     def unique_id(self) -> str:
         """Device Uniqueid."""
         return f"{self.base_unique_id}_powerwall_charging"  # pylint: disable=home-assistant-entity-unique-id-redundant-domain
 
     @property
+    @override
     def is_on(self) -> bool:
         """Powerwall is charging."""
         meter = self.data.meters.get_meter(MeterType.BATTERY)

--- a/homeassistant/components/powerwall/config_flow.py
+++ b/homeassistant/components/powerwall/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from aiohttp import CookieJar
 from tesla_powerwall import (
@@ -136,6 +136,7 @@ class PowerwallConfigFlow(ConfigFlow, domain=DOMAIN):
             or not async_last_update_was_successful(self.hass, entry)
         ) and not await _powerwall_is_reachable(ip_address, password)
 
+    @override
     async def async_step_dhcp(
         self, discovery_info: DhcpServiceInfo
     ) -> ConfigFlowResult:
@@ -251,6 +252,7 @@ class PowerwallConfigFlow(ConfigFlow, domain=DOMAIN):
             },
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/powerwall/sensor.py
+++ b/homeassistant/components/powerwall/sensor.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from operator import attrgetter, methodcaller
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from tesla_powerwall import (
     BatteryResponse,
@@ -288,11 +288,13 @@ class PowerWallChargeSensor(PowerWallEntity, SensorEntity):
     _attr_device_class = SensorDeviceClass.BATTERY
 
     @property
+    @override
     def unique_id(self) -> str:
         """Device Unique ID."""
         return f"{self.base_unique_id}_charge"
 
     @property
+    @override
     def native_value(self) -> int:
         """Get the current value in percentage."""
         return round(self.data.charge)
@@ -317,6 +319,7 @@ class PowerWallEnergySensor(PowerWallEntity, SensorEntity):
         self._attr_unique_id = f"{self.base_unique_id}_{meter.value}_{description.key}"
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Get the current value."""
         meter = self.data.meters.get_meter(self._meter)
@@ -334,11 +337,13 @@ class PowerWallBackupReserveSensor(PowerWallEntity, SensorEntity):
     _attr_native_unit_of_measurement = PERCENTAGE
 
     @property
+    @override
     def unique_id(self) -> str:
         """Device Unique ID."""
         return f"{self.base_unique_id}_backup_reserve"
 
     @property
+    @override
     def native_value(self) -> int | None:
         """Get the current value in percentage."""
         if self.data.backup_reserve is None:
@@ -362,6 +367,7 @@ class PowerWallMaxPowerSensor(PowerWallEntity, SensorEntity):
         self._attr_unique_id = f"{self.base_unique_id}_{description.key}"
 
     @property
+    @override
     def native_value(self) -> int | None:
         """Get the current value in watts."""
         return self.entity_description.value_fn(self.data)
@@ -375,11 +381,13 @@ class PowerWallOperationModeSensor(PowerWallEntity, SensorEntity):
     _attr_options = [mode.value for mode in OperationMode]
 
     @property
+    @override
     def unique_id(self) -> str:
         """Device Unique ID."""
         return f"{self.base_unique_id}_operation_mode"
 
     @property
+    @override
     def native_value(self) -> str | None:
         """Get the current operation mode."""
         if self.data.operation_mode is None:
@@ -407,6 +415,7 @@ class PowerWallEnergyDirectionSensor(PowerWallEntity, SensorEntity):
         self._attr_unique_id = f"{self.base_unique_id}_{meter.value}_{meter_direction}"
 
     @property
+    @override
     def available(self) -> bool:
         """Check if the reading is actually available.
 
@@ -434,6 +443,7 @@ class PowerWallExportSensor(PowerWallEnergyDirectionSensor):
         super().__init__(powerwall_data, meter, _METER_DIRECTION_EXPORT)
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Get the current value in kWh."""
         meter = self.meter
@@ -454,6 +464,7 @@ class PowerWallImportSensor(PowerWallEnergyDirectionSensor):
         super().__init__(powerwall_data, meter, _METER_DIRECTION_IMPORT)
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Get the current value in kWh."""
         meter = self.meter
@@ -480,6 +491,7 @@ class PowerWallBatterySensor[_ValueT: _ValueType](BatteryEntity, SensorEntity):
         self._attr_unique_id = f"{self.base_unique_id}_{description.key}"
 
     @property
+    @override
     def native_value(self) -> float | int | str | None:
         """Get the current value."""
         return self.entity_description.value_fn(self.battery_data)

--- a/homeassistant/components/powerwall/switch.py
+++ b/homeassistant/components/powerwall/switch.py
@@ -1,6 +1,6 @@
 """Support for Powerwall Switches (V2 API only)."""
 
-from typing import Any
+from typing import Any, override
 
 from tesla_powerwall import GridStatus, IslandMode, PowerwallError
 
@@ -45,14 +45,17 @@ class PowerwallOffGridEnabledEntity(PowerWallEntity, SwitchEntity):
         self._attr_unique_id = f"{self.base_unique_id}_off_grid_operation"
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if the powerwall is off-grid."""
         return self.coordinator.data.grid_status in OFF_GRID_STATUSES
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn off-grid mode on."""
         await self._async_set_island_mode(IslandMode.OFFGRID)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off-grid mode off (return to on-grid usage)."""
         await self._async_set_island_mode(IslandMode.ONGRID)

--- a/homeassistant/components/prana/config_flow.py
+++ b/homeassistant/components/prana/config_flow.py
@@ -1,7 +1,7 @@
 """Configuration flow for Prana integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from prana_local_api_client.exceptions import PranaApiCommunicationError
 from prana_local_api_client.models.prana_device_info import PranaDeviceInfo
@@ -29,6 +29,7 @@ class PranaConfigFlow(ConfigFlow, domain=DOMAIN):
     _host: str
     _device_info: PranaDeviceInfo
 
+    @override
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:
@@ -64,6 +65,7 @@ class PranaConfigFlow(ConfigFlow, domain=DOMAIN):
             },
         )
 
+    @override
     async def async_step_user(
         self,
         user_input: dict[str, Any] | None = None,

--- a/homeassistant/components/prana/coordinator.py
+++ b/homeassistant/components/prana/coordinator.py
@@ -5,6 +5,7 @@ Responsible for polling the device REST endpoints and normalizing data for entit
 
 from datetime import timedelta
 import logging
+from typing import override
 
 from prana_local_api_client.exceptions import (
     PranaApiCommunicationError,
@@ -48,12 +49,14 @@ class PranaCoordinator(DataUpdateCoordinator[PranaState]):
 
         self.api_client = PranaLocalApiClient(host=entry.data[CONF_HOST], port=80)
 
+    @override
     async def _async_setup(self) -> None:
         try:
             self.device_info = await self.api_client.get_device_info()
         except PranaApiCommunicationError as err:
             raise ConfigEntryNotReady("Could not fetch device info") from err
 
+    @override
     async def _async_update_data(self) -> PranaState:
         """Fetch and normalize device state for all platforms."""
         try:

--- a/homeassistant/components/prana/fan.py
+++ b/homeassistant/components/prana/fan.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
 import math
-from typing import Any
+from typing import Any, override
 
 from prana_local_api_client.models.prana_state import FanState
 
@@ -114,6 +114,7 @@ class PranaFan(PranaBaseEntity, FanEntity):
         return self.entity_description.key
 
     @property
+    @override
     def speed_count(self) -> int:
         """Return the number of speeds the fan supports."""
         return int_states_in_range(
@@ -121,6 +122,7 @@ class PranaFan(PranaBaseEntity, FanEntity):
         )
 
     @property
+    @override
     def percentage(self) -> int | None:
         """Return the current fan speed percentage."""
         current_speed = self.entity_description.value_fn(self.coordinator).speed
@@ -128,6 +130,7 @@ class PranaFan(PranaBaseEntity, FanEntity):
             self.entity_description.speed_range(self.coordinator), current_speed
         )
 
+    @override
     async def async_set_percentage(self, percentage: int) -> None:
         """Set fan speed (0-100%) by converting to device-specific speed steps."""
         if percentage == 0:
@@ -146,10 +149,12 @@ class PranaFan(PranaBaseEntity, FanEntity):
         await self.coordinator.async_refresh()
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if the fan is on."""
         return self.entity_description.value_fn(self.coordinator).is_on
 
+    @override
     async def async_turn_on(
         self,
         percentage: int | None = None,
@@ -169,17 +174,20 @@ class PranaFan(PranaBaseEntity, FanEntity):
         if percentage is None and preset_mode is None:
             await self.coordinator.async_refresh()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the fan off."""
         await self.coordinator.api_client.set_speed_is_on(False, self._api_target_key)
         await self.coordinator.async_refresh()
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode (e.g., night or boost)."""
         await self.coordinator.api_client.set_switch(preset_mode, True)
         await self.coordinator.async_refresh()
 
     @property
+    @override
     def preset_mode(self) -> str | None:
         """Return the current preset mode."""
         if self.coordinator.data.night:

--- a/homeassistant/components/prana/number.py
+++ b/homeassistant/components/prana/number.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.number import (
     NumberEntity,
@@ -70,10 +70,12 @@ class PranaNumber(PranaBaseEntity, NumberEntity):
     entity_description: PranaNumberEntityDescription
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the entity value."""
         return self.entity_description.value_fn(self.coordinator)
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Set new value."""
         await self.entity_description.set_value_fn(self.coordinator.api_client, value)

--- a/homeassistant/components/prana/sensor.py
+++ b/homeassistant/components/prana/sensor.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
+from typing import override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -124,6 +125,7 @@ class PranaSensor(PranaBaseEntity, SensorEntity):
     entity_description: PranaSensorEntityDescription
 
     @property
+    @override
     def native_value(self) -> StateType | None:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.coordinator)

--- a/homeassistant/components/prana/switch.py
+++ b/homeassistant/components/prana/switch.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.core import HomeAssistant
@@ -82,15 +82,18 @@ class PranaSwitch(PranaBaseEntity, SwitchEntity):
     entity_description: PranaSwitchEntityDescription
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return switch on/off state."""
         return self.entity_description.value_fn(self.coordinator)
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         await self.coordinator.api_client.set_switch(self.entity_description.key, True)
         await self.coordinator.async_refresh()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         await self.coordinator.api_client.set_switch(self.entity_description.key, False)

--- a/homeassistant/components/private_ble_device/config_flow.py
+++ b/homeassistant/components/private_ble_device/config_flow.py
@@ -3,6 +3,7 @@
 import base64
 import binascii
 import logging
+from typing import override
 
 import voluptuous as vol
 
@@ -45,6 +46,7 @@ class BLEDeviceTrackerConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, str] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/private_ble_device/device_tracker.py
+++ b/homeassistant/components/private_ble_device/device_tracker.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Mapping
 import logging
+from typing import override
 
 from homeassistant.components import bluetooth
 from homeassistant.components.device_tracker import BaseScannerEntity, SourceType
@@ -33,6 +34,7 @@ class BasePrivateDeviceTracker(BasePrivateDeviceEntity, BaseScannerEntity):
     _attr_name = None
 
     @property
+    @override
     def extra_state_attributes(self) -> Mapping[str, str]:
         """Return extra state attributes for this device."""
         if last_info := self._last_info:
@@ -43,6 +45,7 @@ class BasePrivateDeviceTracker(BasePrivateDeviceEntity, BaseScannerEntity):
         return {}
 
     @callback
+    @override
     def _async_track_unavailable(
         self, service_info: bluetooth.BluetoothServiceInfoBleak
     ) -> None:
@@ -50,6 +53,7 @@ class BasePrivateDeviceTracker(BasePrivateDeviceEntity, BaseScannerEntity):
         self.async_write_ha_state()
 
     @callback
+    @override
     def _async_track_service_info(
         self,
         service_info: bluetooth.BluetoothServiceInfoBleak,
@@ -59,6 +63,7 @@ class BasePrivateDeviceTracker(BasePrivateDeviceEntity, BaseScannerEntity):
         self.async_write_ha_state()
 
     @property
+    @override
     def is_connected(self) -> bool:
         """Return true if the device is connected."""
         return bool(self._last_info)

--- a/homeassistant/components/private_ble_device/entity.py
+++ b/homeassistant/components/private_ble_device/entity.py
@@ -2,6 +2,7 @@
 
 from abc import abstractmethod
 import binascii
+from typing import override
 
 from homeassistant.components import bluetooth
 from homeassistant.config_entries import ConfigEntry
@@ -37,6 +38,7 @@ class BasePrivateDeviceEntity(Entity):
         self._irk = binascii.unhexlify(irk)
         self._last_info: bluetooth.BluetoothServiceInfoBleak | None = None
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Configure entity when it is added to Home Assistant."""
         coordinator = async_get_coordinator(self.hass)

--- a/homeassistant/components/private_ble_device/sensor.py
+++ b/homeassistant/components/private_ble_device/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from bluetooth_data_tools import calculate_distance_meters
 
@@ -120,6 +121,7 @@ class PrivateBLEDeviceSensor(BasePrivateDeviceEntity, SensorEntity):
         super().__init__(config_entry)
 
     @callback
+    @override
     def _async_track_service_info(
         self,
         service_info: bluetooth.BluetoothServiceInfoBleak,
@@ -131,6 +133,7 @@ class PrivateBLEDeviceSensor(BasePrivateDeviceEntity, SensorEntity):
         self.async_write_ha_state()
 
     @callback
+    @override
     def _async_track_unavailable(
         self, service_info: bluetooth.BluetoothServiceInfoBleak
     ) -> None:
@@ -139,6 +142,7 @@ class PrivateBLEDeviceSensor(BasePrivateDeviceEntity, SensorEntity):
         self.async_write_ha_state()
 
     @property
+    @override
     def native_value(self) -> str | int | float | None:
         """Return the state of the sensor."""
         assert self._last_info

--- a/homeassistant/components/probe_plus/config_flow.py
+++ b/homeassistant/components/probe_plus/config_flow.py
@@ -2,7 +2,7 @@
 
 import dataclasses
 import logging
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -44,6 +44,7 @@ class ProbeConfigFlow(ConfigFlow, domain=DOMAIN):
         """Initialize the config flow."""
         self._discovered_devices: dict[str, Discovery] = {}
 
+    @override
     async def async_step_bluetooth(
         self, discovery_info: BluetoothServiceInfo
     ) -> ConfigFlowResult:
@@ -83,6 +84,7 @@ class ProbeConfigFlow(ConfigFlow, domain=DOMAIN):
             },
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/probe_plus/coordinator.py
+++ b/homeassistant/components/probe_plus/coordinator.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import logging
+from typing import override
 
 from pyprobeplus import ProbePlusDevice
 from pyprobeplus.exceptions import ProbePlusDeviceNotFound, ProbePlusError
@@ -56,6 +57,7 @@ class ProbePlusDataUpdateCoordinator(DataUpdateCoordinator[None]):
             notify_callback=self.async_update_listeners,
         )
 
+    @override
     async def _async_update_data(self) -> None:
         """Connect to the Probe Plus device on a set interval.
 

--- a/homeassistant/components/probe_plus/entity.py
+++ b/homeassistant/components/probe_plus/entity.py
@@ -1,6 +1,7 @@
 """Probe Plus base entity type."""
 
 from dataclasses import dataclass
+from typing import override
 
 from pyprobeplus import ProbePlusDevice
 
@@ -46,6 +47,7 @@ class ProbePlusEntity(CoordinatorEntity[ProbePlusDataUpdateCoordinator]):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if the entity is available."""
         return super().available and self.coordinator.device.connected

--- a/homeassistant/components/probe_plus/sensor.py
+++ b/homeassistant/components/probe_plus/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from homeassistant.components.sensor import (
     RestoreSensor,
@@ -101,6 +102,7 @@ class ProbeSensor(ProbePlusEntity, RestoreSensor):
     entity_description: ProbePlusSensorEntityDescription
 
     @property
+    @override
     def native_value(self) -> int | float | None:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.device)

--- a/homeassistant/components/profiler/config_flow.py
+++ b/homeassistant/components/profiler/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for Profiler integration."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 
@@ -12,6 +12,7 @@ class ProfilerConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/progettihwsw/binary_sensor.py
+++ b/homeassistant/components/progettihwsw/binary_sensor.py
@@ -3,6 +3,7 @@
 import asyncio
 from datetime import timedelta
 import logging
+from typing import override
 
 from ProgettiHWSW.input import Input
 
@@ -63,6 +64,7 @@ class ProgettihwswBinarySensor(CoordinatorEntity, BinarySensorEntity):
         self._sensor = sensor
 
     @property
+    @override
     def is_on(self) -> bool:
         """Get sensor state."""
         return self.coordinator.data[self._sensor.id]

--- a/homeassistant/components/progettihwsw/config_flow.py
+++ b/homeassistant/components/progettihwsw/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for ProgettiHWSW Automation integration."""
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from ProgettiHWSW.ProgettiHWSWAPI import ProgettiHWSWAPI
 import voluptuous as vol
@@ -75,6 +75,7 @@ class ProgettiHWSWConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/progettihwsw/switch.py
+++ b/homeassistant/components/progettihwsw/switch.py
@@ -3,7 +3,7 @@
 import asyncio
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from ProgettiHWSW.relay import Relay
 
@@ -63,22 +63,26 @@ class ProgettihwswSwitch(CoordinatorEntity, SwitchEntity):
         self._switch = switch
         self._attr_name = name
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         await self._switch.control(True)
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         await self._switch.control(False)
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_toggle(self, **kwargs: Any) -> None:
         """Toggle the state of switch."""
         await self._switch.toggle()
         await self.coordinator.async_request_refresh()
 
     @property
+    @override
     def is_on(self) -> bool:
         """Get switch state."""
         return self.coordinator.data[self._switch.id]

--- a/homeassistant/components/proliphix/climate.py
+++ b/homeassistant/components/proliphix/climate.py
@@ -1,6 +1,6 @@
 """Support for Proliphix NT10e Thermostats."""
 
-from typing import Any
+from typing import Any, override
 
 import proliphix
 import voluptuous as vol
@@ -71,21 +71,25 @@ class ProliphixThermostat(ClimateEntity):
         self._attr_name = self._pdp.name
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the device specific state attributes."""
         return {ATTR_FAN: self._pdp.fan_state}
 
     @property
+    @override
     def current_temperature(self) -> float:
         """Return the current temperature."""
         return self._pdp.cur_temp
 
     @property
+    @override
     def target_temperature(self) -> float:
         """Return the temperature we try to reach."""
         return self._pdp.setback
 
     @property
+    @override
     def hvac_action(self) -> HVACAction:
         """Return the current state of the thermostat."""
         state = self._pdp.hvac_state
@@ -98,6 +102,7 @@ class ProliphixThermostat(ClimateEntity):
         return HVACAction.IDLE
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode:
         """Return the current state of the thermostat."""
         if self._pdp.is_heating:
@@ -107,10 +112,12 @@ class ProliphixThermostat(ClimateEntity):
         return HVACMode.OFF
 
     @property
+    @override
     def hvac_modes(self) -> list[HVACMode]:
         """Return available HVAC modes."""
         return []
 
+    @override
     def set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:

--- a/homeassistant/components/prosegur/alarm_control_panel.py
+++ b/homeassistant/components/prosegur/alarm_control_panel.py
@@ -1,6 +1,7 @@
 """Support for Prosegur alarm control panels."""
 
 import logging
+from typing import override
 
 from pyprosegur.auth import Auth
 from pyprosegur.installation import Installation, Status
@@ -81,14 +82,17 @@ class ProsegurAlarm(AlarmControlPanelEntity):
         self._attr_alarm_state = STATE_MAPPING.get(self._installation.status)
         self._attr_available = True
 
+    @override
     async def async_alarm_disarm(self, code: str | None = None) -> None:
         """Send disarm command."""
         await self._installation.disarm(self._auth)
 
+    @override
     async def async_alarm_arm_home(self, code: str | None = None) -> None:
         """Send arm away command."""
         await self._installation.arm_partially(self._auth)
 
+    @override
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command."""
         await self._installation.arm(self._auth)

--- a/homeassistant/components/prosegur/camera.py
+++ b/homeassistant/components/prosegur/camera.py
@@ -1,6 +1,7 @@
 """Support for Prosegur cameras."""
 
 import logging
+from typing import override
 
 from pyprosegur.auth import Auth
 from pyprosegur.exceptions import ProsegurException
@@ -72,6 +73,7 @@ class ProsegurCamera(Camera):
             configuration_url="https://smart.prosegur.com",
         )
 
+    @override
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:

--- a/homeassistant/components/prosegur/config_flow.py
+++ b/homeassistant/components/prosegur/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyprosegur.auth import COUNTRY, Auth
 from pyprosegur.installation import Installation
@@ -50,6 +50,7 @@ class ProsegurConfigFlow(ConfigFlow, domain=DOMAIN):
     user_input: dict
     contracts: list[dict[str, str]]
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/prowl/config_flow.py
+++ b/homeassistant/components/prowl/config_flow.py
@@ -1,7 +1,7 @@
 """The config flow for the Prowl component."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 import prowlpy
 import voluptuous as vol
@@ -20,6 +20,7 @@ class ProwlConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/prowl/notify.py
+++ b/homeassistant/components/prowl/notify.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from typing import Any
+from typing import Any, override
 
 import httpx
 import prowlpy
@@ -64,6 +64,7 @@ class ProwlNotificationService(BaseNotificationService):
         self._hass = hass
         self._prowl = prowlpy.AsyncProwl(api_key, client=httpx_client)
 
+    @override
     async def async_send_message(self, message: str, **kwargs: Any) -> None:
         """Send the message to the user."""
         data = kwargs.get(ATTR_DATA, {})
@@ -114,6 +115,7 @@ class ProwlNotificationEntity(NotifyEntity):
         self._attr_name = name
         self._attr_unique_id = name
 
+    @override
     async def async_send_message(self, message: str, title: str | None = None) -> None:
         """Send the message."""
         _LOGGER.debug("Sending Prowl notification from entity %s", self.name)

--- a/homeassistant/components/proximity/config_flow.py
+++ b/homeassistant/components/proximity/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for proximity."""
 
-from typing import Any, cast
+from typing import Any, cast, override
 
 import voluptuous as vol
 
@@ -85,10 +85,12 @@ class ProximityConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(config_entry: ConfigEntry) -> ProximityOptionsFlow:
         """Get the options flow for this handler."""
         return ProximityOptionsFlow()
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/proximity/coordinator.py
+++ b/homeassistant/components/proximity/coordinator.py
@@ -3,7 +3,7 @@
 from collections import defaultdict
 from dataclasses import dataclass
 import logging
-from typing import cast
+from typing import cast, override
 
 from homeassistant.components.zone import DOMAIN as ZONE_DOMAIN
 from homeassistant.config_entries import ConfigEntry
@@ -233,6 +233,7 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
 
         return "stationary"
 
+    @override
     async def _async_update_data(self) -> ProximityData:
         """Calculate Proximity data."""
         if (zone_state := self.hass.states.get(self.proximity_zone_id)) is None:

--- a/homeassistant/components/proximity/sensor.py
+++ b/homeassistant/components/proximity/sensor.py
@@ -1,6 +1,6 @@
 """Support for Proximity sensors."""
 
-from typing import NamedTuple
+from typing import NamedTuple, override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -145,6 +145,7 @@ class ProximitySensor(CoordinatorEntity[ProximityDataUpdateCoordinator], SensorE
         self._attr_device_info = _device_info(coordinator)
 
     @property
+    @override
     def native_value(self) -> str | float | None:
         """Return native sensor value."""
         if (
@@ -183,6 +184,7 @@ class ProximityTrackedEntitySensor(
             "tracked_entity": tracked_entity_descriptor.name
         }
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register entity mapping."""
         await super().async_added_to_hass()
@@ -196,6 +198,7 @@ class ProximityTrackedEntitySensor(
         return self.coordinator.data.entities[self.tracked_entity_id]
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return (
@@ -204,6 +207,7 @@ class ProximityTrackedEntitySensor(
         )
 
     @property
+    @override
     def native_value(self) -> str | float | None:
         """Return native sensor value."""
         return self.data.get(self.entity_description.key)

--- a/homeassistant/components/proxmoxve/binary_sensor.py
+++ b/homeassistant/components/proxmoxve/binary_sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -215,6 +215,7 @@ class ProxmoxNodeBinarySensor(ProxmoxNodeEntity, BinarySensorEntity):
     entity_description: ProxmoxNodeBinarySensorEntityDescription
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
         return self.entity_description.state_fn(self.coordinator.data[self.device_name])
@@ -226,6 +227,7 @@ class ProxmoxVMBinarySensor(ProxmoxVMEntity, BinarySensorEntity):
     entity_description: ProxmoxVMBinarySensorEntityDescription
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
         return self.entity_description.state_fn(self.vm_data)
@@ -237,6 +239,7 @@ class ProxmoxContainerBinarySensor(ProxmoxContainerEntity, BinarySensorEntity):
     entity_description: ProxmoxContainerBinarySensorEntityDescription
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
         return self.entity_description.state_fn(self.container_data)
@@ -248,6 +251,7 @@ class ProxmoxStorageBinarySensor(ProxmoxStorageEntity, BinarySensorEntity):
     entity_description: ProxmoxStorageBinarySensorEntityDescription
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
         return self.entity_description.state_fn(self.storage_data)

--- a/homeassistant/components/proxmoxve/button.py
+++ b/homeassistant/components/proxmoxve/button.py
@@ -3,7 +3,7 @@
 from abc import abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from proxmoxer import AuthenticationError
 from proxmoxer.core import ResourceException
@@ -316,6 +316,7 @@ class ProxmoxBaseButton(ButtonEntity):
     async def _async_press_call(self) -> None:
         """Abstract method used per Proxmox button class."""
 
+    @override
     async def async_press(self) -> None:
         """Trigger the Proxmox button press service."""
         try:
@@ -347,6 +348,7 @@ class ProxmoxNodeButtonEntity(ProxmoxNodeEntity, ProxmoxBaseButton):
 
     entity_description: ProxmoxNodeButtonNodeEntityDescription
 
+    @override
     async def _async_press_call(self) -> None:
         """Execute the node button action via executor."""
         node_id = self._node_data.node["node"]
@@ -372,6 +374,7 @@ class ProxmoxVMButtonEntity(ProxmoxVMEntity, ProxmoxBaseButton):
 
     entity_description: ProxmoxVMButtonEntityDescription
 
+    @override
     async def _async_press_call(self) -> None:
         """Execute the VM button action via executor."""
         vmid = self.vm_data["vmid"]
@@ -398,6 +401,7 @@ class ProxmoxContainerButtonEntity(ProxmoxContainerEntity, ProxmoxBaseButton):
 
     entity_description: ProxmoxContainerButtonEntityDescription
 
+    @override
     async def _async_press_call(self) -> None:
         """Execute the container button action via executor."""
         vmid = self.container_data["vmid"]

--- a/homeassistant/components/proxmoxve/config_flow.py
+++ b/homeassistant/components/proxmoxve/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from proxmoxer import AuthenticationError, ProxmoxAPI
 from proxmoxer.core import ResourceException
@@ -167,6 +167,7 @@ class ProxmoxveConfigFlow(ConfigFlow, domain=DOMAIN):
     _data: dict[str, Any] = {}
     _entry: ConfigEntry
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/proxmoxve/coordinator.py
+++ b/homeassistant/components/proxmoxve/coordinator.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from proxmoxer import AuthenticationError, ProxmoxAPI
 from proxmoxer.core import ResourceException
@@ -100,6 +100,7 @@ class ProxmoxCoordinator(DataUpdateCoordinator[dict[str, ProxmoxNodeData]]):
             Callable[[list[tuple[ProxmoxNodeData, dict[str, Any]]]], None]
         ] = []
 
+    @override
     async def _async_setup(self) -> None:
         """Set up the coordinator."""
         try:
@@ -145,6 +146,7 @@ class ProxmoxCoordinator(DataUpdateCoordinator[dict[str, ProxmoxNodeData]]):
                 translation_placeholders={"error": repr(err)},
             ) from err
 
+    @override
     async def _async_update_data(self) -> dict[str, ProxmoxNodeData]:
         """Fetch data from Proxmox VE API."""
 

--- a/homeassistant/components/proxmoxve/entity.py
+++ b/homeassistant/components/proxmoxve/entity.py
@@ -1,6 +1,6 @@
 """Proxmox parent entity class."""
 
-from typing import Any
+from typing import Any, override
 
 from yarl import URL
 
@@ -62,6 +62,7 @@ class ProxmoxNodeEntity(ProxmoxCoordinatorEntity):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return if the device is available."""
         return super().available and self.device_name in self.coordinator.data
@@ -110,6 +111,7 @@ class ProxmoxStorageEntity(ProxmoxCoordinatorEntity):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return if the device is available."""
         return (
@@ -163,6 +165,7 @@ class ProxmoxVMEntity(ProxmoxCoordinatorEntity):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return if the device is available."""
         return (
@@ -219,6 +222,7 @@ class ProxmoxContainerEntity(ProxmoxCoordinatorEntity):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return if the device is available."""
         return (

--- a/homeassistant/components/proxmoxve/sensor.py
+++ b/homeassistant/components/proxmoxve/sensor.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.sensor import (
     EntityCategory,
@@ -528,6 +528,7 @@ class ProxmoxNodeSensor(ProxmoxNodeEntity, SensorEntity):
     entity_description: ProxmoxNodeSensorEntityDescription
 
     @property
+    @override
     def native_value(self) -> StateType | datetime:
         """Return the native value of the sensor."""
         return self.entity_description.value_fn(self.coordinator.data[self.device_name])
@@ -539,6 +540,7 @@ class ProxmoxVMSensor(ProxmoxVMEntity, SensorEntity):
     entity_description: ProxmoxVMSensorEntityDescription
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the native value of the sensor."""
         return self.entity_description.value_fn(self.vm_data)
@@ -550,6 +552,7 @@ class ProxmoxContainerSensor(ProxmoxContainerEntity, SensorEntity):
     entity_description: ProxmoxContainerSensorEntityDescription
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the native value of the sensor."""
         return self.entity_description.value_fn(self.container_data)
@@ -561,6 +564,7 @@ class ProxmoxStorageSensor(ProxmoxStorageEntity, SensorEntity):
     entity_description: ProxmoxStorageSensorEntityDescription
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the native value of the sensor."""
         return self.entity_description.value_fn(self.storage_data)

--- a/homeassistant/components/proxy/camera.py
+++ b/homeassistant/components/proxy/camera.py
@@ -4,6 +4,7 @@ import asyncio
 from datetime import timedelta
 import io
 import logging
+from typing import override
 
 from PIL import Image
 import voluptuous as vol
@@ -239,6 +240,7 @@ class ProxyCamera(Camera):
         self._last_image = None
         self._mode = config.get(CONF_MODE)
 
+    @override
     def camera_image(
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
@@ -247,6 +249,7 @@ class ProxyCamera(Camera):
             self.async_camera_image(), self.hass.loop
         ).result()
 
+    @override
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
@@ -276,6 +279,7 @@ class ProxyCamera(Camera):
             self._last_image = image_bytes
         return image_bytes
 
+    @override
     async def handle_async_mjpeg_stream(self, request):
         """Generate an HTTP MJPEG stream from camera images."""
         if not self._stream_opts:
@@ -288,6 +292,7 @@ class ProxyCamera(Camera):
         )
 
     @property
+    @override
     def name(self):
         """Return the name of this camera."""
         return self._name

--- a/homeassistant/components/prusalink/binary_sensor.py
+++ b/homeassistant/components/prusalink/binary_sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import cast
+from typing import cast, override
 
 from pyprusalink.types import JobInfo, PrinterInfo, PrinterStatus, StatusInfo
 from pyprusalink.types_legacy import LegacyPrinterStatus
@@ -106,6 +106,7 @@ class PrusaLinkBinarySensorEntity(PrusaLinkEntity, BinarySensorEntity):
         self._attr_unique_id = f"{coordinator.config_entry.entry_id}_{description.key}"
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/prusalink/button.py
+++ b/homeassistant/components/prusalink/button.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any, cast, override
 
 from pyprusalink import JobInfo, LegacyPrinterStatus, PrinterStatus, PrusaLink
 from pyprusalink.types import Conflict, PrinterState
@@ -102,6 +102,7 @@ class PrusaLinkButtonEntity(PrusaLinkEntity, ButtonEntity):
         self.entity_description = description
         self._attr_unique_id = f"{coordinator.config_entry.entry_id}_{description.key}"
 
+    @override
     async def async_press(self) -> None:
         """Press the button."""
         job_id = self.coordinator.data["job"]["id"]

--- a/homeassistant/components/prusalink/camera.py
+++ b/homeassistant/components/prusalink/camera.py
@@ -1,6 +1,7 @@
 """Camera entity for PrusaLink."""
 
 from dataclasses import dataclass
+from typing import override
 
 from pyprusalink.types import PrinterState
 
@@ -50,6 +51,7 @@ class PrusaLinkJobPreviewEntity(PrusaLinkEntity, Camera):
         Camera.__init__(self)
         self._attr_unique_id = f"{self.coordinator.config_entry.entry_id}_job_preview"
 
+    @override
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:

--- a/homeassistant/components/prusalink/config_flow.py
+++ b/homeassistant/components/prusalink/config_flow.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from typing import Any
+from typing import Any, override
 
 from awesomeversion import AwesomeVersion, AwesomeVersionException
 from httpx import HTTPError, InvalidURL
@@ -85,6 +85,7 @@ class PrusaLinkConfigFlow(ConfigFlow, domain=DOMAIN):
     VERSION = 1
     MINOR_VERSION = 2
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/prusalink/coordinator.py
+++ b/homeassistant/components/prusalink/coordinator.py
@@ -5,7 +5,7 @@ import asyncio
 from datetime import timedelta
 import logging
 from time import monotonic
-from typing import TypeVar
+from typing import TypeVar, override
 
 from httpx import ConnectError
 from pyprusalink import (
@@ -73,6 +73,7 @@ class PrusaLinkUpdateCoordinator(DataUpdateCoordinator[T], ABC):
             ),
         )
 
+    @override
     async def _async_update_data(self) -> T:
         """Update the data."""
         try:
@@ -116,6 +117,7 @@ class PrusaLinkUpdateCoordinator(DataUpdateCoordinator[T], ABC):
 class StatusCoordinator(PrusaLinkUpdateCoordinator[PrinterStatus]):
     """Printer update coordinator."""
 
+    @override
     async def _fetch_data(self) -> PrinterStatus:
         """Fetch the printer data."""
         return await self.api.get_status()
@@ -124,6 +126,7 @@ class StatusCoordinator(PrusaLinkUpdateCoordinator[PrinterStatus]):
 class LegacyStatusCoordinator(PrusaLinkUpdateCoordinator[LegacyPrinterStatus]):
     """Printer legacy update coordinator."""
 
+    @override
     async def _fetch_data(self) -> LegacyPrinterStatus:
         """Fetch the printer data."""
         return await self.api.get_legacy_printer()
@@ -137,6 +140,7 @@ class JobUpdateCoordinator(PrusaLinkUpdateCoordinator[JobInfo | None]):
     coordinator's data must be `None`-aware.
     """
 
+    @override
     async def _fetch_data(self) -> JobInfo | None:
         """Fetch the printer data."""
         return await self.api.get_job()
@@ -145,6 +149,7 @@ class JobUpdateCoordinator(PrusaLinkUpdateCoordinator[JobInfo | None]):
 class InfoUpdateCoordinator(PrusaLinkUpdateCoordinator[PrinterInfo]):
     """Info update coordinator."""
 
+    @override
     async def _fetch_data(self) -> PrinterInfo:
         """Fetch the printer data."""
         return await self.api.get_info()
@@ -153,6 +158,7 @@ class InfoUpdateCoordinator(PrusaLinkUpdateCoordinator[PrinterInfo]):
 class VersionUpdateCoordinator(PrusaLinkUpdateCoordinator[VersionInfo]):
     """Version update coordinator."""
 
+    @override
     async def _fetch_data(self) -> VersionInfo:
         """Fetch the version data."""
         return await self.api.get_version()

--- a/homeassistant/components/prusalink/entity.py
+++ b/homeassistant/components/prusalink/entity.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
@@ -27,6 +27,7 @@ class PrusaLinkEntity(CoordinatorEntity[PrusaLinkUpdateCoordinator]):
     entity_description: PrusaLinkEntityDescription
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         # `coordinator.data` can be None when the underlying endpoint
@@ -41,6 +42,7 @@ class PrusaLinkEntity(CoordinatorEntity[PrusaLinkUpdateCoordinator]):
         )
 
     @property
+    @override
     def device_info(self) -> DeviceInfo:
         """Return device information about this PrusaLink device."""
         coordinators = self.coordinator.config_entry.runtime_data

--- a/homeassistant/components/prusalink/sensor.py
+++ b/homeassistant/components/prusalink/sensor.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import cast
+from typing import cast, override
 
 from pyprusalink.types import (
     JobFilePrint,
@@ -275,6 +275,7 @@ class PrusaLinkSensorEntity(PrusaLinkEntity, SensorEntity):
         self._attr_unique_id = f"{coordinator.config_entry.entry_id}_{description.key}"
 
     @property
+    @override
     def native_value(self) -> datetime | StateType:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/ps4/config_flow.py
+++ b/homeassistant/components/ps4/config_flow.py
@@ -1,7 +1,7 @@
 """Config Flow for PlayStation 4."""
 
 from collections import OrderedDict
-from typing import Any
+from typing import Any, override
 
 from pyps4_2ndscreen.errors import CredentialTimeout
 from pyps4_2ndscreen.helpers import Helper
@@ -58,6 +58,7 @@ class PlayStation4FlowHandler(ConfigFlow, domain=DOMAIN):
         self.location: location_util.LocationInfo | None = None
         self.device_list: list[str] = []
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -2,7 +2,7 @@
 
 from contextlib import suppress
 import logging
-from typing import Any, cast
+from typing import Any, cast, override
 
 from pyps4_2ndscreen.errors import NotReady, PSDataIncomplete
 from pyps4_2ndscreen.media_art import TYPE_APP as PS_TYPE_APP
@@ -125,6 +125,7 @@ class PS4Device(MediaPlayerEntity):
                 self._region,
             )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Subscribe PS4 events."""
         self.hass.data[PS4_DATA].devices.append(self)
@@ -379,6 +380,7 @@ class PS4Device(MediaPlayerEntity):
 
             self._attr_unique_id = format_unique_id(self._creds, status["host-id"])
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Remove Entity from Home Assistant."""
         # Close TCP Transport.
@@ -388,6 +390,7 @@ class PS4Device(MediaPlayerEntity):
         self.hass.data[PS4_DATA].devices.remove(self)
 
     @property
+    @override
     def entity_picture(self) -> str | None:
         """Return picture."""
         if (
@@ -402,32 +405,39 @@ class PS4Device(MediaPlayerEntity):
         return None
 
     @property
+    @override
     def media_image_url(self) -> str | None:
         """Image url of current playing media."""
         if self.media_content_id is None:
             return None
         return self._media_image
 
+    @override
     async def async_turn_off(self) -> None:
         """Turn off media player."""
         await self._ps4.standby()
 
+    @override
     async def async_turn_on(self) -> None:
         """Turn on the media player."""
         self._ps4.wakeup()
 
+    @override
     async def async_toggle(self) -> None:
         """Toggle media player."""
         await self._ps4.toggle()
 
+    @override
     async def async_media_pause(self) -> None:
         """Send keypress ps to return to menu."""
         await self.async_send_remote_control("ps")
 
+    @override
     async def async_media_stop(self) -> None:
         """Send keypress ps to return to menu."""
         await self.async_send_remote_control("ps")
 
+    @override
     async def async_select_source(self, source: str) -> None:
         """Select input source."""
         for title_id, data in self._games.items():

--- a/homeassistant/components/ptdevices/config_flow.py
+++ b/homeassistant/components/ptdevices/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for PTDevices integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 import aioptdevices
 from aioptdevices.configuration import Configuration
@@ -73,6 +73,7 @@ class PTDevicesConfigFlow(ConfigFlow, domain=DOMAIN):
     VERSION = 1
     MINOR_VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/ptdevices/coordinator.py
+++ b/homeassistant/components/ptdevices/coordinator.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 import logging
-from typing import Final
+from typing import Final, override
 
 import aioptdevices
 from aioptdevices.interface import Interface, PTDevicesResponseData
@@ -54,6 +54,7 @@ class PTDevicesCoordinator(DataUpdateCoordinator[PTDevicesResponseData]):
 
         self.interface = ptdevices_interface
 
+    @override
     async def _async_update_data(self) -> PTDevicesResponseData:
         try:
             data = await self.interface.get_data()

--- a/homeassistant/components/ptdevices/entity.py
+++ b/homeassistant/components/ptdevices/entity.py
@@ -1,6 +1,6 @@
 """PTDevices integration."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -44,6 +44,7 @@ class PTDevicesEntity(CoordinatorEntity[PTDevicesCoordinator]):
         return self.coordinator.data[self._device_id]
 
     @property
+    @override
     def available(self) -> bool:
         """Return if the device is available."""
         return super().available and self._device_id in self.coordinator.data

--- a/homeassistant/components/ptdevices/sensor.py
+++ b/homeassistant/components/ptdevices/sensor.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import cast
+from typing import cast, override
 
 from aioptdevices.interface import PTDevicesStatusStates
 
@@ -198,6 +198,7 @@ class PTDevicesSensorEntity(PTDevicesEntity, SensorEntity):
         self.entity_description = description
 
     @property
+    @override
     def native_value(self) -> float | int | str | None:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.device)

--- a/homeassistant/components/pterodactyl/binary_sensor.py
+++ b/homeassistant/components/pterodactyl/binary_sensor.py
@@ -1,5 +1,7 @@
 """Binary sensor platform of the Pterodactyl integration."""
 
+from typing import override
+
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
@@ -59,6 +61,7 @@ class PterodactylBinarySensorEntity(PterodactylEntity, BinarySensorEntity):
         self._attr_unique_id = f"{self.game_server_data.uuid}_{description.key}"
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return binary sensor state."""
         return self.game_server_data.state == "running"

--- a/homeassistant/components/pterodactyl/button.py
+++ b/homeassistant/components/pterodactyl/button.py
@@ -1,6 +1,7 @@
 """Button platform for the Pterodactyl integration."""
 
 from dataclasses import dataclass
+from typing import override
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.core import HomeAssistant
@@ -88,6 +89,7 @@ class PterodactylButtonEntity(PterodactylEntity, ButtonEntity):
         self.entity_description = description
         self._attr_unique_id = f"{self.game_server_data.uuid}_{description.key}"
 
+    @override
     async def async_press(self) -> None:
         """Handle the button press."""
         try:

--- a/homeassistant/components/pterodactyl/config_flow.py
+++ b/homeassistant/components/pterodactyl/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 from yarl import URL
@@ -57,6 +57,7 @@ class PterodactylConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return errors
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/pterodactyl/coordinator.py
+++ b/homeassistant/components/pterodactyl/coordinator.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import logging
+from typing import override
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY, CONF_URL
@@ -44,6 +45,7 @@ class PterodactylCoordinator(DataUpdateCoordinator[dict[str, PterodactylData]]):
             update_interval=SCAN_INTERVAL,
         )
 
+    @override
     async def _async_setup(self) -> None:
         """Set up the Pterodactyl data coordinator."""
         self.api = PterodactylAPI(
@@ -59,6 +61,7 @@ class PterodactylCoordinator(DataUpdateCoordinator[dict[str, PterodactylData]]):
         except PterodactylAuthorizationError as error:
             raise ConfigEntryAuthFailed(error) from error
 
+    @override
     async def _async_update_data(self) -> dict[str, PterodactylData]:
         """Get updated data from the Pterodactyl server."""
         try:

--- a/homeassistant/components/pterodactyl/entity.py
+++ b/homeassistant/components/pterodactyl/entity.py
@@ -1,5 +1,7 @@
 """Base entity for the Pterodactyl integration."""
 
+from typing import override
+
 from yarl import URL
 
 from homeassistant.config_entries import ConfigEntry
@@ -41,6 +43,7 @@ class PterodactylEntity(CoordinatorEntity[PterodactylCoordinator]):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return binary sensor availability."""
         return super().available and self.identifier in self.coordinator.data

--- a/homeassistant/components/pterodactyl/sensor.py
+++ b/homeassistant/components/pterodactyl/sensor.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from typing import override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -178,6 +179,7 @@ class PterodactylSensorEntity(PterodactylEntity, SensorEntity):
         self._attr_unique_id = f"{self.game_server_data.uuid}_{description.key}"
 
     @property
+    @override
     def native_value(self) -> StateType | datetime:
         """Return native value of sensor."""
         return self.entity_description.value_fn(self.game_server_data)

--- a/homeassistant/components/pulseaudio_loopback/switch.py
+++ b/homeassistant/components/pulseaudio_loopback/switch.py
@@ -1,7 +1,7 @@
 """Switch logic for loading/unloading pulseaudio loopback modules."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from pulsectl import Pulse, PulseError
 import voluptuous as vol
@@ -103,20 +103,24 @@ class PALoopbackSwitch(SwitchEntity):
         return None
 
     @property
+    @override
     def available(self) -> bool:
         """Return true when connected to server."""
         return self._pa_svr.connected
 
     @property
+    @override
     def name(self):
         """Return the name of the switch."""
         return self._name
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if device is on."""
         return self._module_idx is not None
 
+    @override
     def turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
         if not self.is_on:
@@ -127,6 +131,7 @@ class PALoopbackSwitch(SwitchEntity):
         else:
             _LOGGER.warning(IGNORED_SWITCH_WARN)
 
+    @override
     def turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
         if self.is_on:

--- a/homeassistant/components/pure_energie/config_flow.py
+++ b/homeassistant/components/pure_energie/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for Pure Energie integration."""
 
-from typing import Any
+from typing import Any, override
 
 from gridnet import Device, GridNet, GridNetConnectionError
 import voluptuous as vol
@@ -21,6 +21,7 @@ class PureEnergieFlowHandler(ConfigFlow, domain=DOMAIN):
     discovered_host: str
     discovered_device: Device
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -55,6 +56,7 @@ class PureEnergieFlowHandler(ConfigFlow, domain=DOMAIN):
             errors=errors or {},
         )
 
+    @override
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/pure_energie/coordinator.py
+++ b/homeassistant/components/pure_energie/coordinator.py
@@ -1,6 +1,6 @@
 """Coordinator for the Pure Energie integration."""
 
-from typing import NamedTuple
+from typing import NamedTuple, override
 
 from gridnet import Device, GridNet, SmartBridge
 
@@ -45,6 +45,7 @@ class PureEnergieDataUpdateCoordinator(DataUpdateCoordinator[PureEnergieData]):
             self.config_entry.data[CONF_HOST], session=async_get_clientsession(hass)
         )
 
+    @override
     async def _async_update_data(self) -> PureEnergieData:
         """Fetch data from SmartBridge."""
         return PureEnergieData(

--- a/homeassistant/components/pure_energie/sensor.py
+++ b/homeassistant/components/pure_energie/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from homeassistant.components.sensor import (
     DOMAIN as SENSOR_DOMAIN,
@@ -105,6 +106,7 @@ class PureEnergieSensorEntity(
         )
 
     @property
+    @override
     def native_value(self) -> int | float:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/purpleair/config_flow.py
+++ b/homeassistant/components/purpleair/config_flow.py
@@ -4,7 +4,7 @@ import asyncio
 from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import dataclass, field
-from typing import Any, cast
+from typing import Any, cast, override
 
 from aiopurpleair import API
 from aiopurpleair.endpoints.sensors import NearbySensorResult
@@ -203,6 +203,7 @@ class PurpleAirConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> PurpleAirOptionsFlowHandler:
@@ -287,6 +288,7 @@ class PurpleAirConfigFlow(ConfigFlow, domain=DOMAIN):
             self._get_reauth_entry(), data={CONF_API_KEY: api_key}
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/purpleair/coordinator.py
+++ b/homeassistant/components/purpleair/coordinator.py
@@ -1,6 +1,7 @@
 """Define a PurpleAir DataUpdateCoordinator."""
 
 from datetime import timedelta
+from typing import override
 
 from aiopurpleair import API
 from aiopurpleair.errors import InvalidApiKeyError, PurpleAirError
@@ -67,6 +68,7 @@ class PurpleAirDataUpdateCoordinator(DataUpdateCoordinator[GetSensorsResponse]):
             update_interval=UPDATE_INTERVAL,
         )
 
+    @override
     async def _async_update_data(self) -> GetSensorsResponse:
         """Get the latest sensor information."""
         try:

--- a/homeassistant/components/purpleair/entity.py
+++ b/homeassistant/components/purpleair/entity.py
@@ -1,7 +1,7 @@
 """The PurpleAir integration."""
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, override
 
 from aiopurpleair.models.sensors import SensorModel
 
@@ -40,6 +40,7 @@ class PurpleAirEntity(CoordinatorEntity[PurpleAirDataUpdateCoordinator]):
         self._entry = entry
 
     @property
+    @override
     def extra_state_attributes(self) -> Mapping[str, Any]:
         """Return entity specific state attributes."""
         attrs = {}

--- a/homeassistant/components/purpleair/sensor.py
+++ b/homeassistant/components/purpleair/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from aiopurpleair.models.sensors import SensorModel
 
@@ -191,6 +192,7 @@ class PurpleAirSensorEntity(PurpleAirEntity, SensorEntity):
         self.entity_description = description
 
     @property
+    @override
     def native_value(self) -> float | str | None:
         """Return the sensor value."""
         return self.entity_description.value_fn(self.sensor_data)

--- a/homeassistant/components/push/camera.py
+++ b/homeassistant/components/push/camera.py
@@ -4,7 +4,7 @@ import asyncio
 from collections import deque
 from datetime import timedelta
 import logging
-from typing import Any, cast
+from typing import Any, cast, override
 
 from aiohttp import web
 import voluptuous as vol
@@ -124,6 +124,7 @@ class PushCamera(Camera):
         self.webhook_id = webhook_id
         self.webhook_url = webhook.async_generate_url(hass, webhook_id)
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Call when entity is added to hass."""
         self.hass.data[PUSH_CAMERA_DATA][self.webhook_id] = self
@@ -169,6 +170,7 @@ class PushCamera(Camera):
 
         self.async_write_ha_state()
 
+    @override
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
@@ -181,6 +183,7 @@ class PushCamera(Camera):
         return self._current_image
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         return {

--- a/homeassistant/components/pushbullet/config_flow.py
+++ b/homeassistant/components/pushbullet/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for pushbullet integration."""
 
-from typing import Any
+from typing import Any, override
 
 from pushbullet import InvalidKeyError, PushBullet, PushbulletError
 import voluptuous as vol
@@ -24,6 +24,7 @@ CONFIG_SCHEMA = vol.Schema(
 class PushBulletConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for pushbullet integration."""
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/pushbullet/notify.py
+++ b/homeassistant/components/pushbullet/notify.py
@@ -2,7 +2,7 @@
 
 import logging
 import mimetypes
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from pushbullet import PushBullet, PushError
 from pushbullet.channel import Channel
@@ -57,6 +57,7 @@ class PushBulletNotificationService(BaseNotificationService):
             },
         }
 
+    @override
     def send_message(self, message: str, **kwargs: Any) -> None:
         """Send a message to a specified target.
 

--- a/homeassistant/components/pushbullet/sensor.py
+++ b/homeassistant/components/pushbullet/sensor.py
@@ -1,5 +1,7 @@
 """Pushbullet platform for sensor component."""
 
+from typing import override
+
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
 from homeassistant.const import CONF_NAME, MAX_LENGTH_STATE_STATE
 from homeassistant.core import HomeAssistant, callback
@@ -126,6 +128,7 @@ class PushBulletNotificationSensor(SensorEntity):
             pass
         self.async_write_ha_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
         self.async_on_remove(

--- a/homeassistant/components/pushover/config_flow.py
+++ b/homeassistant/components/pushover/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for pushover integration."""
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, override
 
 from pushover_complete import BadAPIRequestError, PushoverAPI
 import voluptuous as vol
@@ -84,6 +84,7 @@ class PushBulletConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/pushover/notify.py
+++ b/homeassistant/components/pushover/notify.py
@@ -1,7 +1,7 @@
 """Pushover platform for notify component."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from pushover_complete import BadAPIRequestError, PushoverAPI
 
@@ -62,6 +62,7 @@ class PushoverNotificationService(BaseNotificationService):
         self._user_key = user_key
         self.pushover = pushover
 
+    @override
     def send_message(self, message: str = "", **kwargs: Any) -> None:
         """Send a message to a user."""
 

--- a/homeassistant/components/pushsafer/notify.py
+++ b/homeassistant/components/pushsafer/notify.py
@@ -4,7 +4,7 @@ import base64
 from http import HTTPStatus
 import logging
 import mimetypes
-from typing import Any
+from typing import Any, override
 
 import requests
 from requests.auth import HTTPBasicAuth
@@ -74,6 +74,7 @@ class PushsaferNotificationService(BaseNotificationService):
         """Initialize the service."""
         self._private_key = private_key
 
+    @override
     def send_message(self, message: str = "", **kwargs: Any) -> None:
         """Send a message to specified target."""
         targets: list[str] | None

--- a/homeassistant/components/pvoutput/config_flow.py
+++ b/homeassistant/components/pvoutput/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow to configure the PVOutput integration."""
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, override
 
 from pvo import PVOutput, PVOutputAuthenticationError, PVOutputError
 import voluptuous as vol
@@ -30,6 +30,7 @@ class PVOutputFlowHandler(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/pvoutput/coordinator.py
+++ b/homeassistant/components/pvoutput/coordinator.py
@@ -1,5 +1,7 @@
 """DataUpdateCoordinator for the PVOutput integration."""
 
+from typing import override
+
 from pvo import (
     PVOutput,
     PVOutputAuthenticationError,
@@ -38,6 +40,7 @@ class PVOutputDataUpdateCoordinator(DataUpdateCoordinator[Status]):
             hass, LOGGER, config_entry=entry, name=DOMAIN, update_interval=SCAN_INTERVAL
         )
 
+    @override
     async def _async_update_data(self) -> Status:
         """Fetch system status from PVOutput."""
         try:

--- a/homeassistant/components/pvoutput/sensor.py
+++ b/homeassistant/components/pvoutput/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from pvo import Status, System
 
@@ -143,6 +144,7 @@ class PVOutputSensorEntity(
         )
 
     @property
+    @override
     def native_value(self) -> int | float | None:
         """Return the state of the device."""
         return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/pvpc_hourly_pricing/config_flow.py
+++ b/homeassistant/components/pvpc_hourly_pricing/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for pvpc_hourly_pricing."""
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, override
 
 from esios_api import DEFAULT_POWER_KW, PVPCData
 import voluptuous as vol
@@ -50,12 +50,14 @@ class TariffSelectorConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> PVPCOptionsFlowHandler:
         """Get the options flow for this handler."""
         return PVPCOptionsFlowHandler()
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/pvpc_hourly_pricing/coordinator.py
+++ b/homeassistant/components/pvpc_hourly_pricing/coordinator.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import logging
+from typing import override
 
 from esios_api import BadApiTokenAuthError, EsiosApiData, PVPCData
 
@@ -54,6 +55,7 @@ class ElecPricesDataUpdateCoordinator(DataUpdateCoordinator[EsiosApiData]):
         """Return entry ID."""
         return self.config_entry.entry_id
 
+    @override
     async def _async_update_data(self) -> EsiosApiData:
         """Update electricity prices from the ESIOS API."""
         try:

--- a/homeassistant/components/pvpc_hourly_pricing/sensor.py
+++ b/homeassistant/components/pvpc_hourly_pricing/sensor.py
@@ -3,7 +3,7 @@
 from collections.abc import Mapping
 from datetime import datetime
 import logging
-from typing import Any
+from typing import Any, override
 
 from esios_api.const import KEY_INJECTION, KEY_MAG, KEY_OMIE, KEY_PVPC
 
@@ -185,12 +185,14 @@ class ElecPriceSensor(CoordinatorEntity[ElecPricesDataUpdateCoordinator], Sensor
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return self.coordinator.data.availability.get(
             self.entity_description.key, False
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Handle entity which will be added."""
         await super().async_added_to_hass()
@@ -224,11 +226,13 @@ class ElecPriceSensor(CoordinatorEntity[ElecPricesDataUpdateCoordinator], Sensor
         self.async_write_ha_state()
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
         return self.coordinator.api.states.get(self.entity_description.key)
 
     @property
+    @override
     def extra_state_attributes(self) -> Mapping[str, Any]:
         """Return the state attributes."""
         sensor_attributes = self.coordinator.api.sensor_attributes.get(

--- a/homeassistant/components/pyload/button.py
+++ b/homeassistant/components/pyload/button.py
@@ -3,7 +3,7 @@
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Any
+from typing import Any, override
 
 from pyloadapi import CannotConnect, InvalidAuth, PyLoadAPI
 
@@ -80,6 +80,7 @@ class PyLoadBinarySensor(BasePyLoadEntity, ButtonEntity):
 
     entity_description: PyLoadButtonEntityDescription
 
+    @override
     async def async_press(self) -> None:
         """Handle the button press."""
         try:

--- a/homeassistant/components/pyload/config_flow.py
+++ b/homeassistant/components/pyload/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from aiohttp import CookieJar
 from pyloadapi import CannotConnect, InvalidAuth, ParserError, PyLoadAPI
@@ -103,6 +103,7 @@ class PyLoadConfigFlow(ConfigFlow, domain=DOMAIN):
 
     _hassio_discovery: HassioServiceInfo | None = None
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -218,6 +219,7 @@ class PyLoadConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    @override
     async def async_step_hassio(
         self, discovery_info: HassioServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/pyload/coordinator.py
+++ b/homeassistant/components/pyload/coordinator.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
+from typing import override
 
 from pyloadapi import CannotConnect, InvalidAuth, ParserError, PyLoadAPI
 
@@ -56,6 +57,7 @@ class PyLoadCoordinator(DataUpdateCoordinator[PyLoadData]):
         self.pyload = pyload
         self.version: str | None = None
 
+    @override
     async def _async_update_data(self) -> PyLoadData:
         """Fetch data from API endpoint."""
         try:
@@ -79,6 +81,7 @@ class PyLoadCoordinator(DataUpdateCoordinator[PyLoadData]):
                 translation_key="setup_parse_exception",
             ) from e
 
+    @override
     async def _async_setup(self) -> None:
         """Set up the coordinator."""
 

--- a/homeassistant/components/pyload/sensor.py
+++ b/homeassistant/components/pyload/sensor.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
+from typing import override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -108,6 +109,7 @@ class PyLoadSensor(BasePyLoadEntity, SensorEntity):
     entity_description: PyLoadSensorEntityDescription
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/pyload/switch.py
+++ b/homeassistant/components/pyload/switch.py
@@ -3,7 +3,7 @@
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Any
+from typing import Any, override
 
 from pyloadapi import CannotConnect, InvalidAuth, PyLoadAPI
 
@@ -83,12 +83,14 @@ class PyLoadSwitchEntity(BasePyLoadEntity, SwitchEntity):
     entity_description: PyLoadSwitchEntityDescription
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return the state of the device."""
         return self.entity_description.value_fn(
             self.coordinator.data,
         )
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         try:
@@ -106,6 +108,7 @@ class PyLoadSwitchEntity(BasePyLoadEntity, SwitchEntity):
 
         await self.coordinator.async_refresh()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         try:
@@ -123,6 +126,7 @@ class PyLoadSwitchEntity(BasePyLoadEntity, SwitchEntity):
 
         await self.coordinator.async_refresh()
 
+    @override
     async def async_toggle(self, **kwargs: Any) -> None:
         """Toggle the entity."""
         try:

--- a/homeassistant/components/qbittorrent/config_flow.py
+++ b/homeassistant/components/qbittorrent/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for qBittorrent."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from qbittorrentapi import APIConnectionError, Forbidden403Error, LoginFailed
 import voluptuous as vol
@@ -27,6 +27,7 @@ USER_DATA_SCHEMA = vol.Schema(
 class QbittorrentConfigFlow(ConfigFlow, domain=DOMAIN):
     """Config flow for the qBittorrent integration."""
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/qbittorrent/coordinator.py
+++ b/homeassistant/components/qbittorrent/coordinator.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import logging
+from typing import override
 
 from qbittorrentapi import (
     APIConnectionError,
@@ -52,6 +53,7 @@ class QBittorrentDataCoordinator(DataUpdateCoordinator[SyncMainDataDictionary]):
             update_interval=timedelta(seconds=30),
         )
 
+    @override
     async def _async_update_data(self) -> SyncMainDataDictionary:
         try:
             data = await self.hass.async_add_executor_job(self.client.sync_maindata)

--- a/homeassistant/components/qbittorrent/sensor.py
+++ b/homeassistant/components/qbittorrent/sensor.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 import logging
-from typing import Any, cast
+from typing import Any, cast, override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -269,6 +269,7 @@ class QBittorrentSensor(CoordinatorEntity[QBittorrentDataCoordinator], SensorEnt
         )
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the value of the sensor."""
         return self.entity_description.value_fn(self.coordinator)

--- a/homeassistant/components/qbittorrent/switch.py
+++ b/homeassistant/components/qbittorrent/switch.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.core import HomeAssistant
@@ -75,10 +75,12 @@ class QBittorrentSwitch(CoordinatorEntity[QBittorrentDataCoordinator], SwitchEnt
         )
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if device is on."""
         return self.entity_description.is_on_func(self.coordinator)
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on this switch."""
         await self.hass.async_add_executor_job(
@@ -86,6 +88,7 @@ class QBittorrentSwitch(CoordinatorEntity[QBittorrentDataCoordinator], SwitchEnt
         )
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off this switch."""
         await self.hass.async_add_executor_job(
@@ -93,6 +96,7 @@ class QBittorrentSwitch(CoordinatorEntity[QBittorrentDataCoordinator], SwitchEnt
         )
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_toggle(self, **kwargs: Any) -> None:
         """Toggle the device."""
         await self.hass.async_add_executor_job(

--- a/homeassistant/components/qbus/binary_sensor.py
+++ b/homeassistant/components/qbus/binary_sensor.py
@@ -1,7 +1,7 @@
 """Support for Qbus binary sensor."""
 
 from dataclasses import dataclass
-from typing import cast
+from typing import cast, override
 
 from qbusmqttapi.discovery import QbusMqttDevice, QbusMqttOutput
 from qbusmqttapi.factory import QbusMqttTopicFactory
@@ -103,6 +103,7 @@ class QbusWeatherBinarySensor(QbusEntity, BinarySensorEntity):
 
         self.entity_description = description
 
+    @override
     async def _handle_state_received(self, state: QbusMqttWeatherState) -> None:
         if value := state.read_property(self.entity_description.property, None):
             self._attr_is_on = (
@@ -127,6 +128,7 @@ class QbusControllerConnectedBinarySensor(BinarySensorEntity):
             identifiers={create_device_identifier(controller)}
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
         topic = QbusMqttTopicFactory().get_device_state_topic(self._controller.id)

--- a/homeassistant/components/qbus/climate.py
+++ b/homeassistant/components/qbus/climate.py
@@ -1,7 +1,7 @@
 """Support for Qbus thermostat."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from qbusmqttapi.const import KEY_PROPERTIES_REGIME, KEY_PROPERTIES_SET_TEMPERATURE
 from qbusmqttapi.discovery import QbusMqttOutput
@@ -91,6 +91,7 @@ class QbusClimate(QbusEntity, ClimateEntity):
 
         self._request_state_debouncer: Debouncer | None = None
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
         self._request_state_debouncer = Debouncer(
@@ -102,6 +103,7 @@ class QbusClimate(QbusEntity, ClimateEntity):
         )
         await super().async_added_to_hass()
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new target preset mode."""
 
@@ -120,6 +122,7 @@ class QbusClimate(QbusEntity, ClimateEntity):
 
         await self._async_publish_output_state(state)
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         temperature = kwargs.get(ATTR_TEMPERATURE)
@@ -130,6 +133,7 @@ class QbusClimate(QbusEntity, ClimateEntity):
 
             await self._async_publish_output_state(state)
 
+    @override
     async def _handle_state_received(self, state: QbusMqttThermoState) -> None:
         if preset_mode := state.read_regime():
             self._attr_preset_mode = preset_mode

--- a/homeassistant/components/qbus/config_flow.py
+++ b/homeassistant/components/qbus/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Qbus."""
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from qbusmqttapi.discovery import QbusMqttDevice
 from qbusmqttapi.factory import QbusMqttMessageFactory, QbusMqttTopicFactory
@@ -33,6 +33,7 @@ class QbusFlowHandler(ConfigFlow, domain=DOMAIN):
 
         self._device: QbusMqttDevice | None = None
 
+    @override
     async def async_step_mqtt(
         self, discovery_info: MqttServiceInfo
     ) -> ConfigFlowResult:
@@ -79,6 +80,7 @@ class QbusFlowHandler(ConfigFlow, domain=DOMAIN):
             },
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/qbus/coordinator.py
+++ b/homeassistant/components/qbus/coordinator.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 import logging
-from typing import cast
+from typing import cast, override
 
 from qbusmqttapi.discovery import QbusDiscovery, QbusMqttDevice
 from qbusmqttapi.factory import QbusMqttMessageFactory, QbusMqttTopicFactory
@@ -59,6 +59,7 @@ class QbusControllerCoordinator(DataUpdateCoordinator[QbusMqttDevice | None]):
 
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self.shutdown)
 
+    @override
     async def _async_update_data(self) -> QbusMqttDevice | None:
         return self._controller
 

--- a/homeassistant/components/qbus/cover.py
+++ b/homeassistant/components/qbus/cover.py
@@ -1,6 +1,6 @@
 """Support for Qbus cover."""
 
-from typing import Any
+from typing import Any, override
 
 from qbusmqttapi.const import (
     KEY_PROPERTIES_SHUTTER_POSITION,
@@ -88,6 +88,7 @@ class QbusCover(QbusEntity, CoverEntity):
         self._target_state: str | None = None
         self._previous_state: str | None = None
 
+    @override
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
 
@@ -100,6 +101,7 @@ class QbusCover(QbusEntity, CoverEntity):
 
         await self._async_publish_output_state(state)
 
+    @override
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
 
@@ -115,36 +117,42 @@ class QbusCover(QbusEntity, CoverEntity):
 
         await self._async_publish_output_state(state)
 
+    @override
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
         state = QbusMqttShutterState(id=self._mqtt_output.id, type=StateType.STATE)
         state.write_state("stop")
         await self._async_publish_output_state(state)
 
+    @override
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
         state = QbusMqttShutterState(id=self._mqtt_output.id, type=StateType.STATE)
         state.write_position(int(kwargs[ATTR_POSITION]))
         await self._async_publish_output_state(state)
 
+    @override
     async def async_open_cover_tilt(self, **kwargs: Any) -> None:
         """Open the cover tilt."""
         state = QbusMqttShutterState(id=self._mqtt_output.id, type=StateType.STATE)
         state.write_slat_position(50)
         await self._async_publish_output_state(state)
 
+    @override
     async def async_close_cover_tilt(self, **kwargs: Any) -> None:
         """Close the cover tilt."""
         state = QbusMqttShutterState(id=self._mqtt_output.id, type=StateType.STATE)
         state.write_slat_position(0)
         await self._async_publish_output_state(state)
 
+    @override
     async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
         """Move the cover tilt to a specific position."""
         state = QbusMqttShutterState(id=self._mqtt_output.id, type=StateType.STATE)
         state.write_slat_position(int(kwargs[ATTR_TILT_POSITION]))
         await self._async_publish_output_state(state)
 
+    @override
     async def _handle_state_received(self, state: QbusMqttShutterState) -> None:
         output_state = state.read_state()
         shutter_position = state.read_position()

--- a/homeassistant/components/qbus/entity.py
+++ b/homeassistant/components/qbus/entity.py
@@ -3,7 +3,7 @@
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 import re
-from typing import cast
+from typing import cast, override
 
 from qbusmqttapi.discovery import QbusMqttDevice, QbusMqttOutput
 from qbusmqttapi.factory import QbusMqttMessageFactory, QbusMqttTopicFactory
@@ -122,6 +122,7 @@ class QbusEntity[StateT: QbusMqttState](Entity, ABC):
                 via_device=create_device_identifier(mqtt_output.device),
             )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
         self.async_on_remove(

--- a/homeassistant/components/qbus/light.py
+++ b/homeassistant/components/qbus/light.py
@@ -1,6 +1,6 @@
 """Support for Qbus light."""
 
-from typing import Any
+from typing import Any, override
 
 from qbusmqttapi.discovery import QbusMqttOutput
 from qbusmqttapi.state import (
@@ -79,6 +79,7 @@ class QbusLight(QbusEntity, LightEntity):
 
         self._set_state(0)
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         brightness = kwargs.get(ATTR_BRIGHTNESS)
@@ -95,6 +96,7 @@ class QbusLight(QbusEntity, LightEntity):
 
         await self._async_publish_output_state(state)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         state = QbusMqttAnalogState(id=self._mqtt_output.id, type=StateType.ACTION)
@@ -102,6 +104,7 @@ class QbusLight(QbusEntity, LightEntity):
 
         await self._async_publish_output_state(state)
 
+    @override
     async def _handle_state_received(self, state: QbusMqttAnalogState) -> None:
         percentage = state.read_percentage()
 
@@ -148,6 +151,7 @@ class QbusMultiColor(QbusEntity, LightEntity):
 
         self._set_state(brightness=0)
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
 
@@ -178,6 +182,7 @@ class QbusMultiColor(QbusEntity, LightEntity):
 
         await self._async_publish_output_state(state)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         state = QbusMqttMultiColorState(id=self._mqtt_output.id, type=StateType.STATE)
@@ -185,6 +190,7 @@ class QbusMultiColor(QbusEntity, LightEntity):
 
         await self._async_publish_output_state(state)
 
+    @override
     async def _handle_state_received(self, state: QbusMqttMultiColorState) -> None:
         if state.type == StateType.EVENT:
             # An event doesn't contain all properties, request full state

--- a/homeassistant/components/qbus/scene.py
+++ b/homeassistant/components/qbus/scene.py
@@ -1,6 +1,6 @@
 """Support for Qbus scene."""
 
-from typing import Any
+from typing import Any, override
 
 from qbusmqttapi.discovery import QbusMqttOutput
 from qbusmqttapi.state import QbusMqttState, StateAction, StateType
@@ -48,6 +48,7 @@ class QbusScene(QbusEntity, BaseScene):
 
         self._attr_name = mqtt_output.name.title()
 
+    @override
     async def _async_activate(self, **kwargs: Any) -> None:
         """Activate scene."""
         state = QbusMqttState(
@@ -55,5 +56,6 @@ class QbusScene(QbusEntity, BaseScene):
         )
         await self._async_publish_output_state(state)
 
+    @override
     async def _handle_state_received(self, state: QbusMqttState) -> None:
         self._async_record_activation()

--- a/homeassistant/components/qbus/select.py
+++ b/homeassistant/components/qbus/select.py
@@ -1,5 +1,7 @@
 """Support for Qbus select."""
 
+from typing import override
+
 from qbusmqttapi.const import KEY_PROPERTIES_VALUE
 from qbusmqttapi.discovery import QbusMqttOutput
 from qbusmqttapi.state import QbusMqttStepperState, StateType
@@ -64,6 +66,7 @@ class QbusStepper(QbusEntity, SelectEntity):
         }
         self._attr_options = [item["name"] for item in value_list]
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         value = self._name_to_value.get(option)
@@ -83,6 +86,7 @@ class QbusStepper(QbusEntity, SelectEntity):
 
         await self._async_publish_output_state(state)
 
+    @override
     async def _handle_state_received(self, state: QbusMqttStepperState) -> None:
         """Update the state from a received Qbus state."""
         value = state.read_value()

--- a/homeassistant/components/qbus/sensor.py
+++ b/homeassistant/components/qbus/sensor.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 from enum import StrEnum
+from typing import override
 
 from qbusmqttapi.discovery import QbusMqttOutput
 from qbusmqttapi.state import (
@@ -328,6 +329,7 @@ class QbusGaugeVariantSensor(QbusEntity, SensorEntity):
         if allowed_units is not None and unit in allowed_units:
             self._attr_native_unit_of_measurement = unit
 
+    @override
     async def _handle_state_received(self, state: QbusMqttGaugeState) -> None:
         self._attr_native_value = state.read_value(GaugeStateProperty.CURRENT_VALUE)
 
@@ -354,6 +356,7 @@ class QbusHumiditySensor(QbusEntity, SensorEntity):
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_state_class = SensorStateClass.MEASUREMENT
 
+    @override
     async def _handle_state_received(self, state: QbusMqttHumidityState) -> None:
         self._attr_native_value = state.read_value()
 
@@ -367,6 +370,7 @@ class QbusThermoSensor(QbusEntity, SensorEntity):
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
     _attr_state_class = SensorStateClass.MEASUREMENT
 
+    @override
     async def _handle_state_received(self, state: QbusMqttThermoState) -> None:
         self._attr_native_value = state.read_current_temperature()
 
@@ -382,6 +386,7 @@ class QbusVentilationSensor(QbusEntity, SensorEntity):
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_suggested_display_precision = 0
 
+    @override
     async def _handle_state_received(self, state: QbusMqttVentilationState) -> None:
         self._attr_native_value = state.read_co2()
 
@@ -405,6 +410,7 @@ class QbusWeatherSensor(QbusEntity, SensorEntity):
         if description.key == "temperature":
             self._attr_name = None
 
+    @override
     async def _handle_state_received(self, state: QbusMqttWeatherState) -> None:
         if value := state.read_property(self.entity_description.property, None):
             self.native_value = (

--- a/homeassistant/components/qbus/switch.py
+++ b/homeassistant/components/qbus/switch.py
@@ -1,6 +1,6 @@
 """Support for Qbus switch."""
 
-from typing import Any
+from typing import Any, override
 
 from qbusmqttapi.discovery import QbusMqttOutput
 from qbusmqttapi.state import QbusMqttOnOffState, StateType
@@ -53,6 +53,7 @@ class QbusSwitch(QbusEntity, SwitchEntity):
 
         self._attr_is_on = False
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         state = QbusMqttOnOffState(id=self._mqtt_output.id, type=StateType.STATE)
@@ -60,6 +61,7 @@ class QbusSwitch(QbusEntity, SwitchEntity):
 
         await self._async_publish_output_state(state)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         state = QbusMqttOnOffState(id=self._mqtt_output.id, type=StateType.STATE)
@@ -67,5 +69,6 @@ class QbusSwitch(QbusEntity, SwitchEntity):
 
         await self._async_publish_output_state(state)
 
+    @override
     async def _handle_state_received(self, state: QbusMqttOnOffState) -> None:
         self._attr_is_on = state.read_value()

--- a/homeassistant/components/qingping/binary_sensor.py
+++ b/homeassistant/components/qingping/binary_sensor.py
@@ -1,5 +1,7 @@
 """Support for Qingping binary sensors."""
 
+from typing import override
+
 from qingping_ble import (
     BinarySensorDeviceClass as QingpingBinarySensorDeviceClass,
     SensorUpdate,
@@ -98,6 +100,7 @@ class QingpingBluetoothSensorEntity(
     """Representation of a Qingping binary sensor."""
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return the native value."""
         return self.processor.entity_data.get(self.entity_key)

--- a/homeassistant/components/qingping/config_flow.py
+++ b/homeassistant/components/qingping/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for Qingping integration."""
 
-from typing import Any
+from typing import Any, override
 
 from qingping_ble import QingpingBluetoothDeviceData as DeviceData
 import voluptuous as vol
@@ -49,6 +49,7 @@ class QingpingConfigFlow(ConfigFlow, domain=DOMAIN):
             ADDITIONAL_DISCOVERY_TIMEOUT,
         )
 
+    @override
     async def async_step_bluetooth(
         self, discovery_info: BluetoothServiceInfoBleak
     ) -> ConfigFlowResult:
@@ -85,6 +86,7 @@ class QingpingConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="bluetooth_confirm", description_placeholders=placeholders
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/qingping/sensor.py
+++ b/homeassistant/components/qingping/sensor.py
@@ -1,5 +1,7 @@
 """Support for Qingping sensors."""
 
+from typing import override
+
 from qingping_ble import (
     SensorDeviceClass as QingpingSensorDeviceClass,
     SensorUpdate,
@@ -164,6 +166,7 @@ class QingpingBluetoothSensorEntity(
     """Representation of a Qingping sensor."""
 
     @property
+    @override
     def native_value(self) -> int | float | None:
         """Return the native value."""
         return self.processor.entity_data.get(self.entity_key)

--- a/homeassistant/components/qld_bushfire/geo_location.py
+++ b/homeassistant/components/qld_bushfire/geo_location.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from georss_qld_bushfire_alert_client import (
     QldBushfireAlertFeedEntry,
@@ -174,6 +174,7 @@ class QldBushfireLocationEvent(GeolocationEvent):
         self._remove_signal_delete: Callable[[], None]
         self._remove_signal_update: Callable[[], None]
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Call when entity is added to hass."""
         self._remove_signal_delete = async_dispatcher_connect(
@@ -219,6 +220,7 @@ class QldBushfireLocationEvent(GeolocationEvent):
         self._status = feed_entry.status
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the device state attributes."""
         return {

--- a/homeassistant/components/qnap/config_flow.py
+++ b/homeassistant/components/qnap/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow to configure qnap component."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from qnapstats import QNAPStats
 from requests.exceptions import ConnectTimeout
@@ -73,6 +73,7 @@ class QnapConfigFlow(ConfigFlow, domain=DOMAIN):
             return errors, stats
         return errors, None
 
+    @override
     async def async_step_user(
         self,
         user_input: dict[str, Any] | None = None,

--- a/homeassistant/components/qnap/coordinator.py
+++ b/homeassistant/components/qnap/coordinator.py
@@ -3,7 +3,7 @@
 from contextlib import contextmanager, nullcontext
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 import warnings
 
 from qnapstats import QNAPStats
@@ -85,6 +85,7 @@ class QnapCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
                 "bandwidth": self._api.get_bandwidth(),
             }
 
+    @override
     async def _async_update_data(self) -> dict[str, dict[str, Any]]:
         """Get the latest data from the Qnap API."""
         return await self.hass.async_add_executor_job(self._sync_update)

--- a/homeassistant/components/qnap/sensor.py
+++ b/homeassistant/components/qnap/sensor.py
@@ -1,7 +1,7 @@
 """Support for QNAP NAS Sensors."""
 
 from datetime import timedelta
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -334,6 +334,7 @@ class QNAPCPUSensor(QNAPSensor):
     """A QNAP sensor that monitors CPU stats."""
 
     @property
+    @override
     def native_value(self):
         """Return the state of the sensor."""
         if self.entity_description.key == "cpu_temp":
@@ -348,6 +349,7 @@ class QNAPMemorySensor(QNAPSensor):
     """A QNAP sensor that monitors memory stats."""
 
     @property
+    @override
     def native_value(self):
         """Return the state of the sensor."""
         free = float(self.coordinator.data["system_stats"]["memory"]["free"])
@@ -374,6 +376,7 @@ class QNAPNetworkSensor(QNAPSensor):
     monitor_device: str
 
     @property
+    @override
     def native_value(self):
         """Return the state of the sensor."""
         nic = self.coordinator.data["system_stats"]["nics"][self.monitor_device]
@@ -400,6 +403,7 @@ class QNAPSystemSensor(QNAPSensor):
     """A QNAP sensor that monitors overall system health."""
 
     @property
+    @override
     def native_value(self):
         """Return the state of the sensor."""
         if self.entity_description.key == "status":
@@ -427,6 +431,7 @@ class QNAPDriveSensor(QNAPSensor):
     monitor_device: str
 
     @property
+    @override
     def native_value(self):
         """Return the state of the sensor."""
         data = self.coordinator.data["smart_drive_health"][self.monitor_device]
@@ -440,6 +445,7 @@ class QNAPDriveSensor(QNAPSensor):
         return None
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return the state attributes."""
         if self.coordinator.data:
@@ -459,6 +465,7 @@ class QNAPVolumeSensor(QNAPSensor):
     monitor_device: str
 
     @property
+    @override
     def native_value(self):
         """Return the state of the sensor."""
         data = self.coordinator.data["volumes"][self.monitor_device]

--- a/homeassistant/components/qnap_qsw/binary_sensor.py
+++ b/homeassistant/components/qnap_qsw/binary_sensor.py
@@ -1,7 +1,7 @@
 """Support for the QNAP QSW binary sensors."""
 
 from dataclasses import dataclass, replace
-from typing import Final
+from typing import Final, override
 
 from aioqsw.const import (
     QSD_ANOMALY,
@@ -152,6 +152,7 @@ class QswBinarySensor(QswSensorEntity, BinarySensorEntity):
         self._async_update_attrs()
 
     @callback
+    @override
     def _async_update_attrs(self) -> None:
         """Update binary sensor attributes."""
         self._attr_is_on = self.get_device_value(

--- a/homeassistant/components/qnap_qsw/button.py
+++ b/homeassistant/components/qnap_qsw/button.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Final
+from typing import Final, override
 
 from aioqsw.localapi import QnapQswApi
 
@@ -67,6 +67,7 @@ class QswButton(QswDataEntity, ButtonEntity):
         self._attr_unique_id = f"{entry.unique_id}_{description.key}"
         self.entity_description = description
 
+    @override
     async def async_press(self) -> None:
         """Triggers the QNAP QSW button action."""
         await self.entity_description.press_action(self.coordinator.qsw)

--- a/homeassistant/components/qnap_qsw/config_flow.py
+++ b/homeassistant/components/qnap_qsw/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for QNAP QSW."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from aioqsw.exceptions import LoginError, QswError
 from aioqsw.localapi import ConnectionOptions, QnapQswApi
@@ -25,6 +25,7 @@ class QNapQSWConfigFlow(ConfigFlow, domain=DOMAIN):
     _discovered_mac: str | None = None
     _discovered_url: str | None = None
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -70,6 +71,7 @@ class QNapQSWConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    @override
     async def async_step_dhcp(
         self, discovery_info: DhcpServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/qnap_qsw/coordinator.py
+++ b/homeassistant/components/qnap_qsw/coordinator.py
@@ -4,7 +4,7 @@ import asyncio
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from aioqsw.exceptions import QswError
 from aioqsw.localapi import QnapQswApi
@@ -51,6 +51,7 @@ class QswDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             update_interval=DATA_SCAN_INTERVAL,
         )
 
+    @override
     async def _async_update_data(self) -> dict[str, Any]:
         """Update data via library."""
         async with asyncio.timeout(QSW_TIMEOUT_SEC):
@@ -80,6 +81,7 @@ class QswFirmwareCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             update_interval=FW_SCAN_INTERVAL,
         )
 
+    @override
     async def _async_update_data(self) -> dict[str, Any]:
         """Update firmware data via library."""
         async with asyncio.timeout(QSW_TIMEOUT_SEC):

--- a/homeassistant/components/qnap_qsw/entity.py
+++ b/homeassistant/components/qnap_qsw/entity.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Any
+from typing import Any, override
 
 from aioqsw.const import (
     QSD_FIRMWARE,
@@ -101,6 +101,7 @@ class QswSensorEntity(QswDataEntity):
     entity_description: QswEntityDescription
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Update attributes when the coordinator updates."""
         self._async_update_attrs()

--- a/homeassistant/components/qnap_qsw/sensor.py
+++ b/homeassistant/components/qnap_qsw/sensor.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass, replace
 from datetime import datetime
-from typing import Final
+from typing import Final, override
 
 from aioqsw.const import (
     QSD_FAN1_SPEED,
@@ -369,6 +369,7 @@ class QswSensor(QswSensorEntity, SensorEntity):
         self._async_update_attrs()
 
     @callback
+    @override
     def _async_update_attrs(self) -> None:
         """Update sensor attributes."""
         value = self.get_device_value(

--- a/homeassistant/components/qnap_qsw/update.py
+++ b/homeassistant/components/qnap_qsw/update.py
@@ -1,6 +1,6 @@
 """Support for the QNAP QSW update."""
 
-from typing import Any, Final
+from typing import Any, Final, override
 
 from aioqsw.const import (
     QSD_DESCRIPTION,
@@ -67,6 +67,7 @@ class QswUpdate(QswFirmwareEntity, UpdateEntity):
         self._async_update_attrs()
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Update attributes when the coordinator updates."""
         self._async_update_attrs()
@@ -82,6 +83,7 @@ class QswUpdate(QswFirmwareEntity, UpdateEntity):
             QSD_FIRMWARE_CHECK, QSD_DESCRIPTION
         )
 
+    @override
     async def async_install(
         self, version: str | None, backup: bool, **kwargs: Any
     ) -> None:

--- a/homeassistant/components/qrcode/image_processing.py
+++ b/homeassistant/components/qrcode/image_processing.py
@@ -1,6 +1,7 @@
 """Support for the QR code image processing."""
 
 import io
+from typing import override
 
 from PIL import Image
 from pyzbar import pyzbar
@@ -39,6 +40,7 @@ class QrEntity(ImageProcessingEntity):
             self._attr_name = f"QR {split_entity_id(camera_entity)[1]}"
         self._attr_state = None
 
+    @override
     def process_image(self, image: bytes) -> None:
         """Process image."""
         stream = io.BytesIO(image)

--- a/homeassistant/components/quantum_gateway/device_tracker.py
+++ b/homeassistant/components/quantum_gateway/device_tracker.py
@@ -1,5 +1,7 @@
 """Support for Verizon FiOS Quantum Gateways."""
 
+from typing import override
+
 from quantum_gateway import QuantumGatewayScanner
 from requests.exceptions import RequestException
 import voluptuous as vol
@@ -57,6 +59,7 @@ class QuantumGatewayDeviceScanner(DeviceScanner):
         if not self.success_init:
             LOGGER.error("Unable to login to gateway. Check password and host")
 
+    @override
     def scan_devices(self):
         """Scan for new devices and return a list of found MACs."""
         connected_devices = []
@@ -66,6 +69,7 @@ class QuantumGatewayDeviceScanner(DeviceScanner):
             LOGGER.error("Unable to scan devices. Check connection to router")
         return connected_devices
 
+    @override
     def get_device_name(self, device):
         """Return the name of the given device or None if we don't know."""
         return self.quantum.get_device_name(device)

--- a/homeassistant/components/qvr_pro/camera.py
+++ b/homeassistant/components/qvr_pro/camera.py
@@ -1,7 +1,7 @@
 """Support for QVR Pro streams."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyqvrpro.client import QVRResponseError
 
@@ -72,25 +72,30 @@ class QVRProCamera(Camera):
         super().__init__()
 
     @property
+    @override
     def name(self):
         """Return the name of the entity."""
         return self._name
 
     @property
+    @override
     def model(self):
         """Return the model of the entity."""
         return self._model
 
     @property
+    @override
     def brand(self):
         """Return the brand of the entity."""
         return self._brand
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Get the state attributes."""
         return {"qvr_guid": self.guid}
 
+    @override
     def camera_image(
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
@@ -105,6 +110,7 @@ class QVRProCamera(Camera):
 
         return self._client.get_snapshot(self.guid)
 
+    @override
     async def stream_source(self):
         """Get stream source."""
         return self._stream_source

--- a/homeassistant/components/qwikswitch/binary_sensor.py
+++ b/homeassistant/components/qwikswitch/binary_sensor.py
@@ -1,7 +1,7 @@
 """Support for Qwikswitch Binary Sensors."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyqwikswitch.qwikswitch import SENSORS
 
@@ -52,6 +52,7 @@ class QSBinarySensor(QSEntity, BinarySensorEntity):
         self._attr_unique_id = f"qs{self.qsid}:{self.channel}"
 
     @callback
+    @override
     def update_packet(self, packet):
         """Receive update packet from QSUSB."""
         val = self._decode(packet, channel=self.channel)

--- a/homeassistant/components/qwikswitch/entity.py
+++ b/homeassistant/components/qwikswitch/entity.py
@@ -1,5 +1,7 @@
 """Support for Qwikswitch devices."""
 
+from typing import override
+
 from homeassistant.components.light import ATTR_BRIGHTNESS
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -24,6 +26,7 @@ class QSEntity(Entity):
         """Receive update packet from QSUSB. Match dispather_send signature."""
         self.async_write_ha_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Listen for updates from QSUSb via dispatcher."""
         self.async_on_remove(

--- a/homeassistant/components/qwikswitch/light.py
+++ b/homeassistant/components/qwikswitch/light.py
@@ -1,5 +1,7 @@
 """Support for Qwikswitch Relays and Dimmers."""
 
+from typing import override
+
 from homeassistant.components.light import ColorMode, LightEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -28,16 +30,19 @@ class QSLight(QSToggleEntity, LightEntity):
     """Light based on a Qwikswitch relay/dimmer module."""
 
     @property
+    @override
     def brightness(self) -> int | None:
         """Return the brightness of this light (0-255)."""
         return self.device.value if self.device.is_dimmer else None
 
     @property
+    @override
     def color_mode(self) -> ColorMode:
         """Return the color mode of the light."""
         return ColorMode.BRIGHTNESS if self.device.is_dimmer else ColorMode.ONOFF
 
     @property
+    @override
     def supported_color_modes(self) -> set[ColorMode]:
         """Flag supported color modes."""
         return {self.color_mode}

--- a/homeassistant/components/qwikswitch/sensor.py
+++ b/homeassistant/components/qwikswitch/sensor.py
@@ -1,7 +1,7 @@
 """Support for Qwikswitch Sensors."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyqwikswitch.qwikswitch import SENSORS
 
@@ -55,6 +55,7 @@ class QSSensor(QSEntity, SensorEntity):
         self._attr_native_unit_of_measurement = unit
 
     @callback
+    @override
     def update_packet(self, packet):
         """Receive update packet from QSUSB."""
         val = self._decode(packet, channel=self.channel)

--- a/homeassistant/components/rabbitair/config_flow.py
+++ b/homeassistant/components/rabbitair/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Rabbit Air integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from rabbitair import UdpClient
 import voluptuous as vol
@@ -55,6 +55,7 @@ class RabbitAirConfigFlow(ConfigFlow, domain=DOMAIN):
 
     _discovered_host: str | None = None
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -97,6 +98,7 @@ class RabbitAirConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    @override
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/rabbitair/coordinator.py
+++ b/homeassistant/components/rabbitair/coordinator.py
@@ -3,7 +3,7 @@
 from collections.abc import Coroutine
 from datetime import timedelta
 import logging
-from typing import Any, cast
+from typing import Any, cast, override
 
 from rabbitair import Client, State
 
@@ -31,6 +31,7 @@ class RabbitAirDebouncer(Debouncer[Coroutine[Any, Any, None]]):
         # one-second intervals.
         super().__init__(hass, _LOGGER, cooldown=2.0, immediate=False)
 
+    @override
     async def async_call(self) -> None:
         """Call the function."""
         # Restart the timer.
@@ -61,9 +62,11 @@ class RabbitAirDataUpdateCoordinator(DataUpdateCoordinator[State]):
             request_refresh_debouncer=RabbitAirDebouncer(hass),
         )
 
+    @override
     async def _async_update_data(self) -> State:
         return await self.device.get_state()
 
+    @override
     async def _async_refresh(
         self,
         log_failures: bool = True,

--- a/homeassistant/components/rabbitair/fan.py
+++ b/homeassistant/components/rabbitair/fan.py
@@ -1,6 +1,6 @@
 """Support for Rabbit Air fan entity."""
 
-from typing import Any
+from typing import Any, override
 
 from rabbitair import Mode, Model, Speed
 
@@ -76,6 +76,7 @@ class RabbitAirFanEntity(RabbitAirBaseEntity, FanEntity):
         self._get_state_from_coordinator_data()
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self._get_state_from_coordinator_data()
@@ -106,12 +107,14 @@ class RabbitAirFanEntity(RabbitAirBaseEntity, FanEntity):
                 k for k, v in PRESET_MODES.items() if v is data.mode
             )
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
         await self._set_state(power=True, mode=PRESET_MODES[preset_mode])
         self._attr_preset_mode = preset_mode
         self.async_write_ha_state()
 
+    @override
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed of the fan, as a percentage."""
         if percentage > 0:
@@ -124,6 +127,7 @@ class RabbitAirFanEntity(RabbitAirBaseEntity, FanEntity):
             self._attr_preset_mode = None
         self.async_write_ha_state()
 
+    @override
     async def async_turn_on(
         self,
         percentage: int | None = None,
@@ -144,6 +148,7 @@ class RabbitAirFanEntity(RabbitAirBaseEntity, FanEntity):
             self._attr_preset_mode = preset_mode
         self.async_write_ha_state()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the fan off."""
         await self._set_state(power=False)

--- a/homeassistant/components/rabbitair/sensor.py
+++ b/homeassistant/components/rabbitair/sensor.py
@@ -1,5 +1,7 @@
 """Support for Rabbit Air sensors."""
 
+from typing import override
+
 from rabbitair import Quality
 
 from homeassistant.components.sensor import (
@@ -55,6 +57,7 @@ class RabbitAirAirQualitySensor(RabbitAirBaseEntity, SensorEntity):
         self._attr_unique_id = f"{entry.unique_id}_{self.entity_description.key}"
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the air quality state."""
         return _quality_value(self.coordinator.data.quality)

--- a/homeassistant/components/rachio/binary_sensor.py
+++ b/homeassistant/components/rachio/binary_sensor.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 import logging
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -173,6 +173,7 @@ class RachioControllerBinarySensor(RachioDevice, BinarySensorEntity):
 
         self.async_write_ha_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Subscribe to updates."""
         self._attr_is_on = self.entity_description.is_on(self._controller)
@@ -204,6 +205,7 @@ class RachioHoseTimerBinarySensor(RachioHoseTimerEntity, BinarySensorEntity):
         self._update_attr()
 
     @callback
+    @override
     def _update_attr(self) -> None:
         """Handle updated coordinator data."""
         self._attr_is_on = self.entity_description.value_fn(self)

--- a/homeassistant/components/rachio/calendar.py
+++ b/homeassistant/components/rachio/calendar.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.calendar import (
     CalendarEntity,
@@ -70,6 +70,7 @@ class RachioCalendarEntity(
         self._previous_event: dict[str, Any] | None = None
 
     @property
+    @override
     def event(self) -> CalendarEvent | None:
         """Return the next upcoming event."""
         if not (event := self._handle_upcoming_event()):
@@ -114,6 +115,7 @@ class RachioCalendarEntity(
         self._previous_event = event  # Store for future use
         return event
 
+    @override
     async def async_get_events(
         self, hass: HomeAssistant, start_date: datetime, end_date: datetime
     ) -> list[CalendarEvent]:
@@ -156,6 +158,7 @@ class RachioCalendarEntity(
                 event_list.append(event)
         return event_list
 
+    @override
     async def async_delete_event(
         self,
         uid: str,

--- a/homeassistant/components/rachio/config_flow.py
+++ b/homeassistant/components/rachio/config_flow.py
@@ -2,7 +2,7 @@
 
 from http import HTTPStatus
 import logging
-from typing import Any
+from typing import Any, override
 
 from rachiopy import Rachio
 from requests.exceptions import ConnectTimeout
@@ -69,6 +69,7 @@ class RachioConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -97,6 +98,7 @@ class RachioConfigFlow(ConfigFlow, domain=DOMAIN):
             },
         )
 
+    @override
     async def async_step_homekit(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:
@@ -108,6 +110,7 @@ class RachioConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> OptionsFlowHandler:

--- a/homeassistant/components/rachio/coordinator.py
+++ b/homeassistant/components/rachio/coordinator.py
@@ -3,7 +3,7 @@
 from datetime import datetime, timedelta
 import logging
 from operator import itemgetter
-from typing import Any
+from typing import Any, override
 
 from rachiopy import Rachio
 from requests.exceptions import Timeout
@@ -60,6 +60,7 @@ class RachioUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             ),
         )
 
+    @override
     async def _async_update_data(self) -> dict[str, Any]:
         """Update smart hose timer data."""
         try:
@@ -92,6 +93,7 @@ class RachioScheduleUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]
             update_interval=timedelta(minutes=30),
         )
 
+    @override
     async def _async_update_data(self) -> list[dict[str, Any]]:
         """Retrieve data for the past week and the next 60 days."""
         _now: datetime = dt_util.now()

--- a/homeassistant/components/rachio/device.py
+++ b/homeassistant/components/rachio/device.py
@@ -2,7 +2,7 @@
 
 from http import HTTPStatus
 import logging
-from typing import Any
+from typing import Any, override
 
 from rachiopy import Rachio
 import voluptuous as vol
@@ -291,6 +291,7 @@ class RachioIro:
         current_webhook_id = new_webhook[1][KEY_ID]
         self.hass.bus.listen(EVENT_HOMEASSISTANT_STOP, _deinit_webhooks)
 
+    @override
     def __str__(self) -> str:
         """Display the controller as a string."""
         return f'Rachio controller "{self.name}"'

--- a/homeassistant/components/rachio/entity.py
+++ b/homeassistant/components/rachio/entity.py
@@ -1,7 +1,7 @@
 """Adapter to wrap the rachiopy api for home assistant."""
 
 from abc import abstractmethod
-from typing import Any
+from typing import Any, override
 
 from homeassistant.core import callback
 from homeassistant.helpers import device_registry as dr
@@ -82,6 +82,7 @@ class RachioHoseTimerEntity(CoordinatorEntity[RachioUpdateCoordinator]):
         return self.coordinator.data[self.id][KEY_STATE][KEY_REPORTED_STATE]
 
     @property
+    @override
     def available(self) -> bool:
         """Return if the entity is available."""
         return super().available and self.reported_state[KEY_CONNECTED]
@@ -104,6 +105,7 @@ class RachioHoseTimerEntity(CoordinatorEntity[RachioUpdateCoordinator]):
         """Update the state and attributes."""
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self._update_attr()

--- a/homeassistant/components/rachio/switch.py
+++ b/homeassistant/components/rachio/switch.py
@@ -4,7 +4,7 @@ from abc import abstractmethod
 from contextlib import suppress
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -227,11 +227,13 @@ class RachioStandbySwitch(RachioSwitch):
     _attr_translation_key = "standby"
 
     @property
+    @override
     def unique_id(self) -> str:
         """Return a unique id by combining controller id and purpose."""
         return f"{self._controller.controller_id}-standby"
 
     @callback
+    @override
     def _async_handle_update(self, *args, **kwargs) -> None:
         """Update the state using webhook data."""
         if args[0][0][KEY_SUBTYPE] == SUBTYPE_SLEEP_MODE_ON:
@@ -241,14 +243,17 @@ class RachioStandbySwitch(RachioSwitch):
 
         self.async_write_ha_state()
 
+    @override
     def turn_on(self, **kwargs: Any) -> None:
         """Put the controller in standby mode."""
         self._controller.rachio.device.turn_off(self._controller.controller_id)
 
+    @override
     def turn_off(self, **kwargs: Any) -> None:
         """Resume controller functionality."""
         self._controller.rachio.device.turn_on(self._controller.controller_id)
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Subscribe to updates."""
         if KEY_ON in self._controller.init_data:
@@ -275,11 +280,13 @@ class RachioRainDelay(RachioSwitch):
         super().__init__(controller)
 
     @property
+    @override
     def unique_id(self) -> str:
         """Return a unique id by combining controller id and purpose."""
         return f"{self._controller.controller_id}-delay"
 
     @callback
+    @override
     def _async_handle_update(self, *args, **kwargs) -> None:
         """Update the state using webhook data."""
         if self._cancel_update:
@@ -306,16 +313,19 @@ class RachioRainDelay(RachioSwitch):
         self._cancel_update = None
         self.async_write_ha_state()
 
+    @override
     def turn_on(self, **kwargs: Any) -> None:
         """Activate a 24 hour rain delay on the controller."""
         self._controller.rachio.device.rain_delay(self._controller.controller_id, 86400)
         _LOGGER.debug("Starting rain delay for 24 hours")
 
+    @override
     def turn_off(self, **kwargs: Any) -> None:
         """Resume controller functionality."""
         self._controller.rachio.device.rain_delay(self._controller.controller_id, 0)
         _LOGGER.debug("Canceling rain delay")
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Subscribe to updates."""
         if KEY_RAIN_DELAY in self._controller.init_data:
@@ -364,6 +374,7 @@ class RachioZone(RachioSwitch):
         self._attr_unique_id = f"{controller.controller_id}-zone-{self.id}"
         super().__init__(controller)
 
+    @override
     def __str__(self):
         """Display the zone as a string."""
         return f'Rachio Zone "{self.name}" on {self._controller!s}'
@@ -379,6 +390,7 @@ class RachioZone(RachioSwitch):
         return self._zone_enabled
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the optional state attributes."""
         props = {ATTR_ZONE_NUMBER: self._zone_number, ATTR_ZONE_SUMMARY: self._summary}
@@ -397,6 +409,7 @@ class RachioZone(RachioSwitch):
                 props[ATTR_ZONE_SLOPE] = "Steep"
         return props
 
+    @override
     def turn_on(self, **kwargs: Any) -> None:
         """Start watering this zone."""
         # Stop other zones first
@@ -420,6 +433,7 @@ class RachioZone(RachioSwitch):
             str(manual_run_time),
         )
 
+    @override
     def turn_off(self, **kwargs: Any) -> None:
         """Stop watering all zones."""
         self._controller.stop_watering()
@@ -430,6 +444,7 @@ class RachioZone(RachioSwitch):
         self._controller.rachio.zone.set_moisture_percent(self.id, percent / 100)
 
     @callback
+    @override
     def _async_handle_update(self, *args, **kwargs) -> None:
         """Handle incoming webhook zone data."""
         if args[0][KEY_ZONE_ID] != self.zone_id:
@@ -448,6 +463,7 @@ class RachioZone(RachioSwitch):
 
         self.async_write_ha_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Subscribe to updates."""
         self._attr_is_on = self.zone_id == self._current_schedule.get(KEY_ZONE_ID)
@@ -477,11 +493,13 @@ class RachioSchedule(RachioSwitch):
         super().__init__(controller)
 
     @property
+    @override
     def icon(self) -> str:
         """Return the icon to display."""
         return "mdi:water" if self.schedule_is_enabled else "mdi:water-off"
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the optional state attributes."""
         return {
@@ -496,6 +514,7 @@ class RachioSchedule(RachioSwitch):
         """Return whether the schedule is allowed to run."""
         return self._schedule_enabled
 
+    @override
     def turn_on(self, **kwargs: Any) -> None:
         """Start this schedule."""
         self._controller.rachio.schedulerule.start(self._schedule_id)
@@ -505,11 +524,13 @@ class RachioSchedule(RachioSwitch):
             self._controller.name,
         )
 
+    @override
     def turn_off(self, **kwargs: Any) -> None:
         """Stop watering all zones."""
         self._controller.stop_watering()
 
     @callback
+    @override
     def _async_handle_update(self, *args, **kwargs) -> None:
         """Handle incoming webhook schedule data."""
         # Schedule ID not passed when running individual zones, so we catch that error
@@ -525,6 +546,7 @@ class RachioSchedule(RachioSwitch):
 
         self.async_write_ha_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Subscribe to updates."""
         self._attr_is_on = self._schedule_id == self._current_schedule.get(
@@ -551,6 +573,7 @@ class RachioValve(RachioHoseTimerEntity, SwitchEntity):
         self._attr_unique_id = f"{self.id}-valve"
         self._update_attr()
 
+    @override
     def turn_on(self, **kwargs: Any) -> None:
         """Turn on this valve."""
         if ATTR_DURATION in kwargs:
@@ -567,6 +590,7 @@ class RachioValve(RachioHoseTimerEntity, SwitchEntity):
         self.schedule_update_ha_state(force_refresh=True)
         _LOGGER.debug("Starting valve %s for %s", self._name, str(manual_run_time))
 
+    @override
     def turn_off(self, **kwargs: Any) -> None:
         """Turn off this valve."""
         self._base.stop_watering(self.id)
@@ -575,6 +599,7 @@ class RachioValve(RachioHoseTimerEntity, SwitchEntity):
         _LOGGER.debug("Stopping watering on valve %s", self._name)
 
     @callback
+    @override
     def _update_attr(self) -> None:
         """Handle updated coordinator data."""
         self._static_attrs = self.reported_state

--- a/homeassistant/components/radarr/binary_sensor.py
+++ b/homeassistant/components/radarr/binary_sensor.py
@@ -1,5 +1,7 @@
 """Support for Radarr binary sensors."""
 
+from typing import override
+
 from aiopyarr import Health
 
 from homeassistant.components.binary_sensor import (
@@ -37,6 +39,7 @@ class RadarrBinarySensor(RadarrEntity[list[Health]], BinarySensorEntity):
     """Implementation of a Radarr binary sensor."""
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return True if the entity is on."""
         return any(report.source in HEALTH_ISSUES for report in self.coordinator.data)

--- a/homeassistant/components/radarr/calendar.py
+++ b/homeassistant/components/radarr/calendar.py
@@ -1,6 +1,7 @@
 """Support for Radarr calendar items."""
 
 from datetime import datetime
+from typing import override
 
 from homeassistant.components.calendar import (
     CalendarEntity,
@@ -35,6 +36,7 @@ class RadarrCalendarEntity(RadarrEntity, CalendarEntity):
     coordinator: CalendarUpdateCoordinator
 
     @property
+    @override
     def event(self) -> CalendarEvent | None:
         """Return the next upcoming event."""
         if not self.coordinator.event:
@@ -46,6 +48,7 @@ class RadarrCalendarEntity(RadarrEntity, CalendarEntity):
             description=self.coordinator.event.description,
         )
 
+    @override
     # pylint: disable-next=home-assistant-return-type
     async def async_get_events(  # type: ignore[override]
         self, hass: HomeAssistant, start_date: datetime, end_date: datetime
@@ -54,6 +57,7 @@ class RadarrCalendarEntity(RadarrEntity, CalendarEntity):
         return await self.coordinator.async_get_events(start_date, end_date)
 
     @callback
+    @override
     def _async_write_ha_state(self) -> None:
         """Write the state to the state machine."""
         if self.coordinator.event:

--- a/homeassistant/components/radarr/config_flow.py
+++ b/homeassistant/components/radarr/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Radarr."""
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, override
 
 from aiohttp import ClientConnectorError
 from aiopyarr import exceptions
@@ -39,6 +39,7 @@ class RadarrConfigFlow(ConfigFlow, domain=DOMAIN):
         self._set_confirm_only()
         return self.async_show_form(step_id="reauth_confirm")
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/radarr/coordinator.py
+++ b/homeassistant/components/radarr/coordinator.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 import asyncio
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
-from typing import Generic, TypeVar, cast
+from typing import Generic, TypeVar, cast, override
 
 from aiopyarr import (
     Health,
@@ -79,6 +79,7 @@ class RadarrDataUpdateCoordinator(DataUpdateCoordinator[T], ABC, Generic[T]):  #
         self.api_client = api_client
         self.host_configuration = host_configuration
 
+    @override
     async def _async_update_data(self) -> T:
         """Get the latest data from Radarr."""
         try:
@@ -100,6 +101,7 @@ class RadarrDataUpdateCoordinator(DataUpdateCoordinator[T], ABC, Generic[T]):  #
 class StatusDataUpdateCoordinator(RadarrDataUpdateCoordinator[SystemStatus]):
     """Status update coordinator for Radarr."""
 
+    @override
     async def _fetch_data(self) -> SystemStatus:
         """Fetch the data."""
         return await self.api_client.async_get_system_status()
@@ -108,6 +110,7 @@ class StatusDataUpdateCoordinator(RadarrDataUpdateCoordinator[SystemStatus]):
 class DiskSpaceDataUpdateCoordinator(RadarrDataUpdateCoordinator[list[RootFolder]]):
     """Disk space update coordinator for Radarr."""
 
+    @override
     async def _fetch_data(self) -> list[RootFolder]:
         """Fetch the data."""
         root_folders = await self.api_client.async_get_root_folders()
@@ -119,6 +122,7 @@ class DiskSpaceDataUpdateCoordinator(RadarrDataUpdateCoordinator[list[RootFolder
 class HealthDataUpdateCoordinator(RadarrDataUpdateCoordinator[list[Health]]):
     """Health update coordinator."""
 
+    @override
     async def _fetch_data(self) -> list[Health]:
         """Fetch the health data."""
         health = await self.api_client.async_get_failed_health_checks()
@@ -130,6 +134,7 @@ class HealthDataUpdateCoordinator(RadarrDataUpdateCoordinator[list[Health]]):
 class MoviesDataUpdateCoordinator(RadarrDataUpdateCoordinator[int]):
     """Movies count update coordinator."""
 
+    @override
     async def _fetch_data(self) -> int:
         """Fetch the total count of movies in Radarr."""
         return len(cast(list[RadarrMovie], await self.api_client.async_get_movies()))
@@ -138,6 +143,7 @@ class MoviesDataUpdateCoordinator(RadarrDataUpdateCoordinator[int]):
 class QueueDataUpdateCoordinator(RadarrDataUpdateCoordinator[int]):
     """Queue count update coordinator."""
 
+    @override
     async def _fetch_data(self) -> int:
         """Fetch the number of movies in the download queue."""
         # page_size=1 is sufficient since we only need the totalRecords count
@@ -161,6 +167,7 @@ class CalendarUpdateCoordinator(RadarrDataUpdateCoordinator[None]):
         self.event: RadarrEvent | None = None
         self._events: list[RadarrEvent] = []
 
+    @override
     async def _fetch_data(self) -> None:
         """Fetch the calendar."""
         self.event = None

--- a/homeassistant/components/radarr/entity.py
+++ b/homeassistant/components/radarr/entity.py
@@ -1,5 +1,7 @@
 """The Radarr component."""
 
+from typing import override
+
 from homeassistant.const import ATTR_SW_VERSION
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
@@ -26,6 +28,7 @@ class RadarrEntity(CoordinatorEntity[RadarrDataUpdateCoordinator[T]]):
         self._attr_unique_id = f"{coordinator.config_entry.entry_id}_{description.key}"
 
     @property
+    @override
     def device_info(self) -> DeviceInfo:
         """Return device information about the Radarr instance."""
         device_info = DeviceInfo(

--- a/homeassistant/components/radarr/sensor.py
+++ b/homeassistant/components/radarr/sensor.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 import dataclasses
 from datetime import UTC, datetime
-from typing import Any, Generic
+from typing import Any, Generic, override
 
 from aiopyarr import Diskspace, RootFolder, SystemStatus
 
@@ -148,6 +148,7 @@ class RadarrSensor(RadarrEntity[T], SensorEntity):
         self.folder_name = folder_name
 
     @property
+    @override
     def native_value(self) -> str | int | datetime:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.coordinator.data, self.folder_name)

--- a/homeassistant/components/radio_browser/config_flow.py
+++ b/homeassistant/components/radio_browser/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for Radio Browser integration."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 
@@ -12,6 +12,7 @@ class RadioBrowserConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/radio_browser/media_source.py
+++ b/homeassistant/components/radio_browser/media_source.py
@@ -1,6 +1,7 @@
 """Expose Radio Browser as a media source."""
 
 import mimetypes
+from typing import override
 
 from aiodns.error import DNSError
 import pycountry
@@ -53,6 +54,7 @@ class RadioMediaSource(MediaSource):
         """Return the radio browser."""
         return self.entry.runtime_data
 
+    @override
     async def async_resolve_media(self, item: MediaSourceItem) -> PlayMedia:
         """Resolve selected Radio station to a streaming URL."""
 
@@ -80,6 +82,7 @@ class RadioMediaSource(MediaSource):
 
         return PlayMedia(station.url_resolved, mime_type)
 
+    @override
     async def async_browse_media(
         self,
         item: MediaSourceItem,

--- a/homeassistant/components/radio_frequency/entity.py
+++ b/homeassistant/components/radio_frequency/entity.py
@@ -1,7 +1,7 @@
 """Base entity for the radio frequency integration."""
 
 from abc import abstractmethod
-from typing import final
+from typing import final, override
 
 from rf_protocols import ModulationType, RadioFrequencyCommand
 
@@ -48,6 +48,7 @@ class RadioFrequencyTransmitterEntity(RestoreEntity):
 
     @property
     @final
+    @override
     def state(self) -> str | None:
         """Return the entity state."""
         return self.__last_command_sent
@@ -63,6 +64,7 @@ class RadioFrequencyTransmitterEntity(RestoreEntity):
         self.async_write_ha_state()
 
     @final
+    @override
     async def async_internal_added_to_hass(self) -> None:
         """Call when the radio frequency entity is added to hass."""
         await super().async_internal_added_to_hass()

--- a/homeassistant/components/radiotherm/climate.py
+++ b/homeassistant/components/radiotherm/climate.py
@@ -1,6 +1,6 @@
 """Support for Radio Thermostat wifi-enabled home thermostats."""
 
-from typing import Any
+from typing import Any, override
 
 import radiotherm
 
@@ -129,6 +129,7 @@ class RadioThermostat(RadioThermostatEntity, ClimateEntity):
         self._attr_supported_features |= ClimateEntityFeature.PRESET_MODE
         self._attr_preset_modes = PRESET_MODES
 
+    @override
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Turn fan on/off."""
         if (code := FAN_MODE_TO_CODE.get(fan_mode)) is None:
@@ -143,6 +144,7 @@ class RadioThermostat(RadioThermostatEntity, ClimateEntity):
         self.device.fmode = code
 
     @callback
+    @override
     def _process_data(self) -> None:
         """Update and validate the data from the thermostat."""
         data = self.data.tstat
@@ -173,6 +175,7 @@ class RadioThermostat(RadioThermostatEntity, ClimateEntity):
             elif self.hvac_action == HVACAction.HEATING:
                 self._attr_target_temperature = data["t_heat"]
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
@@ -195,6 +198,7 @@ class RadioThermostat(RadioThermostatEntity, ClimateEntity):
             elif self.hvac_action == HVACAction.HEATING:
                 self.device.t_heat = temperature
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set operation mode (auto, cool, heat, off)."""
         await self.hass.async_add_executor_job(self._set_hvac_mode, hvac_mode)
@@ -212,6 +216,7 @@ class RadioThermostat(RadioThermostatEntity, ClimateEntity):
         elif hvac_mode == HVACMode.HEAT:
             self.device.t_heat = self.target_temperature
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set Preset mode (Home, Alternate, Away, Holiday)."""
         if preset_mode not in PRESET_MODES:

--- a/homeassistant/components/radiotherm/config_flow.py
+++ b/homeassistant/components/radiotherm/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Radio Thermostat integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 from urllib.error import URLError
 
 from radiotherm.validate import RadiothermTstatError
@@ -41,6 +41,7 @@ class RadioThermConfigFlow(ConfigFlow, domain=DOMAIN):
         self.discovered_ip: str | None = None
         self.discovered_init_data: RadioThermInitData | None = None
 
+    @override
     async def async_step_dhcp(
         self, discovery_info: DhcpServiceInfo
     ) -> ConfigFlowResult:
@@ -84,6 +85,7 @@ class RadioThermConfigFlow(ConfigFlow, domain=DOMAIN):
             description_placeholders=placeholders,
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/radiotherm/coordinator.py
+++ b/homeassistant/components/radiotherm/coordinator.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import logging
+from typing import override
 from urllib.error import URLError
 
 from radiotherm.validate import RadiothermTstatError
@@ -41,6 +42,7 @@ class RadioThermUpdateCoordinator(DataUpdateCoordinator[RadioThermUpdate]):
             update_interval=UPDATE_INTERVAL,
         )
 
+    @override
     async def _async_update_data(self) -> RadioThermUpdate:
         """Update data from the thermostat."""
         try:

--- a/homeassistant/components/radiotherm/entity.py
+++ b/homeassistant/components/radiotherm/entity.py
@@ -1,6 +1,7 @@
 """The Radio Thermostat integration base entity."""
 
 from abc import abstractmethod
+from typing import override
 
 from homeassistant.core import callback
 from homeassistant.helpers import device_registry as dr
@@ -41,6 +42,7 @@ class RadioThermostatEntity(CoordinatorEntity[RadioThermUpdateCoordinator]):
         """Update and validate the data from the thermostat."""
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         self._process_data()
         return super()._handle_coordinator_update()

--- a/homeassistant/components/radiotherm/switch.py
+++ b/homeassistant/components/radiotherm/switch.py
@@ -1,6 +1,6 @@
 """Support for radiotherm switches."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant, callback
@@ -32,6 +32,7 @@ class RadioThermHoldSwitch(RadioThermostatEntity, SwitchEntity):
         self._attr_unique_id = f"{coordinator.init_data.mac}_hold"
 
     @callback
+    @override
     def _process_data(self) -> None:
         """Update and validate the data from the thermostat."""
         data = self.data.tstat
@@ -48,10 +49,12 @@ class RadioThermHoldSwitch(RadioThermostatEntity, SwitchEntity):
         self.async_write_ha_state()
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Enable permanent hold."""
         await self._async_set_hold(True)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Disable permanent hold."""
         await self._async_set_hold(False)

--- a/homeassistant/components/rainbird/binary_sensor.py
+++ b/homeassistant/components/rainbird/binary_sensor.py
@@ -1,6 +1,7 @@
 """Support for Rain Bird Irrigation system LNK WiFi Module."""
 
 import logging
+from typing import override
 
 from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
@@ -52,6 +53,7 @@ class RainBirdSensor(CoordinatorEntity[RainbirdUpdateCoordinator], BinarySensorE
             self._attr_name = f"{coordinator.device_name} Rainsensor"
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return True if entity is on."""
         return self.coordinator.data.rain

--- a/homeassistant/components/rainbird/calendar.py
+++ b/homeassistant/components/rainbird/calendar.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime
 import logging
+from typing import override
 
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
 from homeassistant.core import HomeAssistant
@@ -65,6 +66,7 @@ class RainBirdCalendarEntity(
             self._attr_name = device_name
 
     @property
+    @override
     def event(self) -> CalendarEvent | None:
         """Return the next upcoming event."""
         schedule = self.coordinator.data
@@ -83,6 +85,7 @@ class RainBirdCalendarEntity(
             rrule=program_event.rrule_str,
         )
 
+    @override
     async def async_get_events(
         self, hass: HomeAssistant, start_date: datetime, end_date: datetime
     ) -> list[CalendarEvent]:
@@ -106,6 +109,7 @@ class RainBirdCalendarEntity(
             for program_event in cursor
         ]
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()

--- a/homeassistant/components/rainbird/config_flow.py
+++ b/homeassistant/components/rainbird/config_flow.py
@@ -3,7 +3,7 @@
 import asyncio
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyrainbird.async_client import create_controller
 from pyrainbird.data import WifiParams
@@ -62,6 +62,7 @@ class RainbirdConfigFlowHandler(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: RainbirdConfigEntry,
     ) -> RainBirdOptionsFlowHandler:
@@ -97,6 +98,7 @@ class RainbirdConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/rainbird/coordinator.py
+++ b/homeassistant/components/rainbird/coordinator.py
@@ -4,6 +4,7 @@ import asyncio
 from dataclasses import dataclass
 import datetime
 import logging
+from typing import override
 
 import aiohttp
 from pyrainbird.async_client import (
@@ -118,6 +119,7 @@ class RainbirdUpdateCoordinator(DataUpdateCoordinator[RainbirdDeviceState]):
             device_info["connections"] = {(CONNECTION_NETWORK_MAC, mac_address)}
         return device_info
 
+    @override
     async def _async_update_data(self) -> RainbirdDeviceState:
         """Fetch data from Rain Bird device."""
         try:
@@ -171,6 +173,7 @@ class RainbirdScheduleUpdateCoordinator(DataUpdateCoordinator[Schedule]):
         self._controller = controller
         self._device_lock = device_lock
 
+    @override
     async def _async_update_data(self) -> Schedule:
         """Fetch data from Rain Bird device."""
         try:

--- a/homeassistant/components/rainbird/number.py
+++ b/homeassistant/components/rainbird/number.py
@@ -1,6 +1,7 @@
 """The number platform for rainbird."""
 
 import logging
+from typing import override
 
 from pyrainbird.exceptions import RainbirdApiException, RainbirdDeviceBusyException
 
@@ -55,10 +56,12 @@ class RainDelayNumber(CoordinatorEntity[RainbirdUpdateCoordinator], NumberEntity
             self._attr_name = f"{coordinator.device_name} Rain delay"
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the value reported by the sensor."""
         return self.coordinator.data.rain_delay
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
         try:

--- a/homeassistant/components/rainbird/sensor.py
+++ b/homeassistant/components/rainbird/sensor.py
@@ -1,6 +1,7 @@
 """Support for Rain Bird Irrigation system LNK Wi-Fi Module."""
 
 import logging
+from typing import override
 
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
 from homeassistant.core import HomeAssistant
@@ -58,6 +59,7 @@ class RainBirdSensor(CoordinatorEntity[RainbirdUpdateCoordinator], SensorEntity)
             )
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the value reported by the sensor."""
         return self.coordinator.data.rain_delay

--- a/homeassistant/components/rainbird/switch.py
+++ b/homeassistant/components/rainbird/switch.py
@@ -1,7 +1,7 @@
 """Support for Rain Bird Irrigation system LNK Wi-Fi Module."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyrainbird.exceptions import RainbirdApiException, RainbirdDeviceBusyException
 
@@ -70,10 +70,12 @@ class RainBirdSwitch(CoordinatorEntity[RainbirdUpdateCoordinator], SwitchEntity)
             )
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return state attributes."""
         return {"zone": self._zone}
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         try:
@@ -94,6 +96,7 @@ class RainBirdSwitch(CoordinatorEntity[RainbirdUpdateCoordinator], SwitchEntity)
         self.async_write_ha_state()
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         try:
@@ -113,6 +116,7 @@ class RainBirdSwitch(CoordinatorEntity[RainbirdUpdateCoordinator], SwitchEntity)
         await self.coordinator.async_request_refresh()
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if switch is on."""
         return self._zone in self.coordinator.data.active_zones

--- a/homeassistant/components/raincloud/binary_sensor.py
+++ b/homeassistant/components/raincloud/binary_sensor.py
@@ -1,6 +1,7 @@
 """Support for Melnor RainCloud sprinkler water timer."""
 
 import logging
+from typing import override
 
 import voluptuous as vol
 
@@ -70,6 +71,7 @@ class RainCloudBinarySensor(RainCloudEntity, BinarySensorEntity):
             self._attr_is_on = state
 
     @property
+    @override
     def icon(self) -> str | None:
         """Return the icon of this device."""
         if self._sensor_type == "is_watering":

--- a/homeassistant/components/raincloud/entity.py
+++ b/homeassistant/components/raincloud/entity.py
@@ -1,6 +1,6 @@
 """Support for Melnor RainCloud sprinkler water timer."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
@@ -42,6 +42,7 @@ class RainCloudEntity(Entity):
         self._attr_name = f"{self.data.name} {KEY_MAP.get(self._sensor_type)}"
         self._attr_icon = ICON_MAP.get(self._sensor_type)
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
         self.async_on_remove(
@@ -55,6 +56,7 @@ class RainCloudEntity(Entity):
         self.schedule_update_ha_state(True)
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         return {"identifier": self.data.serial}

--- a/homeassistant/components/raincloud/sensor.py
+++ b/homeassistant/components/raincloud/sensor.py
@@ -1,7 +1,7 @@
 """Support for Melnor RainCloud sprinkler water timer."""
 
 import logging
-from typing import cast
+from typing import cast, override
 
 import voluptuous as vol
 
@@ -70,6 +70,7 @@ class RainCloudSensor(RainCloudEntity, SensorEntity):
     """A sensor implementation for raincloud device."""
 
     @property
+    @override
     def native_unit_of_measurement(self) -> str | None:
         """Return the units of measurement."""
         return UNIT_OF_MEASUREMENT_MAP.get(self._sensor_type)
@@ -83,6 +84,7 @@ class RainCloudSensor(RainCloudEntity, SensorEntity):
             self._attr_native_value = getattr(self.data, self._sensor_type)
 
     @property
+    @override
     def icon(self) -> str | None:
         """Icon to use in the frontend, if any."""
         if self._sensor_type == "battery" and self.native_value is not None:

--- a/homeassistant/components/raincloud/switch.py
+++ b/homeassistant/components/raincloud/switch.py
@@ -1,7 +1,7 @@
 """Support for Melnor RainCloud sprinkler water timer."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -66,6 +66,7 @@ class RainCloudSwitch(RainCloudEntity, SwitchEntity):
         super().__init__(*args)
         self._default_watering_timer = default_watering_timer
 
+    @override
     def turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
         if self._sensor_type == "manual_watering":
@@ -74,6 +75,7 @@ class RainCloudSwitch(RainCloudEntity, SwitchEntity):
             self.data.auto_watering = True
         self._attr_is_on = True
 
+    @override
     def turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
         if self._sensor_type == "manual_watering":
@@ -91,6 +93,7 @@ class RainCloudSwitch(RainCloudEntity, SwitchEntity):
             self._attr_is_on = self.data.auto_watering
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         return {

--- a/homeassistant/components/rainforest_eagle/config_flow.py
+++ b/homeassistant/components/rainforest_eagle/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Rainforest Eagle integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -41,6 +41,7 @@ class RainforestEagleConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/rainforest_eagle/sensor.py
+++ b/homeassistant/components/rainforest_eagle/sensor.py
@@ -1,5 +1,7 @@
 """Support for the Rainforest Eagle energy monitor."""
 
+from typing import override
+
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -88,11 +90,13 @@ class EagleSensor(CoordinatorEntity[EagleDataCoordinator], SensorEntity):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return super().available and self.coordinator.is_connected
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return native value of the sensor."""
         return self.coordinator.data.get(self.entity_description.key)

--- a/homeassistant/components/rainforest_raven/config_flow.py
+++ b/homeassistant/components/rainforest_raven/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Rainforest RAVEn devices."""
 
 import asyncio
-from typing import Any
+from typing import Any, override
 
 from aioraven.data import MeterType
 from aioraven.device import RAVEnConnectionError
@@ -98,6 +98,7 @@ class RainforestRavenConfigFlow(ConfigFlow, domain=DOMAIN):
         )
         return self.async_show_form(step_id="meters", data_schema=schema, errors=errors)
 
+    @override
     async def async_step_usb(self, discovery_info: UsbServiceInfo) -> ConfigFlowResult:
         """Handle USB Discovery."""
         dev_path = discovery_info.device
@@ -111,6 +112,7 @@ class RainforestRavenConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="cannot_connect")
         return await self.async_step_meters()
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/rainforest_raven/coordinator.py
+++ b/homeassistant/components/rainforest_raven/coordinator.py
@@ -4,7 +4,7 @@ import asyncio
 from dataclasses import asdict
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from aioraven.data import DeviceInfo as RAVEnDeviceInfo
 from aioraven.device import RAVEnConnectionError
@@ -103,11 +103,13 @@ class RAVEnDataCoordinator(DataUpdateCoordinator):
             )
         return None
 
+    @override
     async def async_shutdown(self) -> None:
         """Shutdown the coordinator."""
         await self._cleanup_device()
         await super().async_shutdown()
 
+    @override
     async def _async_update_data(self) -> dict[str, Any]:
         try:
             device = await self._get_device()

--- a/homeassistant/components/rainforest_raven/sensor.py
+++ b/homeassistant/components/rainforest_raven/sensor.py
@@ -1,7 +1,7 @@
 """Sensor entity for a Rainforest RAVEn device."""
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -141,6 +141,7 @@ class RAVEnSensor(CoordinatorEntity[RAVEnDataCoordinator], SensorEntity):
         return self.coordinator.data.get(self.entity_description.message_key, {})
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return entity specific state attributes."""
         if self.entity_description.attribute_keys:
@@ -151,6 +152,7 @@ class RAVEnSensor(CoordinatorEntity[RAVEnDataCoordinator], SensorEntity):
         return None
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return native value of the sensor."""
         return str(self._data.get(self.entity_description.key))
@@ -174,6 +176,7 @@ class RAVEnMeterSensor(RAVEnSensor):
         )
 
     @property
+    @override
     def _data(self) -> Any:
         """Return the raw sensor data from the source."""
         return (

--- a/homeassistant/components/rainmachine/binary_sensor.py
+++ b/homeassistant/components/rainmachine/binary_sensor.py
@@ -1,6 +1,7 @@
 """Binary sensors for key RainMachine data."""
 
 from dataclasses import dataclass
+from typing import override
 
 from homeassistant.components.binary_sensor import (
     DOMAIN as BINARY_SENSOR_DOMAIN,
@@ -142,6 +143,7 @@ class CurrentRestrictionsBinarySensor(RainMachineEntity, BinarySensorEntity):
     entity_description: RainMachineBinarySensorDescription
 
     @callback
+    @override
     def update_from_latest_data(self) -> None:
         """Update the state."""
         if self.entity_description.key == TYPE_FREEZE:
@@ -164,6 +166,7 @@ class ProvisionSettingsBinarySensor(RainMachineEntity, BinarySensorEntity):
     entity_description: RainMachineBinarySensorDescription
 
     @callback
+    @override
     def update_from_latest_data(self) -> None:
         """Update the state."""
         if self.entity_description.key == TYPE_FLOW_SENSOR:

--- a/homeassistant/components/rainmachine/button.py
+++ b/homeassistant/components/rainmachine/button.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from typing import override
 
 from regenmaschine.controller import Controller
 from regenmaschine.errors import RainMachineError
@@ -69,6 +70,7 @@ class RainMachineButton(RainMachineEntity, ButtonEntity):
 
     entity_description: RainMachineButtonDescription
 
+    @override
     async def async_press(self) -> None:
         """Send out a restart command."""
         try:

--- a/homeassistant/components/rainmachine/config_flow.py
+++ b/homeassistant/components/rainmachine/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow to configure the RainMachine component."""
 
-from typing import Any
+from typing import Any, override
 
 from regenmaschine import Client
 from regenmaschine.controller import Controller
@@ -57,18 +57,21 @@ class RainMachineFlowHandler(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> RainMachineOptionsFlowHandler:
         """Define the config flow to handle options."""
         return RainMachineOptionsFlowHandler()
 
+    @override
     async def async_step_homekit(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:
         """Handle a flow initialized by homekit discovery."""
         return await self.async_step_homekit_zeroconf(discovery_info)
 
+    @override
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:
@@ -120,6 +123,7 @@ class RainMachineFlowHandler(ConfigFlow, domain=DOMAIN):
             }
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/rainmachine/entity.py
+++ b/homeassistant/components/rainmachine/entity.py
@@ -1,6 +1,7 @@
 """Support for RainMachine devices."""
 
 from dataclasses import dataclass
+from typing import override
 
 from homeassistant.const import CONF_IP_ADDRESS, CONF_PORT
 from homeassistant.core import callback
@@ -43,6 +44,7 @@ class RainMachineEntity(CoordinatorEntity[RainMachineDataUpdateCoordinator]):
         self.entity_description = description
 
     @property
+    @override
     def device_info(self) -> DeviceInfo:
         """Return device information about this controller."""
         return DeviceInfo(
@@ -60,11 +62,13 @@ class RainMachineEntity(CoordinatorEntity[RainMachineDataUpdateCoordinator]):
         )
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Respond to a DataUpdateCoordinator update."""
         self.update_from_latest_data()
         self.async_write_ha_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()

--- a/homeassistant/components/rainmachine/select.py
+++ b/homeassistant/components/rainmachine/select.py
@@ -1,6 +1,7 @@
 """Support for RainMachine selects."""
 
 from dataclasses import dataclass
+from typing import override
 
 from regenmaschine.errors import RainMachineError
 
@@ -129,6 +130,7 @@ class FreezeProtectionTemperatureSelect(RainMachineEntity, SelectEntity):
 
         self._attr_options = list(self._label_to_api_value_map)
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         try:
@@ -139,6 +141,7 @@ class FreezeProtectionTemperatureSelect(RainMachineEntity, SelectEntity):
             raise HomeAssistantError(f"Error while setting {self.name}: {err}") from err
 
     @callback
+    @override
     def update_from_latest_data(self) -> None:
         """Update the entity when new data is received."""
         raw_value = self.coordinator.data[self.entity_description.data_key]

--- a/homeassistant/components/rainmachine/sensor.py
+++ b/homeassistant/components/rainmachine/sensor.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Any, cast
+from typing import Any, cast, override
 
 from homeassistant.components.sensor import (
     DOMAIN as SENSOR_DOMAIN,
@@ -249,6 +249,7 @@ class TimeRemainingSensor(RainMachineEntity, RestoreSensor):
         """Return the data key that contains the activity status."""
         return "state"
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Handle entity which will be added."""
         if restored_data := await self.async_get_last_sensor_data():
@@ -260,6 +261,7 @@ class TimeRemainingSensor(RainMachineEntity, RestoreSensor):
         raise NotImplementedError
 
     @callback
+    @override
     def update_from_latest_data(self) -> None:
         """Update the state."""
         self._previous_run_state = self._current_run_state
@@ -294,10 +296,12 @@ class ProgramTimeRemainingSensor(TimeRemainingSensor):
     """Define a sensor that shows the amount of time remaining for a program."""
 
     @property
+    @override
     def status_key(self) -> str:
         """Return the data key that contains the activity status."""
         return "status"
 
+    @override
     def calculate_seconds_remaining(self) -> int:
         """Calculate the number of seconds remaining."""
         return sum(
@@ -312,6 +316,7 @@ class ProvisionSettingsSensor(RainMachineEntity, SensorEntity):
     entity_description: RainMachineSensorDataDescription
 
     @callback
+    @override
     def update_from_latest_data(self) -> None:
         """Update the state."""
         system = self.coordinator.data.get("system", {})
@@ -349,6 +354,7 @@ class ProvisionSettingsSensor(RainMachineEntity, SensorEntity):
 class ZoneTimeRemainingSensor(TimeRemainingSensor):
     """Define a sensor that shows the amount of time remaining for a zone."""
 
+    @override
     def calculate_seconds_remaining(self) -> int:
         """Calculate the number of seconds remaining."""
         return cast(

--- a/homeassistant/components/rainmachine/switch.py
+++ b/homeassistant/components/rainmachine/switch.py
@@ -4,7 +4,7 @@ import asyncio
 from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Concatenate
+from typing import Any, Concatenate, override
 
 from regenmaschine.errors import RainMachineError
 import voluptuous as vol
@@ -305,6 +305,7 @@ class RainMachineActivitySwitch(RainMachineBaseSwitch):
             self.entity_description.kind
         )
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off.
 
@@ -326,6 +327,7 @@ class RainMachineActivitySwitch(RainMachineBaseSwitch):
         """Turn the switch off when its associated activity is active."""
         raise NotImplementedError
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         if (
@@ -367,6 +369,7 @@ class RainMachineEnabledSwitch(RainMachineBaseSwitch):
         )
 
     @callback
+    @override
     def update_from_latest_data(self) -> None:
         """Update the entity when new data is received."""
         self._attr_is_on = self.coordinator.data[self.entity_description.uid]["active"]
@@ -375,27 +378,32 @@ class RainMachineEnabledSwitch(RainMachineBaseSwitch):
 class RainMachineProgram(RainMachineActivitySwitch):
     """Define a RainMachine program."""
 
+    @override
     async def async_start_program(self) -> None:
         """Start the program."""
         await self.async_turn_on()
 
+    @override
     async def async_stop_program(self) -> None:
         """Stop the program."""
         await self.async_turn_off()
 
     @raise_on_request_error
+    @override
     async def async_turn_off_when_active(self, **kwargs: Any) -> None:
         """Turn the switch off when its associated activity is active."""
         await self._data.controller.programs.stop(self.entity_description.uid)
         self._update_activities()
 
     @raise_on_request_error
+    @override
     async def async_turn_on_when_active(self, **kwargs: Any) -> None:
         """Turn the switch on when its associated activity is active."""
         await self._data.controller.programs.start(self.entity_description.uid)
         self._update_activities()
 
     @callback
+    @override
     def update_from_latest_data(self) -> None:
         """Update the entity when new data is received."""
         data = self.coordinator.data[self.entity_description.uid]
@@ -426,6 +434,7 @@ class RainMachineProgramEnabled(RainMachineEnabledSwitch):
     """Define a switch to enable/disable a RainMachine program."""
 
     @raise_on_request_error
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Disable the program."""
         tasks = [
@@ -436,6 +445,7 @@ class RainMachineProgramEnabled(RainMachineEnabledSwitch):
         self._update_activities()
 
     @raise_on_request_error
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Enable the program."""
         await self._data.controller.programs.enable(self.entity_description.uid)
@@ -449,6 +459,7 @@ class RainMachineRestrictionSwitch(RainMachineBaseSwitch):
     entity_description: RainMachineRestrictionSwitchDescription
 
     @raise_on_request_error
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Disable the restriction."""
         await self._data.controller.restrictions.set_universal(
@@ -458,6 +469,7 @@ class RainMachineRestrictionSwitch(RainMachineBaseSwitch):
         self.async_write_ha_state()
 
     @raise_on_request_error
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Enable the restriction."""
         await self._data.controller.restrictions.set_universal(
@@ -467,6 +479,7 @@ class RainMachineRestrictionSwitch(RainMachineBaseSwitch):
         self.async_write_ha_state()
 
     @callback
+    @override
     def update_from_latest_data(self) -> None:
         """Update the entity when new data is received."""
         self._attr_is_on = self.coordinator.data[self.entity_description.data_key]
@@ -475,21 +488,25 @@ class RainMachineRestrictionSwitch(RainMachineBaseSwitch):
 class RainMachineZone(RainMachineActivitySwitch):
     """Define a RainMachine zone."""
 
+    @override
     async def async_start_zone(self, *, zone_run_time: int) -> None:
         """Start a particular zone for a certain amount of time."""
         await self.async_turn_on(duration=zone_run_time)
 
+    @override
     async def async_stop_zone(self) -> None:
         """Stop a zone."""
         await self.async_turn_off()
 
     @raise_on_request_error
+    @override
     async def async_turn_off_when_active(self, **kwargs: Any) -> None:
         """Turn the switch off when its associated activity is active."""
         await self._data.controller.zones.stop(self.entity_description.uid)
         self._update_activities()
 
     @raise_on_request_error
+    @override
     async def async_turn_on_when_active(self, **kwargs: Any) -> None:
         """Turn the switch on when its associated activity is active."""
         # 1. Use duration parameter if provided from service call
@@ -511,6 +528,7 @@ class RainMachineZone(RainMachineActivitySwitch):
         self._update_activities()
 
     @callback
+    @override
     def update_from_latest_data(self) -> None:
         """Update the entity when new data is received."""
         data = self.coordinator.data[self.entity_description.uid]
@@ -556,6 +574,7 @@ class RainMachineZoneEnabled(RainMachineEnabledSwitch):
     """Define a switch to enable/disable a RainMachine zone."""
 
     @raise_on_request_error
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Disable the zone."""
         tasks = [
@@ -566,6 +585,7 @@ class RainMachineZoneEnabled(RainMachineEnabledSwitch):
         self._update_activities()
 
     @raise_on_request_error
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Enable the zone."""
         await self._data.controller.zones.enable(self.entity_description.uid)

--- a/homeassistant/components/rainmachine/update.py
+++ b/homeassistant/components/rainmachine/update.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any
+from typing import Any, override
 
 from regenmaschine.errors import RequestError
 
@@ -76,6 +76,7 @@ class RainMachineUpdateEntity(RainMachineEntity, UpdateEntity):
         | UpdateEntityFeature.SPECIFIC_VERSION
     )
 
+    @override
     async def async_install(
         self, version: str | None, backup: bool, **kwargs: Any
     ) -> None:
@@ -88,6 +89,7 @@ class RainMachineUpdateEntity(RainMachineEntity, UpdateEntity):
         await self.coordinator.async_refresh()
 
     @callback
+    @override
     def update_from_latest_data(self) -> None:
         """Update the state."""
         if version := self._version_coordinator.data["swVer"]:

--- a/homeassistant/components/random/config_flow.py
+++ b/homeassistant/components/random/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable, Coroutine, Mapping
 from enum import StrEnum
-from typing import Any, cast
+from typing import Any, cast, override
 
 import voluptuous as vol
 
@@ -187,6 +187,7 @@ class RandomConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
     options_flow_reloads = True
 
     @callback
+    @override
     def async_config_entry_title(self, options: Mapping[str, Any]) -> str:
         """Return config entry title."""
         return cast(str, options["name"])

--- a/homeassistant/components/rapt_ble/config_flow.py
+++ b/homeassistant/components/rapt_ble/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for rapt_ble."""
 
-from typing import Any
+from typing import Any, override
 
 from rapt_ble import RAPTPillBluetoothDeviceData as DeviceData
 import voluptuous as vol
@@ -27,6 +27,7 @@ class RAPTPillConfigFlow(ConfigFlow, domain=DOMAIN):
         self._discovered_device: DeviceData | None = None
         self._discovered_devices: dict[str, str] = {}
 
+    @override
     async def async_step_bluetooth(
         self, discovery_info: BluetoothServiceInfoBleak
     ) -> ConfigFlowResult:
@@ -59,6 +60,7 @@ class RAPTPillConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="bluetooth_confirm", description_placeholders=placeholders
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/rapt_ble/sensor.py
+++ b/homeassistant/components/rapt_ble/sensor.py
@@ -1,5 +1,7 @@
 """Support for RAPT Pill hydrometers."""
 
+from typing import override
+
 from rapt_ble import DeviceClass, DeviceKey, SensorUpdate, Units
 
 from homeassistant.components.bluetooth.passive_update_processor import (
@@ -119,6 +121,7 @@ class RAPTPillBluetoothSensorEntity(
     """Representation of a RAPT Pill BLE sensor."""
 
     @property
+    @override
     def native_value(self) -> int | float | None:
         """Return the native value."""
         return self.processor.entity_data.get(self.entity_key)

--- a/homeassistant/components/raspyrfm/switch.py
+++ b/homeassistant/components/raspyrfm/switch.py
@@ -1,6 +1,6 @@
 """Support for switches that can be controlled using the RaspyRFM rc module."""
 
-from typing import Any
+from typing import Any, override
 
 from raspyrfm_client import RaspyRFMClient
 from raspyrfm_client.device_implementations.controlunit.actions import Action
@@ -115,6 +115,7 @@ class RaspyRFMSwitch(SwitchEntity):
 
         self._attr_is_on = None
 
+    @override
     def turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
 
@@ -122,6 +123,7 @@ class RaspyRFMSwitch(SwitchEntity):
         self._attr_is_on = True
         self.schedule_update_ha_state()
 
+    @override
     def turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
 

--- a/homeassistant/components/rdw/binary_sensor.py
+++ b/homeassistant/components/rdw/binary_sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from vehicle import Vehicle
 
@@ -70,6 +71,7 @@ class RDWBinarySensorEntity(RDWEntity, BinarySensorEntity):
         self._attr_unique_id = f"{coordinator.data.license_plate}_{description.key}"
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return the state of the sensor."""
         return bool(self.entity_description.is_on_fn(self.coordinator.data))

--- a/homeassistant/components/rdw/config_flow.py
+++ b/homeassistant/components/rdw/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow to configure the RDW integration."""
 
-from typing import Any
+from typing import Any, override
 
 from vehicle import RDW, RDWError, RDWUnknownLicensePlateError
 import voluptuous as vol
@@ -16,6 +16,7 @@ class RDWFlowHandler(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/rdw/coordinator.py
+++ b/homeassistant/components/rdw/coordinator.py
@@ -1,5 +1,7 @@
 """Data update coordinator for RDW."""
 
+from typing import override
+
 from vehicle import RDW, RDWConnectionError, RDWError, Vehicle
 
 from homeassistant.config_entries import ConfigEntry
@@ -31,6 +33,7 @@ class RDWDataUpdateCoordinator(DataUpdateCoordinator[Vehicle]):
             license_plate=config_entry.data[CONF_LICENSE_PLATE],
         )
 
+    @override
     async def _async_update_data(self) -> Vehicle:
         """Fetch data from RDW."""
         try:

--- a/homeassistant/components/rdw/sensor.py
+++ b/homeassistant/components/rdw/sensor.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import date
+from typing import override
 
 from vehicle import Vehicle
 
@@ -70,6 +71,7 @@ class RDWSensorEntity(RDWEntity, SensorEntity):
         self._attr_unique_id = f"{coordinator.data.license_plate}_{description.key}"
 
     @property
+    @override
     def native_value(self) -> date | str | float | None:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/recollect_waste/calendar.py
+++ b/homeassistant/components/recollect_waste/calendar.py
@@ -1,6 +1,7 @@
 """Support for ReCollect Waste calendars."""
 
 import datetime
+from typing import override
 
 from aiorecollect.client import PickupEvent
 
@@ -58,11 +59,13 @@ class ReCollectWasteCalendar(ReCollectWasteEntity, CalendarEntity):
         self._event: CalendarEvent | None = None
 
     @property
+    @override
     def event(self) -> CalendarEvent | None:
         """Return the next upcoming event."""
         return self._event
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         try:
@@ -80,6 +83,7 @@ class ReCollectWasteCalendar(ReCollectWasteEntity, CalendarEntity):
 
         super()._handle_coordinator_update()
 
+    @override
     async def async_get_events(
         self,
         hass: HomeAssistant,

--- a/homeassistant/components/recollect_waste/config_flow.py
+++ b/homeassistant/components/recollect_waste/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for ReCollect Waste integration."""
 
-from typing import Any
+from typing import Any, override
 
 from aiorecollect.client import Client
 from aiorecollect.errors import RecollectError
@@ -26,12 +26,14 @@ class RecollectWasteConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: RecollectWasteConfigEntry,
     ) -> RecollectWasteOptionsFlowHandler:
         """Define the config flow to handle options."""
         return RecollectWasteOptionsFlowHandler()
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/recollect_waste/coordinator.py
+++ b/homeassistant/components/recollect_waste/coordinator.py
@@ -1,6 +1,7 @@
 """Data update coordinator for ReCollect Waste."""
 
 from datetime import timedelta
+from typing import override
 
 from aiorecollect.client import Client, PickupEvent
 from aiorecollect.errors import RecollectError
@@ -43,6 +44,7 @@ class ReCollectWasteDataUpdateCoordinator(DataUpdateCoordinator[list[PickupEvent
             session=aiohttp_client.async_get_clientsession(hass),
         )
 
+    @override
     async def _async_update_data(self) -> list[PickupEvent]:
         """Fetch data from ReCollect."""
         try:

--- a/homeassistant/components/recollect_waste/entity.py
+++ b/homeassistant/components/recollect_waste/entity.py
@@ -1,5 +1,7 @@
 """Define a base ReCollect Waste entity."""
 
+from typing import override
+
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -31,6 +33,7 @@ class ReCollectWasteEntity(CoordinatorEntity[ReCollectWasteDataUpdateCoordinator
         self._attr_extra_state_attributes = {}
         self._entry = entry
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
         await super().async_added_to_hass()

--- a/homeassistant/components/recollect_waste/sensor.py
+++ b/homeassistant/components/recollect_waste/sensor.py
@@ -1,5 +1,7 @@
 """Support for ReCollect Waste sensors."""
 
+from typing import override
+
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -67,6 +69,7 @@ class ReCollectWasteSensor(ReCollectWasteEntity, SensorEntity):
         self.entity_description = description
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         relevant_events = (

--- a/homeassistant/components/recorder/core.py
+++ b/homeassistant/components/recorder/core.py
@@ -10,7 +10,7 @@ import queue
 import sqlite3
 import threading
 import time
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, cast, override
 
 from propcache.api import cached_property
 import psutil_home_assistant as ha_psutil
@@ -668,6 +668,7 @@ class Recorder(threading.Thread):
             )
             return SHUTDOWN_TASK
 
+    @override
     def run(self) -> None:
         """Run the recorder thread."""
         self.is_running = True

--- a/homeassistant/components/recorder/db_schema.py
+++ b/homeassistant/components/recorder/db_schema.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from datetime import datetime, timedelta
 import logging
 import time
-from typing import Any, Final, Protocol, Self
+from typing import Any, Final, Protocol, Self, override
 
 import ciso8601
 from fnv_hash_fast import fnv1a_32
@@ -171,6 +171,7 @@ def compile_char_one(type_: TypeDecorator, compiler: Any, **kw: Any) -> str:
 class FAST_PYSQLITE_DATETIME(sqlite.DATETIME):
     """Use ciso8601 to parse datetimes instead of sqlalchemy built-in regex."""
 
+    @override
     def result_processor(self, dialect: Dialect, coltype: Any) -> Callable | None:
         """Offload the datetime parsing to ciso8601."""
         return lambda value: None if value is None else ciso8601.parse_datetime(value)
@@ -179,6 +180,7 @@ class FAST_PYSQLITE_DATETIME(sqlite.DATETIME):
 class NativeLargeBinary(LargeBinary):
     """A faster version of LargeBinary for native bytes engines."""
 
+    @override
     def result_processor(self, dialect: Dialect, coltype: Any) -> Callable | None:
         """No conversion needed for engines that support native bytes."""
         return None
@@ -233,6 +235,7 @@ class _LiteralProcessorType(Protocol):
 class JSONLiteral(JSON):
     """Teach SA how to literalize json."""
 
+    @override
     def literal_processor(self, dialect: Dialect) -> _LiteralProcessorType:
         """Processor to convert a value to JSON."""
 
@@ -283,6 +286,7 @@ class Events(Base):
     event_data_rel: Mapped[EventData | None] = relationship("EventData")
     event_type_rel: Mapped[EventTypes | None] = relationship("EventTypes")
 
+    @override
     def __repr__(self) -> str:
         """Return string representation of instance for debugging."""
         return (
@@ -346,6 +350,7 @@ class EventData(Base):
         Text().with_variant(mysql.LONGTEXT, "mysql", "mariadb")
     )
 
+    @override
     def __repr__(self) -> str:
         """Return string representation of instance for debugging."""
         return (
@@ -388,6 +393,7 @@ class EventTypes(Base):
         String(MAX_LENGTH_EVENT_EVENT_TYPE), index=True, unique=True
     )
 
+    @override
     def __repr__(self) -> str:
         """Return string representation of instance for debugging."""
         return (
@@ -447,6 +453,7 @@ class States(Base):
     )
     states_meta_rel: Mapped[StatesMeta | None] = relationship("StatesMeta")
 
+    @override
     def __repr__(self) -> str:
         """Return string representation of instance for debugging."""
         return (
@@ -543,6 +550,7 @@ class StateAttributes(Base):
         Text().with_variant(mysql.LONGTEXT, "mysql", "mariadb")
     )
 
+    @override
     def __repr__(self) -> str:
         """Return string representation of instance for debugging."""
         return (
@@ -608,6 +616,7 @@ class StatesMeta(Base):
         String(MAX_LENGTH_STATE_ENTITY_ID), index=True, unique=True
     )
 
+    @override
     def __repr__(self) -> str:
         """Return string representation of instance for debugging."""
         return (
@@ -802,6 +811,7 @@ class RecorderRuns(Base):
     closed_incorrect: Mapped[bool] = mapped_column(Boolean, default=False)
     created: Mapped[datetime] = mapped_column(DATETIME_TYPE, default=dt_util.utcnow)
 
+    @override
     def __repr__(self) -> str:
         """Return string representation of instance for debugging."""
         end = (
@@ -835,6 +845,7 @@ class SchemaChanges(Base):
     schema_version: Mapped[int | None] = mapped_column(Integer)
     changed: Mapped[datetime] = mapped_column(DATETIME_TYPE, default=dt_util.utcnow)
 
+    @override
     def __repr__(self) -> str:
         """Return string representation of instance for debugging."""
         return (
@@ -854,6 +865,7 @@ class StatisticsRuns(Base):
     run_id: Mapped[int] = mapped_column(ID_TYPE, Identity(), primary_key=True)
     start: Mapped[datetime] = mapped_column(DATETIME_TYPE, index=True)
 
+    @override
     def __repr__(self) -> str:
         """Return string representation of instance for debugging."""
         return (

--- a/homeassistant/components/recorder/executor.py
+++ b/homeassistant/components/recorder/executor.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from concurrent.futures.thread import _threads_queues, _worker
 import threading
-from typing import Any
+from typing import Any, override
 import weakref
 
 from homeassistant.util.executor import InterruptibleThreadPoolExecutor
@@ -32,6 +32,7 @@ class DBInterruptibleThreadPoolExecutor(InterruptibleThreadPoolExecutor):
         self.recorder_and_worker_thread_ids = recorder_and_worker_thread_ids
         super().__init__(*args, **kwargs)
 
+    @override
     def _adjust_thread_count(self) -> None:
         """Overridden to add support for shutdown hook.
 

--- a/homeassistant/components/recorder/filters.py
+++ b/homeassistant/components/recorder/filters.py
@@ -1,7 +1,7 @@
 """Provide pre-made queries on top of the recorder component."""
 
 from collections.abc import Callable, Collection, Iterable
-from typing import Any
+from typing import Any, override
 
 from sqlalchemy import Column, Text, cast, not_, or_
 from sqlalchemy.sql.elements import ColumnElement
@@ -99,6 +99,7 @@ class Filters:
         self._included_domains = included_domains or []
         self._included_entity_globs = included_entity_globs or []
 
+    @override
     def __repr__(self) -> str:
         """Return human readable excludes/includes."""
         return (

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, replace as dataclass_replace
 from datetime import timedelta
 import logging
 from time import time
-from typing import TYPE_CHECKING, Any, TypedDict, cast, final
+from typing import TYPE_CHECKING, Any, TypedDict, cast, final, override
 from uuid import UUID
 
 import sqlalchemy
@@ -1043,6 +1043,7 @@ class _SchemaVersionMigrator(ABC):
 
     __migrators: dict[int, type[_SchemaVersionMigrator]] = {}
 
+    @override
     def __init_subclass__(cls, target_version: int, **kwargs: Any) -> None:
         """Post initialisation processing."""
         super().__init_subclass__(**kwargs)
@@ -1089,12 +1090,14 @@ class _SchemaVersionMigrator(ABC):
 
 
 class _SchemaVersion1Migrator(_SchemaVersionMigrator, target_version=1):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         # This used to create ix_events_time_fired, but it was removed in version 32
 
 
 class _SchemaVersion2Migrator(_SchemaVersionMigrator, target_version=2):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         # Create compound start/end index for recorder_runs
@@ -1108,12 +1111,14 @@ class _SchemaVersion2Migrator(_SchemaVersionMigrator, target_version=2):
 
 
 class _SchemaVersion3Migrator(_SchemaVersionMigrator, target_version=3):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         # There used to be a new index here, but it was removed in version 4.
 
 
 class _SchemaVersion4Migrator(_SchemaVersionMigrator, target_version=4):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         # Queries were rewritten in this schema release. Most indexes from
@@ -1135,6 +1140,7 @@ class _SchemaVersion4Migrator(_SchemaVersionMigrator, target_version=4):
 
 
 class _SchemaVersion5Migrator(_SchemaVersionMigrator, target_version=5):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         # Create supporting index for States.event_id foreign key
@@ -1144,6 +1150,7 @@ class _SchemaVersion5Migrator(_SchemaVersionMigrator, target_version=5):
 
 
 class _SchemaVersion6Migrator(_SchemaVersionMigrator, target_version=6):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         _add_columns(
@@ -1169,6 +1176,7 @@ class _SchemaVersion6Migrator(_SchemaVersionMigrator, target_version=6):
 
 
 class _SchemaVersion7Migrator(_SchemaVersionMigrator, target_version=7):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         # There used to be a ix_states_entity_id index here,
@@ -1176,6 +1184,7 @@ class _SchemaVersion7Migrator(_SchemaVersionMigrator, target_version=7):
 
 
 class _SchemaVersion8Migrator(_SchemaVersionMigrator, target_version=8):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         _add_columns(self.session_maker, "events", ["context_parent_id CHARACTER(36)"])
@@ -1185,6 +1194,7 @@ class _SchemaVersion8Migrator(_SchemaVersionMigrator, target_version=8):
 
 
 class _SchemaVersion9Migrator(_SchemaVersionMigrator, target_version=9):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         # We now get the context from events with a join
@@ -1209,12 +1219,14 @@ class _SchemaVersion9Migrator(_SchemaVersionMigrator, target_version=9):
 
 
 class _SchemaVersion10Migrator(_SchemaVersionMigrator, target_version=10):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         # Now done in step 11
 
 
 class _SchemaVersion11Migrator(_SchemaVersionMigrator, target_version=11):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         _create_index(
@@ -1234,6 +1246,7 @@ class _SchemaVersion11Migrator(_SchemaVersionMigrator, target_version=11):
 
 
 class _SchemaVersion12Migrator(_SchemaVersionMigrator, target_version=12):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         if self.engine.dialect.name == SupportedDialect.MYSQL:
@@ -1246,6 +1259,7 @@ class _SchemaVersion12Migrator(_SchemaVersionMigrator, target_version=12):
 
 
 class _SchemaVersion13Migrator(_SchemaVersionMigrator, target_version=13):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         if self.engine.dialect.name == SupportedDialect.MYSQL:
@@ -1268,6 +1282,7 @@ class _SchemaVersion13Migrator(_SchemaVersionMigrator, target_version=13):
 
 
 class _SchemaVersion14Migrator(_SchemaVersionMigrator, target_version=14):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         _modify_columns(
@@ -1276,12 +1291,14 @@ class _SchemaVersion14Migrator(_SchemaVersionMigrator, target_version=14):
 
 
 class _SchemaVersion15Migrator(_SchemaVersionMigrator, target_version=15):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         # This dropped the statistics table, done again in version 18.
 
 
 class _SchemaVersion16Migrator(_SchemaVersionMigrator, target_version=16):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         # Dropping foreign key constraints is not supported by SQLite
@@ -1299,12 +1316,14 @@ class _SchemaVersion16Migrator(_SchemaVersionMigrator, target_version=16):
 
 
 class _SchemaVersion17Migrator(_SchemaVersionMigrator, target_version=17):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         # This dropped the statistics table, done again in version 18.
 
 
 class _SchemaVersion18Migrator(_SchemaVersionMigrator, target_version=18):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         # Recreate the statistics and statistics meta tables.
@@ -1330,6 +1349,7 @@ class _SchemaVersion18Migrator(_SchemaVersionMigrator, target_version=18):
 
 
 class _SchemaVersion19Migrator(_SchemaVersionMigrator, target_version=19):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         # This adds the statistic runs table, insert a fake run to prevent duplicating
@@ -1339,6 +1359,7 @@ class _SchemaVersion19Migrator(_SchemaVersionMigrator, target_version=19):
 
 
 class _SchemaVersion20Migrator(_SchemaVersionMigrator, target_version=20):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         # This changed the precision of statistics from float to double
@@ -1358,6 +1379,7 @@ class _SchemaVersion20Migrator(_SchemaVersionMigrator, target_version=20):
 
 
 class _SchemaVersion21Migrator(_SchemaVersionMigrator, target_version=21):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         # Try to change the character set of events, states and statistics_meta tables
@@ -1367,6 +1389,7 @@ class _SchemaVersion21Migrator(_SchemaVersionMigrator, target_version=21):
 
 
 class _SchemaVersion22Migrator(_SchemaVersionMigrator, target_version=22):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         # Recreate the all statistics tables for Oracle DB with Identity columns
@@ -1439,6 +1462,7 @@ class _SchemaVersion22Migrator(_SchemaVersionMigrator, target_version=22):
 
 
 class _SchemaVersion23Migrator(_SchemaVersionMigrator, target_version=23):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         # Add name column to StatisticsMeta
@@ -1446,6 +1470,7 @@ class _SchemaVersion23Migrator(_SchemaVersionMigrator, target_version=23):
 
 
 class _SchemaVersion24Migrator(_SchemaVersionMigrator, target_version=24):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         # This used to create the unique indices for start and statistic_id
@@ -1454,6 +1479,7 @@ class _SchemaVersion24Migrator(_SchemaVersionMigrator, target_version=24):
 
 
 class _SchemaVersion25Migrator(_SchemaVersionMigrator, target_version=25):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         _add_columns(
@@ -1467,6 +1493,7 @@ class _SchemaVersion25Migrator(_SchemaVersionMigrator, target_version=25):
 
 
 class _SchemaVersion26Migrator(_SchemaVersionMigrator, target_version=26):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         _create_index(
@@ -1478,6 +1505,7 @@ class _SchemaVersion26Migrator(_SchemaVersionMigrator, target_version=26):
 
 
 class _SchemaVersion27Migrator(_SchemaVersionMigrator, target_version=27):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         _add_columns(
@@ -1487,6 +1515,7 @@ class _SchemaVersion27Migrator(_SchemaVersionMigrator, target_version=27):
 
 
 class _SchemaVersion28Migrator(_SchemaVersionMigrator, target_version=28):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         _add_columns(self.session_maker, "events", ["origin_idx INTEGER"])
@@ -1511,6 +1540,7 @@ class _SchemaVersion28Migrator(_SchemaVersionMigrator, target_version=28):
 
 
 class _SchemaVersion29Migrator(_SchemaVersionMigrator, target_version=29):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         # Recreate statistics_meta index to block duplicated statistic_id
@@ -1551,6 +1581,7 @@ class _SchemaVersion29Migrator(_SchemaVersionMigrator, target_version=29):
 
 
 class _SchemaVersion30Migrator(_SchemaVersionMigrator, target_version=30):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         # This added a column to the statistics_meta table, removed again before
@@ -1561,6 +1592,7 @@ class _SchemaVersion30Migrator(_SchemaVersionMigrator, target_version=30):
 
 
 class _SchemaVersion31Migrator(_SchemaVersionMigrator, target_version=31):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         # Once we require SQLite >= 3.35.5, we should drop the column:
@@ -1602,6 +1634,7 @@ class _SchemaVersion31Migrator(_SchemaVersionMigrator, target_version=31):
 
 
 class _SchemaVersion32Migrator(_SchemaVersionMigrator, target_version=32):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         # Migration is done in two steps to ensure we can start using
@@ -1620,6 +1653,7 @@ class _SchemaVersion32Migrator(_SchemaVersionMigrator, target_version=32):
 
 
 class _SchemaVersion33Migrator(_SchemaVersionMigrator, target_version=33):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         # This index is no longer used and can cause MySQL to use the wrong index
@@ -1629,6 +1663,7 @@ class _SchemaVersion33Migrator(_SchemaVersionMigrator, target_version=33):
 
 
 class _SchemaVersion34Migrator(_SchemaVersionMigrator, target_version=34):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         # Once we require SQLite >= 3.35.5, we should drop the columns:
@@ -1683,6 +1718,7 @@ class _SchemaVersion34Migrator(_SchemaVersionMigrator, target_version=34):
 
 
 class _SchemaVersion35Migrator(_SchemaVersionMigrator, target_version=35):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         # Migration is done in two steps to ensure we can start using
@@ -1710,6 +1746,7 @@ class _SchemaVersion35Migrator(_SchemaVersionMigrator, target_version=35):
 
 
 class _SchemaVersion36Migrator(_SchemaVersionMigrator, target_version=36):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         for table in ("states", "events"):
@@ -1731,6 +1768,7 @@ class _SchemaVersion36Migrator(_SchemaVersionMigrator, target_version=36):
 
 
 class _SchemaVersion37Migrator(_SchemaVersionMigrator, target_version=37):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         _add_columns(
@@ -1751,6 +1789,7 @@ class _SchemaVersion37Migrator(_SchemaVersionMigrator, target_version=37):
 
 
 class _SchemaVersion38Migrator(_SchemaVersionMigrator, target_version=38):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         _add_columns(
@@ -1770,6 +1809,7 @@ class _SchemaVersion38Migrator(_SchemaVersionMigrator, target_version=38):
 
 
 class _SchemaVersion39Migrator(_SchemaVersionMigrator, target_version=39):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         # Dropping indexes with PostgreSQL never worked correctly if there was a prefix
@@ -1830,6 +1870,7 @@ class _SchemaVersion39Migrator(_SchemaVersionMigrator, target_version=39):
 
 
 class _SchemaVersion40Migrator(_SchemaVersionMigrator, target_version=40):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         # ix_events_event_type_id is a left-prefix of
@@ -1851,6 +1892,7 @@ class _SchemaVersion40Migrator(_SchemaVersionMigrator, target_version=40):
 
 
 class _SchemaVersion41Migrator(_SchemaVersionMigrator, target_version=41):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         _create_index(
@@ -1865,6 +1907,7 @@ class _SchemaVersion41Migrator(_SchemaVersionMigrator, target_version=41):
 
 
 class _SchemaVersion42Migrator(_SchemaVersionMigrator, target_version=42):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         # If the user had a previously failed migration, or they
@@ -1878,6 +1921,7 @@ class _SchemaVersion42Migrator(_SchemaVersionMigrator, target_version=42):
 
 
 class _SchemaVersion43Migrator(_SchemaVersionMigrator, target_version=43):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         _add_columns(
@@ -1888,6 +1932,7 @@ class _SchemaVersion43Migrator(_SchemaVersionMigrator, target_version=43):
 
 
 class _SchemaVersion44Migrator(_SchemaVersionMigrator, target_version=44):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         # The changes in this version are identical to the changes in version
@@ -1897,6 +1942,7 @@ class _SchemaVersion44Migrator(_SchemaVersionMigrator, target_version=44):
 
 
 class _SchemaVersion45Migrator(_SchemaVersionMigrator, target_version=45):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         # The changes in this version are identical to the changes in version
@@ -1938,6 +1984,7 @@ FOREIGN_COLUMNS = (
 
 
 class _SchemaVersion46Migrator(_SchemaVersionMigrator, target_version=46):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         # We skip this step for SQLITE, it doesn't have differently sized integers
@@ -1989,6 +2036,7 @@ class _SchemaVersion46Migrator(_SchemaVersionMigrator, target_version=46):
 
 
 class _SchemaVersion47Migrator(_SchemaVersionMigrator, target_version=47):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         # We skip this step for SQLITE, it doesn't have differently sized integers
@@ -2008,6 +2056,7 @@ class _SchemaVersion47Migrator(_SchemaVersionMigrator, target_version=47):
 
 
 class _SchemaVersion48Migrator(_SchemaVersionMigrator, target_version=48):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         # https://github.com/home-assistant/core/issues/134002
@@ -2019,6 +2068,7 @@ class _SchemaVersion48Migrator(_SchemaVersionMigrator, target_version=48):
 
 
 class _SchemaVersion49Migrator(_SchemaVersionMigrator, target_version=49):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         _add_columns(
@@ -2049,6 +2099,7 @@ class _SchemaVersion49Migrator(_SchemaVersionMigrator, target_version=49):
 
 
 class _SchemaVersion50Migrator(_SchemaVersionMigrator, target_version=50):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         with session_scope(session=self.session_maker()) as session:
@@ -2057,12 +2108,14 @@ class _SchemaVersion50Migrator(_SchemaVersionMigrator, target_version=50):
 
 
 class _SchemaVersion51Migrator(_SchemaVersionMigrator, target_version=51):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         # Replaced with version 52 which corrects issues with MySQL string comparisons.
 
 
 class _SchemaVersion52Migrator(_SchemaVersionMigrator, target_version=52):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         if self.engine.dialect.name == SupportedDialect.MYSQL:
@@ -2132,6 +2185,7 @@ class _SchemaVersion52Migrator(_SchemaVersionMigrator, target_version=52):
 
 
 class _SchemaVersion53Migrator(_SchemaVersionMigrator, target_version=53):
+    @override
     def _apply_update(self) -> None:
         """Version specific update method."""
         # Try to change the character set of events, states and statistics_meta tables
@@ -2595,6 +2649,7 @@ class MigrationTask(RecorderTask):
     migrator: BaseRunTimeMigration
     commit_before = False
 
+    @override
     def run(self, instance: Recorder) -> None:
         """Run migration task."""
         if not self.migrator.migrate_data(instance):
@@ -2761,6 +2816,7 @@ class BaseOffLineMigration(BaseMigration):
         _LOGGER.warning("Data migration step '%s' completed", self.migration_id)
 
     @database_job_retry_wrapper_method("migrate data", 10)
+    @override
     def migrate_data(self, instance: Recorder) -> bool:
         """Migrate some data, returns True if migration is completed."""
         return self._migrate_data(instance)
@@ -2798,6 +2854,7 @@ class BaseRunTimeMigration(BaseMigration):
             self.migration_done(instance, session)
 
     @retryable_database_job_method("migrate data")
+    @override
     def migrate_data(self, instance: Recorder) -> bool:
         """Migrate some data, returns True if migration is completed."""
         return self._migrate_data(instance)
@@ -2810,6 +2867,7 @@ class BaseMigrationWithQuery(BaseMigration):
     def needs_migrate_query(self) -> StatementLambdaElement:
         """Return the query to check if the migration needs to run."""
 
+    @override
     def needs_migrate_impl(
         self, instance: Recorder, session: Session
     ) -> DataMigrationStatus:
@@ -2829,6 +2887,7 @@ class StatesContextIDMigration(BaseMigrationWithQuery, BaseOffLineMigration):
     migration_version = 2
     index_to_drop = ("states", "ix_states_context_id", LegacyBase)
 
+    @override
     def migrate_data_impl(self, instance: Recorder) -> DataMigrationStatus:
         """Migrate states context_ids to use binary format, return True if completed."""
         _to_bytes = _context_id_to_bytes
@@ -2865,6 +2924,7 @@ class StatesContextIDMigration(BaseMigrationWithQuery, BaseOffLineMigration):
         _LOGGER.debug("Migrating states context_ids to binary format: done=%s", is_done)
         return DataMigrationStatus(needs_migrate=not is_done, migration_done=is_done)
 
+    @override
     def needs_migrate_query(self) -> StatementLambdaElement:
         """Return the query to check if the migration needs to run."""
         return has_states_context_ids_to_migrate()
@@ -2879,6 +2939,7 @@ class EventsContextIDMigration(BaseMigrationWithQuery, BaseOffLineMigration):
     migration_version = 2
     index_to_drop = ("events", "ix_events_context_id", LegacyBase)
 
+    @override
     def migrate_data_impl(self, instance: Recorder) -> DataMigrationStatus:
         """Migrate events context_ids to use binary format, return True if completed."""
         _to_bytes = _context_id_to_bytes
@@ -2915,6 +2976,7 @@ class EventsContextIDMigration(BaseMigrationWithQuery, BaseOffLineMigration):
         _LOGGER.debug("Migrating events context_ids to binary format: done=%s", is_done)
         return DataMigrationStatus(needs_migrate=not is_done, migration_done=is_done)
 
+    @override
     def needs_migrate_query(self) -> StatementLambdaElement:
         """Return the query to check if the migration needs to run."""
         return has_events_context_ids_to_migrate()
@@ -2927,6 +2989,7 @@ class EventTypeIDMigration(BaseMigrationWithQuery, BaseOffLineMigration):
     max_initial_schema_version = EVENT_TYPE_IDS_SCHEMA_VERSION - 1
     migration_id = "event_type_id_migration"
 
+    @override
     def migrate_data_impl(self, instance: Recorder) -> DataMigrationStatus:
         """Migrate event_type to event_type_ids, return True if completed."""
         session_maker = instance.get_session
@@ -2985,6 +3048,7 @@ class EventTypeIDMigration(BaseMigrationWithQuery, BaseOffLineMigration):
         _LOGGER.debug("Migrating event_types done=%s", is_done)
         return DataMigrationStatus(needs_migrate=not is_done, migration_done=is_done)
 
+    @override
     def needs_migrate_query(self) -> StatementLambdaElement:
         """Check if the data is migrated."""
         return has_event_type_to_migrate()
@@ -2997,6 +3061,7 @@ class EntityIDMigration(BaseMigrationWithQuery, BaseOffLineMigration):
     max_initial_schema_version = STATES_META_SCHEMA_VERSION - 1
     migration_id = "entity_id_migration"
 
+    @override
     def migrate_data_impl(self, instance: Recorder) -> DataMigrationStatus:
         """Migrate entity_ids to states_meta, return True if completed.
 
@@ -3066,6 +3131,7 @@ class EntityIDMigration(BaseMigrationWithQuery, BaseOffLineMigration):
         _LOGGER.debug("Migrating entity_ids done=%s", is_done)
         return DataMigrationStatus(needs_migrate=not is_done, migration_done=is_done)
 
+    @override
     def needs_migrate_query(self) -> StatementLambdaElement:
         """Check if the data is migrated."""
         return has_entity_ids_to_migrate()
@@ -3086,6 +3152,7 @@ class EventIDPostMigration(BaseRunTimeMigration):
     task = MigrationTask
     migration_version = 2
 
+    @override
     def migrate_data_impl(self, instance: Recorder) -> DataMigrationStatus:
         """Remove old event_id index from states, returns True if completed.
 
@@ -3152,6 +3219,7 @@ class EventIDPostMigration(BaseRunTimeMigration):
             )
         )
 
+    @override
     def needs_migrate_impl(
         self, instance: Recorder, session: Session
     ) -> DataMigrationStatus:
@@ -3180,11 +3248,13 @@ class EntityIDPostMigration(BaseMigrationWithQuery, BaseOffLineMigration):
         LegacyBase,
     )
 
+    @override
     def migrate_data_impl(self, instance: Recorder) -> DataMigrationStatus:
         """Migrate some data, returns True if migration is completed."""
         is_done = post_migrate_entity_ids(instance)
         return DataMigrationStatus(needs_migrate=not is_done, migration_done=is_done)
 
+    @override
     def needs_migrate_query(self) -> StatementLambdaElement:
         """Check if the data is migrated."""
         return has_used_states_entity_ids()

--- a/homeassistant/components/recorder/models/state.py
+++ b/homeassistant/components/recorder/models/state.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from propcache.api import cached_property
 from sqlalchemy.engine.row import Row
@@ -57,6 +57,7 @@ class LazyState(State):
         self.context = EMPTY_CONTEXT
 
     @cached_property
+    @override
     def attributes(self) -> dict[str, Any]:  # type: ignore[override]
         """State attributes."""
         return decode_attributes_from_source(
@@ -69,6 +70,7 @@ class LazyState(State):
         return getattr(self._row, "last_changed_ts", None)
 
     @cached_property
+    @override
     def last_changed(self) -> datetime:  # type: ignore[override]
         """Last changed datetime."""
         return dt_util.utc_from_timestamp(
@@ -81,6 +83,7 @@ class LazyState(State):
         return getattr(self._row, "last_reported_ts", None)
 
     @cached_property
+    @override
     def last_reported(self) -> datetime:  # type: ignore[override]
         """Last reported datetime."""
         return dt_util.utc_from_timestamp(
@@ -88,6 +91,7 @@ class LazyState(State):
         )
 
     @cached_property
+    @override
     def last_updated(self) -> datetime:  # type: ignore[override]
         """Last updated datetime."""
         if TYPE_CHECKING:
@@ -95,6 +99,7 @@ class LazyState(State):
         return dt_util.utc_from_timestamp(self._last_updated_ts)
 
     @cached_property
+    @override
     def last_updated_timestamp(self) -> float:  # type: ignore[override]
         """Last updated timestamp."""
         if TYPE_CHECKING:
@@ -102,6 +107,7 @@ class LazyState(State):
         return self._last_updated_ts
 
     @cached_property
+    @override
     def last_changed_timestamp(self) -> float:
         """Last changed timestamp."""
         ts = self._last_changed_ts or self._last_updated_ts
@@ -110,6 +116,7 @@ class LazyState(State):
         return ts
 
     @cached_property
+    @override
     def last_reported_timestamp(self) -> float:
         """Last reported timestamp."""
         ts = self._last_reported_ts or self._last_updated_ts
@@ -117,6 +124,7 @@ class LazyState(State):
             assert ts is not None
         return ts
 
+    @override
     def as_dict(self) -> dict[str, Any]:  # type: ignore[override]
         """Return a dict representation of the LazyState.
 

--- a/homeassistant/components/recorder/pool.py
+++ b/homeassistant/components/recorder/pool.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import threading
 import traceback
-from typing import Any
+from typing import Any, override
 
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.pool import (
@@ -52,6 +52,7 @@ class RecorderPool(SingletonThreadPool, NullPool):
         self.recorder_and_worker_thread_ids = recorder_and_worker_thread_ids
         SingletonThreadPool.__init__(self, creator, **kw)
 
+    @override
     def recreate(self) -> RecorderPool:
         """Recreate the pool."""
         self.logger.info("Pool recreating")
@@ -68,6 +69,7 @@ class RecorderPool(SingletonThreadPool, NullPool):
             recorder_and_worker_thread_ids=self.recorder_and_worker_thread_ids,
         )
 
+    @override
     def _do_return_conn(self, record: ConnectionPoolEntry) -> None:
         if threading.get_ident() in self.recorder_and_worker_thread_ids:
             super()._do_return_conn(record)
@@ -84,12 +86,14 @@ class RecorderPool(SingletonThreadPool, NullPool):
         ):
             conn.close()
 
+    @override
     def dispose(self) -> None:
         """Dispose of the connection."""
         if threading.get_ident() in self.recorder_and_worker_thread_ids:
             super().dispose()
 
-    def _do_get(self) -> ConnectionPoolEntry:  # type: ignore[return]  # noqa: RET503
+    @override  # noqa: RET503
+    def _do_get(self) -> ConnectionPoolEntry:  # type: ignore[return]
         if threading.get_ident() in self.recorder_and_worker_thread_ids:
             return super()._do_get()
         try:
@@ -118,6 +122,7 @@ class RecorderPool(SingletonThreadPool, NullPool):
         )
         return NullPool._create_connection(self)  # noqa: SLF001
 
+    @override
     def connect(self) -> PoolProxiedConnection:
         """Return a connection from the pool."""
         if threading.get_ident() in self.recorder_and_worker_thread_ids:
@@ -135,6 +140,7 @@ class MutexPool(StaticPool):
     _reference_counter = 0
     pool_lock: threading.RLock
 
+    @override
     def _do_return_conn(self, record: ConnectionPoolEntry) -> None:
         if DEBUG_MUTEX_POOL_TRACE:
             trace = traceback.extract_stack()
@@ -153,6 +159,7 @@ class MutexPool(StaticPool):
             )
         MutexPool.pool_lock.release()
 
+    @override
     def _do_get(self) -> ConnectionPoolEntry:
         if DEBUG_MUTEX_POOL_TRACE:
             trace = traceback.extract_stack()

--- a/homeassistant/components/recorder/tasks.py
+++ b/homeassistant/components/recorder/tasks.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from datetime import datetime
 import logging
 import threading
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from homeassistant.helpers.recorder import DATA_RECORDER
 from homeassistant.helpers.typing import UndefinedType
@@ -44,6 +44,7 @@ class ChangeStatisticsUnitTask(RecorderTask):
     new_unit_of_measurement: str
     old_unit_of_measurement: str
 
+    @override
     def run(self, instance: Recorder) -> None:
         """Handle the task."""
         statistics.change_statistics_unit(
@@ -61,6 +62,7 @@ class ClearStatisticsTask(RecorderTask):
     on_done: Callable[[], None] | None
     statistic_ids: list[str]
 
+    @override
     def run(self, instance: Recorder) -> None:
         """Handle the task."""
         statistics.clear_statistics(instance, self.statistic_ids)
@@ -78,6 +80,7 @@ class UpdateStatisticsMetadataTask(RecorderTask):
     new_unit_class: str | None | UndefinedType
     new_unit_of_measurement: str | None | UndefinedType
 
+    @override
     def run(self, instance: Recorder) -> None:
         """Handle the task."""
         statistics.update_statistics_metadata(
@@ -98,6 +101,7 @@ class UpdateStatesMetadataTask(RecorderTask):
     entity_id: str
     new_entity_id: str
 
+    @override
     def run(self, instance: Recorder) -> None:
         """Handle the task."""
         entity_registry.update_states_metadata(
@@ -115,6 +119,7 @@ class PurgeTask(RecorderTask):
     repack: bool
     apply_filter: bool
 
+    @override
     def run(self, instance: Recorder) -> None:
         """Purge the database."""
         if purge.purge_old_data(
@@ -138,6 +143,7 @@ class PurgeEntitiesTask(RecorderTask):
     entity_filter: Callable[[str], bool]
     purge_before: datetime
 
+    @override
     def run(self, instance: Recorder) -> None:
         """Purge entities from the database."""
         if purge.purge_entity_data(instance, self.entity_filter, self.purge_before):
@@ -153,6 +159,7 @@ class PerodicCleanupTask(RecorderTask):
     Trigger cleanup tasks when auto purge is disabled.
     """
 
+    @override
     def run(self, instance: Recorder) -> None:
         """Handle the task."""
         periodic_db_cleanups(instance)
@@ -165,6 +172,7 @@ class StatisticsTask(RecorderTask):
     start: datetime
     fire_events: bool
 
+    @override
     def run(self, instance: Recorder) -> None:
         """Run statistics task."""
         if statistics.compile_statistics(instance, self.start, self.fire_events):
@@ -177,6 +185,7 @@ class StatisticsTask(RecorderTask):
 class CompileMissingStatisticsTask(RecorderTask):
     """An object to insert into the recorder queue to compile missing statistics."""
 
+    @override
     def run(self, instance: Recorder) -> None:
         """Run statistics task to compile missing statistics."""
         if statistics.compile_missing_statistics(instance):
@@ -193,6 +202,7 @@ class ImportStatisticsTask(RecorderTask):
     statistics: Iterable[StatisticData]
     table: type[Statistics | StatisticsShortTerm]
 
+    @override
     def run(self, instance: Recorder) -> None:
         """Run statistics task."""
         if statistics.import_statistics(
@@ -214,6 +224,7 @@ class AdjustStatisticsTask(RecorderTask):
     sum_adjustment: float
     adjustment_unit: str
 
+    @override
     def run(self, instance: Recorder) -> None:
         """Run statistics task."""
         if statistics.adjust_statistics(
@@ -244,6 +255,7 @@ class WaitTask(RecorderTask):
 
     commit_before = False
 
+    @override
     def run(self, instance: Recorder) -> None:
         """Handle the task."""
         instance._queue_watch.set()  # noqa: SLF001
@@ -257,6 +269,7 @@ class DatabaseLockTask(RecorderTask):
     database_unlock: threading.Event
     queue_overflow: bool
 
+    @override
     def run(self, instance: Recorder) -> None:
         """Handle the task."""
         instance._lock_database(self)  # noqa: SLF001
@@ -268,6 +281,7 @@ class StopTask(RecorderTask):
 
     commit_before = False
 
+    @override
     def run(self, instance: Recorder) -> None:
         """Handle the task."""
         instance.stop_requested = True
@@ -279,6 +293,7 @@ class KeepAliveTask(RecorderTask):
 
     commit_before = False
 
+    @override
     def run(self, instance: Recorder) -> None:
         """Handle the task."""
         instance._send_keep_alive()  # noqa: SLF001
@@ -290,6 +305,7 @@ class CommitTask(RecorderTask):
 
     commit_before = False
 
+    @override
     def run(self, instance: Recorder) -> None:
         """Handle the task."""
         instance._commit_event_session_or_retry()  # noqa: SLF001
@@ -303,6 +319,7 @@ class AddRecorderPlatformTask(RecorderTask):
     platform: Any
     commit_before = False
 
+    @override
     def run(self, instance: Recorder) -> None:
         """Handle the task."""
         hass = instance.hass
@@ -319,6 +336,7 @@ class SynchronizeTask(RecorderTask):
     # commit_before is the default
     future: asyncio.Future
 
+    @override
     def run(self, instance: Recorder) -> None:
         """Handle the task."""
         # Does not use a tracked task to avoid
@@ -337,6 +355,7 @@ class AdjustLRUSizeTask(RecorderTask):
 
     commit_before = False
 
+    @override
     def run(self, instance: Recorder) -> None:
         """Handle the task to adjust the size."""
         instance._adjust_lru_size()  # noqa: SLF001
@@ -348,6 +367,7 @@ class RefreshEventTypesTask(RecorderTask):
 
     event_types: list[EventType[Any] | str]
 
+    @override
     def run(self, instance: Recorder) -> None:
         """Refresh event types."""
         with session_scope(session=instance.get_session(), read_only=True) as session:

--- a/homeassistant/components/recswitch/switch.py
+++ b/homeassistant/components/recswitch/switch.py
@@ -1,7 +1,7 @@
 """Support for Ankuoo RecSwitch MS6126 devices."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyrecswitch import RSNetwork, RSNetworkError
 import voluptuous as vol
@@ -65,24 +65,29 @@ class RecSwitchSwitch(SwitchEntity):
             self.device_name = DEFAULT_NAME.format(self.mac_address)
 
     @property
+    @override
     def unique_id(self):
         """Return the switch unique ID."""
         return self.mac_address
 
     @property
+    @override
     def name(self):
         """Return the switch name."""
         return self.device_name
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if switch is on."""
         return self.gpio_state
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the switch."""
         await self.async_set_gpio_status(True)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the switch."""
         await self.async_set_gpio_status(False)

--- a/homeassistant/components/reddit/sensor.py
+++ b/homeassistant/components/reddit/sensor.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 import praw
 import voluptuous as vol
@@ -111,6 +111,7 @@ class RedditSensor(SensorEntity):
         self._subreddit_data: list = []
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         return {

--- a/homeassistant/components/redgtech/config_flow.py
+++ b/homeassistant/components/redgtech/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for the Redgtech integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from redgtech_api.api import RedgtechAPI, RedgtechAuthError, RedgtechConnectionError
 import voluptuous as vol
@@ -17,6 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 class RedgtechConfigFlow(ConfigFlow, domain=DOMAIN):
     """Config Flow for Redgtech integration."""
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/redgtech/coordinator.py
+++ b/homeassistant/components/redgtech/coordinator.py
@@ -4,7 +4,7 @@ from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from redgtech_api.api import RedgtechAPI, RedgtechAuthError, RedgtechConnectionError
 
@@ -95,6 +95,7 @@ class RedgtechDataUpdateCoordinator(DataUpdateCoordinator[dict[str, RedgtechDevi
             )
             return await api_call(*args)
 
+    @override
     async def _async_update_data(self) -> dict[str, RedgtechDevice]:
         """Fetch data from the API on demand.
 

--- a/homeassistant/components/redgtech/switch.py
+++ b/homeassistant/components/redgtech/switch.py
@@ -1,6 +1,6 @@
 """Integration for Redgtech switches."""
 
-from typing import Any
+from typing import Any, override
 
 from redgtech_api.api import RedgtechAuthError, RedgtechConnectionError
 
@@ -54,6 +54,7 @@ class RedgtechSwitch(CoordinatorEntity[RedgtechDataUpdateCoordinator], SwitchEnt
         )
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if the switch is on."""
         if device := self.coordinator.data.get(self.device.unique_id):
@@ -84,10 +85,12 @@ class RedgtechSwitch(CoordinatorEntity[RedgtechDataUpdateCoordinator], SwitchEnt
 
         await self.coordinator.async_refresh()
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         await self._set_state(True)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         await self._set_state(False)

--- a/homeassistant/components/refoss/coordinator.py
+++ b/homeassistant/components/refoss/coordinator.py
@@ -1,6 +1,7 @@
 """Helper and coordinator for refoss."""
 
 from datetime import timedelta
+from typing import override
 
 from refoss_ha.controller.device import BaseDevice
 from refoss_ha.exceptions import DeviceTimeoutError
@@ -31,6 +32,7 @@ class RefossDataUpdateCoordinator(DataUpdateCoordinator[None]):
         self.device = device
         self._error_count = 0
 
+    @override
     async def _async_update_data(self) -> None:
         """Update the state of the device."""
         try:

--- a/homeassistant/components/refoss/sensor.py
+++ b/homeassistant/components/refoss/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from refoss_ha.controller.electricity import ElectricityXMix
 
@@ -164,6 +165,7 @@ class RefossSensor(RefossEntity, SensorEntity):
         self._attr_translation_placeholders = {"channel_name": channel_name}
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the native value."""
         value = self.coordinator.device.get_value(

--- a/homeassistant/components/refoss/switch.py
+++ b/homeassistant/components/refoss/switch.py
@@ -1,6 +1,6 @@
 """Switch for Refoss."""
 
-from typing import Any
+from typing import Any, override
 
 from refoss_ha.controller.toggle import ToggleXMix
 
@@ -57,20 +57,24 @@ class RefossSwitch(RefossEntity, SwitchEntity):
         self._attr_name = str(channel)
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if switch is on."""
         return self.coordinator.device.is_on(channel=self.channel_id)
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         await self.coordinator.device.async_turn_on(self.channel_id)
         self.async_write_ha_state()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         await self.coordinator.device.async_turn_off(self.channel_id)
         self.async_write_ha_state()
 
+    @override
     async def async_toggle(self, **kwargs: Any) -> None:
         """Toggle the switch."""
         await self.coordinator.device.async_toggle(channel=self.channel_id)

--- a/homeassistant/components/rehlko/binary_sensor.py
+++ b/homeassistant/components/rehlko/binary_sensor.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 import logging
+from typing import override
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -115,6 +116,7 @@ class RehlkoBinarySensorEntity(RehlkoEntity, BinarySensorEntity):
     entity_description: RehlkoBinarySensorEntityDescription
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return the state of the binary sensor."""
         if self._rehlko_value == self.entity_description.on_value:
@@ -160,6 +162,7 @@ class RehlkoLoadshedBinarySensorEntity(RehlkoEntity, BinarySensorEntity):
         self._attr_translation_placeholders = {"display_name": display_name}
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return the state of the binary sensor."""
         if not (loadshed_data := self.coordinator.data.get("loadShed")) or not (

--- a/homeassistant/components/rehlko/config_flow.py
+++ b/homeassistant/components/rehlko/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from aiokem import AioKem, AuthenticationError
 import voluptuous as vol
@@ -21,6 +21,7 @@ class RehlkoConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/rehlko/coordinator.py
+++ b/homeassistant/components/rehlko/coordinator.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from aiokem import AioKem, CommunicationError
 
@@ -58,6 +58,7 @@ class RehlkoUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             update_interval=SCAN_INTERVAL_MINUTES,
         )
 
+    @override
     async def _async_update_data(self) -> dict[str, Any]:
         """Update data via library."""
         try:

--- a/homeassistant/components/rehlko/entity.py
+++ b/homeassistant/components/rehlko/entity.py
@@ -1,6 +1,6 @@
 """Base class for Rehlko entities."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -78,6 +78,7 @@ class RehlkoEntity(CoordinatorEntity[RehlkoUpdateCoordinator]):
         return self.coordinator.data[self.entity_description.key]
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return super().available and (

--- a/homeassistant/components/rehlko/sensor.py
+++ b/homeassistant/components/rehlko/sensor.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
+from typing import override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -257,6 +258,7 @@ class RehlkoSensorEntity(RehlkoEntity, SensorEntity):
     entity_description: RehlkoSensorEntityDescription
 
     @property
+    @override
     def native_value(self) -> StateType | datetime:
         """Return the sensor state."""
         if self.entity_description.value_fn:

--- a/homeassistant/components/rejseplanen/sensor.py
+++ b/homeassistant/components/rejseplanen/sensor.py
@@ -8,7 +8,7 @@ from contextlib import suppress
 from datetime import datetime, timedelta
 import logging
 from operator import itemgetter
-from typing import Any
+from typing import Any, override
 
 import rjpl
 import voluptuous as vol
@@ -113,16 +113,19 @@ class RejseplanenTransportSensor(SensorEntity):
         self._times = self._state = None
 
     @property
+    @override
     def name(self):
         """Return the name of the sensor."""
         return self._name
 
     @property
+    @override
     def native_value(self):
         """Return the state of the sensor."""
         return self._state
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         if not self._times:
@@ -143,6 +146,7 @@ class RejseplanenTransportSensor(SensorEntity):
         return attributes
 
     @property
+    @override
     def native_unit_of_measurement(self):
         """Return the unit this state is expressed in."""
         return UnitOfTime.MINUTES

--- a/homeassistant/components/remember_the_milk/entity.py
+++ b/homeassistant/components/remember_the_milk/entity.py
@@ -1,5 +1,7 @@
 """Support to interact with Remember The Milk."""
 
+from typing import override
+
 from rtmapi import Rtm, RtmRequestFailedException
 
 from homeassistant.const import CONF_ID, CONF_NAME, STATE_OK
@@ -135,11 +137,13 @@ class RememberTheMilkEntity(Entity):
             )
 
     @property
+    @override
     def name(self) -> str:
         """Return the name of the device."""
         return self._name
 
     @property
+    @override
     def state(self) -> str:
         """Return the state of the device."""
         if not self._token_valid:

--- a/homeassistant/components/remote/__init__.py
+++ b/homeassistant/components/remote/__init__.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 from enum import IntFlag
 import functools as ft
 import logging
-from typing import Any, final
+from typing import Any, final, override
 
 from propcache.api import cached_property
 import voluptuous as vol
@@ -162,6 +162,7 @@ class RemoteEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_)
     _attr_supported_features: RemoteEntityFeature = RemoteEntityFeature(0)
 
     @cached_property
+    @override
     def supported_features(self) -> RemoteEntityFeature:
         """Flag supported features."""
         return self._attr_supported_features
@@ -178,6 +179,7 @@ class RemoteEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_)
 
     @final
     @property
+    @override
     def state_attributes(self) -> dict[str, Any] | None:
         """Return optional state attributes."""
         if RemoteEntityFeature.ACTIVITY not in self.supported_features:

--- a/homeassistant/components/remote_calendar/calendar.py
+++ b/homeassistant/components/remote_calendar/calendar.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime, timedelta
 import logging
+from typing import override
 
 from ical.event import Event
 from ical.timeline import Timeline, materialize_timeline
@@ -60,6 +61,7 @@ class RemoteCalendarEntity(
         self._timeline: Timeline | None = None
 
     @property
+    @override
     def event(self) -> CalendarEvent | None:
         """Return the next upcoming event."""
         if self._timeline is None:
@@ -70,6 +72,7 @@ class RemoteCalendarEntity(
             return _get_calendar_event(event)
         return None
 
+    @override
     async def async_get_events(
         self, hass: HomeAssistant, start_date: datetime, end_date: datetime
     ) -> list[CalendarEvent]:
@@ -85,6 +88,7 @@ class RemoteCalendarEntity(
 
         return await self.hass.async_add_executor_job(events_in_range)
 
+    @override
     async def async_update(self) -> None:
         """Refresh the timeline.
 

--- a/homeassistant/components/remote_calendar/config_flow.py
+++ b/homeassistant/components/remote_calendar/config_flow.py
@@ -2,7 +2,7 @@
 
 from http import HTTPStatus
 import logging
-from typing import Any
+from typing import Any, override
 
 from httpx import HTTPError, InvalidURL, TimeoutException
 import voluptuous as vol
@@ -43,6 +43,7 @@ class RemoteCalendarConfigFlow(ConfigFlow, domain=DOMAIN):
         super().__init__()
         self.data: dict[str, Any] = {}
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/remote_calendar/coordinator.py
+++ b/homeassistant/components/remote_calendar/coordinator.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import logging
+from typing import override
 
 from httpx import HTTPError, InvalidURL, TimeoutException
 from ical.calendar import Calendar
@@ -49,6 +50,7 @@ class RemoteCalendarDataUpdateCoordinator(DataUpdateCoordinator[Calendar]):
         self._username: str | None = config_entry.data.get(CONF_USERNAME)
         self._password: str | None = config_entry.data.get(CONF_PASSWORD)
 
+    @override
     async def _async_update_data(self) -> Calendar:
         """Update data from the url."""
         try:

--- a/homeassistant/components/remote_rpi_gpio/binary_sensor.py
+++ b/homeassistant/components/remote_rpi_gpio/binary_sensor.py
@@ -1,5 +1,7 @@
 """Support for binary sensor using RPi GPIO."""
 
+from typing import override
+
 from gpiozero import DigitalInputDevice
 import requests
 import voluptuous as vol
@@ -79,6 +81,7 @@ class RemoteRPiGPIOBinarySensor(BinarySensorEntity):
         self._state = False
         self._sensor = sensor
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
 
@@ -91,6 +94,7 @@ class RemoteRPiGPIOBinarySensor(BinarySensorEntity):
         self._sensor.when_activated = read_gpio
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return the state of the entity."""
         return self._state != self._invert_logic

--- a/homeassistant/components/remote_rpi_gpio/switch.py
+++ b/homeassistant/components/remote_rpi_gpio/switch.py
@@ -1,6 +1,6 @@
 """Allows to configure a switch using RPi GPIO."""
 
-from typing import Any
+from typing import Any, override
 
 from gpiozero import LED
 import voluptuous as vol
@@ -65,12 +65,14 @@ class RemoteRPiGPIOSwitch(SwitchEntity):
         self._attr_is_on = False
         self._switch = led
 
+    @override
     def turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
         write_output(self._switch, 1)
         self._attr_is_on = True
         self.schedule_update_ha_state()
 
+    @override
     def turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
         write_output(self._switch, 0)

--- a/homeassistant/components/renault/binary_sensor.py
+++ b/homeassistant/components/renault/binary_sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from renault_api.kamereon.enums import ChargeState, PlugState
 from renault_api.kamereon.models import (
@@ -69,6 +70,7 @@ class RenaultBinarySensor[T: KamereonVehicleDataAttributes](
     entity_description: RenaultBinarySensorEntityDescription[T]
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
         return self.entity_description.value_lambda(self)

--- a/homeassistant/components/renault/button.py
+++ b/homeassistant/components/renault/button.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.core import HomeAssistant
@@ -45,6 +45,7 @@ class RenaultButtonEntity(RenaultEntity, ButtonEntity):
 
     entity_description: RenaultButtonEntityDescription
 
+    @override
     async def async_press(self) -> None:
         """Process the button press."""
         await self.entity_description.async_press(self)

--- a/homeassistant/components/renault/config_flow.py
+++ b/homeassistant/components/renault/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 import aiohttp
 from renault_api.const import AVAILABLE_LOCALES
@@ -39,6 +39,7 @@ class RenaultFlowHandler(ConfigFlow, domain=DOMAIN):
         """Initialize the Renault config flow."""
         self.renault_config: dict[str, Any] = {}
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/renault/coordinator.py
+++ b/homeassistant/components/renault/coordinator.py
@@ -4,7 +4,7 @@ import asyncio
 from collections.abc import Awaitable, Callable
 from datetime import timedelta
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from renault_api.kamereon.exceptions import (
     AccessDeniedException,
@@ -60,6 +60,7 @@ class RenaultDataUpdateCoordinator[T: KamereonVehicleDataAttributes](
         self._has_already_worked = False
         self._hub = hub
 
+    @override
     async def _async_update_data(self) -> T:
         """Fetch the latest data from the source."""
 
@@ -109,6 +110,7 @@ class RenaultDataUpdateCoordinator[T: KamereonVehicleDataAttributes](
         self.assumed_state = False
         return data
 
+    @override
     async def async_config_entry_first_refresh(self) -> None:
         """Refresh data for the first time when a config entry is setup.
 

--- a/homeassistant/components/renault/device_tracker.py
+++ b/homeassistant/components/renault/device_tracker.py
@@ -1,6 +1,7 @@
 """Support for Renault device trackers."""
 
 from dataclasses import dataclass
+from typing import override
 
 from renault_api.kamereon.models import KamereonVehicleLocationData
 
@@ -48,11 +49,13 @@ class RenaultDeviceTracker(
     entity_description: RenaultTrackerEntityDescription
 
     @property
+    @override
     def latitude(self) -> float | None:
         """Return latitude value of the device."""
         return self.coordinator.data.gpsLatitude
 
     @property
+    @override
     def longitude(self) -> float | None:
         """Return longitude value of the device."""
         return self.coordinator.data.gpsLongitude

--- a/homeassistant/components/renault/entity.py
+++ b/homeassistant/components/renault/entity.py
@@ -1,6 +1,7 @@
 """Base classes for Renault entities."""
 
 from dataclasses import dataclass
+from typing import override
 
 from renault_api.kamereon.models import KamereonVehicleDataAttributes
 
@@ -51,6 +52,7 @@ class RenaultDataEntity[T: KamereonVehicleDataAttributes](
         RenaultEntity.__init__(self, vehicle, description)
 
     @property
+    @override
     def assumed_state(self) -> bool:
         """Return True if unable to access real state of the entity."""
         return self.coordinator.assumed_state

--- a/homeassistant/components/renault/number.py
+++ b/homeassistant/components/renault/number.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from renault_api.kamereon.models import (
     KamereonVehicleBatterySocData,
@@ -111,10 +111,12 @@ class RenaultNumberEntity[T: KamereonVehicleDataAttributes](
     entity_description: RenaultNumberEntityDescription[T]
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the entity value to represent the entity state."""
         return self.entity_description.value_fn(self)
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
         await self.entity_description.update_fn(self, value)

--- a/homeassistant/components/renault/select.py
+++ b/homeassistant/components/renault/select.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from renault_api.kamereon.models import (
     KamereonVehicleChargeModeData,
@@ -54,10 +54,12 @@ class RenaultSelectEntity[T: KamereonVehicleDataAttributes](
     entity_description: RenaultSelectEntityDescription[T]
 
     @property
+    @override
     def current_option(self) -> str | None:
         """Return the selected entity option to represent the entity state."""
         return self.entity_description.value_fn(self)
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         await self.entity_description.update_fn(self, option)

--- a/homeassistant/components/renault/sensor.py
+++ b/homeassistant/components/renault/sensor.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any
+from typing import Any, override
 
 from renault_api.kamereon.models import (
     KamereonVehicleBatteryStatusData,
@@ -81,6 +81,7 @@ class RenaultSensor[T: KamereonVehicleDataAttributes](
     entity_description: RenaultSensorEntityDescription[T]
 
     @property
+    @override
     def native_value(self) -> StateType | datetime:
         """Return the state of this entity."""
         return self.entity_description.value_lambda(self)

--- a/homeassistant/components/renson/binary_sensor.py
+++ b/homeassistant/components/renson/binary_sensor.py
@@ -1,6 +1,7 @@
 """Binary sensors for renson."""
 
 from dataclasses import dataclass
+from typing import override
 
 from renson_endura_delta.field_enum import (
     AIR_QUALITY_CONTROL_FIELD,
@@ -113,6 +114,7 @@ class RensonBinarySensor(RensonEntity, BinarySensorEntity):
         self.entity_description = description
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         all_data = self.coordinator.data

--- a/homeassistant/components/renson/button.py
+++ b/homeassistant/components/renson/button.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from renson_endura_delta.renson import RensonVentilation
 
@@ -81,6 +82,7 @@ class RensonButton(RensonEntity, ButtonEntity):
 
         self.entity_description = description
 
+    @override
     def press(self) -> None:
         """Triggers the action."""
         self.entity_description.action_fn(self.api)

--- a/homeassistant/components/renson/config_flow.py
+++ b/homeassistant/components/renson/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Renson integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from renson_endura_delta import renson
 import voluptuous as vol
@@ -38,6 +38,7 @@ class RensonConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return {"title": "Renson"}
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/renson/coordinator.py
+++ b/homeassistant/components/renson/coordinator.py
@@ -4,7 +4,7 @@ import asyncio
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from renson_endura_delta.renson import RensonVentilation
 
@@ -51,6 +51,7 @@ class RensonCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         )
         self.api = api
 
+    @override
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from API endpoint."""
         async with asyncio.timeout(30):

--- a/homeassistant/components/renson/fan.py
+++ b/homeassistant/components/renson/fan.py
@@ -2,7 +2,7 @@
 
 import logging
 import math
-from typing import Any
+from typing import Any, override
 
 from renson_endura_delta.field_enum import (
     BREEZE_LEVEL_FIELD,
@@ -127,6 +127,7 @@ class RensonFan(RensonEntity, FanEntity):
         self._attr_speed_count = int_states_in_range(SPEED_RANGE)
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         level = self.api.parse_value(
@@ -155,6 +156,7 @@ class RensonFan(RensonEntity, FanEntity):
 
         super()._handle_coordinator_update()
 
+    @override
     async def async_turn_on(
         self,
         percentage: int | None = None,
@@ -167,10 +169,12 @@ class RensonFan(RensonEntity, FanEntity):
 
         await self.async_set_percentage(percentage)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the fan (to away)."""
         await self.async_set_percentage(0)
 
+    @override
     async def async_set_percentage(self, percentage: int) -> None:
         """Set fan speed percentage."""
         _LOGGER.debug("Changing fan speed percentage to %s", percentage)

--- a/homeassistant/components/renson/number.py
+++ b/homeassistant/components/renson/number.py
@@ -1,6 +1,7 @@
 """Platform to control a Renson ventilation unit."""
 
 import logging
+from typing import override
 
 from renson_endura_delta.field_enum import FILTER_PRESET_FIELD, DataType
 from renson_endura_delta.renson import RensonVentilation
@@ -61,6 +62,7 @@ class RensonNumber(RensonEntity, NumberEntity):
         self.entity_description = description
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self._attr_native_value = self.api.parse_value(
@@ -70,6 +72,7 @@ class RensonNumber(RensonEntity, NumberEntity):
 
         super()._handle_coordinator_update()
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
 

--- a/homeassistant/components/renson/sensor.py
+++ b/homeassistant/components/renson/sensor.py
@@ -1,6 +1,7 @@
 """Sensor data of the Renson ventilation unit."""
 
 from dataclasses import dataclass
+from typing import override
 
 from renson_endura_delta.field_enum import (
     AIR_QUALITY_FIELD,
@@ -246,6 +247,7 @@ class RensonSensor(RensonEntity, SensorEntity):
         self.raw_format = description.raw_format
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         all_data = self.coordinator.data

--- a/homeassistant/components/renson/switch.py
+++ b/homeassistant/components/renson/switch.py
@@ -1,7 +1,7 @@
 """Breeze switch of the Renson ventilation unit."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from renson_endura_delta.field_enum import CURRENT_LEVEL_FIELD, DataType
 from renson_endura_delta.renson import Level, RensonVentilation
@@ -33,6 +33,7 @@ class RensonBreezeSwitch(RensonEntity, SwitchEntity):
 
         self._attr_is_on = False
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the switch."""
         _LOGGER.debug("Enable Breeze")
@@ -40,6 +41,7 @@ class RensonBreezeSwitch(RensonEntity, SwitchEntity):
         await self.hass.async_add_executor_job(self.api.set_manual_level, Level.BREEZE)
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the switch."""
         _LOGGER.debug("Disable Breeze")
@@ -48,6 +50,7 @@ class RensonBreezeSwitch(RensonEntity, SwitchEntity):
         await self.coordinator.async_request_refresh()
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
 

--- a/homeassistant/components/renson/time.py
+++ b/homeassistant/components/renson/time.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, time
+from typing import override
 
 from renson_endura_delta.field_enum import DAYTIME_FIELD, NIGHTTIME_FIELD, FieldEnum
 from renson_endura_delta.renson import RensonVentilation
@@ -74,6 +75,7 @@ class RensonTime(RensonEntity, TimeEntity):
         self.entity_description = description
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
 
@@ -88,6 +90,7 @@ class RensonTime(RensonEntity, TimeEntity):
 
         super()._handle_coordinator_update()
 
+    @override
     def set_value(self, value: time) -> None:
         """Triggers the action."""
 

--- a/homeassistant/components/reolink/binary_sensor.py
+++ b/homeassistant/components/reolink/binary_sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from reolink_aio.api import (
     FACE_DETECTION_TYPE,
@@ -363,6 +364,7 @@ class ReolinkBinarySensorEntity(ReolinkChannelCoordinatorEntity, BinarySensorEnt
         super().__init__(reolink_data, channel)
 
     @property
+    @override
     def is_on(self) -> bool:
         """State of the sensor."""
         return self.entity_description.value(self._host.api, self._channel)
@@ -371,6 +373,7 @@ class ReolinkBinarySensorEntity(ReolinkChannelCoordinatorEntity, BinarySensorEnt
 class ReolinkPushBinarySensorEntity(ReolinkBinarySensorEntity):
     """Binary-sensor class for Reolink IP camera motion sensors."""
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Entity created."""
         await super().async_added_to_hass()
@@ -424,6 +427,7 @@ class ReolinkSmartAIBinarySensorEntity(
         }
 
     @property
+    @override
     def is_on(self) -> bool:
         """State of the sensor."""
         return self.entity_description.value(
@@ -454,6 +458,7 @@ class ReolinkIndexBinarySensorEntity(
         self._attr_translation_placeholders = {"index": str(index)}
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """State of the sensor."""
         return self.entity_description.value(self._host.api, self._channel, self._index)

--- a/homeassistant/components/reolink/button.py
+++ b/homeassistant/components/reolink/button.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from reolink_aio.api import GuardEnum, Host, PtzEnum
 
@@ -236,6 +236,7 @@ class ReolinkButtonEntity(ReolinkChannelCoordinatorEntity, ButtonEntity):
             self._attr_supported_features = SUPPORT_PTZ_SPEED
 
     @raise_translated_error
+    @override
     async def async_press(self) -> None:
         """Execute the button action."""
         await self.entity_description.method(self._host.api, self._channel)
@@ -263,6 +264,7 @@ class ReolinkHostButtonEntity(ReolinkHostCoordinatorEntity, ButtonEntity):
         super().__init__(reolink_data)
 
     @raise_translated_error
+    @override
     async def async_press(self) -> None:
         """Execute the button action."""
         await self.entity_description.method(self._host.api)

--- a/homeassistant/components/reolink/camera.py
+++ b/homeassistant/components/reolink/camera.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 import logging
+from typing import override
 
 from reolink_aio.api import DUAL_LENS_SINGLE_MOTION_MODELS
 
@@ -145,6 +146,7 @@ class ReolinkCamera(ReolinkChannelCoordinatorEntity, Camera):
                 f"{entity_description.translation_key}_lens_{self._channel}"
             )
 
+    @override
     async def stream_source(self) -> str | None:
         """Return the source of the stream."""
         return await self._host.api.get_stream_source(
@@ -152,6 +154,7 @@ class ReolinkCamera(ReolinkChannelCoordinatorEntity, Camera):
         )
 
     @raise_translated_error
+    @override
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:

--- a/homeassistant/components/reolink/config_flow.py
+++ b/homeassistant/components/reolink/config_flow.py
@@ -3,7 +3,7 @@
 import asyncio
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from reolink_aio.api import ALLOWED_SPECIAL_CHARS
 from reolink_aio.baichuan import DEFAULT_BC_PORT
@@ -116,6 +116,7 @@ class ReolinkFlowHandler(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: ReolinkConfigEntry,
     ) -> ReolinkOptionsFlowHandler:
@@ -153,6 +154,7 @@ class ReolinkFlowHandler(ConfigFlow, domain=DOMAIN):
         self._password = entry_data[CONF_PASSWORD]
         return await self.async_step_user()
 
+    @override
     async def async_step_dhcp(
         self, discovery_info: DhcpServiceInfo
     ) -> ConfigFlowResult:
@@ -241,6 +243,7 @@ class ReolinkFlowHandler(ConfigFlow, domain=DOMAIN):
             description_placeholders=placeholders,
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/reolink/coordinator.py
+++ b/homeassistant/components/reolink/coordinator.py
@@ -3,6 +3,7 @@
 import asyncio
 from datetime import timedelta
 import logging
+from typing import override
 
 from reolink_aio.exceptions import (
     CredentialsInvalidError,
@@ -79,6 +80,7 @@ class ReolinkDeviceCoordinator(ReolinkCoordinator):
         self._last_known_firmware: dict[int | None, str | None] = {}
         self.firmware_coordinator: ReolinkFirmwareCoordinator | None = None
 
+    @override
     async def _async_update_data(self) -> None:
         """Update the host state cache and renew the ONVIF-subscription."""
         async with asyncio.timeout(self._update_timeout):
@@ -156,6 +158,7 @@ class ReolinkFirmwareCoordinator(ReolinkCoordinator):
             update_interval=None,  # Do not auto-fetch, resume 24h
         )
 
+    @override
     async def _async_update_data(self) -> None:
         """Check for firmware updates."""
         async with asyncio.timeout(self._min_timeout):

--- a/homeassistant/components/reolink/entity.py
+++ b/homeassistant/components/reolink/entity.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from reolink_aio.api import DUAL_LENS_DUAL_MOTION_MODELS, DUAL_LENS_MODELS, Chime, Host
 
@@ -94,6 +95,7 @@ class ReolinkHostCoordinatorEntity(CoordinatorEntity[ReolinkCoordinator]):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available."""
         if self.entity_description.always_available:
@@ -123,6 +125,7 @@ class ReolinkHostCoordinatorEntity(CoordinatorEntity[ReolinkCoordinator]):
             callback_id, self._push_callback, cmd_id
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Entity created."""
         await super().async_added_to_hass()
@@ -139,6 +142,7 @@ class ReolinkHostCoordinatorEntity(CoordinatorEntity[ReolinkCoordinator]):
         # Privacy mode
         self.register_callback(f"{callback_id}_623", 623)
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Entity removed."""
         cmd_key = self.entity_description.cmd_key
@@ -153,6 +157,7 @@ class ReolinkHostCoordinatorEntity(CoordinatorEntity[ReolinkCoordinator]):
 
         await super().async_will_remove_from_hass()
 
+    @override
     async def async_update(self) -> None:
         """Force full update from the generic entity update service."""
         for channel in self._host.api.channels:
@@ -238,6 +243,7 @@ class ReolinkChannelCoordinatorEntity(ReolinkHostCoordinatorEntity):
             )
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available."""
         if self.entity_description.always_available:
@@ -249,12 +255,14 @@ class ReolinkChannelCoordinatorEntity(ReolinkHostCoordinatorEntity):
             and not self._host.api.baichuan.privacy_mode(self._channel)
         )
 
+    @override
     def register_callback(self, callback_id: str, cmd_id: int) -> None:
         """Register callback for TCP push events."""
         self._host.api.baichuan.register_callback(
             callback_id, self._push_callback, cmd_id, self._channel
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Entity created."""
         await super().async_added_to_hass()
@@ -262,6 +270,7 @@ class ReolinkChannelCoordinatorEntity(ReolinkHostCoordinatorEntity):
         if cmd_key is not None:
             self._host.async_register_update_cmd(cmd_key, self._channel)
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Entity removed."""
         cmd_key = self.entity_description.cmd_key
@@ -303,6 +312,7 @@ class ReolinkHostChimeCoordinatorEntity(ReolinkHostCoordinatorEntity):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available."""
         return super().available and self._chime.online
@@ -340,6 +350,7 @@ class ReolinkChimeCoordinatorEntity(ReolinkChannelCoordinatorEntity):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available."""
         return self._chime.online and super().available

--- a/homeassistant/components/reolink/light.py
+++ b/homeassistant/components/reolink/light.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from reolink_aio.api import Host
 from reolink_aio.const import MAX_COLOR_TEMP, MIN_COLOR_TEMP
@@ -150,11 +150,13 @@ class ReolinkLightEntity(ReolinkChannelCoordinatorEntity, LightEntity):
             self._attr_color_mode = ColorMode.ONOFF
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if light is on."""
         return self.entity_description.is_on_fn(self._host.api, self._channel)
 
     @property
+    @override
     def brightness(self) -> int | None:
         """Return the brightness of this light between 1.255."""
         assert self.entity_description.get_brightness_fn is not None
@@ -168,6 +170,7 @@ class ReolinkLightEntity(ReolinkChannelCoordinatorEntity, LightEntity):
         return color_util.value_to_brightness((1, 100), bright_pct)
 
     @property
+    @override
     def color_temp_kelvin(self) -> int | None:
         """Return the color temperature of this light in kelvin."""
         assert self.entity_description.get_color_temp_fn is not None
@@ -175,6 +178,7 @@ class ReolinkLightEntity(ReolinkChannelCoordinatorEntity, LightEntity):
         return self.entity_description.get_color_temp_fn(self._host.api, self._channel)
 
     @raise_translated_error
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn light off."""
         await self.entity_description.turn_on_off_fn(
@@ -183,6 +187,7 @@ class ReolinkLightEntity(ReolinkChannelCoordinatorEntity, LightEntity):
         self.async_write_ha_state()
 
     @raise_translated_error
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn light on."""
         if (
@@ -223,17 +228,20 @@ class ReolinkHostLightEntity(ReolinkHostCoordinatorEntity, LightEntity):
         super().__init__(reolink_data)
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if light is on."""
         return self.entity_description.is_on_fn(self._host.api)
 
     @raise_translated_error
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn light off."""
         await self.entity_description.turn_on_off_fn(self._host.api, False)
         self.async_write_ha_state()
 
     @raise_translated_error
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn light on."""
         await self.entity_description.turn_on_off_fn(self._host.api, True)

--- a/homeassistant/components/reolink/media_source.py
+++ b/homeassistant/components/reolink/media_source.py
@@ -2,6 +2,7 @@
 
 import datetime as dt
 import logging
+from typing import override
 
 from reolink_aio.api import DUAL_LENS_MODELS
 from reolink_aio.enums import VodRequestType
@@ -57,6 +58,7 @@ class ReolinkVODMediaSource(MediaSource):
         super().__init__(DOMAIN)
         self.hass = hass
 
+    @override
     async def async_resolve_media(self, item: MediaSourceItem) -> PlayMedia:
         """Resolve media to a url."""
         identifier = ["UNKNOWN"]
@@ -113,6 +115,7 @@ class ReolinkVODMediaSource(MediaSource):
         stream_url = stream_url.replace("master_", "")
         return PlayMedia(stream_url, mime_type)
 
+    @override
     async def async_browse_media(
         self,
         item: MediaSourceItem,

--- a/homeassistant/components/reolink/number.py
+++ b/homeassistant/components/reolink/number.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from reolink_aio.api import Chime, Host
 
@@ -1005,11 +1005,13 @@ class ReolinkNumberEntity(ReolinkChannelCoordinatorEntity, NumberEntity):
         self._attr_mode = entity_description.mode
 
     @property
+    @override
     def native_value(self) -> float | None:
         """State of the number entity."""
         return self.entity_description.value(self._host.api, self._channel)
 
     @raise_translated_error
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
         await self.entity_description.method(self._host.api, self._channel, value)
@@ -1046,6 +1048,7 @@ class ReolinkSmartAINumberEntity(ReolinkChannelCoordinatorEntity, NumberEntity):
         }
 
     @property
+    @override
     def native_value(self) -> float | None:
         """State of the number entity."""
         return self.entity_description.value(
@@ -1053,6 +1056,7 @@ class ReolinkSmartAINumberEntity(ReolinkChannelCoordinatorEntity, NumberEntity):
         )
 
     @raise_translated_error
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
         await self.entity_description.method(
@@ -1078,11 +1082,13 @@ class ReolinkHostNumberEntity(ReolinkHostCoordinatorEntity, NumberEntity):
         self._attr_mode = entity_description.mode
 
     @property
+    @override
     def native_value(self) -> float | None:
         """State of the number entity."""
         return self.entity_description.value(self._host.api)
 
     @raise_translated_error
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
         await self.entity_description.method(self._host.api, value)
@@ -1107,11 +1113,13 @@ class ReolinkChimeNumberEntity(ReolinkChimeCoordinatorEntity, NumberEntity):
         self._attr_mode = entity_description.mode
 
     @property
+    @override
     def native_value(self) -> float | None:
         """State of the number entity."""
         return self.entity_description.value(self._chime)
 
     @raise_translated_error
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
         await self.entity_description.method(self._chime, value)
@@ -1136,11 +1144,13 @@ class ReolinkHostChimeNumberEntity(ReolinkHostChimeCoordinatorEntity, NumberEnti
         self._attr_mode = entity_description.mode
 
     @property
+    @override
     def native_value(self) -> float | None:
         """State of the number entity."""
         return self.entity_description.value(self._chime)
 
     @raise_translated_error
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
         await self.entity_description.method(self._chime, value)

--- a/homeassistant/components/reolink/select.py
+++ b/homeassistant/components/reolink/select.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 import logging
-from typing import Any
+from typing import Any, override
 
 from reolink_aio.api import (
     BinningModeEnum,
@@ -470,6 +470,7 @@ class ReolinkSelectEntity(ReolinkChannelCoordinatorEntity, SelectEntity):
             self._attr_options = entity_description.get_options
 
     @property
+    @override
     def current_option(self) -> str | None:
         """Return the current option."""
         if self.entity_description.value is None:
@@ -487,6 +488,7 @@ class ReolinkSelectEntity(ReolinkChannelCoordinatorEntity, SelectEntity):
         return option
 
     @raise_translated_error
+    @override
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         await self.entity_description.method(self._host.api, self._channel, option)
@@ -509,11 +511,13 @@ class ReolinkHostSelectEntity(ReolinkHostCoordinatorEntity, SelectEntity):
         self._attr_options = entity_description.get_options(self._host.api)
 
     @property
+    @override
     def current_option(self) -> str | None:
         """Return the current option."""
         return self.entity_description.value(self._host.api)
 
     @raise_translated_error
+    @override
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         await self.entity_description.method(self._host.api, option)
@@ -537,11 +541,13 @@ class ReolinkChimeSelectEntity(ReolinkChimeCoordinatorEntity, SelectEntity):
         self._attr_options = entity_description.get_options
 
     @property
+    @override
     def current_option(self) -> str | None:
         """Return the current option."""
         return self.entity_description.value(self._chime)
 
     @raise_translated_error
+    @override
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         await self.entity_description.method(self._chime, option)
@@ -565,11 +571,13 @@ class ReolinkHostChimeSelectEntity(ReolinkHostChimeCoordinatorEntity, SelectEnti
         self._attr_options = entity_description.get_options
 
     @property
+    @override
     def current_option(self) -> str | None:
         """Return the current option."""
         return self.entity_description.value(self._chime)
 
     @raise_translated_error
+    @override
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         await self.entity_description.method(self._chime, option)

--- a/homeassistant/components/reolink/sensor.py
+++ b/homeassistant/components/reolink/sensor.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import date, datetime
 from decimal import Decimal
+from typing import override
 
 from reolink_aio.api import Host
 from reolink_aio.const import YOLO_DETECT_TYPES
@@ -258,6 +259,7 @@ class ReolinkSensorEntity(ReolinkChannelCoordinatorEntity, SensorEntity):
         super().__init__(reolink_data, channel)
 
     @property
+    @override
     def native_value(self) -> StateType | date | datetime | Decimal:
         """Return the value reported by the sensor."""
         return self.entity_description.value(self._host.api, self._channel)
@@ -278,6 +280,7 @@ class ReolinkHostSensorEntity(ReolinkHostCoordinatorEntity, SensorEntity):
         super().__init__(reolink_data)
 
     @property
+    @override
     def native_value(self) -> StateType | date | datetime | Decimal:
         """Return the value reported by the sensor."""
         return self.entity_description.value(self._host.api)
@@ -308,11 +311,13 @@ class ReolinkHddSensorEntity(ReolinkHostCoordinatorEntity, SensorEntity):
             self._attr_translation_key = "sd_storage"
 
     @property
+    @override
     def native_value(self) -> StateType | date | datetime | Decimal:
         """Return the value reported by the sensor."""
         return self.entity_description.value(self._host.api, self._hdd_index)
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available."""
         return self._host.api.hdd_available(self._hdd_index) and super().available

--- a/homeassistant/components/reolink/siren.py
+++ b/homeassistant/components/reolink/siren.py
@@ -1,7 +1,7 @@
 """Component providing support for Reolink siren entities."""
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.siren import (
     ATTR_DURATION,
@@ -100,11 +100,13 @@ class ReolinkSirenEntity(ReolinkChannelCoordinatorEntity, SirenEntity):
         super().__init__(reolink_data, channel)
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """State of the siren."""
         return self._host.api.baichuan.siren_state(self._channel)
 
     @raise_translated_error
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the siren."""
         if (volume := kwargs.get(ATTR_VOLUME_LEVEL)) is not None:
@@ -113,6 +115,7 @@ class ReolinkSirenEntity(ReolinkChannelCoordinatorEntity, SirenEntity):
         await self._host.api.set_siren(self._channel, True, duration)
 
     @raise_translated_error
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the siren."""
         await self._host.api.set_siren(self._channel, False, None)
@@ -136,6 +139,7 @@ class ReolinkHostSirenEntity(ReolinkHostCoordinatorEntity, SirenEntity):
         super().__init__(reolink_data)
 
     @raise_translated_error
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the siren."""
         if (volume := kwargs.get(ATTR_VOLUME_LEVEL)) is not None:

--- a/homeassistant/components/reolink/switch.py
+++ b/homeassistant/components/reolink/switch.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from reolink_aio.api import Chime, Host
 
@@ -381,17 +381,20 @@ class ReolinkSwitchEntity(ReolinkChannelCoordinatorEntity, SwitchEntity):
         super().__init__(reolink_data, channel)
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if switch is on."""
         return self.entity_description.value(self._host.api, self._channel)
 
     @raise_translated_error
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         await self.entity_description.method(self._host.api, self._channel, True)
         self.async_write_ha_state()
 
     @raise_translated_error
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         await self.entity_description.method(self._host.api, self._channel, False)
@@ -413,17 +416,20 @@ class ReolinkHostSwitchEntity(ReolinkHostCoordinatorEntity, SwitchEntity):
         super().__init__(reolink_data)
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if switch is on."""
         return self.entity_description.value(self._host.api)
 
     @raise_translated_error
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         await self.entity_description.method(self._host.api, True)
         self.async_write_ha_state()
 
     @raise_translated_error
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         await self.entity_description.method(self._host.api, False)
@@ -446,17 +452,20 @@ class ReolinkChimeSwitchEntity(ReolinkChimeCoordinatorEntity, SwitchEntity):
         super().__init__(reolink_data, chime)
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if switch is on."""
         return self.entity_description.value(self._chime)
 
     @raise_translated_error
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         await self.entity_description.method(self._chime, True)
         self.async_write_ha_state()
 
     @raise_translated_error
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         await self.entity_description.method(self._chime, False)
@@ -479,17 +488,20 @@ class ReolinkHostChimeSwitchEntity(ReolinkHostChimeCoordinatorEntity, SwitchEnti
         super().__init__(reolink_data, chime)
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if switch is on."""
         return self.entity_description.value(self._chime)
 
     @raise_translated_error
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         await self.entity_description.method(self._chime, True)
         self.async_write_ha_state()
 
     @raise_translated_error
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         await self.entity_description.method(self._chime, False)
@@ -518,11 +530,13 @@ class ReolinkIndexSwitchEntity(ReolinkChannelCoordinatorEntity, SwitchEntity):
         self._attr_unique_id = f"{self._attr_unique_id}_{index}"
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if switch is on."""
         return self.entity_description.value(self._host.api, self._channel, self._index)
 
     @raise_translated_error
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         await self.entity_description.method(
@@ -531,6 +545,7 @@ class ReolinkIndexSwitchEntity(ReolinkChannelCoordinatorEntity, SwitchEntity):
         self.async_write_ha_state()
 
     @raise_translated_error
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         await self.entity_description.method(

--- a/homeassistant/components/reolink/update.py
+++ b/homeassistant/components/reolink/update.py
@@ -1,7 +1,7 @@
 """Update entities for Reolink devices."""
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from reolink_aio.exceptions import ReolinkError
 from reolink_aio.software_version import NewSoftwareVersion, SoftwareVersion
@@ -115,11 +115,13 @@ class ReolinkUpdateBaseEntity(CoordinatorEntity[ReolinkCoordinator], UpdateEntit
         self._reolink_data = reolink_data
 
     @property
+    @override
     def installed_version(self) -> str | None:
         """Version currently in use."""
         return self._host.api.camera_sw_version(self._channel)
 
     @property
+    @override
     def latest_version(self) -> str | None:
         """Latest version available for install."""
         new_firmware = self._host.api.firmware_update_available(self._channel)
@@ -132,16 +134,19 @@ class ReolinkUpdateBaseEntity(CoordinatorEntity[ReolinkCoordinator], UpdateEntit
         return new_firmware.version_string
 
     @property
+    @override
     def in_progress(self) -> bool:
         """Update installation progress."""
         return self._host.api.sw_upload_progress(self._channel) < 100
 
     @property
+    @override
     def update_percentage(self) -> int:
         """Update installation progress."""
         return self._host.api.sw_upload_progress(self._channel)
 
     @property
+    @override
     def supported_features(self) -> UpdateEntityFeature:
         """Flag supported features."""
         supported_features = UpdateEntityFeature.INSTALL
@@ -152,12 +157,14 @@ class ReolinkUpdateBaseEntity(CoordinatorEntity[ReolinkCoordinator], UpdateEntit
         return supported_features
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available."""
         if self._installing or self._cancel_update is not None:
             return True
         return super().available
 
+    @override
     def version_is_newer(self, latest_version: str, installed_version: str) -> bool:
         """Return True if latest_version is newer than installed_version."""
         try:
@@ -169,6 +176,7 @@ class ReolinkUpdateBaseEntity(CoordinatorEntity[ReolinkCoordinator], UpdateEntit
 
         return latest > installed
 
+    @override
     async def async_release_notes(self) -> str | None:
         """Return the release notes."""
         new_firmware = self._host.api.firmware_update_available(self._channel)
@@ -182,6 +190,7 @@ class ReolinkUpdateBaseEntity(CoordinatorEntity[ReolinkCoordinator], UpdateEntit
         )
 
     @raise_translated_error
+    @override
     async def async_install(
         self, version: str | None, backup: bool, **kwargs: Any
     ) -> None:
@@ -242,11 +251,13 @@ class ReolinkUpdateBaseEntity(CoordinatorEntity[ReolinkCoordinator], UpdateEntit
         finally:
             self._cancel_update = None
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Entity created."""
         await super().async_added_to_hass()
         self._host.firmware_ch_list.append(self._channel)
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Entity removed."""
         await super().async_will_remove_from_hass()

--- a/homeassistant/components/repairs/issue_handler.py
+++ b/homeassistant/components/repairs/issue_handler.py
@@ -1,6 +1,6 @@
 """The repairs integration."""
 
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -47,6 +47,7 @@ class RepairsFlowManager(
 ):
     """Manage repairs flows."""
 
+    @override
     async def async_create_flow(
         self,
         handler_key: str,
@@ -75,6 +76,7 @@ class RepairsFlowManager(
         flow.data = issue.data
         return flow
 
+    @override
     async def async_finish_flow(
         self,
         flow: data_entry_flow.FlowHandler[

--- a/homeassistant/components/repairs/websocket_api.py
+++ b/homeassistant/components/repairs/websocket_api.py
@@ -1,7 +1,7 @@
 """The repairs websocket API."""
 
 from http import HTTPStatus
-from typing import Any
+from typing import Any, override
 
 from aiohttp import web
 import voluptuous as vol
@@ -121,6 +121,7 @@ class RepairsFlowIndexView(FlowManagerIndexView):
             extra=vol.ALLOW_EXTRA,
         )
     )
+    @override
     async def post(self, request: web.Request, data: dict[str, Any]) -> web.Response:
         """Handle a POST request."""
         try:
@@ -147,11 +148,13 @@ class RepairsFlowResourceView(FlowManagerResourceView):
     name = "api:repairs:issues:fix:resource"
 
     @require_admin(permission=POLICY_EDIT)
+    @override
     async def get(self, request: web.Request, /, flow_id: str) -> web.Response:
         """Get the current state of a data_entry_flow."""
         return await super().get(request, flow_id)
 
     @require_admin(permission=POLICY_EDIT)
+    @override
     async def post(self, request: web.Request, flow_id: str) -> web.Response:
         """Handle a POST request."""
         return await super().post(request, flow_id)

--- a/homeassistant/components/repetier/sensor.py
+++ b/homeassistant/components/repetier/sensor.py
@@ -2,6 +2,7 @@
 
 import logging
 import time
+from typing import override
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.core import HomeAssistant, callback
@@ -85,6 +86,7 @@ class RepetierSensor(SensorEntity):
         """Get new data and update state."""
         self.async_schedule_update_ha_state(True)
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Connect update callbacks."""
         self.async_on_remove(
@@ -116,12 +118,14 @@ class RepetierTempSensor(RepetierSensor):
     """Represent a Repetier temp sensor."""
 
     @property
+    @override
     def native_value(self):
         """Return sensor state."""
         if self._attr_native_value is None:
             return None
         return round(self._attr_native_value, 2)
 
+    @override
     def update(self) -> None:
         """Update the sensor."""
         if (data := self._get_data()) is None:
@@ -137,6 +141,7 @@ class RepetierJobSensor(RepetierSensor):
     """Represent a Repetier job sensor."""
 
     @property
+    @override
     def native_value(self):
         """Return sensor state."""
         if self._attr_native_value is None:
@@ -149,6 +154,7 @@ class RepetierJobEndSensor(RepetierSensor):
 
     _attr_device_class = SensorDeviceClass.TIMESTAMP
 
+    @override
     def update(self) -> None:
         """Update the sensor."""
         if (data := self._get_data()) is None:
@@ -173,6 +179,7 @@ class RepetierJobStartSensor(RepetierSensor):
 
     _attr_device_class = SensorDeviceClass.TIMESTAMP
 
+    @override
     def update(self) -> None:
         """Update the sensor."""
         if (data := self._get_data()) is None:

--- a/homeassistant/components/rest/binary_sensor.py
+++ b/homeassistant/components/rest/binary_sensor.py
@@ -2,6 +2,7 @@
 
 import logging
 import ssl
+from typing import override
 from xml.parsers.expat import ExpatError
 
 import voluptuous as vol
@@ -134,12 +135,14 @@ class RestBinarySensor(ManualTriggerEntity, RestEntity, BinarySensorEntity):
         self._value_template: ValueTemplate | None = config.get(CONF_VALUE_TEMPLATE)
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         available1 = RestEntity.available.fget(self)  # type: ignore[attr-defined]
         available2 = ManualTriggerEntity.available.fget(self)  # type: ignore[attr-defined]
         return bool(available1 and available2)
 
+    @override
     def _update_from_rest_data(self) -> None:
         """Update state from the rest data."""
         if self.rest.data is None:

--- a/homeassistant/components/rest/entity.py
+++ b/homeassistant/components/rest/entity.py
@@ -1,7 +1,7 @@
 """The base entity for the rest component."""
 
 from abc import abstractmethod
-from typing import Any
+from typing import Any, override
 
 from homeassistant.core import callback
 from homeassistant.helpers.entity import Entity
@@ -29,12 +29,14 @@ class RestEntity(Entity):
         self._attr_force_update = force_update
 
     @property
+    @override
     def available(self) -> bool:
         """Return the availability of this sensor."""
         if self._coordinator and not self._coordinator.last_update_success:
             return False
         return self.rest.data is not None
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()

--- a/homeassistant/components/rest/notify.py
+++ b/homeassistant/components/rest/notify.py
@@ -2,7 +2,7 @@
 
 from http import HTTPStatus
 import logging
-from typing import Any
+from typing import Any, override
 
 import httpx
 import voluptuous as vol
@@ -145,6 +145,7 @@ class RestNotificationService(BaseNotificationService):
         self._auth = auth
         self._verify_ssl = verify_ssl
 
+    @override
     async def async_send_message(self, message: str = "", **kwargs: Any) -> None:
         """Send a message to a user."""
         data = {self._message_param_name: message}

--- a/homeassistant/components/rest/sensor.py
+++ b/homeassistant/components/rest/sensor.py
@@ -2,7 +2,7 @@
 
 import logging
 import ssl
-from typing import Any
+from typing import Any, override
 from xml.parsers.expat import ExpatError
 
 import voluptuous as vol
@@ -141,6 +141,7 @@ class RestSensor(ManualTriggerSensorEntity, RestEntity):
         self._attr_extra_state_attributes = {}
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         available1 = RestEntity.available.fget(self)  # type: ignore[attr-defined]
@@ -148,10 +149,12 @@ class RestSensor(ManualTriggerSensorEntity, RestEntity):
         return bool(available1 and available2)
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra attributes."""
         return dict(self._attr_extra_state_attributes)
 
+    @override
     def _update_from_rest_data(self) -> None:
         """Update state from the rest data."""
         try:

--- a/homeassistant/components/rest/switch.py
+++ b/homeassistant/components/rest/switch.py
@@ -2,7 +2,7 @@
 
 from http import HTTPStatus
 import logging
-from typing import Any
+from typing import Any, override
 
 import httpx
 import voluptuous as vol
@@ -154,11 +154,13 @@ class RestSwitch(ManualTriggerEntity, SwitchEntity):
         self._timeout: int = config[CONF_TIMEOUT]
         self._verify_ssl: bool = config[CONF_VERIFY_SSL]
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Handle adding to Home Assistant."""
         await super().async_added_to_hass()
         await self.async_update()
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
         body_on_t = self._body_on.async_render(parse_result=False)
@@ -181,6 +183,7 @@ class RestSwitch(ManualTriggerEntity, SwitchEntity):
 
         self._attr_is_on = True
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
         body_off_t = self._body_off.async_render(parse_result=False)

--- a/homeassistant/components/rflink/binary_sensor.py
+++ b/homeassistant/components/rflink/binary_sensor.py
@@ -1,6 +1,6 @@
 """Support for Rflink binary sensors."""
 
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -98,6 +98,7 @@ class RflinkBinarySensor(RflinkDevice, BinarySensorEntity, RestoreEntity):
         self._delay_listener = None
         super().__init__(device_id, **kwargs)
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Restore RFLink BinarySensor state."""
         await super().async_added_to_hass()
@@ -107,6 +108,7 @@ class RflinkBinarySensor(RflinkDevice, BinarySensorEntity, RestoreEntity):
             else:
                 self._state = False
 
+    @override
     def _handle_event(self, event):
         """Domain specific event handler."""
         command = event["command"]
@@ -131,6 +133,7 @@ class RflinkBinarySensor(RflinkDevice, BinarySensorEntity, RestoreEntity):
             )
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
         return self._state

--- a/homeassistant/components/rflink/cover.py
+++ b/homeassistant/components/rflink/cover.py
@@ -1,7 +1,7 @@
 """Support for Rflink Cover devices."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -137,12 +137,14 @@ async def async_setup_platform(
 class RflinkCover(RflinkCommand, CoverEntity, RestoreEntity):
     """Rflink entity which can switch on/stop/off (eg: cover)."""
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Restore RFLink cover state (OPEN/CLOSE)."""
         await super().async_added_to_hass()
         if (old_state := await self.async_get_last_state()) is not None:
             self._state = old_state.state == CoverState.OPEN
 
+    @override
     def _handle_event(self, event):
         """Adjust state if Rflink picks up a remote command for this device."""
         self.cancel_queued_send_commands()
@@ -154,23 +156,28 @@ class RflinkCover(RflinkCommand, CoverEntity, RestoreEntity):
             self._state = False
 
     @property
+    @override
     def is_closed(self) -> bool | None:
         """Return if the cover is closed."""
         return not self._state
 
     @property
+    @override
     def assumed_state(self) -> bool:
         """Return True because covers can be stopped midway."""
         return True
 
+    @override
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Turn the device close."""
         await self._async_handle_command("close_cover")
 
+    @override
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Turn the device open."""
         await self._async_handle_command("open_cover")
 
+    @override
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Turn the device stop."""
         await self._async_handle_command("stop_cover")
@@ -179,6 +186,7 @@ class RflinkCover(RflinkCommand, CoverEntity, RestoreEntity):
 class InvertedRflinkCover(RflinkCover):
     """Rflink cover that has inverted open/close commands."""
 
+    @override
     async def _async_send_command(self, cmd, repetitions):
         """Will invert only the UP/DOWN commands."""
         _LOGGER.debug("Getting command: %s for Rflink device: %s", cmd, self._device_id)

--- a/homeassistant/components/rflink/entity.py
+++ b/homeassistant/components/rflink/entity.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from typing import override
 
 from rflink.protocol import ProtocolBase
 
@@ -97,6 +98,7 @@ class RflinkDevice(Entity):
         return self._state
 
     @property
+    @override
     def assumed_state(self) -> bool:
         """Assume device state until first device event sets state."""
         return self._state is None
@@ -107,6 +109,7 @@ class RflinkDevice(Entity):
         self._attr_available = availability
         self.async_write_ha_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register update callback."""
         await super().async_added_to_hass()
@@ -287,12 +290,14 @@ class RflinkCommand(RflinkDevice):
 class SwitchableRflinkDevice(RflinkCommand, RestoreEntity):
     """Rflink entity which can switch on/off (eg: light, switch)."""
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Restore RFLink device state (ON/OFF)."""
         await super().async_added_to_hass()
         if (old_state := await self.async_get_last_state()) is not None:
             self._state = old_state.state == STATE_ON
 
+    @override
     def _handle_event(self, event):
         """Adjust state if Rflink picks up a remote command for this device."""
         self.cancel_queued_send_commands()

--- a/homeassistant/components/rflink/light.py
+++ b/homeassistant/components/rflink/light.py
@@ -2,7 +2,7 @@
 
 import logging
 import re
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -207,6 +207,7 @@ class DimmableRflinkLight(SwitchableRflinkDevice, LightEntity):
     _attr_supported_color_modes = {ColorMode.BRIGHTNESS}
     _brightness = 255
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Restore RFLink light brightness attribute."""
         await super().async_added_to_hass()
@@ -219,6 +220,7 @@ class DimmableRflinkLight(SwitchableRflinkDevice, LightEntity):
             # restore also brightness in dimmables devices
             self._brightness = int(old_state.attributes[ATTR_BRIGHTNESS])
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
         if ATTR_BRIGHTNESS in kwargs:
@@ -230,6 +232,7 @@ class DimmableRflinkLight(SwitchableRflinkDevice, LightEntity):
         # Turn on light at the requested dim level
         await self._async_handle_command("dim", self._brightness)
 
+    @override
     def _handle_event(self, event):
         """Adjust state if Rflink picks up a remote command for this device."""
         self.cancel_queued_send_commands()
@@ -245,6 +248,7 @@ class DimmableRflinkLight(SwitchableRflinkDevice, LightEntity):
             self._state = True
 
     @property
+    @override
     def brightness(self) -> int:
         """Return the brightness of this light between 0..255."""
         return self._brightness
@@ -265,6 +269,7 @@ class HybridRflinkLight(DimmableRflinkLight):
     Which results in a nice house disco :)
     """
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on and set dim level."""
         await super().async_turn_on(**kwargs)
@@ -283,6 +288,7 @@ class ToggleRflinkLight(RflinkLight):
     and if the light is off and 'on' gets sent, the light will turn on.
     """
 
+    @override
     def _handle_event(self, event):
         """Adjust state if Rflink picks up a remote command for this device."""
         self.cancel_queued_send_commands()
@@ -292,10 +298,12 @@ class ToggleRflinkLight(RflinkLight):
             # if the state is true, it gets set as false
             self._state = self._state in [None, False]
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
         await self._async_handle_command("toggle")
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
         await self._async_handle_command("toggle")

--- a/homeassistant/components/rflink/sensor.py
+++ b/homeassistant/components/rflink/sensor.py
@@ -1,7 +1,7 @@
 """Support for Rflink sensors."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from rflink.parser import PACKET_FIELDS, UNITS
 import voluptuous as vol
@@ -370,10 +370,12 @@ class RflinkSensor(RflinkDevice, SensorEntity):
 
         super().__init__(device_id, initial_event=initial_event, **kwargs)
 
+    @override
     def _handle_event(self, event):
         """Domain specific event handler."""
         self._state = event["value"]
 
+    @override
     # pylint: disable-next=home-assistant-missing-super-call
     async def async_added_to_hass(self) -> None:
         """Register update callback."""
@@ -414,6 +416,7 @@ class RflinkSensor(RflinkDevice, SensorEntity):
             self.handle_event_callback(self._initial_event)
 
     @property
+    @override
     def native_unit_of_measurement(self):
         """Return measurement unit."""
         if self._unit_of_measurement:
@@ -423,6 +426,7 @@ class RflinkSensor(RflinkDevice, SensorEntity):
         return None
 
     @property
+    @override
     def native_value(self):
         """Return value."""
         return self._state

--- a/homeassistant/components/rfxtrx/binary_sensor.py
+++ b/homeassistant/components/rfxtrx/binary_sensor.py
@@ -1,7 +1,7 @@
 """Support for RFXtrx binary sensors."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 import RFXtrx as rfxtrxmod
 
@@ -152,6 +152,7 @@ class RfxtrxBinarySensor(RfxtrxEntity, BinarySensorEntity):
         self._cmd_on = cmd_on
         self._cmd_off = cmd_off
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Restore device state."""
         await super().async_added_to_hass()
@@ -188,6 +189,7 @@ class RfxtrxBinarySensor(RfxtrxEntity, BinarySensorEntity):
         elif event.values.get("Sensor Status") in SENSOR_STATUS_OFF:
             self._attr_is_on = False
 
+    @override
     def _apply_event(self, event: rfxtrxmod.RFXtrxEvent) -> None:
         """Apply command from rfxtrx."""
         super()._apply_event(event)
@@ -197,6 +199,7 @@ class RfxtrxBinarySensor(RfxtrxEntity, BinarySensorEntity):
             self._apply_event_standard(event)
 
     @callback
+    @override
     def _handle_event(
         self, event: rfxtrxmod.RFXtrxEvent, device_id: DeviceTuple
     ) -> None:

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -4,7 +4,7 @@ import asyncio
 from contextlib import suppress
 import copy
 import itertools
-from typing import Any, TypedDict, cast
+from typing import Any, TypedDict, cast, override
 
 import RFXtrx as rfxtrxmod
 import voluptuous as vol
@@ -495,6 +495,7 @@ class RfxtrxConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -626,6 +627,7 @@ class RfxtrxConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> RfxtrxOptionsFlow:

--- a/homeassistant/components/rfxtrx/cover.py
+++ b/homeassistant/components/rfxtrx/cover.py
@@ -1,7 +1,7 @@
 """Support for RFXtrx covers."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 import RFXtrx as rfxtrxmod
 
@@ -87,6 +87,7 @@ class RfxtrxCover(RfxtrxCommandEntity, CoverEntity):
                 | CoverEntityFeature.STOP_TILT
             )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Restore device state."""
         await super().async_added_to_hass()
@@ -96,6 +97,7 @@ class RfxtrxCover(RfxtrxCommandEntity, CoverEntity):
             if old_state is not None:
                 self._attr_is_closed = old_state.state != CoverState.OPEN
 
+    @override
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Move the cover up."""
         if self._venetian_blind_mode == CONST_VENETIAN_BLIND_MODE_US:
@@ -107,6 +109,7 @@ class RfxtrxCover(RfxtrxCommandEntity, CoverEntity):
         self._attr_is_closed = False
         self.async_write_ha_state()
 
+    @override
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Move the cover down."""
         if self._venetian_blind_mode == CONST_VENETIAN_BLIND_MODE_US:
@@ -118,12 +121,14 @@ class RfxtrxCover(RfxtrxCommandEntity, CoverEntity):
         self._attr_is_closed = True
         self.async_write_ha_state()
 
+    @override
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
         await self._async_send(self._device.send_stop)
         self._attr_is_closed = False
         self.async_write_ha_state()
 
+    @override
     async def async_open_cover_tilt(self, **kwargs: Any) -> None:
         """Tilt the cover up."""
         if self._venetian_blind_mode == CONST_VENETIAN_BLIND_MODE_US:
@@ -131,6 +136,7 @@ class RfxtrxCover(RfxtrxCommandEntity, CoverEntity):
         elif self._venetian_blind_mode == CONST_VENETIAN_BLIND_MODE_EU:
             await self._async_send(self._device.send_up05sec)
 
+    @override
     async def async_close_cover_tilt(self, **kwargs: Any) -> None:
         """Tilt the cover down."""
         if self._venetian_blind_mode == CONST_VENETIAN_BLIND_MODE_US:
@@ -138,12 +144,14 @@ class RfxtrxCover(RfxtrxCommandEntity, CoverEntity):
         elif self._venetian_blind_mode == CONST_VENETIAN_BLIND_MODE_EU:
             await self._async_send(self._device.send_down05sec)
 
+    @override
     async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
         """Stop the cover tilt."""
         await self._async_send(self._device.send_stop)
         self._attr_is_closed = False
         self.async_write_ha_state()
 
+    @override
     def _apply_event(self, event: rfxtrxmod.RFXtrxEvent) -> None:
         """Apply command from rfxtrx."""
         assert isinstance(event, rfxtrxmod.ControlEvent)
@@ -154,6 +162,7 @@ class RfxtrxCover(RfxtrxCommandEntity, CoverEntity):
             self._attr_is_closed = True
 
     @callback
+    @override
     def _handle_event(
         self, event: rfxtrxmod.RFXtrxEvent, device_id: DeviceTuple
     ) -> None:

--- a/homeassistant/components/rfxtrx/entity.py
+++ b/homeassistant/components/rfxtrx/entity.py
@@ -1,7 +1,7 @@
 """Support for RFXtrx devices."""
 
 from collections.abc import Callable
-from typing import cast
+from typing import cast, override
 
 import RFXtrx as rfxtrxmod
 
@@ -55,6 +55,7 @@ class RfxtrxEntity(RestoreEntity):
         # group events regardless of their group indices.
         (self._group_id, _, _) = device_id.id_string.partition(":")
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Restore RFXtrx device state (ON/OFF)."""
         if self._event:
@@ -65,6 +66,7 @@ class RfxtrxEntity(RestoreEntity):
         )
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, str] | None:
         """Return the device state attributes."""
         if not self._event:

--- a/homeassistant/components/rfxtrx/event.py
+++ b/homeassistant/components/rfxtrx/event.py
@@ -1,7 +1,7 @@
 """Support for RFXtrx sensors."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from RFXtrx import ControlEvent, RFXtrxDevice, RFXtrxEvent, SensorEvent
 
@@ -82,6 +82,7 @@ class RfxtrxEventEntity(RfxtrxEntity, EventEntity):
         self._value_attribute = value_attribute
 
     @callback
+    @override
     def _handle_event(self, event: RFXtrxEvent, device_id: DeviceTuple) -> None:
         """Check if event applies to me and update."""
         if not self._event_applies(event, device_id):

--- a/homeassistant/components/rfxtrx/light.py
+++ b/homeassistant/components/rfxtrx/light.py
@@ -1,7 +1,7 @@
 """Support for RFXtrx lights."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 import RFXtrx as rfxtrxmod
 
@@ -61,6 +61,7 @@ class RfxtrxLight(RfxtrxCommandEntity, LightEntity):
     _attr_brightness: int = 0
     _device: rfxtrxmod.LightingDevice
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Restore RFXtrx device state (ON/OFF)."""
         await super().async_added_to_hass()
@@ -72,6 +73,7 @@ class RfxtrxLight(RfxtrxCommandEntity, LightEntity):
                 if brightness := old_state.attributes.get(ATTR_BRIGHTNESS):
                     self._attr_brightness = int(brightness)
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
         brightness = kwargs.get(ATTR_BRIGHTNESS)
@@ -85,6 +87,7 @@ class RfxtrxLight(RfxtrxCommandEntity, LightEntity):
 
         self.async_write_ha_state()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
         await self._async_send(self._device.send_off)
@@ -92,6 +95,7 @@ class RfxtrxLight(RfxtrxCommandEntity, LightEntity):
         self._attr_brightness = 0
         self.async_write_ha_state()
 
+    @override
     def _apply_event(self, event: rfxtrxmod.RFXtrxEvent) -> None:
         """Apply command from rfxtrx."""
         assert isinstance(event, rfxtrxmod.ControlEvent)
@@ -106,6 +110,7 @@ class RfxtrxLight(RfxtrxCommandEntity, LightEntity):
             self._attr_is_on = brightness > 0
 
     @callback
+    @override
     def _handle_event(
         self, event: rfxtrxmod.RFXtrxEvent, device_id: DeviceTuple
     ) -> None:

--- a/homeassistant/components/rfxtrx/sensor.py
+++ b/homeassistant/components/rfxtrx/sensor.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from datetime import date, datetime
 from decimal import Decimal
 import logging
-from typing import Any, cast
+from typing import Any, cast, override
 
 from RFXtrx import ControlEvent, RFXtrxDevice, RFXtrxEvent, SensorEvent
 
@@ -291,6 +291,7 @@ class RfxtrxSensor(RfxtrxEntity, SensorEntity):
         self.entity_description = entity_description
         self._attr_unique_id = "_".join(x for x in (*device_id, entity_description.key))
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Restore device state."""
         await super().async_added_to_hass()
@@ -303,6 +304,7 @@ class RfxtrxSensor(RfxtrxEntity, SensorEntity):
             self._apply_event(get_rfx_object(event))
 
     @property
+    @override
     def native_value(self) -> StateType | date | datetime | Decimal:
         """Return the state of the sensor."""
         if not self._event:
@@ -311,6 +313,7 @@ class RfxtrxSensor(RfxtrxEntity, SensorEntity):
         return self.entity_description.convert(value)
 
     @callback
+    @override
     def _handle_event(self, event: RFXtrxEvent, device_id: DeviceTuple) -> None:
         """Check if event applies to me and update."""
         if device_id != self._device_id:

--- a/homeassistant/components/rfxtrx/siren.py
+++ b/homeassistant/components/rfxtrx/siren.py
@@ -1,7 +1,7 @@
 """Support for RFXtrx sirens."""
 
 from datetime import datetime
-from typing import Any
+from typing import Any, override
 
 import RFXtrx as rfxtrxmod
 
@@ -114,6 +114,7 @@ class RfxtrxOffDelayMixin(Entity):  # pylint: disable=home-assistant-enforce-cla
             self._timeout()
             self._timeout = None
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Run when entity will be removed from hass."""
         self._cancel_timeout()
@@ -140,10 +141,12 @@ class RfxtrxChime(RfxtrxCommandEntity, SirenEntity, RfxtrxOffDelayMixin):
         self._off_delay = off_delay
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if device is on."""
         return self._timeout is not None
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
         self._cancel_timeout()
@@ -159,6 +162,7 @@ class RfxtrxChime(RfxtrxCommandEntity, SirenEntity, RfxtrxOffDelayMixin):
 
         self.async_write_ha_state()
 
+    @override
     def _apply_event(self, event: rfxtrxmod.ControlEvent) -> None:
         """Apply a received event."""
         super()._apply_event(event)
@@ -169,6 +173,7 @@ class RfxtrxChime(RfxtrxCommandEntity, SirenEntity, RfxtrxOffDelayMixin):
             self._setup_timeout()
 
     @callback
+    @override
     def _handle_event(
         self, event: rfxtrxmod.RFXtrxEvent, device_id: DeviceTuple
     ) -> None:
@@ -199,10 +204,12 @@ class RfxtrxSecurityPanic(RfxtrxCommandEntity, SirenEntity, RfxtrxOffDelayMixin)
         self._off_delay = off_delay
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if device is on."""
         return self._timeout is not None
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
         self._cancel_timeout()
@@ -213,6 +220,7 @@ class RfxtrxSecurityPanic(RfxtrxCommandEntity, SirenEntity, RfxtrxOffDelayMixin)
 
         self.async_write_ha_state()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
         self._cancel_timeout()
@@ -221,6 +229,7 @@ class RfxtrxSecurityPanic(RfxtrxCommandEntity, SirenEntity, RfxtrxOffDelayMixin)
 
         self.async_write_ha_state()
 
+    @override
     def _apply_event(self, event: rfxtrxmod.SensorEvent) -> None:
         """Apply a received event."""
         super()._apply_event(event)
@@ -234,6 +243,7 @@ class RfxtrxSecurityPanic(RfxtrxCommandEntity, SirenEntity, RfxtrxOffDelayMixin)
             self._cancel_timeout()
 
     @callback
+    @override
     def _handle_event(
         self, event: rfxtrxmod.RFXtrxEvent, device_id: DeviceTuple
     ) -> None:

--- a/homeassistant/components/rfxtrx/switch.py
+++ b/homeassistant/components/rfxtrx/switch.py
@@ -1,7 +1,7 @@
 """Support for RFXtrx switches."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 import RFXtrx as rfxtrxmod
 
@@ -83,6 +83,7 @@ class RfxtrxSwitch(RfxtrxCommandEntity, SwitchEntity):
         self._cmd_on = cmd_on
         self._cmd_off = cmd_off
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Restore device state."""
         await super().async_added_to_hass()
@@ -112,6 +113,7 @@ class RfxtrxSwitch(RfxtrxCommandEntity, SwitchEntity):
         elif event.values["Command"] in COMMAND_OFF_LIST:
             self._attr_is_on = False
 
+    @override
     def _apply_event(self, event: rfxtrxmod.RFXtrxEvent) -> None:
         """Apply command from rfxtrx."""
         super()._apply_event(event)
@@ -121,6 +123,7 @@ class RfxtrxSwitch(RfxtrxCommandEntity, SwitchEntity):
             self._apply_event_standard(event)
 
     @callback
+    @override
     def _handle_event(
         self, event: rfxtrxmod.RFXtrxEvent, device_id: DeviceTuple
     ) -> None:
@@ -130,6 +133,7 @@ class RfxtrxSwitch(RfxtrxCommandEntity, SwitchEntity):
 
             self.async_write_ha_state()
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
         if self._cmd_on is not None:
@@ -139,6 +143,7 @@ class RfxtrxSwitch(RfxtrxCommandEntity, SwitchEntity):
         self._attr_is_on = True
         self.async_write_ha_state()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
         if self._cmd_off is not None:

--- a/homeassistant/components/rhasspy/config_flow.py
+++ b/homeassistant/components/rhasspy/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for Rhasspy integration."""
 
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -14,6 +14,7 @@ class RhasspyConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/ridwell/calendar.py
+++ b/homeassistant/components/ridwell/calendar.py
@@ -1,6 +1,7 @@
 """Support for Ridwell calendars."""
 
 import datetime
+from typing import override
 
 from aioridwell.model import PickupCategory, RidwellAccount, RidwellPickupEvent
 
@@ -91,12 +92,14 @@ class RidwellCalendar(RidwellEntity, CalendarEntity):
         self._event: CalendarEvent | None = None
 
     @property
+    @override
     def event(self) -> CalendarEvent | None:
         """Return the next upcoming event."""
         return async_get_calendar_event_from_pickup_event(
             self.next_pickup_event, self.coordinator.config_entry
         )
 
+    @override
     async def async_get_events(
         self,
         hass: HomeAssistant,

--- a/homeassistant/components/ridwell/config_flow.py
+++ b/homeassistant/components/ridwell/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Ridwell integration."""
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from aioridwell import async_get_client
 from aioridwell.errors import InvalidCredentialsError, RidwellError
@@ -105,6 +105,7 @@ class RidwellConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: RidwellConfigEntry,
     ) -> SchemaOptionsFlowHandler:
@@ -147,6 +148,7 @@ class RidwellConfigFlow(ConfigFlow, domain=DOMAIN):
             "reauth_confirm", STEP_REAUTH_CONFIRM_DATA_SCHEMA
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/ridwell/coordinator.py
+++ b/homeassistant/components/ridwell/coordinator.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from datetime import timedelta
-from typing import cast
+from typing import cast, override
 
 from aioridwell.client import async_get_client
 from aioridwell.errors import InvalidCredentialsError, RidwellError
@@ -45,6 +45,7 @@ class RidwellDataUpdateCoordinator(
             update_interval=UPDATE_INTERVAL,
         )
 
+    @override
     async def _async_update_data(self) -> dict[str, list[RidwellPickupEvent]]:
         """Fetch the latest data from the source."""
         data = {}

--- a/homeassistant/components/ridwell/sensor.py
+++ b/homeassistant/components/ridwell/sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 from datetime import date
-from typing import Any
+from typing import Any, override
 
 from aioridwell.model import RidwellAccount
 
@@ -60,6 +60,7 @@ class RidwellSensor(RidwellEntity, SensorEntity):
         self.entity_description = description
 
     @property
+    @override
     def extra_state_attributes(self) -> Mapping[str, Any]:
         """Return entity specific state attributes."""
         attrs: dict[str, Any] = {
@@ -82,6 +83,7 @@ class RidwellSensor(RidwellEntity, SensorEntity):
         return attrs
 
     @property
+    @override
     def native_value(self) -> date:
         """Return the value reported by the sensor."""
         return self.next_pickup_event.pickup_date

--- a/homeassistant/components/ridwell/switch.py
+++ b/homeassistant/components/ridwell/switch.py
@@ -1,6 +1,6 @@
 """Support for Ridwell buttons."""
 
-from typing import Any
+from typing import Any, override
 
 from aioridwell.errors import RidwellError
 from aioridwell.model import EventState, RidwellAccount
@@ -49,10 +49,12 @@ class RidwellSwitch(RidwellEntity, SwitchEntity):
         self.entity_description = description
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return True if entity is on."""
         return self.next_pickup_event.state is EventState.SCHEDULED
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         try:
@@ -62,6 +64,7 @@ class RidwellSwitch(RidwellEntity, SwitchEntity):
 
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         try:

--- a/homeassistant/components/ring/binary_sensor.py
+++ b/homeassistant/components/ring/binary_sensor.py
@@ -3,7 +3,7 @@
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Generic
+from typing import Any, Generic, override
 
 from ring_doorbell import RingCapability, RingEvent
 from ring_doorbell.const import KIND_DING, KIND_MOTION
@@ -137,20 +137,24 @@ class RingBinarySensor(
         )
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         if alert := self._get_coordinator_alert():
             self._async_handle_event(alert)
         super()._handle_coordinator_update()
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return self.coordinator.event_listener.started
 
+    @override
     async def async_update(self) -> None:
         """All updates are passive."""
 
     @property
+    @override
     def extra_state_attributes(self) -> Mapping[str, Any] | None:
         """Return the state attributes."""
         attrs = super().extra_state_attributes

--- a/homeassistant/components/ring/button.py
+++ b/homeassistant/components/ring/button.py
@@ -1,5 +1,7 @@
 """Component providing support for Ring buttons."""
 
+from typing import override
+
 from ring_doorbell import RingOther
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
@@ -53,6 +55,7 @@ class RingDoorButton(RingEntity[RingOther], ButtonEntity):
         self._attr_unique_id = f"{device.id}-{description.key}"
 
     @exception_wrap
+    @override
     async def async_press(self) -> None:
         """Open the door."""
         await self._device.async_open_door()

--- a/homeassistant/components/ring/camera.py
+++ b/homeassistant/components/ring/camera.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
-from typing import TYPE_CHECKING, Any, Generic
+from typing import TYPE_CHECKING, Any, Generic, override
 
 from aiohttp import web
 from haffmpeg.camera import CameraMjpeg
@@ -121,6 +121,7 @@ class RingCam(RingEntity[RingDoorBell], Camera):
             self._attr_supported_features |= CameraEntityFeature.STREAM
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Call update method."""
         self._device = self._get_coordinator_data().get_video_device(
@@ -142,6 +143,7 @@ class RingCam(RingEntity[RingDoorBell], Camera):
             self.async_write_ha_state()
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         return {
@@ -149,6 +151,7 @@ class RingCam(RingEntity[RingDoorBell], Camera):
             "last_video_id": self._last_video_id,
         }
 
+    @override
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
@@ -175,6 +178,7 @@ class RingCam(RingEntity[RingDoorBell], Camera):
 
         return image
 
+    @override
     async def handle_async_mjpeg_stream(
         self, request: web.Request
     ) -> web.StreamResponse | None:
@@ -196,6 +200,7 @@ class RingCam(RingEntity[RingDoorBell], Camera):
         finally:
             await stream.close()
 
+    @override
     async def async_handle_async_webrtc_offer(
         self, offer_sdp: str, session_id: str, send_message: WebRTCSendMessage
     ) -> None:
@@ -221,6 +226,7 @@ class RingCam(RingEntity[RingDoorBell], Camera):
             offer_sdp, session_id, message_wrapper, keep_alive_timeout=None
         )
 
+    @override
     async def async_on_webrtc_candidate(
         self, session_id: str, candidate: RTCIceCandidateInit
     ) -> None:
@@ -238,10 +244,12 @@ class RingCam(RingEntity[RingDoorBell], Camera):
         )
 
     @callback
+    @override
     def close_webrtc_session(self, session_id: str) -> None:
         """Close a WebRTC session."""
         self._device.sync_close_webrtc_stream(session_id)
 
+    @override
     async def async_update(self) -> None:
         """Update camera entity and refresh attributes."""
         if (
@@ -291,10 +299,12 @@ class RingCam(RingEntity[RingDoorBell], Camera):
         self._attr_motion_detection_enabled = new_state
         self.async_write_ha_state()
 
+    @override
     async def async_enable_motion_detection(self) -> None:
         """Enable motion detection in the camera."""
         await self._async_set_motion_detection_enabled(True)
 
+    @override
     async def async_disable_motion_detection(self) -> None:
         """Disable motion detection in camera."""
         await self._async_set_motion_detection_enabled(False)

--- a/homeassistant/components/ring/config_flow.py
+++ b/homeassistant/components/ring/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 import uuid
 
 from ring_doorbell import Auth, AuthenticationError, Requires2FAError
@@ -77,6 +77,7 @@ class RingConfigFlow(ConfigFlow, domain=DOMAIN):
     user_pass: dict[str, Any] = {}
     hardware_id: str | None = None
 
+    @override
     async def async_step_dhcp(
         self, discovery_info: DhcpServiceInfo
     ) -> ConfigFlowResult:
@@ -96,6 +97,7 @@ class RingConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return await self.async_step_user()
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/ring/coordinator.py
+++ b/homeassistant/components/ring/coordinator.py
@@ -4,7 +4,7 @@ from asyncio import TaskGroup
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 import logging
-from typing import Any
+from typing import Any, override
 
 from ring_doorbell import (
     AuthenticationError,
@@ -90,6 +90,7 @@ class RingDataCoordinator(DataUpdateCoordinator[RingDevices]):
                 translation_key="api_error",
             ) from err
 
+    @override
     async def _async_update_data(self) -> RingDevices:
         """Fetch data from API endpoint."""
         update_method: str = (
@@ -201,6 +202,7 @@ class RingListenCoordinator(BaseDataUpdateCoordinatorProtocol):
                 update_callback()
 
     @callback
+    @override
     def async_add_listener(
         self, update_callback: CALLBACK_TYPE, context: Any = None
     ) -> Callable[[], None]:

--- a/homeassistant/components/ring/entity.py
+++ b/homeassistant/components/ring/entity.py
@@ -3,7 +3,7 @@
 from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import dataclass
 import logging
-from typing import Any, Concatenate, Generic, TypeVar, cast
+from typing import Any, Concatenate, Generic, TypeVar, cast, override
 
 from ring_doorbell import (
     AuthenticationError,
@@ -191,6 +191,7 @@ class RingEntity(RingBaseEntity[RingDataCoordinator, RingDeviceT], CoordinatorEn
         return self.coordinator.data
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         self._device = cast(
             RingDeviceT,

--- a/homeassistant/components/ring/event.py
+++ b/homeassistant/components/ring/event.py
@@ -1,7 +1,7 @@
 """Component providing support for ring events."""
 
 from dataclasses import dataclass
-from typing import Generic
+from typing import Generic, override
 
 from ring_doorbell import RingCapability, RingEvent as RingAlert
 from ring_doorbell.const import KIND_DING, KIND_INTERCOM_UNLOCK, KIND_MOTION
@@ -99,6 +99,7 @@ class RingEvent(RingBaseEntity[RingListenCoordinator, RingDeviceT], EventEntity)
         )
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         if (alert := self._get_coordinator_alert()) and not alert.is_update:
             if alert.kind == KIND_DING:
@@ -108,9 +109,11 @@ class RingEvent(RingBaseEntity[RingListenCoordinator, RingDeviceT], EventEntity)
         super()._handle_coordinator_update()
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return self.coordinator.event_listener.started
 
+    @override
     async def async_update(self) -> None:
         """All updates are passive."""

--- a/homeassistant/components/ring/light.py
+++ b/homeassistant/components/ring/light.py
@@ -3,7 +3,7 @@
 from datetime import timedelta
 from enum import StrEnum, auto
 import logging
-from typing import Any
+from typing import Any, override
 
 from ring_doorbell import RingStickUpCam
 
@@ -70,6 +70,7 @@ class RingLight(RingEntity[RingStickUpCam], LightEntity):
         self._no_updates_until = dt_util.utcnow()
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Call update method."""
         if self._no_updates_until > dt_util.utcnow():
@@ -89,10 +90,12 @@ class RingLight(RingEntity[RingStickUpCam], LightEntity):
         self._no_updates_until = dt_util.utcnow() + SKIP_UPDATES_DELAY
         self.async_write_ha_state()
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on for 30 seconds."""
         await self._async_set_light(OnOffState.ON)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
         await self._async_set_light(OnOffState.OFF)

--- a/homeassistant/components/ring/number.py
+++ b/homeassistant/components/ring/number.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any, Generic, cast
+from typing import Any, Generic, cast, override
 
 from ring_doorbell import RingChime, RingDoorBell, RingGeneric, RingOther
 import ring_doorbell.const
@@ -133,6 +133,7 @@ class RingNumber(RingEntity[RingDeviceT], NumberEntity):
             self._attr_native_value = float(native_value)
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Call update method."""
 
@@ -146,6 +147,7 @@ class RingNumber(RingEntity[RingDeviceT], NumberEntity):
         super()._handle_coordinator_update()
 
     @refresh_after
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Call setter on Ring device."""
         await self.entity_description.setter_fn(self._device, value)

--- a/homeassistant/components/ring/sensor.py
+++ b/homeassistant/components/ring/sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Generic, cast
+from typing import Any, Generic, cast, override
 
 from ring_doorbell import (
     RingCapability,
@@ -89,6 +89,7 @@ class RingSensor(RingEntity[RingDeviceT], SensorEntity):
         self._attr_native_value = self.entity_description.value_fn(self._device)
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Call update method."""
 

--- a/homeassistant/components/ring/siren.py
+++ b/homeassistant/components/ring/siren.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 import logging
-from typing import Any, Generic, cast
+from typing import Any, Generic, cast, override
 
 from ring_doorbell import (
     RingCapability,
@@ -145,16 +145,19 @@ class RingSiren(RingEntity[RingDeviceT], SirenEntity):
             self.async_write_ha_state()
 
     @refresh_after
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the siren."""
         await self._async_set_siren(True, **kwargs)
 
     @refresh_after
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the siren."""
         await self._async_set_siren(False)
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Call update method."""
         if not self.entity_description.is_on_fn:

--- a/homeassistant/components/ring/switch.py
+++ b/homeassistant/components/ring/switch.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable, Coroutine, Sequence
 from dataclasses import dataclass
 import logging
-from typing import Any, Generic, Self, cast
+from typing import Any, Generic, Self, cast, override
 
 from ring_doorbell import RingCapability, RingDoorBell, RingStickUpCam
 from ring_doorbell.const import DOORBELL_EXISTING_TYPE
@@ -129,6 +129,7 @@ class RingSwitch(RingEntity[RingDeviceT], SwitchEntity):
         self._attr_is_on = description.is_on_fn(device)
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Call update method."""
         self._device = cast(
@@ -149,10 +150,12 @@ class RingSwitch(RingEntity[RingDeviceT], SwitchEntity):
         self._attr_is_on = switch_on
         self.async_write_ha_state()
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the siren on for 30 seconds."""
         await self._async_set_switch(True)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the siren off."""
         await self._async_set_switch(False)

--- a/homeassistant/components/ripple/sensor.py
+++ b/homeassistant/components/ripple/sensor.py
@@ -1,6 +1,7 @@
 """Support for Ripple sensors."""
 
 from datetime import timedelta
+from typing import override
 
 from pyripple import get_balance
 import voluptuous as vol
@@ -53,16 +54,19 @@ class RippleSensor(SensorEntity):
         self._unit_of_measurement = "XRP"
 
     @property
+    @override
     def name(self):
         """Return the name of the sensor."""
         return self._name
 
     @property
+    @override
     def native_value(self):
         """Return the state of the sensor."""
         return self._state
 
     @property
+    @override
     def native_unit_of_measurement(self):
         """Return the unit of measurement this sensor expresses itself in."""
         return self._unit_of_measurement

--- a/homeassistant/components/risco/alarm_control_panel.py
+++ b/homeassistant/components/risco/alarm_control_panel.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyrisco.common import Partition
 from pyrisco.local.partition import Partition as LocalPartition
@@ -108,6 +108,7 @@ class RiscoAlarm(AlarmControlPanelEntity):
             self._attr_supported_features |= STATES_TO_SUPPORTED_FEATURES[state]
 
     @property
+    @override
     def alarm_state(self) -> AlarmControlPanelState | None:
         """Return the state of the device."""
         if self._partition.triggered:
@@ -131,6 +132,7 @@ class RiscoAlarm(AlarmControlPanelEntity):
         """Validate given code."""
         return code == self._code
 
+    @override
     async def async_alarm_disarm(self, code: str | None = None) -> None:
         """Send disarm command."""
         if self._code_disarm_required and not self._validate_code(code):
@@ -138,18 +140,22 @@ class RiscoAlarm(AlarmControlPanelEntity):
             return
         await self._call_alarm_method("disarm")
 
+    @override
     async def async_alarm_arm_home(self, code: str | None = None) -> None:
         """Send arm home command."""
         await self._arm(AlarmControlPanelState.ARMED_HOME, code)
 
+    @override
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command."""
         await self._arm(AlarmControlPanelState.ARMED_AWAY, code)
 
+    @override
     async def async_alarm_arm_night(self, code: str | None = None) -> None:
         """Send arm night command."""
         await self._arm(AlarmControlPanelState.ARMED_NIGHT, code)
 
+    @override
     async def async_alarm_arm_custom_bypass(self, code: str | None = None) -> None:
         """Send arm custom bypass command."""
         await self._arm(AlarmControlPanelState.ARMED_CUSTOM_BYPASS, code)
@@ -197,9 +203,11 @@ class RiscoCloudAlarm(RiscoAlarm, RiscoCloudEntity):
             manufacturer="Risco",
         )
 
+    @override
     def _get_data_from_coordinator(self) -> None:
         self._partition = self.coordinator.data.partitions[self._partition_id]
 
+    @override
     async def _call_alarm_method(self, method: str, *args: Any) -> None:
         alarm = await getattr(self._risco, method)(self._partition_id, *args)
         self._partition = alarm.partitions[self._partition_id]
@@ -233,9 +241,11 @@ class RiscoLocalAlarm(RiscoAlarm):
             manufacturer="Risco",
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Subscribe to updates."""
         self._partition_updates[self._partition_id] = self.async_write_ha_state
 
+    @override
     async def _call_alarm_method(self, method: str, *args: Any) -> None:
         await getattr(self._partition, method)(*args)

--- a/homeassistant/components/risco/binary_sensor.py
+++ b/homeassistant/components/risco/binary_sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 from itertools import chain
-from typing import Any
+from typing import Any, override
 
 from pyrisco.cloud.zone import Zone as CloudZone
 from pyrisco.common import System
@@ -114,6 +114,7 @@ class RiscoCloudBinarySensor(RiscoCloudZoneEntity, BinarySensorEntity):
         super().__init__(coordinator=coordinator, suffix="", zone_id=zone_id, zone=zone)
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if sensor is on."""
         return self._zone.triggered
@@ -130,6 +131,7 @@ class RiscoLocalBinarySensor(RiscoLocalZoneEntity, BinarySensorEntity):
         super().__init__(system_id=system_id, suffix="", zone_id=zone_id, zone=zone)
 
     @property
+    @override
     def extra_state_attributes(self) -> Mapping[str, Any] | None:
         """Return the state attributes."""
         return {
@@ -138,6 +140,7 @@ class RiscoLocalBinarySensor(RiscoLocalZoneEntity, BinarySensorEntity):
         }
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if sensor is on."""
         return self._zone.triggered
@@ -158,6 +161,7 @@ class RiscoLocalAlarmedBinarySensor(RiscoLocalZoneEntity, BinarySensorEntity):
         )
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if sensor is on."""
         return self._zone.alarmed
@@ -178,6 +182,7 @@ class RiscoLocalArmedBinarySensor(RiscoLocalZoneEntity, BinarySensorEntity):
         )
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if sensor is on."""
         return self._zone.armed
@@ -206,6 +211,7 @@ class RiscoSystemBinarySensor(BinarySensorEntity):
         )
         self.entity_description = entity_description
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Subscribe to updates."""
         self.async_on_remove(
@@ -215,6 +221,7 @@ class RiscoSystemBinarySensor(BinarySensorEntity):
         )
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if sensor is on."""
         return getattr(self._system, self._property)

--- a/homeassistant/components/risco/config_flow.py
+++ b/homeassistant/components/risco/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyrisco import CannotConnectError, RiscoCloud, RiscoLocal, UnauthorizedError
 import voluptuous as vol
@@ -121,12 +121,14 @@ class RiscoConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: RiscoConfigEntry,
     ) -> RiscoOptionsFlowHandler:
         """Define the config flow to handle options."""
         return RiscoOptionsFlowHandler(config_entry)
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/risco/coordinator.py
+++ b/homeassistant/components/risco/coordinator.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyrisco import CannotConnectError, OperationError, RiscoCloud, UnauthorizedError
 from pyrisco.cloud.alarm import Alarm
@@ -46,6 +46,7 @@ class RiscoDataUpdateCoordinator(DataUpdateCoordinator[Alarm]):
             ),
         )
 
+    @override
     async def _async_update_data(self) -> Alarm:
         """Fetch data from risco."""
         try:
@@ -80,6 +81,7 @@ class RiscoEventsDataUpdateCoordinator(DataUpdateCoordinator[list[Event]]):
             update_interval=timedelta(seconds=60),
         )
 
+    @override
     async def _async_update_data(self) -> list[Event]:
         """Fetch data from risco."""
         last_store = await self._store.async_load() or {}

--- a/homeassistant/components/risco/entity.py
+++ b/homeassistant/components/risco/entity.py
@@ -1,6 +1,6 @@
 """A risco entity base class."""
 
-from typing import Any
+from typing import Any, override
 
 from pyrisco import RiscoCloud
 from pyrisco.cloud.zone import Zone as CloudZone
@@ -33,6 +33,7 @@ class RiscoCloudEntity(CoordinatorEntity[RiscoDataUpdateCoordinator]):
     def _get_data_from_coordinator(self) -> None:
         raise NotImplementedError
 
+    @override
     def _handle_coordinator_update(self) -> None:
         self._get_data_from_coordinator()
         self.async_write_ha_state()
@@ -70,6 +71,7 @@ class RiscoCloudZoneEntity(RiscoCloudEntity):
         )
         self._attr_extra_state_attributes = {"zone_id": zone_id}
 
+    @override
     def _get_data_from_coordinator(self) -> None:
         self._zone = self.coordinator.data.zones[self._zone_id]
 
@@ -102,6 +104,7 @@ class RiscoLocalZoneEntity(Entity):
         )
         self._attr_extra_state_attributes = {"zone_id": zone_id}
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Subscribe to updates."""
         signal = zone_update_signal(self._zone_id)

--- a/homeassistant/components/risco/sensor.py
+++ b/homeassistant/components/risco/sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Collection, Mapping
 from datetime import datetime
-from typing import Any
+from typing import Any, override
 
 from pyrisco.cloud.event import Event
 
@@ -87,11 +87,13 @@ class RiscoSensor(CoordinatorEntity[RiscoEventsDataUpdateCoordinator], SensorEnt
         self._attr_name = f"Risco {self.coordinator.risco.site_name} {name} Events"
         self._attr_device_class = SensorDeviceClass.TIMESTAMP
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()
         self._entity_registry = er.async_get(self.hass)
 
+    @override
     def _handle_coordinator_update(self) -> None:
         events = self.coordinator.data
         for event in reversed(events):
@@ -104,6 +106,7 @@ class RiscoSensor(CoordinatorEntity[RiscoEventsDataUpdateCoordinator], SensorEnt
             self.async_write_ha_state()
 
     @property
+    @override
     def native_value(self) -> datetime | None:
         """Value of sensor."""
         if self._event is None:
@@ -114,6 +117,7 @@ class RiscoSensor(CoordinatorEntity[RiscoEventsDataUpdateCoordinator], SensorEnt
         return None
 
     @property
+    @override
     def extra_state_attributes(self) -> Mapping[str, Any] | None:
         """State attributes."""
         if self._event is None:

--- a/homeassistant/components/risco/switch.py
+++ b/homeassistant/components/risco/switch.py
@@ -1,6 +1,6 @@
 """Support for bypassing Risco alarm zones."""
 
-from typing import Any
+from typing import Any, override
 
 from pyrisco.common import Zone
 
@@ -52,14 +52,17 @@ class RiscoCloudSwitch(RiscoCloudZoneEntity, SwitchEntity):
         )
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if the zone is bypassed."""
         return self._zone.bypassed
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         await self._bypass(True)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         await self._bypass(False)
@@ -86,14 +89,17 @@ class RiscoLocalSwitch(RiscoLocalZoneEntity, SwitchEntity):
         )
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if the zone is bypassed."""
         return self._zone.bypassed
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         await self._bypass(True)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         await self._bypass(False)

--- a/homeassistant/components/rituals_perfume_genie/binary_sensor.py
+++ b/homeassistant/components/rituals_perfume_genie/binary_sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from pyrituals import Diffuser
 
@@ -61,6 +62,7 @@ class RitualsBinarySensorEntity(DiffuserEntity, BinarySensorEntity):
     entity_description: RitualsBinarySensorEntityDescription
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return the state of the binary sensor."""
         return self.entity_description.is_on_fn(self.coordinator.diffuser)

--- a/homeassistant/components/rituals_perfume_genie/config_flow.py
+++ b/homeassistant/components/rituals_perfume_genie/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Rituals Perfume Genie integration."""
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from aiohttp import ClientError
 from pyrituals import Account, AuthenticationException
@@ -26,6 +26,7 @@ class RitualsPerfumeGenieConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 2
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/rituals_perfume_genie/coordinator.py
+++ b/homeassistant/components/rituals_perfume_genie/coordinator.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import logging
+from typing import override
 
 from aiohttp import ClientError, ClientResponseError
 from pyrituals import Account, AuthenticationException, Diffuser
@@ -42,6 +43,7 @@ class RitualsDataUpdateCoordinator(DataUpdateCoordinator[None]):
             update_interval=update_interval,
         )
 
+    @override
     async def _async_update_data(self) -> None:
         """Fetch data from Rituals, with one silent re-auth on 401.
 

--- a/homeassistant/components/rituals_perfume_genie/entity.py
+++ b/homeassistant/components/rituals_perfume_genie/entity.py
@@ -1,6 +1,6 @@
 """Base class for Rituals Perfume Genie diffuser entity."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
@@ -43,6 +43,7 @@ class DiffuserEntity(CoordinatorEntity[RitualsDataUpdateCoordinator]):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return if the entity is available."""
         return super().available and self.coordinator.diffuser.is_online

--- a/homeassistant/components/rituals_perfume_genie/number.py
+++ b/homeassistant/components/rituals_perfume_genie/number.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from pyrituals import Diffuser
 
@@ -56,10 +56,12 @@ class RitualsNumberEntity(DiffuserEntity, NumberEntity):
     entity_description: RitualsNumberEntityDescription
 
     @property
+    @override
     def native_value(self) -> int:
         """Return the number value."""
         return self.entity_description.value_fn(self.coordinator.diffuser)
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Change to new number value."""
         if not value.is_integer():

--- a/homeassistant/components/rituals_perfume_genie/select.py
+++ b/homeassistant/components/rituals_perfume_genie/select.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from typing import override
 
 from pyrituals import Diffuser
 
@@ -71,10 +72,12 @@ class RitualsSelectEntity(DiffuserEntity, SelectEntity):
         )
 
     @property
+    @override
     def current_option(self) -> str:
         """Return the selected entity option to represent the entity state."""
         return self.entity_description.current_fn(self.coordinator.diffuser)
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         await self.entity_description.select_fn(self.coordinator.diffuser, option)

--- a/homeassistant/components/rituals_perfume_genie/sensor.py
+++ b/homeassistant/components/rituals_perfume_genie/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from pyrituals import Diffuser
 
@@ -79,6 +80,7 @@ class RitualsSensorEntity(DiffuserEntity, SensorEntity):
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     @property
+    @override
     def native_value(self) -> str | int:
         """Return the sensor value."""
         return self.entity_description.value_fn(self.coordinator.diffuser)

--- a/homeassistant/components/rituals_perfume_genie/switch.py
+++ b/homeassistant/components/rituals_perfume_genie/switch.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from pyrituals import Diffuser
 
@@ -66,12 +66,14 @@ class RitualsSwitchEntity(DiffuserEntity, SwitchEntity):
         super().__init__(coordinator, description)
         self._attr_is_on = description.is_on_fn(coordinator.diffuser)
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         await self.entity_description.turn_on_fn(self.coordinator.diffuser)
         self._attr_is_on = True
         self.async_write_ha_state()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         await self.entity_description.turn_off_fn(self.coordinator.diffuser)
@@ -79,6 +81,7 @@ class RitualsSwitchEntity(DiffuserEntity, SwitchEntity):
         self.async_write_ha_state()
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self._attr_is_on = self.entity_description.is_on_fn(self.coordinator.diffuser)

--- a/homeassistant/components/rmvtransport/sensor.py
+++ b/homeassistant/components/rmvtransport/sensor.py
@@ -3,7 +3,7 @@
 import asyncio
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from RMVtransport import RMVtransport
 from RMVtransport.rmvtransport import (
@@ -151,16 +151,19 @@ class RMVDepartureSensor(SensorEntity):
         self._attr_icon = ICONS[None]
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available."""
         return self._state is not None
 
     @property
+    @override
     def native_value(self):
         """Return the next departure time."""
         return self._state
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         try:

--- a/homeassistant/components/roborock/binary_sensor.py
+++ b/homeassistant/components/roborock/binary_sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from roborock.data import CleanFluidStatus, RoborockStateCode
 from roborock.data.v1.v1_containers import StatusField, StatusV2
@@ -208,6 +209,7 @@ class RoborockBinarySensorEntity(RoborockCoordinatedEntityV1, BinarySensorEntity
         self.entity_description = description
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return the value reported by the sensor."""
         if (data := self.coordinator.data) is not None:
@@ -230,6 +232,7 @@ class RoborockBinarySensorEntityA01(RoborockCoordinatedEntityA01, BinarySensorEn
         super().__init__(f"{description.key}_{coordinator.duid_slug}", coordinator)
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return the value reported by the sensor."""
         value = self.coordinator.data[self.entity_description.data_protocol]

--- a/homeassistant/components/roborock/button.py
+++ b/homeassistant/components/roborock/button.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 import itertools
 import logging
-from typing import Any
+from typing import Any, override
 
 from roborock.devices.traits.v1.consumeable import ConsumableAttribute
 from roborock.exceptions import RoborockException
@@ -213,6 +213,7 @@ class RoborockButtonEntity(RoborockEntityV1, ButtonEntity):
         self.entity_description = entity_description
         self._consumable = coordinator.properties_api.consumables
 
+    @override
     async def async_press(self) -> None:
         """Press the button."""
         try:
@@ -249,6 +250,7 @@ class RoborockRoutineButtonEntity(RoborockEntity, ButtonEntity):
         self._coordinator = coordinator
         self.entity_description = entity_description
 
+    @override
     async def async_press(self, **kwargs: Any) -> None:
         """Press the button."""
         await self._coordinator.execute_routines(self._routine_id)
@@ -270,6 +272,7 @@ class RoborockButtonEntityA01(RoborockCoordinatedEntityA01, ButtonEntity):
             f"{entity_description.key}_{coordinator.duid_slug}", coordinator
         )
 
+    @override
     async def async_press(self) -> None:
         """Press the button."""
         try:
@@ -306,6 +309,7 @@ class RoborockQ10EmptyDustbinButtonEntity(
             coordinator,
         )
 
+    @override
     async def async_press(self, **kwargs: Any) -> None:
         """Press the button to empty dustbin."""
         try:

--- a/homeassistant/components/roborock/config_flow.py
+++ b/homeassistant/components/roborock/config_flow.py
@@ -3,7 +3,7 @@
 from collections.abc import Mapping
 from copy import deepcopy
 import logging
-from typing import Any
+from typing import Any, override
 from urllib.parse import urlparse
 
 from roborock.data import UserData
@@ -69,6 +69,7 @@ class RoborockFlowHandler(ConfigFlow, domain=DOMAIN):
         self._username: str | None = None
         self._client: RoborockApiClient | None = None
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -210,6 +211,7 @@ class RoborockFlowHandler(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    @override
     async def async_step_dhcp(
         self, discovery_info: DhcpServiceInfo
     ) -> ConfigFlowResult:
@@ -264,6 +266,7 @@ class RoborockFlowHandler(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: RoborockConfigEntry,
     ) -> RoborockOptionsFlowHandler:

--- a/homeassistant/components/roborock/coordinator.py
+++ b/homeassistant/components/roborock/coordinator.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from propcache.api import cached_property
 from roborock import B01Props
@@ -135,6 +135,7 @@ class RoborockDataUpdateCoordinator(DataUpdateCoordinator[DeviceState | None]):
             sw_version=self._device.device_info.fv,
         )
 
+    @override
     async def _async_setup(self) -> None:
         """Set up the coordinator."""
         await self._verify_api()
@@ -235,6 +236,7 @@ class RoborockDataUpdateCoordinator(DataUpdateCoordinator[DeviceState | None]):
         )
         _LOGGER.debug("Updated device properties")
 
+    @override
     async def _async_update_data(self) -> DeviceState | None:
         """Update data via library."""
         await self._verify_api()
@@ -312,6 +314,7 @@ class RoborockDataUpdateCoordinator(DataUpdateCoordinator[DeviceState | None]):
         # We optimize streaming updates to catch state transitions immediately, but
         # secondary updates (like refreshing the map) can happen on their own interval.
 
+    @override
     async def async_shutdown(self) -> None:
         """Shutdown coordinator and unsubscribe update listeners."""
         await super().async_shutdown()
@@ -460,6 +463,7 @@ class RoborockWashingMachineUpdateCoordinator(
             RoborockZeoProtocol.SOUND_SET,
         ]
 
+    @override
     async def _async_update_data(
         self,
     ) -> dict[RoborockZeoProtocol, StateType]:
@@ -498,6 +502,7 @@ class RoborockWetDryVacUpdateCoordinator(
             RoborockDyadDataProtocol.TOTAL_RUN_TIME,
         ]
 
+    @override
     async def _async_update_data(
         self,
     ) -> dict[RoborockDyadDataProtocol, StateType]:
@@ -579,6 +584,7 @@ class RoborockB01Q7UpdateCoordinator(RoborockDataUpdateCoordinatorB01):
             RoborockB01Props.QUANTITY,
         ]
 
+    @override
     async def _async_update_data(
         self,
     ) -> B01Props:
@@ -631,6 +637,7 @@ class RoborockB01Q10UpdateCoordinator(DataUpdateCoordinator[None]):
         self.api = api
         self.device_info = get_device_info(device)
 
+    @override
     async def _async_update_data(self) -> None:
         """Request a status push from the device.
 

--- a/homeassistant/components/roborock/entity.py
+++ b/homeassistant/components/roborock/entity.py
@@ -1,6 +1,6 @@
 """Support for Roborock device base class."""
 
-from typing import Any
+from typing import Any, override
 
 from roborock.devices.traits.v1.command import CommandTrait
 from roborock.exceptions import RoborockException
@@ -93,6 +93,7 @@ class RoborockCoordinatedEntityV1(
         CoordinatorEntity.__init__(self, coordinator=coordinator)
         self._attr_unique_id = unique_id
 
+    @override
     async def send(
         self,
         command: RoborockCommand | str,

--- a/homeassistant/components/roborock/image.py
+++ b/homeassistant/components/roborock/image.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime
 import logging
+from typing import override
 
 from roborock.devices.traits.v1.home import HomeTrait
 from roborock.devices.traits.v1.map_content import MapContent
@@ -75,6 +76,7 @@ class RoborockMap(RoborockCoordinatedEntityV1, ImageEntity):
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_image_last_updated = None
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass load any previously cached maps from disk."""
         await super().async_added_to_hass()
@@ -90,6 +92,7 @@ class RoborockMap(RoborockCoordinatedEntityV1, ImageEntity):
         return None
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator.
 
@@ -102,6 +105,7 @@ class RoborockMap(RoborockCoordinatedEntityV1, ImageEntity):
             self._attr_image_last_updated = self.coordinator.last_home_update
         super()._handle_coordinator_update()
 
+    @override
     async def async_image(self) -> bytes | None:
         """Get the cached image."""
         if (map_content := self._map_content) is None:

--- a/homeassistant/components/roborock/number.py
+++ b/homeassistant/components/roborock/number.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 import logging
-from typing import Any
+from typing import Any, override
 
 from roborock.devices.traits.v1 import PropertiesApi
 from roborock.exceptions import RoborockException
@@ -93,10 +93,12 @@ class RoborockNumberEntity(RoborockEntityV1, NumberEntity):
         self._trait = trait
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Get native value."""
         return self.entity_description.get_value(self._trait)
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Set number value."""
         try:

--- a/homeassistant/components/roborock/roborock_storage.py
+++ b/homeassistant/components/roborock/roborock_storage.py
@@ -3,7 +3,7 @@
 import logging
 from pathlib import Path
 import shutil
-from typing import Any
+from typing import Any, override
 
 from roborock.devices.cache import Cache, CacheData
 
@@ -55,6 +55,7 @@ class StoreImpl(Store[dict[str, Any]]):
             private=True,
         )
 
+    @override
     async def _async_migrate_func(
         self,
         old_major_version: int,
@@ -82,6 +83,7 @@ class CacheStore(Cache):
         self._cache_store = StoreImpl(hass, entry_id)
         self._cache_data: CacheData | None = None
 
+    @override
     async def get(self) -> CacheData:
         """Retrieve cached metadata."""
         if self._cache_data is None:
@@ -92,6 +94,7 @@ class CacheStore(Cache):
 
         return self._cache_data
 
+    @override
     async def set(self, value: CacheData) -> None:
         """Save cached metadata."""
         self._cache_data = value

--- a/homeassistant/components/roborock/select.py
+++ b/homeassistant/components/roborock/select.py
@@ -4,7 +4,7 @@ import asyncio
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 import logging
-from typing import Any
+from typing import Any, override
 
 from roborock import B01Props, CleanTypeMapping
 from roborock.data import (
@@ -305,6 +305,7 @@ class RoborockB01SelectEntity(RoborockCoordinatedEntityB01Q7, SelectEntity):
         )
         self._attr_options = options
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
         try:
@@ -320,6 +321,7 @@ class RoborockB01SelectEntity(RoborockCoordinatedEntityB01Q7, SelectEntity):
         await self.coordinator.async_refresh()
 
     @property
+    @override
     def current_option(self) -> str | None:
         """Return the current option."""
         return self.entity_description.value_fn(self.coordinator.data)
@@ -345,6 +347,7 @@ class RoborockSelectEntity(RoborockCoordinatedEntityV1, SelectEntity):
         )
         self._attr_options = options
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
         await self.send(
@@ -355,6 +358,7 @@ class RoborockSelectEntity(RoborockCoordinatedEntityV1, SelectEntity):
         )
 
     @property
+    @override
     def current_option(self) -> str | None:
         """Get the current status of the select entity from device props."""
         return self.entity_description.value_fn(self.coordinator.properties_api)
@@ -386,6 +390,7 @@ class RoborockCurrentMapSelectEntity(RoborockCoordinatedEntityV1, SelectEntity):
             for map_id, map_ in (self._home_trait.home_map_info or {}).items()
         }
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
         for map_id, map_name in self._available_map_names.items():
@@ -413,11 +418,13 @@ class RoborockCurrentMapSelectEntity(RoborockCoordinatedEntityV1, SelectEntity):
                 break
 
     @property
+    @override
     def options(self) -> list[str]:
         """Gets all of the names of rooms that we are currently aware of."""
         return list(self._available_map_names.values())
 
     @property
+    @override
     def current_option(self) -> str | None:
         """Get the current status of the select entity from device_status."""
         if current_map_info := self._home_trait.current_map_data:
@@ -443,6 +450,7 @@ class RoborockSelectEntityA01(RoborockCoordinatedEntityA01, SelectEntity):
         )
         self._attr_options = list(entity_description.enum_class.keys())
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
         # Get the protocol value for the selected option
@@ -470,6 +478,7 @@ class RoborockSelectEntityA01(RoborockCoordinatedEntityA01, SelectEntity):
         await self.coordinator.async_request_refresh()
 
     @property
+    @override
     def current_option(self) -> str | None:
         """Get the current status of the select entity from coordinator data."""
         if self.entity_description.data_protocol not in self.coordinator.data:
@@ -503,6 +512,7 @@ class RoborockQ10CleanModeSelectEntity(RoborockCoordinatedEntityB01Q10, SelectEn
             coordinator,
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register trait listener for push-based status updates."""
         await super().async_added_to_hass()
@@ -511,11 +521,13 @@ class RoborockQ10CleanModeSelectEntity(RoborockCoordinatedEntityB01Q10, SelectEn
         )
 
     @property
+    @override
     def options(self) -> list[str]:
         """Return available cleaning modes."""
         return [mode.value for mode in YXCleanType if mode != YXCleanType.UNKNOWN]
 
     @property
+    @override
     def current_option(self) -> str | None:
         """Get the current cleaning mode."""
         clean_mode = self.coordinator.api.status.clean_mode
@@ -523,6 +535,7 @@ class RoborockQ10CleanModeSelectEntity(RoborockCoordinatedEntityB01Q10, SelectEn
             return None
         return clean_mode.value
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Set the cleaning mode."""
         try:

--- a/homeassistant/components/roborock/sensor.py
+++ b/homeassistant/components/roborock/sensor.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 import datetime
 import logging
+from typing import override
 
 from roborock.data import (
     B01Props,
@@ -601,6 +602,7 @@ class RoborockSensorEntity(RoborockCoordinatedEntityV1, SensorEntity):
         )
 
     @property
+    @override
     def native_value(self) -> StateType | datetime.datetime:
         """Return the value reported by the sensor."""
         if self.coordinator.data is None:
@@ -629,6 +631,7 @@ class RoborockCurrentRoom(RoborockCoordinatedEntityV1, SensorEntity):
         self._map_content_trait = coordinator.properties_api.map_content
 
     @property
+    @override
     def options(self) -> list[str]:
         """Return the currently valid rooms."""
         if self._home_trait.current_map_data is not None:
@@ -636,6 +639,7 @@ class RoborockCurrentRoom(RoborockCoordinatedEntityV1, SensorEntity):
         return []
 
     @property
+    @override
     def native_value(self) -> str | None:
         """Return the value reported by the sensor."""
         if (
@@ -664,6 +668,7 @@ class RoborockSensorEntityA01(RoborockCoordinatedEntityA01, SensorEntity):
         super().__init__(f"{description.key}_{coordinator.duid_slug}", coordinator)
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the value reported by the sensor."""
         return self.coordinator.data[self.entity_description.data_protocol]
@@ -684,6 +689,7 @@ class RoborockSensorEntityB01Q7(RoborockCoordinatedEntityB01Q7, SensorEntity):
         super().__init__(f"{description.key}_{coordinator.duid_slug}", coordinator)
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the value reported by the sensor."""
         return self.entity_description.value_fn(self.coordinator.data)
@@ -703,6 +709,7 @@ class RoborockSensorEntityB01Q10(RoborockCoordinatedEntityB01Q10, SensorEntity):
         self.entity_description = description
         super().__init__(f"{description.key}_{coordinator.duid_slug}", coordinator)
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register trait listener for push-based status updates."""
         await super().async_added_to_hass()
@@ -711,6 +718,7 @@ class RoborockSensorEntityB01Q10(RoborockCoordinatedEntityB01Q10, SensorEntity):
         )
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the value reported by the sensor."""
         return self.entity_description.value_fn(self.coordinator.api.status)

--- a/homeassistant/components/roborock/switch.py
+++ b/homeassistant/components/roborock/switch.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 import logging
-from typing import Any
+from typing import Any, override
 
 from roborock.devices.traits.v1 import PropertiesApi
 from roborock.devices.traits.v1.common import RoborockSwitchBase
@@ -145,6 +145,7 @@ class RoborockSwitch(RoborockEntityV1, SwitchEntity):
         )
         self._trait = trait
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the switch."""
         try:
@@ -155,6 +156,7 @@ class RoborockSwitch(RoborockEntityV1, SwitchEntity):
                 translation_key="update_options_failed",
             ) from err
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the switch."""
         try:
@@ -166,6 +168,7 @@ class RoborockSwitch(RoborockEntityV1, SwitchEntity):
             ) from err
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return True if entity is on."""
         return self._trait.is_on
@@ -185,6 +188,7 @@ class RoborockSwitchA01(RoborockCoordinatedEntityA01, SwitchEntity):
         self.entity_description = description
         super().__init__(f"{description.key}_{coordinator.duid_slug}", coordinator)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the switch."""
         try:
@@ -198,6 +202,7 @@ class RoborockSwitchA01(RoborockCoordinatedEntityA01, SwitchEntity):
                 translation_key="update_options_failed",
             ) from err
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the switch."""
         try:
@@ -212,6 +217,7 @@ class RoborockSwitchA01(RoborockCoordinatedEntityA01, SwitchEntity):
             ) from err
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return True if entity is on."""
         status = self.coordinator.data.get(self.entity_description.data_protocol)

--- a/homeassistant/components/roborock/time.py
+++ b/homeassistant/components/roborock/time.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 import datetime
 from datetime import time
 import logging
-from typing import Any
+from typing import Any, override
 
 from roborock.data import DnDTimer, ValleyElectricityTimer
 from roborock.exceptions import RoborockException
@@ -158,10 +158,12 @@ class RoborockTimeEntity(RoborockEntityV1, TimeEntity):
         self._trait = trait
 
     @property
+    @override
     def native_value(self) -> time | None:
         """Return the value reported by the time."""
         return self.entity_description.get_value(self._trait)
 
+    @override
     async def async_set_value(self, value: time) -> None:
         """Set the time."""
         try:

--- a/homeassistant/components/roborock/vacuum.py
+++ b/homeassistant/components/roborock/vacuum.py
@@ -1,7 +1,7 @@
 """Support for Roborock vacuum class."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from roborock.data import RoborockStateCode, SCWindMapping, WorkStatusMapping
 from roborock.data.b01_q10.b01_q10_code_mappings import (
@@ -159,6 +159,7 @@ class RoborockVacuum(RoborockCoordinatedEntityV1, StateVacuumEntity):
         self._maps_trait = coordinator.properties_api.maps
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator.
 
@@ -179,6 +180,7 @@ class RoborockVacuum(RoborockCoordinatedEntityV1, StateVacuumEntity):
             self.async_create_segments_issue()
 
     @property
+    @override
     def fan_speed_list(self) -> list[str]:
         """Get the list of available fan speeds."""
         if self.coordinator.data is None:
@@ -186,6 +188,7 @@ class RoborockVacuum(RoborockCoordinatedEntityV1, StateVacuumEntity):
         return [mode.value for mode in self._status_trait.fan_speed_options]
 
     @property
+    @override
     def activity(self) -> VacuumActivity | None:
         """Return the status of the vacuum cleaner."""
         if self.coordinator.data is None or self._status_trait.state is None:
@@ -193,12 +196,14 @@ class RoborockVacuum(RoborockCoordinatedEntityV1, StateVacuumEntity):
         return STATE_CODE_TO_STATE.get(self._status_trait.state)
 
     @property
+    @override
     def fan_speed(self) -> str | None:
         """Return the fan speed of the vacuum cleaner."""
         if self.coordinator.data is None:
             return None
         return self._status_trait.fan_speed_name
 
+    @override
     async def async_start(self) -> None:
         """Start the vacuum."""
         command = RoborockCommand.APP_START
@@ -213,26 +218,32 @@ class RoborockVacuum(RoborockCoordinatedEntityV1, StateVacuumEntity):
                 command = RoborockCommand.APP_RESUME_BUILD_MAP
         await self.send(command)
 
+    @override
     async def async_pause(self) -> None:
         """Pause the vacuum."""
         await self.send(RoborockCommand.APP_PAUSE)
 
+    @override
     async def async_stop(self, **kwargs: Any) -> None:
         """Stop the vacuum."""
         await self.send(RoborockCommand.APP_STOP)
 
+    @override
     async def async_return_to_base(self, **kwargs: Any) -> None:
         """Send vacuum back to base."""
         await self.send(RoborockCommand.APP_CHARGE)
 
+    @override
     async def async_clean_spot(self, **kwargs: Any) -> None:
         """Spot clean."""
         await self.send(RoborockCommand.APP_SPOT)
 
+    @override
     async def async_locate(self, **kwargs: Any) -> None:
         """Locate vacuum."""
         await self.send(RoborockCommand.FIND_ME)
 
+    @override
     async def async_set_fan_speed(self, fan_speed: str, **kwargs: Any) -> None:
         """Set vacuum fan speed."""
         if self.coordinator.data is None:
@@ -255,6 +266,7 @@ class RoborockVacuum(RoborockCoordinatedEntityV1, StateVacuumEntity):
         """Send vacuum to a specific target point."""
         await self.send(RoborockCommand.APP_GOTO_TARGET, [x, y])
 
+    @override
     async def async_get_segments(self) -> list[Segment]:
         """Get the segments that can be cleaned."""
         home_map_info = self._home_trait.home_map_info
@@ -270,6 +282,7 @@ class RoborockVacuum(RoborockCoordinatedEntityV1, StateVacuumEntity):
             for room in map_info.rooms
         ]
 
+    @override
     async def async_clean_segments(self, segment_ids: list[str], **kwargs: Any) -> None:
         """Clean the specified segments."""
         parsed: list[tuple[int, int]] = []
@@ -291,6 +304,7 @@ class RoborockVacuum(RoborockCoordinatedEntityV1, StateVacuumEntity):
             [{"segments": current_map_segments}],
         )
 
+    @override
     async def async_send_command(
         self,
         command: str,
@@ -376,11 +390,13 @@ class RoborockQ7Vacuum(RoborockCoordinatedEntityB01Q7, StateVacuumEntity):
         )
 
     @property
+    @override
     def fan_speed_list(self) -> list[str]:
         """Get the list of available fan speeds."""
         return SCWindMapping.keys()
 
     @property
+    @override
     def activity(self) -> VacuumActivity | None:
         """Return the status of the vacuum cleaner."""
         if self.coordinator.data.status is not None:
@@ -388,10 +404,12 @@ class RoborockQ7Vacuum(RoborockCoordinatedEntityB01Q7, StateVacuumEntity):
         return None
 
     @property
+    @override
     def fan_speed(self) -> str | None:
         """Return the fan speed of the vacuum cleaner."""
         return self.coordinator.data.wind_name
 
+    @override
     async def async_start(self) -> None:
         """Start the vacuum."""
         try:
@@ -405,6 +423,7 @@ class RoborockQ7Vacuum(RoborockCoordinatedEntityB01Q7, StateVacuumEntity):
                 },
             ) from err
 
+    @override
     async def async_pause(self) -> None:
         """Pause the vacuum."""
         try:
@@ -418,6 +437,7 @@ class RoborockQ7Vacuum(RoborockCoordinatedEntityB01Q7, StateVacuumEntity):
                 },
             ) from err
 
+    @override
     async def async_stop(self, **kwargs: Any) -> None:
         """Stop the vacuum."""
         try:
@@ -431,6 +451,7 @@ class RoborockQ7Vacuum(RoborockCoordinatedEntityB01Q7, StateVacuumEntity):
                 },
             ) from err
 
+    @override
     async def async_return_to_base(self, **kwargs: Any) -> None:
         """Send vacuum back to base."""
         try:
@@ -444,6 +465,7 @@ class RoborockQ7Vacuum(RoborockCoordinatedEntityB01Q7, StateVacuumEntity):
                 },
             ) from err
 
+    @override
     async def async_locate(self, **kwargs: Any) -> None:
         """Locate vacuum."""
         try:
@@ -457,6 +479,7 @@ class RoborockQ7Vacuum(RoborockCoordinatedEntityB01Q7, StateVacuumEntity):
                 },
             ) from err
 
+    @override
     async def async_set_fan_speed(self, fan_speed: str, **kwargs: Any) -> None:
         """Set vacuum fan speed."""
         try:
@@ -480,6 +503,7 @@ class RoborockQ7Vacuum(RoborockCoordinatedEntityB01Q7, StateVacuumEntity):
                 },
             ) from err
 
+    @override
     async def async_send_command(
         self,
         command: str,
@@ -542,6 +566,7 @@ class RoborockQ10Vacuum(RoborockCoordinatedEntityB01Q10, StateVacuumEntity):
             coordinator,
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register trait listener for push-based status updates."""
         await super().async_added_to_hass()
@@ -550,6 +575,7 @@ class RoborockQ10Vacuum(RoborockCoordinatedEntityB01Q10, StateVacuumEntity):
         )
 
     @property
+    @override
     def activity(self) -> VacuumActivity | None:
         """Return the status of the vacuum cleaner."""
         if self.coordinator.api.status.status is not None:
@@ -557,12 +583,14 @@ class RoborockQ10Vacuum(RoborockCoordinatedEntityB01Q10, StateVacuumEntity):
         return None
 
     @property
+    @override
     def fan_speed(self) -> str | None:
         """Return the fan speed of the vacuum cleaner."""
         if (fan_level := self.coordinator.api.status.fan_level) is not None:
             return fan_level.value
         return None
 
+    @override
     async def async_start(self) -> None:
         """Start the vacuum."""
         try:
@@ -576,6 +604,7 @@ class RoborockQ10Vacuum(RoborockCoordinatedEntityB01Q10, StateVacuumEntity):
                 },
             ) from err
 
+    @override
     async def async_pause(self) -> None:
         """Pause the vacuum."""
         try:
@@ -589,6 +618,7 @@ class RoborockQ10Vacuum(RoborockCoordinatedEntityB01Q10, StateVacuumEntity):
                 },
             ) from err
 
+    @override
     async def async_stop(self, **kwargs: Any) -> None:
         """Stop the vacuum."""
         try:
@@ -602,6 +632,7 @@ class RoborockQ10Vacuum(RoborockCoordinatedEntityB01Q10, StateVacuumEntity):
                 },
             ) from err
 
+    @override
     async def async_return_to_base(self, **kwargs: Any) -> None:
         """Send vacuum back to base."""
         try:
@@ -615,6 +646,7 @@ class RoborockQ10Vacuum(RoborockCoordinatedEntityB01Q10, StateVacuumEntity):
                 },
             ) from err
 
+    @override
     async def async_locate(self, **kwargs: Any) -> None:
         """Locate vacuum."""
         try:
@@ -628,6 +660,7 @@ class RoborockQ10Vacuum(RoborockCoordinatedEntityB01Q10, StateVacuumEntity):
                 },
             ) from err
 
+    @override
     async def async_set_fan_speed(self, fan_speed: str, **kwargs: Any) -> None:
         """Set vacuum fan speed."""
         try:
@@ -651,6 +684,7 @@ class RoborockQ10Vacuum(RoborockCoordinatedEntityB01Q10, StateVacuumEntity):
                 },
             ) from err
 
+    @override
     async def async_send_command(
         self,
         command: str,

--- a/homeassistant/components/rocketchat/notify.py
+++ b/homeassistant/components/rocketchat/notify.py
@@ -2,7 +2,7 @@
 
 from http import HTTPStatus
 import logging
-from typing import Any
+from typing import Any, override
 
 from rocketchat_API.APIExceptions.RocketExceptions import (
     RocketAuthenticationException,
@@ -69,6 +69,7 @@ class RocketChatNotificationService(BaseNotificationService):
         self._room = room
         self._server = RocketChat(username, password, server_url=url)
 
+    @override
     def send_message(self, message: str = "", **kwargs: Any) -> None:
         """Send a message to Rocket.Chat."""
         data = kwargs.get(ATTR_DATA) or {}

--- a/homeassistant/components/roku/binary_sensor.py
+++ b/homeassistant/components/roku/binary_sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from rokuecp.models import Device as RokuDevice
 
@@ -75,6 +76,7 @@ class RokuBinarySensorEntity(RokuEntity, BinarySensorEntity):
     entity_description: RokuBinarySensorEntityDescription
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/roku/config_flow.py
+++ b/homeassistant/components/roku/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Roku."""
 
 import logging
-from typing import Any
+from typing import Any, override
 from urllib.parse import urlparse
 
 from rokuecp import Roku, RokuError
@@ -87,6 +87,7 @@ class RokuConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle reconfiguration of the integration."""
         return await self.async_step_user(user_input)
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -119,6 +120,7 @@ class RokuConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_create_entry(title=info["title"], data=user_input)
 
+    @override
     async def async_step_homekit(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:
@@ -149,6 +151,7 @@ class RokuConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return await self.async_step_discovery_confirm()
 
+    @override
     async def async_step_ssdp(
         self, discovery_info: SsdpServiceInfo
     ) -> ConfigFlowResult:
@@ -193,6 +196,7 @@ class RokuConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: RokuConfigEntry,
     ) -> RokuOptionsFlowHandler:

--- a/homeassistant/components/roku/coordinator.py
+++ b/homeassistant/components/roku/coordinator.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime, timedelta
 import logging
+from typing import override
 
 from rokuecp import Roku, RokuError
 from rokuecp.models import Device
@@ -61,6 +62,7 @@ class RokuDataUpdateCoordinator(DataUpdateCoordinator[Device]):
             ),
         )
 
+    @override
     async def _async_update_data(self) -> Device:
         """Fetch data from Roku."""
         full_update = self.last_full_update is None or utcnow() >= (

--- a/homeassistant/components/roku/media_player.py
+++ b/homeassistant/components/roku/media_player.py
@@ -3,7 +3,7 @@
 import datetime as dt
 import logging
 import mimetypes
-from typing import Any
+from typing import Any, override
 
 from rokuecp.helpers import guess_stream_format
 import yarl
@@ -122,6 +122,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
         return self.coordinator.data.media.duration > 0
 
     @property
+    @override
     def state(self) -> MediaPlayerState | None:
         """Return the state of the device."""
         if self.coordinator.data.state.standby:
@@ -147,6 +148,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
         return None
 
     @property
+    @override
     def media_content_type(self) -> MediaType | None:
         """Content type of current playing media."""
         if self.app_id is None or self.app_name in ("Power Saver", "Roku"):
@@ -158,6 +160,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
         return MediaType.APP
 
     @property
+    @override
     def media_image_url(self) -> str | None:
         """Image url of current playing media."""
         if self.app_id is None or self.app_name in ("Power Saver", "Roku"):
@@ -166,6 +169,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
         return self.coordinator.roku.app_icon_url(self.app_id)
 
     @property
+    @override
     def app_name(self) -> str | None:
         """Name of the current running app."""
         if self.coordinator.data.app is not None:
@@ -174,6 +178,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
         return None
 
     @property
+    @override
     def app_id(self) -> str | None:
         """Return the ID of the current running app."""
         if self.coordinator.data.app is not None:
@@ -182,6 +187,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
         return None
 
     @property
+    @override
     def media_channel(self) -> str | None:
         """Return the TV channel currently tuned."""
         if self.app_id != "tvinput.dtv" or self.coordinator.data.channel is None:
@@ -192,6 +198,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
         return format_channel_name(channel.number, channel.name)
 
     @property
+    @override
     def media_title(self) -> str | None:
         """Return the title of current playing media."""
         if self.app_id != "tvinput.dtv" or self.coordinator.data.channel is None:
@@ -203,6 +210,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
         return None
 
     @property
+    @override
     def media_duration(self) -> int | None:
         """Duration of current playing media in seconds."""
         if self.coordinator.data.media is not None and self._media_playback_trackable():
@@ -211,6 +219,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
         return None
 
     @property
+    @override
     def media_position(self) -> int | None:
         """Position of current playing media in seconds."""
         if self.coordinator.data.media is not None and self._media_playback_trackable():
@@ -219,6 +228,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
         return None
 
     @property
+    @override
     def media_position_updated_at(self) -> dt.datetime | None:
         """When was the position of the current playing media valid."""
         if self.coordinator.data.media is not None and self._media_playback_trackable():
@@ -227,6 +237,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
         return None
 
     @property
+    @override
     def source(self) -> str | None:
         """Return the current input source."""
         if self.coordinator.data.app is not None:
@@ -235,6 +246,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
         return None
 
     @property
+    @override
     def source_list(self) -> list[str]:
         """List of available input sources."""
         return [
@@ -249,6 +261,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
         """Emulate opening the search screen and entering the search keyword."""
         await self.coordinator.roku.search(keyword)
 
+    @override
     async def async_get_browse_image(
         self,
         media_content_type: MediaType | str,
@@ -262,6 +275,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
 
         return (None, None)
 
+    @override
     async def async_browse_media(
         self,
         media_content_type: MediaType | str | None = None,
@@ -277,18 +291,21 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
         )
 
     @roku_exception_handler()
+    @override
     async def async_turn_on(self) -> None:
         """Turn on the Roku."""
         await self.coordinator.roku.remote("poweron")
         await self.coordinator.async_request_refresh()
 
     @roku_exception_handler(ignore_timeout=True)
+    @override
     async def async_turn_off(self) -> None:
         """Turn off the Roku."""
         await self.coordinator.roku.remote("poweroff")
         await self.coordinator.async_request_refresh()
 
     @roku_exception_handler()
+    @override
     async def async_media_pause(self) -> None:
         """Send pause command."""
         if self.state not in {MediaPlayerState.OFF, MediaPlayerState.PAUSED}:
@@ -296,6 +313,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
             await self.coordinator.async_request_refresh()
 
     @roku_exception_handler()
+    @override
     async def async_media_play(self) -> None:
         """Send play command."""
         if self.state not in {MediaPlayerState.OFF, MediaPlayerState.PLAYING}:
@@ -303,6 +321,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
             await self.coordinator.async_request_refresh()
 
     @roku_exception_handler()
+    @override
     async def async_media_play_pause(self) -> None:
         """Send play/pause command."""
         if self.state != MediaPlayerState.OFF:
@@ -310,34 +329,40 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
             await self.coordinator.async_request_refresh()
 
     @roku_exception_handler()
+    @override
     async def async_media_previous_track(self) -> None:
         """Send previous track command."""
         await self.coordinator.roku.remote("reverse")
         await self.coordinator.async_request_refresh()
 
     @roku_exception_handler()
+    @override
     async def async_media_next_track(self) -> None:
         """Send next track command."""
         await self.coordinator.roku.remote("forward")
         await self.coordinator.async_request_refresh()
 
     @roku_exception_handler()
+    @override
     async def async_mute_volume(self, mute: bool) -> None:
         """Mute the volume."""
         await self.coordinator.roku.remote("volume_mute")
         await self.coordinator.async_request_refresh()
 
     @roku_exception_handler()
+    @override
     async def async_volume_up(self) -> None:
         """Volume up media player."""
         await self.coordinator.roku.remote("volume_up")
 
     @roku_exception_handler()
+    @override
     async def async_volume_down(self) -> None:
         """Volume down media player."""
         await self.coordinator.roku.remote("volume_down")
 
     @roku_exception_handler()
+    @override
     async def async_play_media(
         self, media_type: MediaType | str, media_id: str, **kwargs: Any
     ) -> None:
@@ -453,6 +478,7 @@ class RokuMediaPlayer(RokuEntity, MediaPlayerEntity):
         await self.coordinator.async_request_refresh()
 
     @roku_exception_handler()
+    @override
     async def async_select_source(self, source: str) -> None:
         """Select input source."""
         if source == "Home":

--- a/homeassistant/components/roku/remote.py
+++ b/homeassistant/components/roku/remote.py
@@ -1,7 +1,7 @@
 """Support for the Roku remote."""
 
 from collections.abc import Iterable
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.remote import ATTR_NUM_REPEATS, RemoteEntity
 from homeassistant.core import HomeAssistant
@@ -36,23 +36,27 @@ class RokuRemote(RokuEntity, RemoteEntity):
     _attr_name = None
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if device is on."""
         return not self.coordinator.data.state.standby
 
     @roku_exception_handler()
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
         await self.coordinator.roku.remote("poweron")
         await self.coordinator.async_request_refresh()
 
     @roku_exception_handler(ignore_timeout=True)
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
         await self.coordinator.roku.remote("poweroff")
         await self.coordinator.async_request_refresh()
 
     @roku_exception_handler()
+    @override
     async def async_send_command(self, command: Iterable[str], **kwargs: Any) -> None:
         """Send a command to one device."""
         num_repeats = kwargs[ATTR_NUM_REPEATS]

--- a/homeassistant/components/roku/select.py
+++ b/homeassistant/components/roku/select.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from typing import override
 
 from rokuecp import Roku
 from rokuecp.models import Device as RokuDevice
@@ -137,16 +138,19 @@ class RokuSelectEntity(RokuEntity, SelectEntity):
     entity_description: RokuSelectEntityDescription
 
     @property
+    @override
     def current_option(self) -> str | None:
         """Return the current value."""
         return self.entity_description.value_fn(self.coordinator.data)
 
     @property
+    @override
     def options(self) -> list[str]:
         """Return a set of selectable options."""
         return self.entity_description.options_fn(self.coordinator.data)
 
     @roku_exception_handler()
+    @override
     async def async_select_option(self, option: str) -> None:
         """Set the option."""
         await self.entity_description.set_fn(

--- a/homeassistant/components/roku/sensor.py
+++ b/homeassistant/components/roku/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from rokuecp.models import Device as RokuDevice
 
@@ -61,6 +62,7 @@ class RokuSensorEntity(RokuEntity, SensorEntity):
     entity_description: RokuSensorEntityDescription
 
     @property
+    @override
     def native_value(self) -> str | None:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/romy/binary_sensor.py
+++ b/homeassistant/components/romy/binary_sensor.py
@@ -1,5 +1,7 @@
 """Checking binary status values from your ROMY."""
 
+from typing import override
+
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
@@ -66,6 +68,7 @@ class RomyBinarySensor(RomyEntity, BinarySensorEntity):
         self.entity_description = entity_description
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return the value of the sensor."""
         return bool(self.romy.binary_sensors[self.entity_description.key])

--- a/homeassistant/components/romy/config_flow.py
+++ b/homeassistant/components/romy/config_flow.py
@@ -1,5 +1,7 @@
 """Config flow for ROMY integration."""
 
+from typing import override
+
 import romy
 import voluptuous as vol
 
@@ -22,6 +24,7 @@ class RomyConfigFlow(ConfigFlow, domain=DOMAIN):
         self.password: str = ""
         self.robot_name_given_by_user: str = ""
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, str] | None = None
     ) -> ConfigFlowResult:
@@ -81,6 +84,7 @@ class RomyConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    @override
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/romy/coordinator.py
+++ b/homeassistant/components/romy/coordinator.py
@@ -1,5 +1,7 @@
 """ROMY coordinator."""
 
+from typing import override
+
 from romy import RomyRobot
 
 from homeassistant.config_entries import ConfigEntry
@@ -29,6 +31,7 @@ class RomyVacuumCoordinator(DataUpdateCoordinator[None]):
         )
         self.romy = romy
 
+    @override
     async def _async_update_data(self) -> None:
         """Update ROMY Vacuum Cleaner data."""
         await self.romy.async_update()

--- a/homeassistant/components/romy/sensor.py
+++ b/homeassistant/components/romy/sensor.py
@@ -1,5 +1,7 @@
 """Sensor checking adc and status values from your ROMY."""
 
+from typing import override
+
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -104,6 +106,7 @@ class RomySensor(RomyEntity, SensorEntity):
         self.entity_description = entity_description
 
     @property
+    @override
     def native_value(self) -> int:
         """Return the value of the sensor."""
         value: int = self.romy.sensors[self.entity_description.key]

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -4,7 +4,7 @@ For more details about this platform, please refer to the documentation
 https://home-assistant.io/components/vacuum.romy/.
 """
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.vacuum import (
     StateVacuumEntity,
@@ -72,6 +72,7 @@ class RomyVacuumEntity(RomyEntity, StateVacuumEntity):
         self._attr_unique_id = self.romy.unique_id
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self._attr_fan_speed = FAN_SPEEDS[self.romy.fan_speed]
@@ -87,21 +88,25 @@ class RomyVacuumEntity(RomyEntity, StateVacuumEntity):
 
         self.async_write_ha_state()
 
+    @override
     async def async_start(self, **kwargs: Any) -> None:
         """Turn the vacuum on."""
         LOGGER.debug("async_start")
         await self.romy.async_clean_start_or_continue()
 
+    @override
     async def async_stop(self, **kwargs: Any) -> None:
         """Stop the vacuum cleaner."""
         LOGGER.debug("async_stop")
         await self.romy.async_stop()
 
+    @override
     async def async_return_to_base(self, **kwargs: Any) -> None:
         """Return vacuum back to base."""
         LOGGER.debug("async_return_to_base")
         await self.romy.async_return_to_base()
 
+    @override
     async def async_set_fan_speed(self, fan_speed: str, **kwargs: Any) -> None:
         """Set fan speed."""
         LOGGER.debug("async_set_fan_speed to %s", fan_speed)

--- a/homeassistant/components/roomba/binary_sensor.py
+++ b/homeassistant/components/roomba/binary_sensor.py
@@ -1,5 +1,7 @@
 """Roomba binary sensor entities."""
 
+from typing import override
+
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
@@ -34,15 +36,18 @@ class RoombaBinStatus(IRobotEntity, BinarySensorEntity):
     _attr_translation_key = "bin_full"
 
     @property
+    @override
     def unique_id(self):
         """Return the ID of this sensor."""
         return f"bin_{self._blid}"
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return the state of the sensor."""
         return roomba_reported_state(self.vacuum).get("bin", {}).get("full", False)
 
+    @override
     def new_state_filter(self, new_state):
         """Filter the new state."""
         return "bin" in new_state
@@ -54,11 +59,13 @@ class RoombaCharging(IRobotEntity, BinarySensorEntity):
     _attr_device_class = BinarySensorDeviceClass.BATTERY_CHARGING
 
     @property
+    @override
     def unique_id(self) -> str:
         """Return the ID of this sensor."""
         return f"charging_{self._blid}"
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return the state of the sensor."""
         return (
@@ -68,6 +75,7 @@ class RoombaCharging(IRobotEntity, BinarySensorEntity):
             == "charge"
         )
 
+    @override
     def new_state_filter(self, new_state):
         """Filter the new state."""
         return "cleanMissionStatus" in new_state

--- a/homeassistant/components/roomba/config_flow.py
+++ b/homeassistant/components/roomba/config_flow.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from functools import partial
-from typing import Any
+from typing import Any, override
 
 from roombapy import RoombaFactory, RoombaInfo
 from roombapy.discovery import RoombaDiscovery
@@ -83,12 +83,14 @@ class RoombaConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: RoombaConfigEntry,
     ) -> RoombaOptionsFlowHandler:
         """Get the options flow for this handler."""
         return RoombaOptionsFlowHandler()
 
+    @override
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:
@@ -97,6 +99,7 @@ class RoombaConfigFlow(ConfigFlow, domain=DOMAIN):
             discovery_info.host, discovery_info.hostname.lower().removesuffix(".local.")
         )
 
+    @override
     async def async_step_dhcp(
         self, discovery_info: DhcpServiceInfo
     ) -> ConfigFlowResult:
@@ -146,6 +149,7 @@ class RoombaConfigFlow(ConfigFlow, domain=DOMAIN):
         self._abort_if_unique_id_configured()
         return await self.async_step_link()
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/roomba/entity.py
+++ b/homeassistant/components/roomba/entity.py
@@ -1,5 +1,7 @@
 """Base class for iRobot devices."""
 
+from typing import override
+
 from homeassistant.const import ATTR_CONNECTIONS
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -49,6 +51,7 @@ class IRobotEntity(Entity):
         return f"roomba_{self._blid}"
 
     @property
+    @override
     def unique_id(self):
         """Return the uniqueid of the vacuum cleaner."""
         return self.robot_unique_id
@@ -87,6 +90,7 @@ class IRobotEntity(Entity):
             return None
         return dt_util.utc_from_timestamp(ts)
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register callback function."""
         self.vacuum.register_on_message_callback(self.on_message)

--- a/homeassistant/components/roomba/sensor.py
+++ b/homeassistant/components/roomba/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from roombapy import Roomba
 
@@ -177,11 +178,13 @@ class RoombaSensor(IRobotEntity, SensorEntity):
         self.entity_description = entity_description
 
     @property
+    @override
     def unique_id(self) -> str:
         """Return a unique ID."""
         return f"{self.entity_description.key}_{self._blid}"
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self)

--- a/homeassistant/components/roomba/vacuum.py
+++ b/homeassistant/components/roomba/vacuum.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.vacuum import (
     ATTR_STATUS,
@@ -121,6 +121,7 @@ class IRobotVacuum(IRobotEntity, StateVacuumEntity):
         self._cap_position = self.vacuum_state.get("cap", {}).get("pose") == 1
 
     @property
+    @override
     def activity(self) -> VacuumActivity:
         """Return the state of the vacuum cleaner."""
         clean_mission_status = self.vacuum_state.get("cleanMissionStatus", {})
@@ -138,6 +139,7 @@ class IRobotVacuum(IRobotEntity, StateVacuumEntity):
         return state
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the device."""
         state = self.vacuum_state
@@ -198,6 +200,7 @@ class IRobotVacuum(IRobotEntity, StateVacuumEntity):
 
         return (cleaning_time, cleaned_area)
 
+    @override
     def on_message(self, json_data):
         """Update state on message change."""
         state = json_data.get("state", {}).get("reported", {})
@@ -205,6 +208,7 @@ class IRobotVacuum(IRobotEntity, StateVacuumEntity):
             _LOGGER.debug("Got new state from the vacuum: %s", json_data)
             self.schedule_update_ha_state()
 
+    @override
     async def async_start(self) -> None:
         """Start or resume the cleaning task."""
         if self.state == VacuumActivity.PAUSED:
@@ -212,14 +216,17 @@ class IRobotVacuum(IRobotEntity, StateVacuumEntity):
         else:
             await self.hass.async_add_executor_job(self.vacuum.send_command, "start")
 
+    @override
     async def async_stop(self, **kwargs: Any) -> None:
         """Stop the vacuum cleaner."""
         await self.hass.async_add_executor_job(self.vacuum.send_command, "stop")
 
+    @override
     async def async_pause(self) -> None:
         """Pause the cleaning cycle."""
         await self.hass.async_add_executor_job(self.vacuum.send_command, "pause")
 
+    @override
     async def async_return_to_base(self, **kwargs: Any) -> None:
         """Set the vacuum cleaner to return to the dock."""
         if self.state == VacuumActivity.CLEANING:
@@ -230,10 +237,12 @@ class IRobotVacuum(IRobotEntity, StateVacuumEntity):
                 await asyncio.sleep(1)
         await self.hass.async_add_executor_job(self.vacuum.send_command, "dock")
 
+    @override
     async def async_locate(self, **kwargs: Any) -> None:
         """Located vacuum."""
         await self.hass.async_add_executor_job(self.vacuum.send_command, "find")
 
+    @override
     async def async_send_command(
         self,
         command: str,
@@ -251,6 +260,7 @@ class RoombaVacuum(IRobotVacuum):
     """Basic Roomba robot (without carpet boost)."""
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the device."""
         state_attrs = super().extra_state_attributes
@@ -274,6 +284,7 @@ class RoombaVacuumCarpetBoost(RoombaVacuum):
     _attr_supported_features = SUPPORT_ROOMBA_CARPET_BOOST
 
     @property
+    @override
     def fan_speed(self) -> str | None:
         """Return the fan speed of the vacuum cleaner."""
         fan_speed = None
@@ -288,6 +299,7 @@ class RoombaVacuumCarpetBoost(RoombaVacuum):
                 fan_speed = FAN_SPEED_ECO
         return fan_speed
 
+    @override
     async def async_set_fan_speed(self, fan_speed: str, **kwargs: Any) -> None:
         """Set fan speed."""
         if fan_speed.capitalize() in FAN_SPEEDS:
@@ -333,6 +345,7 @@ class BraavaJet(IRobotVacuum):
         ]
 
     @property
+    @override
     def fan_speed(self) -> str:
         """Return the fan speed of the vacuum cleaner."""
         # Mopping behavior and spray amount as fan speed
@@ -349,6 +362,7 @@ class BraavaJet(IRobotVacuum):
         pad_wetness_value = pad_wetness.get("disposable")
         return f"{behavior}-{pad_wetness_value}"
 
+    @override
     async def async_set_fan_speed(self, fan_speed: str, **kwargs: Any) -> None:
         """Set fan speed."""
         try:
@@ -399,6 +413,7 @@ class BraavaJet(IRobotVacuum):
         await self.hass.async_add_executor_job(_set_mop_preferences)
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the device."""
         state_attrs = super().extra_state_attributes

--- a/homeassistant/components/roon/config_flow.py
+++ b/homeassistant/components/roon/config_flow.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from typing import Any
+from typing import Any, override
 
 from roonapi import RoonApi, RoonDiscovery
 import voluptuous as vol
@@ -131,6 +131,7 @@ class RoonConfigFlow(ConfigFlow, domain=DOMAIN):
         self._port = None
         self._servers: list[tuple[str, int]] = []
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/roon/event.py
+++ b/homeassistant/components/roon/event.py
@@ -1,7 +1,7 @@
 """Roon event entities."""
 
 import logging
-from typing import cast
+from typing import cast, override
 
 from homeassistant.components.event import EventDeviceClass, EventEntity
 from homeassistant.core import HomeAssistant, callback
@@ -92,6 +92,7 @@ class RoonEventEntity(EventEntity):
         self._trigger_event(event)
         self.schedule_update_ha_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register volume hooks with the roon api."""
 
@@ -107,6 +108,7 @@ class RoonEventEntity(EventEntity):
             False,
         )
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Unregister volume hooks from the roon api."""
         self._server.roonapi.unregister_volume_control(self.unique_id)

--- a/homeassistant/components/roon/media_player.py
+++ b/homeassistant/components/roon/media_player.py
@@ -1,7 +1,7 @@
 """MediaPlayer platform for Roon integration."""
 
 import logging
-from typing import Any, cast
+from typing import Any, cast, override
 
 from roonapi import split_media_path
 
@@ -112,6 +112,7 @@ class RoonDevice(MediaPlayerEntity):
         self._entry_id = entry_id
         self.update_data(player_data)
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register callback."""
         self.async_on_remove(
@@ -130,6 +131,7 @@ class RoonDevice(MediaPlayerEntity):
         self.async_write_ha_state()
 
     @property
+    @override
     def group_members(self):
         """Return the grouped players."""
 
@@ -137,6 +139,7 @@ class RoonDevice(MediaPlayerEntity):
         return [self._server.entity_id(roon_name) for roon_name in roon_names]
 
     @property
+    @override
     def device_info(self) -> DeviceInfo | None:
         """Return the device info."""
         if self.unique_id is None:
@@ -310,11 +313,13 @@ class RoonDevice(MediaPlayerEntity):
         return self._output_id
 
     @property
+    @override
     def media_album_artist(self) -> str | None:
         """Album artist of current playing media (Music track only)."""
         return self.media_artist
 
     @property
+    @override
     def media_content_type(self) -> str:
         """Return the media type."""
         return MediaType.MUSIC
@@ -324,10 +329,12 @@ class RoonDevice(MediaPlayerEntity):
         """Return power state of source controls."""
         return self._supports_standby
 
+    @override
     def media_play(self) -> None:
         """Send play command to device."""
         self._server.roonapi.playback_control(self.output_id, "play")
 
+    @override
     def media_pause(self) -> None:
         """Send pause command to device."""
         self._server.roonapi.playback_control(self.output_id, "pause")
@@ -336,18 +343,22 @@ class RoonDevice(MediaPlayerEntity):
         """Toggle play command to device."""
         self._server.roonapi.playback_control(self.output_id, "playpause")
 
+    @override
     def media_stop(self) -> None:
         """Send stop command to device."""
         self._server.roonapi.playback_control(self.output_id, "stop")
 
+    @override
     def media_next_track(self) -> None:
         """Send next track command to device."""
         self._server.roonapi.playback_control(self.output_id, "next")
 
+    @override
     def media_previous_track(self) -> None:
         """Send previous track command to device."""
         self._server.roonapi.playback_control(self.output_id, "previous")
 
+    @override
     def media_seek(self, position: float) -> None:
         """Send seek command to device."""
         self._server.roonapi.seek(self.output_id, position)
@@ -355,11 +366,13 @@ class RoonDevice(MediaPlayerEntity):
         self._attr_media_position = round(position)
         self.schedule_update_ha_state()
 
+    @override
     def set_volume_level(self, volume: float) -> None:
         """Send new volume_level to device."""
         volume = volume * 100
         self._server.roonapi.set_volume_percent(self.output_id, volume)
 
+    @override
     def mute_volume(self, mute=True):
         """Send mute/unmute to device."""
         self._server.roonapi.mute(self.output_id, mute)
@@ -378,6 +391,7 @@ class RoonDevice(MediaPlayerEntity):
         else:
             self._server.roonapi.change_volume_percent(self.output_id, -3)
 
+    @override
     def turn_on(self) -> None:
         """Turn on device (if supported)."""
         if not (self.supports_standby and "source_controls" in self.player_data):
@@ -390,6 +404,7 @@ class RoonDevice(MediaPlayerEntity):
                 )
                 return
 
+    @override
     def turn_off(self) -> None:
         """Turn off device (if supported)."""
         if not (self.supports_standby and "source_controls" in self.player_data):
@@ -401,16 +416,19 @@ class RoonDevice(MediaPlayerEntity):
                 self._server.roonapi.standby(self.output_id, source["control_key"])
                 return
 
+    @override
     def set_shuffle(self, shuffle: bool) -> None:
         """Set shuffle state."""
         self._server.roonapi.shuffle(self.output_id, shuffle)
 
+    @override
     def set_repeat(self, repeat: RepeatMode) -> None:
         """Set repeat mode."""
         if repeat not in REPEAT_MODE_MAPPING_TO_ROON:
             raise ValueError(f"Unsupported repeat mode: {repeat}")
         self._server.roonapi.repeat(self.output_id, REPEAT_MODE_MAPPING_TO_ROON[repeat])
 
+    @override
     def play_media(
         self, media_type: MediaType | str, media_id: str, **kwargs: Any
     ) -> None:
@@ -431,6 +449,7 @@ class RoonDevice(MediaPlayerEntity):
                     path_list,
                 )
 
+    @override
     def join_players(self, group_members: list[str]) -> None:
         """Join `group_members` as a player group with the current player."""
 
@@ -474,6 +493,7 @@ class RoonDevice(MediaPlayerEntity):
             [self._output_id] + [sync_available[name] for name in names]
         )
 
+    @override
     def unjoin_player(self) -> None:
         """Remove this player from any group."""
 
@@ -513,6 +533,7 @@ class RoonDevice(MediaPlayerEntity):
             self._server.roonapi.transfer_zone, self._zone_id, transfer_id
         )
 
+    @override
     async def async_browse_media(
         self,
         media_content_type: MediaType | str | None = None,

--- a/homeassistant/components/route_b_smart_meter/config_flow.py
+++ b/homeassistant/components/route_b_smart_meter/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Smart Meter B Route integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from momonga import Momonga, MomongaSkJoinFailure, MomongaSkScanFailure
 import voluptuous as vol
@@ -65,6 +65,7 @@ class BRouteConfigFlow(ConfigFlow, domain=DOMAIN):
         devices = await async_scan_serial_ports(self.hass)
         return {port.device: port for port in devices if isinstance(port, USBDevice)}
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/route_b_smart_meter/coordinator.py
+++ b/homeassistant/components/route_b_smart_meter/coordinator.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 import logging
 import time
+from typing import override
 
 from momonga import Momonga, MomongaError
 
@@ -66,6 +67,7 @@ class BRouteUpdateCoordinator(DataUpdateCoordinator[BRouteData]):
 
         self.device_info_data = BRouteDeviceInfo()
 
+    @override
     async def _async_setup(self) -> None:
         def fetch() -> None:
             self.api.open()
@@ -103,6 +105,7 @@ class BRouteUpdateCoordinator(DataUpdateCoordinator[BRouteData]):
             total_consumption=self.api.get_measured_cumulative_energy(),
         )
 
+    @override
     async def _async_update_data(self) -> BRouteData:
         """Update data."""
         try:

--- a/homeassistant/components/route_b_smart_meter/sensor.py
+++ b/homeassistant/components/route_b_smart_meter/sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -123,6 +123,7 @@ class SmartMeterBRouteSensor(CoordinatorEntity[BRouteUpdateCoordinator], SensorE
         self._attr_device_info = _build_device_info(coordinator)
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
         return self.entity_description.value_accessor(self.coordinator.data)

--- a/homeassistant/components/rova/config_flow.py
+++ b/homeassistant/components/rova/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for the Rova platform."""
 
-from typing import Any
+from typing import Any, override
 
 from requests.exceptions import ConnectTimeout, HTTPError
 from rova.rova import Rova
@@ -16,6 +16,7 @@ class RovaConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/rova/coordinator.py
+++ b/homeassistant/components/rova/coordinator.py
@@ -1,6 +1,7 @@
 """Coordinator for Rova."""
 
 from datetime import datetime, timedelta
+from typing import override
 
 from rova.rova import Rova
 
@@ -34,6 +35,7 @@ class RovaCoordinator(DataUpdateCoordinator[dict[str, datetime]]):
         )
         self.api = api
 
+    @override
     async def _async_update_data(self) -> dict[str, datetime]:
         """Fetch data from Rova API."""
 

--- a/homeassistant/components/rova/sensor.py
+++ b/homeassistant/components/rova/sensor.py
@@ -1,6 +1,7 @@
 """Support for Rova garbage calendar."""
 
 from datetime import datetime
+from typing import override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -75,6 +76,7 @@ class RovaSensor(CoordinatorEntity[RovaCoordinator], SensorEntity):
         )
 
     @property
+    @override
     def native_value(self) -> datetime | None:
         """Return the state of the sensor."""
         return self.coordinator.data.get(self.entity_description.key)

--- a/homeassistant/components/ruckus_unleashed/config_flow.py
+++ b/homeassistant/components/ruckus_unleashed/config_flow.py
@@ -3,7 +3,7 @@
 from collections.abc import Mapping
 import logging
 import operator
-from typing import Any
+from typing import Any, override
 
 from aioruckus import AjaxSession, SystemStat
 from aioruckus.exceptions import AuthenticationError, SchemaError
@@ -79,12 +79,14 @@ class RuckusConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> RuckusOptionsFlowHandler:
         """Get the options flow for this handler."""
         return RuckusOptionsFlowHandler()
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/ruckus_unleashed/coordinator.py
+++ b/homeassistant/components/ruckus_unleashed/coordinator.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import logging
+from typing import override
 
 from aioruckus import AjaxSession
 from aioruckus.exceptions import AuthenticationError, SchemaError
@@ -46,11 +47,13 @@ class RuckusDataUpdateCoordinator(DataUpdateCoordinator):
         _LOGGER.debug("fetched %d active clients", len(clients))
         return {client[API_CLIENT_MAC]: client for client in clients}
 
+    @override
     async def async_shutdown(self) -> None:
         """Close the Ruckus session on shutdown."""
         await super().async_shutdown()
         await self.ruckus.close()
 
+    @override
     async def _async_update_data(self) -> dict:
         """Fetch Ruckus data."""
         try:

--- a/homeassistant/components/ruckus_unleashed/device_tracker.py
+++ b/homeassistant/components/ruckus_unleashed/device_tracker.py
@@ -1,6 +1,7 @@
 """Support for Ruckus devices."""
 
 import logging
+from typing import override
 
 from homeassistant.components.device_tracker import ScannerEntity
 from homeassistant.core import HomeAssistant, callback
@@ -98,11 +99,13 @@ class RuckusDevice(CoordinatorEntity, ScannerEntity):
         self._name = name
 
     @property
+    @override
     def mac_address(self) -> str:
         """Return a mac address."""
         return self._mac
 
     @property
+    @override
     def name(self) -> str:
         """Return the name."""
         if not self.is_connected:
@@ -110,6 +113,7 @@ class RuckusDevice(CoordinatorEntity, ScannerEntity):
         return self.coordinator.data[KEY_SYS_CLIENTS][self._mac][API_CLIENT_HOSTNAME]
 
     @property
+    @override
     def ip_address(self) -> str | None:
         """Return the ip address."""
         if not self.is_connected:
@@ -117,6 +121,7 @@ class RuckusDevice(CoordinatorEntity, ScannerEntity):
         return self.coordinator.data[KEY_SYS_CLIENTS][self._mac][API_CLIENT_IP]
 
     @property
+    @override
     def is_connected(self) -> bool:
         """Return true if the device is connected to the network."""
         return self._mac in self.coordinator.data[KEY_SYS_CLIENTS]

--- a/homeassistant/components/russound_rio/config_flow.py
+++ b/homeassistant/components/russound_rio/config_flow.py
@@ -2,7 +2,7 @@
 
 from contextlib import suppress
 import logging
-from typing import Any
+from typing import Any, override
 
 from aiorussound import RussoundTcpConnectionHandler
 from aiorussound.connection import (
@@ -115,6 +115,7 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
             data=data,
         )
 
+    @override
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:
@@ -162,6 +163,7 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
             },
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/russound_rio/entity.py
+++ b/homeassistant/components/russound_rio/entity.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Awaitable, Callable, Coroutine
 from functools import wraps
-from typing import Any, Concatenate
+from typing import Any, Concatenate, override
 
 from aiorussound.rio import RussoundRIOClient
 from aiorussound.rio.client import Controller, ZoneControlSurface
@@ -90,10 +90,12 @@ class RussoundBaseEntity(Entity):
         self._controller = _client.controllers[self._controller.controller_id]
         self.async_write_ha_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register callback handlers."""
         await self._client.register_state_update_callbacks(self._state_update_callback)
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Remove callbacks."""
         self._client.unregister_state_update_callbacks(self._state_update_callback)

--- a/homeassistant/components/russound_rio/media_player.py
+++ b/homeassistant/components/russound_rio/media_player.py
@@ -3,7 +3,7 @@
 import asyncio
 import datetime as dt
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from aiorussound.const import FeatureFlag
 from aiorussound.rio import Controller, Source
@@ -90,6 +90,7 @@ class RussoundZoneDevice(RussoundBaseEntity, MediaPlayerEntity):
         return self._zone.fetch_current_source()
 
     @property
+    @override
     def state(self) -> MediaPlayerState | None:
         """Return the state of the device."""
         status = self._zone.status
@@ -107,11 +108,13 @@ class RussoundZoneDevice(RussoundBaseEntity, MediaPlayerEntity):
         return MediaPlayerState.ON
 
     @property
+    @override
     def source(self) -> str:
         """Get the currently selected source."""
         return self._source.name
 
     @property
+    @override
     def source_list(self) -> list[str]:
         """Return a list of available input sources."""
         if TYPE_CHECKING:
@@ -130,41 +133,49 @@ class RussoundZoneDevice(RussoundBaseEntity, MediaPlayerEntity):
         return [x.name for x in available_sources]
 
     @property
+    @override
     def media_title(self) -> str | None:
         """Title of current playing media."""
         return self._source.song_name or self._source.channel
 
     @property
+    @override
     def media_artist(self) -> str | None:
         """Artist of current playing media, music track only."""
         return self._source.artist_name
 
     @property
+    @override
     def media_album_name(self) -> str | None:
         """Album name of current playing media, music track only."""
         return self._source.album_name
 
     @property
+    @override
     def media_image_url(self) -> str | None:
         """Image url of current playing media."""
         return self._source.cover_art_url
 
     @property
+    @override
     def media_duration(self) -> int | None:
         """Duration of the current media."""
         return self._source.track_time
 
     @property
+    @override
     def media_position(self) -> int | None:
         """Position of the current media."""
         return self._source.play_time
 
     @property
+    @override
     def media_position_updated_at(self) -> dt.datetime:
         """Last time the media position was updated."""
         return self._source.position_last_updated
 
     @property
+    @override
     def volume_level(self) -> float:
         """Volume level of the media player (0..1).
 
@@ -174,27 +185,32 @@ class RussoundZoneDevice(RussoundBaseEntity, MediaPlayerEntity):
         return self._zone.volume / 50.0
 
     @property
+    @override
     def is_volume_muted(self) -> bool:
         """Return whether zone is muted."""
         return self._zone.is_mute
 
     @command
+    @override
     async def async_turn_off(self) -> None:
         """Turn off the zone."""
         await self._zone.zone_off()
 
     @command
+    @override
     async def async_turn_on(self) -> None:
         """Turn on the zone."""
         await self._zone.zone_on()
 
     @command
+    @override
     async def async_set_volume_level(self, volume: float) -> None:
         """Set the volume level."""
         rvol = int(volume * 50.0)
         await self._zone.set_volume(str(rvol))
 
     @command
+    @override
     async def async_select_source(self, source: str) -> None:
         """Select the source input for this zone."""
         for source_id, src in self._sources.items():
@@ -204,16 +220,19 @@ class RussoundZoneDevice(RussoundBaseEntity, MediaPlayerEntity):
             break
 
     @command
+    @override
     async def async_volume_up(self) -> None:
         """Step the volume up."""
         await self._zone.volume_up()
 
     @command
+    @override
     async def async_volume_down(self) -> None:
         """Step the volume down."""
         await self._zone.volume_down()
 
     @command
+    @override
     async def async_mute_volume(self, mute: bool) -> None:
         """Mute the media player."""
         if FeatureFlag.COMMANDS_ZONE_MUTE_OFF_ON in self._client.supported_features:
@@ -227,11 +246,13 @@ class RussoundZoneDevice(RussoundBaseEntity, MediaPlayerEntity):
             await self._zone.toggle_mute()
 
     @command
+    @override
     async def async_media_seek(self, position: float) -> None:
         """Seek to a position in the current media."""
         await self._zone.set_seek_time(int(position))
 
     @command
+    @override
     async def async_play_media(
         self, media_type: MediaType | str, media_id: str, **kwargs: Any
     ) -> None:
@@ -265,6 +286,7 @@ class RussoundZoneDevice(RussoundBaseEntity, MediaPlayerEntity):
             )
         await self._zone.restore_preset(preset_id)
 
+    @override
     async def async_browse_media(
         self,
         media_content_type: MediaType | str | None = None,

--- a/homeassistant/components/russound_rio/number.py
+++ b/homeassistant/components/russound_rio/number.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from typing import override
 
 from aiorussound.rio.client import Controller, ZoneControlSurface
 
@@ -102,11 +103,13 @@ class RussoundNumberEntity(RussoundBaseEntity, NumberEntity):
         )
 
     @property
+    @override
     def native_value(self) -> float:
         """Return the native value of the entity."""
         return float(self.entity_description.value_fn(self._zone))
 
     @command
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Set the value."""
         await self.entity_description.set_value_fn(self._zone, value)

--- a/homeassistant/components/russound_rio/select.py
+++ b/homeassistant/components/russound_rio/select.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from typing import override
 
 from aiorussound.rio.client import Controller, ZoneControlSurface
 from aiorussound.rio.models import PartyMode
@@ -75,11 +76,13 @@ class RussoundSelectEntity(RussoundBaseEntity, SelectEntity):
         )
 
     @property
+    @override
     def current_option(self) -> str | None:
         """Return the state of the select."""
         return self.entity_description.value_fn(self._zone)
 
     @command
+    @override
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         await self.entity_description.set_value_fn(self._zone, option)

--- a/homeassistant/components/russound_rio/switch.py
+++ b/homeassistant/components/russound_rio/switch.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from aiorussound.rio.client import Controller, ZoneControlSurface
 
@@ -70,16 +70,19 @@ class RussoundSwitchEntity(RussoundBaseEntity, SwitchEntity):
         )
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return the state of the switch."""
         return self.entity_description.value_fn(self._zone)
 
     @command
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         await self.entity_description.set_value_fn(self._zone, True)
 
     @command
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         await self.entity_description.set_value_fn(self._zone, False)

--- a/homeassistant/components/russound_rnet/media_player.py
+++ b/homeassistant/components/russound_rnet/media_player.py
@@ -5,7 +5,7 @@ from collections.abc import Callable, Coroutine
 import contextlib
 import logging
 import math
-from typing import Any
+from typing import Any, override
 
 from aiorussound import RussoundTcpConnectionHandler
 from aiorussound.exceptions import CommandError
@@ -185,6 +185,7 @@ class RussoundRNETDevice(MediaPlayerEntity):
         if self.source_list and 0 <= index < len(self.source_list):
             self._attr_source = self.source_list[index]
 
+    @override
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume level. Volume has a range (0..1)."""
         device_volume = max(0, min(_MAX_VOLUME, int(volume * _MAX_VOLUME)))
@@ -194,6 +195,7 @@ class RussoundRNETDevice(MediaPlayerEntity):
             )
         )
 
+    @override
     async def async_turn_on(self) -> None:
         """Turn the media player on."""
         await self._async_run_with_retry(
@@ -202,6 +204,7 @@ class RussoundRNETDevice(MediaPlayerEntity):
             )
         )
 
+    @override
     async def async_turn_off(self) -> None:
         """Turn off media player."""
         await self._async_run_with_retry(
@@ -210,6 +213,7 @@ class RussoundRNETDevice(MediaPlayerEntity):
             )
         )
 
+    @override
     async def async_mute_volume(self, mute: bool) -> None:
         """Send mute command."""
 
@@ -219,6 +223,7 @@ class RussoundRNETDevice(MediaPlayerEntity):
 
         await self._async_run_with_retry(_mute_if_needed)
 
+    @override
     async def async_select_source(self, source: str) -> None:
         """Set the input source."""
         if self.source_list and source in self.source_list:

--- a/homeassistant/components/ruuvi_gateway/config_flow.py
+++ b/homeassistant/components/ruuvi_gateway/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Ruuvi Gateway integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 import aioruuvigateway.api as gw_api
 from aioruuvigateway.excs import CannotConnect, InvalidAuth
@@ -62,6 +62,7 @@ class RuuviConfigFlow(ConfigFlow, domain=DOMAIN):
             errors["base"] = "unknown"
         return (None, errors)
 
+    @override
     async def async_step_user(
         self,
         user_input: dict[str, Any] | None = None,
@@ -79,6 +80,7 @@ class RuuviConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=(errors or None),
         )
 
+    @override
     async def async_step_dhcp(
         self, discovery_info: DhcpServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/ruuvi_gateway/coordinator.py
+++ b/homeassistant/components/ruuvi_gateway/coordinator.py
@@ -1,6 +1,7 @@
 """Update coordinator for Ruuvi Gateway."""
 
 import logging
+from typing import override
 
 from aioruuvigateway.api import get_gateway_history_data
 from aioruuvigateway.models import TagData
@@ -37,6 +38,7 @@ class RuuviGatewayUpdateCoordinator(DataUpdateCoordinator[list[TagData]]):
         self.token = config_entry.data[CONF_TOKEN]
         self.last_tag_datas: dict[str, TagData] = {}
 
+    @override
     async def _async_update_data(self) -> list[TagData]:
         changed_tag_datas: list[TagData] = []
         async with get_async_client(self.hass) as client:

--- a/homeassistant/components/ruuvitag_ble/config_flow.py
+++ b/homeassistant/components/ruuvitag_ble/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for ruuvitag_ble."""
 
-from typing import Any
+from typing import Any, override
 
 from ruuvitag_ble import RuuvitagBluetoothDeviceData
 import voluptuous as vol
@@ -27,6 +27,7 @@ class RuuvitagConfigFlow(ConfigFlow, domain=DOMAIN):
         self._discovered_device: RuuvitagBluetoothDeviceData | None = None
         self._discovered_devices: dict[str, str] = {}
 
+    @override
     async def async_step_bluetooth(
         self, discovery_info: BluetoothServiceInfoBleak
     ) -> ConfigFlowResult:
@@ -59,6 +60,7 @@ class RuuvitagConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="bluetooth_confirm", description_placeholders=placeholders
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/ruuvitag_ble/sensor.py
+++ b/homeassistant/components/ruuvitag_ble/sensor.py
@@ -1,5 +1,7 @@
 """Support for RuuviTag sensors."""
 
+from typing import override
+
 from sensor_state_data import (
     DeviceKey,
     SensorDeviceClass as SSDSensorDeviceClass,
@@ -221,6 +223,7 @@ class RuuvitagBluetoothSensorEntity(
     """Representation of a Ruuvi BLE sensor."""
 
     @property
+    @override
     def native_value(self) -> int | float | None:
         """Return the native value."""
         return self.processor.entity_data.get(self.entity_key)

--- a/homeassistant/components/rympro/config_flow.py
+++ b/homeassistant/components/rympro/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyrympro import CannotConnectError, RymPro, UnauthorizedError
 import voluptuous as vol
@@ -44,6 +44,7 @@ class RymproConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/rympro/coordinator.py
+++ b/homeassistant/components/rympro/coordinator.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import logging
+from typing import override
 
 from pyrympro import CannotConnectError, OperationError, RymPro, UnauthorizedError
 
@@ -37,6 +38,7 @@ class RymProDataUpdateCoordinator(DataUpdateCoordinator[dict[int, dict]]):
             update_interval=interval,
         )
 
+    @override
     async def _async_update_data(self) -> dict[int, dict]:
         """Fetch data from Rym Pro."""
         try:

--- a/homeassistant/components/rympro/sensor.py
+++ b/homeassistant/components/rympro/sensor.py
@@ -1,6 +1,7 @@
 """Sensor for RymPro meters."""
 
 from dataclasses import dataclass
+from typing import override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -99,6 +100,7 @@ class RymProSensor(CoordinatorEntity[RymProDataUpdateCoordinator], SensorEntity)
         self.entity_description = description
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the state of the sensor."""
         return self.coordinator.data[self._meter_id][self.entity_description.value_key]


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In preparation to enable the mypy check for `@override` in https://github.com/home-assistant/core/pull/171853

To make it easier to review, you can get a simplified diff with only changed lines (no context), and check that only imports changed and `@override` lines added: `git show override_componets_p_r --unified=0 | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)'`

Or get a diff with only the non-decorator changes:

`git show override_componets_p_r --unified=0 | grep -E '^[+-]' | grep -vE '^(\+\+\+|---) ' | grep -vE '^[+-][[:space:]]*@override$' | grep -vE '^[+-]from typing import '`

To reproduce and double check this change, run the following:

```bash
# generate errors list:
python extract_override_errors.py homeassistant/components

# filter component range
grep -E 'components/[p-r]' explicit_override_errors.txt | sort -o explicit_override_errors.txt

# add override decorator and ruff it
python add_override_decorators.py explicit_override_errors.txt
```

The two scripts can be found in https://github.com/home-assistant/core/pull/171853

### Extra manual changes:

- In `homeassistant/components/radarr/calendar.py` and `homeassistant/components/rflink/sensor.py`, moved `@override` above the suppression comment.
- In `homeassistant/components/recorder/pool.py`, moved the `# noqa: RET503` onto the `@override` line.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
