### PR TITLE
Remove runtime_data dependency from SIA options flow

### DIFF
--- a/homeassistant/components/sia/config_flow.py
+++ b/homeassistant/components/sia/config_flow.py
@@ -29,7 +29,7 @@ from .const import (
     DOMAIN,
     TITLE,
 )
-from .hub import SIAConfigEntry, SIAHub
+from .hub import SIAConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -180,17 +180,15 @@ class SIAOptionsFlowHandler(OptionsFlow):
     def __init__(self, config_entry: SIAConfigEntry) -> None:
         """Initialize SIA options flow."""
         self.options = deepcopy(dict(config_entry.options))
-        self.hub: SIAHub | None = None
-        self.accounts_todo: list = []
+        self.accounts_todo: list[str] = []
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Manage the SIA options."""
-        self.hub = self.config_entry.runtime_data
-        assert self.hub is not None
-        assert self.hub.sia_accounts is not None
-        self.accounts_todo = [a.account_id for a in self.hub.sia_accounts]
+        self.accounts_todo = [
+            a[CONF_ACCOUNT] for a in self.config_entry.data[CONF_ACCOUNTS]
+        ]
         return await self.async_step_options()
 
     async def async_step_options(

--- a/tests/components/sia/test_config_flow.py
+++ b/tests/components/sia/test_config_flow.py
@@ -312,6 +312,30 @@ async def test_unknown_account(hass: HomeAssistant, flow_at_user_step) -> None:
         assert result_err["data_schema"] == ACCOUNT_SCHEMA
 
 
+async def test_options_not_loaded(hass: HomeAssistant) -> None:
+    """Test options flow works when entry is not loaded."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=BASE_OUT["data"],
+        options=BASE_OUT["options"],
+        title="SIA Alarm on port 7777",
+        entry_id=BASIS_CONFIG_ENTRY_ID,
+        version=1,
+    )
+    config_entry.add_to_hass(hass)
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "options"
+
+    updated = await hass.config_entries.options.async_configure(
+        result["flow_id"], BASIC_OPTIONS
+    )
+    assert updated["type"] is FlowResultType.CREATE_ENTRY
+    assert updated["data"] == {
+        CONF_ACCOUNTS: {BASIC_CONFIG[CONF_ACCOUNT]: BASIC_OPTIONS}
+    }
+
+
 async def test_options_basic(hass: HomeAssistant) -> None:
     """Test options flow for single account."""
     config_entry = MockConfigEntry(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The SIA options flow accessed `runtime_data` to get the list of account IDs, which caused a crash when the config entry was not in the `LOADED` state (for example, during setup retry due to a connection error). This meant users could not reconfigure the integration while it was in an error state.

The account IDs are already available in `config_entry.data`, so this PR reads them from there instead. This removes the dependency on `runtime_data` entirely, making the options flow work regardless of the entry's state.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #174321
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr