### PR TITLE
Use value comparison for value-based enums

### DIFF
--- a/homeassistant/components/dlna_dmr/media_player.py
+++ b/homeassistant/components/dlna_dmr/media_player.py
@@ -718,7 +718,7 @@ class DlnaDmrEntity(MediaPlayerEntity):
 
         # If already playing, or don't want to autoplay, no need to call Play
         autoplay = extra.get("autoplay", True)
-        if self._device.transport_state is TransportState.PLAYING or not autoplay:
+        if self._device.transport_state == TransportState.PLAYING or not autoplay:
             return
 
         # Play it
@@ -748,7 +748,7 @@ class DlnaDmrEntity(MediaPlayerEntity):
         if not (play_mode := self._device.play_mode):
             return None
 
-        if play_mode is PlayMode.VENDOR_DEFINED:
+        if play_mode == PlayMode.VENDOR_DEFINED:
             return None
 
         return play_mode in (PlayMode.SHUFFLE, PlayMode.RANDOM)
@@ -782,10 +782,10 @@ class DlnaDmrEntity(MediaPlayerEntity):
         if not (play_mode := self._device.play_mode):
             return None
 
-        if play_mode is PlayMode.VENDOR_DEFINED:
+        if play_mode == PlayMode.VENDOR_DEFINED:
             return None
 
-        if play_mode is PlayMode.REPEAT_ONE:
+        if play_mode == PlayMode.REPEAT_ONE:
             return RepeatMode.ONE
 
         if play_mode in (PlayMode.REPEAT_ALL, PlayMode.RANDOM):

--- a/homeassistant/components/elevenlabs/stt.py
+++ b/homeassistant/components/elevenlabs/stt.py
@@ -150,9 +150,9 @@ class ElevenLabsSTTEntity(SpeechToTextEntity):
 
         raw_pcm_compatible = (
             metadata.codec == AudioCodecs.PCM
-            and metadata.sample_rate is AudioSampleRates.SAMPLERATE_16000
-            and metadata.channel is AudioChannels.CHANNEL_MONO
-            and metadata.bit_rate is AudioBitRates.BITRATE_16
+            and metadata.sample_rate == AudioSampleRates.SAMPLERATE_16000
+            and metadata.channel == AudioChannels.CHANNEL_MONO
+            and metadata.bit_rate == AudioBitRates.BITRATE_16
         )
         if raw_pcm_compatible:
             file_format = "pcm_s16le_16"

