### PR TITLE
Clarify the media player play media action name

### DIFF
--- a/homeassistant/components/media_player/strings.json
+++ b/homeassistant/components/media_player/strings.json
@@ -370,7 +370,7 @@
           "name": "Media"
         }
       },
-      "name": "Play media"
+      "name": "Play specified media"
     },
     "repeat_set": {
       "description": "Sets the repeat mode of a media player.",


### PR DESCRIPTION
## Proposed change

The `media_player.play_media` action was named "Play media", which is identical to the name of the `media_player.media_play` action. Two different actions sharing the same display name is confusing. This renames `play_media` to "Play specified media", which matches what it does (it plays a specific piece of media, while `media_play` resumes playback). Only the display name changes; the action key, fields, and description are untouched, so nothing breaks.

This is part of a wider effort to make the naming of triggers, conditions, and actions consistent across Home Assistant. The naming review and reasoning behind these changes is documented here: https://docs.google.com/document/d/18ZsosVR0OAOwkoQV1wmQ4FNSw18KV7EbPl0eNVP2uzA/edit?tab=t.0#heading=h.vwrsknoq58h0

The full sheet of proposed changes can be found here: https://docs.google.com/spreadsheets/d/1ahVHTWEZhk2-pwToI_ovHDBXIxHDmVqzRG41bwHGhMc/edit?gid=560897381#gid=560897381

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
