### PR TITLE
Fix bosch_shc power sensor missing state_class for Energy Dashboard

### DIFF
--- a/homeassistant/components/bosch_shc/sensor.py
+++ b/homeassistant/components/bosch_shc/sensor.py
@@ -98,6 +98,7 @@ SENSOR_DESCRIPTIONS: dict[str, SHCSensorEntityDescription] = {
     POWER_SENSOR: SHCSensorEntityDescription(
         key=POWER_SENSOR,
         device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfPower.WATT,
         value_fn=lambda device: device.powerconsumption,
     ),
@@ -106,7 +107,11 @@ SENSOR_DESCRIPTIONS: dict[str, SHCSensorEntityDescription] = {
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-        value_fn=lambda device: device.energyconsumption / 1000.0,
+        value_fn=lambda device: (
+            device.energyconsumption / 1000.0
+            if device.energyconsumption is not None
+            else None
+        ),
     ),
     VALVE_TAPPET_SENSOR: SHCSensorEntityDescription(
         key=VALVE_TAPPET_SENSOR,

--- a/tests/components/bosch_shc/test_sensor.py
+++ b/tests/components/bosch_shc/test_sensor.py
@@ -1,0 +1,58 @@
+"""Tests for the Bosch SHC sensor platform."""
+
+from homeassistant.components.bosch_shc.sensor import (
+    ENERGY_SENSOR,
+    POWER_SENSOR,
+    SENSOR_DESCRIPTIONS,
+)
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.const import UnitOfEnergy, UnitOfPower
+
+
+def test_power_sensor_description_has_state_class() -> None:
+    """Test that the power sensor description includes state_class MEASUREMENT.
+
+    Without state_class the HA recorder skips the entity in _get_sensor_states
+    and never compiles long-term statistics for it.  That means the sensor does
+    not appear in the Energy Dashboard "Individual Devices" power-rate picker
+    (unit_class='power') and cannot be linked to an individual device entry.
+
+    Regression test for GitHub issue home-assistant/core#167569.
+    """
+    desc = SENSOR_DESCRIPTIONS[POWER_SENSOR]
+    assert desc.device_class == SensorDeviceClass.POWER
+    assert desc.state_class == SensorStateClass.MEASUREMENT
+    assert desc.native_unit_of_measurement == UnitOfPower.WATT
+
+
+def test_energy_sensor_description_state_class_and_unit() -> None:
+    """Test that the energy sensor description has the attributes required by
+    the Energy Dashboard Individual Devices picker (unit_class='energy').
+
+    The picker filters statistics by unit_class.  For kWh sensors with
+    device_class ENERGY and state_class TOTAL_INCREASING the recorder produces
+    statistics with unit_class='energy', which is what the picker expects.
+    """
+    desc = SENSOR_DESCRIPTIONS[ENERGY_SENSOR]
+    assert desc.device_class == SensorDeviceClass.ENERGY
+    assert desc.state_class == SensorStateClass.TOTAL_INCREASING
+    assert desc.native_unit_of_measurement == UnitOfEnergy.KILO_WATT_HOUR
+
+
+def test_energy_sensor_value_fn_handles_none() -> None:
+    """The energy value_fn must not raise when the device reports no value.
+
+    A missing energyconsumption would otherwise raise TypeError (None / 1000.0)
+    and take the entity unavailable; the guard returns None instead.
+    """
+    desc = SENSOR_DESCRIPTIONS[ENERGY_SENSOR]
+
+    class _Dev:
+        energyconsumption = None
+
+    assert desc.value_fn(_Dev()) is None
+
+    class _Dev2:
+        energyconsumption = 2500.0
+
+    assert desc.value_fn(_Dev2()) == 2.5

--- a/tests/components/bosch_shc/test_sensor.py
+++ b/tests/components/bosch_shc/test_sensor.py
@@ -26,8 +26,7 @@ def test_power_sensor_description_has_state_class() -> None:
 
 
 def test_energy_sensor_description_state_class_and_unit() -> None:
-    """Test that the energy sensor description has the attributes required by
-    the Energy Dashboard Individual Devices picker (unit_class='energy').
+    """Test the energy sensor description matches the Energy Dashboard picker.
 
     The picker filters statistics by unit_class.  For kWh sensors with
     device_class ENERGY and state_class TOTAL_INCREASING the recorder produces


### PR DESCRIPTION
## Proposed change

The `POWER_SENSOR` entity description in the `bosch_shc` sensor platform was missing `state_class=SensorStateClass.MEASUREMENT`. Without a `state_class`, the recorder (`_get_sensor_states`) skips the entity, so **no long-term statistics are compiled** for it — and the sensor never appears in the Energy Dashboard **Individual Devices** power-rate picker (which filters statistics by `unit_class="power"`).

This affects all power-metering devices in the integration (`smart_plugs`, `smart_plugs_compact`, `light_switches_bsm`). It is most visible on fresh `plug_compact` setups (no legacy statistics), as reported in #167569. The HACS upstream already sets `_attr_state_class = SensorStateClass.MEASUREMENT` on its power sensor, confirming the intended value.

While here, `ENERGY_SENSOR.value_fn` is guarded against a missing `energyconsumption` (the previous `None / 1000.0` would raise `TypeError` and take the entity unavailable).

Fixes #167569

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #167569

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format`/`ruff check`).
- [x] Tests have been added to verify that the new code works (`tests/components/bosch_shc/test_sensor.py`).

## No breaking changes

Entity unique IDs, `device_class`, and unit are unchanged. Adding `state_class` only starts statistics collection — it does not reset or recreate existing entities.