--- a/homeassistant/components/google/calendar.py
+++ b/homeassistant/components/google/calendar.py
@@ -143,7 +143,7 @@ def _get_entity_descriptions(
         local_sync = True
         if (
             search := data.get(CONF_SEARCH)
-        ) or calendar_item.access_role is AccessRole.FREE_BUSY_READER:
+        ) or calendar_item.access_role == AccessRole.FREE_BUSY_READER:
             read_only = True
             local_sync = False
         entity_description = GoogleCalendarEntityDescription(
@@ -386,14 +386,14 @@ class GoogleCalendarEntity(
         """Return True if the event is visible and not declined."""
 
         if any(
-            attendee.is_self and attendee.response_status is ResponseStatus.DECLINED
+            attendee.is_self and attendee.response_status == ResponseStatus.DECLINED
             for attendee in event.attendees
         ):
             return False
         # Calendar enttiy may be limited to a specific event type
         if (
             self.entity_description.event_type is not None
-            and self.entity_description.event_type is not event.event_type
+            and self.entity_description.event_type != event.event_type
         ):
             return False
         # Default calendar entity omits the special types but includes all the others

--- a/homeassistant/components/google_generative_ai_conversation/entity.py
+++ b/homeassistant/components/google_generative_ai_conversation/entity.py
@@ -754,7 +754,7 @@ async def async_prepare_files_for_prompt(
                 config={"http_options": {"timeout": TIMEOUT_MILLIS}},
             )
 
-        if uploaded_file.state is FileState.FAILED:
+        if uploaded_file.state == FileState.FAILED:
             raise HomeAssistantError(
                 f"File `{uploaded_file.name}` processing"
                 " failed, reason:"
@@ -766,7 +766,7 @@ async def async_prepare_files_for_prompt(
     tasks = [
         asyncio.create_task(wait_for_file_processing(part))
         for part in prompt_parts
-        if part.state is not FileState.ACTIVE
+        if part.state != FileState.ACTIVE
     ]
     async with asyncio.timeout(TIMEOUT_MILLIS / 1000):
         await asyncio.gather(*tasks)

--- a/homeassistant/components/hassio/update.py
+++ b/homeassistant/components/hassio/update.py
@@ -247,7 +247,7 @@ class SupervisorOSUpdateEntity(HassioOSEntity, UpdateEntity):
     def release_url(self) -> str | None:
         """URL to the full release notes of the latest version available."""
         version = AwesomeVersion(self.latest_version)
-        if version.dev or version.strategy is AwesomeVersionStrategy.UNKNOWN:
+        if version.dev or version.strategy == AwesomeVersionStrategy.UNKNOWN:
             return "https://github.com/home-assistant/operating-system/commits/dev"
         return (
             f"https://github.com/home-assistant/operating-system/releases/tag/{version}"
@@ -304,7 +304,7 @@ class SupervisorSupervisorUpdateEntity(HassioSupervisorEntity, UpdateEntity):
     def release_url(self) -> str | None:
         """URL to the full release notes of the latest version available."""
         version = AwesomeVersion(self.latest_version)
-        if version.dev or version.strategy is AwesomeVersionStrategy.UNKNOWN:
+        if version.dev or version.strategy == AwesomeVersionStrategy.UNKNOWN:
             return "https://github.com/home-assistant/supervisor/commits/main"
         return f"https://github.com/home-assistant/supervisor/releases/tag/{version}"
 

--- a/homeassistant/components/rainforest_raven/config_flow.py
+++ b/homeassistant/components/rainforest_raven/config_flow.py
@@ -59,7 +59,7 @@ class RainforestRavenConfigFlow(ConfigFlow, domain=DOMAIN):
                     meter_info = await raven_device.get_meter_info(meter=meter)
                     if meter_info and (
                         meter_info.meter_type is None
-                        or meter_info.meter_type is MeterType.ELECTRIC
+                        or meter_info.meter_type == MeterType.ELECTRIC
                     ):
                         self._meter_macs.add(meter.hex())
         self._dev_path = dev_path

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -705,7 +705,7 @@ class ReolinkHost:
                 self._api.host,
                 sub_type,
             )
-            if sub_type is SubType.push:
+            if sub_type == SubType.push:
                 await self.subscribe()
                 return
 

--- a/homeassistant/components/sleepiq/number.py
+++ b/homeassistant/components/sleepiq/number.py
@@ -86,7 +86,7 @@ async def _async_set_foot_warmer_time(
     foot_warmer: SleepIQFootWarmer, time: int
 ) -> None:
     temperature = FootWarmingTemps(foot_warmer.temperature)
-    if temperature is not FootWarmingTemps.OFF:
+    if temperature != FootWarmingTemps.OFF:
         await foot_warmer.turn_on(temperature, time)
 
     foot_warmer.timer = time
@@ -105,7 +105,7 @@ async def _async_set_core_climate_time(
     core_climate: SleepIQCoreClimate, time: int
 ) -> None:
     temperature = CoreTemps(core_climate.temperature)
-    if temperature is not CoreTemps.OFF:
+    if temperature != CoreTemps.OFF:
         await core_climate.turn_on(temperature, time)
 
     core_climate.timer = time

--- a/homeassistant/components/sleepiq/select.py
+++ b/homeassistant/components/sleepiq/select.py
@@ -57,7 +57,7 @@ class SleepIQSelectEntity(SleepIQBedEntity[SleepIQDataUpdateCoordinator], Select
 
         self._attr_name = f"SleepNumber {bed.name} Foundation Preset"
         self._attr_unique_id = f"{bed.id}_preset"
-        if preset.side is not Side.NONE:
+        if preset.side != Side.NONE:
             self._attr_name += f" {preset.side_full}"
             self._attr_unique_id += f"_{preset.side.value}"
         self._attr_options = preset.options
@@ -164,7 +164,7 @@ class SleepIQCoreTempSelectEntity(
         temperature = self.HA_TO_SLEEPIQ_CORE_TEMP_MAP[option]
         timer = self.core_climate.timer or 240
 
-        if temperature is CoreTemps.OFF:
+        if temperature == CoreTemps.OFF:
             await self.core_climate.turn_off()
         else:
             await self.core_climate.turn_on(temperature, timer)

--- a/homeassistant/components/ssdp/scanner.py
+++ b/homeassistant/components/ssdp/scanner.py
@@ -367,7 +367,7 @@ class Scanner:
         callbacks = self._async_get_matching_callbacks(combined_headers)
 
         # If there are no changes from a search, do not trigger a config flow
-        if source is not SsdpSource.SEARCH_ALIVE:
+        if source != SsdpSource.SEARCH_ALIVE:
             matching_domains = self.integration_matchers.async_matching_domains(
                 CaseInsensitiveDict(combined_headers.as_dict(), **info_desc)
             )
@@ -375,7 +375,7 @@ class Scanner:
         if (
             not callbacks
             and not matching_domains
-            and source is not SsdpSource.ADVERTISEMENT_BYEBYE
+            and source != SsdpSource.ADVERTISEMENT_BYEBYE
         ):
             return
 
@@ -390,7 +390,7 @@ class Scanner:
 
         # Config flows should only be created for alive/update
         # messages from alive devices
-        if source is SsdpSource.ADVERTISEMENT_BYEBYE:
+        if source == SsdpSource.ADVERTISEMENT_BYEBYE:
             self._async_dismiss_discoveries(discovery_info)
             return
 

--- a/homeassistant/components/tesla_fleet/coordinator.py
+++ b/homeassistant/components/tesla_fleet/coordinator.py
@@ -113,7 +113,7 @@ class TeslaFleetVehicleDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.endpoints = (
             ENDPOINTS
             if location
-            else [ep for ep in ENDPOINTS if ep is not VehicleDataEndpoint.LOCATION_DATA]
+            else [ep for ep in ENDPOINTS if ep != VehicleDataEndpoint.LOCATION_DATA]
         )
 
     async def _async_update_data(self) -> dict[str, Any]:

--- a/tests/components/homeassistant_sky_connect/test_const.py
+++ b/tests/components/homeassistant_sky_connect/test_const.py
@@ -16,7 +16,7 @@ def test_hardware_variant(
     usb_product_name: str, expected_variant: HardwareVariant
 ) -> None:
     """Test hardware variant parsing."""
-    assert HardwareVariant.from_usb_product_name(usb_product_name) is expected_variant
+    assert HardwareVariant.from_usb_product_name(usb_product_name) == expected_variant
 
 
 def test_hardware_variant_invalid() -> None:

--- a/tests/components/homeassistant_sky_connect/test_util.py
+++ b/tests/components/homeassistant_sky_connect/test_util.py
@@ -65,7 +65,7 @@ def test_get_usb_service_info() -> None:
 
 def test_get_hardware_variant() -> None:
     """Test `get_hardware_variant` extraction."""
-    assert get_hardware_variant(SKYCONNECT_CONFIG_ENTRY) is HardwareVariant.SKYCONNECT
+    assert get_hardware_variant(SKYCONNECT_CONFIG_ENTRY) == HardwareVariant.SKYCONNECT
     assert (
-        get_hardware_variant(CONNECT_ZBT1_CONFIG_ENTRY) is HardwareVariant.CONNECT_ZBT1
+        get_hardware_variant(CONNECT_ZBT1_CONFIG_ENTRY) == HardwareVariant.CONNECT_ZBT1
     )

--- a/tests/components/stt/test_init.py
+++ b/tests/components/stt/test_init.py
@@ -268,11 +268,11 @@ async def test_stream_audio_uses_enum_values(
     assert isinstance(metadata.codec, AudioCodecs)
     assert metadata.codec == AudioCodecs.PCM
     assert isinstance(metadata.bit_rate, AudioBitRates)
-    assert metadata.bit_rate is AudioBitRates.BITRATE_16
+    assert metadata.bit_rate == AudioBitRates.BITRATE_16
     assert isinstance(metadata.sample_rate, AudioSampleRates)
-    assert metadata.sample_rate is AudioSampleRates.SAMPLERATE_16000
+    assert metadata.sample_rate == AudioSampleRates.SAMPLERATE_16000
     assert isinstance(metadata.channel, AudioChannels)
-    assert metadata.channel is AudioChannels.CHANNEL_MONO
+    assert metadata.channel == AudioChannels.CHANNEL_MONO
 
 
 @pytest.mark.parametrize(

--- a/tests/components/vera/common.py
+++ b/tests/components/vera/common.py
@@ -139,7 +139,7 @@ class ComponentFactory:
         self.vera_controller_class_mock.return_value = controller
 
         # Setup component through config flow.
-        if controller_config.config_source is ConfigSource.CONFIG_FLOW:
+        if controller_config.config_source == ConfigSource.CONFIG_FLOW:
             await hass.config_entries.flow.async_init(
                 DOMAIN,
                 context={"source": config_entries.SOURCE_USER},
@@ -148,7 +148,7 @@ class ComponentFactory:
             await hass.async_block_till_done()
 
         # Setup component directly from config entry.
-        if controller_config.config_source is ConfigSource.CONFIG_ENTRY:
+        if controller_config.config_source == ConfigSource.CONFIG_ENTRY:
             entry = MockConfigEntry(
                 domain=DOMAIN,
                 data=controller_config.config,

--- a/tests/components/zha/test_helpers.py
+++ b/tests/components/zha/test_helpers.py
@@ -108,11 +108,11 @@ async def test_zcl_schema_conversions(hass: HomeAssistant) -> None:
     assert isinstance(converted_data["action"], lighting.Color.ColorLoopAction)
     assert (
         converted_data["action"]
-        is lighting.Color.ColorLoopAction.Activate_from_current_hue
+        == lighting.Color.ColorLoopAction.Activate_from_current_hue
     )
 
     assert isinstance(converted_data["direction"], lighting.Color.ColorLoopDirection)
-    assert converted_data["direction"] is lighting.Color.ColorLoopDirection.Increment
+    assert converted_data["direction"] == lighting.Color.ColorLoopDirection.Increment
 
     assert isinstance(converted_data["time"], uint16_t)
     assert converted_data["time"] == 20
@@ -141,11 +141,11 @@ async def test_zcl_schema_conversions(hass: HomeAssistant) -> None:
     assert isinstance(converted_data["action"], lighting.Color.ColorLoopAction)
     assert (
         converted_data["action"]
-        is lighting.Color.ColorLoopAction.Activate_from_current_hue
+        == lighting.Color.ColorLoopAction.Activate_from_current_hue
     )
 
     assert isinstance(converted_data["direction"], lighting.Color.ColorLoopDirection)
-    assert converted_data["direction"] is lighting.Color.ColorLoopDirection.Increment
+    assert converted_data["direction"] == lighting.Color.ColorLoopDirection.Increment
 
     assert isinstance(converted_data["time"], uint16_t)
     assert converted_data["time"] == 20


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Working more on https://github.com/home-assistant/core/pull/171551, copilot pointed out that value-based mixin enums are not excluded from the mypy plugin.

E.g.
```python
class TransportState(str, Enum):  # Still a StrEnum
    PLAYING = "PLAYING"
```

After fixing this in the mypy plugin, I saw that PRs #171591/#171689 which migrated `==`/`!=` to `is`/`is not`, also migrated some enums that are value-based using this mixin pattern. For those, `is` is not equivalent to `==` and can silently break when a caller passes the underlying value. I have not seen any issues caused by these changes so far, but regardless, this PR reverts those Enums just in case.

This PR only changes lines previously touched by #171591/#171689.

Source:
- elevenlabs/stt: AudioSampleRates / AudioChannels / AudioBitRates
- dlna_dmr: TransportState / PlayMode
- google calendar: AccessRole / ResponseStatus / EventTypeEnum
- google_generative_ai_conversation: FileState
- hassio: AwesomeVersionStrategy
- rainforest_raven: MeterType
- reolink: SubType
- sleepiq: FootWarmingTemps / CoreTemps / Side
- ssdp: SsdpSource
- tesla_fleet: VehicleDataEndpoint

Tests:
- stt: AudioBitRates / AudioSampleRates / AudioChannels
- vera: ConfigSource
- zha: Color.ColorLoopAction / ColorLoopDirection
- homeassistant_sky_connect: HardwareVariant

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #171551
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
