### PR TITLE
Handle ApplicationNotAllowedError in Overkiz cloud config flow

### DIFF
--- a/homeassistant/components/overkiz/config_flow.py
+++ b/homeassistant/components/overkiz/config_flow.py
@@ -14,6 +14,7 @@ from pyoverkiz.client import GatewayCandidate, OverkizClient
 from pyoverkiz.const import SERVERS_WITH_LOCAL_API, SUPPORTED_SERVERS
 from pyoverkiz.enums import APIType, Server
 from pyoverkiz.exceptions import (
+    ApplicationNotAllowedError,
     BadCredentialsError,
     CozyTouchBadCredentialsError,
     MaintenanceError,
@@ -191,6 +192,8 @@ class OverkizConfigFlow(
                 await self.async_validate_input(user_input)
             except TooManyRequestsError:
                 errors["base"] = "too_many_requests"
+            except ApplicationNotAllowedError:
+                errors["base"] = "application_not_allowed"
             except (BadCredentialsError, NotAuthenticatedError) as exception:
                 # If authentication with CozyTouch auth server is
                 # valid, but token is invalid for Overkiz API

--- a/homeassistant/components/overkiz/strings.json
+++ b/homeassistant/components/overkiz/strings.json
@@ -18,6 +18,7 @@
       "user_rejected_authorize": "[%key:common::config_flow::abort::oauth2_user_rejected_authorize%]"
     },
     "error": {
+      "application_not_allowed": "Your setup cannot be accessed through this application.",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "certificate_verify_failed": "Cannot connect to host, certificate verify failed.",
       "developer_mode_disabled": "Developer Mode disabled. Activate the Developer Mode of your Somfy TaHoma box first.",

--- a/tests/components/overkiz/test_config_flow.py
+++ b/tests/components/overkiz/test_config_flow.py
@@ -11,6 +11,7 @@ from pyoverkiz.const import (
     REXEL_OAUTH_TOKEN_URL,
 )
 from pyoverkiz.exceptions import (
+    ApplicationNotAllowedError,
     BadCredentialsError,
     MaintenanceError,
     NoSuchTokenError,
@@ -229,6 +230,7 @@ async def test_form_local_happy_flow(
         (MaintenanceError, "server_in_maintenance"),
         (TooManyAttemptsBannedError, "too_many_attempts"),
         (UnknownUserError, "unsupported_hardware"),
+        (ApplicationNotAllowedError, "application_not_allowed"),
         (Exception, "unknown"),
     ],
 )


### PR DESCRIPTION
## Proposed change

When setting up the Overkiz integration via the cloud API, some users (e.g. with a Somfy Connectivity Kit) hit an `ApplicationNotAllowedError`, raised by pyoverkiz when the API returns `RESOURCE_ACCESS_DENIED` ("Your setup cannot be accessed through this application"). This exception was not caught in the config flow, so the user was shown a generic "Unexpected error" with no indication of what went wrong.

This PR catches `ApplicationNotAllowedError` in the cloud authentication step and maps it to a dedicated, translatable error message so the user understands their setup cannot be accessed through this application. A test case covering the new error mapping is added.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #166808
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
