### PR TITLE
Add override decorator to components N to O

### DIFF
--- a/homeassistant/components/nad/media_player.py
+++ b/homeassistant/components/nad/media_player.py
@@ -1,5 +1,7 @@
 """Support for interfacing with NAD receivers through RS-232."""
 
+from typing import override
+
 from nad_receiver import NADReceiver, NADReceiverTCP, NADReceiverTelnet
 import voluptuous as vol
 
@@ -101,10 +103,12 @@ class NAD(MediaPlayerEntity):
             port = self.config[CONF_PORT]
             self._nad_receiver = NADReceiverTelnet(host, port)
 
+    @override
     def turn_off(self) -> None:
         """Turn the media player off."""
         self._nad_receiver.main_power("=", "Off")
 
+    @override
     def turn_on(self) -> None:
         """Turn the media player on."""
         self._nad_receiver.main_power("=", "On")
@@ -117,10 +121,12 @@ class NAD(MediaPlayerEntity):
         """Volume down the media player."""
         self._nad_receiver.main_volume("-")
 
+    @override
     def set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""
         self._nad_receiver.main_volume("=", self.calc_db(volume))
 
+    @override
     def mute_volume(self, mute: bool) -> None:
         """Mute (true) or unmute (false) media player."""
         if mute:
@@ -128,16 +134,19 @@ class NAD(MediaPlayerEntity):
         else:
             self._nad_receiver.main_mute("=", "Off")
 
+    @override
     def select_source(self, source: str) -> None:
         """Select input source."""
         self._nad_receiver.main_source("=", self._reverse_mapping.get(source))
 
     @property
+    @override
     def source_list(self):
         """List of available input sources."""
         return sorted(self._reverse_mapping)
 
     @property
+    @override
     def available(self) -> bool:
         """Return if device is available."""
         return self.state is not None
@@ -202,14 +211,17 @@ class NADtcp(MediaPlayerEntity):
             self._attr_volume_step = 2 * config[CONF_VOLUME_STEP] / vol_range
         self._source_list = self._nad_receiver.available_sources()
 
+    @override
     def turn_off(self) -> None:
         """Turn the media player off."""
         self._nad_receiver.power_off()
 
+    @override
     def turn_on(self) -> None:
         """Turn the media player on."""
         self._nad_receiver.power_on()
 
+    @override
     def set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""
         nad_volume_to_set = round(
@@ -217,6 +229,7 @@ class NADtcp(MediaPlayerEntity):
         )
         self._nad_receiver.set_volume(nad_volume_to_set)
 
+    @override
     def mute_volume(self, mute: bool) -> None:
         """Mute (true) or unmute (false) media player."""
         if mute:
@@ -224,11 +237,13 @@ class NADtcp(MediaPlayerEntity):
         else:
             self._nad_receiver.unmute()
 
+    @override
     def select_source(self, source: str) -> None:
         """Select input source."""
         self._nad_receiver.select_source(source)
 
     @property
+    @override
     def source_list(self):
         """List of available input sources."""
         return self._nad_receiver.available_sources()

--- a/homeassistant/components/nam/button.py
+++ b/homeassistant/components/nam/button.py
@@ -1,6 +1,7 @@
 """Support for the Nettigo Air Monitor service."""
 
 import logging
+from typing import override
 
 from aiohttp.client_exceptions import ClientError
 from nettigo_air_monitor import ApiError, AuthFailedError
@@ -60,6 +61,7 @@ class NAMButton(CoordinatorEntity[NAMDataUpdateCoordinator], ButtonEntity):
         self._attr_unique_id = f"{coordinator.unique_id}-{description.key}"
         self.entity_description = description
 
+    @override
     async def async_press(self) -> None:
         """Triggers the restart."""
         try:

--- a/homeassistant/components/nam/config_flow.py
+++ b/homeassistant/components/nam/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from aiohttp.client_exceptions import ClientConnectorError
 from nettigo_air_monitor import (
@@ -48,6 +48,7 @@ class NAMFlowHandler(ConfigFlow, domain=DOMAIN):
     host: str
     auth_enabled: bool = False
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -112,6 +113,7 @@ class NAMFlowHandler(ConfigFlow, domain=DOMAIN):
             step_id="credentials", data_schema=AUTH_SCHEMA, errors=errors
         )
 
+    @override
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/nam/coordinator.py
+++ b/homeassistant/components/nam/coordinator.py
@@ -1,7 +1,7 @@
 """The Nettigo Air Monitor coordinator."""
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from nettigo_air_monitor import (
     ApiError,
@@ -57,6 +57,7 @@ class NAMDataUpdateCoordinator(DataUpdateCoordinator[NAMSensors]):
             update_interval=DEFAULT_UPDATE_INTERVAL,
         )
 
+    @override
     async def _async_update_data(self) -> NAMSensors:
         """Update data via library."""
         try:

--- a/homeassistant/components/nam/sensor.py
+++ b/homeassistant/components/nam/sensor.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 import logging
+from typing import override
 
 from nettigo_air_monitor import NAMSensors
 
@@ -414,6 +415,7 @@ class NAMSensor(CoordinatorEntity[NAMDataUpdateCoordinator], SensorEntity):
         self.entity_description = description
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         available = super().available
@@ -427,6 +429,7 @@ class NAMSensor(CoordinatorEntity[NAMDataUpdateCoordinator], SensorEntity):
         )
 
     @property
+    @override
     def native_value(self) -> StateType | datetime:
         """Return the state."""
         return self.entity_description.value(self.coordinator.data)

--- a/homeassistant/components/namecheapdns/config_flow.py
+++ b/homeassistant/components/namecheapdns/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from aiohttp import ClientError
 import voluptuous as vol
@@ -50,6 +50,7 @@ STEP_RECONFIGURE_DATA_SCHEMA = vol.Schema(
 class NamecheapDnsConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Namecheap DynamicDNS."""
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/namecheapdns/coordinator.py
+++ b/homeassistant/components/namecheapdns/coordinator.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import logging
+from typing import override
 
 from aiohttp import ClientError
 
@@ -41,6 +42,7 @@ class NamecheapDnsUpdateCoordinator(DataUpdateCoordinator[None]):
 
         self.session = async_get_clientsession(hass)
 
+    @override
     async def _async_update_data(self) -> None:
         """Update Namecheap DNS."""
         host = self.config_entry.data[CONF_HOST]

--- a/homeassistant/components/nanoleaf/button.py
+++ b/homeassistant/components/nanoleaf/button.py
@@ -1,5 +1,7 @@
 """Support for Nanoleaf buttons."""
 
+from typing import override
+
 from homeassistant.components.button import ButtonDeviceClass, ButtonEntity
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
@@ -29,6 +31,7 @@ class NanoleafIdentifyButton(NanoleafEntity, ButtonEntity):
         super().__init__(coordinator)
         self._attr_unique_id = f"{self._nanoleaf.serial_no}_identify"
 
+    @override
     async def async_press(self) -> None:
         """Identify the Nanoleaf."""
         await self._nanoleaf.identify()

--- a/homeassistant/components/nanoleaf/config_flow.py
+++ b/homeassistant/components/nanoleaf/config_flow.py
@@ -3,7 +3,7 @@
 from collections.abc import Mapping
 import logging
 import os
-from typing import Any, Final, cast
+from typing import Any, Final, cast, override
 
 from aionanoleaf2 import InvalidToken, Nanoleaf, Unauthorized, Unavailable
 import voluptuous as vol
@@ -49,6 +49,7 @@ class NanoleafConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -92,6 +93,7 @@ class NanoleafConfigFlow(ConfigFlow, domain=DOMAIN):
         self.context["title_placeholders"] = {"name": self._get_reauth_entry().title}
         return await self.async_step_link()
 
+    @override
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:
@@ -99,6 +101,7 @@ class NanoleafConfigFlow(ConfigFlow, domain=DOMAIN):
         _LOGGER.debug("Zeroconf discovered: %s", discovery_info)
         return await self._async_homekit_zeroconf_discovery_handler(discovery_info)
 
+    @override
     async def async_step_homekit(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:
@@ -116,6 +119,7 @@ class NanoleafConfigFlow(ConfigFlow, domain=DOMAIN):
             discovery_info.properties[ATTR_PROPERTIES_ID],
         )
 
+    @override
     async def async_step_ssdp(
         self, discovery_info: SsdpServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/nanoleaf/coordinator.py
+++ b/homeassistant/components/nanoleaf/coordinator.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import logging
+from typing import override
 
 from aionanoleaf2 import InvalidToken, Nanoleaf, Unavailable
 
@@ -33,6 +34,7 @@ class NanoleafCoordinator(DataUpdateCoordinator[None]):
         )
         self.nanoleaf = nanoleaf
 
+    @override
     async def _async_update_data(self) -> None:
         try:
             await self.nanoleaf.get_info()

--- a/homeassistant/components/nanoleaf/event.py
+++ b/homeassistant/components/nanoleaf/event.py
@@ -1,5 +1,7 @@
 """Support for Nanoleaf event entity."""
 
+from typing import override
+
 from homeassistant.components.event import EventEntity
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -37,6 +39,7 @@ class NanoleafGestureEvent(NanoleafEntity, EventEntity):
         super().__init__(coordinator)
         self._attr_unique_id = f"{self._nanoleaf.serial_no}_gesture"
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Subscribe to Nanoleaf events."""
         await super().async_added_to_hass()

--- a/homeassistant/components/nanoleaf/light.py
+++ b/homeassistant/components/nanoleaf/light.py
@@ -1,6 +1,6 @@
 """Support for Nanoleaf Lights."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -47,16 +47,19 @@ class NanoleafLight(NanoleafEntity, LightEntity):
         self._attr_min_color_temp_kelvin = self._nanoleaf.color_temperature_min
 
     @property
+    @override
     def brightness(self) -> int:
         """Return the brightness of the light."""
         return int(self._nanoleaf.brightness * 2.55)
 
     @property
+    @override
     def color_temp_kelvin(self) -> int | None:
         """Return the color temperature value in Kelvin."""
         return self._nanoleaf.color_temperature
 
     @property
+    @override
     def effect(self) -> str | None:
         """Return the current effect."""
         # The API returns the *Solid* effect if the Nanoleaf is in HS or CT mode.
@@ -68,21 +71,25 @@ class NanoleafLight(NanoleafEntity, LightEntity):
         )
 
     @property
+    @override
     def effect_list(self) -> list[str]:
         """Return the list of supported effects."""
         return self._nanoleaf.effects_list
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if light is on."""
         return self._nanoleaf.is_on
 
     @property
+    @override
     def hs_color(self) -> tuple[int, int]:
         """Return the color in HS."""
         return self._nanoleaf.hue, self._nanoleaf.saturation
 
     @property
+    @override
     def color_mode(self) -> ColorMode:
         """Return the color mode of the light."""
         # According to API docs, color mode is "ct", "effect" or "hs"
@@ -92,6 +99,7 @@ class NanoleafLight(NanoleafEntity, LightEntity):
         # Home Assistant does not have an "effect" color mode, just report hs
         return ColorMode.HS
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Instruct the light to turn on."""
         brightness = kwargs.get(ATTR_BRIGHTNESS)
@@ -125,6 +133,7 @@ class NanoleafLight(NanoleafEntity, LightEntity):
                 await self._nanoleaf.set_brightness(int(brightness / 2.55))
         await self.coordinator.async_refresh()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Instruct the light to turn off."""
         transition: float | None = kwargs.get(ATTR_TRANSITION)

--- a/homeassistant/components/nasweb/alarm_control_panel.py
+++ b/homeassistant/components/nasweb/alarm_control_panel.py
@@ -2,6 +2,7 @@
 
 import logging
 import time
+from typing import override
 
 from webio_api import Zone as NASwebZone
 from webio_api.const import STATE_ZONE_ALARM, STATE_ZONE_ARMED, STATE_ZONE_DISARMED
@@ -100,6 +101,7 @@ class ZoneEntity(AlarmControlPanelEntity, BaseCoordinatorEntity):
             identifiers={(DOMAIN, self._zone.webio_serial)},
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()
@@ -117,6 +119,7 @@ class ZoneEntity(AlarmControlPanelEntity, BaseCoordinatorEntity):
             self._attr_available = available if available is not None else False
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self._attr_alarm_state = NASWEB_STATE_TO_HA_STATE[self._zone.state]
@@ -131,6 +134,7 @@ class ZoneEntity(AlarmControlPanelEntity, BaseCoordinatorEntity):
         self._set_attr_available(self._zone.last_update, self._zone.available)
         self.async_write_ha_state()
 
+    @override
     async def async_update(self) -> None:
         """Update the entity.
 
@@ -140,14 +144,17 @@ class ZoneEntity(AlarmControlPanelEntity, BaseCoordinatorEntity):
         """
 
     @property
+    @override
     def supported_features(self) -> AlarmControlPanelEntityFeature:
         """Return the list of supported features."""
         return AlarmControlPanelEntityFeature.ARM_AWAY
 
+    @override
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Arm away ZoneEntity."""
         await self._zone.arm(code)
 
+    @override
     async def async_alarm_disarm(self, code: str | None = None) -> None:
         """Disarm ZoneEntity."""
         await self._zone.disarm(code)

--- a/homeassistant/components/nasweb/climate.py
+++ b/homeassistant/components/nasweb/climate.py
@@ -1,7 +1,7 @@
 """Platform for NASweb thermostat."""
 
 import time
-from typing import Any
+from typing import Any, override
 
 from webio_api import Thermostat as NASwebThermostat
 from webio_api.const import KEY_THERMOSTAT
@@ -80,6 +80,7 @@ class Thermostat(ClimateEntity, BaseCoordinatorEntity):
             identifiers={(DOMAIN, self._thermostat.webio_serial)}
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()
@@ -97,6 +98,7 @@ class Thermostat(ClimateEntity, BaseCoordinatorEntity):
             self._attr_available = available if available is not None else False
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self._attr_current_temperature = self._thermostat.current_temp
@@ -148,6 +150,7 @@ class Thermostat(ClimateEntity, BaseCoordinatorEntity):
             return HVACAction.FAN
         return HVACAction.IDLE
 
+    @override
     async def async_update(self) -> None:
         """Update the entity.
 
@@ -156,10 +159,12 @@ class Thermostat(ClimateEntity, BaseCoordinatorEntity):
         takes care of updates via push notifications.
         """
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set HVACMode for Thermostat."""
         await self._thermostat.set_hvac_mode(hvac_mode)
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set temperature range for Thermostat."""
         await self._thermostat.set_temperature(

--- a/homeassistant/components/nasweb/config_flow.py
+++ b/homeassistant/components/nasweb/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for NASweb integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 from webio_api import WebioAPI
@@ -79,6 +79,7 @@ class NASwebConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/nasweb/coordinator.py
+++ b/homeassistant/components/nasweb/coordinator.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from datetime import datetime, timedelta
 import logging
 import time
-from typing import Any
+from typing import Any, override
 
 from aiohttp.web import Request, Response
 from webio_api import WebioAPI
@@ -116,6 +116,7 @@ class NASwebCoordinator(BaseDataUpdateCoordinatorProtocol):
         return self._last_update is not None
 
     @callback
+    @override
     def async_add_listener(
         self, update_callback: CALLBACK_TYPE, context: Any = None
     ) -> Callable[[], None]:

--- a/homeassistant/components/nasweb/sensor.py
+++ b/homeassistant/components/nasweb/sensor.py
@@ -2,6 +2,7 @@
 
 import logging
 import time
+from typing import override
 
 from webio_api import Input as NASwebInput, TempSensor
 from webio_api.const import (
@@ -93,6 +94,7 @@ class BaseSensorEntity(SensorEntity, BaseCoordinatorEntity):
         self._attr_has_entity_name = True
         self._attr_should_poll = False
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()
@@ -109,6 +111,7 @@ class BaseSensorEntity(SensorEntity, BaseCoordinatorEntity):
         else:
             self._attr_available = available if available is not None else False
 
+    @override
     async def async_update(self) -> None:
         """Update the entity.
 
@@ -149,6 +152,7 @@ class InputStateSensor(BaseSensorEntity):
         )
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         if self._input.state is None or self._input.state in self._attr_options:
@@ -181,6 +185,7 @@ class TemperatureSensor(BaseSensorEntity):
         )
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self._attr_native_value = self._temp_sensor.value

--- a/homeassistant/components/nasweb/switch.py
+++ b/homeassistant/components/nasweb/switch.py
@@ -2,7 +2,7 @@
 
 import logging
 import time
-from typing import Any
+from typing import Any, override
 
 from webio_api import Output as NASwebOutput
 from webio_api.const import STATE_ENTITY_UNAVAILABLE, STATE_OUTPUT_OFF, STATE_OUTPUT_ON
@@ -102,12 +102,14 @@ class RelaySwitch(SwitchEntity, BaseCoordinatorEntity):
             identifiers={(DOMAIN, self._output.webio_serial)},
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()
         self._handle_coordinator_update()
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self._attr_is_on = NASWEB_STATE_TO_HA_STATE[self._output.state]
@@ -122,6 +124,7 @@ class RelaySwitch(SwitchEntity, BaseCoordinatorEntity):
             )
         self.async_write_ha_state()
 
+    @override
     async def async_update(self) -> None:
         """Update the entity.
 
@@ -130,10 +133,12 @@ class RelaySwitch(SwitchEntity, BaseCoordinatorEntity):
         takes care of updates via push notifications.
         """
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn On RelaySwitch."""
         await self._output.turn_on()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn Off RelaySwitch."""
         await self._output.turn_off()

--- a/homeassistant/components/neato/api.py
+++ b/homeassistant/components/neato/api.py
@@ -1,7 +1,7 @@
 """API for Neato Botvac bound to Home Assistant OAuth."""
 
 from asyncio import run_coroutine_threadsafe
-from typing import Any
+from typing import Any, override
 
 import pybotvac
 
@@ -43,10 +43,12 @@ class NeatoImplementation(AuthImplementation):
     """
 
     @property
+    @override
     def extra_authorize_data(self) -> dict[str, Any]:
         """Extra data that needs to be appended to the authorize url."""
         return {"client_secret": self.client_secret}
 
+    @override
     async def async_generate_authorize_url(self, flow_id: str) -> str:
         """Generate a url for the user to authorize.
 

--- a/homeassistant/components/neato/button.py
+++ b/homeassistant/components/neato/button.py
@@ -1,5 +1,7 @@
 """Support for Neato buttons."""
 
+from typing import override
+
 from pybotvac import Robot
 
 from homeassistant.components.button import ButtonEntity
@@ -36,6 +38,7 @@ class NeatoDismissAlertButton(NeatoEntity, ButtonEntity):
         super().__init__(robot)
         self._attr_unique_id = f"{robot.serial}_dismiss_alert"
 
+    @override
     async def async_press(self) -> None:
         """Press the button."""
         await self.hass.async_add_executor_job(self.robot.dismiss_current_alert)

--- a/homeassistant/components/neato/camera.py
+++ b/homeassistant/components/neato/camera.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from pybotvac.exceptions import NeatoRobotException
 from pybotvac.robot import Robot
@@ -61,6 +61,7 @@ class NeatoCleaningMap(NeatoEntity, Camera):
         self._image_url: str | None = None
         self._image: bytes | None = None
 
+    @override
     def camera_image(
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
@@ -110,11 +111,13 @@ class NeatoCleaningMap(NeatoEntity, Camera):
         self._available = True
 
     @property
+    @override
     def available(self) -> bool:
         """Return if the robot is available."""
         return self._available
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the vacuum cleaner."""
         data: dict[str, Any] = {}

--- a/homeassistant/components/neato/config_flow.py
+++ b/homeassistant/components/neato/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlowResult
 from homeassistant.helpers import config_entry_oauth2_flow
@@ -18,10 +18,12 @@ class OAuth2FlowHandler(
     DOMAIN = DOMAIN
 
     @property
+    @override
     def logger(self) -> logging.Logger:
         """Return logger."""
         return logging.getLogger(__name__)
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -47,6 +49,7 @@ class OAuth2FlowHandler(
             return self.async_show_form(step_id="reauth_confirm")
         return await self.async_step_user()
 
+    @override
     async def async_oauth_create_entry(self, data: dict[str, Any]) -> ConfigFlowResult:
         """Create an entry for the flow. Update an entry if one already exist."""
         current_entries = self._async_current_entries()

--- a/homeassistant/components/neato/sensor.py
+++ b/homeassistant/components/neato/sensor.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from pybotvac.exceptions import NeatoRobotException
 from pybotvac.robot import Robot
@@ -72,6 +72,7 @@ class NeatoSensor(NeatoEntity, SensorEntity):
         _LOGGER.debug("self._state=%s", self._state)
 
     @property
+    @override
     def native_value(self) -> str | None:
         """Return the state."""
         if self._state is not None:

--- a/homeassistant/components/neato/switch.py
+++ b/homeassistant/components/neato/switch.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from pybotvac.exceptions import NeatoRobotException
 from pybotvac.robot import Robot
@@ -89,12 +89,14 @@ class NeatoConnectedSwitch(NeatoEntity, SwitchEntity):
             )
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if switch is on."""
         return bool(
             self.type == SWITCH_TYPE_SCHEDULE and self._schedule_state == STATE_ON
         )
 
+    @override
     def turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         if self.type == SWITCH_TYPE_SCHEDULE:
@@ -106,6 +108,7 @@ class NeatoConnectedSwitch(NeatoEntity, SwitchEntity):
                     "Neato switch connection error '%s': %s", self.entity_id, ex
                 )
 
+    @override
     def turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         if self.type == SWITCH_TYPE_SCHEDULE:

--- a/homeassistant/components/neato/vacuum.py
+++ b/homeassistant/components/neato/vacuum.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from pybotvac import Robot
 from pybotvac.exceptions import NeatoRobotException
@@ -228,6 +228,7 @@ class NeatoConnectedVacuum(NeatoEntity, StateVacuumEntity):
                     )
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the vacuum cleaner."""
         data: dict[str, Any] = {}
@@ -258,6 +259,7 @@ class NeatoConnectedVacuum(NeatoEntity, StateVacuumEntity):
         return data
 
     @property
+    @override
     def device_info(self) -> DeviceInfo:
         """Device info for neato robot."""
         device_info = self._attr_device_info
@@ -267,6 +269,7 @@ class NeatoConnectedVacuum(NeatoEntity, StateVacuumEntity):
             device_info["sw_version"] = self._robot_stats["firmware"]
         return device_info
 
+    @override
     def start(self) -> None:
         """Start cleaning or resume cleaning."""
         if self._state:
@@ -281,6 +284,7 @@ class NeatoConnectedVacuum(NeatoEntity, StateVacuumEntity):
                     "Neato vacuum connection error for '%s': %s", self.entity_id, ex
                 )
 
+    @override
     def pause(self) -> None:
         """Pause the vacuum."""
         try:
@@ -291,6 +295,7 @@ class NeatoConnectedVacuum(NeatoEntity, StateVacuumEntity):
                 "Neato vacuum connection error for '%s': %s", self.entity_id, ex
             )
 
+    @override
     def return_to_base(self, **kwargs: Any) -> None:
         """Set the vacuum cleaner to return to the dock."""
         try:
@@ -304,6 +309,7 @@ class NeatoConnectedVacuum(NeatoEntity, StateVacuumEntity):
                 "Neato vacuum connection error for '%s': %s", self.entity_id, ex
             )
 
+    @override
     def stop(self, **kwargs: Any) -> None:
         """Stop the vacuum cleaner."""
         try:
@@ -314,6 +320,7 @@ class NeatoConnectedVacuum(NeatoEntity, StateVacuumEntity):
                 "Neato vacuum connection error for '%s': %s", self.entity_id, ex
             )
 
+    @override
     def locate(self, **kwargs: Any) -> None:
         """Locate the robot by making it emit a sound."""
         try:
@@ -324,6 +331,7 @@ class NeatoConnectedVacuum(NeatoEntity, StateVacuumEntity):
                 "Neato vacuum connection error for '%s': %s", self.entity_id, ex
             )
 
+    @override
     def clean_spot(self, **kwargs: Any) -> None:
         """Run a spot cleaning starting from the base."""
         try:

--- a/homeassistant/components/nederlandse_spoorwegen/binary_sensor.py
+++ b/homeassistant/components/nederlandse_spoorwegen/binary_sensor.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
 import logging
+from typing import override
 
 from ns_api import Trip
 
@@ -111,6 +112,7 @@ class NSBinarySensor(CoordinatorEntity[NSDataUpdateCoordinator], BinarySensorEnt
         )
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
         if not (trip := self.coordinator.data.first_trip):

--- a/homeassistant/components/nederlandse_spoorwegen/config_flow.py
+++ b/homeassistant/components/nederlandse_spoorwegen/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Nederlandse Spoorwegen integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from ns_api import NSAPI, Station
 from requests.exceptions import (
@@ -76,6 +76,7 @@ class NSConfigFlow(ConfigFlow, domain=DOMAIN):
                 return {"base": "already_configured"}
         return {}
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -124,6 +125,7 @@ class NSConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @classmethod
     @callback
+    @override
     def async_get_supported_subentry_types(
         cls, config_entry: ConfigEntry
     ) -> dict[str, type[ConfigSubentryFlow]]:

--- a/homeassistant/components/nederlandse_spoorwegen/coordinator.py
+++ b/homeassistant/components/nederlandse_spoorwegen/coordinator.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 import logging
+from typing import override
 
 from ns_api import NSAPI, Trip
 from requests.exceptions import ConnectionError, HTTPError, Timeout
@@ -77,6 +78,7 @@ class NSDataUpdateCoordinator(DataUpdateCoordinator[NSRouteResult]):
         self.via = subentry.data.get(CONF_VIA)
         self.departure_time = subentry.data.get(CONF_TIME)  # str | None
 
+    @override
     async def _async_update_data(self) -> NSRouteResult:
         """Fetch data from NS API for this specific route."""
         trips: list[Trip] = []

--- a/homeassistant/components/nederlandse_spoorwegen/sensor.py
+++ b/homeassistant/components/nederlandse_spoorwegen/sensor.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any
+from typing import Any, override
 
 from ns_api import Trip
 
@@ -205,6 +205,7 @@ class NSSensor(CoordinatorEntity[NSDataUpdateCoordinator], SensorEntity):
         )
 
     @property
+    @override
     def native_value(self) -> StateType | datetime:
         """Return the native value of the sensor."""
         data = (
@@ -218,6 +219,7 @@ class NSSensor(CoordinatorEntity[NSDataUpdateCoordinator], SensorEntity):
         return self.entity_description.value_fn(data)
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return the state attributes."""
         if self.entity_description.key != "actual_departure":

--- a/homeassistant/components/ness_alarm/alarm_control_panel.py
+++ b/homeassistant/components/ness_alarm/alarm_control_panel.py
@@ -1,6 +1,7 @@
 """Support for Ness D8X/D16X alarm panel."""
 
 import logging
+from typing import override
 
 from nessclient import ArmingMode, ArmingState, Client
 
@@ -69,6 +70,7 @@ class NessAlarmPanel(AlarmControlPanelEntity):
             features |= AlarmControlPanelEntityFeature.ARM_HOME
         self._attr_supported_features = features
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
         self.async_on_remove(
@@ -77,18 +79,22 @@ class NessAlarmPanel(AlarmControlPanelEntity):
             )
         )
 
+    @override
     async def async_alarm_disarm(self, code: str | None = None) -> None:
         """Send disarm command."""
         await self._client.disarm(code)
 
+    @override
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command."""
         await self._client.arm_away(code)
 
+    @override
     async def async_alarm_arm_home(self, code: str | None = None) -> None:
         """Send arm home command."""
         await self._client.arm_home(code)
 
+    @override
     async def async_alarm_trigger(self, code: str | None = None) -> None:
         """Send trigger/panic command."""
         await self._client.panic(code)

--- a/homeassistant/components/ness_alarm/binary_sensor.py
+++ b/homeassistant/components/ness_alarm/binary_sensor.py
@@ -1,5 +1,7 @@
 """Support for Ness D8X/D16X zone states - represented as binary sensors."""
 
+from typing import override
+
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
@@ -76,6 +78,7 @@ class NessZoneBinarySensor(BinarySensorEntity):
             identifiers={(DOMAIN, self._attr_unique_id)},
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
         self.async_on_remove(

--- a/homeassistant/components/ness_alarm/config_flow.py
+++ b/homeassistant/components/ness_alarm/config_flow.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 from types import MappingProxyType
-from typing import Any
+from typing import Any, override
 
 from nessclient import Client
 import voluptuous as vol
@@ -70,6 +70,7 @@ class NessAlarmConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @classmethod
     @callback
+    @override
     def async_get_supported_subentry_types(
         cls, config_entry: ConfigEntry
     ) -> dict[str, type[ConfigSubentryFlow]]:
@@ -80,6 +81,7 @@ class NessAlarmConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> OptionsFlow:
@@ -99,6 +101,7 @@ class NessAlarmConfigFlow(ConfigFlow, domain=DOMAIN):
         finally:
             await client.close()
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -4,6 +4,7 @@ from abc import ABC, abstractmethod
 import asyncio
 from http import HTTPStatus
 import logging
+from typing import override
 
 from aiohttp import ClientError, web
 from google_nest_sdm.camera_traits import CameraClipPreviewTrait
@@ -434,10 +435,12 @@ class NestEventMediaView(NestEventViewBase):
     url = "/api/nest/event_media/{device_id}/{event_token}"
     name = "api:nest:event_media"
 
+    @override
     async def load_media(self, nest_device: Device, event_token: str) -> Media | None:
         """Load the specified media."""
         return await nest_device.event_media_manager.get_media_from_token(event_token)
 
+    @override
     async def handle_media(self, media: Media) -> web.StreamResponse:
         """Process the specified media."""
         return web.Response(body=media.contents, content_type=media.content_type)
@@ -462,6 +465,7 @@ class NestEventMediaThumbnailView(NestEventViewBase):
         self._lock = asyncio.Lock()
         self.hass = hass
 
+    @override
     async def load_media(self, nest_device: Device, event_token: str) -> Media | None:
         """Load the specified media."""
         if CameraClipPreviewTrait.NAME in nest_device.traits:
@@ -473,6 +477,7 @@ class NestEventMediaThumbnailView(NestEventViewBase):
                 )
         return await nest_device.event_media_manager.get_media_from_token(event_token)
 
+    @override
     async def handle_media(self, media: Media) -> web.StreamResponse:
         """Start a GET request."""
         contents = media.contents

--- a/homeassistant/components/nest/api.py
+++ b/homeassistant/components/nest/api.py
@@ -2,7 +2,7 @@
 
 import datetime
 import logging
-from typing import cast
+from typing import cast, override
 
 from aiohttp import ClientSession
 from google.oauth2.credentials import Credentials
@@ -42,11 +42,13 @@ class AsyncConfigEntryAuth(AbstractAuth):
         self._client_id = client_id
         self._client_secret = client_secret
 
+    @override
     async def async_get_access_token(self) -> str:
         """Return a valid access token for SDM API."""
         await self._oauth_session.async_ensure_token_valid()
         return cast(str, self._oauth_session.token["access_token"])
 
+    @override
     async def async_get_creds(self) -> Credentials:
         """Return an OAuth credential for Pub/Sub Subscriber.
 
@@ -87,10 +89,12 @@ class AccessTokenAuthImpl(AbstractAuth):
         super().__init__(websession, host)
         self._access_token = access_token
 
+    @override
     async def async_get_access_token(self) -> str:
         """Return the access token."""
         return self._access_token
 
+    @override
     async def async_get_creds(self) -> Credentials:
         """Return an OAuth credential for Pub/Sub Subscriber."""
         return Credentials(  # type: ignore[no-untyped-call]

--- a/homeassistant/components/nest/camera.py
+++ b/homeassistant/components/nest/camera.py
@@ -7,6 +7,7 @@ import datetime
 import functools
 import logging
 from pathlib import Path
+from typing import override
 
 from google_nest_sdm.camera_traits import (
     CameraLiveStreamTrait,
@@ -152,6 +153,7 @@ class NestCameraBaseEntity(Camera, ABC):
         # The API "name" field is a unique device identifier.
         self._attr_unique_id = f"{self._device.name}-camera"
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Run when entity is added to register update signal handler."""
         self.async_on_remove(
@@ -173,11 +175,13 @@ class NestRTSPEntity(NestCameraBaseEntity):
         self._refresh_unsub: Callable[[], None] | None = None
 
     @property
+    @override
     def use_stream_for_stills(self) -> bool:
         """Always use the RTSP stream to generate snapshots."""
         return True
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available."""
         # Cameras are marked unavailable on stream errors in #54659 however nest
@@ -187,6 +191,7 @@ class NestRTSPEntity(NestCameraBaseEntity):
         # streams are fixed, just leave the streams as available.
         return True
 
+    @override
     async def stream_source(self) -> str | None:
         """Return the source of the stream."""
         async with self._create_stream_url_lock:
@@ -229,6 +234,7 @@ class NestRTSPEntity(NestCameraBaseEntity):
             self.stream.update_source(self._rtsp_stream.rtsp_stream_url)
         return self._rtsp_stream.expires_at
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Invalidates the RTSP token when unloaded."""
         await super().async_will_remove_from_hass()
@@ -262,6 +268,7 @@ class NestWebRTCEntity(NestCameraBaseEntity):
             return webrtc_stream.expires_at
         return None
 
+    @override
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
@@ -277,6 +284,7 @@ class NestWebRTCEntity(NestCameraBaseEntity):
         """Return placeholder image to use when no stream is available."""
         return PLACEHOLDER.read_bytes()
 
+    @override
     async def async_handle_async_webrtc_offer(
         self, offer_sdp: str, session_id: str, send_message: WebRTCSendMessage
     ) -> None:
@@ -298,6 +306,7 @@ class NestWebRTCEntity(NestCameraBaseEntity):
         )
         self._refresh_unsub[session_id] = refresh.unsub
 
+    @override
     async def async_on_webrtc_candidate(
         self, session_id: str, candidate: RTCIceCandidateInit
     ) -> None:
@@ -305,6 +314,7 @@ class NestWebRTCEntity(NestCameraBaseEntity):
         return
 
     @callback
+    @override
     def close_webrtc_session(self, session_id: str) -> None:
         """Close a WebRTC session."""
         if (stream := self._webrtc_sessions.pop(session_id, None)) is not None:
@@ -324,10 +334,12 @@ class NestWebRTCEntity(NestCameraBaseEntity):
         super().close_webrtc_session(session_id)
 
     @callback
+    @override
     def _async_get_webrtc_client_configuration(self) -> WebRTCClientConfiguration:
         """Return the WebRTC client configuration adjustable per integration."""
         return WebRTCClientConfiguration(data_channel="dataSendChannel")
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Invalidates the RTSP token when unloaded."""
         await super().async_will_remove_from_hass()

--- a/homeassistant/components/nest/climate.py
+++ b/homeassistant/components/nest/climate.py
@@ -1,7 +1,7 @@
 """Support for Google Nest SDM climate devices."""
 
 from datetime import timedelta
-from typing import Any, cast
+from typing import Any, cast, override
 
 from google_nest_sdm.device import Device
 from google_nest_sdm.device_traits import FanTrait, HumidityTrait, TemperatureTrait
@@ -118,10 +118,12 @@ class ThermostatEntity(ClimateEntity):
             self._attr_hvac_modes = []
 
     @property
+    @override
     def available(self) -> bool:
         """Return device availability."""
         return self._device_info.available
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Run when entity is added to register update signal handler."""
         self._attr_supported_features = self._get_supported_features()
@@ -130,6 +132,7 @@ class ThermostatEntity(ClimateEntity):
         )
 
     @property
+    @override
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
         if TemperatureTrait.NAME not in self._device.traits:
@@ -138,6 +141,7 @@ class ThermostatEntity(ClimateEntity):
         return trait.ambient_temperature_celsius
 
     @property
+    @override
     def current_humidity(self) -> float | None:
         """Return the current humidity."""
         if HumidityTrait.NAME not in self._device.traits:
@@ -146,6 +150,7 @@ class ThermostatEntity(ClimateEntity):
         return trait.ambient_humidity_percent
 
     @property
+    @override
     def target_temperature(self) -> float | None:
         """Return the temperature currently set to be reached."""
         if not (trait := self._target_temperature_trait):
@@ -157,6 +162,7 @@ class ThermostatEntity(ClimateEntity):
         return None
 
     @property
+    @override
     def target_temperature_high(self) -> float | None:
         """Return the upper bound target temperature."""
         if self.hvac_mode != HVACMode.HEAT_COOL:
@@ -166,6 +172,7 @@ class ThermostatEntity(ClimateEntity):
         return trait.cool_celsius
 
     @property
+    @override
     def target_temperature_low(self) -> float | None:
         """Return the lower bound target temperature."""
         if self.hvac_mode != HVACMode.HEAT_COOL:
@@ -194,6 +201,7 @@ class ThermostatEntity(ClimateEntity):
         return None
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode:
         """Return the current operation (e.g. heat, cool, idle)."""
         hvac_mode = HVACMode.OFF
@@ -204,6 +212,7 @@ class ThermostatEntity(ClimateEntity):
         return hvac_mode
 
     @property
+    @override
     def hvac_action(self) -> HVACAction | None:
         """Return the current HVAC action (heating, cooling)."""
         trait = self._device.traits[ThermostatHvacTrait.NAME]
@@ -212,6 +221,7 @@ class ThermostatEntity(ClimateEntity):
         return THERMOSTAT_HVAC_STATUS_MAP.get(trait.status)
 
     @property
+    @override
     def preset_mode(self) -> str:
         """Return the current active preset."""
         if ThermostatEcoTrait.NAME in self._device.traits:
@@ -220,6 +230,7 @@ class ThermostatEntity(ClimateEntity):
         return PRESET_NONE
 
     @property
+    @override
     def preset_modes(self) -> list[str]:
         """Return the available presets."""
         if ThermostatEcoTrait.NAME not in self._device.traits:
@@ -231,6 +242,7 @@ class ThermostatEntity(ClimateEntity):
         ]
 
     @property
+    @override
     def fan_mode(self) -> str:
         """Return the current fan mode."""
         if (
@@ -242,6 +254,7 @@ class ThermostatEntity(ClimateEntity):
         return FAN_OFF
 
     @property
+    @override
     def fan_modes(self) -> list[str]:
         """Return the list of available fan modes."""
         if (
@@ -267,6 +280,7 @@ class ThermostatEntity(ClimateEntity):
                 features |= ClimateEntityFeature.FAN_MODE
         return features
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         api_mode = THERMOSTAT_INV_MODE_MAP[hvac_mode]
@@ -278,6 +292,7 @@ class ThermostatEntity(ClimateEntity):
                 f"Error setting {self.entity_id} HVAC mode to {hvac_mode}: {err}"
             ) from err
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         hvac_mode = self.hvac_mode
@@ -313,6 +328,7 @@ class ThermostatEntity(ClimateEntity):
                 f"Error setting {self.entity_id} temperature to {kwargs}: {err}"
             ) from err
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new target preset mode."""
         if preset_mode not in self.preset_modes:
@@ -327,6 +343,7 @@ class ThermostatEntity(ClimateEntity):
                 f"Error setting {self.entity_id} preset mode to {preset_mode}: {err}"
             ) from err
 
+    @override
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""
         if fan_mode not in self.fan_modes:

--- a/homeassistant/components/nest/config_flow.py
+++ b/homeassistant/components/nest/config_flow.py
@@ -10,7 +10,7 @@ some overrides to custom steps inserted in the middle of the flow.
 
 from collections.abc import Iterable, Mapping
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from google_nest_sdm.admin_client import (
     DEFAULT_TOPIC_IAM_POLICY,
@@ -113,11 +113,13 @@ class NestFlowHandler(
         self._eligible_subscriptions: EligibleSubscriptions | None = None
 
     @property
+    @override
     def logger(self) -> logging.Logger:
         """Return logger."""
         return logging.getLogger(__name__)
 
     @property
+    @override
     def extra_authorize_data(self) -> dict[str, str]:
         """Extra data that needs to be appended to the authorize url."""
         return {
@@ -127,6 +129,7 @@ class NestFlowHandler(
             "prompt": "consent",
         }
 
+    @override
     async def async_generate_authorize_url(self) -> str:
         """Generate a url for the user to authorize based on user input."""
         project_id = self._data.get(CONF_PROJECT_ID)
@@ -134,6 +137,7 @@ class NestFlowHandler(
         authorize_url = OAUTH2_AUTHORIZE.format(project_id=project_id)
         return f"{authorize_url}{query}"
 
+    @override
     async def async_oauth_create_entry(self, data: dict[str, Any]) -> ConfigFlowResult:
         """Complete OAuth setup and finish pubsub or finish."""
         _LOGGER.debug("Finishing post-oauth configuration")
@@ -161,6 +165,7 @@ class NestFlowHandler(
             return self.async_show_form(step_id="reauth_confirm")
         return await self.async_step_user()
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/nest/event.py
+++ b/homeassistant/components/nest/event.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 import logging
+from typing import override
 
 from google_nest_sdm.device import Device
 from google_nest_sdm.event import EventMessage, EventType
@@ -124,6 +125,7 @@ class NestTraitEventEntity(EventEntity):
             self.async_write_ha_state()
             return
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Run when entity is added to attach an event listener."""
         self.async_on_remove(self._device.add_event_callback(self._async_handle_event))

--- a/homeassistant/components/nest/media_source.py
+++ b/homeassistant/components/nest/media_source.py
@@ -23,7 +23,7 @@ import logging
 import os
 import pathlib
 import shutil
-from typing import Any
+from typing import Any, override
 
 from google_nest_sdm.camera_traits import CameraClipPreviewTrait, CameraEventImageTrait
 from google_nest_sdm.device import Device
@@ -156,6 +156,7 @@ class NestEventMediaStore(EventMediaStore):
             datetime.timedelta(days=1),
         )
 
+    @override
     async def async_load(self) -> dict | None:
         """Load data."""
         if self._data is None:
@@ -168,6 +169,7 @@ class NestEventMediaStore(EventMediaStore):
                 self._data = data
         return self._data
 
+    @override
     async def async_save(self, data: dict) -> None:
         """Save data."""
         self._data = data
@@ -177,6 +179,7 @@ class NestEventMediaStore(EventMediaStore):
 
         self._store.async_delay_save(provide_data, STORAGE_SAVE_DELAY_SECONDS)
 
+    @override
     def get_media_key(self, device_id: str, event: ImageEventBase) -> str:
         """Return the filename to use for a new event."""
         if event.event_image_type != EventImageType.IMAGE:
@@ -190,6 +193,7 @@ class NestEventMediaStore(EventMediaStore):
             else "unknown_device"
         )
 
+    @override
     def get_image_media_key(self, device_id: str, event: ImageEventBase) -> str:
         """Return the filename for image media for an event."""
         device_id_str = self._map_device_id(device_id)
@@ -197,6 +201,7 @@ class NestEventMediaStore(EventMediaStore):
         event_type_str = EVENT_NAME_MAP.get(event.event_type, "event")
         return f"{device_id_str}/{time_str}-{event_type_str}.jpg"
 
+    @override
     def get_clip_preview_media_key(self, device_id: str, event: ImageEventBase) -> str:
         """Return the filename for clip preview media for an event session."""
         device_id_str = self._map_device_id(device_id)
@@ -204,6 +209,7 @@ class NestEventMediaStore(EventMediaStore):
         event_type_str = EVENT_NAME_MAP.get(event.event_type, "event")
         return f"{device_id_str}/{time_str}-{event_type_str}.mp4"
 
+    @override
     def get_clip_preview_thumbnail_media_key(
         self, device_id: str, event: ImageEventBase
     ) -> str:
@@ -217,6 +223,7 @@ class NestEventMediaStore(EventMediaStore):
         """Return the filename in storage for a media key."""
         return f"{self._media_path}/{media_key}"
 
+    @override
     async def async_load_media(self, media_key: str) -> bytes | None:
         """Load media content."""
         filename = self.get_media_filename(media_key)
@@ -234,6 +241,7 @@ class NestEventMediaStore(EventMediaStore):
             _LOGGER.error("Unable to read media file: %s %s", filename, err)
             return None
 
+    @override
     async def async_save_media(self, media_key: str, content: bytes) -> None:
         """Write media content."""
         filename = self.get_media_filename(media_key)
@@ -254,6 +262,7 @@ class NestEventMediaStore(EventMediaStore):
         except OSError as err:
             _LOGGER.error("Unable to write media file: %s %s", filename, err)
 
+    @override
     async def async_remove_media(self, media_key: str) -> None:
         """Remove media content."""
         filename = self.get_media_filename(media_key)
@@ -412,6 +421,7 @@ class NestMediaSource(MediaSource):
         super().__init__(DOMAIN)
         self.hass = hass
 
+    @override
     async def async_resolve_media(self, item: MediaSourceItem) -> PlayMedia:
         """Resolve media identifier to a url."""
         media_id: MediaId | None = parse_media_id(item.identifier)
@@ -444,6 +454,7 @@ class NestMediaSource(MediaSource):
             content_type,
         )
 
+    @override
     async def async_browse_media(self, item: MediaSourceItem) -> BrowseMediaSource:
         """Return media for the specified level of the directory tree.
 

--- a/homeassistant/components/nest/sensor.py
+++ b/homeassistant/components/nest/sensor.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime
 import logging
+from typing import override
 
 from google_nest_sdm.device import Device
 from google_nest_sdm.device_traits import FanTrait, HumidityTrait, TemperatureTrait
@@ -67,10 +68,12 @@ class SensorBase(SensorEntity):
         self._attr_device_info = self._device_info.device_info
 
     @property
+    @override
     def available(self) -> bool:
         """Return the device availability."""
         return self._device_info.available
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Run when entity is added to register update signal handler."""
         self.async_on_remove(
@@ -90,6 +93,7 @@ class TemperatureSensor(SensorBase):
         self._attr_unique_id = f"{device.name}-temperature"
 
     @property
+    @override
     def native_value(self) -> float:
         """Return the state of the sensor."""
         trait: TemperatureTrait = self._device.traits[TemperatureTrait.NAME]
@@ -111,6 +115,7 @@ class HumiditySensor(SensorBase):
         self._attr_unique_id = f"{device.name}-humidity"
 
     @property
+    @override
     def native_value(self) -> int:
         """Return the state of the sensor."""
         trait: HumidityTrait = self._device.traits[HumidityTrait.NAME]
@@ -131,6 +136,7 @@ class FanTimerSensor(SensorBase):
         self._attr_unique_id = f"{device.name}-fan-timer"
 
     @property
+    @override
     def native_value(self) -> datetime | None:
         """Return the state of the sensor."""
         trait: FanTrait = self._device.traits[FanTrait.NAME]

--- a/homeassistant/components/netatmo/api.py
+++ b/homeassistant/components/netatmo/api.py
@@ -1,7 +1,7 @@
 """API for Netatmo bound to HASS OAuth."""
 
 from collections.abc import Iterable
-from typing import cast
+from typing import cast, override
 
 from aiohttp import ClientSession
 import pyatmo
@@ -38,6 +38,7 @@ class AsyncConfigEntryNetatmoAuth(pyatmo.AbstractAsyncAuth):
         super().__init__(websession)
         self._oauth_session = oauth_session
 
+    @override
     async def async_get_access_token(self) -> str:
         """Return a valid access token for Netatmo API."""
         await self._oauth_session.async_ensure_token_valid()

--- a/homeassistant/components/netatmo/binary_sensor.py
+++ b/homeassistant/components/netatmo/binary_sensor.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
 import logging
-from typing import Any, Final, cast
+from typing import Any, Final, cast, override
 
 from pyatmo.modules.device_types import DeviceCategory as NetatmoDeviceCategory
 
@@ -303,6 +303,7 @@ class NetatmoBinarySensor(NetatmoModuleEntity, BinarySensorEntity):
             )
 
     @callback
+    @override
     def async_update_callback(self) -> None:
         """Update the entity's state."""
 
@@ -365,6 +366,7 @@ class NetatmoOpeningBinarySensor(NetatmoBinarySensor):
             self._attr_translation_key = translation_key
 
     @callback
+    @override
     def async_update_callback(self) -> None:
         """Update the entity's state."""
 

--- a/homeassistant/components/netatmo/button.py
+++ b/homeassistant/components/netatmo/button.py
@@ -1,6 +1,7 @@
 """Support for Netatmo/Bubendorff button."""
 
 import logging
+from typing import override
 
 from pyatmo import modules as NaModules
 
@@ -63,10 +64,12 @@ class NetatmoCoverPreferredPositionButton(NetatmoModuleEntity, ButtonEntity):
         )
 
     @callback
+    @override
     def async_update_callback(self) -> None:
         """Update the entity's state."""
         # No state to update for button
 
+    @override
     async def async_press(self) -> None:
         """Handle button press to move the cover to a preferred position."""
         _LOGGER.debug("Moving %s to a preferred position", self.device.entity_id)

--- a/homeassistant/components/netatmo/camera.py
+++ b/homeassistant/components/netatmo/camera.py
@@ -2,7 +2,7 @@
 # pylint: disable=home-assistant-use-runtime-data  # Uses legacy hass.data[DOMAIN] pattern
 
 import logging
-from typing import Any, cast
+from typing import Any, cast, override
 
 import aiohttp
 from pyatmo import ApiError as NetatmoApiError, modules as NaModules
@@ -123,6 +123,7 @@ class NetatmoCamera(NetatmoModuleEntity, Camera):
             ]
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Entity created."""
         await super().async_added_to_hass()
@@ -205,6 +206,7 @@ class NetatmoCamera(NetatmoModuleEntity, Camera):
             self.async_write_ha_state()
             return
 
+    @override
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
@@ -222,6 +224,7 @@ class NetatmoCamera(NetatmoModuleEntity, Camera):
         return None
 
     @property
+    @override
     def supported_features(self) -> CameraEntityFeature:
         """Return supported features."""
         supported_features = CameraEntityFeature.ON_OFF
@@ -230,6 +233,7 @@ class NetatmoCamera(NetatmoModuleEntity, Camera):
         return supported_features
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return entity specific state attributes."""
         return {
@@ -243,14 +247,17 @@ class NetatmoCamera(NetatmoModuleEntity, Camera):
             "light_state": self._light_state,
         }
 
+    @override
     async def async_turn_off(self) -> None:
         """Turn off camera."""
         await self.device.async_monitoring_off()
 
+    @override
     async def async_turn_on(self) -> None:
         """Turn on camera."""
         await self.device.async_monitoring_on()
 
+    @override
     async def stream_source(self) -> str:
         """Return the stream source."""
         if self.device.is_local:
@@ -261,6 +268,7 @@ class NetatmoCamera(NetatmoModuleEntity, Camera):
         return f"{self.device.vpn_url}/live/files/{self._quality}/index.m3u8"
 
     @callback
+    @override
     def async_update_callback(self) -> None:
         """Update the entity's state."""
         self._attr_is_on = self.device.alim_status is not None

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -2,7 +2,7 @@
 # pylint: disable=home-assistant-use-runtime-data  # Uses legacy hass.data[DOMAIN] pattern
 
 import logging
-from typing import Any, cast
+from typing import Any, cast, override
 
 from pyatmo.modules import NATherm1
 from pyatmo.modules.device_types import DeviceType
@@ -224,6 +224,7 @@ class NetatmoThermostat(NetatmoRoomEntity, ClimateEntity):
             f"{self.device.entity_id}-{device_type_to_str(self.device_type)}"
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Entity created."""
         await super().async_added_to_hass()
@@ -328,6 +329,7 @@ class NetatmoThermostat(NetatmoRoomEntity, ClimateEntity):
                 return
 
     @property
+    @override
     def hvac_action(self) -> HVACAction:
         """Return the current running hvac operation if supported."""
         if self.device_type != NA_VALVE and self._boilerstatus is not None:
@@ -339,6 +341,7 @@ class NetatmoThermostat(NetatmoRoomEntity, ClimateEntity):
             return HVACAction.HEATING
         return HVACAction.IDLE
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         if hvac_mode == HVACMode.OFF:
@@ -348,6 +351,7 @@ class NetatmoThermostat(NetatmoRoomEntity, ClimateEntity):
         elif hvac_mode == HVACMode.HEAT:
             await self.async_set_preset_mode(PRESET_BOOST)
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
         if (
@@ -380,6 +384,7 @@ class NetatmoThermostat(NetatmoRoomEntity, ClimateEntity):
 
         self.async_write_ha_state()
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature for 2 hours."""
         await self.device.async_therm_set(
@@ -387,6 +392,7 @@ class NetatmoThermostat(NetatmoRoomEntity, ClimateEntity):
         )
         self.async_write_ha_state()
 
+    @override
     async def async_turn_off(self) -> None:
         """Turn the entity off."""
         if self.device_type == NA_VALVE:
@@ -398,17 +404,20 @@ class NetatmoThermostat(NetatmoRoomEntity, ClimateEntity):
             await self.device.async_therm_set(STATE_NETATMO_OFF)
         self.async_write_ha_state()
 
+    @override
     async def async_turn_on(self) -> None:
         """Turn the entity on."""
         await self.device.async_therm_set(STATE_NETATMO_HOME)
         self.async_write_ha_state()
 
     @property
+    @override
     def available(self) -> bool:
         """If the device hasn't been able to connect, mark as unavailable."""
         return bool(self._connected)
 
     @callback
+    @override
     def async_update_callback(self) -> None:
         """Update the entity's state."""
         if not self.device.reachable:

--- a/homeassistant/components/netatmo/config_flow.py
+++ b/homeassistant/components/netatmo/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 import uuid
 
 import voluptuous as vol
@@ -38,6 +38,7 @@ class NetatmoFlowHandler(
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: NetatmoConfigEntry,
     ) -> OptionsFlow:
@@ -45,16 +46,19 @@ class NetatmoFlowHandler(
         return NetatmoOptionsFlowHandler(config_entry)
 
     @property
+    @override
     def logger(self) -> logging.Logger:
         """Return logger."""
         return logging.getLogger(__name__)
 
     @property
+    @override
     def extra_authorize_data(self) -> dict:
         """Extra data that needs to be appended to the authorize url."""
         scopes = get_api_scopes(self.flow_impl.domain)
         return {"scope": " ".join(scopes)}
 
+    @override
     async def async_step_user(self, user_input: dict | None = None) -> ConfigFlowResult:
         """Handle a flow start."""
         await self.async_set_unique_id(DOMAIN)
@@ -79,6 +83,7 @@ class NetatmoFlowHandler(
 
         return await self.async_step_user()
 
+    @override
     async def async_oauth_create_entry(self, data: dict) -> ConfigFlowResult:
         """Create an oauth config entry or update existing entry for reauth."""
         existing_entry = await self.async_set_unique_id(DOMAIN)

--- a/homeassistant/components/netatmo/cover.py
+++ b/homeassistant/components/netatmo/cover.py
@@ -1,7 +1,7 @@
 """Support for Netatmo/Bubendorff covers."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyatmo import modules as NaModules
 
@@ -75,27 +75,32 @@ class NetatmoCover(NetatmoModuleEntity, CoverEntity):
             f"{self.device.entity_id}-{device_type_to_str(self.device_type)}"
         )
 
+    @override
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
         await self.device.async_close()
         self._attr_is_closed = True
         self.async_write_ha_state()
 
+    @override
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
         await self.device.async_open()
         self._attr_is_closed = False
         self.async_write_ha_state()
 
+    @override
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
         await self.device.async_stop()
 
+    @override
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover shutter to a specific position."""
         await self.device.async_set_target_position(kwargs[ATTR_POSITION])
 
     @callback
+    @override
     def async_update_callback(self) -> None:
         """Update the entity's state."""
         self._attr_is_closed = self.device.current_position == 0

--- a/homeassistant/components/netatmo/entity.py
+++ b/homeassistant/components/netatmo/entity.py
@@ -1,7 +1,7 @@
 """Base class for Netatmo entities."""
 
 from abc import abstractmethod
-from typing import Any, cast
+from typing import Any, cast, override
 
 from pyatmo import DeviceType, Home, Module, Room
 from pyatmo.modules.base_class import NetatmoBase, Place
@@ -36,6 +36,7 @@ class NetatmoBaseEntity(Entity):
         self._publishers: list[dict[str, Any]] = []
         self._attr_extra_state_attributes = {}
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Entity created."""
         for publisher in self._publishers:
@@ -73,6 +74,7 @@ class NetatmoBaseEntity(Entity):
 
         self.async_update_callback()
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Run when entity will be removed from hass."""
         await super().async_will_remove_from_hass()
@@ -131,6 +133,7 @@ class NetatmoRoomEntity(NetatmoDeviceEntity):
             suggested_area=room.room.name,
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Entity created."""
         await super().async_added_to_hass()
@@ -143,6 +146,7 @@ class NetatmoRoomEntity(NetatmoDeviceEntity):
             self.hass.data[DOMAIN][DATA_DEVICE_IDS][self.device.entity_id] = device.id
 
     @property
+    @override
     def device_type(self) -> DeviceType:
         """Return the device type."""
         assert self.device.climate_type
@@ -167,6 +171,7 @@ class NetatmoModuleEntity(NetatmoDeviceEntity):
         )
 
     @property
+    @override
     def device_type(self) -> DeviceType:
         """Return the device type."""
         return self.device.device_type
@@ -202,6 +207,7 @@ class NetatmoWeatherModuleEntity(NetatmoModuleEntity):
                 )
 
     @property
+    @override
     def device_type(self) -> DeviceType:
         """Return the Netatmo device type."""
         if "." not in self.device.device_type:

--- a/homeassistant/components/netatmo/fan.py
+++ b/homeassistant/components/netatmo/fan.py
@@ -1,7 +1,7 @@
 """Support for Netatmo/Bubendorff fans."""
 
 import logging
-from typing import Final
+from typing import Final, override
 
 from pyatmo import modules as NaModules
 
@@ -67,11 +67,13 @@ class NetatmoFan(NetatmoModuleEntity, FanEntity):
             f"{self.device.entity_id}-{device_type_to_str(self.device_type)}"
         )
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode of the fan."""
         await self.device.async_set_fan_speed(PRESET_MAPPING[preset_mode])
 
     @callback
+    @override
     def async_update_callback(self) -> None:
         """Update the entity's state."""
         if self.device.fan_speed is None:

--- a/homeassistant/components/netatmo/light.py
+++ b/homeassistant/components/netatmo/light.py
@@ -1,7 +1,7 @@
 """Support for the Netatmo camera lights."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyatmo import modules as NaModules
 
@@ -87,6 +87,7 @@ class NetatmoCameraLight(NetatmoModuleEntity, LightEntity):
             ]
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Entity created."""
         await super().async_added_to_hass()
@@ -118,21 +119,25 @@ class NetatmoCameraLight(NetatmoModuleEntity, LightEntity):
             return
 
     @property
+    @override
     def available(self) -> bool:
         """If the webhook is not established, mark as unavailable."""
         return bool(self.data_handler.webhook)
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn camera floodlight on."""
         _LOGGER.debug("Turn camera '%s' on", self.name)
         await self.device.async_floodlight_on()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn camera floodlight into auto mode."""
         _LOGGER.debug("Turn camera '%s' to auto mode", self.name)
         await self.device.async_floodlight_auto()
 
     @callback
+    @override
     def async_update_callback(self) -> None:
         """Update the entity's state."""
         self._attr_is_on = bool(self.device.floodlight == "on")
@@ -168,6 +173,7 @@ class NetatmoLight(NetatmoModuleEntity, LightEntity):
             ]
         )
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn light on."""
         if ATTR_BRIGHTNESS in kwargs:
@@ -181,6 +187,7 @@ class NetatmoLight(NetatmoModuleEntity, LightEntity):
         self._attr_is_on = True
         self.async_write_ha_state()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn light off."""
         await self.device.async_off()
@@ -188,6 +195,7 @@ class NetatmoLight(NetatmoModuleEntity, LightEntity):
         self.async_write_ha_state()
 
     @callback
+    @override
     def async_update_callback(self) -> None:
         """Update the entity's state."""
         self._attr_is_on = self.device.on is True

--- a/homeassistant/components/netatmo/media_source.py
+++ b/homeassistant/components/netatmo/media_source.py
@@ -4,6 +4,7 @@
 import datetime as dt
 import logging
 import re
+from typing import override
 
 from homeassistant.components.media_player import BrowseError, MediaClass, MediaType
 from homeassistant.components.media_source import (
@@ -42,12 +43,14 @@ class NetatmoSource(MediaSource):
         self.hass = hass
         self.events = self.hass.data[DOMAIN][DATA_EVENTS]
 
+    @override
     async def async_resolve_media(self, item: MediaSourceItem) -> PlayMedia:
         """Resolve media to a url."""
         _, camera_id, event_id = async_parse_identifier(item)
         url = self.events[camera_id][event_id]["media_url"]
         return PlayMedia(url, MIME_TYPE)
 
+    @override
     async def async_browse_media(self, item: MediaSourceItem) -> BrowseMediaSource:
         """Return media."""
         try:

--- a/homeassistant/components/netatmo/select.py
+++ b/homeassistant/components/netatmo/select.py
@@ -2,6 +2,7 @@
 # pylint: disable=home-assistant-use-runtime-data  # Uses legacy hass.data[DOMAIN] pattern
 
 import logging
+from typing import override
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.core import HomeAssistant, callback
@@ -77,6 +78,7 @@ class NetatmoScheduleSelect(NetatmoBaseEntity, SelectEntity):
             schedule.name for schedule in self.home.schedules.values() if schedule.name
         ]
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Entity created."""
         await super().async_added_to_hass()
@@ -104,6 +106,7 @@ class NetatmoScheduleSelect(NetatmoBaseEntity, SelectEntity):
                 self._attr_current_option = schedule.name
                 self.async_write_ha_state()
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         for sid, schedule in self.hass.data[DOMAIN][DATA_SCHEDULES][
@@ -121,6 +124,7 @@ class NetatmoScheduleSelect(NetatmoBaseEntity, SelectEntity):
             break
 
     @callback
+    @override
     def async_update_callback(self) -> None:
         """Update the entity's state."""
         schedule = self.home.get_selected_schedule()

--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
 import logging
-from typing import Any, Final, cast
+from typing import Any, Final, cast, override
 
 import pyatmo
 from pyatmo.modules import PublicWeatherArea
@@ -660,6 +660,7 @@ class NetatmoBaseSensor(NetatmoModuleEntity, SensorEntity):
     # and meter sensors to prevent breaking changes, as they
     # were the first ones implemented.
     @callback
+    @override
     def async_update_callback(self) -> None:
         """Update the entity's state (the legacy way)."""
         # Keep the last known value for these legacy sensors when the device is
@@ -695,6 +696,7 @@ class NetatmoWeatherSensor(NetatmoWeatherModuleEntity, NetatmoBaseSensor):
         self._attr_unique_id = f"{self.device.entity_id}-{description.key}"
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available."""
         return (
@@ -707,6 +709,7 @@ class NetatmoWeatherSensor(NetatmoWeatherModuleEntity, NetatmoBaseSensor):
         )
 
     @callback
+    @override
     def async_update_callback(self) -> None:
         """Update the entity's state."""
         value = cast(
@@ -785,6 +788,7 @@ class NetatmoClimateBatterySensor(NetatmoLegacySensor):
         )
 
     @callback
+    @override
     def async_update_callback(self) -> None:
         """Update the entity's state."""
         if not self.device.reachable:
@@ -829,6 +833,7 @@ class NetatmoSensor(NetatmoBaseSensor):
     # except is_sticky, otherwise it is set to the
     # processed value
     @callback
+    @override
     def async_update_callback(self) -> None:
         """Update the entity's state."""
         if not self.device.reachable:
@@ -884,6 +889,7 @@ class NetatmoRoomSensor(NetatmoRoomEntity, SensorEntity):
         )
 
     @callback
+    @override
     def async_update_callback(self) -> None:
         """Update the entity's state."""
         if (state := getattr(self.device, self.entity_description.key)) is None:
@@ -943,6 +949,7 @@ class NetatmoPublicSensor(NetatmoBaseEntity, SensorEntity):
             configuration_url=CONF_URL_PUBLIC_WEATHER,
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Entity created."""
         await super().async_added_to_hass()
@@ -979,6 +986,7 @@ class NetatmoPublicSensor(NetatmoBaseEntity, SensorEntity):
         )
 
     @callback
+    @override
     def async_update_callback(self) -> None:
         """Update the entity's state."""
         data = self.entity_description.value_fn(self._station)

--- a/homeassistant/components/netatmo/switch.py
+++ b/homeassistant/components/netatmo/switch.py
@@ -1,7 +1,7 @@
 """Support for Netatmo/BTicino/Legrande switches."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyatmo import modules as NaModules
 
@@ -65,16 +65,19 @@ class NetatmoSwitch(NetatmoModuleEntity, SwitchEntity):
         self._attr_is_on = self.device.on
 
     @callback
+    @override
     def async_update_callback(self) -> None:
         """Update the entity's state."""
         self._attr_is_on = self.device.on
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the zone on."""
         await self.device.async_on()
         self._attr_is_on = True
         self.async_write_ha_state()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the zone off."""
         await self.device.async_off()

--- a/homeassistant/components/netdata/sensor.py
+++ b/homeassistant/components/netdata/sensor.py
@@ -1,6 +1,7 @@
 """Support gathering system information of hosts which are running netdata."""
 
 import logging
+from typing import override
 
 from netdata import Netdata
 from netdata.exceptions import NetdataError
@@ -121,6 +122,7 @@ class NetdataSensor(SensorEntity):
         self._invert = invert
 
     @property
+    @override
     def available(self) -> bool:
         """Could the resource be accessed during the last update call."""
         return self.netdata.available
@@ -145,6 +147,7 @@ class NetdataAlarms(SensorEntity):
         self._port = port
 
     @property
+    @override
     def icon(self) -> str:
         """Status symbol if type is symbol."""
         if self._attr_native_value == "ok":
@@ -156,6 +159,7 @@ class NetdataAlarms(SensorEntity):
         return "mdi:crosshairs-question"
 
     @property
+    @override
     def available(self) -> bool:
         """Could the resource be accessed during the last update call."""
         return self.netdata.available

--- a/homeassistant/components/netgear/button.py
+++ b/homeassistant/components/netgear/button.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.button import (
     ButtonDeviceClass,
@@ -65,11 +65,13 @@ class NetgearRouterButtonEntity(NetgearRouterCoordinatorEntity, ButtonEntity):
             f"{coordinator.router.serial_number}-{entity_description.key}"
         )
 
+    @override
     async def async_press(self) -> None:
         """Triggers the button press service."""
         async_action = self.entity_description.action(self._router)
         await async_action()
 
     @callback
+    @override
     def async_update_device(self) -> None:
         """Update the Netgear device."""

--- a/homeassistant/components/netgear/config_flow.py
+++ b/homeassistant/components/netgear/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow to configure the Netgear integration."""
 
 import logging
-from typing import Any, cast
+from typing import Any, cast, override
 from urllib.parse import urlparse
 
 from pynetgear import DEFAULT_HOST, DEFAULT_PORT, DEFAULT_USER
@@ -104,6 +104,7 @@ class NetgearFlowHandler(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> OptionsFlowHandler:
@@ -131,6 +132,7 @@ class NetgearFlowHandler(ConfigFlow, domain=DOMAIN):
             description_placeholders=self.placeholders,
         )
 
+    @override
     async def async_step_ssdp(
         self, discovery_info: SsdpServiceInfo
     ) -> ConfigFlowResult:
@@ -176,6 +178,7 @@ class NetgearFlowHandler(ConfigFlow, domain=DOMAIN):
 
         return await self.async_step_user()
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/netgear/coordinator.py
+++ b/homeassistant/components/netgear/coordinator.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -70,6 +70,7 @@ class NetgearTrackerCoordinator(NetgearDataCoordinator[bool]):
             hass, router, entry, name="Devices", update_interval=SCAN_INTERVAL
         )
 
+    @override
     async def _async_update_data(self) -> bool:
         """Fetch data from the router."""
         if self.router.track_devices:
@@ -88,6 +89,7 @@ class NetgearTrafficMeterCoordinator(NetgearDataCoordinator[dict[str, Any] | Non
             hass, router, entry, name="Traffic meter", update_interval=SCAN_INTERVAL
         )
 
+    @override
     async def _async_update_data(self) -> dict[str, Any] | None:
         """Fetch data from the router."""
         return await self.router.async_get_traffic_meter()
@@ -104,6 +106,7 @@ class NetgearSpeedTestCoordinator(NetgearDataCoordinator[dict[str, Any] | None])
             hass, router, entry, name="Speed test", update_interval=SPEED_TEST_INTERVAL
         )
 
+    @override
     async def _async_update_data(self) -> dict[str, Any] | None:
         """Fetch data from the router."""
         return await self.router.async_get_speed_test()
@@ -120,6 +123,7 @@ class NetgearFirmwareCoordinator(NetgearDataCoordinator[dict[str, Any] | None]):
             hass, router, entry, name="Firmware", update_interval=SCAN_INTERVAL_FIRMWARE
         )
 
+    @override
     async def _async_update_data(self) -> dict[str, Any] | None:
         """Check for new firmware of the router."""
         return await self.router.async_check_new_firmware()
@@ -136,6 +140,7 @@ class NetgearUtilizationCoordinator(NetgearDataCoordinator[dict[str, Any] | None
             hass, router, entry, name="Utilization", update_interval=SCAN_INTERVAL
         )
 
+    @override
     async def _async_update_data(self) -> dict[str, Any] | None:
         """Fetch data from the router."""
         return await self.router.async_get_utilization()
@@ -156,6 +161,7 @@ class NetgearLinkCoordinator(NetgearDataCoordinator[dict[str, Any] | None]):
             update_interval=SCAN_INTERVAL,
         )
 
+    @override
     async def _async_update_data(self) -> dict[str, Any] | None:
         """Fetch data from the router."""
         return await self.router.async_get_link_status()

--- a/homeassistant/components/netgear/device_tracker.py
+++ b/homeassistant/components/netgear/device_tracker.py
@@ -1,6 +1,7 @@
 """Support for Netgear routers."""
 
 import logging
+from typing import override
 
 from homeassistant.components.device_tracker import ScannerEntity
 from homeassistant.core import HomeAssistant, callback
@@ -70,6 +71,7 @@ class NetgearScannerEntity(NetgearDeviceEntity, ScannerEntity):
         return hostname
 
     @callback
+    @override
     def async_update_device(self) -> None:
         """Update the Netgear device."""
         self._device = self._router.devices[self._mac]
@@ -77,26 +79,31 @@ class NetgearScannerEntity(NetgearDeviceEntity, ScannerEntity):
         self._icon = DEVICE_ICONS.get(self._device["device_type"], "mdi:help-network")
 
     @property
+    @override
     def is_connected(self) -> bool:
         """Return true if the device is connected to the router."""
         return self._active
 
     @property
+    @override
     def ip_address(self) -> str:
         """Return the IP address."""
         return self._device["ip"]
 
     @property
+    @override
     def mac_address(self) -> str:
         """Return the mac address."""
         return self._mac
 
     @property
+    @override
     def hostname(self) -> str | None:
         """Return the hostname."""
         return self._hostname
 
     @property
+    @override
     def icon(self) -> str:
         """Return the icon."""
         return self._icon

--- a/homeassistant/components/netgear/entity.py
+++ b/homeassistant/components/netgear/entity.py
@@ -1,7 +1,7 @@
 """Represent the Netgear router and its devices."""
 
 from abc import abstractmethod
-from typing import Any
+from typing import Any, override
 
 from homeassistant.const import CONF_HOST
 from homeassistant.core import callback
@@ -54,6 +54,7 @@ class NetgearDeviceEntity(CoordinatorEntity[NetgearTrackerCoordinator]):
         """Update the Netgear device."""
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self.async_update_device()
@@ -101,6 +102,7 @@ class NetgearRouterCoordinatorEntity[T: NetgearDataCoordinator[Any]](
         """Update the Netgear device."""
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self.async_update_device()

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from datetime import date, datetime
 from decimal import Decimal
 import logging
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.sensor import (
     RestoreSensor,
@@ -338,16 +338,19 @@ class NetgearSensorEntity(NetgearDeviceEntity, SensorEntity):
         self._state = device.get(attribute)
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return super().available and self._device.get(self._attribute) is not None
 
     @property
+    @override
     def native_value(self):
         """Return the state of the sensor."""
         return self._state
 
     @callback
+    @override
     def async_update_device(self) -> None:
         """Update the Netgear device."""
         self._device = self._router.devices[self._mac]
@@ -380,10 +383,12 @@ class NetgearRouterSensorEntity(NetgearRouterCoordinatorEntity, RestoreSensor):
         self.async_update_device()
 
     @property
+    @override
     def native_value(self):
         """Return the state of the sensor."""
         return self._value
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Handle entity which will be added."""
         await super().async_added_to_hass()
@@ -395,6 +400,7 @@ class NetgearRouterSensorEntity(NetgearRouterCoordinatorEntity, RestoreSensor):
                 await self.coordinator.async_request_refresh()
 
     @callback
+    @override
     def async_update_device(self) -> None:
         """Update the Netgear device."""
         if self.coordinator.data is None:

--- a/homeassistant/components/netgear/switch.py
+++ b/homeassistant/components/netgear/switch.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from pynetgear import ALLOW, BLOCK
 
@@ -157,17 +157,20 @@ class NetgearAllowBlock(NetgearDeviceEntity, SwitchEntity):
         self._attr_unique_id = f"{self._mac}-{entity_description.key}"
         self.async_update_device()
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         await self._router.async_allow_block_device(self._mac, ALLOW)
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         await self._router.async_allow_block_device(self._mac, BLOCK)
         await self.coordinator.async_request_refresh()
 
     @callback
+    @override
     def async_update_device(self) -> None:
         """Update the Netgear device."""
         self._device = self._router.devices[self._mac]
@@ -197,6 +200,7 @@ class NetgearRouterSwitchEntity(NetgearRouterEntity, SwitchEntity):
         self._attr_is_on = None
         self._attr_available = False
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Fetch state when entity is added."""
         await self.async_update()
@@ -214,6 +218,7 @@ class NetgearRouterSwitchEntity(NetgearRouterEntity, SwitchEntity):
             self._attr_is_on = response
             self._attr_available = True
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         async with self._router.api_lock:
@@ -221,6 +226,7 @@ class NetgearRouterSwitchEntity(NetgearRouterEntity, SwitchEntity):
                 self.entity_description.action(self._router), True
             )
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         async with self._router.api_lock:

--- a/homeassistant/components/netgear/update.py
+++ b/homeassistant/components/netgear/update.py
@@ -1,7 +1,7 @@
 """Update entities for Netgear devices."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.update import (
     UpdateDeviceClass,
@@ -46,6 +46,7 @@ class NetgearUpdateEntity(
         self._attr_unique_id = f"{coordinator.router.serial_number}-update"
 
     @property
+    @override
     def installed_version(self) -> str | None:
         """Version currently in use."""
         if self.coordinator.data is not None:
@@ -53,6 +54,7 @@ class NetgearUpdateEntity(
         return None
 
     @property
+    @override
     def latest_version(self) -> str | None:
         """Latest version available for install."""
         if self.coordinator.data is not None:
@@ -64,12 +66,14 @@ class NetgearUpdateEntity(
         return self.installed_version
 
     @property
+    @override
     def release_summary(self) -> str | None:
         """Release summary."""
         if self.coordinator.data is not None:
             return self.coordinator.data.get("ReleaseNote")
         return None
 
+    @override
     async def async_install(
         self, version: str | None, backup: bool, **kwargs: Any
     ) -> None:
@@ -77,5 +81,6 @@ class NetgearUpdateEntity(
         await self._router.async_update_new_firmware()
 
     @callback
+    @override
     def async_update_device(self) -> None:
         """Update the Netgear device."""

--- a/homeassistant/components/netgear_lte/binary_sensor.py
+++ b/homeassistant/components/netgear_lte/binary_sensor.py
@@ -1,5 +1,7 @@
 """Support for Netgear LTE binary sensors."""
 
+from typing import override
+
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
@@ -49,6 +51,7 @@ class NetgearLTEBinarySensor(LTEEntity, BinarySensorEntity):
     """Netgear LTE binary sensor entity."""
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if the binary sensor is on."""
         return getattr(self.coordinator.data, self.entity_description.key)

--- a/homeassistant/components/netgear_lte/config_flow.py
+++ b/homeassistant/components/netgear_lte/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for Netgear LTE integration."""
 
-from typing import Any
+from typing import Any, override
 
 from aiohttp.cookiejar import CookieJar
 from eternalegypt import Error, Modem
@@ -18,6 +18,7 @@ from .const import DEFAULT_HOST, DOMAIN, MANUFACTURER
 class NetgearLTEFlowHandler(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Netgear LTE."""
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/netgear_lte/coordinator.py
+++ b/homeassistant/components/netgear_lte/coordinator.py
@@ -1,6 +1,7 @@
 """Data update coordinator for the Netgear LTE integration."""
 
 from datetime import timedelta
+from typing import override
 
 from eternalegypt.eternalegypt import Error, Information, Modem
 
@@ -34,6 +35,7 @@ class NetgearLTEDataUpdateCoordinator(DataUpdateCoordinator[Information]):
         )
         self.modem = modem
 
+    @override
     async def _async_update_data(self) -> Information:
         """Get the latest data."""
         try:

--- a/homeassistant/components/netgear_lte/notify.py
+++ b/homeassistant/components/netgear_lte/notify.py
@@ -1,6 +1,6 @@
 """Support for Netgear LTE notifications."""
 
-from typing import Any
+from typing import Any, override
 
 import eternalegypt
 from eternalegypt.eternalegypt import Modem
@@ -38,6 +38,7 @@ class NetgearNotifyService(BaseNotificationService):
         self.modem: Modem = discovery_info["modem"]
         discovery_info["entry"].async_on_unload(self.async_unregister_services)
 
+    @override
     async def async_send_message(self, message: str = "", **kwargs: Any) -> None:
         """Send a message to a user."""
 

--- a/homeassistant/components/netgear_lte/sensor.py
+++ b/homeassistant/components/netgear_lte/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from eternalegypt.eternalegypt import Information
 
@@ -137,6 +138,7 @@ class NetgearLTESensor(LTEEntity, SensorEntity):
     entity_description: NetgearLTESensorEntityDescription
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
         if self.entity_description.value_fn is not None:

--- a/homeassistant/components/netio/switch.py
+++ b/homeassistant/components/netio/switch.py
@@ -3,7 +3,7 @@
 from collections import namedtuple
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from pynetio import Netio
 import voluptuous as vol
@@ -146,19 +146,23 @@ class NetioSwitch(SwitchEntity):
         self.netio = netio
 
     @property
+    @override
     def name(self):
         """Return the device's name."""
         return self._name
 
     @property
+    @override
     def available(self) -> bool:
         """Return true if entity is available."""
         return not hasattr(self, "telnet")
 
+    @override
     def turn_on(self, **kwargs: Any) -> None:
         """Turn switch on."""
         self._set(True)
 
+    @override
     def turn_off(self, **kwargs: Any) -> None:
         """Turn switch off."""
         self._set(False)
@@ -172,6 +176,7 @@ class NetioSwitch(SwitchEntity):
         self.schedule_update_ha_state()
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return the switch's status."""
         return self.netio.states[int(self.outlet) - 1]

--- a/homeassistant/components/neurio_energy/sensor.py
+++ b/homeassistant/components/neurio_energy/sensor.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import logging
+from typing import override
 
 import neurio
 import requests.exceptions
@@ -198,16 +199,19 @@ class NeurioEnergy(SensorEntity):
             self._attr_state_class = SensorStateClass.TOTAL_INCREASING
 
     @property
+    @override
     def name(self):
         """Return the name of the sensor."""
         return self._name
 
     @property
+    @override
     def native_value(self):
         """Return the state of the sensor."""
         return self._state
 
     @property
+    @override
     def native_unit_of_measurement(self):
         """Return the unit of measurement of this entity, if any."""
         return self._unit_of_measurement

--- a/homeassistant/components/nexia/binary_sensor.py
+++ b/homeassistant/components/nexia/binary_sensor.py
@@ -1,5 +1,7 @@
 """Support for Nexia / Trane XL Thermostats."""
 
+from typing import override
+
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -53,6 +55,7 @@ class NexiaBinarySensor(NexiaThermostatEntity, BinarySensorEntity):
         self._attr_translation_key = translation_key
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return the status of the sensor."""
         return getattr(self._thermostat, self._call)()

--- a/homeassistant/components/nexia/climate.py
+++ b/homeassistant/components/nexia/climate.py
@@ -1,6 +1,6 @@
 """Support for Nexia / Trane XL thermostats."""
 
-from typing import Any
+from typing import Any, override
 
 from nexia.const import (
     HOLD_PERMANENT,
@@ -197,15 +197,18 @@ class NexiaZone(NexiaThermostatZoneEntity, ClimateEntity):
         return self._thermostat.is_blower_active()
 
     @property
+    @override
     def current_temperature(self) -> int:
         """Return the current temperature."""
         return self._zone.get_temperature()
 
     @property
+    @override
     def fan_mode(self) -> str | None:
         """Return the fan setting."""
         return self._thermostat.get_fan_mode()
 
+    @override
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""
         await self._thermostat.set_fan_mode(fan_mode)
@@ -223,10 +226,12 @@ class NexiaZone(NexiaThermostatZoneEntity, ClimateEntity):
         self._signal_thermostat_update()
 
     @property
+    @override
     def preset_mode(self) -> str | None:
         """Preset that is active."""
         return self._zone.get_preset()
 
+    @override
     async def async_set_humidity(self, humidity: int) -> None:
         """Set humidity targets.
 
@@ -249,6 +254,7 @@ class NexiaZone(NexiaThermostatZoneEntity, ClimateEntity):
         self._signal_thermostat_update()
 
     @property
+    @override
     def target_humidity(self) -> float | None:
         """Humidity indoors setpoint.
 
@@ -273,6 +279,7 @@ class NexiaZone(NexiaThermostatZoneEntity, ClimateEntity):
         return None
 
     @property
+    @override
     def current_humidity(self) -> float | None:
         """Humidity indoors."""
         if self._has_relative_humidity:
@@ -280,6 +287,7 @@ class NexiaZone(NexiaThermostatZoneEntity, ClimateEntity):
         return None
 
     @property
+    @override
     def target_temperature(self) -> int | None:
         """Temperature we try to reach."""
         current_mode = self._zone.get_current_mode()
@@ -291,6 +299,7 @@ class NexiaZone(NexiaThermostatZoneEntity, ClimateEntity):
         return None
 
     @property
+    @override
     def target_temperature_high(self) -> int | None:
         """Highest temperature we are trying to reach."""
         current_mode = self._zone.get_current_mode()
@@ -300,6 +309,7 @@ class NexiaZone(NexiaThermostatZoneEntity, ClimateEntity):
         return self._zone.get_cooling_setpoint()
 
     @property
+    @override
     def target_temperature_low(self) -> int | None:
         """Lowest temperature we are trying to reach."""
         current_mode = self._zone.get_current_mode()
@@ -309,6 +319,7 @@ class NexiaZone(NexiaThermostatZoneEntity, ClimateEntity):
         return self._zone.get_heating_setpoint()
 
     @property
+    @override
     def hvac_action(self) -> HVACAction:
         """Operation ie. heat, cool, idle."""
         system_status = self._thermostat.get_system_status()
@@ -327,6 +338,7 @@ class NexiaZone(NexiaThermostatZoneEntity, ClimateEntity):
         return HVACAction.IDLE
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode:
         """Return current mode, as the user-visible name."""
         mode = self._zone.get_requested_mode()
@@ -342,6 +354,7 @@ class NexiaZone(NexiaThermostatZoneEntity, ClimateEntity):
 
         return NEXIA_TO_HA_HVAC_MODE_MAP[mode]
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set target temperature."""
         new_heat_temp = kwargs.get(ATTR_TARGET_TEMP_LOW)
@@ -382,6 +395,7 @@ class NexiaZone(NexiaThermostatZoneEntity, ClimateEntity):
         self._signal_zone_update()
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, str] | None:
         """Return the device specific state attributes."""
         if not self._has_relative_humidity:
@@ -398,21 +412,25 @@ class NexiaZone(NexiaThermostatZoneEntity, ClimateEntity):
             attrs[ATTR_HUMIDIFY_SETPOINT] = humdify_setpoint
         return attrs
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode."""
         await self._zone.set_preset(preset_mode)
         self._signal_zone_update()
 
+    @override
     async def async_turn_off(self) -> None:
         """Turn off the zone."""
         await self.async_set_hvac_mode(HVACMode.OFF)
         self._signal_zone_update()
 
+    @override
     async def async_turn_on(self) -> None:
         """Turn on the zone."""
         await self.async_set_hvac_mode(HVACMode.AUTO)
         self._signal_zone_update()
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set the system mode (Auto, Heat_Cool, Cool, Heat, etc)."""
         if hvac_mode == HVACMode.OFF:

--- a/homeassistant/components/nexia/config_flow.py
+++ b/homeassistant/components/nexia/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Nexia integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 import aiohttp
 from nexia.const import BRAND_ASAIR, BRAND_NEXIA, BRAND_TRANE
@@ -83,6 +83,7 @@ class NexiaConfigFlow(ConfigFlow, domain=DOMAIN):
     VERSION = 1
     MINOR_VERSION = 2
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/nexia/coordinator.py
+++ b/homeassistant/components/nexia/coordinator.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from nexia.home import NexiaHome
 
@@ -37,6 +37,7 @@ class NexiaDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             always_update=False,
         )
 
+    @override
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from API endpoint."""
         return await self.nexia_home.update()

--- a/homeassistant/components/nexia/entity.py
+++ b/homeassistant/components/nexia/entity.py
@@ -1,6 +1,6 @@
 """The nexia integration base entity."""
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from nexia.thermostat import NexiaThermostat
 from nexia.zone import NexiaThermostatZone
@@ -64,6 +64,7 @@ class NexiaThermostatEntity(NexiaEntity):
         )
         self._thermostat_signal = f"{SIGNAL_THERMOSTAT_UPDATE}-{thermostat_id}"
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Listen for signals for services."""
         await super().async_added_to_hass()
@@ -87,6 +88,7 @@ class NexiaThermostatEntity(NexiaEntity):
         async_dispatcher_send(self.hass, self._thermostat_signal)
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if thermostat is available and data is available."""
         return super().available and self._thermostat.is_online
@@ -115,6 +117,7 @@ class NexiaThermostatZoneEntity(NexiaThermostatEntity):
         }
         self._zone_signal = f"{SIGNAL_ZONE_UPDATE}-{zone.zone_id}"
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Listen for signals for services."""
         await super().async_added_to_hass()

--- a/homeassistant/components/nexia/number.py
+++ b/homeassistant/components/nexia/number.py
@@ -1,5 +1,7 @@
 """Support for Nexia / Trane XL Thermostats."""
 
+from typing import override
+
 from nexia.thermostat import NexiaThermostat
 
 from homeassistant.components.number import NumberEntity
@@ -57,11 +59,13 @@ class NexiaFanSpeedEntity(NexiaThermostatEntity, NumberEntity):
         self._attr_native_max_value = percent_conv(max_value)
 
     @property
+    @override
     def native_value(self) -> float:
         """Return the current value."""
         fan_speed = self._thermostat.get_fan_speed_setpoint()
         return percent_conv(fan_speed)
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Set a new value."""
         await self._thermostat.set_fan_setpoint(value / 100)

--- a/homeassistant/components/nexia/scene.py
+++ b/homeassistant/components/nexia/scene.py
@@ -1,6 +1,6 @@
 """Support for Nexia Automations."""
 
-from typing import Any
+from typing import Any, override
 
 from nexia.automation import NexiaAutomation
 
@@ -47,6 +47,7 @@ class NexiaAutomationScene(NexiaEntity, Scene):
         self._automation = automation
         self._attr_extra_state_attributes = {ATTR_DESCRIPTION: automation.description}
 
+    @override
     async def async_activate(self, **kwargs: Any) -> None:
         """Activate an automation scene."""
         await self._automation.activate()

--- a/homeassistant/components/nexia/sensor.py
+++ b/homeassistant/components/nexia/sensor.py
@@ -1,5 +1,7 @@
 """Support for Nexia / Trane XL Thermostats."""
 
+from typing import override
+
 from nexia.const import UNIT_CELSIUS
 from nexia.thermostat import NexiaThermostat
 
@@ -213,6 +215,7 @@ class NexiaThermostatSensor(NexiaThermostatEntity, SensorEntity):
             self._attr_translation_key = translation_key
 
     @property
+    @override
     def native_value(self):
         """Return the state of the sensor."""
         val = getattr(self._thermostat, self._call)()
@@ -253,6 +256,7 @@ class NexiaThermostatZoneSensor(NexiaThermostatZoneEntity, SensorEntity):
             self._attr_translation_key = translation_key
 
     @property
+    @override
     def native_value(self):
         """Return the state of the sensor."""
         val = getattr(self._zone, self._call)()

--- a/homeassistant/components/nexia/switch.py
+++ b/homeassistant/components/nexia/switch.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Iterable
 import functools as ft
-from typing import Any
+from typing import Any, override
 
 from nexia.const import OPERATION_MODE_OFF
 from nexia.roomiq import NexiaRoomIQHarmonizer
@@ -72,10 +72,12 @@ class NexiaHoldSwitch(NexiaThermostatZoneEntity, SwitchEntity):
         super().__init__(coordinator, zone, zone_id)
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return if the zone is in hold mode."""
         return self._zone.is_in_permanent_hold()
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Enable permanent hold."""
         if self._zone.get_current_mode() == OPERATION_MODE_OFF:
@@ -84,6 +86,7 @@ class NexiaHoldSwitch(NexiaThermostatZoneEntity, SwitchEntity):
             await self._zone.set_permanent_hold()
         self._signal_zone_update()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Disable permanent hold."""
         await self._zone.call_return_to_schedule()
@@ -115,6 +118,7 @@ class NexiaRoomIQSwitch(NexiaThermostatZoneEntity, SwitchEntity):
             room_iq_zones[zone.zone_id] = self._harmonizer
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return if the sensor is part of the zone average temperature."""
         if self._harmonizer.request_pending():
@@ -122,11 +126,13 @@ class NexiaRoomIQSwitch(NexiaThermostatZoneEntity, SwitchEntity):
 
         return self._zone.get_sensor_by_id(self._sensor_id).weight > 0.0
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Include this sensor."""
         self._harmonizer.trigger_add_sensor(self._sensor_id)
         self._signal_zone_update()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Remove this sensor."""
         self._harmonizer.trigger_remove_sensor(self._sensor_id)
@@ -149,15 +155,18 @@ class NexiaEmergencyHeatSwitch(NexiaThermostatEntity, SwitchEntity):
         )
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return if the zone is in hold mode."""
         return self._thermostat.is_emergency_heat_active()
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Enable permanent hold."""
         await self._thermostat.set_emergency_heat(True)
         self._signal_thermostat_update()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Disable permanent hold."""
         await self._thermostat.set_emergency_heat(False)

--- a/homeassistant/components/nextbus/config_flow.py
+++ b/homeassistant/components/nextbus/config_flow.py
@@ -2,6 +2,7 @@
 
 from collections import Counter
 import logging
+from typing import override
 
 from py_nextbus import NextBusClient
 import voluptuous as vol
@@ -84,6 +85,7 @@ class NextBusFlowHandler(ConfigFlow, domain=DOMAIN):
         self.data: dict[str, str] = {}
         self._client = NextBusClient()
 
+    @override
     async def async_step_user(
         self,
         user_input: dict[str, str] | None = None,

--- a/homeassistant/components/nextbus/sensor.py
+++ b/homeassistant/components/nextbus/sensor.py
@@ -1,7 +1,7 @@
 """NextBus sensor."""
 
 import logging
-from typing import cast
+from typing import cast, override
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.config_entries import ConfigEntry
@@ -95,12 +95,14 @@ class NextBusDepartureSensor(
         msg = f"{self.agency}:{self.route}:{self.stop}:{message}"
         _LOGGER.error(msg, *args)
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Read data from coordinator after adding to hass."""
         self._handle_coordinator_update()
         await super().async_added_to_hass()
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Update sensor with new departures times."""
         results = self.coordinator.get_prediction_data(self.stop, self.route)

--- a/homeassistant/components/nextcloud/binary_sensor.py
+++ b/homeassistant/components/nextcloud/binary_sensor.py
@@ -1,6 +1,6 @@
 """Summary binary data from Nextcoud."""
 
-from typing import Final
+from typing import Final, override
 
 from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
@@ -67,6 +67,7 @@ class NextcloudBinarySensor(NextcloudEntity, BinarySensorEntity):
     """Represents a Nextcloud binary sensor."""
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if the binary sensor is on."""
         val = self.coordinator.data.get(self.entity_description.key)

--- a/homeassistant/components/nextcloud/config_flow.py
+++ b/homeassistant/components/nextcloud/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow to configure the Nextcloud integration."""
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, override
 
 from nextcloudmonitor import (
     NextcloudMonitor,
@@ -46,6 +46,7 @@ class NextcloudConfigFlow(ConfigFlow, domain=DOMAIN):
             user_input.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL),
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/nextcloud/coordinator.py
+++ b/homeassistant/components/nextcloud/coordinator.py
@@ -1,7 +1,7 @@
 """Data update coordinator for the Nextcloud integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from nextcloudmonitor import NextcloudMonitor, NextcloudMonitorError
 
@@ -69,6 +69,7 @@ class NextcloudDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 leaf = False
         return result
 
+    @override
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch all Nextcloud data."""
 

--- a/homeassistant/components/nextcloud/sensor.py
+++ b/homeassistant/components/nextcloud/sensor.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Final
+from typing import Final, override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -617,6 +617,7 @@ class NextcloudSensor(NextcloudEntity, SensorEntity):
     entity_description: NextcloudSensorEntityDescription
 
     @property
+    @override
     def native_value(self) -> str | int | float | datetime:
         """Return the state for this sensor."""
         val = self.coordinator.data.get(self.entity_description.key)

--- a/homeassistant/components/nextcloud/update.py
+++ b/homeassistant/components/nextcloud/update.py
@@ -1,5 +1,7 @@
 """Update data from Nextcoud."""
 
+from typing import override
+
 from homeassistant.components.update import UpdateEntity, UpdateEntityDescription
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -30,11 +32,13 @@ class NextcloudUpdateSensor(NextcloudEntity, UpdateEntity):
     """Represents a Nextcloud update entity."""
 
     @property
+    @override
     def installed_version(self) -> str:
         """Version installed and in use."""
         return self.coordinator.data["system_version"]
 
     @property
+    @override
     def latest_version(self) -> str:
         """Latest version available for install."""
         return self.coordinator.data.get(
@@ -42,6 +46,7 @@ class NextcloudUpdateSensor(NextcloudEntity, UpdateEntity):
         )
 
     @property
+    @override
     def release_url(self) -> str | None:
         """URL to the full release notes of the latest version available."""
         ver = "-".join(self.latest_version.split(".")[:3])

--- a/homeassistant/components/nextdns/binary_sensor.py
+++ b/homeassistant/components/nextdns/binary_sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from nextdns import ConnectionStatus
 
@@ -64,6 +65,7 @@ class NextDnsBinarySensor(NextDnsEntity, BinarySensorEntity):
     entity_description: NextDnsBinarySensorEntityDescription
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return True if the binary sensor is on."""
         return self.entity_description.state(

--- a/homeassistant/components/nextdns/button.py
+++ b/homeassistant/components/nextdns/button.py
@@ -1,5 +1,7 @@
 """Support for the NextDNS service."""
 
+from typing import override
+
 from aiohttp import ClientError
 from aiohttp.client_exceptions import ClientConnectorError
 from nextdns import ApiError, InvalidApiKeyError
@@ -38,6 +40,7 @@ async def async_setup_entry(
 class NextDnsButton(NextDnsEntity, ButtonEntity):
     """Define an NextDNS button."""
 
+    @override
     async def async_press(self) -> None:
         """Trigger cleaning logs."""
         try:

--- a/homeassistant/components/nextdns/config_flow.py
+++ b/homeassistant/components/nextdns/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from aiohttp.client_exceptions import ClientConnectorError
 from nextdns import ApiError, InvalidApiKeyError, NextDns
@@ -68,6 +68,7 @@ class NextDnsFlowHandler(ConfigFlow, domain=DOMAIN):
         self.nextdns: NextDns
         self.api_key: str
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/nextdns/coordinator.py
+++ b/homeassistant/components/nextdns/coordinator.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from aiohttp.client_exceptions import ClientConnectorError
 from nextdns import (
@@ -64,6 +64,7 @@ class NextDnsUpdateCoordinator[CoordinatorDataT: NextDnsData](
             update_interval=self._update_interval,
         )
 
+    @override
     async def _async_update_data(self) -> CoordinatorDataT:
         """Update data via internal method."""
         try:
@@ -98,6 +99,7 @@ class NextDnsStatusUpdateCoordinator(NextDnsUpdateCoordinator[AnalyticsStatus]):
 
     _update_interval = UPDATE_INTERVAL_ANALYTICS
 
+    @override
     async def _async_update_data_internal(self) -> AnalyticsStatus:
         """Update data via library."""
         return await self.nextdns.get_analytics_status(self.profile_id)
@@ -108,6 +110,7 @@ class NextDnsDnssecUpdateCoordinator(NextDnsUpdateCoordinator[AnalyticsDnssec]):
 
     _update_interval = UPDATE_INTERVAL_ANALYTICS
 
+    @override
     async def _async_update_data_internal(self) -> AnalyticsDnssec:
         """Update data via library."""
         return await self.nextdns.get_analytics_dnssec(self.profile_id)
@@ -118,6 +121,7 @@ class NextDnsEncryptionUpdateCoordinator(NextDnsUpdateCoordinator[AnalyticsEncry
 
     _update_interval = UPDATE_INTERVAL_ANALYTICS
 
+    @override
     async def _async_update_data_internal(self) -> AnalyticsEncryption:
         """Update data via library."""
         return await self.nextdns.get_analytics_encryption(self.profile_id)
@@ -128,6 +132,7 @@ class NextDnsIpVersionsUpdateCoordinator(NextDnsUpdateCoordinator[AnalyticsIpVer
 
     _update_interval = UPDATE_INTERVAL_ANALYTICS
 
+    @override
     async def _async_update_data_internal(self) -> AnalyticsIpVersions:
         """Update data via library."""
         return await self.nextdns.get_analytics_ip_versions(self.profile_id)
@@ -138,6 +143,7 @@ class NextDnsProtocolsUpdateCoordinator(NextDnsUpdateCoordinator[AnalyticsProtoc
 
     _update_interval = UPDATE_INTERVAL_ANALYTICS
 
+    @override
     async def _async_update_data_internal(self) -> AnalyticsProtocols:
         """Update data via library."""
         return await self.nextdns.get_analytics_protocols(self.profile_id)
@@ -148,6 +154,7 @@ class NextDnsSettingsUpdateCoordinator(NextDnsUpdateCoordinator[Settings]):
 
     _update_interval = UPDATE_INTERVAL_SETTINGS
 
+    @override
     async def _async_update_data_internal(self) -> Settings:
         """Update data via library."""
         return await self.nextdns.get_settings(self.profile_id)
@@ -158,6 +165,7 @@ class NextDnsConnectionUpdateCoordinator(NextDnsUpdateCoordinator[ConnectionStat
 
     _update_interval = UPDATE_INTERVAL_CONNECTION
 
+    @override
     async def _async_update_data_internal(self) -> ConnectionStatus:
         """Update data via library."""
         return await self.nextdns.connection_status(self.profile_id)

--- a/homeassistant/components/nextdns/sensor.py
+++ b/homeassistant/components/nextdns/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from nextdns import (
     AnalyticsDnssec,
@@ -302,6 +303,7 @@ class NextDnsSensor[CoordinatorDataT: NextDnsData](
     entity_description: NextDnsSensorEntityDescription[CoordinatorDataT]
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
         return self.entity_description.value(self.coordinator.data)

--- a/homeassistant/components/nextdns/switch.py
+++ b/homeassistant/components/nextdns/switch.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from aiohttp import ClientError
 from aiohttp.client_exceptions import ClientConnectorError
@@ -555,15 +555,18 @@ class NextDnsSwitch(NextDnsEntity, SwitchEntity):
         self._attr_is_on = description.state(coordinator.data)
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self._attr_is_on = self.entity_description.state(self.coordinator.data)
         self.async_write_ha_state()
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on switch."""
         await self.async_set_setting(True)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off switch."""
         await self.async_set_setting(False)

--- a/homeassistant/components/nfandroidtv/config_flow.py
+++ b/homeassistant/components/nfandroidtv/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for NFAndroidTV integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from notifications_android_tv.notifications import ConnectError, Notifications
 import voluptuous as vol
@@ -17,6 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 class NFAndroidTVFlowHandler(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for NFAndroidTV."""
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/nfandroidtv/notify.py
+++ b/homeassistant/components/nfandroidtv/notify.py
@@ -2,7 +2,7 @@
 
 from io import BufferedReader
 import logging
-from typing import Any
+from typing import Any, override
 
 from notifications_android_tv.notifications import ConnectError, Notifications
 import requests
@@ -76,6 +76,7 @@ class NFAndroidTVNotificationService(BaseNotificationService):
         self.is_allowed_path = is_allowed_path
         self.notify: Notifications | None = None
 
+    @override
     def send_message(self, message: str, **kwargs: Any) -> None:
         """Send a message to an Android TV device."""
         if self.notify is None:

--- a/homeassistant/components/nibe_heatpump/binary_sensor.py
+++ b/homeassistant/components/nibe_heatpump/binary_sensor.py
@@ -1,5 +1,7 @@
 """The Nibe Heat Pump binary sensors."""
 
+from typing import override
+
 from nibe.coil import Coil, CoilData
 
 from homeassistant.components.binary_sensor import ENTITY_ID_FORMAT, BinarySensorEntity
@@ -37,5 +39,6 @@ class BinarySensor(CoilEntity, BinarySensorEntity):
         super().__init__(coordinator, coil, ENTITY_ID_FORMAT)
         self._on_value = coil.get_mapping_for(1)
 
+    @override
     def _async_read_coil(self, data: CoilData) -> None:
         self._attr_is_on = data.value == self._on_value

--- a/homeassistant/components/nibe_heatpump/button.py
+++ b/homeassistant/components/nibe_heatpump/button.py
@@ -1,5 +1,7 @@
 """The Nibe Heat Pump sensors."""
 
+from typing import override
+
 from nibe.coil_groups import UNIT_COILGROUPS, UnitCoilGroup
 from nibe.exceptions import CoilNotFoundException
 
@@ -47,6 +49,7 @@ class NibeAlarmResetButton(CoordinatorEntity[CoilCoordinator], ButtonEntity):
         self._attr_unique_id = f"{coordinator.unique_id}-alarm_reset"
         self._attr_device_info = coordinator.device_info
 
+    @override
     async def async_press(self) -> None:
         """Execute the command."""
         await self.coordinator.async_write_coil(self._reset_coil, 0)
@@ -54,6 +57,7 @@ class NibeAlarmResetButton(CoordinatorEntity[CoilCoordinator], ButtonEntity):
         await self.coordinator.async_read_coil(self._alarm_coil)
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         if coil := self.coordinator.data.get(self._alarm_coil.address):

--- a/homeassistant/components/nibe_heatpump/climate.py
+++ b/homeassistant/components/nibe_heatpump/climate.py
@@ -1,7 +1,7 @@
 """The Nibe Heat Pump climate."""
 
 from datetime import date
-from typing import Any
+from typing import Any, override
 
 from nibe.coil import Coil
 from nibe.coil_groups import (
@@ -127,6 +127,7 @@ class NibeClimateEntity(CoordinatorEntity[CoilCoordinator], ClimateEntity):
             self._attr_temperature_unit = self._coil_current.unit
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         def _get_value(coil: Coil) -> int | str | float | date | None:
             return self.coordinator.get_coil_value(coil)
@@ -183,6 +184,7 @@ class NibeClimateEntity(CoordinatorEntity[CoilCoordinator], ClimateEntity):
         self.async_write_ha_state()
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         coordinator = self.coordinator
@@ -199,6 +201,7 @@ class NibeClimateEntity(CoordinatorEntity[CoilCoordinator], ClimateEntity):
 
         return False
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set target temperatures."""
         coordinator = self.coordinator
@@ -234,6 +237,7 @@ class NibeClimateEntity(CoordinatorEntity[CoilCoordinator], ClimateEntity):
         ):
             await coordinator.async_write_coil(self._coil_setpoint_cool, temperature)
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         coordinator = self.coordinator

--- a/homeassistant/components/nibe_heatpump/config_flow.py
+++ b/homeassistant/components/nibe_heatpump/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for Nibe Heat Pump integration."""
 
-from typing import Any
+from typing import Any, override
 
 from nibe.connection.modbus import Modbus
 from nibe.connection.nibegw import NibeGW
@@ -178,6 +178,7 @@ class NibeHeatPumpConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/nibe_heatpump/coordinator.py
+++ b/homeassistant/components/nibe_heatpump/coordinator.py
@@ -4,7 +4,7 @@ import asyncio
 from collections import defaultdict
 from collections.abc import Callable, Iterable
 from datetime import date, timedelta
-from typing import Any
+from typing import Any, override
 
 from nibe.coil import Coil, CoilData
 from nibe.connection import Connection
@@ -53,6 +53,7 @@ class ContextCoordinator[_DataTypeT, _ContextTypeT](DataUpdateCoordinator[_DataT
             update_callback()
 
     @callback
+    @override
     def async_add_listener(
         self, update_callback: CALLBACK_TYPE, context: Any = None
     ) -> Callable[[], None]:
@@ -179,6 +180,7 @@ class CoilCoordinator(ContextCoordinator[dict[int, CoilData], int]):
         """Read coil and update state using callbacks."""
         return await self.connection.read_coil(coil)
 
+    @override
     async def _async_update_data(self) -> dict[int, CoilData]:
         self.task = asyncio.current_task()
         try:
@@ -216,6 +218,7 @@ class CoilCoordinator(ContextCoordinator[dict[int, CoilData], int]):
 
         return result
 
+    @override
     async def async_shutdown(self):
         """Make sure a coordinator is shut down as well as it's connection."""
         await super().async_shutdown()

--- a/homeassistant/components/nibe_heatpump/entity.py
+++ b/homeassistant/components/nibe_heatpump/entity.py
@@ -1,5 +1,7 @@
 """The Nibe Heat Pump coordinator."""
 
+from typing import override
+
 from nibe.coil import Coil, CoilData
 
 from homeassistant.helpers.entity import async_generate_entity_id
@@ -28,6 +30,7 @@ class CoilEntity(CoordinatorEntity[CoilCoordinator]):
         self._coil = coil
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return self.coordinator.last_update_success and self._coil.address in (
@@ -41,6 +44,7 @@ class CoilEntity(CoordinatorEntity[CoilCoordinator]):
         """Write coil and update state."""
         await self.coordinator.async_write_coil(self._coil, value)
 
+    @override
     def _handle_coordinator_update(self) -> None:
         data = self.coordinator.data.get(self._coil.address)
         if data is not None:

--- a/homeassistant/components/nibe_heatpump/number.py
+++ b/homeassistant/components/nibe_heatpump/number.py
@@ -1,5 +1,7 @@
 """The Nibe Heat Pump numbers."""
 
+from typing import override
+
 from nibe.coil import Coil, CoilData
 
 from homeassistant.components.number import ENTITY_ID_FORMAT, NumberEntity, NumberMode
@@ -59,6 +61,7 @@ class Number(CoilEntity, NumberEntity):
         self._attr_native_unit_of_measurement = coil.unit
         self._attr_mode = NumberMode.BOX
 
+    @override
     def _async_read_coil(self, data: CoilData) -> None:
         if data.value is None:
             self._attr_native_value = None
@@ -69,6 +72,7 @@ class Number(CoilEntity, NumberEntity):
         except ValueError:
             self._attr_native_value = None
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Set new value."""
         await self._async_write_coil(value)

--- a/homeassistant/components/nibe_heatpump/select.py
+++ b/homeassistant/components/nibe_heatpump/select.py
@@ -1,5 +1,7 @@
 """The Nibe Heat Pump select."""
 
+from typing import override
+
 from nibe.coil import Coil, CoilData
 
 from homeassistant.components.select import ENTITY_ID_FORMAT, SelectEntity
@@ -39,6 +41,7 @@ class Select(CoilEntity, SelectEntity):
         self._attr_options = list(coil.mappings.values())
         self._attr_current_option = None
 
+    @override
     def _async_read_coil(self, data: CoilData) -> None:
         if not isinstance(data.value, str):
             self._attr_current_option = None
@@ -46,6 +49,7 @@ class Select(CoilEntity, SelectEntity):
 
         self._attr_current_option = data.value
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Support writing value."""
         await self._async_write_coil(option)

--- a/homeassistant/components/nibe_heatpump/sensor.py
+++ b/homeassistant/components/nibe_heatpump/sensor.py
@@ -1,5 +1,7 @@
 """The Nibe Heat Pump sensors."""
 
+from typing import override
+
 from nibe.coil import Coil, CoilData
 
 from homeassistant.components.sensor import (
@@ -212,5 +214,6 @@ class Sensor(CoilEntity, SensorEntity):
             self._attr_native_unit_of_measurement = coil.unit
             self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
+    @override
     def _async_read_coil(self, data: CoilData):
         self._attr_native_value = data.value

--- a/homeassistant/components/nibe_heatpump/switch.py
+++ b/homeassistant/components/nibe_heatpump/switch.py
@@ -1,6 +1,6 @@
 """The Nibe Heat Pump switch."""
 
-from typing import Any
+from typing import Any, override
 
 from nibe.coil import Coil, CoilData
 
@@ -40,13 +40,16 @@ class Switch(CoilEntity, SwitchEntity):
         self._on_value = coil.get_mapping_for(1)
         self._off_value = coil.get_mapping_for(0)
 
+    @override
     def _async_read_coil(self, data: CoilData) -> None:
         self._attr_is_on = data.value == self._on_value
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         await self._async_write_coil(self._on_value)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         await self._async_write_coil(self._off_value)

--- a/homeassistant/components/nibe_heatpump/water_heater.py
+++ b/homeassistant/components/nibe_heatpump/water_heater.py
@@ -1,6 +1,7 @@
 """The Nibe Heat Pump sensors."""
 
 from datetime import date
+from typing import override
 
 from nibe.coil import Coil
 from nibe.coil_groups import WATER_HEATER_COILGROUPS, WaterHeaterCoilGroup
@@ -122,6 +123,7 @@ class WaterHeater(CoordinatorEntity[CoilCoordinator], WaterHeaterEntity):
         self._attr_temperature_unit = self._coil_current.unit
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         if not self.coordinator.data:
             return
@@ -162,6 +164,7 @@ class WaterHeater(CoordinatorEntity[CoilCoordinator], WaterHeaterEntity):
         super()._handle_coordinator_update()
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         if not self.coordinator.last_update_success:
@@ -177,6 +180,7 @@ class WaterHeater(CoordinatorEntity[CoilCoordinator], WaterHeaterEntity):
 
         return False
 
+    @override
     async def async_set_operation_mode(self, operation_mode: str) -> None:
         """Set new target operation mode."""
         if not self._coil_temporary_lux:

--- a/homeassistant/components/nice_go/config_flow.py
+++ b/homeassistant/components/nice_go/config_flow.py
@@ -3,7 +3,7 @@
 from collections.abc import Mapping
 from datetime import datetime
 import logging
-from typing import Any
+from typing import Any, override
 
 from nice_go import AuthFailedError, NiceGOApi
 import voluptuous as vol
@@ -29,6 +29,7 @@ class NiceGOConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/nice_go/coordinator.py
+++ b/homeassistant/components/nice_go/coordinator.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime
 import json
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from nice_go import (
     BARRIER_STATUS,
@@ -139,9 +139,11 @@ class NiceGOUpdateCoordinator(DataUpdateCoordinator[dict[str, NiceGODevice]]):
             vacation_mode=vacation_mode,
         )
 
+    @override
     async def _async_update_data(self) -> dict[str, NiceGODevice]:
         return self.data
 
+    @override
     async def _async_setup(self) -> None:
         """Set up the coordinator."""
         async with asyncio.timeout(10):

--- a/homeassistant/components/nice_go/cover.py
+++ b/homeassistant/components/nice_go/cover.py
@@ -1,6 +1,6 @@
 """Cover entity for Nice G.O."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.cover import (
     CoverDeviceClass,
@@ -43,11 +43,13 @@ class NiceGOCoverEntity(NiceGOEntity, CoverEntity):
     _attr_name = None
 
     @property
+    @override
     def device_class(self) -> CoverDeviceClass:
         """Return the class of this device, from component DEVICE_CLASSES."""
         return DEVICE_CLASSES.get(self.data.type, CoverDeviceClass.GARAGE)
 
     @property
+    @override
     def is_closed(self) -> bool:
         """Return if cover is closed."""
         return self.data.barrier_status == "closed"
@@ -58,16 +60,19 @@ class NiceGOCoverEntity(NiceGOEntity, CoverEntity):
         return self.data.barrier_status == "open"
 
     @property
+    @override
     def is_opening(self) -> bool:
         """Return if cover is opening."""
         return self.data.barrier_status == "opening"
 
     @property
+    @override
     def is_closing(self) -> bool:
         """Return if cover is closing."""
         return self.data.barrier_status == "closing"
 
     @retry("close_cover_error")
+    @override
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the garage door."""
         if self.is_closed:
@@ -76,6 +81,7 @@ class NiceGOCoverEntity(NiceGOEntity, CoverEntity):
         await self.coordinator.api.close_barrier(self._device_id)
 
     @retry("open_cover_error")
+    @override
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the garage door."""
         if self.is_opened:

--- a/homeassistant/components/nice_go/entity.py
+++ b/homeassistant/components/nice_go/entity.py
@@ -1,5 +1,7 @@
 """Base entity for Nice G.O."""
 
+from typing import override
+
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -35,6 +37,7 @@ class NiceGOEntity(CoordinatorEntity[NiceGOUpdateCoordinator]):
         return self.coordinator.data[self._device_id]
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return super().available and self.data.connected

--- a/homeassistant/components/nice_go/event.py
+++ b/homeassistant/components/nice_go/event.py
@@ -1,7 +1,7 @@
 """Nice G.O. event platform."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.event import EventEntity
 from homeassistant.core import HomeAssistant
@@ -37,6 +37,7 @@ class NiceGOEventEntity(NiceGOEntity, EventEntity):
     _attr_translation_key = "barrier_obstructed"
     _attr_event_types = [EVENT_BARRIER_OBSTRUCTED]
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Listen for events."""
         await super().async_added_to_hass()

--- a/homeassistant/components/nice_go/light.py
+++ b/homeassistant/components/nice_go/light.py
@@ -1,7 +1,7 @@
 """Nice G.O. light."""
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from homeassistant.components.light import ColorMode, LightEntity
 from homeassistant.const import Platform
@@ -53,6 +53,7 @@ class NiceGOLightEntity(NiceGOEntity, LightEntity):
     _attr_translation_key = "light"
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return if the light is on or not."""
         if TYPE_CHECKING:
@@ -60,12 +61,14 @@ class NiceGOLightEntity(NiceGOEntity, LightEntity):
         return self.data.light_status
 
     @retry("light_on_error")
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the light."""
 
         await self.coordinator.api.light_on(self._device_id)
 
     @retry("light_off_error")
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the light."""
 

--- a/homeassistant/components/nice_go/switch.py
+++ b/homeassistant/components/nice_go/switch.py
@@ -1,7 +1,7 @@
 """Nice G.O. switch platform."""
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
 from homeassistant.const import Platform
@@ -53,6 +53,7 @@ class NiceGOSwitchEntity(NiceGOEntity, SwitchEntity):
     _attr_translation_key = "vacation_mode"
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return if switch is on."""
         if TYPE_CHECKING:
@@ -60,12 +61,14 @@ class NiceGOSwitchEntity(NiceGOEntity, SwitchEntity):
         return self.data.vacation_mode
 
     @retry("switch_on_error")
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
 
         await self.coordinator.api.vacation_mode_on(self.data.id)
 
     @retry("switch_off_error")
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
 

--- a/homeassistant/components/nightscout/config_flow.py
+++ b/homeassistant/components/nightscout/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Nightscout integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from aiohttp import ClientError, ClientResponseError
 from py_nightscout import Api as NightscoutAPI
@@ -42,6 +42,7 @@ class NightscoutConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/niko_home_control/climate.py
+++ b/homeassistant/components/niko_home_control/climate.py
@@ -1,6 +1,6 @@
 """Support for Niko Home Control thermostats."""
 
-from typing import Any
+from typing import Any, override
 
 from nhc.const import THERMOSTAT_MODES, THERMOSTAT_MODES_REVERSE
 from nhc.thermostat import NHCThermostat
@@ -67,23 +67,28 @@ class NikoHomeControlClimate(NikoHomeControlEntity, ClimateEntity):
         """Return the Niko mode."""
         return THERMOSTAT_MODES_REVERSE.get(mode, NikoHomeControlThermostatModes.OFF)
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         if ATTR_TEMPERATURE in kwargs:
             await self._action.set_temperature(kwargs.get(ATTR_TEMPERATURE))
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
         await self._action.set_mode(self._get_niko_mode(preset_mode))
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         await self._action.set_mode(NIKO_HOME_CONTROL_THERMOSTAT_MODES_MAP[hvac_mode])
 
+    @override
     async def async_turn_off(self) -> None:
         """Turn thermostat off."""
         await self._action.set_mode(NikoHomeControlThermostatModes.OFF)
 
+    @override
     def update_state(self) -> None:
         """Update the state of the entity."""
         if self._action.state == NikoHomeControlThermostatModes.OFF:

--- a/homeassistant/components/niko_home_control/config_flow.py
+++ b/homeassistant/components/niko_home_control/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for the Niko home control integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from nhc.controller import NHCController
 import voluptuous as vol
@@ -60,6 +60,7 @@ class NikoHomeControlConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="reconfigure", data_schema=DATA_SCHEMA, errors=errors
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/niko_home_control/cover.py
+++ b/homeassistant/components/niko_home_control/cover.py
@@ -1,6 +1,6 @@
 """Cover Platform for Niko Home Control."""
 
-from typing import Any
+from typing import Any, override
 
 from nhc.cover import NHCCover
 
@@ -35,18 +35,22 @@ class NikoHomeControlCover(NikoHomeControlEntity, CoverEntity):
     )
     _action: NHCCover
 
+    @override
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
         await self._action.open()
 
+    @override
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
         await self._action.close()
 
+    @override
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
         await self._action.stop()
 
+    @override
     def update_state(self):
         """Update HA state."""
         self._attr_is_closed = self._action.state == 0

--- a/homeassistant/components/niko_home_control/entity.py
+++ b/homeassistant/components/niko_home_control/entity.py
@@ -1,6 +1,7 @@
 """Base class for Niko Home Control entities."""
 
 from abc import abstractmethod
+from typing import override
 
 from nhc.action import NHCAction
 from nhc.controller import NHCController
@@ -32,6 +33,7 @@ class NikoHomeControlEntity(Entity):
         )
         self.update_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Subscribe to updates."""
         self.async_on_remove(

--- a/homeassistant/components/niko_home_control/light.py
+++ b/homeassistant/components/niko_home_control/light.py
@@ -1,6 +1,6 @@
 """Light platform Niko Home Control."""
 
-from typing import Any
+from typing import Any, override
 
 from nhc.light import NHCLight
 
@@ -49,14 +49,17 @@ class NikoHomeControlLight(NikoHomeControlEntity, LightEntity):
             self._attr_supported_color_modes = {ColorMode.BRIGHTNESS}
             self._attr_brightness = action.state
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Instruct the light to turn on."""
         await self._action.turn_on(kwargs.get(ATTR_BRIGHTNESS))
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Instruct the light to turn off."""
         await self._action.turn_off()
 
+    @override
     def update_state(self) -> None:
         """Handle updates from the controller."""
         state = self._action.state

--- a/homeassistant/components/niko_home_control/scene.py
+++ b/homeassistant/components/niko_home_control/scene.py
@@ -1,6 +1,6 @@
 """Scene Platform for Niko Home Control."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.scene import BaseScene
 from homeassistant.core import HomeAssistant
@@ -29,10 +29,12 @@ class NikoHomeControlScene(NikoHomeControlEntity, BaseScene):
 
     _attr_name = None
 
+    @override
     async def _async_activate(self, **kwargs: Any) -> None:
         """Activate scene. Try to get entities into requested state."""
         await self._action.activate()
 
+    @override
     def update_state(self) -> None:
         """Update HA state."""
         self._async_record_activation()

--- a/homeassistant/components/nilu/air_quality.py
+++ b/homeassistant/components/nilu/air_quality.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import logging
+from typing import override
 
 from niluclient import (
     CO,
@@ -188,66 +189,79 @@ class NiluSensor(AirQualityEntity):
             self._attrs[CONF_LONGITUDE] = api_data.data.longitude
 
     @property
+    @override
     def extra_state_attributes(self) -> dict:
         """Return other details about the sensor state."""
         return self._attrs
 
     @property
+    @override
     def name(self) -> str:
         """Return the name of the sensor."""
         return self._name
 
     @property
+    @override
     def air_quality_index(self) -> str | None:
         """Return the Air Quality Index (AQI)."""
         return self._max_aqi
 
     @property
+    @override
     def carbon_monoxide(self) -> str | None:
         """Return the CO (carbon monoxide) level."""
         return self.get_component_state(CO)
 
     @property
+    @override
     def carbon_dioxide(self) -> str | None:
         """Return the CO2 (carbon dioxide) level."""
         return self.get_component_state(CO2)
 
     @property
+    @override
     def nitrogen_oxide(self) -> str | None:
         """Return the N2O (nitrogen oxide) level."""
         return self.get_component_state(NOX)
 
     @property
+    @override
     def nitrogen_monoxide(self) -> str | None:
         """Return the NO (nitrogen monoxide) level."""
         return self.get_component_state(NO)
 
     @property
+    @override
     def nitrogen_dioxide(self) -> str | None:
         """Return the NO2 (nitrogen dioxide) level."""
         return self.get_component_state(NO2)
 
     @property
+    @override
     def ozone(self) -> str | None:
         """Return the O3 (ozone) level."""
         return self.get_component_state(OZONE)
 
     @property
+    @override
     def particulate_matter_2_5(self) -> str | None:
         """Return the particulate matter 2.5 level."""
         return self.get_component_state(PM25)
 
     @property
+    @override
     def particulate_matter_10(self) -> str | None:
         """Return the particulate matter 10 level."""
         return self.get_component_state(PM10)
 
     @property
+    @override
     def particulate_matter_0_1(self) -> str | None:
         """Return the particulate matter 0.1 level."""
         return self.get_component_state(PM1)
 
     @property
+    @override
     def sulphur_dioxide(self) -> str | None:
         """Return the SO2 (sulphur dioxide) level."""
         return self.get_component_state(SO2)

--- a/homeassistant/components/nina/binary_sensor.py
+++ b/homeassistant/components/nina/binary_sensor.py
@@ -1,6 +1,6 @@
 """NINA binary sensor platform."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -70,6 +70,7 @@ class NINAMessage(NinaEntity, BinarySensorEntity):
         self._attr_unique_id = f"{region}-{slot_id}"
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return the state of the sensor."""
         if self._get_active_warnings_count() <= self._warning_index:
@@ -78,6 +79,7 @@ class NINAMessage(NinaEntity, BinarySensorEntity):
         return self._get_warning_data().is_valid
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra attributes of the sensor."""
         if not self.is_on:

--- a/homeassistant/components/nina/config_flow.py
+++ b/homeassistant/components/nina/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for Nina integration."""
 
-from typing import Any
+from typing import Any, override
 
 from pynina import ApiError, Nina
 import voluptuous as vol
@@ -128,6 +128,7 @@ class NinaConfigFlow(ConfigFlow, domain=DOMAIN):
         for name in CONST_REGIONS:
             self.regions[name] = {}
 
+    @override
     async def async_step_user(
         self,
         user_input: dict[str, Any] | None = None,
@@ -187,6 +188,7 @@ class NinaConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> OptionsFlowHandler:

--- a/homeassistant/components/nina/coordinator.py
+++ b/homeassistant/components/nina/coordinator.py
@@ -4,7 +4,7 @@ import asyncio
 from dataclasses import dataclass
 from datetime import datetime
 import re
-from typing import Any
+from typing import Any, override
 
 from pynina import ApiError, Nina
 
@@ -76,6 +76,7 @@ class NINADataUpdateCoordinator(
             update_interval=SCAN_INTERVAL,
         )
 
+    @override
     async def _async_update_data(self) -> dict[str, list[NinaWarningData]]:
         """Update data."""
         async with asyncio.timeout(10):

--- a/homeassistant/components/nina/sensor.py
+++ b/homeassistant/components/nina/sensor.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import datetime
+from typing import override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -144,6 +145,7 @@ class NinaSensor(NinaEntity, SensorEntity):
         self._attr_unique_id = f"{region}-{slot_id}-{self.entity_description.key}"
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         if self._get_active_warnings_count() <= self._warning_index:
@@ -152,6 +154,7 @@ class NinaSensor(NinaEntity, SensorEntity):
         return self._get_warning_data().is_valid and super().available
 
     @property
+    @override
     def native_value(self) -> str | datetime | None:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self._get_warning_data())

--- a/homeassistant/components/nintendo_parental_controls/config_flow.py
+++ b/homeassistant/components/nintendo_parental_controls/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from pynintendoauth.exceptions import HttpException, InvalidSessionTokenException
 from pynintendoparental import Authenticator
@@ -25,6 +25,7 @@ class NintendoConfigFlow(ConfigFlow, domain=DOMAIN):
         """Initialize a new config flow instance."""
         self.auth: Authenticator | None = None
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/nintendo_parental_controls/coordinator.py
+++ b/homeassistant/components/nintendo_parental_controls/coordinator.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import logging
+from typing import override
 
 from pynintendoauth.exceptions import (
     HttpException,
@@ -47,6 +48,7 @@ class NintendoUpdateCoordinator(DataUpdateCoordinator[None]):
             authenticator, hass.config.time_zone, hass.config.language
         )
 
+    @override
     async def _async_update_data(self) -> None:
         """Update data from Nintendo's API."""
         try:

--- a/homeassistant/components/nintendo_parental_controls/entity.py
+++ b/homeassistant/components/nintendo_parental_controls/entity.py
@@ -1,5 +1,7 @@
 """Base entity definition for Nintendo parental controls."""
 
+from typing import override
+
 from pynintendoparental.device import Device
 
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -31,11 +33,13 @@ class NintendoDevice(CoordinatorEntity[NintendoUpdateCoordinator]):
             serial_number=device.extra["serialNumber"],
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is loaded."""
         await super().async_added_to_hass()
         self._device.add_device_callback(self.async_write_ha_state)
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """When will be removed from HASS."""
         self._device.remove_device_callback(self.async_write_ha_state)

--- a/homeassistant/components/nintendo_parental_controls/number.py
+++ b/homeassistant/components/nintendo_parental_controls/number.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.number import (
     NumberEntity,
@@ -80,10 +80,12 @@ class NintendoParentalControlsNumberEntity(NintendoDevice, NumberEntity):
         self.entity_description = description
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the state of the entity."""
         return self.entity_description.value_fn(self._device)
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Update entity state."""
         await self.entity_description.set_native_value_fn(self._device, value)

--- a/homeassistant/components/nintendo_parental_controls/select.py
+++ b/homeassistant/components/nintendo_parental_controls/select.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Any
+from typing import Any, override
 
 from pynintendoparental.enum import DeviceTimerMode
 
@@ -76,16 +76,19 @@ class NintendoParentalSelectEntity(NintendoDevice, SelectEntity):
         self.entity_description = description
 
     @property
+    @override
     def current_option(self) -> str | None:
         """Return the current selected option."""
         option = self.entity_description.get_option(self._device)
         return option.name.lower() if option else None
 
     @property
+    @override
     def options(self) -> list[str]:
         """Return a list of available options."""
         return [option.name.lower() for option in self.entity_description.options_enum]
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         enum_option = self.entity_description.options_enum[option.upper()]

--- a/homeassistant/components/nintendo_parental_controls/sensor.py
+++ b/homeassistant/components/nintendo_parental_controls/sensor.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
+from typing import override
 
 from pynintendoparental.player import Player
 
@@ -131,11 +132,13 @@ class NintendoParentalControlsDeviceSensorEntity(NintendoDevice, SensorEntity):
         self.entity_description = description
 
     @property
+    @override
     def native_value(self) -> datetime | int | float | None:
         """Return the native value."""
         return self.entity_description.value_fn(self._device)
 
     @property
+    @override
     def available(self) -> bool:
         """Return if the sensor is available."""
         return super().available and self.entity_description.available_fn(self._device)
@@ -163,6 +166,7 @@ class NintendoParentalControlsPlayerSensorEntity(NintendoDevice, SensorEntity):
         self._attr_unique_id = f"{device.device_id}_{player_id}_{description.key}"
 
     @property
+    @override
     def entity_picture(self) -> str | None:
         """Return the entity picture."""
         if self.player_id not in self._device.players:
@@ -170,6 +174,7 @@ class NintendoParentalControlsPlayerSensorEntity(NintendoDevice, SensorEntity):
         return self._device.get_player(self.player_id).player_image
 
     @property
+    @override
     def native_value(self) -> int | float | None:
         """Return the native value."""
         if self.player_id not in self._device.players:

--- a/homeassistant/components/nintendo_parental_controls/switch.py
+++ b/homeassistant/components/nintendo_parental_controls/switch.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Any
+from typing import Any, override
 
 from pynintendoparental.enum import RestrictionMode
 
@@ -79,14 +79,17 @@ class NintendoParentalControlsSwitchEntity(NintendoDevice, SwitchEntity):
         self.entity_description = description
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return entity state."""
         return self.entity_description.is_on(self._device)
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         await self.entity_description.turn_on_fn(self._device)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         await self.entity_description.turn_off_fn(self._device)

--- a/homeassistant/components/nintendo_parental_controls/time.py
+++ b/homeassistant/components/nintendo_parental_controls/time.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from datetime import time
 from enum import StrEnum
 import logging
-from typing import Any
+from typing import Any, override
 
 from pynintendoparental.exceptions import BedtimeOutOfRangeError
 
@@ -91,10 +91,12 @@ class NintendoParentalControlsTimeEntity(NintendoDevice, TimeEntity):
         self.entity_description = description
 
     @property
+    @override
     def native_value(self) -> time | None:
         """Return the time."""
         return self.entity_description.value_fn(self._device)
 
+    @override
     async def async_set_value(self, value: time) -> None:
         """Update the value."""
         try:

--- a/homeassistant/components/nissan_leaf/binary_sensor.py
+++ b/homeassistant/components/nissan_leaf/binary_sensor.py
@@ -1,6 +1,7 @@
 """Plugged In Status Support for the Nissan Leaf."""
 
 import logging
+from typing import override
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -47,16 +48,19 @@ class LeafPluggedInSensor(LeafEntity, BinarySensorEntity):
         self._attr_unique_id = f"{self.car.leaf.vin.lower()}_plugstatus"
 
     @property
+    @override
     def name(self) -> str:
         """Sensor name."""
         return f"{self.car.leaf.nickname} Plug Status"
 
     @property
+    @override
     def available(self) -> bool:
         """Sensor availability."""
         return self.car.data[DATA_PLUGGED_IN] is not None
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if plugged in."""
         return bool(self.car.data[DATA_PLUGGED_IN])
@@ -73,16 +77,19 @@ class LeafChargingSensor(LeafEntity, BinarySensorEntity):
         self._attr_unique_id = f"{self.car.leaf.vin.lower()}_chargingstatus"
 
     @property
+    @override
     def name(self) -> str:
         """Sensor name."""
         return f"{self.car.leaf.nickname} Charging Status"
 
     @property
+    @override
     def available(self) -> bool:
         """Sensor availability."""
         return self.car.data[DATA_CHARGING] is not None
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if charging."""
         return bool(self.car.data[DATA_CHARGING])

--- a/homeassistant/components/nissan_leaf/button.py
+++ b/homeassistant/components/nissan_leaf/button.py
@@ -1,6 +1,7 @@
 """Button to start charging the Nissan Leaf."""
 
 import logging
+from typing import override
 
 from homeassistant.components.button import ButtonEntity
 from homeassistant.core import HomeAssistant
@@ -37,15 +38,18 @@ class LeafChargingButton(LeafEntity, ButtonEntity):
     _attr_icon = "mdi:power"
 
     @property
+    @override
     def name(self) -> str:
         """Sensor name."""
         return f"Start {self.car.leaf.nickname} Charging"
 
     @property
+    @override
     def available(self) -> bool:
         """Button availability."""
         return self.car.data[DATA_CHARGING] is not None
 
+    @override
     async def async_press(self) -> None:
         """Start charging."""
         await self.car.async_start_charging()

--- a/homeassistant/components/nissan_leaf/entity.py
+++ b/homeassistant/components/nissan_leaf/entity.py
@@ -1,7 +1,7 @@
 """Support for the Nissan Leaf Carwings/Nissan Connect API."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -29,6 +29,7 @@ class LeafEntity(Entity):
         )
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return default attributes for Nissan leaf entities."""
         return {
@@ -39,6 +40,7 @@ class LeafEntity(Entity):
             "vin": self.car.leaf.vin,
         }
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
         self.log_registration()

--- a/homeassistant/components/nissan_leaf/sensor.py
+++ b/homeassistant/components/nissan_leaf/sensor.py
@@ -1,6 +1,7 @@
 """Battery Charge and Range Support for the Nissan Leaf."""
 
 import logging
+from typing import override
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.const import PERCENTAGE, UnitOfLength
@@ -56,11 +57,13 @@ class LeafBatterySensor(LeafEntity, SensorEntity):
         self._attr_unique_id = f"{self.car.leaf.vin.lower()}_soc"
 
     @property
+    @override
     def name(self) -> str:
         """Sensor Name."""
         return f"{self.car.leaf.nickname} Charge"
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Battery state percentage."""
         if self.car.data[DATA_BATTERY] is None:
@@ -68,6 +71,7 @@ class LeafBatterySensor(LeafEntity, SensorEntity):
         return round(self.car.data[DATA_BATTERY])  # type: ignore[no-any-return]
 
     @property
+    @override
     def icon(self) -> str:
         """Battery state icon handling."""
         chargestate = self.car.data[DATA_CHARGING]
@@ -89,12 +93,14 @@ class LeafRangeSensor(LeafEntity, SensorEntity):
             self._attr_unique_id = f"{self.car.leaf.vin.lower()}_range"
 
     @property
+    @override
     def name(self) -> str:
         """Update sensor name depending on AC."""
         if self._ac_on is True:
             return f"{self.car.leaf.nickname} Range (AC)"
         return f"{self.car.leaf.nickname} Range"
 
+    @override
     def log_registration(self) -> None:
         """Log registration."""
         _LOGGER.debug(
@@ -103,6 +109,7 @@ class LeafRangeSensor(LeafEntity, SensorEntity):
         )
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Battery range in miles or kms."""
         ret: float | None
@@ -122,6 +129,7 @@ class LeafRangeSensor(LeafEntity, SensorEntity):
         return round(ret)
 
     @property
+    @override
     def native_unit_of_measurement(self) -> str:
         """Battery range unit."""
         if self.car.hass.config.units is US_CUSTOMARY_SYSTEM or self.car.force_miles:

--- a/homeassistant/components/nissan_leaf/switch.py
+++ b/homeassistant/components/nissan_leaf/switch.py
@@ -1,7 +1,7 @@
 """Charge and Climate Control Support for the Nissan Leaf."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant
@@ -42,10 +42,12 @@ class LeafClimateSwitch(LeafEntity, SwitchEntity):
         self._attr_unique_id = f"{self.car.leaf.vin.lower()}_climatecontrol"
 
     @property
+    @override
     def name(self) -> str:
         """Switch name."""
         return f"{self.car.leaf.nickname} Climate Control"
 
+    @override
     def log_registration(self) -> None:
         """Log registration."""
         _LOGGER.debug(
@@ -54,6 +56,7 @@ class LeafClimateSwitch(LeafEntity, SwitchEntity):
         )
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return climate control attributes."""
         attrs = super().extra_state_attributes
@@ -61,15 +64,18 @@ class LeafClimateSwitch(LeafEntity, SwitchEntity):
         return attrs
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if climate control is on."""
         return bool(self.car.data[DATA_CLIMATE])
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on climate control."""
         if await self.car.async_set_climate(True):
             self.car.data[DATA_CLIMATE] = True
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off climate control."""
         if await self.car.async_set_climate(False):

--- a/homeassistant/components/nmap_tracker/config_flow.py
+++ b/homeassistant/components/nmap_tracker/config_flow.py
@@ -2,7 +2,7 @@
 
 from ipaddress import ip_address, ip_network, summarize_address_range
 import re
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -222,6 +222,7 @@ class NmapTrackerConfigFlow(ConfigFlow, domain=DOMAIN):
         """Initialize config flow."""
         self.options: dict[str, Any] = {}
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -259,6 +260,7 @@ class NmapTrackerConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: NmapTrackerConfigEntry,
     ) -> OptionsFlowHandler:

--- a/homeassistant/components/nmap_tracker/device_tracker.py
+++ b/homeassistant/components/nmap_tracker/device_tracker.py
@@ -1,7 +1,7 @@
 """Support for scanning a network with nmap."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.device_tracker import ScannerEntity
 from homeassistant.core import HomeAssistant, callback
@@ -68,31 +68,37 @@ class NmapTrackerEntity(ScannerEntity):
         return self._tracked[self._mac_address]
 
     @property
+    @override
     def is_connected(self) -> bool:
         """Return device status."""
         return self._active
 
     @property
+    @override
     def name(self) -> str:
         """Return device name."""
         return self._device.name
 
     @property
+    @override
     def unique_id(self) -> str:
         """Return device unique id."""
         return self._mac_address
 
     @property
+    @override
     def ip_address(self) -> str:
         """Return the primary ip address of the device."""
         return self._device.ipv4
 
     @property
+    @override
     def mac_address(self) -> str:
         """Return the mac address of the device."""
         return self._mac_address
 
     @property
+    @override
     def hostname(self) -> str | None:
         """Return hostname of the device."""
         if not self._device.hostname:
@@ -105,6 +111,7 @@ class NmapTrackerEntity(ScannerEntity):
         self._active = online
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the attributes."""
         return {
@@ -120,6 +127,7 @@ class NmapTrackerEntity(ScannerEntity):
         self.async_process_update(online)
         self.async_write_ha_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register state update callback."""
         self.async_on_remove(

--- a/homeassistant/components/nmbs/config_flow.py
+++ b/homeassistant/components/nmbs/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for NMBS integration."""
 
-from typing import Any
+from typing import Any, override
 
 from pyrail import iRail
 from pyrail.models import StationDetails
@@ -46,6 +46,7 @@ class NMBSConfigFlow(ConfigFlow, domain=DOMAIN):
             for station in self.stations
         ]
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/nmbs/sensor.py
+++ b/homeassistant/components/nmbs/sensor.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyrail import iRail
 from pyrail.models import ConnectionDetails, LiveboardDeparture, StationDetails
@@ -116,11 +116,13 @@ class NMBSLiveBoard(SensorEntity):
         self.entity_registry_enabled_default = False
 
     @property
+    @override
     def name(self) -> str:
         """Return the sensor default name."""
         return f"Trains in {self._station.standard_name}"
 
     @property
+    @override
     def unique_id(self) -> str:
         """Return the unique ID."""
 
@@ -129,6 +131,7 @@ class NMBSLiveBoard(SensorEntity):
         return f"nmbs_live_{unique_id}{vias}"  # pylint: disable=home-assistant-entity-unique-id-redundant-domain
 
     @property
+    @override
     def icon(self) -> str:
         """Return the default icon or an alert icon if delays."""
         if self._attrs and int(self._attrs.delay) > 0:
@@ -137,11 +140,13 @@ class NMBSLiveBoard(SensorEntity):
         return DEFAULT_ICON
 
     @property
+    @override
     def native_value(self) -> str | None:
         """Return sensor state."""
         return self._state
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return the sensor attributes if data is available."""
         if self._state is None or not self._attrs:
@@ -213,6 +218,7 @@ class NMBSSensor(SensorEntity):
         self._state = None
 
     @property
+    @override
     def unique_id(self) -> str:
         """Return the unique ID."""
         unique_id = f"{self._station_from.id}_{self._station_to.id}"
@@ -221,6 +227,7 @@ class NMBSSensor(SensorEntity):
         return f"nmbs_connection_{unique_id}{vias}"  # pylint: disable=home-assistant-entity-unique-id-redundant-domain
 
     @property
+    @override
     def name(self) -> str:
         """Return the name of the sensor."""
         if self._name is None:
@@ -231,6 +238,7 @@ class NMBSSensor(SensorEntity):
         return self._name
 
     @property
+    @override
     def icon(self) -> str:
         """Return the sensor default icon or an alert icon if any delay."""
         if self._attrs:
@@ -241,6 +249,7 @@ class NMBSSensor(SensorEntity):
         return "mdi:train"
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return sensor attributes if data is available."""
         if self._state is None or not self._attrs:
@@ -285,6 +294,7 @@ class NMBSSensor(SensorEntity):
         return attrs
 
     @property
+    @override
     def native_value(self) -> int | None:
         """Return the state of the device."""
         return self._state

--- a/homeassistant/components/noaa_tides/sensor.py
+++ b/homeassistant/components/noaa_tides/sensor.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 import logging
-from typing import TYPE_CHECKING, Any, Literal, TypedDict
+from typing import TYPE_CHECKING, Any, Literal, TypedDict, override
 
 import noaa_coops as coops
 import requests
@@ -108,11 +108,13 @@ class NOAATidesAndCurrentsSensor(SensorEntity):
         self._attr_unique_id = f"{get_station_unique_id(station_id)}_summary"
 
     @property
+    @override
     def name(self) -> str:
         """Return the name of the sensor."""
         return self._name
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of this device."""
         attr: dict[str, Any] = {}
@@ -139,6 +141,7 @@ class NOAATidesAndCurrentsSensor(SensorEntity):
         return attr
 
     @property
+    @override
     def native_value(self) -> str | None:
         """Return the state."""
         if self.data is None:

--- a/homeassistant/components/nobo_hub/climate.py
+++ b/homeassistant/components/nobo_hub/climate.py
@@ -1,6 +1,6 @@
 """Python Control of Nobø Hub - Nobø Energy Control."""
 
-from typing import Any
+from typing import Any, override
 
 from pynobo import PynoboError, nobo
 
@@ -104,11 +104,13 @@ class NoboZone(NoboBaseEntity, ClimateEntity):
         )
         self._read_state()
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target HVAC mode."""
         preset = PRESET_COMFORT if hvac_mode == HVACMode.HEAT else PRESET_NONE
         await self._apply_preset(preset, "set_hvac_mode_failed")
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new zone override."""
         await self._apply_preset(preset_mode, "set_preset_mode_failed")
@@ -139,6 +141,7 @@ class NoboZone(NoboBaseEntity, ClimateEntity):
                 translation_key=translation_key,
             ) from err
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         if ATTR_TARGET_TEMP_LOW in kwargs:
@@ -159,6 +162,7 @@ class NoboZone(NoboBaseEntity, ClimateEntity):
         self._read_state()
 
     @callback
+    @override
     def _read_state(self) -> None:
         """Copy the current hub state onto the entity attributes."""
         if self._id not in self._nobo.zones:

--- a/homeassistant/components/nobo_hub/config_flow.py
+++ b/homeassistant/components/nobo_hub/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Nobø Ecohub integration."""
 
 import socket
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from pynobo import nobo
 import voluptuous as vol
@@ -43,6 +43,7 @@ class NoboHubConfigFlow(ConfigFlow, domain=DOMAIN):
         self._hub: str | None = None
         self._mac: str | None = None
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -72,6 +73,7 @@ class NoboHubConfigFlow(ConfigFlow, domain=DOMAIN):
             data_schema=data_schema,
         )
 
+    @override
     async def async_step_dhcp(
         self, discovery_info: DhcpServiceInfo
     ) -> ConfigFlowResult:
@@ -257,6 +259,7 @@ class NoboHubConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: NoboHubConfigEntry,
     ) -> OptionsFlowHandler:

--- a/homeassistant/components/nobo_hub/entity.py
+++ b/homeassistant/components/nobo_hub/entity.py
@@ -1,5 +1,7 @@
 """Base entity for the Nobø Ecohub integration."""
 
+from typing import override
+
 from pynobo import nobo
 
 from homeassistant.core import callback
@@ -16,11 +18,13 @@ class NoboBaseEntity(Entity):
         """Initialize the entity."""
         self._nobo = hub
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register callback with hub."""
         await super().async_added_to_hass()
         self._nobo.register_callback(self._handle_hub_update)
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Deregister callback from hub."""
         self._nobo.deregister_callback(self._handle_hub_update)

--- a/homeassistant/components/nobo_hub/select.py
+++ b/homeassistant/components/nobo_hub/select.py
@@ -1,5 +1,7 @@
 """Python Control of Nobø Hub - Nobø Energy Control."""
 
+from typing import override
+
 from pynobo import PynoboError, nobo
 
 from homeassistant.components.select import SelectEntity
@@ -76,6 +78,7 @@ class NoboGlobalSelector(NoboBaseEntity, SelectEntity):
             hw_version=hub.hub_info[ATTR_HARDWARE_VERSION],
         )
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Set override."""
         mode = [k for k, v in self._modes.items() if v == option][0]
@@ -94,11 +97,12 @@ class NoboGlobalSelector(NoboBaseEntity, SelectEntity):
         self._read_state()
 
     @callback
+    @override
     def _read_state(self) -> None:
         """Copy the current hub state onto the entity attributes."""
-        for override in self._nobo.overrides.values():
-            if override["target_type"] == nobo.API.OVERRIDE_TARGET_GLOBAL:
-                self._attr_current_option = self._modes[override["mode"]]
+        for override_data in self._nobo.overrides.values():
+            if override_data["target_type"] == nobo.API.OVERRIDE_TARGET_GLOBAL:
+                self._attr_current_option = self._modes[override_data["mode"]]
                 break
 
 
@@ -122,6 +126,7 @@ class NoboProfileSelector(NoboBaseEntity, SelectEntity):
             suggested_area=hub.zones[zone_id][ATTR_NAME],
         )
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Set week profile."""
         week_profile_id = [k for k, v in self._profiles.items() if v == option][0]
@@ -140,6 +145,7 @@ class NoboProfileSelector(NoboBaseEntity, SelectEntity):
         self._read_state()
 
     @callback
+    @override
     def _read_state(self) -> None:
         """Copy the current hub state onto the entity attributes."""
         if self._id not in self._nobo.zones:

--- a/homeassistant/components/nobo_hub/sensor.py
+++ b/homeassistant/components/nobo_hub/sensor.py
@@ -1,5 +1,7 @@
 """Python Control of Nobø Hub - Nobø Energy Control."""
 
+from typing import override
+
 from pynobo import nobo
 
 from homeassistant.components.sensor import (
@@ -68,6 +70,7 @@ class NoboTemperatureSensor(NoboBaseEntity, SensorEntity):
         self._read_state()
 
     @callback
+    @override
     def _read_state(self) -> None:
         """Copy the current hub state onto the entity attributes."""
         if self._id not in self._nobo.components:

--- a/homeassistant/components/nordpool/binary_sensor.py
+++ b/homeassistant/components/nordpool/binary_sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
@@ -76,6 +77,7 @@ class NordpoolPriceBinarySensor(NordpoolBaseEntity, BinarySensorEntity):
         super().__init__(coordinator, entity_description, area)
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
         return self.entity_description.value_fn(self)

--- a/homeassistant/components/nordpool/config_flow.py
+++ b/homeassistant/components/nordpool/config_flow.py
@@ -1,6 +1,6 @@
 """Adds config flow for Nord Pool integration."""
 
-from typing import Any
+from typing import Any, override
 
 from pynordpool import (
     Currency,
@@ -76,6 +76,7 @@ class NordpoolConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/nordpool/coordinator.py
+++ b/homeassistant/components/nordpool/coordinator.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 import aiohttp
 from pynordpool import (
@@ -69,6 +69,7 @@ class NordPoolDataUpdateCoordinator(DataUpdateCoordinator[DeliveryPeriodsData]):
         LOGGER.debug("Next listener update at %s", next_run)
         return next_run
 
+    @override
     async def async_shutdown(self) -> None:
         """Cancel any scheduled call, and ignore new runs."""
         await super().async_shutdown()
@@ -117,6 +118,7 @@ class NordPoolDataUpdateCoordinator(DataUpdateCoordinator[DeliveryPeriodsData]):
             return self.data
         raise UpdateFailed(translation_domain=DOMAIN, translation_key="no_day_data")
 
+    @override
     async def _async_update_data(self) -> DeliveryPeriodsData:
         """Fetch the latest data from the source."""
         return await self.handle_data()

--- a/homeassistant/components/nordpool/sensor.py
+++ b/homeassistant/components/nordpool/sensor.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
+from typing import override
 
 from homeassistant.components.sensor import (
     EntityCategory,
@@ -323,6 +324,7 @@ class NordpoolSensor(NordpoolBaseEntity, SensorEntity):
     entity_description: NordpoolDefaultSensorEntityDescription
 
     @property
+    @override
     def native_value(self) -> str | float | datetime | None:
         """Return value of sensor."""
         return self.entity_description.value_fn(self)
@@ -345,11 +347,13 @@ class NordpoolPriceSensor(NordpoolBaseEntity, SensorEntity):
         self._attr_native_unit_of_measurement = f"{currency}/kWh"
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return value of sensor."""
         return self.entity_description.value_fn(self)
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, str] | None:
         """Return the extra state attributes."""
         return self.entity_description.extra_fn(self)
@@ -377,6 +381,7 @@ class NordpoolBlockPriceSensor(NordpoolBaseEntity, SensorEntity):
         self._attr_translation_placeholders = {"block": block_name}
 
     @property
+    @override
     def native_value(self) -> float | datetime | None:
         """Return value of sensor."""
         return self.entity_description.value_fn(
@@ -401,6 +406,7 @@ class NordpoolDailyAveragePriceSensor(NordpoolBaseEntity, SensorEntity):
         self._attr_native_unit_of_measurement = f"{currency}/kWh"
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return value of sensor."""
         data = self.coordinator.get_data_current_day()

--- a/homeassistant/components/norway_air/air_quality.py
+++ b/homeassistant/components/norway_air/air_quality.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import logging
+from typing import override
 
 import metno
 import voluptuous as vol
@@ -92,6 +93,7 @@ class AirSensor(AirQualityEntity):
         )
 
     @property
+    @override
     def extra_state_attributes(self) -> dict:
         """Return other details about the sensor state."""
         return {
@@ -100,41 +102,48 @@ class AirSensor(AirQualityEntity):
         }
 
     @property
+    @override
     def name(self) -> str:
         """Return the name of the sensor."""
         return self._name
 
     @property
     @round_state
+    @override
     def air_quality_index(self):
         """Return the Air Quality Index (AQI)."""
         return self._api.data.get("aqi")
 
     @property
     @round_state
+    @override
     def nitrogen_dioxide(self):
         """Return the NO2 (nitrogen dioxide) level."""
         return self._api.data.get("no2_concentration")
 
     @property
     @round_state
+    @override
     def ozone(self):
         """Return the O3 (ozone) level."""
         return self._api.data.get("o3_concentration")
 
     @property
     @round_state
+    @override
     def particulate_matter_2_5(self):
         """Return the particulate matter 2.5 level."""
         return self._api.data.get("pm25_concentration")
 
     @property
     @round_state
+    @override
     def particulate_matter_10(self):
         """Return the particulate matter 10 level."""
         return self._api.data.get("pm10_concentration")
 
     @property
+    @override
     def unit_of_measurement(self):
         """Return the unit of measurement of this entity, if any."""
         return self._api.units.get("pm25_concentration")

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -147,6 +147,7 @@ class NotifyEntity(RestoreEntity):
         self.__dict__.pop("state", None)
         self.__last_notified_isoformat = state
 
+    @override
     async def async_internal_added_to_hass(self) -> None:
         """Call when the notify entity is added to hass."""
         await super().async_internal_added_to_hass()

--- a/homeassistant/components/notify_events/notify.py
+++ b/homeassistant/components/notify_events/notify.py
@@ -2,7 +2,7 @@
 
 import logging
 import os.path
-from typing import Any
+from typing import Any, override
 
 from notify_events import Message
 
@@ -122,6 +122,7 @@ class NotifyEventsNotificationService(BaseNotificationService):
 
         return msg
 
+    @override
     def send_message(self, message: str, **kwargs: Any) -> None:
         """Send a message."""
         data = kwargs.get(ATTR_DATA) or {}

--- a/homeassistant/components/notion/binary_sensor.py
+++ b/homeassistant/components/notion/binary_sensor.py
@@ -1,7 +1,7 @@
 """Support for Notion binary sensors."""
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, override
 
 from aionotion.listener.models import ListenerKind
 
@@ -133,6 +133,7 @@ class NotionBinarySensor(NotionEntity, BinarySensorEntity):
     entity_description: NotionBinarySensorDescription
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
         if not self.listener.insights.primary.value:

--- a/homeassistant/components/notion/config_flow.py
+++ b/homeassistant/components/notion/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, override
 
 from aionotion.errors import InvalidCredentialsError, NotionError
 import voluptuous as vol
@@ -108,6 +108,7 @@ class NotionFlowHandler(ConfigFlow, domain=DOMAIN):
             },
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, str] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/notion/coordinator.py
+++ b/homeassistant/components/notion/coordinator.py
@@ -3,7 +3,7 @@
 import asyncio
 from dataclasses import dataclass, field
 from datetime import timedelta
-from typing import Any
+from typing import Any, override
 
 from aionotion.bridge.models import Bridge
 from aionotion.client import Client
@@ -126,6 +126,7 @@ class NotionDataUpdateCoordinator(DataUpdateCoordinator[NotionData]):
 
         self._client = client
 
+    @override
     async def _async_update_data(self) -> NotionData:
         """Fetch data from Notion."""
         data = NotionData(hass=self.hass, entry=self.config_entry)

--- a/homeassistant/components/notion/entity.py
+++ b/homeassistant/components/notion/entity.py
@@ -1,6 +1,7 @@
 """Support for Notion."""
 
 from dataclasses import dataclass
+from typing import override
 
 from aionotion.bridge.models import Bridge
 from aionotion.listener.models import Listener, ListenerKind
@@ -59,6 +60,7 @@ class NotionEntity(CoordinatorEntity[NotionDataUpdateCoordinator]):
         self.entity_description = description
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available."""
         return (
@@ -114,6 +116,7 @@ class NotionEntity(CoordinatorEntity[NotionDataUpdateCoordinator]):
         )
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Respond to a DataUpdateCoordinator update."""
         if self._listener_id in self.coordinator.data.listeners:

--- a/homeassistant/components/notion/sensor.py
+++ b/homeassistant/components/notion/sensor.py
@@ -1,6 +1,7 @@
 """Support for Notion sensors."""
 
 from dataclasses import dataclass
+from typing import override
 
 from aionotion.listener.models import ListenerKind
 
@@ -69,6 +70,7 @@ class NotionSensor(NotionEntity, SensorEntity):
     """Define a Notion sensor."""
 
     @property
+    @override
     def native_unit_of_measurement(self) -> str | None:
         """Return the unit of measurement of the sensor."""
         if self.listener.definition_id == ListenerKind.TEMPERATURE.value:
@@ -80,6 +82,7 @@ class NotionSensor(NotionEntity, SensorEntity):
         return None
 
     @property
+    @override
     def native_value(self) -> str | None:
         """Return the value reported by the sensor."""
         if not self.listener.status_localized:

--- a/homeassistant/components/novy_cooker_hood/config_flow.py
+++ b/homeassistant/components/novy_cooker_hood/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for the Novy Cooker Hood integration."""
 
 import asyncio
-from typing import Any
+from typing import Any, override
 
 from rf_protocols.codes.novy.cooker_hood import NovyCookerHoodButton
 import voluptuous as vol
@@ -44,6 +44,7 @@ class NovyCookerHoodConfigFlow(ConfigFlow, domain=DOMAIN):
         self._transmitter_id: str | None = None
         self._code: int = DEFAULT_CODE
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/novy_cooker_hood/entity.py
+++ b/homeassistant/components/novy_cooker_hood/entity.py
@@ -1,6 +1,7 @@
 """Common entity for the Novy Cooker Hood integration."""
 
 import logging
+from typing import override
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_UNAVAILABLE
@@ -31,6 +32,7 @@ class NovyCookerHoodEntity(Entity):
             model="Cooker Hood",
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Subscribe to transmitter entity state changes."""
         await super().async_added_to_hass()

--- a/homeassistant/components/novy_cooker_hood/fan.py
+++ b/homeassistant/components/novy_cooker_hood/fan.py
@@ -1,7 +1,7 @@
 """Fan platform for the Novy Cooker Hood (calibrated speed control)."""
 
 import math
-from typing import Any
+from typing import Any, override
 
 from rf_protocols.codes.novy.cooker_hood import NovyCookerHoodButton
 from rf_protocols.commands.novy import NovyCookerHoodCommand
@@ -54,17 +54,20 @@ class NovyCookerHoodFan(NovyCookerHoodEntity, FanEntity, RestoreEntity):
         self._attr_unique_id = entry.entry_id
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return whether the fan is currently on."""
         return self._level > 0
 
     @property
+    @override
     def percentage(self) -> int:
         """Return the current speed as a percentage."""
         if self._level == 0:
             return 0
         return ranged_value_to_percentage(_SPEED_RANGE, self._level)
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Restore the last known speed level from the saved percentage."""
         await super().async_added_to_hass()
@@ -75,6 +78,7 @@ class NovyCookerHoodFan(NovyCookerHoodEntity, FanEntity, RestoreEntity):
         if isinstance(last_pct, (int, float)) and last_pct > 0:
             self._level = math.ceil(percentage_to_ranged_value(_SPEED_RANGE, last_pct))
 
+    @override
     async def async_turn_on(
         self,
         percentage: int | None = None,
@@ -88,10 +92,12 @@ class NovyCookerHoodFan(NovyCookerHoodEntity, FanEntity, RestoreEntity):
             level = math.ceil(percentage_to_ranged_value(_SPEED_RANGE, percentage))
         await self._async_set_level(level)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the fan off by sending the calibration sequence to level 0."""
         await self._async_set_level(0)
 
+    @override
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the fan speed via calibration."""
         if percentage <= 0:
@@ -100,6 +106,7 @@ class NovyCookerHoodFan(NovyCookerHoodEntity, FanEntity, RestoreEntity):
         level = math.ceil(percentage_to_ranged_value(_SPEED_RANGE, percentage))
         await self._async_set_level(level)
 
+    @override
     async def async_increase_speed(self, percentage_step: int | None = None) -> None:
         """Bump speed up by N hardware levels (no recalibration)."""
         steps = self._steps_from_percentage(percentage_step)
@@ -109,6 +116,7 @@ class NovyCookerHoodFan(NovyCookerHoodEntity, FanEntity, RestoreEntity):
         self._level = min(SPEED_COUNT, self._level + steps)
         self.async_write_ha_state()
 
+    @override
     async def async_decrease_speed(self, percentage_step: int | None = None) -> None:
         """Bump speed down by N hardware levels (no recalibration)."""
         steps = self._steps_from_percentage(percentage_step)

--- a/homeassistant/components/novy_cooker_hood/light.py
+++ b/homeassistant/components/novy_cooker_hood/light.py
@@ -1,6 +1,6 @@
 """Light platform for the Novy Cooker Hood."""
 
-from typing import Any
+from typing import Any, override
 
 from rf_protocols.codes.novy.cooker_hood import NovyCookerHoodButton
 
@@ -39,18 +39,21 @@ class NovyCookerHoodLight(NovyCookerHoodEntity, LightEntity, RestoreEntity):
         self._code = entry.data[CONF_CODE]
         self._attr_unique_id = entry.entry_id
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Restore the last known on/off state."""
         await super().async_added_to_hass()
         if (last_state := await self.async_get_last_state()) is not None:
             self._attr_is_on = last_state.state == STATE_ON
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on by sending the toggle command."""
         await self._async_send_light()
         self._attr_is_on = True
         self.async_write_ha_state()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off by sending the toggle command."""
         await self._async_send_light()

--- a/homeassistant/components/nrgkick/binary_sensor.py
+++ b/homeassistant/components/nrgkick/binary_sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
@@ -69,6 +70,7 @@ class NRGkickBinarySensor(NRGkickEntity, BinarySensorEntity):
         self.entity_description = entity_description
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return the state of the binary sensor."""
         return self.entity_description.is_on_fn(self.coordinator.data)

--- a/homeassistant/components/nrgkick/config_flow.py
+++ b/homeassistant/components/nrgkick/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from nrgkick_api import NRGkickAPI
 import voluptuous as vol
@@ -168,6 +168,7 @@ class NRGkickConfigFlow(ConfigFlow, domain=DOMAIN):
             errors["base"] = "unknown"
         return None
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -347,6 +348,7 @@ class NRGkickConfigFlow(ConfigFlow, domain=DOMAIN):
             },
         )
 
+    @override
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/nrgkick/coordinator.py
+++ b/homeassistant/components/nrgkick/coordinator.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 import aiohttp
 from nrgkick_api import (
@@ -56,6 +56,7 @@ class NRGkickDataUpdateCoordinator(DataUpdateCoordinator[NRGkickData]):
             always_update=False,
         )
 
+    @override
     async def _async_update_data(self) -> NRGkickData:
         """Update data via library."""
         try:

--- a/homeassistant/components/nrgkick/device_tracker.py
+++ b/homeassistant/components/nrgkick/device_tracker.py
@@ -1,6 +1,6 @@
 """Device tracker platform for NRGkick."""
 
-from typing import Any, Final
+from typing import Any, Final, override
 
 from homeassistant.components.device_tracker import TrackerEntity
 from homeassistant.core import HomeAssistant
@@ -55,16 +55,19 @@ class NRGkickDeviceTracker(NRGkickEntity, TrackerEntity):
         return float(value) if value is not None else None
 
     @property
+    @override
     def latitude(self) -> float | None:
         """Return latitude value of the device."""
         return self._gps_float("latitude")
 
     @property
+    @override
     def longitude(self) -> float | None:
         """Return longitude value of the device."""
         return self._gps_float("longitude")
 
     @property
+    @override
     def location_accuracy(self) -> float:
         """Return the location accuracy of the device."""
         return self._gps_float("accuracy") or 0.0

--- a/homeassistant/components/nrgkick/number.py
+++ b/homeassistant/components/nrgkick/number.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from nrgkick_api.const import (
     CONTROL_KEY_CURRENT_SET,
@@ -130,6 +130,7 @@ class NRGkickNumber(NRGkickEntity, NumberEntity):
         super().__init__(coordinator, description.key)
 
     @property
+    @override
     def native_max_value(self) -> float:
         """Return the maximum value."""
         if self.entity_description.max_value_fn is not None:
@@ -140,6 +141,7 @@ class NRGkickNumber(NRGkickEntity, NumberEntity):
         return super().native_max_value
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the current value."""
         data = self.coordinator.data
@@ -147,6 +149,7 @@ class NRGkickNumber(NRGkickEntity, NumberEntity):
             assert data is not None
         return self.entity_description.value_fn(data)
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Set the value."""
         await self._async_call_api(
@@ -164,6 +167,7 @@ class NRGkickPhaseCountNumber(NRGkickNumber):
     _last_phase_count: float | None = None
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the current value, filtering transient zeros."""
         value = super().native_value
@@ -171,6 +175,7 @@ class NRGkickPhaseCountNumber(NRGkickNumber):
             self._last_phase_count = value
         return self._last_phase_count
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Set phase count with optimistic update."""
         self._last_phase_count = int(value)

--- a/homeassistant/components/nrgkick/sensor.py
+++ b/homeassistant/components/nrgkick/sensor.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Any, cast
+from typing import Any, cast, override
 
 from nrgkick_api import ChargingStatus
 
@@ -790,6 +790,7 @@ class NRGkickSensor(NRGkickEntity, SensorEntity):
         self.entity_description = entity_description
 
     @property
+    @override
     def native_value(self) -> StateType | datetime:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/nrgkick/switch.py
+++ b/homeassistant/components/nrgkick/switch.py
@@ -1,6 +1,6 @@
 """Switch platform for NRGkick."""
 
-from typing import Any
+from typing import Any, override
 
 from nrgkick_api.const import CONTROL_KEY_CHARGE_PAUSE
 
@@ -42,16 +42,19 @@ class NRGkickChargingEnabledSwitch(NRGkickEntity, SwitchEntity):
         super().__init__(coordinator, CHARGING_ENABLED_KEY)
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return the state of the switch."""
         data = self.coordinator.data
         assert data is not None
         return _is_charging_enabled(data)
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on (enable charging)."""
         await self._async_call_api(self.coordinator.api.set_charge_pause(False))
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off (pause charging)."""
         await self._async_call_api(self.coordinator.api.set_charge_pause(True))

--- a/homeassistant/components/nsw_fuel_station/coordinator.py
+++ b/homeassistant/components/nsw_fuel_station/coordinator.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 import datetime
 import logging
+from typing import override
 
 from nsw_fuel import FuelCheckClient, FuelCheckError, Station
 
@@ -38,6 +39,7 @@ class NSWFuelStationCoordinator(DataUpdateCoordinator[StationPriceData]):
         )
         self.client = client
 
+    @override
     async def _async_update_data(self) -> StationPriceData:
         """Fetch data from API."""
         return await self.hass.async_add_executor_job(

--- a/homeassistant/components/nsw_fuel_station/sensor.py
+++ b/homeassistant/components/nsw_fuel_station/sensor.py
@@ -1,6 +1,7 @@
 """Sensor platform to display the current fuel prices at a NSW fuel station."""
 
 import logging
+from typing import override
 
 import voluptuous as vol
 
@@ -96,18 +97,21 @@ class StationPriceSensor(CoordinatorEntity[NSWFuelStationCoordinator], SensorEnt
         self._fuel_type = fuel_type
 
     @property
+    @override
     def name(self) -> str:
         """Return the name of the sensor."""
         station_name = self._get_station_name()
         return f"{station_name} {self._fuel_type}"
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the state of the sensor."""
         prices = self.coordinator.data.prices
         return prices.get((self._station_id, self._fuel_type))
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, int | str]:
         """Return the state attributes of the device."""
         return {
@@ -116,6 +120,7 @@ class StationPriceSensor(CoordinatorEntity[NSWFuelStationCoordinator], SensorEnt
         }
 
     @property
+    @override
     def native_unit_of_measurement(self) -> str:
         """Return the units of measurement."""
         return f"{CURRENCY_CENT}/{UnitOfVolume.LITERS}"
@@ -129,6 +134,7 @@ class StationPriceSensor(CoordinatorEntity[NSWFuelStationCoordinator], SensorEnt
         return f"station {self._station_id}"
 
     @property
+    @override
     def unique_id(self) -> str | None:
         """Return a unique ID."""
         return f"{self._station_id}_{self._fuel_type}"

--- a/homeassistant/components/nsw_rural_fire_service_feed/geo_location.py
+++ b/homeassistant/components/nsw_rural_fire_service_feed/geo_location.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from datetime import datetime, timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from aio_geojson_nsw_rfs_incidents import NswRuralFireServiceIncidentsFeedManager
 from aio_geojson_nsw_rfs_incidents.feed_entry import (
@@ -203,6 +203,7 @@ class NswRuralFireServiceLocationEvent(GeolocationEvent):
         self._remove_signal_delete: Callable[[], None]
         self._remove_signal_update: Callable[[], None]
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Call when entity is added to hass."""
         self._remove_signal_delete = async_dispatcher_connect(
@@ -216,6 +217,7 @@ class NswRuralFireServiceLocationEvent(GeolocationEvent):
             self._update_callback,
         )
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Call when entity will be removed from hass."""
         self._remove_signal_delete()
@@ -258,6 +260,7 @@ class NswRuralFireServiceLocationEvent(GeolocationEvent):
         self._responsible_agency = feed_entry.responsible_agency
 
     @property
+    @override
     def icon(self) -> str:
         """Return the icon to use in the frontend."""
         if self._fire:
@@ -265,6 +268,7 @@ class NswRuralFireServiceLocationEvent(GeolocationEvent):
         return "mdi:alarm-light"
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the device state attributes."""
         return {

--- a/homeassistant/components/ntfy/config_flow.py
+++ b/homeassistant/components/ntfy/config_flow.py
@@ -5,7 +5,7 @@ import logging
 import random
 import re
 import string
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from aiontfy import Ntfy
 from aiontfy.exceptions import (
@@ -166,12 +166,14 @@ class NtfyConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @classmethod
     @callback
+    @override
     def async_get_supported_subentry_types(
         cls, config_entry: ConfigEntry
     ) -> dict[str, type[ConfigSubentryFlow]]:
         """Return subentries supported by this integration."""
         return {SUBENTRY_TYPE_TOPIC: TopicSubentryFlowHandler}
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -235,6 +237,7 @@ class NtfyConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    @override
     async def async_on_create_entry(self, result: ConfigFlowResult) -> ConfigFlowResult:
         """Start subentry flow after creating main entry."""
         subentry_result = await self.hass.config_entries.subentries.async_init(

--- a/homeassistant/components/ntfy/coordinator.py
+++ b/homeassistant/components/ntfy/coordinator.py
@@ -4,6 +4,7 @@ from abc import abstractmethod
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
+from typing import override
 
 from aiontfy import Account as NtfyAccount, Ntfy, Version
 from aiontfy.exceptions import (
@@ -59,6 +60,7 @@ class BaseDataUpdateCoordinator[_DataT](DataUpdateCoordinator[_DataT]):
     async def async_update_data(self) -> _DataT:
         """Fetch the latest data from the source."""
 
+    @override
     async def _async_update_data(self) -> _DataT:
         """Fetch the latest data from the source."""
         try:
@@ -88,6 +90,7 @@ class NtfyDataUpdateCoordinator(BaseDataUpdateCoordinator[NtfyAccount]):
 
     update_interval = timedelta(minutes=15)
 
+    @override
     async def async_update_data(self) -> NtfyAccount:
         """Fetch account data from ntfy."""
 
@@ -105,6 +108,7 @@ class NtfyVersionDataUpdateCoordinator(BaseDataUpdateCoordinator[Version | None]
 
     update_interval = timedelta(hours=3)
 
+    @override
     async def async_update_data(self) -> Version | None:
         """Fetch version data from ntfy."""
         try:
@@ -130,6 +134,7 @@ class NtfyLatestReleaseUpdateCoordinator(DataUpdateCoordinator[LatestRelease]):
         )
         self.update_checker = update_checker
 
+    @override
     async def _async_update_data(self) -> LatestRelease:
         """Fetch latest release data."""
 

--- a/homeassistant/components/ntfy/event.py
+++ b/homeassistant/components/ntfy/event.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from aiontfy import Event, Notification
 from aiontfy.exceptions import (
@@ -82,6 +82,7 @@ class NtfyEventEntity(NtfyBaseEntity, EventEntity):
             self._trigger_event(event, notification.to_dict())
             self.async_write_ha_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
 
@@ -166,6 +167,7 @@ class NtfyEventEntity(NtfyBaseEntity, EventEntity):
             await asyncio.sleep(RECONNECT_INTERVAL)
 
     @property
+    @override
     def entity_picture(self) -> str | None:
         """Return the entity picture to use in the frontend, if any."""
 

--- a/homeassistant/components/ntfy/notify.py
+++ b/homeassistant/components/ntfy/notify.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from aiontfy import Message
 from aiontfy.exceptions import (
@@ -62,6 +62,7 @@ class NtfyNotifyEntity(NtfyBaseEntity, NotifyEntity):
     )
     _attr_supported_features = NotifyEntityFeature.TITLE
 
+    @override
     async def async_send_message(self, message: str, title: str | None = None) -> None:
         """Publish a message to a topic via notify.send_message action."""
         await self._publish(message=message, title=title)

--- a/homeassistant/components/ntfy/sensor.py
+++ b/homeassistant/components/ntfy/sensor.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
+from typing import override
 
 from aiontfy import Account as NtfyAccount
 
@@ -242,6 +243,7 @@ class NtfySensorEntity(NtfyCommonBaseEntity, SensorEntity):
     coordinator: NtfyDataUpdateCoordinator
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
 

--- a/homeassistant/components/ntfy/update.py
+++ b/homeassistant/components/ntfy/update.py
@@ -1,6 +1,7 @@
 """Update platform for the ntfy integration."""
 
 from enum import StrEnum
+from typing import override
 
 from homeassistant.components.update import (
     UpdateEntity,
@@ -72,32 +73,38 @@ class NtfyUpdateEntity(NtfyCommonBaseEntity, UpdateEntity):
             self._attr_device_info.update({"sw_version": self.installed_version})
 
     @property
+    @override
     def installed_version(self) -> str | None:
         """Current version."""
         return self.coordinator.data.version if self.coordinator.data else None
 
     @property
+    @override
     def title(self) -> str | None:
         """Title of the release."""
 
         return f"ntfy {self.update_checker.data.name}"
 
     @property
+    @override
     def release_url(self) -> str | None:
         """URL to the full release notes."""
 
         return self.update_checker.data.html_url
 
     @property
+    @override
     def latest_version(self) -> str | None:
         """Latest version."""
 
         return self.update_checker.data.tag_name.removeprefix("v")
 
+    @override
     async def async_release_notes(self) -> str | None:
         """Return the release notes."""
         return self.update_checker.data.body
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass.
 
@@ -109,6 +116,7 @@ class NtfyUpdateEntity(NtfyCommonBaseEntity, UpdateEntity):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return super().available and self.update_checker.last_update_success

--- a/homeassistant/components/nuheat/climate.py
+++ b/homeassistant/components/nuheat/climate.py
@@ -1,7 +1,7 @@
 """Support for NuHeat thermostats."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from nuheat.config import SCHEDULE_HOLD, SCHEDULE_RUN, SCHEDULE_TEMPORARY_HOLD
 from nuheat.util import (
@@ -91,6 +91,7 @@ class NuHeatThermostat(CoordinatorEntity[NuHeatCoordinator], ClimateEntity):
         self._attr_unique_id = thermostat.serial_number
 
     @property
+    @override
     def temperature_unit(self) -> str:
         """Return the unit of measurement."""
         if self._temperature_unit == "C":
@@ -99,6 +100,7 @@ class NuHeatThermostat(CoordinatorEntity[NuHeatCoordinator], ClimateEntity):
         return UnitOfTemperature.FAHRENHEIT
 
     @property
+    @override
     def current_temperature(self) -> int | None:
         """Return the current temperature."""
         if self._temperature_unit == "C":
@@ -107,10 +109,12 @@ class NuHeatThermostat(CoordinatorEntity[NuHeatCoordinator], ClimateEntity):
         return self._thermostat.fahrenheit
 
     @property
+    @override
     def available(self) -> bool:
         """Return the unique id."""
         return self.coordinator.last_update_success and self._thermostat.online
 
+    @override
     def set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set the system mode."""
         if hvac_mode == HVACMode.AUTO:
@@ -119,6 +123,7 @@ class NuHeatThermostat(CoordinatorEntity[NuHeatCoordinator], ClimateEntity):
             self._set_schedule_mode(SCHEDULE_HOLD)
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode:
         """Return current setting heat or auto."""
         if self._schedule_mode in (SCHEDULE_TEMPORARY_HOLD, SCHEDULE_HOLD):
@@ -126,11 +131,13 @@ class NuHeatThermostat(CoordinatorEntity[NuHeatCoordinator], ClimateEntity):
         return HVACMode.AUTO
 
     @property
+    @override
     def hvac_action(self) -> HVACAction:
         """Return current operation heat or idle."""
         return HVACAction.HEATING if self._thermostat.heating else HVACAction.IDLE
 
     @property
+    @override
     def min_temp(self) -> float:
         """Return the minimum supported temperature for the thermostat."""
         if self._temperature_unit == "C":
@@ -139,6 +146,7 @@ class NuHeatThermostat(CoordinatorEntity[NuHeatCoordinator], ClimateEntity):
         return self._thermostat.min_fahrenheit
 
     @property
+    @override
     def max_temp(self) -> float:
         """Return the maximum supported temperature for the thermostat."""
         if self._temperature_unit == "C":
@@ -147,6 +155,7 @@ class NuHeatThermostat(CoordinatorEntity[NuHeatCoordinator], ClimateEntity):
         return self._thermostat.max_fahrenheit
 
     @property
+    @override
     def target_temperature(self) -> int:
         """Return the currently programmed temperature."""
         if self._temperature_unit == "C":
@@ -155,10 +164,12 @@ class NuHeatThermostat(CoordinatorEntity[NuHeatCoordinator], ClimateEntity):
         return nuheat_to_fahrenheit(self._target_temperature)
 
     @property
+    @override
     def preset_mode(self) -> str:
         """Return current preset mode."""
         return SCHEDULE_MODE_TO_PRESET_MODE_MAP.get(self._schedule_mode, PRESET_RUN)
 
+    @override
     def set_preset_mode(self, preset_mode: str) -> None:
         """Update the hold mode of the thermostat."""
         self._set_schedule_mode(
@@ -172,6 +183,7 @@ class NuHeatThermostat(CoordinatorEntity[NuHeatCoordinator], ClimateEntity):
         self._thermostat.schedule_mode = schedule_mode
         self._schedule_update()
 
+    @override
     def set_temperature(self, **kwargs: Any) -> None:
         """Set a new target temperature."""
         self._set_temperature_and_mode(
@@ -231,6 +243,7 @@ class NuHeatThermostat(CoordinatorEntity[NuHeatCoordinator], ClimateEntity):
         """Force a refresh."""
         await self.coordinator.async_refresh()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()
@@ -243,12 +256,14 @@ class NuHeatThermostat(CoordinatorEntity[NuHeatCoordinator], ClimateEntity):
         self._target_temperature = self._thermostat.target_temperature
 
     @callback
+    @override
     def _handle_coordinator_update(self):
         """Get the latest state from the thermostat."""
         self._update_internal_state()
         self.async_write_ha_state()
 
     @property
+    @override
     def device_info(self) -> DeviceInfo:
         """Return the device_info of the device."""
         return DeviceInfo(

--- a/homeassistant/components/nuheat/config_flow.py
+++ b/homeassistant/components/nuheat/config_flow.py
@@ -2,7 +2,7 @@
 
 from http import HTTPStatus
 import logging
-from typing import Any
+from typing import Any, override
 
 import nuheat
 import requests.exceptions
@@ -65,6 +65,7 @@ class NuHeatConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/nuheat/coordinator.py
+++ b/homeassistant/components/nuheat/coordinator.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import logging
+from typing import override
 
 import nuheat
 
@@ -40,6 +41,7 @@ class NuHeatCoordinator(DataUpdateCoordinator[None]):
         )
         self.thermostat = thermostat
 
+    @override
     async def _async_update_data(self) -> None:
         """Fetch data from API endpoint."""
         await self.hass.async_add_executor_job(self.thermostat.get_data)

--- a/homeassistant/components/nuki/binary_sensor.py
+++ b/homeassistant/components/nuki/binary_sensor.py
@@ -1,5 +1,7 @@
 """Doorsensor Support for the Nuki Lock."""
 
+from typing import override
+
 from pynuki.constants import STATE_DOORSENSOR_OPENED
 from pynuki.device import NukiDevice
 
@@ -46,11 +48,13 @@ class NukiDoorsensorEntity(NukiEntity[NukiDevice], BinarySensorEntity):
     _attr_device_class = BinarySensorDeviceClass.DOOR
 
     @property
+    @override
     def unique_id(self) -> str:
         """Return a unique ID."""
         return f"{self._nuki_device.nuki_id}_doorsensor"
 
     @property
+    @override
     def available(self) -> bool:
         """Return true if door sensor is present and activated."""
         return super().available and self._nuki_device.is_door_sensor_activated
@@ -66,6 +70,7 @@ class NukiDoorsensorEntity(NukiEntity[NukiDevice], BinarySensorEntity):
         return self._nuki_device.door_sensor_state_name
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if the door is open."""
         return self.door_sensor_state == STATE_DOORSENSOR_OPENED
@@ -78,11 +83,13 @@ class NukiRingactionEntity(NukiEntity[NukiDevice], BinarySensorEntity):
     _attr_translation_key = "ring_action"
 
     @property
+    @override
     def unique_id(self) -> str:
         """Return a unique ID."""
         return f"{self._nuki_device.nuki_id}_ringaction"
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return the value of the ring action state."""
         return self._nuki_device.ring_action_state
@@ -96,11 +103,13 @@ class NukiBatteryCriticalEntity(NukiEntity[NukiDevice], BinarySensorEntity):
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     @property
+    @override
     def unique_id(self) -> str:
         """Return a unique ID."""
         return f"{self._nuki_device.nuki_id}_battery_critical"
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return the value of the battery critical."""
         return self._nuki_device.battery_critical
@@ -115,11 +124,13 @@ class NukiBatteryChargingEntity(NukiEntity[NukiDevice], BinarySensorEntity):
     _attr_entity_registry_enabled_default = False
 
     @property
+    @override
     def unique_id(self) -> str:
         """Return a unique ID."""
         return f"{self._nuki_device.nuki_id}_battery_charging"
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return the value of the battery charging."""
         return self._nuki_device.battery_charging

--- a/homeassistant/components/nuki/config_flow.py
+++ b/homeassistant/components/nuki/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from pynuki import NukiBridge
 from pynuki.bridge import InvalidCredentialsException
@@ -71,12 +71,14 @@ class NukiConfigFlow(ConfigFlow, domain=DOMAIN):
         self.discovery_schema: vol.Schema | None = None
         self._data: Mapping[str, Any] = {}
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a flow initiated by the user."""
         return await self.async_step_validate(user_input)
 
+    @override
     async def async_step_dhcp(
         self, discovery_info: DhcpServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/nuki/coordinator.py
+++ b/homeassistant/components/nuki/coordinator.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
+from typing import override
 
 from pynuki import NukiBridge, NukiLock, NukiOpener
 from pynuki.bridge import InvalidCredentialsException
@@ -67,6 +68,7 @@ class NukiCoordinator(DataUpdateCoordinator[None]):
         """Return the parsed id of the Nuki bridge."""
         return parse_id(self.bridge.info()["ids"]["hardwareId"])
 
+    @override
     async def _async_update_data(self) -> None:
         """Fetch data from Nuki bridge."""
         try:

--- a/homeassistant/components/nuki/entity.py
+++ b/homeassistant/components/nuki/entity.py
@@ -1,5 +1,7 @@
 """The nuki component."""
 
+from typing import override
+
 from pynuki.device import NukiDevice
 
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -27,6 +29,7 @@ class NukiEntity[_NukiDeviceT: NukiDevice](CoordinatorEntity[NukiCoordinator]):
         self._nuki_device = nuki_device
 
     @property
+    @override
     def device_info(self) -> DeviceInfo:
         """Device info for Nuki entities."""
         return DeviceInfo(

--- a/homeassistant/components/nuki/lock.py
+++ b/homeassistant/components/nuki/lock.py
@@ -1,7 +1,7 @@
 """Nuki.io lock platform."""
 
 from abc import abstractmethod
-from typing import Any
+from typing import Any, override
 
 from pynuki import NukiLock, NukiOpener
 from pynuki.constants import MODE_OPENER_CONTINUOUS
@@ -64,24 +64,29 @@ class NukiDeviceEntity[_NukiDeviceT: NukiDevice](NukiEntity[_NukiDeviceT], LockE
     _attr_name = None
 
     @property
+    @override
     def unique_id(self) -> str | None:
         """Return a unique ID."""
         return self._nuki_device.nuki_id
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available."""
         return super().available and self._nuki_device.state not in ERROR_STATES
 
     @abstractmethod
+    @override
     def lock(self, **kwargs: Any) -> None:
         """Lock the device."""
 
     @abstractmethod
+    @override
     def unlock(self, **kwargs: Any) -> None:
         """Unlock the device."""
 
     @abstractmethod
+    @override
     def open(self, **kwargs: Any) -> None:
         """Open the door latch."""
 
@@ -90,10 +95,12 @@ class NukiLockEntity(NukiDeviceEntity[NukiLock]):
     """Representation of a Nuki lock."""
 
     @property
+    @override
     def is_locked(self) -> bool:
         """Return true if lock is locked."""
         return self._nuki_device.is_locked
 
+    @override
     def lock(self, **kwargs: Any) -> None:
         """Lock the device."""
         try:
@@ -101,6 +108,7 @@ class NukiLockEntity(NukiDeviceEntity[NukiLock]):
         except RequestException as err:
             raise CannotConnect from err
 
+    @override
     def unlock(self, **kwargs: Any) -> None:
         """Unlock the device."""
         try:
@@ -108,6 +116,7 @@ class NukiLockEntity(NukiDeviceEntity[NukiLock]):
         except RequestException as err:
             raise CannotConnect from err
 
+    @override
     def open(self, **kwargs: Any) -> None:
         """Open the door latch."""
         try:
@@ -131,6 +140,7 @@ class NukiOpenerEntity(NukiDeviceEntity[NukiOpener]):
     """Representation of a Nuki opener."""
 
     @property
+    @override
     def is_locked(self) -> bool:
         """Return true if either ring-to-open or continuous mode is enabled."""
         return not (
@@ -138,6 +148,7 @@ class NukiOpenerEntity(NukiDeviceEntity[NukiOpener]):
             or self._nuki_device.mode == MODE_OPENER_CONTINUOUS
         )
 
+    @override
     def lock(self, **kwargs: Any) -> None:
         """Disable ring-to-open."""
         try:
@@ -145,6 +156,7 @@ class NukiOpenerEntity(NukiDeviceEntity[NukiOpener]):
         except RequestException as err:
             raise CannotConnect from err
 
+    @override
     def unlock(self, **kwargs: Any) -> None:
         """Enable ring-to-open."""
         try:
@@ -152,6 +164,7 @@ class NukiOpenerEntity(NukiDeviceEntity[NukiOpener]):
         except RequestException as err:
             raise CannotConnect from err
 
+    @override
     def open(self, **kwargs: Any) -> None:
         """Buzz open the door."""
         try:

--- a/homeassistant/components/nuki/sensor.py
+++ b/homeassistant/components/nuki/sensor.py
@@ -1,5 +1,7 @@
 """Battery sensor for the Nuki Lock."""
 
+from typing import override
+
 from pynuki.device import NukiDevice
 
 from homeassistant.components.sensor import (
@@ -38,11 +40,13 @@ class NukiBatterySensor(NukiEntity[NukiDevice], SensorEntity):
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     @property
+    @override
     def unique_id(self) -> str:
         """Return a unique ID."""
         return f"{self._nuki_device.nuki_id}_battery_level"
 
     @property
+    @override
     def native_value(self) -> float:
         """Return the state of the sensor."""
         return self._nuki_device.battery_charge

--- a/homeassistant/components/numato/binary_sensor.py
+++ b/homeassistant/components/numato/binary_sensor.py
@@ -2,6 +2,7 @@
 
 from functools import partial
 import logging
+from typing import override
 
 from numato_gpio import NumatoGpioError
 
@@ -101,6 +102,7 @@ class NumatoGpioBinarySensor(BinarySensorEntity):
         self._state = None
         self._api = api
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Connect state update callback."""
         self.async_on_remove(
@@ -118,6 +120,7 @@ class NumatoGpioBinarySensor(BinarySensorEntity):
         self.async_write_ha_state()
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return the state of the entity."""
         return self._state != self._invert_logic

--- a/homeassistant/components/numato/switch.py
+++ b/homeassistant/components/numato/switch.py
@@ -1,7 +1,7 @@
 """Switch platform integration for Numato USB GPIO expanders."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from numato_gpio import NumatoGpioError
 
@@ -78,6 +78,7 @@ class NumatoGpioSwitch(SwitchEntity):
         self._attr_is_on = False
         self._api = api
 
+    @override
     def turn_on(self, **kwargs: Any) -> None:
         """Turn the port on."""
         try:
@@ -95,6 +96,7 @@ class NumatoGpioSwitch(SwitchEntity):
                 err,
             )
 
+    @override
     def turn_off(self, **kwargs: Any) -> None:
         """Turn the port off."""
         try:

--- a/homeassistant/components/number/__init__.py
+++ b/homeassistant/components/number/__init__.py
@@ -6,7 +6,7 @@ import dataclasses
 from datetime import timedelta
 import logging
 from math import ceil, floor
-from typing import TYPE_CHECKING, Any, Self, final
+from typing import TYPE_CHECKING, Any, Self, final, override
 
 from propcache.api import cached_property
 import voluptuous as vol
@@ -201,6 +201,7 @@ class NumberEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     _deprecated_number_entity_reported = False
     _number_option_unit_of_measurement: str | None = None
 
+    @override
     def __init_subclass__(cls, **kwargs: Any) -> None:
         """Post initialisation processing."""
         super().__init_subclass__(**kwargs)
@@ -230,6 +231,7 @@ class NumberEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
                 report_issue,
             )
 
+    @override
     async def async_internal_added_to_hass(self) -> None:
         """Call when the number entity is added to hass."""
         await super().async_internal_added_to_hass()
@@ -238,6 +240,7 @@ class NumberEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         self.async_registry_entry_updated()
 
     @property
+    @override
     def capability_attributes(self) -> dict[str, Any]:
         """Return capability attributes."""
         device_class = self.device_class
@@ -254,6 +257,7 @@ class NumberEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
             ATTR_MODE: self.mode,
         }
 
+    @override
     def _default_to_device_class_name(self) -> bool:
         """Return True if an unnamed entity should be named by its device class.
 
@@ -262,6 +266,7 @@ class NumberEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         return self.device_class is not None
 
     @cached_property
+    @override
     def device_class(self) -> NumberDeviceClass | None:
         """Return the class of this entity."""
         if hasattr(self, "_attr_device_class"):
@@ -353,6 +358,7 @@ class NumberEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
 
     @property
     @final
+    @override
     def state(self) -> float | None:
         """Return the entity state."""
         return self.value
@@ -381,6 +387,7 @@ class NumberEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
 
     @property
     @final
+    @override
     def unit_of_measurement(self) -> str | None:
         """Return the unit of measurement of the entity, after unit conversion."""
         if self._number_option_unit_of_measurement:
@@ -502,6 +509,7 @@ class NumberEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         return value
 
     @callback
+    @override
     def async_registry_entry_updated(self) -> None:
         """Run when the entity registry entry has been updated."""
         if TYPE_CHECKING:
@@ -530,6 +538,7 @@ class NumberExtraStoredData(ExtraStoredData):
     native_unit_of_measurement: str | None
     native_value: float | None
 
+    @override
     def as_dict(self) -> dict[str, Any]:
         """Return a dict representation of the number data."""
         return dataclasses.asdict(self)
@@ -553,6 +562,7 @@ class RestoreNumber(NumberEntity, RestoreEntity):
     """Mixin class for restoring previous number state."""
 
     @property
+    @override
     def extra_restore_state_data(self) -> NumberExtraStoredData:
         """Return number specific state data to be restored."""
         return NumberExtraStoredData(

--- a/homeassistant/components/nut/button.py
+++ b/homeassistant/components/nut/button.py
@@ -1,6 +1,7 @@
 """Provides a switch for switchable NUT outlets."""
 
 import logging
+from typing import override
 
 from homeassistant.components.button import (
     ButtonDeviceClass,
@@ -57,6 +58,7 @@ async def async_setup_entry(
 class NUTButton(NUTBaseEntity, ButtonEntity):
     """Representation of a button entity for NUT."""
 
+    @override
     async def async_press(self) -> None:
         """Press the button."""
         name_list = self.entity_description.key.split(".")

--- a/homeassistant/components/nut/config_flow.py
+++ b/homeassistant/components/nut/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from aionut import NUTError, NUTLoginError
 import voluptuous as vol
@@ -117,6 +117,7 @@ class NutConfigFlow(ConfigFlow, domain=DOMAIN):
         self.title: str | None = None
         self.reauth_entry: ConfigEntry | None = None
 
+    @override
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:
@@ -129,6 +130,7 @@ class NutConfigFlow(ConfigFlow, domain=DOMAIN):
         self.context["title_placeholders"] = self.nut_config.copy()
         return await self.async_step_user()
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/nut/coordinator.py
+++ b/homeassistant/components/nut/coordinator.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from aionut import NUTError, NUTLoginError
 
@@ -55,6 +55,7 @@ class NutCoordinator(DataUpdateCoordinator[dict[str, str]]):
         )
         self._data = data
 
+    @override
     async def _async_update_data(self) -> dict[str, str]:
         """Fetch data from NUT."""
         try:

--- a/homeassistant/components/nut/sensor.py
+++ b/homeassistant/components/nut/sensor.py
@@ -1,7 +1,7 @@
 """Provides a sensor to track various status aspects of a NUT device."""
 
 import logging
-from typing import Final
+from typing import Final, override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -1136,6 +1136,7 @@ class NUTSensor(NUTBaseEntity, SensorEntity):
     """Representation of a sensor entity for NUT status values."""
 
     @property
+    @override
     def native_value(self) -> str | None:
         """Return entity state from NUT device."""
         status = self.coordinator.data

--- a/homeassistant/components/nut/switch.py
+++ b/homeassistant/components/nut/switch.py
@@ -1,7 +1,7 @@
 """Provides a switch for switchable NUT outlets."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.switch import (
     SwitchDeviceClass,
@@ -64,6 +64,7 @@ class NUTSwitch(NUTBaseEntity, SwitchEntity):
     """Representation of a switch entity for NUT status values."""
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return the state of the switch."""
         status = self.coordinator.data
@@ -72,6 +73,7 @@ class NUTSwitch(NUTBaseEntity, SwitchEntity):
             return None
         return bool(state == "on")
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the device."""
 
@@ -79,6 +81,7 @@ class NUTSwitch(NUTBaseEntity, SwitchEntity):
         command_name = f"{outlet}.{outlet_num_str}.load.on"
         await self.pynut_data.async_run_command(command_name)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the device."""
 

--- a/homeassistant/components/nws/config_flow.py
+++ b/homeassistant/components/nws/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for National Weather Service (NWS) integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 import aiohttp
 from pynws import SimpleNWS
@@ -56,6 +56,7 @@ class NWSConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/nws/coordinator.py
+++ b/homeassistant/components/nws/coordinator.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 import aiohttp
 from aiohttp import ClientResponseError
@@ -135,6 +135,7 @@ class NWSObservationDataUpdateCoordinator(TimestampDataUpdateCoordinator[None]):
         await runtime_data.coordinator_forecast.async_refresh()
         await runtime_data.coordinator_forecast_hourly.async_refresh()
 
+    @override
     async def _async_update_data(self) -> None:
         """Update data via library."""
         if self._location_entity_id:

--- a/homeassistant/components/nws/sensor.py
+++ b/homeassistant/components/nws/sensor.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 from datetime import datetime
+from typing import override
 
 from pynws import SimpleNWS
 
@@ -195,11 +196,13 @@ class NWSSensor(CoordinatorEntity[TimestampDataUpdateCoordinator[None]], SensorE
         return self._nws_data.api
 
     @property
+    @override
     def name(self) -> str:
         """Return the sensor name with current station."""
         return f"{self._nws.station} {self.entity_description.name}"
 
     @property
+    @override
     def native_value(self) -> float | datetime | None:
         """Return the state."""
         if (

--- a/homeassistant/components/nws/weather.py
+++ b/homeassistant/components/nws/weather.py
@@ -1,7 +1,7 @@
 """Support for NWS weather service."""
 
 from functools import partial
-from typing import Any, Required, TypedDict, cast
+from typing import Any, Required, TypedDict, cast, override
 
 from pynws import SimpleNWS
 import voluptuous as vol
@@ -159,6 +159,7 @@ class NWSWeather(CoordinatorWeatherEntity[TimestampDataUpdateCoordinator[None]])
         self._attr_unique_id = f"{get_base_unique_id(entry)}_{DAYNIGHT}"
         self._attr_device_info = device_info(entry, nws_data)
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()
@@ -179,11 +180,13 @@ class NWSWeather(CoordinatorWeatherEntity[TimestampDataUpdateCoordinator[None]])
         return self._nws_data.api
 
     @property
+    @override
     def name(self) -> str:
         """Return the station name."""
         return self.nws.station
 
     @property
+    @override
     def native_temperature(self) -> float | None:
         """Return the current temperature."""
         if observation := self.nws.observation:
@@ -191,6 +194,7 @@ class NWSWeather(CoordinatorWeatherEntity[TimestampDataUpdateCoordinator[None]])
         return None
 
     @property
+    @override
     def native_pressure(self) -> int | None:
         """Return the current pressure."""
         if observation := self.nws.observation:
@@ -198,6 +202,7 @@ class NWSWeather(CoordinatorWeatherEntity[TimestampDataUpdateCoordinator[None]])
         return None
 
     @property
+    @override
     def humidity(self) -> float | None:
         """Return the name of the sensor."""
         if observation := self.nws.observation:
@@ -205,6 +210,7 @@ class NWSWeather(CoordinatorWeatherEntity[TimestampDataUpdateCoordinator[None]])
         return None
 
     @property
+    @override
     def native_wind_speed(self) -> float | None:
         """Return the current windspeed."""
         if observation := self.nws.observation:
@@ -212,6 +218,7 @@ class NWSWeather(CoordinatorWeatherEntity[TimestampDataUpdateCoordinator[None]])
         return None
 
     @property
+    @override
     def wind_bearing(self) -> int | None:
         """Return the current wind bearing (degrees)."""
         if observation := self.nws.observation:
@@ -219,6 +226,7 @@ class NWSWeather(CoordinatorWeatherEntity[TimestampDataUpdateCoordinator[None]])
         return None
 
     @property
+    @override
     def condition(self) -> str | None:
         """Return current condition."""
         weather = None
@@ -231,6 +239,7 @@ class NWSWeather(CoordinatorWeatherEntity[TimestampDataUpdateCoordinator[None]])
         return None
 
     @property
+    @override
     def native_visibility(self) -> int | None:
         """Return visibility."""
         if observation := self.nws.observation:
@@ -318,15 +327,18 @@ class NWSWeather(CoordinatorWeatherEntity[TimestampDataUpdateCoordinator[None]])
         return forecast
 
     @callback
+    @override
     def _async_forecast_hourly(self) -> list[Forecast] | None:
         """Return the hourly forecast in native units."""
         return self._forecast(self.nws.forecast_hourly, HOURLY)
 
     @callback
+    @override
     def _async_forecast_twice_daily(self) -> list[Forecast] | None:
         """Return the twice daily forecast in native units."""
         return self._forecast(self.nws.forecast, DAYNIGHT)
 
+    @override
     async def async_update(self) -> None:
         """Update the entity.
 

--- a/homeassistant/components/nx584/alarm_control_panel.py
+++ b/homeassistant/components/nx584/alarm_control_panel.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import logging
+from typing import override
 
 from nx584 import client
 import requests
@@ -136,14 +137,17 @@ class NX584Alarm(AlarmControlPanelEntity):
             if flag == "Siren on":
                 self._attr_alarm_state = AlarmControlPanelState.TRIGGERED
 
+    @override
     def alarm_disarm(self, code: str | None = None) -> None:
         """Send disarm command."""
         self._alarm.disarm(code)
 
+    @override
     def alarm_arm_home(self, code: str | None = None) -> None:
         """Send arm home command."""
         self._alarm.arm("stay")
 
+    @override
     def alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command."""
         self._alarm.arm("exit")

--- a/homeassistant/components/nx584/binary_sensor.py
+++ b/homeassistant/components/nx584/binary_sensor.py
@@ -3,7 +3,7 @@
 import logging
 import threading
 import time
-from typing import Any
+from typing import Any, override
 
 from nx584 import client as nx584_client
 import requests
@@ -96,17 +96,20 @@ class NX584ZoneSensor(BinarySensorEntity):
         self._attr_device_class = zone_type
 
     @property
+    @override
     def name(self):
         """Return the name of the binary sensor."""
         return self._zone["name"]
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if the binary sensor is on."""
         # True means "faulted" or "open" or "abnormal state"
         return self._zone["state"]
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         return {
@@ -144,6 +147,7 @@ class NX584Watcher(threading.Thread):
             if events := self._client.get_events():
                 self._process_events(events)
 
+    @override
     def run(self):
         """Run the watcher."""
         while True:

--- a/homeassistant/components/nyt_games/config_flow.py
+++ b/homeassistant/components/nyt_games/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for NYT Games."""
 
-from typing import Any
+from typing import Any, override
 
 from nyt_games import NYTGamesAuthenticationError, NYTGamesClient, NYTGamesError
 import voluptuous as vol
@@ -15,6 +15,7 @@ from .const import DOMAIN, LOGGER
 class NYTGamesConfigFlow(ConfigFlow, domain=DOMAIN):
     """NYT Games config flow."""
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/nyt_games/coordinator.py
+++ b/homeassistant/components/nyt_games/coordinator.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 from datetime import timedelta
+from typing import override
 
 from nyt_games import Connections, NYTGamesClient, NYTGamesError, SpellingBee, Wordle
 
@@ -45,6 +46,7 @@ class NYTGamesCoordinator(DataUpdateCoordinator[NYTGamesData]):
         )
         self.client = client
 
+    @override
     async def _async_update_data(self) -> NYTGamesData:
         try:
             stats_data = await self.client.get_latest_stats()

--- a/homeassistant/components/nyt_games/sensor.py
+++ b/homeassistant/components/nyt_games/sensor.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import date
+from typing import override
 
 from nyt_games import Connections, SpellingBee, Wordle
 
@@ -187,6 +188,7 @@ class NYTGamesWordleSensor(WordleEntity, SensorEntity):
         )
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.coordinator.data.wordle)
@@ -210,6 +212,7 @@ class NYTGamesSpellingBeeSensor(SpellingBeeEntity, SensorEntity):
         )
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
         assert self.coordinator.data.spelling_bee is not None
@@ -234,6 +237,7 @@ class NYTGamesConnectionsSensor(ConnectionsEntity, SensorEntity):
         )
 
     @property
+    @override
     def native_value(self) -> StateType | date:
         """Return the state of the sensor."""
         assert self.coordinator.data.connections is not None

--- a/homeassistant/components/nzbget/config_flow.py
+++ b/homeassistant/components/nzbget/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for NZBGet."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -52,6 +52,7 @@ class NZBGetConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/nzbget/coordinator.py
+++ b/homeassistant/components/nzbget/coordinator.py
@@ -3,6 +3,7 @@
 import asyncio
 from datetime import timedelta
 import logging
+from typing import override
 
 from pynzbgetapi import NZBGetAPI, NZBGetAPIException
 
@@ -81,6 +82,7 @@ class NZBGetDataUpdateCoordinator(DataUpdateCoordinator):
         self._completed_downloads = actual_completed_downloads
         self._completed_downloads_init = True
 
+    @override
     async def _async_update_data(self) -> dict:
         """Fetch data from NZBGet."""
 

--- a/homeassistant/components/nzbget/sensor.py
+++ b/homeassistant/components/nzbget/sensor.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime, timedelta
 import logging
+from typing import override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -122,6 +123,7 @@ class NZBGetSensor(NZBGetEntity, SensorEntity):
         self._attr_unique_id = f"{entry_id}_{description.key}"
 
     @property
+    @override
     def native_value(self) -> StateType | datetime:
         """Return the state of the sensor."""
         sensor_type = self.entity_description.key

--- a/homeassistant/components/nzbget/switch.py
+++ b/homeassistant/components/nzbget/switch.py
@@ -1,6 +1,6 @@
 """Support for NZBGet switches."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.const import CONF_NAME
@@ -51,15 +51,18 @@ class NZBGetDownloadSwitch(NZBGetEntity, SwitchEntity):
         )
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return the state of the switch."""
         return not self.coordinator.data["status"].get("DownloadPaused", False)
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Set downloads to enabled."""
         await self.hass.async_add_executor_job(self.coordinator.nzbget.resumedownload)
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Set downloads to paused."""
         await self.hass.async_add_executor_job(self.coordinator.nzbget.pausedownload)

--- a/homeassistant/components/oasa_telematics/sensor.py
+++ b/homeassistant/components/oasa_telematics/sensor.py
@@ -3,7 +3,7 @@
 from datetime import datetime, timedelta
 import logging
 from operator import itemgetter
-from typing import Any
+from typing import Any, override
 
 import oasatelematics
 import voluptuous as vol
@@ -82,6 +82,7 @@ class OASATelematicsSensor(SensorEntity):
         self._times: list[dict[str, Any]] | None = None
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         params = {}

--- a/homeassistant/components/obihai/button.py
+++ b/homeassistant/components/obihai/button.py
@@ -1,5 +1,7 @@
 """Obihai button module."""
 
+from typing import override
+
 from homeassistant.components.button import (
     ButtonDeviceClass,
     ButtonEntity,
@@ -46,6 +48,7 @@ class ObihaiButton(ButtonEntity):
         self._pyobihai = requester.pyobihai
         self._attr_unique_id = f"{requester.serial}-reboot"
 
+    @override
     def press(self) -> None:
         """Press button."""
 

--- a/homeassistant/components/obihai/config_flow.py
+++ b/homeassistant/components/obihai/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow to configure the Obihai integration."""
 
 from socket import gaierror, gethostbyname
-from typing import Any
+from typing import Any, override
 
 from pyobihai import PyObihai
 import voluptuous as vol
@@ -55,6 +55,7 @@ class ObihaiFlowHandler(ConfigFlow, domain=DOMAIN):
     discovery_schema: vol.Schema | None = None
     _dhcp_discovery_info: DhcpServiceInfo | None = None
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -92,6 +93,7 @@ class ObihaiFlowHandler(ConfigFlow, domain=DOMAIN):
             data_schema=self.add_suggested_values_to_schema(data_schema, user_input),
         )
 
+    @override
     async def async_step_dhcp(
         self, discovery_info: DhcpServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/obihai/sensor.py
+++ b/homeassistant/components/obihai/sensor.py
@@ -1,6 +1,7 @@
 """Support for Obihai Sensors."""
 
 import datetime
+from typing import override
 
 from requests.exceptions import RequestException
 
@@ -53,6 +54,7 @@ class ObihaiServiceSensors(SensorEntity):
             self._attr_device_class = SensorDeviceClass.TIMESTAMP
 
     @property
+    @override
     def icon(self) -> str:
         """Return an icon."""
 

--- a/homeassistant/components/octoprint/binary_sensor.py
+++ b/homeassistant/components/octoprint/binary_sensor.py
@@ -1,6 +1,7 @@
 """Support for monitoring OctoPrint binary sensors."""
 
 from abc import abstractmethod
+from typing import override
 
 from pyoctoprintapi import OctoprintPrinterInfo
 
@@ -50,6 +51,7 @@ class OctoPrintBinarySensorBase(
         self._attr_device_info = coordinator.device_info
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if binary sensor is on."""
         if not (printer := self.coordinator.data["printer"]):
@@ -58,6 +60,7 @@ class OctoPrintBinarySensorBase(
         return bool(self._get_flag_state(printer))
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return self.coordinator.last_update_success and self.coordinator.data["printer"]
@@ -76,6 +79,7 @@ class OctoPrintPrintingBinarySensor(OctoPrintBinarySensorBase):
         """Initialize a new OctoPrint sensor."""
         super().__init__(coordinator, "Printing", device_id)
 
+    @override
     def _get_flag_state(self, printer_info: OctoprintPrinterInfo) -> bool | None:
         return bool(printer_info.state.flags.printing)
 
@@ -89,5 +93,6 @@ class OctoPrintPrintingErrorBinarySensor(OctoPrintBinarySensorBase):
         """Initialize a new OctoPrint sensor."""
         super().__init__(coordinator, "Printing Error", device_id)
 
+    @override
     def _get_flag_state(self, printer_info: OctoprintPrinterInfo) -> bool | None:
         return bool(printer_info.state.flags.error)

--- a/homeassistant/components/octoprint/button.py
+++ b/homeassistant/components/octoprint/button.py
@@ -1,5 +1,7 @@
 """Support for Octoprint buttons."""
 
+from typing import override
+
 from pyoctoprintapi import OctoprintClient, OctoprintPrinterInfo
 
 from homeassistant.components.button import ButtonDeviceClass, ButtonEntity
@@ -57,6 +59,7 @@ class OctoprintPrinterButton(
         self._attr_device_info = coordinator.device_info
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return self.coordinator.last_update_success and self.coordinator.data["printer"]
@@ -85,6 +88,7 @@ class OctoprintSystemButton(
         self._attr_device_info = coordinator.device_info
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return self.coordinator.last_update_success
@@ -102,6 +106,7 @@ class OctoprintPauseJobButton(OctoprintPrinterButton):
         """Initialize a new OctoPrint button."""
         super().__init__(coordinator, "Pause Job", device_id, client)
 
+    @override
     async def async_press(self) -> None:
         """Handle the button press."""
         printer: OctoprintPrinterInfo = self.coordinator.data["printer"]
@@ -124,6 +129,7 @@ class OctoprintResumeJobButton(OctoprintPrinterButton):
         """Initialize a new OctoPrint button."""
         super().__init__(coordinator, "Resume Job", device_id, client)
 
+    @override
     async def async_press(self) -> None:
         """Handle the button press."""
         printer: OctoprintPrinterInfo = self.coordinator.data["printer"]
@@ -146,6 +152,7 @@ class OctoprintStopJobButton(OctoprintPrinterButton):
         """Initialize a new OctoPrint button."""
         super().__init__(coordinator, "Stop Job", device_id, client)
 
+    @override
     async def async_press(self) -> None:
         """Handle the button press."""
         printer: OctoprintPrinterInfo = self.coordinator.data["printer"]
@@ -166,6 +173,7 @@ class OctoprintShutdownSystemButton(OctoprintSystemButton):
         """Initialize a new OctoPrint button."""
         super().__init__(coordinator, "Shutdown System", device_id, client)
 
+    @override
     async def async_press(self) -> None:
         """Handle the button press."""
         await self.client.shutdown()
@@ -185,6 +193,7 @@ class OctoprintRebootSystemButton(OctoprintSystemButton):
         """Initialize a new OctoPrint button."""
         super().__init__(coordinator, "Reboot System", device_id, client)
 
+    @override
     async def async_press(self) -> None:
         """Handle the button press."""
         await self.client.reboot_system()
@@ -204,6 +213,7 @@ class OctoprintRestartOctoprintButton(OctoprintSystemButton):
         """Initialize a new OctoPrint button."""
         super().__init__(coordinator, "Restart Octoprint", device_id, client)
 
+    @override
     async def async_press(self) -> None:
         """Handle the button press."""
         await self.client.restart()

--- a/homeassistant/components/octoprint/config_flow.py
+++ b/homeassistant/components/octoprint/config_flow.py
@@ -3,7 +3,7 @@
 import asyncio
 from collections.abc import Mapping
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 import aiohttp
 from pyoctoprintapi import ApiError, OctoprintClient, OctoprintException
@@ -62,6 +62,7 @@ class OctoPrintConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle a config flow for OctoPrint."""
         self._sessions: list[aiohttp.ClientSession] = []
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -168,6 +169,7 @@ class OctoPrintConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle import."""
         return await self.async_step_user(import_data)
 
+    @override
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:
@@ -194,6 +196,7 @@ class OctoPrintConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return await self.async_step_user()
 
+    @override
     async def async_step_ssdp(
         self, discovery_info: SsdpServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/octoprint/coordinator.py
+++ b/homeassistant/components/octoprint/coordinator.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 import logging
-from typing import cast
+from typing import cast, override
 
 from pyoctoprintapi import ApiError, OctoprintClient, PrinterOffline
 from pyoctoprintapi.exceptions import UnauthorizedException
@@ -47,6 +47,7 @@ class OctoprintDataUpdateCoordinator(DataUpdateCoordinator):
         self._printer_offline = False
         self.data = {"printer": None, "job": None, "last_read_time": None}
 
+    @override
     async def _async_update_data(self):
         """Update data via API."""
         printer = None

--- a/homeassistant/components/octoprint/number.py
+++ b/homeassistant/components/octoprint/number.py
@@ -1,6 +1,7 @@
 """Support for OctoPrint number entities."""
 
 import logging
+from typing import override
 
 from pyoctoprintapi import OctoprintClient
 
@@ -110,6 +111,7 @@ class OctoPrintTemperatureNumber(
             self._attr_translation_placeholders = {"n": tool[4:]}
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the current target temperature."""
         if not self.coordinator.data["printer"]:
@@ -120,6 +122,7 @@ class OctoPrintTemperatureNumber(
 
         return None
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Set the target temperature."""
 

--- a/homeassistant/components/octoprint/sensor.py
+++ b/homeassistant/components/octoprint/sensor.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime, timedelta
 import logging
+from typing import override
 
 from pyoctoprintapi import OctoprintJobInfo, OctoprintPrinterInfo
 
@@ -143,6 +144,7 @@ class OctoPrintStatusSensor(OctoPrintSensorBase):
         super().__init__(coordinator, "Current State", device_id)
 
     @property
+    @override
     def native_value(self):
         """Return sensor state."""
 
@@ -156,6 +158,7 @@ class OctoPrintStatusSensor(OctoPrintSensorBase):
         return _API_STATE_VALUE.get(printer.state.text)
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return self.coordinator.last_update_success and self.coordinator.data["printer"]
@@ -174,6 +177,7 @@ class OctoPrintJobPercentageSensor(OctoPrintSensorBase):
         super().__init__(coordinator, "Job Percentage", device_id)
 
     @property
+    @override
     def native_value(self):
         """Return sensor state."""
         job: OctoprintJobInfo = self.coordinator.data["job"]
@@ -199,6 +203,7 @@ class OctoPrintEstimatedFinishTimeSensor(OctoPrintSensorBase):
         super().__init__(coordinator, "Estimated Finish Time", device_id)
 
     @property
+    @override
     def native_value(self) -> datetime | None:
         """Return sensor state."""
         job: OctoprintJobInfo = self.coordinator.data["job"]
@@ -229,6 +234,7 @@ class OctoPrintStartTimeSensor(OctoPrintSensorBase):
         super().__init__(coordinator, "Start Time", device_id)
 
     @property
+    @override
     def native_value(self) -> datetime | None:
         """Return sensor state."""
         job: OctoprintJobInfo = self.coordinator.data["job"]
@@ -268,6 +274,7 @@ class OctoPrintTemperatureSensor(OctoPrintSensorBase):
         self._api_tool = tool
 
     @property
+    @override
     def native_value(self):
         """Return sensor state."""
         printer: OctoprintPrinterInfo = self.coordinator.data["printer"]
@@ -289,6 +296,7 @@ class OctoPrintTemperatureSensor(OctoPrintSensorBase):
         return None
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return self.coordinator.last_update_success and self.coordinator.data["printer"]
@@ -308,6 +316,7 @@ class OctoPrintFileNameSensor(OctoPrintSensorBase):
         super().__init__(coordinator, "Current File", device_id)
 
     @property
+    @override
     def native_value(self) -> str | None:
         """Return sensor state."""
         job: OctoprintJobInfo = self.coordinator.data["job"]
@@ -315,6 +324,7 @@ class OctoPrintFileNameSensor(OctoPrintSensorBase):
         return job.job.file.name or None
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         if not self.coordinator.last_update_success:
@@ -339,6 +349,7 @@ class OctoPrintFileSizeSensor(OctoPrintSensorBase):
         super().__init__(coordinator, "Current File Size", device_id)
 
     @property
+    @override
     def native_value(self) -> int | None:
         """Return sensor state."""
         job: OctoprintJobInfo = self.coordinator.data["job"]
@@ -346,6 +357,7 @@ class OctoPrintFileSizeSensor(OctoPrintSensorBase):
         return job.job.file.size or None
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         if not self.coordinator.last_update_success:

--- a/homeassistant/components/oem/climate.py
+++ b/homeassistant/components/oem/climate.py
@@ -1,6 +1,6 @@
 """OpenEnergyMonitor Thermostat Support."""
 
-from typing import Any
+from typing import Any, override
 
 from oemthermostat import Thermostat
 import requests
@@ -82,6 +82,7 @@ class ThermostatDevice(ClimateEntity):
         self._mode = None
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode:
         """Return hvac operation ie. heat, cool mode.
 
@@ -94,6 +95,7 @@ class ThermostatDevice(ClimateEntity):
         return HVACMode.OFF
 
     @property
+    @override
     def hvac_action(self) -> HVACAction:
         """Return current hvac i.e. heat, cool, idle."""
         if not self._mode:
@@ -102,6 +104,7 @@ class ThermostatDevice(ClimateEntity):
             return HVACAction.HEATING
         return HVACAction.IDLE
 
+    @override
     def set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         if hvac_mode == HVACMode.AUTO:
@@ -111,6 +114,7 @@ class ThermostatDevice(ClimateEntity):
         elif hvac_mode == HVACMode.OFF:
             self.thermostat.mode = 0
 
+    @override
     def set_temperature(self, **kwargs: Any) -> None:
         """Set the temperature."""
         temp = kwargs.get(ATTR_TEMPERATURE)

--- a/homeassistant/components/ohmconnect/sensor.py
+++ b/homeassistant/components/ohmconnect/sensor.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 import defusedxml.ElementTree as ET
 import requests
@@ -57,11 +57,13 @@ class OhmconnectSensor(SensorEntity):
         self._attr_unique_id = ohmid
 
     @property
+    @override
     def name(self):
         """Return the name of the sensor."""
         return self._name
 
     @property
+    @override
     def native_value(self):
         """Return the state of the sensor."""
         if self._data.get("active") == "True":
@@ -69,6 +71,7 @@ class OhmconnectSensor(SensorEntity):
         return "Inactive"
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         return {"Address": self._data.get("address"), "ID": self._ohmid}

--- a/homeassistant/components/ohme/button.py
+++ b/homeassistant/components/ohme/button.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from ohme import ApiException, ChargerStatus, OhmeApiClient
 
@@ -56,6 +56,7 @@ class OhmeButton(OhmeEntity, ButtonEntity):
 
     entity_description: OhmeButtonDescription
 
+    @override
     async def async_press(self) -> None:
         """Handle the button press."""
         try:

--- a/homeassistant/components/ohme/config_flow.py
+++ b/homeassistant/components/ohme/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for ohme integration."""
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, override
 
 from ohme import ApiException, AuthException, OhmeApiClient
 import voluptuous as vol
@@ -48,6 +48,7 @@ REAUTH_SCHEMA = vol.Schema(
 class OhmeConfigFlow(ConfigFlow, domain=DOMAIN):
     """Config flow."""
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/ohme/coordinator.py
+++ b/homeassistant/components/ohme/coordinator.py
@@ -4,6 +4,7 @@ from abc import abstractmethod
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
+from typing import override
 
 from ohme import ApiException, OhmeApiClient
 
@@ -50,6 +51,7 @@ class OhmeBaseCoordinator(DataUpdateCoordinator[None]):
         self.name = f"Ohme {self.coordinator_name}"
         self.client = client
 
+    @override
     async def _async_update_data(self) -> None:
         """Fetch data from API endpoint."""
         try:
@@ -70,6 +72,7 @@ class OhmeChargeSessionCoordinator(OhmeBaseCoordinator):
     coordinator_name = "Charge Sessions"
     _default_update_interval = timedelta(seconds=30)
 
+    @override
     async def _internal_update_data(self) -> None:
         """Fetch data from API endpoint."""
         await self.client.async_get_charge_session()
@@ -81,6 +84,7 @@ class OhmeDeviceInfoCoordinator(OhmeBaseCoordinator):
     coordinator_name = "Device Info"
     _default_update_interval = timedelta(minutes=30)
 
+    @override
     async def _internal_update_data(self) -> None:
         """Fetch data from API endpoint."""
         await self.client.async_update_device_info()

--- a/homeassistant/components/ohme/entity.py
+++ b/homeassistant/components/ohme/entity.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from ohme import OhmeApiClient
 
@@ -51,6 +52,7 @@ class OhmeEntity(CoordinatorEntity[OhmeBaseCoordinator]):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return if charger reporting as online."""
         return (

--- a/homeassistant/components/ohme/number.py
+++ b/homeassistant/components/ohme/number.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from ohme import ApiException, OhmeApiClient
 
@@ -87,10 +87,12 @@ class OhmeNumber(OhmeEntity, NumberEntity):
     entity_description: OhmeNumberDescription
 
     @property
+    @override
     def native_value(self) -> float:
         """Return the current value of the number."""
         return self.entity_description.value_fn(self.coordinator.client)
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Set the number value."""
         try:

--- a/homeassistant/components/ohme/select.py
+++ b/homeassistant/components/ohme/select.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
-from typing import Any, Final
+from typing import Any, Final, override
 
 from ohme import ApiException, ChargerMode, OhmeApiClient
 
@@ -68,6 +68,7 @@ class OhmeSelect(OhmeEntity, SelectEntity):
 
     entity_description: OhmeSelectDescription
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Handle the selection of an option."""
         try:
@@ -79,6 +80,7 @@ class OhmeSelect(OhmeEntity, SelectEntity):
         await self.coordinator.async_request_refresh()
 
     @property
+    @override
     def options(self) -> list[str]:
         """Return a set of selectable options."""
         if self.entity_description.options_fn:
@@ -87,6 +89,7 @@ class OhmeSelect(OhmeEntity, SelectEntity):
         return self.entity_description.options
 
     @property
+    @override
     def current_option(self) -> str | None:
         """Return the current selected option."""
         return self.entity_description.current_option_fn(self.coordinator.client)

--- a/homeassistant/components/ohme/sensor.py
+++ b/homeassistant/components/ohme/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from ohme import ChargerStatus, OhmeApiClient
 
@@ -115,6 +116,7 @@ class OhmeSensor(OhmeEntity, SensorEntity):
     entity_description: OhmeSensorDescription
 
     @property
+    @override
     def native_value(self) -> str | int | float | None:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.coordinator.client)

--- a/homeassistant/components/ohme/switch.py
+++ b/homeassistant/components/ohme/switch.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from ohme import ApiException, OhmeApiClient
 
@@ -106,15 +106,18 @@ class OhmeSwitch(OhmeEntity, SwitchEntity):
     entity_description: OhmeSwitchDescription
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return True if entity is on."""
         return self.entity_description.is_on_fn(self.coordinator.client)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         await self.entity_description.off_fn(self.coordinator.client)
         await self.coordinator.async_request_refresh()
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         await self.entity_description.on_fn(self.coordinator.client)
@@ -127,16 +130,19 @@ class OhmeConfigSwitch(OhmeEntity, SwitchEntity):
     entity_description: OhmeConfigSwitchDescription
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return the entity value to represent the entity state."""
         return self.coordinator.client.configuration_value(
             self.entity_description.configuration_key
         )
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         await self._toggle(True)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         await self._toggle(False)

--- a/homeassistant/components/ohme/time.py
+++ b/homeassistant/components/ohme/time.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from datetime import time
-from typing import Any
+from typing import Any, override
 
 from ohme import ApiException, OhmeApiClient
 
@@ -63,10 +63,12 @@ class OhmeTime(OhmeEntity, TimeEntity):
     entity_description: OhmeTimeDescription
 
     @property
+    @override
     def native_value(self) -> time:
         """Return the current value of the time."""
         return self.entity_description.value_fn(self.coordinator.client)
 
+    @override
     async def async_set_value(self, value: time) -> None:
         """Set the time value."""
         try:

--- a/homeassistant/components/ollama/ai_task.py
+++ b/homeassistant/components/ollama/ai_task.py
@@ -2,6 +2,7 @@
 
 from json import JSONDecodeError
 import logging
+from typing import override
 
 from homeassistant.components import ai_task, conversation
 from homeassistant.config_entries import ConfigEntry
@@ -42,6 +43,7 @@ class OllamaTaskEntity(
         | ai_task.AITaskEntityFeature.SUPPORT_ATTACHMENTS
     )
 
+    @override
     async def _async_generate_data(
         self,
         task: ai_task.GenDataTask,

--- a/homeassistant/components/ollama/config_flow.py
+++ b/homeassistant/components/ollama/config_flow.py
@@ -4,7 +4,7 @@ import asyncio
 from collections.abc import Mapping
 import logging
 import sys
-from typing import Any
+from typing import Any, override
 
 import httpx
 import ollama
@@ -126,6 +126,7 @@ class OllamaConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return errors
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -228,6 +229,7 @@ class OllamaConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @classmethod
     @callback
+    @override
     def async_get_supported_subentry_types(
         cls, config_entry: ConfigEntry
     ) -> dict[str, type[ConfigSubentryFlow]]:

--- a/homeassistant/components/ollama/conversation.py
+++ b/homeassistant/components/ollama/conversation.py
@@ -1,6 +1,6 @@
 """The conversation platform for the Ollama integration."""
 
-from typing import Literal
+from typing import Literal, override
 
 from homeassistant.components import conversation
 from homeassistant.config_entries import ConfigSubentry
@@ -46,21 +46,25 @@ class OllamaConversationEntity(
                 conversation.ConversationEntityFeature.CONTROL
             )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to Home Assistant."""
         await super().async_added_to_hass()
         conversation.async_set_agent(self.hass, self.entry, self)
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """When entity will be removed from Home Assistant."""
         conversation.async_unset_agent(self.hass, self.entry)
         await super().async_will_remove_from_hass()
 
     @property
+    @override
     def supported_languages(self) -> list[str] | Literal["*"]:
         """Return a list of supported languages."""
         return MATCH_ALL
 
+    @override
     async def _async_handle_message(
         self,
         user_input: conversation.ConversationInput,

--- a/homeassistant/components/omie/config_flow.py
+++ b/homeassistant/components/omie/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for OMIE - Spain and Portugal electricity prices integration."""
 
-from typing import Any, Final
+from typing import Any, Final, override
 
 from aiohttp import ClientError
 import pyomie.main as pyomie
@@ -21,6 +21,7 @@ class OMIEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/omie/coordinator.py
+++ b/homeassistant/components/omie/coordinator.py
@@ -3,6 +3,7 @@
 import datetime as dt
 from datetime import timedelta
 import logging
+from typing import override
 
 import pyomie.main as pyomie
 from pyomie.model import OMIEResults, SpotData
@@ -39,6 +40,7 @@ class OMIECoordinator(DataUpdateCoordinator[OMIEResults[SpotData]]):
         )
         self._client_session = async_get_clientsession(hass)
 
+    @override
     async def _async_update_data(self) -> OMIEResults[SpotData]:
         """Update OMIE data, fetching the current CET day."""
         cet_today = dt_util.now().astimezone(CET).date()

--- a/homeassistant/components/omie/sensor.py
+++ b/homeassistant/components/omie/sensor.py
@@ -1,5 +1,7 @@
 """Sensor for the OMIE - Spain and Portugal electricity prices integration."""
 
+from typing import override
+
 from homeassistant.components.sensor import (
     SensorEntity,
     SensorEntityDescription,
@@ -52,12 +54,14 @@ class OMIEPriceSensor(CoordinatorEntity[OMIECoordinator], SensorEntity):
         self._attr_unique_id = pyomie_series_name
         self._pyomie_series_name = pyomie_series_name
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Call when entity is added to hass."""
         await super().async_added_to_hass()
         self._handle_coordinator_update()
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Update this sensor's state from the coordinator results."""
         value = self._get_current_quarter_hour_value()
@@ -66,6 +70,7 @@ class OMIEPriceSensor(CoordinatorEntity[OMIECoordinator], SensorEntity):
         super()._handle_coordinator_update()
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return super().available and self._attr_available

--- a/homeassistant/components/omnilogic/config_flow.py
+++ b/homeassistant/components/omnilogic/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Omnilogic integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from omnilogic import LoginException, OmniLogic, OmniLogicException
 import voluptuous as vol
@@ -28,12 +28,14 @@ class OmniLogicConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> OptionsFlowHandler:
         """Get the options flow for this handler."""
         return OptionsFlowHandler()
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/omnilogic/coordinator.py
+++ b/homeassistant/components/omnilogic/coordinator.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from omnilogic import OmniLogic, OmniLogicException
 
@@ -42,6 +42,7 @@ class OmniLogicUpdateCoordinator(DataUpdateCoordinator[dict[tuple, dict[str, Any
             update_interval=timedelta(seconds=polling_interval),
         )
 
+    @override
     async def _async_update_data(self):
         """Fetch data from OmniLogic."""
         try:

--- a/homeassistant/components/omnilogic/sensor.py
+++ b/homeassistant/components/omnilogic/sensor.py
@@ -1,6 +1,6 @@
 """Definition and setup of the Omnilogic Sensors for Home Assistant."""
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.const import (
@@ -96,6 +96,7 @@ class OmniLogicTemperatureSensor(OmnilogicSensor):
     """Define an OmniLogic Temperature (Air/Water) Sensor."""
 
     @property
+    @override
     def native_value(self):
         """Return the state for the temperature sensor."""
         sensor_data = self.coordinator.data[self._item_id][self._state_key]
@@ -126,6 +127,7 @@ class OmniLogicPumpSpeedSensor(OmnilogicSensor):
     """Define an OmniLogic Pump Speed Sensor."""
 
     @property
+    @override
     def native_value(self):
         """Return the state for the pump speed sensor."""
 
@@ -161,6 +163,7 @@ class OmniLogicSaltLevelSensor(OmnilogicSensor):
     """Define an OmniLogic Salt Level Sensor."""
 
     @property
+    @override
     def native_value(self):
         """Return the state for the salt level sensor."""
 
@@ -179,6 +182,7 @@ class OmniLogicChlorinatorSensor(OmnilogicSensor):
     """Define an OmniLogic Chlorinator Sensor."""
 
     @property
+    @override
     def native_value(self):
         """Return the state for the chlorinator sensor."""
         return self.coordinator.data[self._item_id][self._state_key]
@@ -188,6 +192,7 @@ class OmniLogicPHSensor(OmnilogicSensor):
     """Define an OmniLogic pH Sensor."""
 
     @property
+    @override
     def native_value(self):
         """Return the state for the pH sensor."""
 
@@ -232,6 +237,7 @@ class OmniLogicORPSensor(OmnilogicSensor):
         )
 
     @property
+    @override
     def native_value(self):
         """Return the state for the ORP sensor."""
 

--- a/homeassistant/components/omnilogic/switch.py
+++ b/homeassistant/components/omnilogic/switch.py
@@ -1,7 +1,7 @@
 """Platform for Omnilogic switch integration."""
 
 import time
-from typing import Any
+from typing import Any, override
 
 from omnilogic import OmniLogicException
 import voluptuous as vol
@@ -94,6 +94,7 @@ class OmniLogicSwitch(OmniLogicEntity, SwitchEntity):
         self._state_delay = 30
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return the on/off state of the switch."""
         state_int = 0
@@ -116,6 +117,7 @@ class OmniLogicSwitch(OmniLogicEntity, SwitchEntity):
 class OmniLogicRelayControl(OmniLogicSwitch):
     """Define the OmniLogic Relay entity."""
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the relay."""
         self._state = True
@@ -129,6 +131,7 @@ class OmniLogicRelayControl(OmniLogicSwitch):
             1,
         )
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the relay."""
         self._state = False
@@ -175,6 +178,7 @@ class OmniLogicPumpControl(OmniLogicSwitch):
 
         self._last_speed = None
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the pump."""
         self._state = True
@@ -193,6 +197,7 @@ class OmniLogicPumpControl(OmniLogicSwitch):
             on_value,
         )
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the pump."""
         self._state = False

--- a/homeassistant/components/onboarding/__init__.py
+++ b/homeassistant/components/onboarding/__init__.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, TypedDict, override
 
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
@@ -44,6 +44,7 @@ class OnboardingStoreData(TypedDict):
 class OnboardingStorage(Store[OnboardingStoreData]):
     """Store onboarding data."""
 
+    @override
     async def _async_migrate_func(
         self,
         old_major_version: int,

--- a/homeassistant/components/ondilo_ico/config_flow.py
+++ b/homeassistant/components/ondilo_ico/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Ondilo ICO."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.application_credentials import (
     ClientCredential,
@@ -18,6 +18,7 @@ class OndiloIcoOAuth2FlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):
 
     DOMAIN = DOMAIN
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -31,11 +32,13 @@ class OndiloIcoOAuth2FlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):
         return await super().async_step_user(user_input)
 
     @property
+    @override
     def logger(self) -> logging.Logger:
         """Return logger."""
         return logging.getLogger(__name__)
 
     @property
+    @override
     def extra_authorize_data(self) -> dict:
         """Extra data that needs to be appended to the authorize url."""
         return {"scope": "api"}

--- a/homeassistant/components/ondilo_ico/coordinator.py
+++ b/homeassistant/components/ondilo_ico/coordinator.py
@@ -4,7 +4,7 @@ import asyncio
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 from ondilo import OndiloError
 
@@ -62,6 +62,7 @@ class OndiloIcoPoolsCoordinator(DataUpdateCoordinator[dict[str, OndiloIcoPoolDat
         self.config_entry = config_entry
         self._device_registry = dr.async_get(self.hass)
 
+    @override
     async def _async_update_data(self) -> dict[str, OndiloIcoPoolData]:
         """Fetch pools data from API endpoint and update devices."""
         known_pools: set[str] = set(self.data) if self.data else set()
@@ -163,6 +164,7 @@ class OndiloIcoMeasuresCoordinator(DataUpdateCoordinator[OndiloIcoMeasurementDat
         self._next_refresh: datetime | None = None
         self._pool_id = pool_id
 
+    @override
     async def _async_update_data(self) -> OndiloIcoMeasurementData:
         """Fetch measurement data from API endpoint."""
         async with UPDATE_LOCK:

--- a/homeassistant/components/ondilo_ico/sensor.py
+++ b/homeassistant/components/ondilo_ico/sensor.py
@@ -1,5 +1,7 @@
 """Platform for sensor integration."""
 
+from typing import override
+
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -143,6 +145,7 @@ class OndiloICO(CoordinatorEntity[OndiloIcoMeasuresCoordinator], SensorEntity):
         )
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Last value of the sensor."""
         return self.coordinator.data.sensors[self.entity_description.key]

--- a/homeassistant/components/onedrive/backup.py
+++ b/homeassistant/components/onedrive/backup.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncIterator, Callable, Coroutine
 from functools import wraps
 import logging
 from time import time
-from typing import Any, Concatenate
+from typing import Any, Concatenate, override
 
 from aiohttp import ClientTimeout
 from onedrive_personal_sdk.clients.large_file_upload import LargeFileUploadClient
@@ -129,6 +129,7 @@ class OneDriveBackupAgent(BackupAgent):
         self._cache_expiration = time()
 
     @handle_backup_errors
+    @override
     async def async_download_backup(
         self, backup_id: str, **kwargs: Any
     ) -> AsyncIterator[bytes]:
@@ -142,6 +143,7 @@ class OneDriveBackupAgent(BackupAgent):
         return stream.iter_chunked(1024)
 
     @handle_backup_errors
+    @override
     async def async_upload_backup(
         self,
         *,
@@ -216,6 +218,7 @@ class OneDriveBackupAgent(BackupAgent):
         self._cache_expiration = time()
 
     @handle_backup_errors
+    @override
     async def async_delete_backup(
         self,
         backup_id: str,
@@ -238,11 +241,13 @@ class OneDriveBackupAgent(BackupAgent):
         self._cache_expiration = time()
 
     @handle_backup_errors
+    @override
     async def async_list_backups(self, **kwargs: Any) -> list[AgentBackup]:
         """List backups."""
         return list((await self._list_cached_metadata_files()).values())
 
     @handle_backup_errors
+    @override
     async def async_get_backup(self, backup_id: str, **kwargs: Any) -> AgentBackup:
         """Return a backup."""
         return await self._find_backup_by_id(backup_id)

--- a/homeassistant/components/onedrive/config_flow.py
+++ b/homeassistant/components/onedrive/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any, cast
+from typing import Any, cast, override
 
 from onedrive_personal_sdk.clients.client import OneDriveClient
 from onedrive_personal_sdk.exceptions import OneDriveException
@@ -49,11 +49,13 @@ class OneDriveConfigFlow(AbstractOAuth2FlowHandler, domain=DOMAIN):
         self.step_data: dict[str, Any] = {}
 
     @property
+    @override
     def logger(self) -> logging.Logger:
         """Return logger."""
         return logging.getLogger(__name__)
 
     @property
+    @override
     def extra_authorize_data(self) -> dict[str, Any]:
         """Extra data that needs to be appended to the authorize url."""
         return {"scope": " ".join(OAUTH_SCOPES)}
@@ -67,6 +69,7 @@ class OneDriveConfigFlow(AbstractOAuth2FlowHandler, domain=DOMAIN):
             else "Apps"
         )
 
+    @override
     async def async_oauth_create_entry(
         self,
         data: dict[str, Any],
@@ -221,6 +224,7 @@ class OneDriveConfigFlow(AbstractOAuth2FlowHandler, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: OneDriveConfigEntry,
     ) -> OneDriveOptionsFlowHandler:

--- a/homeassistant/components/onedrive/coordinator.py
+++ b/homeassistant/components/onedrive/coordinator.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 import logging
 from time import time
+from typing import override
 
 from onedrive_personal_sdk import OneDriveClient
 from onedrive_personal_sdk.const import DriveState
@@ -55,6 +56,7 @@ class OneDriveUpdateCoordinator(DataUpdateCoordinator[Drive]):
         )
         self._client = client
 
+    @override
     async def _async_update_data(self) -> Drive:
         """Fetch data from API endpoint."""
         expires_at = self.config_entry.data["token"]["expires_at"]

--- a/homeassistant/components/onedrive/sensor.py
+++ b/homeassistant/components/onedrive/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from onedrive_personal_sdk.const import DriveState
 from onedrive_personal_sdk.models.items import DriveQuota
@@ -111,12 +112,14 @@ class OneDriveDriveStateSensor(
         )
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
         assert self.coordinator.data.quota
         return self.entity_description.value_fn(self.coordinator.data.quota)
 
     @property
+    @override
     def available(self) -> bool:
         """Availability of the sensor."""
         return super().available and self.coordinator.data.quota is not None

--- a/homeassistant/components/onedrive_for_business/backup.py
+++ b/homeassistant/components/onedrive_for_business/backup.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncIterator, Callable, Coroutine
 from functools import wraps
 import logging
 from time import time
-from typing import Any, Concatenate
+from typing import Any, Concatenate, override
 
 from aiohttp import ClientTimeout
 from onedrive_personal_sdk.clients.large_file_upload import LargeFileUploadClient
@@ -129,6 +129,7 @@ class OneDriveBackupAgent(BackupAgent):
         self._cache_expiration = time()
 
     @handle_backup_errors
+    @override
     async def async_download_backup(
         self, backup_id: str, **kwargs: Any
     ) -> AsyncIterator[bytes]:
@@ -142,6 +143,7 @@ class OneDriveBackupAgent(BackupAgent):
         return stream.iter_chunked(1024)
 
     @handle_backup_errors
+    @override
     async def async_upload_backup(
         self,
         *,
@@ -210,6 +212,7 @@ class OneDriveBackupAgent(BackupAgent):
         self._cache_expiration = time()
 
     @handle_backup_errors
+    @override
     async def async_delete_backup(
         self,
         backup_id: str,
@@ -226,11 +229,13 @@ class OneDriveBackupAgent(BackupAgent):
         self._cache_expiration = time()
 
     @handle_backup_errors
+    @override
     async def async_list_backups(self, **kwargs: Any) -> list[AgentBackup]:
         """List backups."""
         return list((await self._list_cached_metadata_files()).values())
 
     @handle_backup_errors
+    @override
     async def async_get_backup(self, backup_id: str, **kwargs: Any) -> AgentBackup:
         """Return a backup."""
         return await self._find_backup_by_id(backup_id)

--- a/homeassistant/components/onedrive_for_business/config_flow.py
+++ b/homeassistant/components/onedrive_for_business/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any, cast
+from typing import Any, cast, override
 
 from onedrive_personal_sdk.clients.client import OneDriveClient
 from onedrive_personal_sdk.exceptions import OneDriveException
@@ -39,11 +39,13 @@ class OneDriveForBusinessConfigFlow(AbstractOAuth2FlowHandler, domain=DOMAIN):
     drive: Drive
 
     @property
+    @override
     def logger(self) -> logging.Logger:
         """Return logger."""
         return logging.getLogger(__name__)
 
     @property
+    @override
     def extra_authorize_data(self) -> dict[str, Any]:
         """Extra data that needs to be appended to the authorize url."""
         return {"scope": " ".join(OAUTH_SCOPES)}
@@ -53,6 +55,7 @@ class OneDriveForBusinessConfigFlow(AbstractOAuth2FlowHandler, domain=DOMAIN):
         super().__init__()
         self._data: dict[str, Any] = {}
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -82,6 +85,7 @@ class OneDriveForBusinessConfigFlow(AbstractOAuth2FlowHandler, domain=DOMAIN):
             },
         )
 
+    @override
     async def async_step_pick_implementation(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -89,6 +93,7 @@ class OneDriveForBusinessConfigFlow(AbstractOAuth2FlowHandler, domain=DOMAIN):
         with tenant_id_context(self._data[CONF_TENANT_ID]):
             return await super().async_step_pick_implementation(user_input)
 
+    @override
     async def async_oauth_create_entry(self, data: dict[str, Any]) -> ConfigFlowResult:
         """Handle the initial step."""
 

--- a/homeassistant/components/onedrive_for_business/coordinator.py
+++ b/homeassistant/components/onedrive_for_business/coordinator.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 import logging
 from time import time
+from typing import override
 
 from onedrive_personal_sdk import OneDriveClient
 from onedrive_personal_sdk.const import DriveState
@@ -54,6 +55,7 @@ class OneDriveForBusinessUpdateCoordinator(DataUpdateCoordinator[Drive]):
         )
         self._client = client
 
+    @override
     async def _async_update_data(self) -> Drive:
         """Fetch data from API endpoint."""
         expires_at = self.config_entry.data["token"]["expires_at"]

--- a/homeassistant/components/onedrive_for_business/sensor.py
+++ b/homeassistant/components/onedrive_for_business/sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from onedrive_personal_sdk.const import DriveState
 from onedrive_personal_sdk.models.items import DriveQuota
@@ -111,6 +111,7 @@ class OneDriveDriveStateSensor(
         )
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
         if TYPE_CHECKING:
@@ -118,6 +119,7 @@ class OneDriveDriveStateSensor(
         return self.entity_description.value_fn(self.coordinator.data.quota)
 
     @property
+    @override
     def available(self) -> bool:
         """Availability of the sensor."""
         return super().available and self.coordinator.data.quota is not None

--- a/homeassistant/components/onewire/binary_sensor.py
+++ b/homeassistant/components/onewire/binary_sensor.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import os
+from typing import override
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -149,6 +150,7 @@ class OneWireBinarySensorEntity(OneWireEntity, BinarySensorEntity):
     """Implementation of a 1-Wire binary sensor."""
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if sensor is on."""
         if (state := self._state) is None:

--- a/homeassistant/components/onewire/config_flow.py
+++ b/homeassistant/components/onewire/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for 1-Wire component."""
 
 from copy import deepcopy
-from typing import Any
+from typing import Any, override
 
 from aio_ownet.exceptions import OWServerConnectionError
 from aio_ownet.proxy import OWServerStatelessProxy
@@ -57,6 +57,7 @@ class OneWireFlowHandler(ConfigFlow, domain=DOMAIN):
     VERSION = 1
     _discovery_data: dict[str, Any]
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -105,6 +106,7 @@ class OneWireFlowHandler(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    @override
     async def async_step_hassio(
         self, discovery_info: HassioServiceInfo
     ) -> ConfigFlowResult:
@@ -118,6 +120,7 @@ class OneWireFlowHandler(ConfigFlow, domain=DOMAIN):
         }
         return await self.async_step_discovery_confirm()
 
+    @override
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:
@@ -155,6 +158,7 @@ class OneWireFlowHandler(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: OneWireConfigEntry,
     ) -> OnewireOptionsFlowHandler:

--- a/homeassistant/components/onewire/entity.py
+++ b/homeassistant/components/onewire/entity.py
@@ -1,7 +1,7 @@
 """Support for 1-Wire entities."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from aio_ownet.exceptions import OWServerError
 from aio_ownet.proxy import OWServerStatelessProxy
@@ -35,6 +35,7 @@ class OneWireEntity(Entity):
         self._owproxy = owproxy
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return the state attributes of the entity."""
         return {

--- a/homeassistant/components/onewire/select.py
+++ b/homeassistant/components/onewire/select.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import os
+from typing import override
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.const import EntityCategory
@@ -90,10 +91,12 @@ class OneWireSelectEntity(OneWireEntity, SelectEntity):
     """Implementation of a 1-Wire switch."""
 
     @property
+    @override
     def current_option(self) -> str | None:
         """Return the selected entity option to represent the entity state."""
         return self._state
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         await self._write_value(option.encode("ascii"))

--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -5,7 +5,7 @@ import dataclasses
 from datetime import timedelta
 import logging
 import os
-from typing import Any
+from typing import Any, override
 
 from aio_ownet.exceptions import OWServerReturnError
 
@@ -464,6 +464,7 @@ class OneWireSensorEntity(OneWireEntity, SensorEntity):
     """Implementation of a 1-Wire sensor."""
 
     @property
+    @override
     def native_value(self) -> float | int | None:
         """Return the state of the entity."""
         if (state := self._state) is None:

--- a/homeassistant/components/onewire/switch.py
+++ b/homeassistant/components/onewire/switch.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 import os
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.const import EntityCategory
@@ -202,16 +202,19 @@ class OneWireSwitchEntity(OneWireEntity, SwitchEntity):
     """Implementation of a 1-Wire switch."""
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if switch is on."""
         if (state := self._state) is None:
             return None
         return state == "1"
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         await self._write_value(b"1")
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         await self._write_value(b"0")

--- a/homeassistant/components/onkyo/config_flow.py
+++ b/homeassistant/components/onkyo/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from aioonkyo import ReceiverInfo
 import voluptuous as vol
@@ -87,6 +87,7 @@ class OnkyoConfigFlow(ConfigFlow, domain=DOMAIN):
     _receiver_info: ReceiverInfo
     _discovered_infos: dict[str, ReceiverInfo]
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -184,6 +185,7 @@ class OnkyoConfigFlow(ConfigFlow, domain=DOMAIN):
             ),
         )
 
+    @override
     async def async_step_ssdp(
         self, discovery_info: SsdpServiceInfo
     ) -> ConfigFlowResult:
@@ -334,6 +336,7 @@ class OnkyoConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(config_entry: OnkyoConfigEntry) -> OptionsFlowWithReload:
         """Return the options flow."""
         return OnkyoOptionsFlowHandler()

--- a/homeassistant/components/onkyo/coordinator.py
+++ b/homeassistant/components/onkyo/coordinator.py
@@ -3,7 +3,7 @@
 import asyncio
 from enum import StrEnum
 import logging
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, cast, override
 
 from aioonkyo import Kind, Status, Zone, command, query, status
 
@@ -109,6 +109,7 @@ class ChannelMutingCoordinator(DataUpdateCoordinator[ChannelMutingData]):
 
         self._query_state_task = asyncio.create_task(coro())
 
+    @override
     async def _async_update_data(self) -> ChannelMutingData:
         """Respond to a data update request."""
         self._query_state()

--- a/homeassistant/components/onkyo/media_player.py
+++ b/homeassistant/components/onkyo/media_player.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from aioonkyo import Code, Kind, Status, Zone, command, query, status
 
@@ -237,15 +237,18 @@ class OnkyoMediaPlayer(MediaPlayerEntity):
 
         self._attr_extra_state_attributes = {}
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Entity has been added to hass."""
         await self.query_state()
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Entity will be removed from hass."""
         self.cancel_tasks()
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return self._manager.connected
@@ -273,16 +276,19 @@ class OnkyoMediaPlayer(MediaPlayerEntity):
             self._query_av_info_task.cancel()
             self._query_av_info_task = None
 
+    @override
     async def async_turn_on(self) -> None:
         """Turn the media player on."""
         message = command.Power(self._zone, command.Power.Param.ON)
         await self._manager.write(message)
 
+    @override
     async def async_turn_off(self) -> None:
         """Turn the media player off."""
         message = command.Power(self._zone, command.Power.Param.STANDBY)
         await self._manager.write(message)
 
+    @override
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1.
 
@@ -297,16 +303,19 @@ class OnkyoMediaPlayer(MediaPlayerEntity):
         message = command.Volume(self._zone, value)
         await self._manager.write(message)
 
+    @override
     async def async_volume_up(self) -> None:
         """Increase volume by 1 step."""
         message = command.Volume(self._zone, command.Volume.Param.UP)
         await self._manager.write(message)
 
+    @override
     async def async_volume_down(self) -> None:
         """Decrease volume by 1 step."""
         message = command.Volume(self._zone, command.Volume.Param.DOWN)
         await self._manager.write(message)
 
+    @override
     async def async_mute_volume(self, mute: bool) -> None:
         """Mute the volume."""
         message = command.Muting(
@@ -314,6 +323,7 @@ class OnkyoMediaPlayer(MediaPlayerEntity):
         )
         await self._manager.write(message)
 
+    @override
     async def async_select_source(self, source: str) -> None:
         """Select input source."""
         if source not in self._rev_source_mapping:
@@ -329,6 +339,7 @@ class OnkyoMediaPlayer(MediaPlayerEntity):
         message = command.InputSource(self._zone, self._rev_source_mapping[source])
         await self._manager.write(message)
 
+    @override
     async def async_select_sound_mode(self, sound_mode: str) -> None:
         """Select listening sound mode."""
         if sound_mode not in self._rev_sound_mode_mapping:
@@ -351,6 +362,7 @@ class OnkyoMediaPlayer(MediaPlayerEntity):
         message = command.HDMIOutput(self._rev_hdmi_output_mapping[hdmi_output])
         await self._manager.write(message)
 
+    @override
     async def async_play_media(
         self, media_type: MediaType | str, media_id: str, **kwargs: Any
     ) -> None:

--- a/homeassistant/components/onkyo/switch.py
+++ b/homeassistant/components/onkyo/switch.py
@@ -1,7 +1,7 @@
 """Switch platform."""
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from aioonkyo import command, status
 
@@ -69,22 +69,26 @@ class OnkyoChannelMutingSwitch(
         self._attr_unique_id = f"{identifier}-channel_muting-{channel}"
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return self.coordinator.manager.connected
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Mute the channel."""
         await self.coordinator.async_send_command(
             self._channel, command.ChannelMuting.Param.ON
         )
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Unmute the channel."""
         await self.coordinator.async_send_command(
             self._channel, command.ChannelMuting.Param.OFF
         )
 
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         value = self.coordinator.data.get(self._channel)

--- a/homeassistant/components/onvif/binary_sensor.py
+++ b/homeassistant/components/onvif/binary_sensor.py
@@ -1,5 +1,7 @@
 """Support for ONVIF binary sensors."""
 
+from typing import override
+
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
@@ -100,12 +102,14 @@ class ONVIFBinarySensor(ONVIFBaseEntity, RestoreEntity, BinarySensorEntity):
         super().__init__(device)
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
         if (event := self.device.events.get_uid(self._attr_unique_id)) is not None:
             return event.value
         return self._attr_is_on
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Connect to dispatcher listening for entity data notifications."""
         self.async_on_remove(

--- a/homeassistant/components/onvif/button.py
+++ b/homeassistant/components/onvif/button.py
@@ -1,5 +1,7 @@
 """ONVIF Buttons."""
 
+from typing import override
+
 from homeassistant.components.button import ButtonDeviceClass, ButtonEntity
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
@@ -31,6 +33,7 @@ class RebootButton(ONVIFBaseEntity, ButtonEntity):
         self._attr_name = f"{self.device.name} Reboot"
         self._attr_unique_id = f"{self.mac_or_serial}_reboot"
 
+    @override
     async def async_press(self) -> None:
         """Send out a SystemReboot command."""
         device_mgmt = await self.device.device.create_devicemgmt_service()
@@ -48,6 +51,7 @@ class SetSystemDateAndTimeButton(ONVIFBaseEntity, ButtonEntity):
         self._attr_name = f"{self.device.name} Set System Date and Time"
         self._attr_unique_id = f"{self.mac_or_serial}_setsystemdatetime"
 
+    @override
     async def async_press(self) -> None:
         """Send out a SetSystemDateAndTime command."""
         await self.device.async_manually_set_date_and_time()

--- a/homeassistant/components/onvif/camera.py
+++ b/homeassistant/components/onvif/camera.py
@@ -1,6 +1,7 @@
 """Support for ONVIF Cameras with FFmpeg as decoder."""
 
 import asyncio
+from typing import override
 
 from haffmpeg.camera import CameraMjpeg
 from onvif.exceptions import ONVIFError
@@ -117,14 +118,17 @@ class ONVIFCameraEntity(ONVIFBaseEntity, Camera):
         self._attr_name = f"{device.name} {profile.name}"
 
     @property
+    @override
     def use_stream_for_stills(self) -> bool:
         """Whether or not to use stream to generate stills."""
         return bool(self.stream and self.stream.dynamic_stream_settings.preload_stream)
 
+    @override
     async def stream_source(self):
         """Return the stream source."""
         return await self._async_get_stream_uri()
 
+    @override
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
@@ -158,6 +162,7 @@ class ONVIFCameraEntity(ONVIFBaseEntity, Camera):
             height=height,
         )
 
+    @override
     async def handle_async_mjpeg_stream(self, request):
         """Generate an HTTP MJPEG stream from the camera."""
         LOGGER.debug("Handling mjpeg stream from camera '%s'", self.device.name)

--- a/homeassistant/components/onvif/config_flow.py
+++ b/homeassistant/components/onvif/config_flow.py
@@ -3,7 +3,7 @@
 from collections.abc import Mapping
 import logging
 from pprint import pformat
-from typing import Any
+from typing import Any, override
 from urllib.parse import urlparse
 
 from onvif.util import is_auth_error, stringify_onvif_error
@@ -111,6 +111,7 @@ class OnvifFlowHandler(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> OnvifOptionsFlowHandler:
@@ -123,6 +124,7 @@ class OnvifFlowHandler(ConfigFlow, domain=DOMAIN):
         self.devices: list[dict[str, Any]] = []
         self.onvif_config: dict[str, Any] = {}
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -175,6 +177,7 @@ class OnvifFlowHandler(ConfigFlow, domain=DOMAIN):
             description_placeholders=description_placeholders,
         )
 
+    @override
     async def async_step_dhcp(
         self, discovery_info: DhcpServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/onvif/entity.py
+++ b/homeassistant/components/onvif/entity.py
@@ -1,5 +1,7 @@
 """Base classes for ONVIF entities."""
 
+from typing import override
+
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.entity import Entity
 
@@ -15,6 +17,7 @@ class ONVIFBaseEntity(Entity):
         self.device: ONVIFDevice = device
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if device is available."""
         return self.device.available
@@ -35,6 +38,7 @@ class ONVIFBaseEntity(Entity):
         )
 
     @property
+    @override
     def device_info(self) -> DeviceInfo:
         """Return a device description for device registry."""
         connections: set[tuple[str, str]] = set()

--- a/homeassistant/components/onvif/sensor.py
+++ b/homeassistant/components/onvif/sensor.py
@@ -2,6 +2,7 @@
 
 from datetime import date, datetime
 from decimal import Decimal
+from typing import override
 
 from homeassistant.components.sensor import RestoreSensor, SensorDeviceClass
 from homeassistant.core import HomeAssistant, callback
@@ -98,6 +99,7 @@ class ONVIFSensor(ONVIFBaseEntity, RestoreSensor):
         super().__init__(device)
 
     @property
+    @override
     def native_value(self) -> StateType | date | datetime | Decimal:
         """Return the value reported by the sensor."""
         assert self._attr_unique_id is not None
@@ -105,6 +107,7 @@ class ONVIFSensor(ONVIFBaseEntity, RestoreSensor):
             return event.value
         return self._attr_native_value
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Connect to dispatcher listening for entity data notifications."""
         self.async_on_remove(

--- a/homeassistant/components/onvif/switch.py
+++ b/homeassistant/components/onvif/switch.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.core import HomeAssistant
@@ -88,6 +88,7 @@ class ONVIFSwitch(ONVIFBaseEntity, SwitchEntity):
         self._attr_unique_id = f"{self.mac_or_serial}_{description.key}"
         self.entity_description = description
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on switch."""
         self._attr_is_on = True
@@ -96,6 +97,7 @@ class ONVIFSwitch(ONVIFBaseEntity, SwitchEntity):
             profile, self.entity_description.turn_on_data
         )
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off switch."""
         self._attr_is_on = False

--- a/homeassistant/components/open_meteo/config_flow.py
+++ b/homeassistant/components/open_meteo/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow to configure the Open-Meteo integration."""
 
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -17,6 +17,7 @@ class OpenMeteoFlowHandler(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/open_meteo/coordinator.py
+++ b/homeassistant/components/open_meteo/coordinator.py
@@ -1,5 +1,7 @@
 """DataUpdateCoordinator for the Open-Meteo integration."""
 
+from typing import override
+
 from open_meteo import (
     DailyParameters,
     Forecast,
@@ -39,6 +41,7 @@ class OpenMeteoDataUpdateCoordinator(DataUpdateCoordinator[Forecast]):
         session = async_get_clientsession(hass)
         self.open_meteo = OpenMeteo(session=session)
 
+    @override
     async def _async_update_data(self) -> Forecast:
         """Fetch data from Sensibo."""
         if (zone := self.hass.states.get(self.config_entry.data[CONF_ZONE])) is None:

--- a/homeassistant/components/open_meteo/weather.py
+++ b/homeassistant/components/open_meteo/weather.py
@@ -1,6 +1,7 @@
 """Support for Open-Meteo weather."""
 
 from datetime import datetime, time
+from typing import override
 
 from open_meteo import Forecast as OpenMeteoForecast
 
@@ -68,6 +69,7 @@ class OpenMeteoWeatherEntity(
         )
 
     @property
+    @override
     def condition(self) -> str | None:
         """Return the current condition."""
         if not self.coordinator.data.current_weather:
@@ -77,6 +79,7 @@ class OpenMeteoWeatherEntity(
         )
 
     @property
+    @override
     def native_temperature(self) -> float | None:
         """Return the platform temperature."""
         if not self.coordinator.data.current_weather:
@@ -84,6 +87,7 @@ class OpenMeteoWeatherEntity(
         return self.coordinator.data.current_weather.temperature
 
     @property
+    @override
     def native_wind_speed(self) -> float | None:
         """Return the wind speed."""
         if not self.coordinator.data.current_weather:
@@ -91,6 +95,7 @@ class OpenMeteoWeatherEntity(
         return self.coordinator.data.current_weather.wind_speed
 
     @property
+    @override
     def wind_bearing(self) -> float | str | None:
         """Return the wind bearing."""
         if not self.coordinator.data.current_weather:
@@ -98,6 +103,7 @@ class OpenMeteoWeatherEntity(
         return self.coordinator.data.current_weather.wind_direction
 
     @callback
+    @override
     def _async_forecast_daily(self) -> list[Forecast] | None:
         """Return the daily forecast in native units."""
         if self.coordinator.data.daily is None:
@@ -145,6 +151,7 @@ class OpenMeteoWeatherEntity(
         return forecasts
 
     @callback
+    @override
     def _async_forecast_hourly(self) -> list[Forecast] | None:
         """Return the daily forecast in native units."""
         if self.coordinator.data.hourly is None:

--- a/homeassistant/components/open_router/ai_task.py
+++ b/homeassistant/components/open_router/ai_task.py
@@ -2,6 +2,7 @@
 
 from json import JSONDecodeError
 import logging
+from typing import override
 
 from homeassistant.components import ai_task, conversation
 from homeassistant.core import HomeAssistant
@@ -43,6 +44,7 @@ class OpenRouterAITaskEntity(
         | ai_task.AITaskEntityFeature.SUPPORT_ATTACHMENTS
     )
 
+    @override
     async def _async_generate_data(
         self,
         task: ai_task.GenDataTask,

--- a/homeassistant/components/open_router/config_flow.py
+++ b/homeassistant/components/open_router/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for OpenRouter integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from python_open_router import (
     Model,
@@ -51,6 +51,7 @@ class OpenRouterConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @classmethod
     @callback
+    @override
     def async_get_supported_subentry_types(
         cls, config_entry: ConfigEntry
     ) -> dict[str, type[ConfigSubentryFlow]]:
@@ -60,6 +61,7 @@ class OpenRouterConfigFlow(ConfigFlow, domain=DOMAIN):
             "ai_task_data": AITaskDataFlowHandler,
         }
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/open_router/conversation.py
+++ b/homeassistant/components/open_router/conversation.py
@@ -1,6 +1,6 @@
 """Conversation support for OpenRouter."""
 
-from typing import Literal
+from typing import Literal, override
 
 from homeassistant.components import conversation
 from homeassistant.config_entries import ConfigSubentry
@@ -42,10 +42,12 @@ class OpenRouterConversationEntity(OpenRouterEntity, conversation.ConversationEn
             )
 
     @property
+    @override
     def supported_languages(self) -> list[str] | Literal["*"]:
         """Return a list of supported languages."""
         return MATCH_ALL
 
+    @override
     async def _async_handle_message(
         self,
         user_input: conversation.ConversationInput,

--- a/homeassistant/components/openai_conversation/ai_task.py
+++ b/homeassistant/components/openai_conversation/ai_task.py
@@ -3,7 +3,7 @@
 import base64
 from json import JSONDecodeError
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from openai.types.responses.response_output_item import ImageGenerationCall
 
@@ -63,6 +63,7 @@ class OpenAITaskEntity(
         if not model.startswith(tuple(UNSUPPORTED_IMAGE_MODELS)):
             self._attr_supported_features |= ai_task.AITaskEntityFeature.GENERATE_IMAGE
 
+    @override
     async def _async_generate_data(
         self,
         task: ai_task.GenDataTask,
@@ -100,6 +101,7 @@ class OpenAITaskEntity(
             data=data,
         )
 
+    @override
     async def _async_generate_image(
         self,
         task: ai_task.GenImageTask,

--- a/homeassistant/components/openai_conversation/config_flow.py
+++ b/homeassistant/components/openai_conversation/config_flow.py
@@ -3,7 +3,7 @@
 from collections.abc import Mapping
 import json
 import logging
-from typing import Any
+from typing import Any, override
 
 import openai
 import voluptuous as vol
@@ -127,6 +127,7 @@ class OpenAIConfigFlow(ConfigFlow, domain=DOMAIN):
     VERSION = 2
     MINOR_VERSION = 7
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -211,6 +212,7 @@ class OpenAIConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @classmethod
     @callback
+    @override
     def async_get_supported_subentry_types(
         cls, config_entry: ConfigEntry
     ) -> dict[str, type[ConfigSubentryFlow]]:

--- a/homeassistant/components/openai_conversation/conversation.py
+++ b/homeassistant/components/openai_conversation/conversation.py
@@ -1,6 +1,6 @@
 """Conversation support for OpenAI."""
 
-from typing import Literal
+from typing import Literal, override
 
 from homeassistant.components import conversation
 from homeassistant.config_entries import ConfigSubentry
@@ -49,20 +49,24 @@ class OpenAIConversationEntity(
             )
 
     @property
+    @override
     def supported_languages(self) -> list[str] | Literal["*"]:
         """Return a list of supported languages."""
         return MATCH_ALL
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to Home Assistant."""
         await super().async_added_to_hass()
         conversation.async_set_agent(self.hass, self.entry, self)
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """When entity will be removed from Home Assistant."""
         conversation.async_unset_agent(self.hass, self.entry)
         await super().async_will_remove_from_hass()
 
+    @override
     async def _async_handle_message(
         self,
         user_input: conversation.ConversationInput,

--- a/homeassistant/components/openai_conversation/stt.py
+++ b/homeassistant/components/openai_conversation/stt.py
@@ -3,7 +3,7 @@
 from collections.abc import AsyncIterable
 import io
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 import wave
 
 from openai import OpenAIError
@@ -42,6 +42,7 @@ class OpenAISTTEntity(stt.SpeechToTextEntity, OpenAIBaseLLMEntity):
     """OpenAI Speech to text entity."""
 
     @property
+    @override
     def supported_languages(self) -> list[str]:
         """Return a list of supported languages."""
         # https://developers.openai.com/api/docs/guides/speech-to-text#supported-languages
@@ -108,17 +109,20 @@ class OpenAISTTEntity(stt.SpeechToTextEntity, OpenAIBaseLLMEntity):
         ]
 
     @property
+    @override
     def supported_formats(self) -> list[stt.AudioFormats]:
         """Return a list of supported formats."""
         # https://developers.openai.com/api/docs/guides/speech-to-text#transcriptions
         return [stt.AudioFormats.WAV, stt.AudioFormats.OGG]
 
     @property
+    @override
     def supported_codecs(self) -> list[stt.AudioCodecs]:
         """Return a list of supported codecs."""
         return [stt.AudioCodecs.PCM, stt.AudioCodecs.OPUS]
 
     @property
+    @override
     def supported_bit_rates(self) -> list[stt.AudioBitRates]:
         """Return a list of supported bit rates."""
         return [
@@ -129,6 +133,7 @@ class OpenAISTTEntity(stt.SpeechToTextEntity, OpenAIBaseLLMEntity):
         ]
 
     @property
+    @override
     def supported_sample_rates(self) -> list[stt.AudioSampleRates]:
         """Return a list of supported sample rates."""
         return [
@@ -144,10 +149,12 @@ class OpenAISTTEntity(stt.SpeechToTextEntity, OpenAIBaseLLMEntity):
         ]
 
     @property
+    @override
     def supported_channels(self) -> list[stt.AudioChannels]:
         """Return a list of supported channels."""
         return [stt.AudioChannels.CHANNEL_MONO, stt.AudioChannels.CHANNEL_STEREO]
 
+    @override
     async def async_process_audio_stream(
         self, metadata: stt.SpeechMetadata, stream: AsyncIterable[bytes]
     ) -> stt.SpeechResult:

--- a/homeassistant/components/openai_conversation/tts.py
+++ b/homeassistant/components/openai_conversation/tts.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, override
 
 from openai import OpenAIError
 from propcache.api import cached_property
@@ -145,11 +145,13 @@ class OpenAITTSEntity(TextToSpeechEntity, OpenAIBaseLLMEntity):
         self._attr_name = subentry.title
 
     @callback
+    @override
     def async_get_supported_voices(self, language: str) -> list[Voice]:
         """Return a list of supported voices for a language."""
         return self._supported_voices
 
     @cached_property
+    @override
     def default_options(self) -> Mapping[str, Any]:
         """Return a mapping with the default options."""
         return {
@@ -157,6 +159,7 @@ class OpenAITTSEntity(TextToSpeechEntity, OpenAIBaseLLMEntity):
             ATTR_PREFERRED_FORMAT: "mp3",
         }
 
+    @override
     async def async_get_tts_audio(
         self, message: str, language: str, options: dict[str, Any]
     ) -> TtsAudioType:

--- a/homeassistant/components/openalpr_cloud/image_processing.py
+++ b/homeassistant/components/openalpr_cloud/image_processing.py
@@ -4,7 +4,7 @@ import asyncio
 from base64 import b64encode
 from http import HTTPStatus
 import logging
-from typing import Any
+from typing import Any, override
 
 import aiohttp
 import voluptuous as vol
@@ -99,6 +99,7 @@ class ImageProcessingAlprEntity(ImageProcessingEntity):
         self.vehicles = 0
 
     @property
+    @override
     def state(self) -> str | None:
         """Return the state of the entity."""
         confidence = 0.0
@@ -112,6 +113,7 @@ class ImageProcessingAlprEntity(ImageProcessingEntity):
         return plate
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return device specific state attributes."""
         return {ATTR_PLATES: self.plates, ATTR_VEHICLES: self.vehicles}
@@ -175,6 +177,7 @@ class OpenAlprCloudEntity(ImageProcessingAlprEntity):
         else:
             self._attr_name = f"OpenAlpr {split_entity_id(camera_entity)[1]}"
 
+    @override
     async def async_process_image(self, image: bytes) -> None:
         """Process image.
 

--- a/homeassistant/components/opendisplay/binary_sensor.py
+++ b/homeassistant/components/opendisplay/binary_sensor.py
@@ -1,5 +1,7 @@
 """Binary sensor platform for OpenDisplay devices."""
 
+from typing import override
+
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
@@ -40,11 +42,13 @@ class OpenDisplayConnectivityBinarySensor(OpenDisplayEntity, BinarySensorEntity)
     """Reports whether the OpenDisplay device is currently advertising over BLE."""
 
     @property
+    @override
     def available(self) -> bool:
         """Connectivity is reported regardless of the device's availability."""
         return True
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return True if the device is currently reachable via BLE."""
         return self.coordinator.available

--- a/homeassistant/components/opendisplay/config_flow.py
+++ b/homeassistant/components/opendisplay/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from opendisplay import (
     MANUFACTURER_ID,
@@ -51,6 +51,7 @@ class OpenDisplayConfigFlow(ConfigFlow, domain=DOMAIN):
         ) as device:
             await device.read_firmware_version()
 
+    @override
     async def async_step_bluetooth(
         self, discovery_info: BluetoothServiceInfoBleak
     ) -> ConfigFlowResult:
@@ -87,6 +88,7 @@ class OpenDisplayConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_create_entry(title=self._discovery_info.name, data={})
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/opendisplay/coordinator.py
+++ b/homeassistant/components/opendisplay/coordinator.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass, field
 import logging
+from typing import override
 
 from opendisplay import MANUFACTURER_ID, AdvertisementTracker, parse_advertisement
 from opendisplay.models.advertisement import AdvertisementData, ButtonChangeEvent
@@ -44,6 +45,7 @@ class OpenDisplayCoordinator(PassiveBluetoothDataUpdateCoordinator):
         self._tracker: AdvertisementTracker = AdvertisementTracker()
 
     @callback
+    @override
     def _async_handle_unavailable(
         self, service_info: BluetoothServiceInfoBleak
     ) -> None:
@@ -53,6 +55,7 @@ class OpenDisplayCoordinator(PassiveBluetoothDataUpdateCoordinator):
         super()._async_handle_unavailable(service_info)
 
     @callback
+    @override
     def _async_handle_bluetooth_event(
         self,
         service_info: BluetoothServiceInfoBleak,

--- a/homeassistant/components/opendisplay/event.py
+++ b/homeassistant/components/opendisplay/event.py
@@ -1,6 +1,7 @@
 """Event platform for OpenDisplay devices — button press/release events."""
 
 from dataclasses import dataclass
+from typing import override
 
 from homeassistant.components.event import (
     EventDeviceClass,
@@ -76,6 +77,7 @@ class OpenDisplayEventEntity(OpenDisplayEntity, EventEntity):
     _last_processed_data: object | None = None
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Fire events for button transitions reported by this coordinator update."""
         data = self.coordinator.data

--- a/homeassistant/components/opendisplay/sensor.py
+++ b/homeassistant/components/opendisplay/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from opendisplay import voltage_to_percent
 from opendisplay.models.advertisement import AdvertisementData
@@ -97,6 +98,7 @@ class OpenDisplaySensorEntity(OpenDisplayEntity, SensorEntity):
     entity_description: OpenDisplaySensorEntityDescription
 
     @property
+    @override
     def native_value(self) -> float | int | None:
         """Return the sensor value."""
         if self.coordinator.data is None:

--- a/homeassistant/components/openerz/sensor.py
+++ b/homeassistant/components/openerz/sensor.py
@@ -1,6 +1,7 @@
 """Support for OpenERZ API for Zurich city waste disposal system."""
 
 from datetime import timedelta
+from typing import override
 
 from openerz_api.main import OpenERZConnector
 import voluptuous as vol
@@ -50,11 +51,13 @@ class OpenERZSensor(SensorEntity):
         self.api_connector = api_connector
 
     @property
+    @override
     def name(self):
         """Return the name of the sensor."""
         return self._name
 
     @property
+    @override
     def native_value(self):
         """Return the state of the sensor."""
         return self._state

--- a/homeassistant/components/openevse/binary_sensor.py
+++ b/homeassistant/components/openevse/binary_sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from openevsehttp.__main__ import OpenEVSE
 
@@ -115,6 +116,7 @@ class OpenEVSEBinarySensor(
             self._attr_device_info[ATTR_SERIAL_NUMBER] = unique_id
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return True if the binary sensor is on."""
         return self.entity_description.value_fn(self.coordinator.charger)

--- a/homeassistant/components/openevse/config_flow.py
+++ b/homeassistant/components/openevse/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for OpenEVSE integration."""
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, override
 
 from openevsehttp.__main__ import OpenEVSE
 from openevsehttp.exceptions import AuthenticationError, MissingSerial
@@ -57,6 +57,7 @@ class OpenEVSEConfigFlow(ConfigFlow, domain=DOMAIN):
             return {}, None
         return {}, result.get(CONF_SERIAL)
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -103,6 +104,7 @@ class OpenEVSEConfigFlow(ConfigFlow, domain=DOMAIN):
             data=data,
         )
 
+    @override
     async def async_step_zeroconf(
         self, discovery_info: zeroconf.ZeroconfServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/openevse/coordinator.py
+++ b/homeassistant/components/openevse/coordinator.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import logging
+from typing import override
 
 from openevsehttp.__main__ import OpenEVSE
 from openevsehttp.exceptions import AuthenticationError
@@ -57,6 +58,7 @@ class OpenEVSEDataUpdateCoordinator(DataUpdateCoordinator[None]):
         if self.charger.websocket:
             await self.charger.ws_disconnect()
 
+    @override
     async def _async_update_data(self) -> None:
         """Fetch data from OpenEVSE charger."""
         try:

--- a/homeassistant/components/openevse/number.py
+++ b/homeassistant/components/openevse/number.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from openevsehttp.__main__ import OpenEVSE
 
@@ -98,20 +98,24 @@ class OpenEVSENumber(CoordinatorEntity[OpenEVSEDataUpdateCoordinator], NumberEnt
             self._attr_device_info[ATTR_SERIAL_NUMBER] = unique_id
 
     @property
+    @override
     def native_value(self) -> float:
         """Return the state of the number."""
         return self.entity_description.value_fn(self.coordinator.charger)
 
     @property
+    @override
     def native_min_value(self) -> float:
         """Return the minimum value."""
         return self.entity_description.min_value_fn(self.coordinator.charger)
 
     @property
+    @override
     def native_max_value(self) -> float:
         """Return the maximum value."""
         return self.entity_description.max_value_fn(self.coordinator.charger)
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Set new value."""
         with openevse_exception_handler(value):

--- a/homeassistant/components/openevse/sensor.py
+++ b/homeassistant/components/openevse/sensor.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
 import logging
+from typing import override
 
 from openevsehttp.__main__ import OpenEVSE
 import voluptuous as vol
@@ -460,6 +461,7 @@ class OpenEVSESensor(CoordinatorEntity[OpenEVSEDataUpdateCoordinator], SensorEnt
             self._attr_device_info[ATTR_SERIAL_NUMBER] = unique_id
 
     @property
+    @override
     def native_value(self) -> StateType | datetime:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.coordinator.charger)

--- a/homeassistant/components/openexchangerates/config_flow.py
+++ b/homeassistant/components/openexchangerates/config_flow.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, override
 
 from aioopenexchangerates import (
     Client,
@@ -53,6 +53,7 @@ class OpenExchangeRatesConfigFlow(ConfigFlow, domain=DOMAIN):
         """Initialize the config flow."""
         self.currencies: dict[str, str] = {}
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/openexchangerates/coordinator.py
+++ b/homeassistant/components/openexchangerates/coordinator.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from datetime import timedelta
+from typing import override
 
 from aiohttp import ClientSession
 from aioopenexchangerates import (
@@ -46,6 +47,7 @@ class OpenexchangeratesCoordinator(DataUpdateCoordinator[Latest]):
         self.base = base
         self.client = Client(api_key, session)
 
+    @override
     async def _async_update_data(self) -> Latest:
         """Update data from Open Exchange Rates."""
         try:

--- a/homeassistant/components/openexchangerates/sensor.py
+++ b/homeassistant/components/openexchangerates/sensor.py
@@ -1,5 +1,7 @@
 """Support for openexchangerates.org exchange rates service."""
 
+from typing import override
+
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.const import CONF_QUOTE
 from homeassistant.core import HomeAssistant
@@ -60,6 +62,7 @@ class OpenexchangeratesSensor(
         self._quote = quote
 
     @property
+    @override
     def native_value(self) -> float:
         """Return the state of the sensor."""
         return self.coordinator.data.rates[self._quote]

--- a/homeassistant/components/opengarage/binary_sensor.py
+++ b/homeassistant/components/opengarage/binary_sensor.py
@@ -1,7 +1,7 @@
 """Platform for the opengarage.io binary sensor component."""
 
 import logging
-from typing import cast
+from typing import cast, override
 
 from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
@@ -55,11 +55,13 @@ class OpenGarageBinarySensor(OpenGarageEntity, BinarySensorEntity):
         super().__init__(coordinator, device_id, description)
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available."""
         return super().available and self._available
 
     @callback
+    @override
     def _update_attr(self) -> None:
         """Handle updated data from the coordinator."""
         state = self.coordinator.data.get(self.entity_description.key)

--- a/homeassistant/components/opengarage/button.py
+++ b/homeassistant/components/opengarage/button.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any, cast, override
 
 from opengarage import OpenGarage
 
@@ -66,6 +66,7 @@ class OpenGarageButtonEntity(OpenGarageEntity, ButtonEntity):
         """Initialize the button."""
         super().__init__(coordinator, device_id, description)
 
+    @override
     async def async_press(self) -> None:
         """Press the button."""
         await self.entity_description.press_action(

--- a/homeassistant/components/opengarage/config_flow.py
+++ b/homeassistant/components/opengarage/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for OpenGarage integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 import aiohttp
 import opengarage
@@ -56,6 +56,7 @@ class OpenGarageConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/opengarage/coordinator.py
+++ b/homeassistant/components/opengarage/coordinator.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, override
 
 import opengarage
 
@@ -41,6 +41,7 @@ class OpenGarageDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             update_interval=timedelta(seconds=5),
         )
 
+    @override
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data."""
         data = await self.open_garage_connection.update_state()

--- a/homeassistant/components/opengarage/cover.py
+++ b/homeassistant/components/opengarage/cover.py
@@ -1,7 +1,7 @@
 """Platform for the opengarage.io cover component."""
 
 import logging
-from typing import Any, cast
+from typing import Any, cast, override
 
 from homeassistant.components.cover import (
     CoverDeviceClass,
@@ -48,6 +48,7 @@ class OpenGarageCover(OpenGarageEntity, CoverEntity):
         super().__init__(coordinator, device_id)
 
     @property
+    @override
     def is_closed(self) -> bool | None:
         """Return if the cover is closed."""
         if self._state is None:
@@ -55,6 +56,7 @@ class OpenGarageCover(OpenGarageEntity, CoverEntity):
         return self._state == CoverState.CLOSED
 
     @property
+    @override
     def is_closing(self) -> bool | None:
         """Return if the cover is closing."""
         if self._state is None:
@@ -62,12 +64,14 @@ class OpenGarageCover(OpenGarageEntity, CoverEntity):
         return self._state == CoverState.CLOSING
 
     @property
+    @override
     def is_opening(self) -> bool | None:
         """Return if the cover is opening."""
         if self._state is None:
             return None
         return self._state == CoverState.OPENING
 
+    @override
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
         if self._state in [CoverState.CLOSED, CoverState.CLOSING]:
@@ -76,6 +80,7 @@ class OpenGarageCover(OpenGarageEntity, CoverEntity):
         self._state = CoverState.CLOSING
         await self._push_button()
 
+    @override
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
         if self._state in [CoverState.OPEN, CoverState.OPENING]:
@@ -85,6 +90,7 @@ class OpenGarageCover(OpenGarageEntity, CoverEntity):
         await self._push_button()
 
     @callback
+    @override
     def _update_attr(self) -> None:
         """Update the state and attributes."""
         status = self.coordinator.data

--- a/homeassistant/components/opengarage/entity.py
+++ b/homeassistant/components/opengarage/entity.py
@@ -1,5 +1,7 @@
 """Entity for the opengarage.io component."""
 
+from typing import override
+
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
@@ -37,12 +39,14 @@ class OpenGarageEntity(CoordinatorEntity[OpenGarageDataUpdateCoordinator]):
         """Update the state and attributes."""
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self._update_attr()
         self.async_write_ha_state()
 
     @property
+    @override
     def device_info(self) -> DeviceInfo:
         """Return the device_info of the device."""
         return DeviceInfo(

--- a/homeassistant/components/opengarage/sensor.py
+++ b/homeassistant/components/opengarage/sensor.py
@@ -1,7 +1,7 @@
 """Platform for the opengarage.io sensor component."""
 
 import logging
-from typing import cast
+from typing import cast, override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -76,6 +76,7 @@ class OpenGarageSensor(OpenGarageEntity, SensorEntity):
     """Representation of a OpenGarage sensor."""
 
     @callback
+    @override
     def _update_attr(self) -> None:
         """Handle updated data from the coordinator."""
         self._attr_native_value = self.coordinator.data.get(self.entity_description.key)

--- a/homeassistant/components/openhome/config_flow.py
+++ b/homeassistant/components/openhome/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Linn / OpenHome."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_NAME
@@ -27,6 +27,7 @@ class OpenhomeConfigFlow(ConfigFlow, domain=DOMAIN):
     _host: str | None
     _name: str
 
+    @override
     async def async_step_ssdp(
         self, discovery_info: SsdpServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/openhome/media_player.py
+++ b/homeassistant/components/openhome/media_player.py
@@ -3,7 +3,7 @@
 from collections.abc import Awaitable, Callable, Coroutine
 import functools
 import logging
-from typing import Any, Concatenate
+from typing import Any, Concatenate, override
 
 import aiohttp
 from async_upnp_client.client import UpnpError
@@ -172,18 +172,21 @@ class OpenhomeDevice(MediaPlayerEntity):
 
     # pylint: disable-next=home-assistant-action-swallowed-exception
     @catch_request_errors()
+    @override
     async def async_turn_on(self) -> None:
         """Bring device out of standby."""
         await self._device.set_standby(False)
 
     # pylint: disable-next=home-assistant-action-swallowed-exception
     @catch_request_errors()
+    @override
     async def async_turn_off(self) -> None:
         """Put device in standby."""
         await self._device.set_standby(True)
 
     # pylint: disable-next=home-assistant-action-swallowed-exception
     @catch_request_errors()
+    @override
     async def async_play_media(
         self, media_type: MediaType | str, media_id: str, **kwargs: Any
     ) -> None:
@@ -210,36 +213,42 @@ class OpenhomeDevice(MediaPlayerEntity):
 
     # pylint: disable-next=home-assistant-action-swallowed-exception
     @catch_request_errors()
+    @override
     async def async_media_pause(self) -> None:
         """Send pause command."""
         await self._device.pause()
 
     # pylint: disable-next=home-assistant-action-swallowed-exception
     @catch_request_errors()
+    @override
     async def async_media_stop(self) -> None:
         """Send stop command."""
         await self._device.stop()
 
     # pylint: disable-next=home-assistant-action-swallowed-exception
     @catch_request_errors()
+    @override
     async def async_media_play(self) -> None:
         """Send play command."""
         await self._device.play()
 
     # pylint: disable-next=home-assistant-action-swallowed-exception
     @catch_request_errors()
+    @override
     async def async_media_next_track(self) -> None:
         """Send next track command."""
         await self._device.skip(1)
 
     # pylint: disable-next=home-assistant-action-swallowed-exception
     @catch_request_errors()
+    @override
     async def async_media_previous_track(self) -> None:
         """Send previous track command."""
         await self._device.skip(-1)
 
     # pylint: disable-next=home-assistant-action-swallowed-exception
     @catch_request_errors()
+    @override
     async def async_select_source(self, source: str) -> None:
         """Select input source."""
         await self._device.set_source(self._source_index[source])
@@ -257,28 +266,33 @@ class OpenhomeDevice(MediaPlayerEntity):
 
     # pylint: disable-next=home-assistant-action-swallowed-exception
     @catch_request_errors()
+    @override
     async def async_volume_up(self) -> None:
         """Volume up media player."""
         await self._device.increase_volume()
 
     # pylint: disable-next=home-assistant-action-swallowed-exception
     @catch_request_errors()
+    @override
     async def async_volume_down(self) -> None:
         """Volume down media player."""
         await self._device.decrease_volume()
 
     # pylint: disable-next=home-assistant-action-swallowed-exception
     @catch_request_errors()
+    @override
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""
         await self._device.set_volume(int(volume * 100))
 
     # pylint: disable-next=home-assistant-action-swallowed-exception
     @catch_request_errors()
+    @override
     async def async_mute_volume(self, mute: bool) -> None:
         """Mute (true) or unmute (false) media player."""
         await self._device.set_mute(mute)
 
+    @override
     async def async_browse_media(
         self,
         media_content_type: MediaType | str | None = None,

--- a/homeassistant/components/openhome/update.py
+++ b/homeassistant/components/openhome/update.py
@@ -1,7 +1,7 @@
 """Update entities for Linn devices."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 import aiohttp
 from async_upnp_client.client import UpnpError
@@ -84,6 +84,7 @@ class OpenhomeUpdateEntity(UpdateEntity):
             ]
             self._attr_release_url = software_status["update_info"]["releasenotesuri"]
 
+    @override
     async def async_install(
         self, version: str | None, backup: bool, **kwargs: Any
     ) -> None:

--- a/homeassistant/components/openrgb/config_flow.py
+++ b/homeassistant/components/openrgb/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for the OpenRGB integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from openrgb import OpenRGBClient
 import voluptuous as vol
@@ -88,6 +88,7 @@ class OpenRGBConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/openrgb/coordinator.py
+++ b/homeassistant/components/openrgb/coordinator.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from typing import override
 
 from openrgb import OpenRGBClient
 from openrgb.orgb import Device
@@ -54,6 +55,7 @@ class OpenRGBCoordinator(DataUpdateCoordinator[dict[str, Device]]):
 
         config_entry.async_on_unload(self.async_client_disconnect)
 
+    @override
     async def _async_setup(self) -> None:
         """Set up the coordinator by connecting to the OpenRGB SDK server."""
         try:
@@ -74,6 +76,7 @@ class OpenRGBCoordinator(DataUpdateCoordinator[dict[str, Device]]):
                 },
             ) from err
 
+    @override
     async def _async_update_data(self) -> dict[str, Device]:
         """Fetch data from OpenRGB."""
         async with self.client_lock:

--- a/homeassistant/components/openrgb/light.py
+++ b/homeassistant/components/openrgb/light.py
@@ -1,7 +1,7 @@
 """OpenRGB light platform."""
 
 import asyncio
-from typing import Any
+from typing import Any, override
 
 from openrgb.orgb import Device
 from openrgb.utils import ModeColors, ModeData, RGBColor
@@ -223,6 +223,7 @@ class OpenRGBLight(CoordinatorEntity[OpenRGBCoordinator], LightEntity):
             self._attr_is_on = on_by_color
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         if self.available:
@@ -235,6 +236,7 @@ class OpenRGBLight(CoordinatorEntity[OpenRGBCoordinator], LightEntity):
         self._update_events.clear()
 
     @property
+    @override
     def available(self) -> bool:
         """Return if the light is available."""
         return super().available and self.device_key in self.coordinator.data
@@ -308,6 +310,7 @@ class OpenRGBLight(CoordinatorEntity[OpenRGBCoordinator], LightEntity):
                     },
                 ) from err
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the light."""
         mode = None
@@ -393,6 +396,7 @@ class OpenRGBLight(CoordinatorEntity[OpenRGBCoordinator], LightEntity):
 
         await self._async_refresh_data()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the light."""
         if self._supports_off_mode:

--- a/homeassistant/components/openrgb/select.py
+++ b/homeassistant/components/openrgb/select.py
@@ -1,5 +1,7 @@
 """Select platform for OpenRGB integration."""
 
+from typing import override
+
 from homeassistant.components.select import SelectEntity
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
@@ -68,16 +70,19 @@ class OpenRGBProfileSelect(CoordinatorEntity[OpenRGBCoordinator], SelectEntity):
                 self._state_hash = None
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self._update_attrs()
         super()._handle_coordinator_update()
 
     @property
+    @override
     def available(self) -> bool:
         """Return if the select is available."""
         return super().available and bool(self._attr_options)
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Load the selected profile."""
         async with self.coordinator.client_lock:

--- a/homeassistant/components/opensensemap/air_quality.py
+++ b/homeassistant/components/opensensemap/air_quality.py
@@ -1,5 +1,7 @@
 """Support for openSenseMap Air Quality data."""
 
+from typing import override
+
 import voluptuous as vol
 
 from homeassistant.components.air_quality import (
@@ -183,11 +185,13 @@ class OpenSenseMapQuality(CoordinatorEntity[OpenSenseMapCoordinator], AirQuality
         self._attr_unique_id = station_id
 
     @property
+    @override
     def particulate_matter_2_5(self) -> float | None:
         """Return the particulate matter 2.5 level."""
         return self.coordinator.data.pm2_5.value
 
     @property
+    @override
     def particulate_matter_10(self) -> float | None:
         """Return the particulate matter 10 level."""
         return self.coordinator.data.pm10.value

--- a/homeassistant/components/opensensemap/config_flow.py
+++ b/homeassistant/components/opensensemap/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for the openSenseMap integration."""
 
-from typing import Any
+from typing import Any, override
 
 from opensensemap_api import OpenSenseMap
 from opensensemap_api.exceptions import OpenSenseMapError
@@ -41,6 +41,7 @@ class OpenSenseMapConfigFlow(ConfigFlow, domain=DOMAIN):
             raise InvalidStation
         return api.data["name"]
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/opensensemap/coordinator.py
+++ b/homeassistant/components/opensensemap/coordinator.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import NamedTuple
+from typing import NamedTuple, override
 
 from opensensemap_api import _TITLES, OpenSenseMap
 from opensensemap_api.exceptions import OpenSenseMapError
@@ -104,6 +104,7 @@ class OpenSenseMapCoordinator(DataUpdateCoordinator[OpenSenseMapStationData]):
         )
         self.api = api
 
+    @override
     async def _async_update_data(self) -> OpenSenseMapStationData:
         """Fetch latest data from the openSenseMap API."""
         try:

--- a/homeassistant/components/opensensemap/sensor.py
+++ b/homeassistant/components/opensensemap/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -151,6 +152,7 @@ class OpenSenseMapSensor(CoordinatorEntity[OpenSenseMapCoordinator], SensorEntit
         )
 
     @property
+    @override
     def native_value(self) -> float | str | None:
         """Return the latest value reported by the station."""
         return self.entity_description.value_fn(self.coordinator.data).value

--- a/homeassistant/components/opensky/config_flow.py
+++ b/homeassistant/components/opensky/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for OpenSky integration."""
 
-from typing import Any
+from typing import Any, override
 
 from aiohttp import BasicAuth
 from python_opensky import OpenSky
@@ -34,12 +34,14 @@ class OpenSkyConfigFlowHandler(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: OpenSkyConfigEntry,
     ) -> OpenSkyOptionsFlowHandler:
         """Get the options flow for this handler."""
         return OpenSkyOptionsFlowHandler()
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/opensky/coordinator.py
+++ b/homeassistant/components/opensky/coordinator.py
@@ -1,6 +1,7 @@
 """DataUpdateCoordinator for the OpenSky integration."""
 
 from datetime import timedelta
+from typing import override
 
 from python_opensky import OpenSky, OpenSkyError, StateVector
 
@@ -59,6 +60,7 @@ class OpenSkyDataUpdateCoordinator(DataUpdateCoordinator[int]):
         )
         self._altitude = config_entry.options.get(CONF_ALTITUDE, DEFAULT_ALTITUDE)
 
+    @override
     async def _async_update_data(self) -> int:
         try:
             response = await self._opensky.get_states(bounding_box=self._bounding_box)

--- a/homeassistant/components/opensky/sensor.py
+++ b/homeassistant/components/opensky/sensor.py
@@ -1,5 +1,7 @@
 """Sensor for the Open Sky Network."""
 
+from typing import override
+
 from homeassistant.components.sensor import SensorEntity, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -57,6 +59,7 @@ class OpenSkySensor(CoordinatorEntity[OpenSkyDataUpdateCoordinator], SensorEntit
         )
 
     @property
+    @override
     def native_value(self) -> int:
         """Return the state of the sensor."""
         return self.coordinator.data

--- a/homeassistant/components/opentherm_gw/binary_sensor.py
+++ b/homeassistant/components/opentherm_gw/binary_sensor.py
@@ -1,6 +1,7 @@
 """Support for OpenTherm Gateway binary sensors."""
 
 from dataclasses import dataclass
+from typing import override
 
 from pyotgw import vars as gw_vars
 
@@ -411,6 +412,7 @@ class OpenThermBinarySensor(OpenThermStatusEntity, BinarySensorEntity):
     entity_description: OpenThermBinarySensorEntityDescription
 
     @callback
+    @override
     def receive_report(self, status: dict[OpenThermDataSource, dict]) -> None:
         """Handle status updates from the component."""
         state = status[self.entity_description.device_description.data_source].get(

--- a/homeassistant/components/opentherm_gw/button.py
+++ b/homeassistant/components/opentherm_gw/button.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from typing import override
 
 import pyotgw.vars as gw_vars
 
@@ -69,6 +70,7 @@ class OpenThermButton(OpenThermEntity, ButtonEntity):
     _attr_entity_category = EntityCategory.CONFIG
     entity_description: OpenThermButtonEntityDescription
 
+    @override
     async def async_press(self) -> None:
         """Perform button action."""
         await self.entity_description.action(self._gateway)

--- a/homeassistant/components/opentherm_gw/climate.py
+++ b/homeassistant/components/opentherm_gw/climate.py
@@ -3,7 +3,7 @@
 from collections.abc import Mapping
 from dataclasses import dataclass
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyotgw import vars as gw_vars
 
@@ -109,6 +109,7 @@ class OpenThermClimate(OpenThermStatusEntity, ClimateEntity):
         self._attr_target_temperature_step = entry.options[CONF_SET_PRECISION]
         self.async_write_ha_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Connect to the OpenTherm Gateway device."""
         await super().async_added_to_hass()
@@ -119,6 +120,7 @@ class OpenThermClimate(OpenThermStatusEntity, ClimateEntity):
         )
 
     @callback
+    @override
     def receive_report(self, status: dict[OpenThermDataSource, dict]):
         """Receive and handle a new report from the Gateway."""
         ch_active = status[OpenThermDataSource.BOILER].get(gw_vars.DATA_SLAVE_CH_ACTIVE)
@@ -173,17 +175,20 @@ class OpenThermClimate(OpenThermStatusEntity, ClimateEntity):
         self.async_write_ha_state()
 
     @property
+    @override
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
         return self._new_target_temperature or self._target_temperature
 
     @property
+    @override
     def preset_mode(self) -> str:
         """Return current preset mode."""
         if self._away_state_a or self._away_state_b:
             return PRESET_AWAY
         return PRESET_NONE
 
+    @override
     def set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         raise ServiceValidationError(
@@ -191,10 +196,12 @@ class OpenThermClimate(OpenThermStatusEntity, ClimateEntity):
             translation_key="change_hvac_mode_not_supported",
         )
 
+    @override
     def set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode."""
         _LOGGER.warning("Changing preset mode is not supported")
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         if ATTR_TEMPERATURE in kwargs:

--- a/homeassistant/components/opentherm_gw/config_flow.py
+++ b/homeassistant/components/opentherm_gw/config_flow.py
@@ -1,7 +1,7 @@
 """OpenTherm Gateway config flow."""
 
 import asyncio
-from typing import Any
+from typing import Any, override
 
 import pyotgw
 from pyotgw import vars as gw_vars
@@ -42,6 +42,7 @@ class OpenThermGwConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> OpenThermGwOptionsFlow:
@@ -85,6 +86,7 @@ class OpenThermGwConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self._show_form()
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/opentherm_gw/entity.py
+++ b/homeassistant/components/opentherm_gw/entity.py
@@ -1,6 +1,7 @@
 """Common opentherm_gw entity properties."""
 
 import logging
+from typing import override
 
 import pyotgw.vars as gw_vars
 
@@ -56,6 +57,7 @@ class OpenThermEntity(Entity):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return connection status of the hub to indicate availability."""
         return self._gateway.connected
@@ -66,6 +68,7 @@ class OpenThermStatusEntity(OpenThermEntity):
 
     _attr_should_poll = False
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Subscribe to updates from the component."""
         self.async_on_remove(

--- a/homeassistant/components/opentherm_gw/select.py
+++ b/homeassistant/components/opentherm_gw/select.py
@@ -4,6 +4,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from enum import IntEnum, StrEnum
 from functools import partial
+from typing import override
 
 from pyotgw.vars import (
     OTGW_GPIO_A,
@@ -255,6 +256,7 @@ class OpenThermSelect(OpenThermStatusEntity, SelectEntity):
     _attr_entity_category = EntityCategory.CONFIG
     entity_description: OpenThermSelectEntityDescription
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         new_option = await self.entity_description.select_action(self._gateway, option)
@@ -263,6 +265,7 @@ class OpenThermSelect(OpenThermStatusEntity, SelectEntity):
             self.async_write_ha_state()
 
     @callback
+    @override
     def receive_report(self, status: dict[OpenThermDataSource, dict]) -> None:
         """Handle status updates from the component."""
         state = status[self.entity_description.device_description.data_source].get(

--- a/homeassistant/components/opentherm_gw/sensor.py
+++ b/homeassistant/components/opentherm_gw/sensor.py
@@ -1,6 +1,7 @@
 """Support for OpenTherm Gateway sensors."""
 
 from dataclasses import dataclass
+from typing import override
 
 import pyotgw.vars as gw_vars
 
@@ -896,6 +897,7 @@ class OpenThermSensor(OpenThermStatusEntity, SensorEntity):
     entity_description: OpenThermSensorEntityDescription
 
     @callback
+    @override
     def receive_report(self, status: dict[OpenThermDataSource, dict]) -> None:
         """Handle status updates from the component."""
         self._attr_native_value = status[

--- a/homeassistant/components/opentherm_gw/switch.py
+++ b/homeassistant/components/opentherm_gw/switch.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.config_entries import ConfigEntry
@@ -66,12 +66,14 @@ class OpenThermSwitch(OpenThermEntity, SwitchEntity):
     _attr_entity_registry_enabled_default = False
     entity_description: OpenThermSwitchEntityDescription
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         value = await self.entity_description.turn_off_action(self._gateway)
         self._attr_is_on = bool(value) if value is not None else None
         self.async_write_ha_state()
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         value = await self.entity_description.turn_on_action(self._gateway)

--- a/homeassistant/components/openuv/binary_sensor.py
+++ b/homeassistant/components/openuv/binary_sensor.py
@@ -1,5 +1,7 @@
 """Support for OpenUV binary sensors."""
 
+from typing import override
+
 from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
@@ -45,11 +47,13 @@ class OpenUvBinarySensor(OpenUvEntity, BinarySensorEntity):
     """Define a binary sensor for OpenUV."""
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Update the entity from the latest data."""
         self._update_attrs()
         super()._handle_coordinator_update()
 
+    @override
     def _update_attrs(self) -> None:
         data = self.coordinator.data
 

--- a/homeassistant/components/openuv/config_flow.py
+++ b/homeassistant/components/openuv/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from pyopenuv import Client
 from pyopenuv.errors import OpenUvError
@@ -132,6 +132,7 @@ class OpenUvFlowHandler(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: OpenUvConfigEntry,
     ) -> SchemaOptionsFlowHandler:
@@ -168,6 +169,7 @@ class OpenUvFlowHandler(ConfigFlow, domain=DOMAIN):
 
         return await self._async_verify(data, "reauth_confirm", STEP_REAUTH_SCHEMA)
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/openuv/coordinator.py
+++ b/homeassistant/components/openuv/coordinator.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 import datetime as dt
-from typing import Any, cast
+from typing import Any, cast, override
 
 from pyopenuv.errors import InvalidApiKeyError, OpenUvError
 
@@ -55,6 +55,7 @@ class OpenUvCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.latitude = latitude
         self.longitude = longitude
 
+    @override
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from OpenUV."""
         try:
@@ -72,6 +73,7 @@ class OpenUvProtectionWindowCoordinator(OpenUvCoordinator):
 
     _reprocess_listener: CALLBACK_TYPE | None = None
 
+    @override
     async def _async_update_data(self) -> dict[str, Any]:
         data = await super()._async_update_data()
 

--- a/homeassistant/components/openuv/sensor.py
+++ b/homeassistant/components/openuv/sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -183,6 +183,7 @@ class OpenUvSensor(OpenUvEntity, SensorEntity):
     entity_description: OpenUvSensorEntityDescription
 
     @property
+    @override
     def extra_state_attributes(self) -> Mapping[str, Any]:
         """Return entity specific state attributes."""
         attrs = {}
@@ -192,6 +193,7 @@ class OpenUvSensor(OpenUvEntity, SensorEntity):
         return attrs
 
     @property
+    @override
     def native_value(self) -> int | str:
         """Return the sensor value."""
         return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/openweathermap/config_flow.py
+++ b/homeassistant/components/openweathermap/config_flow.py
@@ -1,5 +1,7 @@
 """Config flow for OpenWeatherMap."""
 
+from typing import override
+
 import voluptuous as vol
 
 from homeassistant.config_entries import (
@@ -65,12 +67,14 @@ class OpenWeatherMapConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> OpenWeatherMapOptionsFlow:
         """Get the options flow for this handler."""
         return OpenWeatherMapOptionsFlow()
 
+    @override
     async def async_step_user(self, user_input=None) -> ConfigFlowResult:
         """Handle a flow initialized by the user."""
         errors = {}

--- a/homeassistant/components/openweathermap/coordinator.py
+++ b/homeassistant/components/openweathermap/coordinator.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from pyopenweathermap import (
     CurrentAirPollution,
@@ -105,6 +105,7 @@ class OWMUpdateCoordinator(DataUpdateCoordinator):
 class WeatherUpdateCoordinator(OWMUpdateCoordinator):
     """Weather data update coordinator."""
 
+    @override
     async def _async_update_data(self):
         """Update the data."""
         try:
@@ -269,6 +270,7 @@ class WeatherUpdateCoordinator(OWMUpdateCoordinator):
 class AirPollutionUpdateCoordinator(OWMUpdateCoordinator):
     """Air Pollution data update coordinator."""
 
+    @override
     async def _async_update_data(self) -> dict[str, Any]:
         """Update the data."""
         try:

--- a/homeassistant/components/openweathermap/sensor.py
+++ b/homeassistant/components/openweathermap/sensor.py
@@ -1,5 +1,7 @@
 """Support for the OpenWeatherMap (OWM) service."""
 
+from typing import override
+
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -278,10 +280,12 @@ class AbstractOpenWeatherMapSensor(SensorEntity):
         )
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available."""
         return self._coordinator.last_update_success
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Connect to dispatcher listening for entity data notifications."""
         self.async_on_remove(
@@ -297,6 +301,7 @@ class OpenWeatherMapSensor(AbstractOpenWeatherMapSensor):
     """Implementation of an OpenWeatherMap sensor."""
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the state of the device."""
         return self._coordinator.data[ATTR_API_CURRENT].get(self.entity_description.key)

--- a/homeassistant/components/openweathermap/weather.py
+++ b/homeassistant/components/openweathermap/weather.py
@@ -1,5 +1,7 @@
 """Support for the OpenWeatherMap (OWM) service."""
 
+from typing import override
+
 from homeassistant.components.weather import (
     Forecast,
     SingleCoordinatorWeatherEntity,
@@ -124,16 +126,19 @@ class OpenWeatherMapWeather(SingleCoordinatorWeatherEntity[OWMUpdateCoordinator]
         )
 
     @property
+    @override
     def condition(self) -> str | None:
         """Return the current condition."""
         return self.coordinator.data[ATTR_API_CURRENT].get(ATTR_API_CONDITION)
 
     @property
+    @override
     def cloud_coverage(self) -> float | None:
         """Return the Cloud coverage in %."""
         return self.coordinator.data[ATTR_API_CURRENT].get(ATTR_API_CLOUDS)
 
     @property
+    @override
     def native_apparent_temperature(self) -> float | None:
         """Return the apparent temperature."""
         return self.coordinator.data[ATTR_API_CURRENT].get(
@@ -141,51 +146,61 @@ class OpenWeatherMapWeather(SingleCoordinatorWeatherEntity[OWMUpdateCoordinator]
         )
 
     @property
+    @override
     def native_temperature(self) -> float | None:
         """Return the temperature."""
         return self.coordinator.data[ATTR_API_CURRENT].get(ATTR_API_TEMPERATURE)
 
     @property
+    @override
     def native_pressure(self) -> float | None:
         """Return the pressure."""
         return self.coordinator.data[ATTR_API_CURRENT].get(ATTR_API_PRESSURE)
 
     @property
+    @override
     def humidity(self) -> float | None:
         """Return the humidity."""
         return self.coordinator.data[ATTR_API_CURRENT].get(ATTR_API_HUMIDITY)
 
     @property
+    @override
     def native_dew_point(self) -> float | None:
         """Return the dew point."""
         return self.coordinator.data[ATTR_API_CURRENT].get(ATTR_API_DEW_POINT)
 
     @property
+    @override
     def native_wind_gust_speed(self) -> float | None:
         """Return the wind gust speed."""
         return self.coordinator.data[ATTR_API_CURRENT].get(ATTR_API_WIND_GUST)
 
     @property
+    @override
     def native_wind_speed(self) -> float | None:
         """Return the wind speed."""
         return self.coordinator.data[ATTR_API_CURRENT].get(ATTR_API_WIND_SPEED)
 
     @property
+    @override
     def wind_bearing(self) -> float | str | None:
         """Return the wind bearing."""
         return self.coordinator.data[ATTR_API_CURRENT].get(ATTR_API_WIND_BEARING)
 
     @property
+    @override
     def native_visibility(self) -> float | None:
         """Return visibility."""
         return self.coordinator.data[ATTR_API_CURRENT].get(ATTR_API_VISIBILITY_DISTANCE)
 
     @callback
+    @override
     def _async_forecast_daily(self) -> list[Forecast] | None:
         """Return the daily forecast in native units."""
         return self.coordinator.data[ATTR_API_DAILY_FORECAST]
 
     @callback
+    @override
     def _async_forecast_hourly(self) -> list[Forecast] | None:
         """Return the hourly forecast in native units."""
         return self.coordinator.data[ATTR_API_HOURLY_FORECAST]

--- a/homeassistant/components/opnsense/config_flow.py
+++ b/homeassistant/components/opnsense/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for OPNsense."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from aiopnsense import (
     OPNsenseBelowMinFirmware,
@@ -111,6 +111,7 @@ class OPNsenseConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors or {},
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/opnsense/coordinator.py
+++ b/homeassistant/components/opnsense/coordinator.py
@@ -1,6 +1,7 @@
 """Coordinator for OPNsense device tracker updates."""
 
 import logging
+from typing import override
 
 from aiopnsense import (
     OPNsenseBelowMinFirmware,
@@ -56,6 +57,7 @@ class OPNsenseDeviceTrackerCoordinator(DataUpdateCoordinator[DeviceDetailsByMAC]
                 out_devices[formatted_mac] = device
         return out_devices
 
+    @override
     async def _async_update_data(self) -> DeviceDetailsByMAC:
         """Fetch data from OPNsense."""
         try:

--- a/homeassistant/components/opnsense/device_tracker.py
+++ b/homeassistant/components/opnsense/device_tracker.py
@@ -1,5 +1,7 @@
 """Device tracker support for OPNsense routers."""
 
+from typing import override
+
 from homeassistant.components.device_tracker import ScannerEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -65,6 +67,7 @@ class OPNsenseDeviceTrackerEntity(
         return None
 
     @property
+    @override
     def is_connected(self) -> bool:
         """Return true if the device is connected to the network."""
         return (
@@ -73,6 +76,7 @@ class OPNsenseDeviceTrackerEntity(
         )
 
     @property
+    @override
     def name(self) -> str:
         """Return device name."""
         device_data = self.device_data
@@ -81,6 +85,7 @@ class OPNsenseDeviceTrackerEntity(
         return f"OPNsense {self.mac_address}"
 
     @property
+    @override
     def ip_address(self) -> str | None:
         """Return the primary IP address of the device."""
         device_data = self.device_data
@@ -89,6 +94,7 @@ class OPNsenseDeviceTrackerEntity(
         return None
 
     @property
+    @override
     def hostname(self) -> str | None:
         """Return hostname of the device."""
         device_data = self.device_data

--- a/homeassistant/components/opower/config_flow.py
+++ b/homeassistant/components/opower/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from opower import (
     CannotConnect,
@@ -56,6 +56,7 @@ class OpowerConfigFlow(ConfigFlow, domain=DOMAIN):
         self._data: dict[str, Any] = {}
         self.mfa_handler: MfaHandlerBase | None = None
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/opower/coordinator.py
+++ b/homeassistant/components/opower/coordinator.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 import logging
-from typing import Any, cast
+from typing import Any, cast, override
 
 from opower import (
     Account,
@@ -97,6 +97,7 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, OpowerData]]):
         # is needed for _insert_statistics.
         self.async_add_listener(_dummy_listener)
 
+    @override
     async def _async_update_data(
         self,
     ) -> dict[str, OpowerData]:

--- a/homeassistant/components/opower/sensor.py
+++ b/homeassistant/components/opower/sensor.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import date, datetime
+from typing import override
 
 from opower import MeterType, UnitOfMeasure
 
@@ -326,11 +327,13 @@ class OpowerSensor(CoordinatorEntity[OpowerCoordinator], SensorEntity):
         self.utility_account_id = utility_account_id
 
     @property
+    @override
     def available(self) -> bool:
         """Return if entity is available."""
         return super().available and self.utility_account_id in self.coordinator.data
 
     @property
+    @override
     def native_value(self) -> StateType | date | datetime:
         """Return the state."""
         return self.entity_description.value_fn(

--- a/homeassistant/components/opple/light.py
+++ b/homeassistant/components/opple/light.py
@@ -1,7 +1,7 @@
 """Support for the Opple light."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from pyoppleio.OppleLightDevice import OppleLightDevice
 import voluptuous as vol
@@ -63,15 +63,18 @@ class OppleLight(LightEntity):
         self._attr_name = name
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if light is available."""
         return self._device.is_online
 
     @property
+    @override
     def unique_id(self):
         """Return unique ID for light."""
         return self._device.mac
 
+    @override
     def turn_on(self, **kwargs: Any) -> None:
         """Instruct the light to turn on."""
         _LOGGER.debug("Turn on light %s %s", self._device.ip, kwargs)
@@ -87,6 +90,7 @@ class OppleLight(LightEntity):
         ):
             self._device.color_temperature = kwargs[ATTR_COLOR_TEMP_KELVIN]
 
+    @override
     def turn_off(self, **kwargs: Any) -> None:
         """Instruct the light to turn off."""
         self._device.power_on = False

--- a/homeassistant/components/oralb/config_flow.py
+++ b/homeassistant/components/oralb/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for oralb ble integration."""
 
-from typing import Any
+from typing import Any, override
 
 from oralb_ble import OralBBluetoothDeviceData as DeviceData
 import voluptuous as vol
@@ -26,6 +26,7 @@ class OralBConfigFlow(ConfigFlow, domain=DOMAIN):
         self._discovered_device: DeviceData | None = None
         self._discovered_devices: dict[str, str] = {}
 
+    @override
     async def async_step_bluetooth(
         self, discovery_info: BluetoothServiceInfoBleak
     ) -> ConfigFlowResult:
@@ -58,6 +59,7 @@ class OralBConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="bluetooth_confirm", description_placeholders=placeholders
         )
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/oralb/sensor.py
+++ b/homeassistant/components/oralb/sensor.py
@@ -1,5 +1,7 @@
 """Support for OralB sensors."""
 
+from typing import override
+
 from oralb_ble import OralBSensor, SensorUpdate
 from oralb_ble.parser import (
     IO_SERIES_MODES,
@@ -149,6 +151,7 @@ class OralBBluetoothSensorEntity(
     """Representation of a OralB sensor."""
 
     @property
+    @override
     def native_value(self) -> str | int | None:
         """Return the native value."""
         value = self.processor.entity_data.get(self.entity_key)
@@ -162,6 +165,7 @@ class OralBBluetoothSensorEntity(
         return value
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available.
 
@@ -174,6 +178,7 @@ class OralBBluetoothSensorEntity(
         return True
 
     @property
+    @override
     def assumed_state(self) -> bool:
         """Return True if the device is no longer broadcasting."""
         return not self.processor.available

--- a/homeassistant/components/oru/sensor.py
+++ b/homeassistant/components/oru/sensor.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import logging
+from typing import override
 
 from oru import Meter, MeterError
 import voluptuous as vol
@@ -63,6 +64,7 @@ class CurrentEnergyUsageSensor(SensorEntity):
         self.meter = meter
 
     @property
+    @override
     def unique_id(self):
         """Return a unique, Home Assistant friendly identifier for this entity."""
         return self.meter.meter_id

--- a/homeassistant/components/orvibo/config_flow.py
+++ b/homeassistant/components/orvibo/config_flow.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from typing import Any
+from typing import Any, override
 
 from orvibo.s20 import S20, S20Exception, discover
 import voluptuous as vol
@@ -65,6 +65,7 @@ class S20ConfigFlow(ConfigFlow, domain=DOMAIN):
 
         self._discovered_switches = _filter_discovered_switches(_unfiltered_switches)
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/orvibo/switch.py
+++ b/homeassistant/components/orvibo/switch.py
@@ -1,7 +1,7 @@
 """Switch platform for the Orvibo integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from orvibo.s20 import S20, S20Exception
 import voluptuous as vol
@@ -155,6 +155,7 @@ class S20Switch(SwitchEntity):
             connections={(CONNECTION_NETWORK_MAC, self._mac)},
         )
 
+    @override
     def turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
         try:
@@ -166,6 +167,7 @@ class S20Switch(SwitchEntity):
                 translation_placeholders={"name": self._name},
             ) from err
 
+    @override
     def turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
         try:

--- a/homeassistant/components/osoenergy/binary_sensor.py
+++ b/homeassistant/components/osoenergy/binary_sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from apyosoenergyapi import OSOEnergy
 from apyosoenergyapi.helper.const import OSOEnergyBinarySensorData
@@ -80,6 +81,7 @@ class OSOEnergyBinarySensor(
         self.entity_description = description
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.entity_data)

--- a/homeassistant/components/osoenergy/config_flow.py
+++ b/homeassistant/components/osoenergy/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from apyosoenergyapi import OSOEnergy
 import voluptuous as vol
@@ -25,6 +25,7 @@ class OSOEnergyFlowHandler(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(self, user_input=None) -> ConfigFlowResult:
         """Handle a flow initialized by the user."""
         errors = {}

--- a/homeassistant/components/osoenergy/sensor.py
+++ b/homeassistant/components/osoenergy/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from apyosoenergyapi import OSOEnergy
 from apyosoenergyapi.helper.const import OSOEnergySensorData
@@ -175,6 +176,7 @@ class OSOEnergySensor(OSOEnergyEntity[OSOEnergySensorData], SensorEntity):
         self.entity_description = description
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.entity_data)

--- a/homeassistant/components/osoenergy/water_heater.py
+++ b/homeassistant/components/osoenergy/water_heater.py
@@ -1,7 +1,7 @@
 """Support for OSO Energy water heaters."""
 
 import datetime as dt
-from typing import Any
+from typing import Any, override
 
 from apyosoenergyapi import OSOEnergy
 from apyosoenergyapi.helper.const import OSOEnergyWaterHeaterData
@@ -191,11 +191,13 @@ class OSOEnergyWaterHeater(
         self._attr_unique_id = entity_data.device_id
 
     @property
+    @override
     def available(self) -> bool:
         """Return if the device is available."""
         return self.entity_data.available
 
     @property
+    @override
     def current_operation(self) -> str:
         """Return current operation."""
         status = self.entity_data.current_operation
@@ -212,56 +214,68 @@ class OSOEnergyWaterHeater(
         return CURRENT_OPERATION_MAP["default"].get(heater_mode, STATE_ELECTRIC)
 
     @property
+    @override
     def current_temperature(self) -> float:
         """Return the current temperature of the heater."""
         return self.entity_data.current_temperature
 
     @property
+    @override
     def is_away_mode_on(self) -> bool:
         """Return if the heater is in away mode."""
         return self.entity_data.isInPowerSave
 
     @property
+    @override
     def target_temperature(self) -> float:
         """Return the temperature we try to reach."""
         return self.entity_data.target_temperature
 
     @property
+    @override
     def target_temperature_high(self) -> float:
         """Return the temperature we try to reach."""
         return self.entity_data.target_temperature_high
 
     @property
+    @override
     def target_temperature_low(self) -> float:
         """Return the temperature we try to reach."""
         return self.entity_data.target_temperature_low
 
     @property
+    @override
     def min_temp(self) -> float:
         """Return the minimum temperature."""
         return self.entity_data.min_temperature
 
     @property
+    @override
     def max_temp(self) -> float:
         """Return the maximum temperature."""
         return self.entity_data.max_temperature
 
+    @override
     async def async_turn_away_mode_on(self) -> None:
         """Turn on away mode."""
         await self.osoenergy.hotwater.enable_holiday_mode(self.entity_data)
 
+    @override
     async def async_turn_away_mode_off(self) -> None:
         """Turn off away mode."""
         await self.osoenergy.hotwater.disable_holiday_mode(self.entity_data)
 
+    @override
     async def async_turn_on(self, **kwargs) -> None:
         """Turn on hotwater."""
         await self.osoenergy.hotwater.turn_on(self.entity_data, True)
 
+    @override
     async def async_turn_off(self, **kwargs) -> None:
         """Turn off hotwater."""
         await self.osoenergy.hotwater.turn_off(self.entity_data, True)
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         target_temperature = int(kwargs.get("temperature", self.target_temperature))

--- a/homeassistant/components/osramlightify/light.py
+++ b/homeassistant/components/osramlightify/light.py
@@ -2,7 +2,7 @@
 
 import logging
 import random
-from typing import Any
+from typing import Any, override
 
 from lightify import Lightify
 import voluptuous as vol
@@ -237,11 +237,13 @@ class Luminary(LightEntity):
         return effects
 
     @property
+    @override
     def name(self):
         """Return the name of the luminary."""
         return self._luminary.name()
 
     @property
+    @override
     def hs_color(self) -> tuple[float, float]:
         """Return last hs color value set."""
         return color_util.color_RGB_to_hs(*self._rgb_color)
@@ -260,6 +262,7 @@ class Luminary(LightEntity):
 
         return False
 
+    @override
     def turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
         transition = int(kwargs.get(ATTR_TRANSITION, 0) * 10)
@@ -283,6 +286,7 @@ class Luminary(LightEntity):
         else:
             self._luminary.set_onoff(True)
 
+    @override
     def turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
         self._attr_is_on = False
@@ -348,10 +352,12 @@ class Luminary(LightEntity):
 class OsramLightifyLight(Luminary):
     """Representation of an Osram Lightify Light."""
 
+    @override
     def _get_unique_id(self):
         """Get a unique ID."""
         return self._luminary.addr()
 
+    @override
     def update_static_attributes(self):
         """Update static attributes of the luminary."""
         super().update_static_attributes()
@@ -370,6 +376,7 @@ class OsramLightifyLight(Luminary):
 class OsramLightifyGroup(Luminary):
     """Representation of an Osram Lightify Group."""
 
+    @override
     def _get_unique_id(self):
         """Get a unique ID for the group."""
         #       Actually, it's a wrong choice for a unique ID, because a combination of
@@ -381,6 +388,7 @@ class OsramLightifyGroup(Luminary):
         #       users.
         return f"{self._luminary.lights()}"
 
+    @override
     def _get_supported_features(self) -> LightEntityFeature:
         """Get list of supported features."""
         features = super()._get_supported_features()
@@ -389,12 +397,14 @@ class OsramLightifyGroup(Luminary):
 
         return features
 
+    @override
     def _get_effect_list(self):
         """Get list of supported effects."""
         effects = super()._get_effect_list()
         effects.extend(self._luminary.scenes())
         return sorted(effects)
 
+    @override
     def play_effect(self, effect, transition):
         """Play selected effect."""
         if super().play_effect(effect, transition):
@@ -406,6 +416,7 @@ class OsramLightifyGroup(Luminary):
 
         return False
 
+    @override
     def update_static_attributes(self):
         """Update static attributes of the luminary."""
         super().update_static_attributes()

--- a/homeassistant/components/otbr/config_flow.py
+++ b/homeassistant/components/otbr/config_flow.py
@@ -2,7 +2,7 @@
 
 from contextlib import suppress
 import logging
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, cast, override
 
 import aiohttp
 import python_otbr_api
@@ -154,6 +154,7 @@ class OTBRConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return border_agent_id
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, str] | None = None
     ) -> ConfigFlowResult:
@@ -185,6 +186,7 @@ class OTBRConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="user", data_schema=data_schema, errors=errors
         )
 
+    @override
     async def async_step_hassio(
         self, discovery_info: HassioServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/otp/config_flow.py
+++ b/homeassistant/components/otp/config_flow.py
@@ -3,7 +3,7 @@
 import binascii
 import logging
 from re import sub
-from typing import Any
+from typing import Any, override
 
 import pyotp
 import voluptuous as vol
@@ -41,6 +41,7 @@ class TOTPConfigFlow(ConfigFlow, domain=DOMAIN):
     VERSION = 1
     user_input: dict[str, Any]
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/otp/sensor.py
+++ b/homeassistant/components/otp/sensor.py
@@ -1,6 +1,7 @@
 """Support for One-Time Password (OTP)."""
 
 import time
+from typing import override
 
 import pyotp
 
@@ -52,6 +53,7 @@ class TOTPSensor(SensorEntity):
             identifiers={(DOMAIN, entry_id)},
         )
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Handle when an entity is about to be added to Home Assistant."""
         self._call_loop()

--- a/homeassistant/components/ouman_eh_800/climate.py
+++ b/homeassistant/components/ouman_eh_800/climate.py
@@ -1,7 +1,7 @@
 """Climate platform for the Ouman EH-800 integration."""
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from ouman_eh_800_api import (
     EnumControlOumanEndpoint,
@@ -134,6 +134,7 @@ class OumanEh800ClimateEntity(OumanEh800Entity, ClimateEntity):
         return value
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode:
         """Return HEAT only when the climate setpoint is controlling the circuit."""
         if self._operation_mode in _HEAT_OPERATION_MODES:
@@ -141,6 +142,7 @@ class OumanEh800ClimateEntity(OumanEh800Entity, ClimateEntity):
         return HVACMode.OFF
 
     @property
+    @override
     def hvac_action(self) -> HVACAction:
         """Return HEATING when the mixing valve is open, IDLE when closed, OFF otherwise."""
         if self.hvac_mode is HVACMode.OFF:
@@ -152,12 +154,14 @@ class OumanEh800ClimateEntity(OumanEh800Entity, ClimateEntity):
         return HVACAction.HEATING if valve_position > 0 else HVACAction.IDLE
 
     @property
+    @override
     def preset_mode(self) -> str | None:
         """Return the current heating sub-mode, or None when shut down."""
         mode = self._operation_mode
         return mode.name.lower() if mode in _HEAT_OPERATION_MODES else None
 
     @property
+    @override
     def current_temperature(self) -> float:
         """Return the current room temperature."""
         value = self.coordinator.data[
@@ -167,6 +171,7 @@ class OumanEh800ClimateEntity(OumanEh800Entity, ClimateEntity):
         return value
 
     @property
+    @override
     def target_temperature(self) -> float:
         """Return the user-set room temperature setpoint."""
         value = self.coordinator.data[
@@ -175,6 +180,7 @@ class OumanEh800ClimateEntity(OumanEh800Entity, ClimateEntity):
         assert isinstance(value, float)
         return value
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set a new room temperature setpoint and optionally the HVAC mode."""
         if (hvac_mode := kwargs.get(ATTR_HVAC_MODE)) is not None:
@@ -184,6 +190,7 @@ class OumanEh800ClimateEntity(OumanEh800Entity, ClimateEntity):
             int(kwargs[ATTR_TEMPERATURE]),
         )
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Switch between heating (default sub-mode) and shutdown."""
         new_mode = (
@@ -195,6 +202,7 @@ class OumanEh800ClimateEntity(OumanEh800Entity, ClimateEntity):
             self.entity_description.operation_mode_endpoint, new_mode
         )
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Switch the heating sub-mode."""
         await self.coordinator.async_set_endpoint_value(

--- a/homeassistant/components/ouman_eh_800/config_flow.py
+++ b/homeassistant/components/ouman_eh_800/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for the Ouman EH-800 integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from ouman_eh_800_api import (
     OumanClientAuthenticationError,
@@ -38,6 +38,7 @@ class OumanEh800ConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/ouman_eh_800/coordinator.py
+++ b/homeassistant/components/ouman_eh_800/coordinator.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import logging
+from typing import override
 
 from ouman_eh_800_api import (
     ControllableEndpoint,
@@ -84,6 +85,7 @@ class OumanEh800Coordinator(DataUpdateCoordinator[dict[OumanEndpoint, OumanValue
             ),
         }
 
+    @override
     async def _async_setup(self) -> None:
         try:
             # Even though not required to fetch values, perform login once
@@ -95,6 +97,7 @@ class OumanEh800Coordinator(DataUpdateCoordinator[dict[OumanEndpoint, OumanValue
         except OumanClientCommunicationError as err:
             raise ConfigEntryNotReady("Error communicating with API") from err
 
+    @override
     async def _async_update_data(self) -> dict[OumanEndpoint, OumanValues]:
         """Fetch registry values from the device."""
         try:

--- a/homeassistant/components/ouman_eh_800/number.py
+++ b/homeassistant/components/ouman_eh_800/number.py
@@ -1,6 +1,7 @@
 """Number platform for the Ouman EH-800 integration."""
 
 from dataclasses import dataclass
+from typing import override
 
 from ouman_eh_800_api import (
     FloatControlOumanEndpoint,
@@ -246,12 +247,14 @@ class OumanEh800NumberEntity(OumanEh800Entity, NumberEntity):
         )
 
     @property
+    @override
     def native_value(self) -> float:
         """Return the current value."""
         value = self.coordinator.data[self._endpoint]
         assert isinstance(value, float)
         return value
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Set a new value on the device."""
         final_value: int | float = (

--- a/homeassistant/components/ouman_eh_800/select.py
+++ b/homeassistant/components/ouman_eh_800/select.py
@@ -1,6 +1,7 @@
 """Select platform for the Ouman EH-800 integration."""
 
 from dataclasses import dataclass
+from typing import override
 
 from ouman_eh_800_api import (
     ControlEnum,
@@ -107,12 +108,14 @@ class OumanEh800SelectEntity(OumanEh800Entity, SelectEntity):
         self._attr_options = [member.name.lower() for member in endpoint.enum_type]
 
     @property
+    @override
     def current_option(self) -> str:
         """Return the currently selected option."""
         value = self.coordinator.data[self._endpoint]
         assert isinstance(value, ControlEnum)
         return value.name.lower()
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Change the selected option on the device."""
         await self.coordinator.async_set_endpoint_value(

--- a/homeassistant/components/ouman_eh_800/sensor.py
+++ b/homeassistant/components/ouman_eh_800/sensor.py
@@ -1,6 +1,7 @@
 """Sensor platform for the Ouman EH-800 integration."""
 
 from dataclasses import dataclass
+from typing import override
 
 from ouman_eh_800_api import (
     L1BaseEndpoints,
@@ -179,6 +180,7 @@ class OumanEh800SensorEntity(OumanEh800Entity, SensorEntity):
     entity_description: OumanEh800SensorDescription
 
     @property
+    @override
     def native_value(self) -> float | str:
         """Return the current sensor value."""
         value = self.coordinator.data[self._endpoint]

--- a/homeassistant/components/ouman_eh_800/valve.py
+++ b/homeassistant/components/ouman_eh_800/valve.py
@@ -1,6 +1,7 @@
 """Valve platform for the Ouman EH-800 integration."""
 
 from dataclasses import dataclass
+from typing import override
 
 from ouman_eh_800_api import IntControlOumanEndpoint, L1BaseEndpoints, L2BaseEndpoints
 
@@ -72,12 +73,14 @@ class OumanEh800ValveEntity(OumanEh800Entity, ValveEntity):
     )
 
     @property
+    @override
     def current_valve_position(self) -> int:
         """Return the current valve position 0-100."""
         value = self.coordinator.data[self._endpoint]
         assert isinstance(value, float)
         return int(value)
 
+    @override
     async def async_set_valve_position(self, position: int) -> None:
         """Move the valve to the given position."""
         await self.coordinator.async_set_endpoint_value(self._endpoint, position)

--- a/homeassistant/components/ourgroceries/config_flow.py
+++ b/homeassistant/components/ourgroceries/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for OurGroceries integration."""
 
 import logging
-from typing import Any
+from typing import Any, override
 
 from aiohttp import ClientError
 from ourgroceries import OurGroceries
@@ -28,6 +28,7 @@ class OurGroceriesConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/ourgroceries/coordinator.py
+++ b/homeassistant/components/ourgroceries/coordinator.py
@@ -3,6 +3,7 @@
 import asyncio
 from datetime import timedelta
 import logging
+from typing import override
 
 from ourgroceries import OurGroceries
 
@@ -50,6 +51,7 @@ class OurGroceriesDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict]]):
             return
         self._cache[list_id] = await self.og.get_list_items(list_id=list_id)
 
+    @override
     async def _async_update_data(self) -> dict[str, dict]:
         """Fetch data from OurGroceries."""
         self.lists = (await self.og.get_my_lists())["shoppingLists"]

--- a/homeassistant/components/ourgroceries/todo.py
+++ b/homeassistant/components/ourgroceries/todo.py
@@ -1,7 +1,7 @@
 """A todo platform for OurGroceries."""
 
 import asyncio
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.todo import (
     TodoItem,
@@ -60,6 +60,7 @@ class OurGroceriesTodoListEntity(
         self._attr_name = list_name
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         if self.coordinator.data is None:
@@ -75,6 +76,7 @@ class OurGroceriesTodoListEntity(
             ]
         super()._handle_coordinator_update()
 
+    @override
     async def async_create_todo_item(self, item: TodoItem) -> None:
         """Create a To-do item."""
         if item.status != TodoItemStatus.NEEDS_ACTION:
@@ -84,6 +86,7 @@ class OurGroceriesTodoListEntity(
         )
         await self.coordinator.async_refresh()
 
+    @override
     async def async_update_todo_item(self, item: TodoItem) -> None:
         """Update a To-do item."""
         if item.summary:
@@ -103,6 +106,7 @@ class OurGroceriesTodoListEntity(
             )
         await self.coordinator.async_refresh()
 
+    @override
     async def async_delete_todo_items(self, uids: list[str]) -> None:
         """Delete a To-do item."""
         await asyncio.gather(
@@ -113,6 +117,7 @@ class OurGroceriesTodoListEntity(
         )
         await self.coordinator.async_refresh()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass update state from existing coordinator data."""
         await super().async_added_to_hass()

--- a/homeassistant/components/overkiz/alarm_control_panel.py
+++ b/homeassistant/components/overkiz/alarm_control_panel.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any, cast, override
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 from pyoverkiz.enums.ui import UIWidget
@@ -250,10 +250,12 @@ class OverkizAlarmControlPanel(OverkizDescriptiveEntity, AlarmControlPanelEntity
         self._attr_supported_features = self.entity_description.supported_features
 
     @property
+    @override
     def alarm_state(self) -> AlarmControlPanelState:
         """Return the state of the device."""
         return self.entity_description.fn_state(self.device.states.get_value)
 
+    @override
     async def async_alarm_disarm(self, code: str | None = None) -> None:
         """Send disarm command."""
         assert self.entity_description.alarm_disarm
@@ -262,6 +264,7 @@ class OverkizAlarmControlPanel(OverkizDescriptiveEntity, AlarmControlPanelEntity
             self.entity_description.alarm_disarm_args,
         )
 
+    @override
     async def async_alarm_arm_home(self, code: str | None = None) -> None:
         """Send arm home command."""
         assert self.entity_description.alarm_arm_home
@@ -270,6 +273,7 @@ class OverkizAlarmControlPanel(OverkizDescriptiveEntity, AlarmControlPanelEntity
             self.entity_description.alarm_arm_home_args,
         )
 
+    @override
     async def async_alarm_arm_night(self, code: str | None = None) -> None:
         """Send arm night command."""
         assert self.entity_description.alarm_arm_night
@@ -278,6 +282,7 @@ class OverkizAlarmControlPanel(OverkizDescriptiveEntity, AlarmControlPanelEntity
             self.entity_description.alarm_arm_night_args,
         )
 
+    @override
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command."""
         assert self.entity_description.alarm_arm_away
@@ -286,6 +291,7 @@ class OverkizAlarmControlPanel(OverkizDescriptiveEntity, AlarmControlPanelEntity
             self.entity_description.alarm_arm_away_args,
         )
 
+    @override
     async def async_alarm_trigger(self, code: str | None = None) -> None:
         """Send alarm trigger command."""
         assert self.entity_description.alarm_trigger

--- a/homeassistant/components/overkiz/application_credentials.py
+++ b/homeassistant/components/overkiz/application_credentials.py
@@ -1,5 +1,7 @@
 """Application credentials platform for Overkiz (Rexel)."""
 
+from typing import override
+
 from pyoverkiz.const import (
     REXEL_OAUTH_AUTHORIZE_URL,
     REXEL_OAUTH_POLICY,
@@ -31,6 +33,7 @@ class OverkizOAuth2Implementation(LocalOAuth2ImplementationWithPkce):
     """Overkiz (Rexel) OAuth2 implementation with PKCE."""
 
     @property
+    @override
     def extra_authorize_data(self) -> dict:
         """Extra data that needs to be appended to the authorize url.
 

--- a/homeassistant/components/overkiz/binary_sensor.py
+++ b/homeassistant/components/overkiz/binary_sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import cast
+from typing import cast, override
 
 from pyoverkiz.enums import OverkizCommandParam, OverkizState
 from pyoverkiz.types import StateType as OverkizStateType
@@ -177,6 +177,7 @@ class OverkizBinarySensor(OverkizDescriptiveEntity, BinarySensorEntity):
     entity_description: OverkizBinarySensorDescription
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return the state of the sensor."""
         if state := self.device.states.get(self.entity_description.key):

--- a/homeassistant/components/overkiz/button.py
+++ b/homeassistant/components/overkiz/button.py
@@ -1,6 +1,7 @@
 """Support for Overkiz (virtual) buttons."""
 
 from dataclasses import dataclass
+from typing import override
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam
 from pyoverkiz.types import StateType as OverkizStateType
@@ -131,6 +132,7 @@ class OverkizButton(OverkizDescriptiveEntity, ButtonEntity):
 
     entity_description: OverkizButtonDescription
 
+    @override
     async def async_press(self) -> None:
         """Handle the button press."""
         if self.entity_description.press_args:

--- a/homeassistant/components/overkiz/climate/atlantic_electrical_heater.py
+++ b/homeassistant/components/overkiz/climate/atlantic_electrical_heater.py
@@ -1,6 +1,6 @@
 """Support for Atlantic Electrical Heater."""
 
-from typing import cast
+from typing import cast, override
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
@@ -54,6 +54,7 @@ class AtlanticElectricalHeater(OverkizEntity, ClimateEntity):
     _attr_translation_key = DOMAIN
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode:
         """Return hvac operation ie. heat, cool mode."""
         if OverkizState.CORE_ON_OFF in self.device.states:
@@ -63,6 +64,7 @@ class AtlanticElectricalHeater(OverkizEntity, ClimateEntity):
 
         return HVACMode.OFF
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         await self.executor.async_execute_command(
@@ -70,6 +72,7 @@ class AtlanticElectricalHeater(OverkizEntity, ClimateEntity):
         )
 
     @property
+    @override
     def preset_mode(self) -> str | None:
         """Return the current preset mode, e.g., home, away, temp."""
         return OVERKIZ_TO_PRESET_MODES[
@@ -78,6 +81,7 @@ class AtlanticElectricalHeater(OverkizEntity, ClimateEntity):
             )
         ]
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
         await self.executor.async_execute_command(

--- a/homeassistant/components/overkiz/climate/atlantic_electrical_heater_with_adjustable_temperature_setpoint.py
+++ b/homeassistant/components/overkiz/climate/atlantic_electrical_heater_with_adjustable_temperature_setpoint.py
@@ -1,6 +1,6 @@
 """Support for Atlantic Electrical Heater (With Adjustable Temperature Setpoint)."""
 
-from typing import Any
+from typing import Any, override
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
@@ -101,6 +101,7 @@ class AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint(
         )
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode:
         """Return hvac operation ie. heat, cool mode."""
         states = self.device.states
@@ -110,6 +111,7 @@ class AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint(
             return OVERKIZ_TO_HVAC_MODE[state.value_as_str]
         return HVACMode.OFF
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         await self.executor.async_execute_command(
@@ -117,6 +119,7 @@ class AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint(
         )
 
     @property
+    @override
     def hvac_action(self) -> HVACAction:
         """Return the current running hvac operation ie. heating, idle, off."""
         states = self.device.states
@@ -125,6 +128,7 @@ class AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint(
         return HVACAction.OFF
 
     @property
+    @override
     def preset_mode(self) -> str | None:
         """Return the current preset mode, e.g., home, away, temp."""
 
@@ -141,6 +145,7 @@ class AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint(
             return PRESET_EXTERNAL
         return None
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
 
@@ -155,6 +160,7 @@ class AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint(
         )
 
     @property
+    @override
     def target_temperature(self) -> float | None:
         """Return the temperature."""
         if state := self.device.states.get(OverkizState.CORE_TARGET_TEMPERATURE):
@@ -162,6 +168,7 @@ class AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint(
         return None
 
     @property
+    @override
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
         if self.temperature_device is not None and (
@@ -172,6 +179,7 @@ class AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint(
             return temperature.value_as_float
         return None
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new temperature."""
         temperature = kwargs[ATTR_TEMPERATURE]

--- a/homeassistant/components/overkiz/climate/atlantic_electrical_towel_dryer.py
+++ b/homeassistant/components/overkiz/climate/atlantic_electrical_towel_dryer.py
@@ -1,6 +1,6 @@
 """Support for Atlantic Electrical Towel Dryer."""
 
-from typing import Any, cast
+from typing import Any, cast, override
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
@@ -73,6 +73,7 @@ class AtlanticElectricalTowelDryer(OverkizEntity, ClimateEntity):
             ]
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode:
         """Return hvac operation ie. heat, cool mode."""
         if OverkizState.CORE_OPERATING_MODE in self.device.states:
@@ -84,6 +85,7 @@ class AtlanticElectricalTowelDryer(OverkizEntity, ClimateEntity):
 
         return HVACMode.OFF
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         await self.executor.async_execute_command(
@@ -92,6 +94,7 @@ class AtlanticElectricalTowelDryer(OverkizEntity, ClimateEntity):
         )
 
     @property
+    @override
     def target_temperature(self) -> float | None:
         """Return the target temperature."""
         state = (
@@ -103,6 +106,7 @@ class AtlanticElectricalTowelDryer(OverkizEntity, ClimateEntity):
         return cast(float, self.device.states.get_value(state))
 
     @property
+    @override
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
         if self.temperature_device is not None and (
@@ -114,6 +118,7 @@ class AtlanticElectricalTowelDryer(OverkizEntity, ClimateEntity):
 
         return None
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new temperature."""
         temperature = kwargs[ATTR_TEMPERATURE]
@@ -128,6 +133,7 @@ class AtlanticElectricalTowelDryer(OverkizEntity, ClimateEntity):
             )
 
     @property
+    @override
     def preset_mode(self) -> str | None:
         """Return the current preset mode, e.g., home, away, temp."""
         if (
@@ -151,6 +157,7 @@ class AtlanticElectricalTowelDryer(OverkizEntity, ClimateEntity):
 
         return PRESET_NONE
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
         # If the preset mode is set to prog, we need to set

--- a/homeassistant/components/overkiz/climate/atlantic_heat_recovery_ventilation.py
+++ b/homeassistant/components/overkiz/climate/atlantic_heat_recovery_ventilation.py
@@ -1,6 +1,6 @@
 """Support for AtlanticHeatRecoveryVentilation."""
 
-from typing import cast
+from typing import cast, override
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
@@ -64,6 +64,7 @@ class AtlanticHeatRecoveryVentilation(OverkizEntity, ClimateEntity):
         )
 
     @property
+    @override
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
         if self.temperature_device is not None and (
@@ -75,10 +76,12 @@ class AtlanticHeatRecoveryVentilation(OverkizEntity, ClimateEntity):
 
         return None
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
         """Not implemented since there is only one hvac_mode."""
 
     @property
+    @override
     def preset_mode(self) -> str | None:
         """Return the current preset mode."""
         ventilation_configuration = self.device.states.get_value(
@@ -101,6 +104,7 @@ class AtlanticHeatRecoveryVentilation(OverkizEntity, ClimateEntity):
 
         return None
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode of the fan."""
         if preset_mode == PRESET_AUTO:
@@ -132,6 +136,7 @@ class AtlanticHeatRecoveryVentilation(OverkizEntity, ClimateEntity):
         )
 
     @property
+    @override
     def fan_mode(self) -> str | None:
         """Return the fan setting."""
         ventilation_mode = cast(
@@ -146,6 +151,7 @@ class AtlanticHeatRecoveryVentilation(OverkizEntity, ClimateEntity):
             cast(str, self.device.states.get_value(OverkizState.IO_AIR_DEMAND_MODE))
         ]
 
+    @override
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""
         if fan_mode == FAN_BYPASS:

--- a/homeassistant/components/overkiz/climate/atlantic_pass_apc_heat_pump_main_component.py
+++ b/homeassistant/components/overkiz/climate/atlantic_pass_apc_heat_pump_main_component.py
@@ -1,7 +1,7 @@
 """Support for Atlantic Pass APC Heat Pump Main Component."""
 
 from asyncio import sleep
-from typing import cast
+from typing import cast, override
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
@@ -44,6 +44,7 @@ class AtlanticPassAPCHeatPumpMainComponent(OverkizEntity, ClimateEntity):
     _attr_translation_key = DOMAIN
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode:
         """Return hvac current mode: stop, cooling, heating."""
         return OVERKIZ_TO_HVAC_MODES[
@@ -53,6 +54,7 @@ class AtlanticPassAPCHeatPumpMainComponent(OverkizEntity, ClimateEntity):
             )
         ]
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode: stop, cooling, heating."""
         # They are mainly managed by the Zone Control device

--- a/homeassistant/components/overkiz/climate/atlantic_pass_apc_heating_zone.py
+++ b/homeassistant/components/overkiz/climate/atlantic_pass_apc_heating_zone.py
@@ -1,6 +1,6 @@
 """Support for Atlantic Pass APC Heating Control."""
 
-from typing import Any, cast
+from typing import Any, cast, override
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
@@ -105,6 +105,7 @@ class AtlanticPassAPCHeatingZone(OverkizEntity, ClimateEntity):
         )
 
     @property
+    @override
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
         if self.temperature_device is not None and (
@@ -117,6 +118,7 @@ class AtlanticPassAPCHeatingZone(OverkizEntity, ClimateEntity):
         return None
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode:
         """Return hvac operation ie. heat, cool mode."""
         return OVERKIZ_TO_HVAC_MODE[
@@ -153,15 +155,18 @@ class AtlanticPassAPCHeatingZone(OverkizEntity, ClimateEntity):
             OverkizCommand.REFRESH_PASS_APC_HEATING_PROFILE
         )
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         await self.async_set_heating_mode(HVAC_MODE_TO_OVERKIZ[hvac_mode])
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
         await self.async_set_heating_mode(PRESET_MODES_TO_OVERKIZ[preset_mode])
 
     @property
+    @override
     def preset_mode(self) -> str | None:
         """Return the current preset mode, e.g., home, away, temp."""
         heating_mode = cast(
@@ -182,6 +187,7 @@ class AtlanticPassAPCHeatingZone(OverkizEntity, ClimateEntity):
         return OVERKIZ_TO_PRESET_MODES[heating_mode]
 
     @property
+    @override
     def target_temperature(self) -> float | None:
         """Return hvac target temperature."""
         current_heating_profile = self.current_heating_profile
@@ -196,6 +202,7 @@ class AtlanticPassAPCHeatingZone(OverkizEntity, ClimateEntity):
             float, self.device.states.get_value(OverkizState.CORE_TARGET_TEMPERATURE)
         )
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new temperature."""
         temperature = kwargs[ATTR_TEMPERATURE]

--- a/homeassistant/components/overkiz/climate/atlantic_pass_apc_zone_control.py
+++ b/homeassistant/components/overkiz/climate/atlantic_pass_apc_zone_control.py
@@ -1,6 +1,6 @@
 """Support for Atlantic Pass APC Zone Control."""
 
-from typing import cast
+from typing import cast, override
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
@@ -55,6 +55,7 @@ class AtlanticPassAPCZoneControl(OverkizEntity, ClimateEntity):
         )
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode:
         """Return hvac operation ie. heat, cool mode."""
 
@@ -77,6 +78,7 @@ class AtlanticPassAPCZoneControl(OverkizEntity, ClimateEntity):
             )
         ]
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
 

--- a/homeassistant/components/overkiz/climate/atlantic_pass_apc_zone_control_zone.py
+++ b/homeassistant/components/overkiz/climate/atlantic_pass_apc_zone_control_zone.py
@@ -1,7 +1,7 @@
 """Support for Atlantic Pass APC Heating Control."""
 
 from asyncio import sleep
-from typing import Any, cast
+from typing import Any, cast, override
 
 from propcache.api import cached_property
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
@@ -183,6 +183,7 @@ class AtlanticPassAPCZoneControlZone(AtlanticPassAPCHeatingZone):
         return HVACAction.OFF
 
     @property
+    @override
     def hvac_action(self) -> HVACAction | None:
         """Return the current running hvac operation."""
 
@@ -201,6 +202,7 @@ class AtlanticPassAPCZoneControlZone(AtlanticPassAPCHeatingZone):
         return hvac_action
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode:
         """Return hvac operation ie. heat, cool, dry, off mode."""
 
@@ -235,6 +237,7 @@ class AtlanticPassAPCZoneControlZone(AtlanticPassAPCHeatingZone):
 
         return device_hvac_mode
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
 
@@ -263,6 +266,7 @@ class AtlanticPassAPCZoneControlZone(AtlanticPassAPCHeatingZone):
         await self.async_refresh_modes()
 
     @property
+    @override
     def preset_mode(self) -> str | None:
         """Return the current preset mode, e.g., schedule, manual."""
 
@@ -289,6 +293,7 @@ class AtlanticPassAPCZoneControlZone(AtlanticPassAPCHeatingZone):
 
         return PRESET_NONE
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
 
@@ -309,6 +314,7 @@ class AtlanticPassAPCZoneControlZone(AtlanticPassAPCHeatingZone):
         await self.async_refresh_modes()
 
     @property
+    @override
     def target_temperature(self) -> float | None:
         """Return hvac target temperature."""
 
@@ -341,6 +347,7 @@ class AtlanticPassAPCZoneControlZone(AtlanticPassAPCHeatingZone):
         )
 
     @property
+    @override
     def target_temperature_high(self) -> float | None:
         """Return the highbound target temperature we try to reach (cooling)."""
 
@@ -353,6 +360,7 @@ class AtlanticPassAPCZoneControlZone(AtlanticPassAPCHeatingZone):
         )
 
     @property
+    @override
     def target_temperature_low(self) -> float | None:
         """Return the lowbound target temperature we try to reach (heating)."""
 
@@ -364,6 +372,7 @@ class AtlanticPassAPCZoneControlZone(AtlanticPassAPCHeatingZone):
             self.device.states.get_value(OverkizState.CORE_HEATING_TARGET_TEMPERATURE),
         )
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new temperature."""
 
@@ -436,6 +445,7 @@ class AtlanticPassAPCZoneControlZone(AtlanticPassAPCHeatingZone):
         )
 
     @property
+    @override
     def min_temp(self) -> float:
         """Return Minimum Temperature for AC of this group."""
 
@@ -460,6 +470,7 @@ class AtlanticPassAPCZoneControlZone(AtlanticPassAPCHeatingZone):
         return super().min_temp
 
     @property
+    @override
     def max_temp(self) -> float:
         """Return Max Temperature for AC of this group."""
 

--- a/homeassistant/components/overkiz/climate/evo_home_controller.py
+++ b/homeassistant/components/overkiz/climate/evo_home_controller.py
@@ -1,6 +1,7 @@
 """Support for EvoHomeController."""
 
 from datetime import timedelta
+from typing import override
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
@@ -51,6 +52,7 @@ class EvoHomeController(OverkizEntity, ClimateEntity):
             self._attr_device_info["manufacturer"] = "EvoHome"
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode:
         """Return hvac operation ie. heat, cool mode."""
         if state := self.device.states.get(OverkizState.RAMSES_RAMSES_OPERATING_MODE):
@@ -64,6 +66,7 @@ class EvoHomeController(OverkizEntity, ClimateEntity):
 
         return HVACMode.OFF
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         await self.executor.async_execute_command(
@@ -71,6 +74,7 @@ class EvoHomeController(OverkizEntity, ClimateEntity):
         )
 
     @property
+    @override
     def preset_mode(self) -> str | None:
         """Return the current preset mode, e.g., home, away, temp."""
         if (
@@ -80,6 +84,7 @@ class EvoHomeController(OverkizEntity, ClimateEntity):
 
         return PRESET_NONE
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
         if preset_mode == PRESET_DAY_OFF:

--- a/homeassistant/components/overkiz/climate/hitachi_air_to_air_heat_pump_hlrrwifi.py
+++ b/homeassistant/components/overkiz/climate/hitachi_air_to_air_heat_pump_hlrrwifi.py
@@ -1,6 +1,6 @@
 """Support for HitachiAirToAirHeatPump."""
 
-from typing import Any, cast
+from typing import Any, cast, override
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
@@ -111,6 +111,7 @@ class HitachiAirToAirHeatPumpHLRRWIFI(OverkizEntity, ClimateEntity):
             self._attr_device_info["manufacturer"] = "Hitachi"
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode:
         """Return hvac operation ie. heat, cool mode."""
         if (
@@ -127,6 +128,7 @@ class HitachiAirToAirHeatPumpHLRRWIFI(OverkizEntity, ClimateEntity):
 
         return HVACMode.OFF
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         if hvac_mode == HVACMode.OFF:
@@ -138,6 +140,7 @@ class HitachiAirToAirHeatPumpHLRRWIFI(OverkizEntity, ClimateEntity):
             )
 
     @property
+    @override
     def fan_mode(self) -> str | None:
         """Return the fan setting."""
         if (state := self.device.states.get(FAN_SPEED_STATE)) and state.value_as_str:
@@ -146,15 +149,18 @@ class HitachiAirToAirHeatPumpHLRRWIFI(OverkizEntity, ClimateEntity):
         return None
 
     @property
+    @override
     def fan_modes(self) -> list[str] | None:
         """Return the list of available fan modes."""
         return [*FAN_MODES_TO_OVERKIZ]
 
+    @override
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""
         await self._global_control(fan_mode=FAN_MODES_TO_OVERKIZ[fan_mode])
 
     @property
+    @override
     def swing_mode(self) -> str | None:
         """Return the swing setting."""
         if (state := self.device.states.get(SWING_STATE)) and state.value_as_str:
@@ -162,11 +168,13 @@ class HitachiAirToAirHeatPumpHLRRWIFI(OverkizEntity, ClimateEntity):
 
         return None
 
+    @override
     async def async_set_swing_mode(self, swing_mode: str) -> None:
         """Set new target swing operation."""
         await self._global_control(swing_mode=SWING_MODES_TO_OVERKIZ[swing_mode])
 
     @property
+    @override
     def target_temperature(self) -> int | None:
         """Return the temperature."""
         if (
@@ -177,6 +185,7 @@ class HitachiAirToAirHeatPumpHLRRWIFI(OverkizEntity, ClimateEntity):
         return None
 
     @property
+    @override
     def current_temperature(self) -> int | None:
         """Return current temperature."""
         if (
@@ -186,12 +195,14 @@ class HitachiAirToAirHeatPumpHLRRWIFI(OverkizEntity, ClimateEntity):
 
         return None
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new temperature."""
         temperature = cast(float, kwargs.get(ATTR_TEMPERATURE))
         await self._global_control(target_temperature=int(temperature))
 
     @property
+    @override
     def preset_mode(self) -> str | None:
         """Return the current preset mode, e.g., home, away, temp."""
         if (state := self.device.states.get(LEAVE_HOME_STATE)) and state.value_as_str:
@@ -203,6 +214,7 @@ class HitachiAirToAirHeatPumpHLRRWIFI(OverkizEntity, ClimateEntity):
 
         return None
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
         if preset_mode == PRESET_HOLIDAY_MODE:

--- a/homeassistant/components/overkiz/climate/hitachi_air_to_air_heat_pump_ovp.py
+++ b/homeassistant/components/overkiz/climate/hitachi_air_to_air_heat_pump_ovp.py
@@ -1,6 +1,6 @@
 """Support for HitachiAirToAirHeatPump."""
 
-from typing import Any
+from typing import Any, override
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
@@ -115,6 +115,7 @@ class HitachiAirToAirHeatPumpOVP(OverkizEntity, ClimateEntity):
             self._attr_device_info["manufacturer"] = "Hitachi"
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode:
         """Return hvac operation ie. heat, cool mode."""
         if (
@@ -133,6 +134,7 @@ class HitachiAirToAirHeatPumpOVP(OverkizEntity, ClimateEntity):
 
         return HVACMode.OFF
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         if hvac_mode == HVACMode.OFF:
@@ -144,6 +146,7 @@ class HitachiAirToAirHeatPumpOVP(OverkizEntity, ClimateEntity):
             )
 
     @property
+    @override
     def fan_mode(self) -> str | None:
         """Return the fan setting."""
         if (
@@ -153,11 +156,13 @@ class HitachiAirToAirHeatPumpOVP(OverkizEntity, ClimateEntity):
 
         return None
 
+    @override
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""
         await self._global_control(fan_mode=FAN_MODES_TO_OVERKIZ[fan_mode])
 
     @property
+    @override
     def swing_mode(self) -> str | None:
         """Return the swing setting."""
         if (
@@ -167,11 +172,13 @@ class HitachiAirToAirHeatPumpOVP(OverkizEntity, ClimateEntity):
 
         return None
 
+    @override
     async def async_set_swing_mode(self, swing_mode: str) -> None:
         """Set new target swing operation."""
         await self._global_control(swing_mode=SWING_MODES_TO_OVERKIZ[swing_mode])
 
     @property
+    @override
     def target_temperature(self) -> int | None:
         """Return the target temperature."""
         if (
@@ -182,6 +189,7 @@ class HitachiAirToAirHeatPumpOVP(OverkizEntity, ClimateEntity):
         return None
 
     @property
+    @override
     def current_temperature(self) -> int | None:
         """Return current temperature."""
         if (
@@ -191,11 +199,13 @@ class HitachiAirToAirHeatPumpOVP(OverkizEntity, ClimateEntity):
 
         return None
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new temperature."""
         await self._global_control(target_temperature=int(kwargs[ATTR_TEMPERATURE]))
 
     @property
+    @override
     def preset_mode(self) -> str | None:
         """Return the current preset mode, e.g., home, away, temp."""
         if (
@@ -209,6 +219,7 @@ class HitachiAirToAirHeatPumpOVP(OverkizEntity, ClimateEntity):
 
         return None
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
         if preset_mode == PRESET_HOLIDAY_MODE:
@@ -244,6 +255,7 @@ class HitachiAirToAirHeatPumpOVP(OverkizEntity, ClimateEntity):
         return None
 
     @property
+    @override
     def min_temp(self) -> float:
         """Return the minimum temperature."""
         if self.hvac_mode == HVACMode.AUTO:
@@ -251,6 +263,7 @@ class HitachiAirToAirHeatPumpOVP(OverkizEntity, ClimateEntity):
         return TEMP_MIN
 
     @property
+    @override
     def max_temp(self) -> float:
         """Return the maximum temperature."""
         if self.hvac_mode == HVACMode.AUTO:

--- a/homeassistant/components/overkiz/climate/hitachi_air_to_water_heating_zone.py
+++ b/homeassistant/components/overkiz/climate/hitachi_air_to_water_heating_zone.py
@@ -1,6 +1,6 @@
 """Support for HitachiAirToWaterHeatingZone."""
 
-from typing import Any, cast
+from typing import Any, cast, override
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
@@ -57,6 +57,7 @@ class HitachiAirToWaterHeatingZone(OverkizEntity, ClimateEntity):
             self._attr_device_info["manufacturer"] = "Hitachi"
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode:
         """Return hvac operation ie. heat, cool mode."""
         if (
@@ -66,6 +67,7 @@ class HitachiAirToWaterHeatingZone(OverkizEntity, ClimateEntity):
 
         return HVACMode.OFF
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         await self.executor.async_execute_command(
@@ -73,6 +75,7 @@ class HitachiAirToWaterHeatingZone(OverkizEntity, ClimateEntity):
         )
 
     @property
+    @override
     def preset_mode(self) -> str | None:
         """Return the current preset mode, e.g., home, away, temp."""
         if (
@@ -82,6 +85,7 @@ class HitachiAirToWaterHeatingZone(OverkizEntity, ClimateEntity):
 
         return PRESET_NONE
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
         await self.executor.async_execute_command(
@@ -89,6 +93,7 @@ class HitachiAirToWaterHeatingZone(OverkizEntity, ClimateEntity):
         )
 
     @property
+    @override
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
         current_temperature = self.device.states.get(
@@ -101,6 +106,7 @@ class HitachiAirToWaterHeatingZone(OverkizEntity, ClimateEntity):
         return None
 
     @property
+    @override
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
         target_temperature = self.device.states.get(
@@ -112,6 +118,7 @@ class HitachiAirToWaterHeatingZone(OverkizEntity, ClimateEntity):
 
         return None
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         temperature = cast(float, kwargs.get(ATTR_TEMPERATURE))

--- a/homeassistant/components/overkiz/climate/somfy_heating_temperature_interface.py
+++ b/homeassistant/components/overkiz/climate/somfy_heating_temperature_interface.py
@@ -1,6 +1,6 @@
 """Support for Somfy Heating Temperature Interface."""
 
-from typing import Any
+from typing import Any, override
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
@@ -97,6 +97,7 @@ class SomfyHeatingTemperatureInterface(OverkizEntity, ClimateEntity):
         )
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode:
         """Return hvac operation i.e. heat, cool mode."""
         state = self.device.states.get(OverkizState.CORE_ON_OFF)
@@ -112,6 +113,7 @@ class SomfyHeatingTemperatureInterface(OverkizEntity, ClimateEntity):
 
         return HVACMode.OFF
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         if hvac_mode is HVACMode.OFF:
@@ -124,6 +126,7 @@ class SomfyHeatingTemperatureInterface(OverkizEntity, ClimateEntity):
             )
 
     @property
+    @override
     def preset_mode(self) -> str | None:
         """Return the current preset mode, e.g., home, away, temp."""
         if (
@@ -134,6 +137,7 @@ class SomfyHeatingTemperatureInterface(OverkizEntity, ClimateEntity):
             return OVERKIZ_TO_PRESET_MODES[state.value_as_str]
         return None
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
         await self.executor.async_execute_command(
@@ -142,6 +146,7 @@ class SomfyHeatingTemperatureInterface(OverkizEntity, ClimateEntity):
         )
 
     @property
+    @override
     def hvac_action(self) -> HVACAction | None:
         """Return the current running hvac operation if supported."""
         if (
@@ -154,6 +159,7 @@ class SomfyHeatingTemperatureInterface(OverkizEntity, ClimateEntity):
         return None
 
     @property
+    @override
     def target_temperature(self) -> float | None:
         """Return the target temperature."""
 
@@ -172,6 +178,7 @@ class SomfyHeatingTemperatureInterface(OverkizEntity, ClimateEntity):
         return None
 
     @property
+    @override
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
         if self.temperature_device is not None and (
@@ -182,6 +189,7 @@ class SomfyHeatingTemperatureInterface(OverkizEntity, ClimateEntity):
             return temperature.value_as_float
         return None
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new temperature."""
         temperature = kwargs[ATTR_TEMPERATURE]

--- a/homeassistant/components/overkiz/climate/somfy_thermostat.py
+++ b/homeassistant/components/overkiz/climate/somfy_thermostat.py
@@ -1,6 +1,6 @@
 """Support for Somfy Smart Thermostat."""
 
-from typing import Any, cast
+from typing import Any, cast, override
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
@@ -75,6 +75,7 @@ class SomfyThermostat(OverkizEntity, ClimateEntity):
         )
 
     @property
+    @override
     def hvac_mode(self) -> HVACMode:
         """Return hvac operation ie. heat, cool mode."""
         if derogation_activation := self.device.states.get_value(
@@ -85,6 +86,7 @@ class SomfyThermostat(OverkizEntity, ClimateEntity):
         return HVACMode.AUTO
 
     @property
+    @override
     def preset_mode(self) -> str:
         """Return the current preset mode, e.g., home, away, temp."""
         if self.hvac_mode == HVACMode.AUTO:
@@ -98,6 +100,7 @@ class SomfyThermostat(OverkizEntity, ClimateEntity):
         return PRESET_NONE
 
     @property
+    @override
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
         if self.temperature_device is not None and (
@@ -109,6 +112,7 @@ class SomfyThermostat(OverkizEntity, ClimateEntity):
         return None
 
     @property
+    @override
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
         if self.hvac_mode == HVACMode.AUTO:
@@ -125,6 +129,7 @@ class SomfyThermostat(OverkizEntity, ClimateEntity):
             ),
         )
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         temperature = kwargs[ATTR_TEMPERATURE]
@@ -141,6 +146,7 @@ class SomfyThermostat(OverkizEntity, ClimateEntity):
         )
         await self.executor.async_execute_command(OverkizCommand.REFRESH_STATE)
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         if hvac_mode == HVACMode.AUTO:
@@ -149,6 +155,7 @@ class SomfyThermostat(OverkizEntity, ClimateEntity):
         else:
             await self.async_set_preset_mode(PRESET_NONE)
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
         if preset_mode in [PRESET_FREEZE, PRESET_NIGHT, PRESET_AWAY, PRESET_HOME]:

--- a/homeassistant/components/overkiz/climate/valve_heating_temperature_interface.py
+++ b/homeassistant/components/overkiz/climate/valve_heating_temperature_interface.py
@@ -1,6 +1,6 @@
 """Support for ValveHeatingTemperatureInterface."""
 
-from typing import Any, cast
+from typing import Any, cast, override
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
@@ -72,6 +72,7 @@ class ValveHeatingTemperatureInterface(OverkizEntity, ClimateEntity):
         )
 
     @property
+    @override
     def hvac_action(self) -> HVACAction | None:
         """Return the current running hvac operation."""
         if (
@@ -81,6 +82,7 @@ class ValveHeatingTemperatureInterface(OverkizEntity, ClimateEntity):
         return OVERKIZ_TO_HVAC_ACTION[cast(str, state)]
 
     @property
+    @override
     def target_temperature(self) -> float:
         """Return the temperature."""
         return cast(
@@ -88,6 +90,7 @@ class ValveHeatingTemperatureInterface(OverkizEntity, ClimateEntity):
         )
 
     @property
+    @override
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
         if self.temperature_device is not None and (
@@ -99,6 +102,7 @@ class ValveHeatingTemperatureInterface(OverkizEntity, ClimateEntity):
 
         return None
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new temperature."""
         temperature = kwargs[ATTR_TEMPERATURE]
@@ -109,11 +113,13 @@ class ValveHeatingTemperatureInterface(OverkizEntity, ClimateEntity):
             OverkizCommandParam.FURTHER_NOTICE,
         )
 
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         return
 
     @property
+    @override
     def preset_mode(self) -> str:
         """Return the current preset mode, e.g., home, away, temp."""
         return OVERKIZ_TO_PRESET_MODE[
@@ -123,6 +129,7 @@ class ValveHeatingTemperatureInterface(OverkizEntity, ClimateEntity):
             )
         ]
 
+    @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
 

--- a/homeassistant/components/overkiz/config_flow.py
+++ b/homeassistant/components/overkiz/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any, cast
+from typing import Any, cast, override
 
 from aiohttp import ClientConnectorCertificateError, ClientError
 from pyoverkiz.auth.credentials import (
@@ -76,6 +76,7 @@ class OverkizConfigFlow(
     _rexel_oauth_data: dict[str, Any]
 
     @property
+    @override
     def logger(self) -> logging.Logger:
         """Return logger."""
         return LOGGER
@@ -116,6 +117,7 @@ class OverkizConfigFlow(
 
         return user_input
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -334,6 +336,7 @@ class OverkizConfigFlow(
             errors=errors,
         )
 
+    @override
     async def async_oauth_create_entry(self, data: dict[str, Any]) -> ConfigFlowResult:
         """Resolve the gateway after a successful Rexel OAuth2 authorization."""
         self._rexel_oauth_data = data
@@ -411,6 +414,7 @@ class OverkizConfigFlow(
 
         return self.async_create_entry(title=gateway.label or "Rexel", data=data)
 
+    @override
     async def async_step_dhcp(
         self, discovery_info: DhcpServiceInfo
     ) -> ConfigFlowResult:
@@ -422,6 +426,7 @@ class OverkizConfigFlow(
         LOGGER.debug("DHCP discovery detected gateway %s", obfuscate_id(gateway_id))
         return await self._process_discovery(gateway_id)
 
+    @override
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:

--- a/homeassistant/components/overkiz/coordinator.py
+++ b/homeassistant/components/overkiz/coordinator.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable, Coroutine
 from datetime import timedelta
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from aiohttp import ClientConnectorError, ServerDisconnectedError
 from pyoverkiz.client import OverkizClient
@@ -87,6 +87,7 @@ class OverkizDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
             and device.ui_class not in IGNORED_OVERKIZ_DEVICES
         )
 
+    @override
     async def _async_update_data(self) -> dict[str, Device]:
         """Fetch Overkiz data via event listener."""
         try:

--- a/homeassistant/components/overkiz/cover.py
+++ b/homeassistant/components/overkiz/cover.py
@@ -1,7 +1,7 @@
 """Support for Overkiz covers - shutters etc."""
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from pyoverkiz.enums import (
     OverkizCommand,
@@ -619,6 +619,7 @@ class OverkizCover(OverkizDescriptiveEntity, CoverEntity):
         self._attr_supported_features = supported_features
 
     @property
+    @override
     def is_closed(self) -> bool | None:
         """Return if the cover is closed."""
         if is_closed_state := self.entity_description.is_closed_state:
@@ -636,6 +637,7 @@ class OverkizCover(OverkizDescriptiveEntity, CoverEntity):
         return None
 
     @property
+    @override
     def current_cover_position(self) -> int | None:
         """Return current position of cover.
 
@@ -689,6 +691,7 @@ class OverkizCover(OverkizDescriptiveEntity, CoverEntity):
 
         return position
 
+    @override
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
         position = kwargs[ATTR_POSITION]
@@ -698,22 +701,26 @@ class OverkizCover(OverkizDescriptiveEntity, CoverEntity):
         if command := self.entity_description.set_position_command:
             await self.executor.async_execute_command(command, position)
 
+    @override
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
         if command := self.entity_description.open_command:
             await self.executor.async_execute_command(command)
 
+    @override
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
         if command := self.entity_description.close_command:
             await self.executor.async_execute_command(command)
 
+    @override
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
         if command := self.entity_description.stop_command:
             await self.executor.async_execute_command(command)
 
     @property
+    @override
     def current_cover_tilt_position(self) -> int | None:
         """Return current position of cover tilt.
 
@@ -733,6 +740,7 @@ class OverkizCover(OverkizDescriptiveEntity, CoverEntity):
 
         return None
 
+    @override
     async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
         """Move the cover tilt to a specific position."""
         position = kwargs[ATTR_TILT_POSITION]
@@ -774,6 +782,7 @@ class OverkizCover(OverkizDescriptiveEntity, CoverEntity):
             tilt_position,
         )
 
+    @override
     async def async_open_cover_tilt(self, **kwargs: Any) -> None:
         """Open the cover tilt."""
         if command := self.entity_description.open_tilt_command:
@@ -781,6 +790,7 @@ class OverkizCover(OverkizDescriptiveEntity, CoverEntity):
                 command, *self.entity_description.open_tilt_command_args
             )
 
+    @override
     async def async_close_cover_tilt(self, **kwargs: Any) -> None:
         """Close the cover tilt."""
         if command := self.entity_description.close_tilt_command:
@@ -788,12 +798,14 @@ class OverkizCover(OverkizDescriptiveEntity, CoverEntity):
                 command, *self.entity_description.close_tilt_command_args
             )
 
+    @override
     async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
         """Stop the cover tilt."""
         if command := self.entity_description.stop_tilt_command:
             await self.executor.async_execute_command(command)
 
     @property
+    @override
     def is_opening(self) -> bool | None:
         """Return if the cover is opening or not."""
         # Check if any open() commands are currently running for this device
@@ -817,6 +829,7 @@ class OverkizCover(OverkizDescriptiveEntity, CoverEntity):
         return self.moving_offset < 0
 
     @property
+    @override
     def is_closing(self) -> bool | None:
         """Return if the cover is closing or not."""
         # Check if any close() commands are currently running for this device
@@ -889,14 +902,17 @@ class OverkizLowSpeedCover(OverkizCover):
         self._attr_name = "Low speed"
         self._attr_unique_id = f"{self._attr_unique_id}_low_speed"
 
+    @override
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
         await self._async_set_cover_position_low_speed(kwargs[ATTR_POSITION])
 
+    @override
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
         await self._async_set_cover_position_low_speed(100)
 
+    @override
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
         await self._async_set_cover_position_low_speed(0)

--- a/homeassistant/components/overkiz/entity.py
+++ b/homeassistant/components/overkiz/entity.py
@@ -1,6 +1,6 @@
 """Parent class for every Overkiz device."""
 
-from typing import cast
+from typing import cast, override
 
 from pyoverkiz.enums import APIType, OverkizAttribute, OverkizCommandParam, OverkizState
 from pyoverkiz.models import Device
@@ -38,6 +38,7 @@ class OverkizEntity(CoordinatorEntity[OverkizDataUpdateCoordinator]):
         self._attr_device_info = self.generate_device_info()
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available."""
         if self.device.available:

--- a/homeassistant/components/overkiz/fan.py
+++ b/homeassistant/components/overkiz/fan.py
@@ -1,7 +1,7 @@
 """Support for Overkiz fans."""
 
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any, cast, override
 
 from pyoverkiz.enums import OverkizCommand, OverkizState
 from pyoverkiz.enums.ui import UIWidget
@@ -82,6 +82,7 @@ class OverkizFan(OverkizDescriptiveEntity, FanEntity):
     )
 
     @property
+    @override
     def percentage(self) -> int | None:
         """Return the current air flow level as a percentage."""
         air_flow = self.device.states.get_value(self.entity_description.percentage)
@@ -92,6 +93,7 @@ class OverkizFan(OverkizDescriptiveEntity, FanEntity):
         return cast(int, air_flow)
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return whether the fan is running."""
         if (percentage := self.percentage) is None:
@@ -99,6 +101,7 @@ class OverkizFan(OverkizDescriptiveEntity, FanEntity):
 
         return percentage > 0
 
+    @override
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the air flow level."""
         if percentage == 0:
@@ -109,6 +112,7 @@ class OverkizFan(OverkizDescriptiveEntity, FanEntity):
             self.entity_description.set_percentage, percentage
         )
 
+    @override
     async def async_turn_on(
         self,
         percentage: int | None = None,
@@ -122,6 +126,7 @@ class OverkizFan(OverkizDescriptiveEntity, FanEntity):
 
         await self.executor.async_execute_command(OverkizCommand.ON)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the fan off."""
         await self.executor.async_execute_command(OverkizCommand.OFF)

--- a/homeassistant/components/overkiz/light.py
+++ b/homeassistant/components/overkiz/light.py
@@ -1,6 +1,6 @@
 """Support for Overkiz lights."""
 
-from typing import Any, cast
+from typing import Any, cast, override
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
@@ -53,6 +53,7 @@ class OverkizLight(OverkizEntity, LightEntity):
         self._attr_supported_color_modes = {self._attr_color_mode}
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if light is on."""
         return (
@@ -61,6 +62,7 @@ class OverkizLight(OverkizEntity, LightEntity):
         )
 
     @property
+    @override
     def rgb_color(self) -> tuple[int, int, int] | None:
         """Return the rgb color value [int, int, int] (0-255)."""
         red = self.device.states.get_value(OverkizState.CORE_RED_COLOR_INTENSITY)
@@ -73,6 +75,7 @@ class OverkizLight(OverkizEntity, LightEntity):
         return (cast(int, red), cast(int, green), cast(int, blue))
 
     @property
+    @override
     def brightness(self) -> int | None:
         """Return the brightness of this light (0-255)."""
         value = self.device.states.get_value(OverkizState.CORE_LIGHT_INTENSITY)
@@ -81,6 +84,7 @@ class OverkizLight(OverkizEntity, LightEntity):
 
         return None
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""
         rgb_color = kwargs.get(ATTR_RGB_COLOR)
@@ -101,6 +105,7 @@ class OverkizLight(OverkizEntity, LightEntity):
 
         await self.executor.async_execute_command(OverkizCommand.ON)
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
         await self.executor.async_execute_command(OverkizCommand.OFF)

--- a/homeassistant/components/overkiz/lock.py
+++ b/homeassistant/components/overkiz/lock.py
@@ -1,6 +1,6 @@
 """Support for Overkiz locks."""
 
-from typing import Any
+from typing import Any, override
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
@@ -30,15 +30,18 @@ async def async_setup_entry(
 class OverkizLock(OverkizEntity, LockEntity):
     """Representation of an Overkiz Lock."""
 
+    @override
     async def async_lock(self, **kwargs: Any) -> None:
         """Lock method."""
         await self.executor.async_execute_command(OverkizCommand.LOCK)
 
+    @override
     async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock method."""
         await self.executor.async_execute_command(OverkizCommand.UNLOCK)
 
     @property
+    @override
     def is_locked(self) -> bool | None:
         """Return a boolean for the state of the lock."""
         return (

--- a/homeassistant/components/overkiz/number.py
+++ b/homeassistant/components/overkiz/number.py
@@ -3,7 +3,7 @@
 import asyncio
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import cast
+from typing import cast, override
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
@@ -248,6 +248,7 @@ class OverkizNumber(OverkizDescriptiveEntity, NumberEntity):
             self._attr_native_max_value = cast(float, state.value)
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the entity value to represent the entity state."""
         if state := self.device.states.get(self.entity_description.key):
@@ -258,6 +259,7 @@ class OverkizNumber(OverkizDescriptiveEntity, NumberEntity):
 
         return None
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Set new value."""
         if self.entity_description.inverted:

--- a/homeassistant/components/overkiz/scene.py
+++ b/homeassistant/components/overkiz/scene.py
@@ -1,6 +1,6 @@
 """Support for Overkiz scenes."""
 
-from typing import Any
+from typing import Any, override
 
 from pyoverkiz.client import OverkizClient
 from pyoverkiz.models import PersistedActionGroup
@@ -35,6 +35,7 @@ class OverkizScene(Scene):
         self._attr_name = self.scenario.label
         self._attr_unique_id = self.scenario.oid
 
+    @override
     async def async_activate(self, **kwargs: Any) -> None:
         """Activate the scene."""
         await self.client.execute_persisted_action_group(self.scenario.oid)

--- a/homeassistant/components/overkiz/select.py
+++ b/homeassistant/components/overkiz/select.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from typing import override
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
@@ -156,6 +157,7 @@ class OverkizSelect(OverkizDescriptiveEntity, SelectEntity):
     entity_description: OverkizSelectDescription
 
     @property
+    @override
     def current_option(self) -> str | None:
         """Return the selected entity option to represent the entity state."""
         if state := self.device.states.get(self.entity_description.key):
@@ -163,6 +165,7 @@ class OverkizSelect(OverkizDescriptiveEntity, SelectEntity):
 
         return None
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         await self.entity_description.select_option(

--- a/homeassistant/components/overkiz/sensor.py
+++ b/homeassistant/components/overkiz/sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import cast
+from typing import cast, override
 
 from pyoverkiz.enums import OverkizAttribute, OverkizState, UIWidget
 from pyoverkiz.types import StateType as OverkizStateType
@@ -582,6 +582,7 @@ class OverkizStateSensor(OverkizDescriptiveEntity, SensorEntity):
     entity_description: OverkizSensorDescription
 
     @property
+    @override
     def native_value(self) -> StateType:
         """Return the value of the sensor."""
         state = self.device.states.get(self.entity_description.key)
@@ -607,6 +608,7 @@ class OverkizStateSensor(OverkizDescriptiveEntity, SensorEntity):
         return state.value
 
     @property
+    @override
     def native_unit_of_measurement(self) -> str | None:
         """Return the unit of measurement."""
         if (
@@ -659,6 +661,7 @@ class OverkizHomeKitSetupCodeSensor(OverkizEntity, SensorEntity):
         self._attr_name = "HomeKit setup code"
 
     @property
+    @override
     def native_value(self) -> str | None:
         """Return the value of the sensor."""
         if state := self.device.attributes.get(OverkizAttribute.HOMEKIT_SETUP_CODE):
@@ -666,6 +669,7 @@ class OverkizHomeKitSetupCodeSensor(OverkizEntity, SensorEntity):
         return None
 
     @property
+    @override
     def device_info(self) -> DeviceInfo:
         """Return device registry information for this entity."""
         # By default this sensor will be listed at a virtual HomekitStack device,

--- a/homeassistant/components/overkiz/siren.py
+++ b/homeassistant/components/overkiz/siren.py
@@ -1,6 +1,6 @@
 """Support for Overkiz sirens."""
 
-from typing import Any
+from typing import Any, override
 
 from pyoverkiz.enums import OverkizState
 from pyoverkiz.enums.command import OverkizCommand, OverkizCommandParam
@@ -42,6 +42,7 @@ class OverkizSiren(OverkizEntity, SirenEntity):
     )
 
     @property
+    @override
     def is_on(self) -> bool:
         """Get whether the siren is in on state."""
         return (
@@ -49,6 +50,7 @@ class OverkizSiren(OverkizEntity, SirenEntity):
             == OverkizCommandParam.ON
         )
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Send the on command."""
         if kwargs.get(ATTR_DURATION):
@@ -67,6 +69,7 @@ class OverkizSiren(OverkizEntity, SirenEntity):
             OverkizCommandParam.MEMORIZED_VOLUME,
         )
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Send the off command."""
         await self.executor.async_execute_command(OverkizCommand.OFF)

--- a/homeassistant/components/overkiz/switch.py
+++ b/homeassistant/components/overkiz/switch.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 from pyoverkiz.enums.ui import UIClass, UIWidget
@@ -142,6 +142,7 @@ class OverkizSwitch(OverkizDescriptiveEntity, SwitchEntity):
     entity_description: OverkizSwitchDescription
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return True if entity is on."""
         if self.entity_description.is_on:
@@ -149,6 +150,7 @@ class OverkizSwitch(OverkizDescriptiveEntity, SwitchEntity):
 
         return None
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         await self.executor.async_execute_command(
@@ -156,6 +158,7 @@ class OverkizSwitch(OverkizDescriptiveEntity, SwitchEntity):
             self.entity_description.turn_on_args,
         )
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         await self.executor.async_execute_command(

--- a/homeassistant/components/overkiz/water_heater/atlantic_domestic_hot_water_production_mlb_component.py
+++ b/homeassistant/components/overkiz/water_heater/atlantic_domestic_hot_water_production_mlb_component.py
@@ -1,6 +1,6 @@
 """Support for AtlanticDomesticHotWaterProductionMBLComponent."""
 
-from typing import Any, cast
+from typing import Any, cast, override
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
@@ -55,6 +55,7 @@ class AtlanticDomesticHotWaterProductionMBLComponent(OverkizEntity, WaterHeaterE
         )
 
     @property
+    @override
     def current_temperature(self) -> float:
         """Return the current temperature."""
         return cast(
@@ -65,6 +66,7 @@ class AtlanticDomesticHotWaterProductionMBLComponent(OverkizEntity, WaterHeaterE
         )
 
     @property
+    @override
     def target_temperature(self) -> float:
         """Return the temperature corresponding to the PRESET."""
         return cast(
@@ -72,6 +74,7 @@ class AtlanticDomesticHotWaterProductionMBLComponent(OverkizEntity, WaterHeaterE
             self.device.states.get_value(OverkizState.CORE_WATER_TARGET_TEMPERATURE),
         )
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new temperature."""
         temperature = kwargs[ATTR_TEMPERATURE]
@@ -96,6 +99,7 @@ class AtlanticDomesticHotWaterProductionMBLComponent(OverkizEntity, WaterHeaterE
         )
 
     @property
+    @override
     def is_away_mode_on(self) -> bool:
         """Return true if away mode is on."""
         return self.device.states.get_value(
@@ -106,6 +110,7 @@ class AtlanticDomesticHotWaterProductionMBLComponent(OverkizEntity, WaterHeaterE
         )
 
     @property
+    @override
     def current_operation(self) -> str:
         """Return current operation."""
         if self.is_away_mode_on:
@@ -128,6 +133,7 @@ class AtlanticDomesticHotWaterProductionMBLComponent(OverkizEntity, WaterHeaterE
 
         return STATE_OFF
 
+    @override
     async def async_set_operation_mode(self, operation_mode: str) -> None:
         """Set new operation mode."""
         if operation_mode == STATE_PERFORMANCE:
@@ -153,6 +159,7 @@ class AtlanticDomesticHotWaterProductionMBLComponent(OverkizEntity, WaterHeaterE
         elif operation_mode == STATE_OFF:
             await self.async_turn_away_mode_on()
 
+    @override
     async def async_turn_away_mode_on(self) -> None:
         """Turn away mode on.
 
@@ -213,6 +220,7 @@ class AtlanticDomesticHotWaterProductionMBLComponent(OverkizEntity, WaterHeaterE
         )
         await self.coordinator.async_refresh()
 
+    @override
     async def async_turn_away_mode_off(self) -> None:
         """Turn away mode off."""
         await self.executor.async_execute_command(

--- a/homeassistant/components/overkiz/water_heater/atlantic_domestic_hot_water_production_v2_ce_flat_c2_io_component.py
+++ b/homeassistant/components/overkiz/water_heater/atlantic_domestic_hot_water_production_v2_ce_flat_c2_io_component.py
@@ -11,7 +11,7 @@ It supports:
 """
 
 from datetime import datetime, timedelta
-from typing import Any, cast
+from typing import Any, cast, override
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 from pyoverkiz.models import Command
@@ -85,6 +85,7 @@ class AtlanticDomesticHotWaterProductionV2CEFLATC2IOComponent(
     _attr_operation_list = [*OPERATION_MODE_TO_OVERKIZ, STATE_PERFORMANCE]
 
     @property
+    @override
     def min_temp(self) -> float:
         """Return the minimum temperature."""
         if min_temp := self.device.states.get(
@@ -94,6 +95,7 @@ class AtlanticDomesticHotWaterProductionV2CEFLATC2IOComponent(
         return DEFAULT_MIN_TEMP
 
     @property
+    @override
     def max_temp(self) -> float:
         """Return the maximum temperature."""
         if max_temp := self.device.states.get(
@@ -103,6 +105,7 @@ class AtlanticDomesticHotWaterProductionV2CEFLATC2IOComponent(
         return DEFAULT_MAX_TEMP
 
     @property
+    @override
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
         if current_temp := self.device.states.get(
@@ -112,6 +115,7 @@ class AtlanticDomesticHotWaterProductionV2CEFLATC2IOComponent(
         return None
 
     @property
+    @override
     def target_temperature(self) -> float | None:
         """Return the target temperature."""
         if target_temp := self.device.states.get(
@@ -120,6 +124,7 @@ class AtlanticDomesticHotWaterProductionV2CEFLATC2IOComponent(
             return target_temp.value_as_float
         return None
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new temperature."""
         temperature = kwargs[ATTR_TEMPERATURE]
@@ -143,6 +148,7 @@ class AtlanticDomesticHotWaterProductionV2CEFLATC2IOComponent(
         )
 
     @property
+    @override
     def is_away_mode_on(self) -> bool:
         """Return true if away mode is on.
 
@@ -155,6 +161,7 @@ class AtlanticDomesticHotWaterProductionV2CEFLATC2IOComponent(
         return absence_mode != OverkizCommandParam.OFF
 
     @property
+    @override
     def current_operation(self) -> str | None:
         """Return current operation."""
         if self.is_boost_mode_on:
@@ -165,6 +172,7 @@ class AtlanticDomesticHotWaterProductionV2CEFLATC2IOComponent(
 
         return None
 
+    @override
     async def async_set_operation_mode(self, operation_mode: str) -> None:
         """Set new operation mode."""
         if operation_mode == STATE_PERFORMANCE:
@@ -199,6 +207,7 @@ class AtlanticDomesticHotWaterProductionV2CEFLATC2IOComponent(
 
         await self.coordinator.async_refresh()
 
+    @override
     async def async_turn_away_mode_on(self, refresh_afterwards: bool = True) -> None:
         """Turn away mode on.
 
@@ -227,6 +236,7 @@ class AtlanticDomesticHotWaterProductionV2CEFLATC2IOComponent(
             refresh_afterwards=refresh_afterwards,
         )
 
+    @override
     async def async_turn_away_mode_off(self, refresh_afterwards: bool = True) -> None:
         """Turn away mode off."""
         await self.executor.async_execute_command(

--- a/homeassistant/components/overkiz/water_heater/atlantic_domestic_hot_water_production_v2_io_component.py
+++ b/homeassistant/components/overkiz/water_heater/atlantic_domestic_hot_water_production_v2_io_component.py
@@ -1,6 +1,6 @@
 """Support for AtlanticDomesticHotWaterProductionV2IOComponent."""
 
-from typing import Any, cast
+from typing import Any, cast, override
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
@@ -44,6 +44,7 @@ class AtlanticDomesticHotWaterProductionV2IOComponent(OverkizEntity, WaterHeater
     ]
 
     @property
+    @override
     def min_temp(self) -> float:
         """Return the minimum temperature."""
 
@@ -55,6 +56,7 @@ class AtlanticDomesticHotWaterProductionV2IOComponent(OverkizEntity, WaterHeater
         return DEFAULT_MIN_TEMP
 
     @property
+    @override
     def max_temp(self) -> float:
         """Return the maximum temperature."""
 
@@ -66,6 +68,7 @@ class AtlanticDomesticHotWaterProductionV2IOComponent(OverkizEntity, WaterHeater
         return DEFAULT_MAX_TEMP
 
     @property
+    @override
     def current_temperature(self) -> float:
         """Return the current temperature."""
 
@@ -77,6 +80,7 @@ class AtlanticDomesticHotWaterProductionV2IOComponent(OverkizEntity, WaterHeater
         )
 
     @property
+    @override
     def target_temperature(self) -> float:
         """Return the temperature corresponding to the PRESET."""
 
@@ -85,6 +89,7 @@ class AtlanticDomesticHotWaterProductionV2IOComponent(OverkizEntity, WaterHeater
             self.device.states.get_value(OverkizState.CORE_TARGET_TEMPERATURE),
         )
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new temperature."""
 
@@ -125,6 +130,7 @@ class AtlanticDomesticHotWaterProductionV2IOComponent(OverkizEntity, WaterHeater
         )
 
     @property
+    @override
     def is_away_mode_on(self) -> bool:
         """Return true if away mode is on."""
 
@@ -146,6 +152,7 @@ class AtlanticDomesticHotWaterProductionV2IOComponent(OverkizEntity, WaterHeater
         return False
 
     @property
+    @override
     def current_operation(self) -> str | None:
         """Return current operation."""
 
@@ -176,6 +183,7 @@ class AtlanticDomesticHotWaterProductionV2IOComponent(OverkizEntity, WaterHeater
 
         return cast(int, boost_mode_duration) > 0
 
+    @override
     async def async_set_operation_mode(self, operation_mode: str) -> None:
         """Set new operation mode."""
 
@@ -245,6 +253,7 @@ class AtlanticDomesticHotWaterProductionV2IOComponent(OverkizEntity, WaterHeater
                 await self.async_turn_boost_mode_on(refresh_afterwards=False)
             await self.coordinator.async_refresh()
 
+    @override
     async def async_turn_away_mode_on(self, refresh_afterwards: bool = True) -> None:
         """Turn away mode on."""
 
@@ -264,6 +273,7 @@ class AtlanticDomesticHotWaterProductionV2IOComponent(OverkizEntity, WaterHeater
         if refresh_afterwards:
             await self.coordinator.async_refresh()
 
+    @override
     async def async_turn_away_mode_off(self, refresh_afterwards: bool = True) -> None:
         """Turn away mode off."""
 

--- a/homeassistant/components/overkiz/water_heater/atlantic_pass_apc_dhw.py
+++ b/homeassistant/components/overkiz/water_heater/atlantic_pass_apc_dhw.py
@@ -1,6 +1,6 @@
 """Support for Atlantic Pass APC DHW."""
 
-from typing import Any, cast
+from typing import Any, cast, override
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
@@ -29,6 +29,7 @@ class AtlanticPassAPCDHW(OverkizEntity, WaterHeaterEntity):
     _attr_operation_list = [STATE_OFF, STATE_HEAT_PUMP, STATE_PERFORMANCE]
 
     @property
+    @override
     def target_temperature(self) -> float:
         """Return the temperature corresponding to the PRESET."""
         if self.is_boost_mode_on:
@@ -52,6 +53,7 @@ class AtlanticPassAPCDHW(OverkizEntity, WaterHeaterEntity):
             self.device.states.get_value(OverkizState.CORE_TARGET_DWH_TEMPERATURE),
         )
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new temperature."""
         temperature = kwargs[ATTR_TEMPERATURE]
@@ -91,6 +93,7 @@ class AtlanticPassAPCDHW(OverkizEntity, WaterHeaterEntity):
         )
 
     @property
+    @override
     def is_away_mode_on(self) -> bool:
         """Return true if away mode is on."""
         return (
@@ -99,6 +102,7 @@ class AtlanticPassAPCDHW(OverkizEntity, WaterHeaterEntity):
         )
 
     @property
+    @override
     def current_operation(self) -> str:
         """Return current operation."""
         if self.is_boost_mode_on:
@@ -109,6 +113,7 @@ class AtlanticPassAPCDHW(OverkizEntity, WaterHeaterEntity):
             return STATE_OFF
         return STATE_HEAT_PUMP
 
+    @override
     async def async_set_operation_mode(self, operation_mode: str) -> None:
         """Set new operation mode."""
         boost_state = OverkizCommandParam.OFF
@@ -126,6 +131,7 @@ class AtlanticPassAPCDHW(OverkizEntity, WaterHeaterEntity):
             OverkizCommand.SET_DHW_ON_OFF_STATE, regular_state
         )
 
+    @override
     async def async_turn_away_mode_on(self) -> None:
         """Turn away mode on."""
         await self.executor.async_execute_command(
@@ -135,6 +141,7 @@ class AtlanticPassAPCDHW(OverkizEntity, WaterHeaterEntity):
             OverkizCommand.SET_DHW_ON_OFF_STATE, OverkizCommandParam.OFF
         )
 
+    @override
     async def async_turn_away_mode_off(self) -> None:
         """Turn away mode off."""
         await self.executor.async_execute_command(

--- a/homeassistant/components/overkiz/water_heater/domestic_hot_water_production.py
+++ b/homeassistant/components/overkiz/water_heater/domestic_hot_water_production.py
@@ -1,6 +1,6 @@
 """Support for DomesticHotWaterProduction."""
 
-from typing import Any, cast
+from typing import Any, cast, override
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
@@ -112,6 +112,7 @@ class DomesticHotWaterProduction(OverkizEntity, WaterHeaterEntity):
         return False
 
     @property
+    @override
     def is_away_mode_on(self) -> bool | None:
         """Return true if away mode is on."""
 
@@ -154,6 +155,7 @@ class DomesticHotWaterProduction(OverkizEntity, WaterHeaterEntity):
         return None
 
     @property
+    @override
     def min_temp(self) -> float:
         """Return the minimum temperature."""
         min_temp = self.device.states.get(
@@ -164,6 +166,7 @@ class DomesticHotWaterProduction(OverkizEntity, WaterHeaterEntity):
         return DEFAULT_MIN_TEMP
 
     @property
+    @override
     def max_temp(self) -> float:
         """Return the maximum temperature."""
         max_temp = self.device.states.get(
@@ -174,6 +177,7 @@ class DomesticHotWaterProduction(OverkizEntity, WaterHeaterEntity):
         return DEFAULT_MAX_TEMP
 
     @property
+    @override
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
         current_temperature = self.device.states.get(
@@ -189,6 +193,7 @@ class DomesticHotWaterProduction(OverkizEntity, WaterHeaterEntity):
         return None
 
     @property
+    @override
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
 
@@ -213,6 +218,7 @@ class DomesticHotWaterProduction(OverkizEntity, WaterHeaterEntity):
         return None
 
     @property
+    @override
     def target_temperature_high(self) -> float | None:
         """Return the highbound target temperature we try to reach."""
         target_temperature_high = self.device.states.get(
@@ -223,6 +229,7 @@ class DomesticHotWaterProduction(OverkizEntity, WaterHeaterEntity):
         return None
 
     @property
+    @override
     def target_temperature_low(self) -> float | None:
         """Return the lowbound target temperature we try to reach."""
         target_temperature_low = self.device.states.get(
@@ -232,6 +239,7 @@ class DomesticHotWaterProduction(OverkizEntity, WaterHeaterEntity):
             return target_temperature_low.value_as_float
         return None
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         target_temperature = kwargs[ATTR_TEMPERATURE]
@@ -257,6 +265,7 @@ class DomesticHotWaterProduction(OverkizEntity, WaterHeaterEntity):
             )
 
     @property
+    @override
     def current_operation(self) -> str | None:
         """Return current operation ie. eco, electric, performance, ..."""
         if self._is_boost_mode_on:
@@ -273,6 +282,7 @@ class DomesticHotWaterProduction(OverkizEntity, WaterHeaterEntity):
 
         return None
 
+    @override
     async def async_set_operation_mode(self, operation_mode: str) -> None:
         """Set new target operation mode."""
 

--- a/homeassistant/components/overkiz/water_heater/hitachi_dhw.py
+++ b/homeassistant/components/overkiz/water_heater/hitachi_dhw.py
@@ -1,6 +1,6 @@
 """Support for Hitachi DHW."""
 
-from typing import Any
+from typing import Any, override
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
@@ -43,6 +43,7 @@ class HitachiDHW(OverkizEntity, WaterHeaterEntity):
     _attr_operation_list = [*OPERATION_MODE_TO_OVERKIZ]
 
     @property
+    @override
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
         current_temperature = self.device.states.get(OverkizState.CORE_DHW_TEMPERATURE)
@@ -53,6 +54,7 @@ class HitachiDHW(OverkizEntity, WaterHeaterEntity):
         return None
 
     @property
+    @override
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
         target_temperature = self.device.states.get(
@@ -64,6 +66,7 @@ class HitachiDHW(OverkizEntity, WaterHeaterEntity):
 
         return None
 
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         await self.executor.async_execute_command(
@@ -72,6 +75,7 @@ class HitachiDHW(OverkizEntity, WaterHeaterEntity):
         )
 
     @property
+    @override
     def current_operation(self) -> str | None:
         """Return current operation ie. eco, electric, performance, ..."""
         modbus_control = self.device.states.get(OverkizState.MODBUS_CONTROL_DHW)
@@ -84,6 +88,7 @@ class HitachiDHW(OverkizEntity, WaterHeaterEntity):
 
         return None
 
+    @override
     async def async_set_operation_mode(self, operation_mode: str) -> None:
         """Set new target operation mode."""
         # Turn water heater off

--- a/homeassistant/components/overseerr/config_flow.py
+++ b/homeassistant/components/overseerr/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Overseerr."""
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, override
 
 from python_overseerr import (
     OverseerrAuthenticationError,
@@ -48,6 +48,7 @@ class OverseerrConfigFlow(ConfigFlow, domain=DOMAIN):
             return "cannot_connect"
         return None
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/overseerr/coordinator.py
+++ b/homeassistant/components/overseerr/coordinator.py
@@ -1,6 +1,7 @@
 """Define an object to coordinate fetching Overseerr data."""
 
 from datetime import timedelta
+from typing import override
 
 from python_overseerr import (
     OverseerrAuthenticationError,
@@ -49,6 +50,7 @@ class OverseerrCoordinator(DataUpdateCoordinator[OverseerrData]):
         self.url = URL.build(host=host, port=port, scheme="https" if ssl else "http")
         self.push = False
 
+    @override
     async def _async_update_data(self) -> OverseerrData:
         """Fetch data from API endpoint."""
         try:

--- a/homeassistant/components/overseerr/event.py
+++ b/homeassistant/components/overseerr/event.py
@@ -1,7 +1,7 @@
 """Support for Overseerr events."""
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.event import EventEntity, EventEntityDescription
 from homeassistant.const import Platform
@@ -76,6 +76,7 @@ class OverseerrEvent(OverseerrEntity, EventEntity):
         self.entity_description = description
         self._attr_available = True
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Subscribe to updates."""
         await super().async_added_to_hass()
@@ -95,12 +96,14 @@ class OverseerrEvent(OverseerrEntity, EventEntity):
             self.async_write_ha_state()
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         if super().available != self._attr_available:
             self._attr_available = super().available
             super()._handle_coordinator_update()
 
     @property
+    @override
     def available(self) -> bool:
         """Return True if entity is available."""
         return self._attr_available and self.coordinator.push

--- a/homeassistant/components/overseerr/sensor.py
+++ b/homeassistant/components/overseerr/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import override
 
 from homeassistant.components.sensor import (
     SensorEntity,
@@ -131,6 +132,7 @@ class OverseerrSensor(OverseerrEntity, SensorEntity):
         self._attr_translation_key = description.key
 
     @property
+    @override
     def native_value(self) -> int:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/ovhcloud_ai_endpoints/config_flow.py
+++ b/homeassistant/components/ovhcloud_ai_endpoints/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, override
 
 from openai import AsyncOpenAI, AuthenticationError, OpenAIError, PermissionDeniedError
 import voluptuous as vol
@@ -42,12 +42,14 @@ class OVHcloudAIEndpointsConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @classmethod
     @callback
+    @override
     def async_get_supported_subentry_types(
         cls, config_entry: ConfigEntry
     ) -> dict[str, type[ConfigSubentryFlow]]:
         """Return subentries supported by this handler."""
         return {"conversation": ConversationFlowHandler}
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/ovhcloud_ai_endpoints/conversation.py
+++ b/homeassistant/components/ovhcloud_ai_endpoints/conversation.py
@@ -1,6 +1,6 @@
 """Conversation support for OVHcloud AI Endpoints."""
 
-from typing import Literal
+from typing import Literal, override
 
 from homeassistant.components import conversation
 from homeassistant.config_entries import ConfigSubentry
@@ -49,10 +49,12 @@ class OVHcloudAIEndpointsConversationEntity(
             )
 
     @property
+    @override
     def supported_languages(self) -> list[str] | Literal["*"]:
         """Return a list of supported languages."""
         return MATCH_ALL
 
+    @override
     async def _async_handle_message(
         self,
         user_input: conversation.ConversationInput,

--- a/homeassistant/components/ovo_energy/config_flow.py
+++ b/homeassistant/components/ovo_energy/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow to configure the OVO Energy integration."""
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, override
 
 import aiohttp
 from ovoenergy import OVOEnergy
@@ -33,6 +33,7 @@ class OVOEnergyFlowHandler(ConfigFlow, domain=DOMAIN):
         self.username = None
         self.account = None
 
+    @override
     async def async_step_user(
         self,
         user_input: Mapping[str, Any] | None = None,

--- a/homeassistant/components/ovo_energy/coordinator.py
+++ b/homeassistant/components/ovo_energy/coordinator.py
@@ -3,6 +3,7 @@
 import asyncio
 from datetime import timedelta
 import logging
+from typing import override
 
 import aiohttp
 from ovoenergy import OVOEnergy
@@ -43,6 +44,7 @@ class OVOEnergyDataUpdateCoordinator(DataUpdateCoordinator[OVODailyUsage]):
         )
         self.client = client
 
+    @override
     async def _async_update_data(self) -> OVODailyUsage:
         """Fetch data from OVO Energy."""
         if (custom_account := self.config_entry.data.get(CONF_ACCOUNT)) is not None:

--- a/homeassistant/components/ovo_energy/entity.py
+++ b/homeassistant/components/ovo_energy/entity.py
@@ -1,5 +1,7 @@
 """Support for OVO Energy."""
 
+from typing import override
+
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -17,6 +19,7 @@ class OVOEnergyDeviceEntity(OVOEnergyEntity):
     """Defines a OVO Energy device entity."""
 
     @property
+    @override
     def device_info(self) -> DeviceInfo:
         """Return device information about this OVO Energy instance."""
         return DeviceInfo(

--- a/homeassistant/components/ovo_energy/sensor.py
+++ b/homeassistant/components/ovo_energy/sensor.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 import dataclasses
 from datetime import datetime, timedelta
-from typing import Final
+from typing import Final, override
 
 from ovoenergy.models import OVODailyUsage
 
@@ -169,6 +169,7 @@ class OVOEnergySensor(OVOEnergyDeviceEntity, SensorEntity):
         self.entity_description = description
 
     @property
+    @override
     def native_value(self) -> StateType | datetime:
         """Return the state."""
         usage = self.coordinator.data

--- a/homeassistant/components/owntracks/config_flow.py
+++ b/homeassistant/components/owntracks/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for OwnTracks."""
 
 import secrets
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components import cloud, webhook
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
@@ -19,6 +19,7 @@ class OwnTracksFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/owntracks/device_tracker.py
+++ b/homeassistant/components/owntracks/device_tracker.py
@@ -1,7 +1,7 @@
 """Device tracker platform that adds support for OwnTracks over MQTT."""
 # pylint: disable=home-assistant-use-runtime-data  # Uses legacy hass.data[DOMAIN] pattern
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.device_tracker import (
     ATTR_SOURCE_TYPE,
@@ -92,26 +92,31 @@ class OwnTracksEntity(TrackerEntity, RestoreEntity):
         self.entity_id = f"{DEVICE_TRACKER_DOMAIN}.{dev_id}"
 
     @property
+    @override
     def unique_id(self) -> str:
         """Return the unique ID."""
         return self._dev_id
 
     @property
+    @override
     def battery_level(self) -> int | None:
         """Return the battery level of the device."""
         return self._data.get("battery")
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return device specific attributes."""
         return self._data.get("attributes")
 
     @property
+    @override
     def location_accuracy(self) -> float:
         """Return the gps accuracy of the device."""
         return self._data.get("gps_accuracy", 0)
 
     @property
+    @override
     def latitude(self) -> float | None:
         """Return latitude value of the device."""
         # Check with "get" instead of "in" because value can be None
@@ -121,6 +126,7 @@ class OwnTracksEntity(TrackerEntity, RestoreEntity):
         return None
 
     @property
+    @override
     def longitude(self) -> float | None:
         """Return longitude value of the device."""
         # Check with "get" instead of "in" because value can be None
@@ -130,16 +136,19 @@ class OwnTracksEntity(TrackerEntity, RestoreEntity):
         return None
 
     @property
+    @override
     def location_name(self) -> str | None:
         """Return a location name for the current location of the device."""
         return self._data.get("location_name")
 
     @property
+    @override
     def source_type(self) -> SourceType:
         """Return the source type, eg gps or router, of the device."""
         return self._data.get("source_type", SourceType.GPS)
 
     @property
+    @override
     def device_info(self) -> DeviceInfo:
         """Return the device info."""
         device_info = DeviceInfo(identifiers={(DOMAIN, self._dev_id)})
@@ -147,6 +156,7 @@ class OwnTracksEntity(TrackerEntity, RestoreEntity):
             device_info["name"] = self._data["host_name"]
         return device_info
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Call when entity about to be added to Home Assistant."""
         await super().async_added_to_hass()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In preparation to enable the mypy check for `@override` in https://github.com/home-assistant/core/pull/171853

To make it easier to review, you can get a simplified diff with only changed lines (no context), and check that only imports changed and `@override` lines added: `git show override_componets_n_o --unified=0 | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)'`

Or get a diff with only the non-decorator changes:

`git show override_componets_n_o --unified=0 | grep -E '^[+-]' | grep -vE '^(\+\+\+|---) ' | grep -vE '^[+-][[:space:]]*@override$' | grep -vE '^[+-]from typing import '`

To reproduce and double check this change, run the following:

```bash
# generate errors list:
python extract_override_errors.py homeassistant/components

# filter component range
grep -E 'components/[n-o]' explicit_override_errors.txt | sort -o explicit_override_errors.txt

# add override decorator and ruff it
python add_override_decorators.py explicit_override_errors.txt
```

The two scripts can be found in https://github.com/home-assistant/core/pull/171853

### Extra manual changes:

In `homeassistant/components/nobo_hub/select.py`, renamed the loop variable to `override_data` to resolve the clash.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
