### PR TITLE
Add Litter-Robot 5 night light

### DIFF
--- a/homeassistant/components/litterrobot/__init__.py
+++ b/homeassistant/components/litterrobot/__init__.py
@@ -23,6 +23,7 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
+    Platform.LIGHT,
     Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,

--- a/homeassistant/components/litterrobot/__init__.py
+++ b/homeassistant/components/litterrobot/__init__.py
@@ -28,6 +28,7 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
+    Platform.LIGHT,
     Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,

--- a/homeassistant/components/litterrobot/icons.json
+++ b/homeassistant/components/litterrobot/icons.json
@@ -34,6 +34,11 @@
         "default": "mdi:delete-variant"
       }
     },
+    "light": {
+      "night_light": {
+        "default": "mdi:lightbulb-night"
+      }
+    },
     "select": {
       "brightness_level": {
         "default": "mdi:lightbulb-question",
@@ -63,6 +68,9 @@
       },
       "meal_insert_size": {
         "default": "mdi:scale"
+      },
+      "night_light_preset": {
+        "default": "mdi:palette"
       }
     },
     "sensor": {

--- a/homeassistant/components/litterrobot/icons.json
+++ b/homeassistant/components/litterrobot/icons.json
@@ -68,9 +68,6 @@
       },
       "meal_insert_size": {
         "default": "mdi:scale"
-      },
-      "night_light_preset": {
-        "default": "mdi:palette"
       }
     },
     "sensor": {

--- a/homeassistant/components/litterrobot/light.py
+++ b/homeassistant/components/litterrobot/light.py
@@ -1,0 +1,120 @@
+"""Support for Litter-Robot night light."""
+
+from typing import Any, override
+
+from pylitterbot import LitterRobot5
+from pylitterbot.robot.litterrobot4 import NightLightMode
+
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    ATTR_RGB_COLOR,
+    ColorMode,
+    LightEntity,
+    LightEntityDescription,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import LitterRobotConfigEntry
+from .entity import LitterRobotEntity, whisker_command
+
+PARALLEL_UPDATES = 1
+
+NIGHT_LIGHT_DESCRIPTION = LightEntityDescription(
+    key="night_light",
+    translation_key="night_light",
+)
+
+
+def _hex_to_rgb(hex_color: str) -> tuple[int, int, int]:
+    """Convert a color hex string into an RGB tuple."""
+    value = hex_color.lstrip("#")
+    if len(value) == 3:
+        value = "".join(component * 2 for component in value)
+    return int(value[0:2], 16), int(value[2:4], 16), int(value[4:6], 16)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: LitterRobotConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Litter-Robot night light using config entry."""
+    coordinator = entry.runtime_data
+    known_robots: set[str] = set()
+
+    def _check_robots() -> None:
+        all_robots = [
+            robot
+            for robot in coordinator.account.robots
+            if isinstance(robot, LitterRobot5)
+        ]
+        current_robots = {robot.serial for robot in all_robots}
+        new_robots = current_robots - known_robots
+        if new_robots:
+            known_robots.update(new_robots)
+            async_add_entities(
+                LitterRobotNightLight(robot, coordinator, NIGHT_LIGHT_DESCRIPTION)
+                for robot in all_robots
+                if robot.serial in new_robots
+            )
+
+    _check_robots()
+    entry.async_on_unload(coordinator.async_add_listener(_check_robots))
+
+
+class LitterRobotNightLight(LitterRobotEntity[LitterRobot5], LightEntity):
+    """Representation of the night light on a Litter-Robot 5."""
+
+    _attr_color_mode = ColorMode.RGB
+    _attr_supported_color_modes = {ColorMode.RGB}
+
+    @property
+    @override
+    def is_on(self) -> bool:
+        """Return whether the night light is on (any mode other than off)."""
+        mode = self.robot.night_light_mode
+        return mode is not None and mode is not NightLightMode.OFF
+
+    @property
+    @override
+    def brightness(self) -> int:
+        """Return the brightness of the night light, scaled to 0-255."""
+        return round(self.robot.night_light_brightness * 255 / 100)
+
+    @property
+    @override
+    def rgb_color(self) -> tuple[int, int, int] | None:
+        """Return the color of the night light."""
+        if (color := self.robot.night_light_color) is None:
+            return None
+        return _hex_to_rgb(color)
+
+    @whisker_command
+    @override
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on the night light, applying any requested color or brightness."""
+        mode = self.robot.night_light_mode
+        brightness = self.robot.night_light_brightness
+        color = self.robot.night_light_color or "#FFFFFF"
+
+        if ATTR_RGB_COLOR in kwargs:
+            rgb = kwargs[ATTR_RGB_COLOR]
+            color = f"#{rgb[0]:02X}{rgb[1]:02X}{rgb[2]:02X}"
+
+        if ATTR_BRIGHTNESS in kwargs:
+            brightness = round(kwargs[ATTR_BRIGHTNESS] * 100 / 255)
+        # Preserve the auto mode when the light is already on; otherwise switch on.
+        if mode is None or mode is NightLightMode.OFF:
+            mode = NightLightMode.ON
+
+        # The API replaces the entire settings object, so send every field.
+        await self.robot.set_night_light_settings(
+            mode=mode, brightness=brightness, color=color
+        )
+
+    @whisker_command
+    @override
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off the night light."""
+        await self.robot.set_night_light_settings(mode=NightLightMode.OFF)

--- a/homeassistant/components/litterrobot/light.py
+++ b/homeassistant/components/litterrobot/light.py
@@ -26,14 +26,6 @@ NIGHT_LIGHT_DESCRIPTION = LightEntityDescription(
 )
 
 
-def _hex_to_rgb(hex_color: str) -> tuple[int, int, int]:
-    """Convert a color hex string into an RGB tuple."""
-    value = hex_color.lstrip("#")
-    if len(value) == 3:
-        value = "".join(component * 2 for component in value)
-    return int(value[0:2], 16), int(value[2:4], 16), int(value[4:6], 16)
-
-
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: LitterRobotConfigEntry,
@@ -86,9 +78,7 @@ class LitterRobotNightLight(LitterRobotEntity[LitterRobot5], LightEntity):
     @override
     def rgb_color(self) -> tuple[int, int, int] | None:
         """Return the color of the night light."""
-        if (color := self.robot.night_light_color) is None:
-            return None
-        return _hex_to_rgb(color)
+        return self.robot.night_light_rgb_color
 
     @whisker_command
     @override
@@ -96,11 +86,10 @@ class LitterRobotNightLight(LitterRobotEntity[LitterRobot5], LightEntity):
         """Turn on the night light, applying any requested color or brightness."""
         mode = self.robot.night_light_mode
         brightness = self.robot.night_light_brightness
-        color = self.robot.night_light_color or "#FFFFFF"
+        color: str | tuple[int, int, int] = self.robot.night_light_color or "#FFFFFF"
 
         if ATTR_RGB_COLOR in kwargs:
-            rgb = kwargs[ATTR_RGB_COLOR]
-            color = f"#{rgb[0]:02X}{rgb[1]:02X}{rgb[2]:02X}"
+            color = kwargs[ATTR_RGB_COLOR]
 
         if ATTR_BRIGHTNESS in kwargs:
             brightness = round(kwargs[ATTR_BRIGHTNESS] * 100 / 255)

--- a/homeassistant/components/litterrobot/light.py
+++ b/homeassistant/components/litterrobot/light.py
@@ -86,7 +86,7 @@ class LitterRobotNightLight(LitterRobotEntity[LitterRobot5], LightEntity):
         """Turn on the night light, applying any requested color or brightness."""
         mode = self.robot.night_light_mode
         brightness = self.robot.night_light_brightness
-        color: str | tuple[int, int, int] = self.robot.night_light_color or "#FFFFFF"
+        color = self.robot.night_light_rgb_color or (255, 255, 255)
 
         if ATTR_RGB_COLOR in kwargs:
             color = kwargs[ATTR_RGB_COLOR]

--- a/homeassistant/components/litterrobot/select.py
+++ b/homeassistant/components/litterrobot/select.py
@@ -19,6 +19,38 @@ PARALLEL_UPDATES = 1
 
 _CastTypeT = TypeVar("_CastTypeT", int, float, str)
 
+# Fully saturated colors (every channel 0 or 255) are the only ones the LED
+# renders accurately at all brightness levels; intermediate colors drift. They
+# are offered as named presets while the light's RGB picker stays available for
+# custom colors.
+NIGHT_LIGHT_PRESETS: dict[str, str] = {
+    "red": "#FF0000",
+    "green": "#00FF00",
+    "blue": "#0000FF",
+    "cyan": "#00FFFF",
+    "magenta": "#FF00FF",
+    "yellow": "#FFFF00",
+    "white": "#FFFFFF",
+}
+
+# The LR5 globe LED renders brightness non-monotonically (a firmware quirk also
+# present in the Whisker app), so LOW/MEDIUM/HIGH map to the percentages that
+# read as dim/medium/bright on the LR5 rather than the LR4 25/50/100 levels. The
+# light entity exposes the full continuous range.
+LR5_GLOBE_BRIGHTNESS: dict[str, int] = {"low": 10, "medium": 100, "high": 75}
+
+
+def _active_night_light_preset(robot: LitterRobot5) -> str | None:
+    """Return the preset matching the current color, or None for a custom color."""
+    if (color := robot.night_light_color) is None:
+        return None
+    # The device may echo an 8-digit #RRGGBBAA value; compare on the RGB part.
+    normalized = "#" + color.lstrip("#").upper()[:6]
+    return next(
+        (name for name, value in NIGHT_LIGHT_PRESETS.items() if value == normalized),
+        None,
+    )
+
 
 @dataclass(frozen=True, kw_only=True)
 class RobotSelectEntityDescription(
@@ -46,8 +78,11 @@ ROBOT_SELECT_MAP: dict[
             select_fn=lambda robot, opt: robot.set_wait_time(int(opt)),
         ),
     ),
-    (LitterRobot4, LitterRobot5): (
-        RobotSelectEntityDescription[LitterRobot4 | LitterRobot5, str](
+    # LR4 globe brightness uses the device's discrete BrightnessLevel enum
+    # (25/50/100). LR5 has its own globe_brightness below with eye-calibrated
+    # percentages, since LR5 firmware renders brightness non-monotonically.
+    LitterRobot4: (
+        RobotSelectEntityDescription[LitterRobot4, str](
             key="globe_brightness",
             translation_key="globe_brightness",
             current_fn=(
@@ -64,6 +99,8 @@ ROBOT_SELECT_MAP: dict[
                 )
             ),
         ),
+    ),
+    (LitterRobot4, LitterRobot5): (
         RobotSelectEntityDescription[LitterRobot4 | LitterRobot5, str](
             key="globe_light",
             translation_key="globe_light",
@@ -96,6 +133,36 @@ ROBOT_SELECT_MAP: dict[
                 lambda robot, opt: robot.set_panel_brightness(
                     BrightnessLevel[opt.upper()]
                 )
+            ),
+        ),
+    ),
+    LitterRobot5: (
+        RobotSelectEntityDescription[LitterRobot5, str](
+            key="globe_brightness",
+            translation_key="globe_brightness",
+            current_fn=lambda robot: next(
+                (
+                    level
+                    for level, pct in LR5_GLOBE_BRIGHTNESS.items()
+                    if pct == robot.night_light_brightness
+                ),
+                None,
+            ),
+            options_fn=lambda _: list(LR5_GLOBE_BRIGHTNESS),
+            select_fn=lambda robot, opt: robot.set_night_light_brightness(
+                LR5_GLOBE_BRIGHTNESS[opt]
+            ),
+        ),
+        RobotSelectEntityDescription[LitterRobot5, str](
+            key="night_light_preset",
+            translation_key="night_light_preset",
+            current_fn=_active_night_light_preset,
+            options_fn=lambda _: list(NIGHT_LIGHT_PRESETS),
+            select_fn=lambda robot, opt: robot.set_night_light_settings(
+                # The API replaces the whole object, so keep mode + brightness.
+                mode=robot.night_light_mode or NightLightMode.ON,
+                brightness=robot.night_light_brightness,
+                color=NIGHT_LIGHT_PRESETS[opt],
             ),
         ),
     ),
@@ -166,7 +233,8 @@ class LitterRobotSelectEntity(
     @override
     def current_option(self) -> str | None:
         """Return the selected entity option to represent the entity state."""
-        return str(self.entity_description.current_fn(self.robot))
+        option = self.entity_description.current_fn(self.robot)
+        return None if option is None else str(option)
 
     @whisker_command
     @override

--- a/homeassistant/components/litterrobot/select.py
+++ b/homeassistant/components/litterrobot/select.py
@@ -19,35 +19,11 @@ PARALLEL_UPDATES = 1
 
 _CastTypeT = TypeVar("_CastTypeT", int, float, str)
 
-# The LED does not necessarily render an arbitrary RGB value as the same color
-# at every brightness level (an LR5 firmware quirk, like the non-monotonic
-# brightness mapping below). These presets are verified on hardware to render
-# true at all brightness levels and are offered as known-good options while the
-# light's RGB picker stays available for custom colors.
-NIGHT_LIGHT_PRESETS: dict[str, tuple[int, int, int]] = {
-    "red": (255, 0, 0),
-    "green": (0, 255, 0),
-    "blue": (0, 0, 255),
-    "cyan": (0, 255, 255),
-    "magenta": (255, 0, 255),
-    "yellow": (255, 255, 0),
-    "white": (255, 255, 255),
-}
-
 # The LR5 globe LED renders brightness non-monotonically (a firmware quirk also
 # present in the Whisker app), so LOW/MEDIUM/HIGH map to the percentages that
 # read as dim/medium/bright on the LR5 rather than the LR4 25/50/100 levels. The
 # light entity exposes the full continuous range.
 LR5_GLOBE_BRIGHTNESS: dict[str, int] = {"low": 10, "medium": 100, "high": 75}
-
-
-def _active_night_light_preset(robot: LitterRobot5) -> str | None:
-    """Return the preset matching the current color, or None for a custom color."""
-    if (rgb := robot.night_light_rgb_color) is None:
-        return None
-    return next(
-        (name for name, value in NIGHT_LIGHT_PRESETS.items() if value == rgb), None
-    )
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -149,18 +125,6 @@ ROBOT_SELECT_MAP: dict[
             options_fn=lambda _: list(LR5_GLOBE_BRIGHTNESS),
             select_fn=lambda robot, opt: robot.set_night_light_brightness(
                 LR5_GLOBE_BRIGHTNESS[opt]
-            ),
-        ),
-        RobotSelectEntityDescription[LitterRobot5, str](
-            key="night_light_preset",
-            translation_key="night_light_preset",
-            current_fn=_active_night_light_preset,
-            options_fn=lambda _: list(NIGHT_LIGHT_PRESETS),
-            select_fn=lambda robot, opt: robot.set_night_light_settings(
-                # The API replaces the whole object, so keep mode + brightness.
-                mode=robot.night_light_mode or NightLightMode.ON,
-                brightness=robot.night_light_brightness,
-                color=NIGHT_LIGHT_PRESETS[opt],
             ),
         ),
     ),

--- a/homeassistant/components/litterrobot/select.py
+++ b/homeassistant/components/litterrobot/select.py
@@ -24,14 +24,14 @@ _CastTypeT = TypeVar("_CastTypeT", int, float, str)
 # brightness mapping below). These presets are verified on hardware to render
 # true at all brightness levels and are offered as known-good options while the
 # light's RGB picker stays available for custom colors.
-NIGHT_LIGHT_PRESETS: dict[str, str] = {
-    "red": "#FF0000",
-    "green": "#00FF00",
-    "blue": "#0000FF",
-    "cyan": "#00FFFF",
-    "magenta": "#FF00FF",
-    "yellow": "#FFFF00",
-    "white": "#FFFFFF",
+NIGHT_LIGHT_PRESETS: dict[str, tuple[int, int, int]] = {
+    "red": (255, 0, 0),
+    "green": (0, 255, 0),
+    "blue": (0, 0, 255),
+    "cyan": (0, 255, 255),
+    "magenta": (255, 0, 255),
+    "yellow": (255, 255, 0),
+    "white": (255, 255, 255),
 }
 
 # The LR5 globe LED renders brightness non-monotonically (a firmware quirk also
@@ -43,13 +43,10 @@ LR5_GLOBE_BRIGHTNESS: dict[str, int] = {"low": 10, "medium": 100, "high": 75}
 
 def _active_night_light_preset(robot: LitterRobot5) -> str | None:
     """Return the preset matching the current color, or None for a custom color."""
-    if (color := robot.night_light_color) is None:
+    if (rgb := robot.night_light_rgb_color) is None:
         return None
-    # The device may echo an 8-digit #RRGGBBAA value; compare on the RGB part.
-    normalized = "#" + color.lstrip("#").upper()[:6]
     return next(
-        (name for name, value in NIGHT_LIGHT_PRESETS.items() if value == normalized),
-        None,
+        (name for name, value in NIGHT_LIGHT_PRESETS.items() if value == rgb), None
     )
 
 

--- a/homeassistant/components/litterrobot/select.py
+++ b/homeassistant/components/litterrobot/select.py
@@ -19,10 +19,11 @@ PARALLEL_UPDATES = 1
 
 _CastTypeT = TypeVar("_CastTypeT", int, float, str)
 
-# Fully saturated colors (every channel 0 or 255) are the only ones the LED
-# renders accurately at all brightness levels; intermediate colors drift. They
-# are offered as named presets while the light's RGB picker stays available for
-# custom colors.
+# The LED does not necessarily render an arbitrary RGB value as the same color
+# at every brightness level (an LR5 firmware quirk, like the non-monotonic
+# brightness mapping below). These presets are verified on hardware to render
+# true at all brightness levels and are offered as known-good options while the
+# light's RGB picker stays available for custom colors.
 NIGHT_LIGHT_PRESETS: dict[str, str] = {
     "red": "#FF0000",
     "green": "#00FF00",

--- a/homeassistant/components/litterrobot/select.py
+++ b/homeassistant/components/litterrobot/select.py
@@ -19,12 +19,6 @@ PARALLEL_UPDATES = 1
 
 _CastTypeT = TypeVar("_CastTypeT", int, float, str)
 
-# The LR5 globe LED renders brightness non-monotonically (a firmware quirk also
-# present in the Whisker app), so LOW/MEDIUM/HIGH map to the percentages that
-# read as dim/medium/bright on the LR5 rather than the LR4 25/50/100 levels. The
-# light entity exposes the full continuous range.
-LR5_GLOBE_BRIGHTNESS: dict[str, int] = {"low": 10, "medium": 100, "high": 75}
-
 
 @dataclass(frozen=True, kw_only=True)
 class RobotSelectEntityDescription(
@@ -52,9 +46,6 @@ ROBOT_SELECT_MAP: dict[
             select_fn=lambda robot, opt: robot.set_wait_time(int(opt)),
         ),
     ),
-    # LR4 globe brightness uses the device's discrete BrightnessLevel enum
-    # (25/50/100). LR5 has its own globe_brightness below with eye-calibrated
-    # percentages, since LR5 firmware renders brightness non-monotonically.
     LitterRobot4: (
         RobotSelectEntityDescription[LitterRobot4, str](
             key="globe_brightness",
@@ -107,24 +98,6 @@ ROBOT_SELECT_MAP: dict[
                 lambda robot, opt: robot.set_panel_brightness(
                     BrightnessLevel[opt.upper()]
                 )
-            ),
-        ),
-    ),
-    LitterRobot5: (
-        RobotSelectEntityDescription[LitterRobot5, str](
-            key="globe_brightness",
-            translation_key="globe_brightness",
-            current_fn=lambda robot: next(
-                (
-                    level
-                    for level, pct in LR5_GLOBE_BRIGHTNESS.items()
-                    if pct == robot.night_light_brightness
-                ),
-                None,
-            ),
-            options_fn=lambda _: list(LR5_GLOBE_BRIGHTNESS),
-            select_fn=lambda robot, opt: robot.set_night_light_brightness(
-                LR5_GLOBE_BRIGHTNESS[opt]
             ),
         ),
     ),

--- a/homeassistant/components/litterrobot/select.py
+++ b/homeassistant/components/litterrobot/select.py
@@ -46,8 +46,8 @@ ROBOT_SELECT_MAP: dict[
             select_fn=lambda robot, opt: robot.set_wait_time(int(opt)),
         ),
     ),
-    LitterRobot4: (
-        RobotSelectEntityDescription[LitterRobot4, str](
+    (LitterRobot4, LitterRobot5): (
+        RobotSelectEntityDescription[LitterRobot4 | LitterRobot5, str](
             key="globe_brightness",
             translation_key="globe_brightness",
             current_fn=(
@@ -64,8 +64,6 @@ ROBOT_SELECT_MAP: dict[
                 )
             ),
         ),
-    ),
-    (LitterRobot4, LitterRobot5): (
         RobotSelectEntityDescription[LitterRobot4 | LitterRobot5, str](
             key="globe_light",
             translation_key="globe_light",

--- a/homeassistant/components/litterrobot/strings.json
+++ b/homeassistant/components/litterrobot/strings.json
@@ -119,18 +119,6 @@
       },
       "meal_insert_size": {
         "name": "Meal insert size"
-      },
-      "night_light_preset": {
-        "name": "Night light preset",
-        "state": {
-          "blue": "Blue",
-          "cyan": "Cyan",
-          "green": "Green",
-          "magenta": "Magenta",
-          "red": "Red",
-          "white": "White",
-          "yellow": "Yellow"
-        }
       }
     },
     "sensor": {

--- a/homeassistant/components/litterrobot/strings.json
+++ b/homeassistant/components/litterrobot/strings.json
@@ -84,6 +84,11 @@
         "name": "Reset waste drawer"
       }
     },
+    "light": {
+      "night_light": {
+        "name": "Night light"
+      }
+    },
     "select": {
       "brightness_level": {
         "name": "Panel brightness",
@@ -114,6 +119,18 @@
       },
       "meal_insert_size": {
         "name": "Meal insert size"
+      },
+      "night_light_preset": {
+        "name": "Night light preset",
+        "state": {
+          "blue": "Blue",
+          "cyan": "Cyan",
+          "green": "Green",
+          "magenta": "Magenta",
+          "red": "Red",
+          "white": "White",
+          "yellow": "Yellow"
+        }
       }
     },
     "sensor": {

--- a/tests/components/litterrobot/conftest.py
+++ b/tests/components/litterrobot/conftest.py
@@ -51,6 +51,7 @@ def create_mock_robot(
         robot.change_filter = AsyncMock(side_effect=side_effect)
         robot.set_night_light_brightness = AsyncMock(side_effect=side_effect)
         robot.set_night_light_mode = AsyncMock(side_effect=side_effect)
+        robot.set_night_light_settings = AsyncMock(side_effect=side_effect)
         robot.set_panel_brightness = AsyncMock(side_effect=side_effect)
     elif v4:
         robot = LitterRobot4(data={**ROBOT_4_DATA, **robot_data}, account=account)

--- a/tests/components/litterrobot/snapshots/test_light.ambr
+++ b/tests/components/litterrobot/snapshots/test_light.ambr
@@ -1,0 +1,74 @@
+# serializer version: 1
+# name: test_all_entities[light.test_night_light-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <LightEntityCapabilityAttribute.SUPPORTED_COLOR_MODES: 'supported_color_modes'>: list([
+        <ColorMode.RGB: 'rgb'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'light',
+    'entity_category': None,
+    'entity_id': 'light.test_night_light',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Night light',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Night light',
+    'platform': 'litterrobot',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'night_light',
+    'unique_id': 'LR5C010001-night_light',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[light.test_night_light-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <LightEntityStateAttribute.BRIGHTNESS: 'brightness'>: 128,
+      <LightEntityStateAttribute.COLOR_MODE: 'color_mode'>: <ColorMode.RGB: 'rgb'>,
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Test Night light',
+      <LightEntityStateAttribute.HS_COLOR: 'hs_color'>: tuple(
+        0.0,
+        0.0,
+      ),
+      <LightEntityStateAttribute.RGB_COLOR: 'rgb_color'>: tuple(
+        255,
+        255,
+        255,
+      ),
+      <LightEntityCapabilityAttribute.SUPPORTED_COLOR_MODES: 'supported_color_modes'>: list([
+        <ColorMode.RGB: 'rgb'>,
+      ]),
+      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <LightEntityFeature: 0>,
+      <LightEntityStateAttribute.XY_COLOR: 'xy_color'>: tuple(
+        0.323,
+        0.329,
+      ),
+    }),
+    'context': <ANY>,
+    'entity_id': 'light.test_night_light',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---

--- a/tests/components/litterrobot/test_light.py
+++ b/tests/components/litterrobot/test_light.py
@@ -1,0 +1,147 @@
+"""Test the Litter-Robot light entity."""
+
+from unittest.mock import MagicMock, patch
+
+from pylitterbot.exceptions import InvalidCommandException
+from pylitterbot.robot.litterrobot4 import NightLightMode
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    ATTR_RGB_COLOR,
+    DOMAIN as LIGHT_DOMAIN,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+)
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from .conftest import create_mock_account, setup_integration
+
+from tests.common import snapshot_platform
+
+NIGHT_LIGHT_ENTITY_ID = "light.test_night_light"
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_all_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    mock_account_with_litterrobot_5: MagicMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the Litter-Robot 5 light entities."""
+    with patch("homeassistant.components.litterrobot.PLATFORMS", [Platform.LIGHT]):
+        entry = await setup_integration(hass, mock_account_with_litterrobot_5)
+
+    await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)
+
+
+async def test_turn_on_brightness(
+    hass: HomeAssistant, mock_account_with_litterrobot_5: MagicMock
+) -> None:
+    """Test setting the night light brightness, preserving mode and color."""
+    await setup_integration(hass, mock_account_with_litterrobot_5, LIGHT_DOMAIN)
+
+    robot = mock_account_with_litterrobot_5.robots[0]
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: NIGHT_LIGHT_ENTITY_ID, ATTR_BRIGHTNESS: 255},
+        blocking=True,
+    )
+    robot.set_night_light_settings.assert_awaited_once_with(
+        mode=NightLightMode.AUTO, brightness=100, color="#FFFFFF"
+    )
+
+
+async def test_turn_on_color(
+    hass: HomeAssistant, mock_account_with_litterrobot_5: MagicMock
+) -> None:
+    """Test setting the night light color, preserving mode and brightness."""
+    await setup_integration(hass, mock_account_with_litterrobot_5, LIGHT_DOMAIN)
+
+    robot = mock_account_with_litterrobot_5.robots[0]
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: NIGHT_LIGHT_ENTITY_ID, ATTR_RGB_COLOR: (255, 0, 0)},
+        blocking=True,
+    )
+    robot.set_night_light_settings.assert_awaited_once_with(
+        mode=NightLightMode.AUTO, brightness=50, color="#FF0000"
+    )
+
+
+async def test_turn_on_from_off_switches_on(hass: HomeAssistant) -> None:
+    """Test turning on a night light that is off switches the mode to on."""
+    mock_account = create_mock_account(
+        robot_data={
+            "nightLightSettings": {
+                "brightness": 50,
+                "color": "#FFFFFF",
+                "mode": "OFF",
+            }
+        },
+        v5=True,
+    )
+    await setup_integration(hass, mock_account, LIGHT_DOMAIN)
+
+    entity = hass.states.get(NIGHT_LIGHT_ENTITY_ID)
+    assert entity
+    assert entity.state == "off"
+
+    robot = mock_account.robots[0]
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: NIGHT_LIGHT_ENTITY_ID},
+        blocking=True,
+    )
+    robot.set_night_light_settings.assert_awaited_once_with(
+        mode=NightLightMode.ON, brightness=50, color="#FFFFFF"
+    )
+
+
+async def test_turn_off(
+    hass: HomeAssistant, mock_account_with_litterrobot_5: MagicMock
+) -> None:
+    """Test turning off the night light."""
+    await setup_integration(hass, mock_account_with_litterrobot_5, LIGHT_DOMAIN)
+
+    robot = mock_account_with_litterrobot_5.robots[0]
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: NIGHT_LIGHT_ENTITY_ID},
+        blocking=True,
+    )
+    robot.set_night_light_settings.assert_awaited_once_with(mode=NightLightMode.OFF)
+
+
+async def test_command_exception(hass: HomeAssistant) -> None:
+    """Test that a LitterRobotException is wrapped in HomeAssistantError."""
+    mock_account = create_mock_account(
+        side_effect=InvalidCommandException("Invalid command: oops"), v5=True
+    )
+    await setup_integration(hass, mock_account, LIGHT_DOMAIN)
+
+    with pytest.raises(HomeAssistantError, match="Invalid command: oops"):
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: NIGHT_LIGHT_ENTITY_ID},
+            blocking=True,
+        )
+
+
+async def test_litter_robot_4_has_no_light(
+    hass: HomeAssistant, mock_account_with_litterrobot_4: MagicMock
+) -> None:
+    """Test that a Litter-Robot 4 creates no light entities."""
+    await setup_integration(hass, mock_account_with_litterrobot_4, LIGHT_DOMAIN)
+
+    assert not hass.states.async_entity_ids(LIGHT_DOMAIN)

--- a/tests/components/litterrobot/test_light.py
+++ b/tests/components/litterrobot/test_light.py
@@ -54,7 +54,7 @@ async def test_turn_on_brightness(
         blocking=True,
     )
     robot.set_night_light_settings.assert_awaited_once_with(
-        mode=NightLightMode.AUTO, brightness=100, color="#FFFFFF"
+        mode=NightLightMode.AUTO, brightness=100, color=(255, 255, 255)
     )
 
 
@@ -102,7 +102,7 @@ async def test_turn_on_from_off_switches_on(hass: HomeAssistant) -> None:
         blocking=True,
     )
     robot.set_night_light_settings.assert_awaited_once_with(
-        mode=NightLightMode.ON, brightness=50, color="#FFFFFF"
+        mode=NightLightMode.ON, brightness=50, color=(255, 255, 255)
     )
 
 

--- a/tests/components/litterrobot/test_light.py
+++ b/tests/components/litterrobot/test_light.py
@@ -72,7 +72,7 @@ async def test_turn_on_color(
         blocking=True,
     )
     robot.set_night_light_settings.assert_awaited_once_with(
-        mode=NightLightMode.AUTO, brightness=50, color="#FF0000"
+        mode=NightLightMode.AUTO, brightness=50, color=(255, 0, 0)
     )
 
 

--- a/tests/components/litterrobot/test_select.py
+++ b/tests/components/litterrobot/test_select.py
@@ -196,7 +196,7 @@ async def test_litterrobot_5_night_light_preset(
     )
     # Selecting a preset writes the color while preserving mode and brightness.
     robot.set_night_light_settings.assert_awaited_once_with(
-        mode=NightLightMode.AUTO, brightness=50, color="#00FFFF"
+        mode=NightLightMode.AUTO, brightness=50, color=(0, 255, 255)
     )
 
 

--- a/tests/components/litterrobot/test_select.py
+++ b/tests/components/litterrobot/test_select.py
@@ -168,59 +168,6 @@ async def test_litterrobot_5_globe_light(
     robot.set_night_light_mode.assert_any_call(NightLightMode.AUTO)
 
 
-async def test_litterrobot_5_night_light_preset(
-    hass: HomeAssistant,
-    mock_account_with_litterrobot_5: MagicMock,
-    entity_registry: er.EntityRegistry,
-) -> None:
-    """Tests the Litter-Robot 5 night light preset select entity."""
-    entity_id = "select.test_night_light_preset"
-    await setup_integration(hass, mock_account_with_litterrobot_5, SELECT_DOMAIN)
-
-    select = hass.states.get(entity_id)
-    assert select
-    assert len(select.attributes[ATTR_OPTIONS]) == 7
-    # The fixture color #FFFFFF matches the white preset.
-    assert select.state == "white"
-
-    entity_entry = entity_registry.async_get(entity_id)
-    assert entity_entry
-    assert entity_entry.entity_category is EntityCategory.CONFIG
-
-    robot: LitterRobot5 = mock_account_with_litterrobot_5.robots[0]
-    await hass.services.async_call(
-        SELECT_DOMAIN,
-        SERVICE_SELECT_OPTION,
-        {ATTR_ENTITY_ID: entity_id, ATTR_OPTION: "cyan"},
-        blocking=True,
-    )
-    # Selecting a preset writes the color while preserving mode and brightness.
-    robot.set_night_light_settings.assert_awaited_once_with(
-        mode=NightLightMode.AUTO, brightness=50, color=(0, 255, 255)
-    )
-
-
-async def test_litterrobot_5_night_light_preset_custom_color(
-    hass: HomeAssistant,
-) -> None:
-    """A color outside the preset list leaves the preset select unknown."""
-    mock_account = create_mock_account(
-        robot_data={
-            "nightLightSettings": {
-                "brightness": 50,
-                "color": "#123456",
-                "mode": "Auto",
-            }
-        },
-        v5=True,
-    )
-    await setup_integration(hass, mock_account, SELECT_DOMAIN)
-
-    select = hass.states.get("select.test_night_light_preset")
-    assert select
-    assert select.state == STATE_UNKNOWN
-
-
 async def test_litterrobot_5_panel_brightness(
     hass: HomeAssistant,
     mock_account_with_litterrobot_5: MagicMock,

--- a/tests/components/litterrobot/test_select.py
+++ b/tests/components/litterrobot/test_select.py
@@ -12,12 +12,12 @@ from homeassistant.components.select import (
     DOMAIN as SELECT_DOMAIN,
     SERVICE_SELECT_OPTION,
 )
-from homeassistant.const import ATTR_ENTITY_ID, EntityCategory
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 
-from .conftest import setup_integration
+from .conftest import create_mock_account, setup_integration
 
 SELECT_ENTITY_ID = "select.test_clean_cycle_wait_time_minutes"
 
@@ -168,6 +168,59 @@ async def test_litterrobot_5_globe_light(
     robot.set_night_light_mode.assert_any_call(NightLightMode.AUTO)
 
 
+async def test_litterrobot_5_night_light_preset(
+    hass: HomeAssistant,
+    mock_account_with_litterrobot_5: MagicMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Tests the Litter-Robot 5 night light preset select entity."""
+    entity_id = "select.test_night_light_preset"
+    await setup_integration(hass, mock_account_with_litterrobot_5, SELECT_DOMAIN)
+
+    select = hass.states.get(entity_id)
+    assert select
+    assert len(select.attributes[ATTR_OPTIONS]) == 7
+    # The fixture color #FFFFFF matches the white preset.
+    assert select.state == "white"
+
+    entity_entry = entity_registry.async_get(entity_id)
+    assert entity_entry
+    assert entity_entry.entity_category is EntityCategory.CONFIG
+
+    robot: LitterRobot5 = mock_account_with_litterrobot_5.robots[0]
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {ATTR_ENTITY_ID: entity_id, ATTR_OPTION: "cyan"},
+        blocking=True,
+    )
+    # Selecting a preset writes the color while preserving mode and brightness.
+    robot.set_night_light_settings.assert_awaited_once_with(
+        mode=NightLightMode.AUTO, brightness=50, color="#00FFFF"
+    )
+
+
+async def test_litterrobot_5_night_light_preset_custom_color(
+    hass: HomeAssistant,
+) -> None:
+    """A color outside the preset list leaves the preset select unknown."""
+    mock_account = create_mock_account(
+        robot_data={
+            "nightLightSettings": {
+                "brightness": 50,
+                "color": "#123456",
+                "mode": "Auto",
+            }
+        },
+        v5=True,
+    )
+    await setup_integration(hass, mock_account, SELECT_DOMAIN)
+
+    select = hass.states.get("select.test_night_light_preset")
+    assert select
+    assert select.state == STATE_UNKNOWN
+
+
 async def test_litterrobot_5_panel_brightness(
     hass: HomeAssistant,
     mock_account_with_litterrobot_5: MagicMock,
@@ -202,3 +255,58 @@ async def test_litterrobot_5_panel_brightness(
         )
 
         assert robot.set_panel_brightness.call_count == count + 1
+
+
+async def test_litterrobot_5_globe_brightness(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Tests the Litter-Robot 5 globe brightness select entity."""
+    entity_id = "select.test_globe_brightness"
+    # A stored brightness of 100 maps to the LR5 "medium" level (the LR5 renders
+    # brightness non-monotonically, so low/medium/high map to 10/100/75).
+    mock_account = create_mock_account(
+        robot_data={
+            "nightLightSettings": {
+                "brightness": 100,
+                "color": "#FFFFFF",
+                "mode": "Auto",
+            }
+        },
+        v5=True,
+    )
+    await setup_integration(hass, mock_account, SELECT_DOMAIN)
+
+    select = hass.states.get(entity_id)
+    assert select
+    assert len(select.attributes[ATTR_OPTIONS]) == 3
+    assert select.state == "medium"
+
+    entity_entry = entity_registry.async_get(entity_id)
+    assert entity_entry
+    assert entity_entry.entity_category is EntityCategory.CONFIG
+
+    robot: LitterRobot5 = mock_account.robots[0]
+
+    # Each option must set the eye-calibrated percentage for that LR5 level.
+    for option, brightness in (("low", 10), ("medium", 100), ("high", 75)):
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {ATTR_ENTITY_ID: entity_id, ATTR_OPTION: option},
+            blocking=True,
+        )
+        robot.set_night_light_brightness.assert_awaited_with(brightness)
+
+    assert robot.set_night_light_brightness.await_count == 3
+
+
+async def test_litterrobot_5_globe_brightness_unmapped(hass: HomeAssistant) -> None:
+    """A brightness with no matching level leaves globe brightness unknown."""
+    # The default LR5 fixture brightness (50) maps to no low/medium/high level.
+    mock_account = create_mock_account(v5=True)
+    await setup_integration(hass, mock_account, SELECT_DOMAIN)
+
+    select = hass.states.get("select.test_globe_brightness")
+    assert select
+    assert select.state == STATE_UNKNOWN

--- a/tests/components/litterrobot/test_select.py
+++ b/tests/components/litterrobot/test_select.py
@@ -12,12 +12,12 @@ from homeassistant.components.select import (
     DOMAIN as SELECT_DOMAIN,
     SERVICE_SELECT_OPTION,
 )
-from homeassistant.const import ATTR_ENTITY_ID, EntityCategory
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 
-from .conftest import setup_integration
+from .conftest import create_mock_account, setup_integration
 
 SELECT_ENTITY_ID = "select.test_clean_cycle_wait_time_minutes"
 
@@ -202,3 +202,27 @@ async def test_litterrobot_5_panel_brightness(
         )
 
         assert robot.set_panel_brightness.call_count == count + 1
+
+
+async def test_globe_brightness_unmapped_level(hass: HomeAssistant) -> None:
+    """A brightness matching no level leaves the select unknown, not "None".
+
+    The LR5 firmware accepts any 0-100 brightness, so a value set outside the
+    discrete levels has no matching option. current_option must return None so
+    the entity reads as unknown, rather than the string "None".
+    """
+    mock_account = create_mock_account(
+        robot_data={
+            "nightLightSettings": {
+                "brightness": 60,
+                "color": "#FFFFFF",
+                "mode": "Auto",
+            }
+        },
+        v5=True,
+    )
+    await setup_integration(hass, mock_account, SELECT_DOMAIN)
+
+    select = hass.states.get("select.test_globe_brightness")
+    assert select
+    assert select.state == STATE_UNKNOWN

--- a/tests/components/litterrobot/test_select.py
+++ b/tests/components/litterrobot/test_select.py
@@ -12,12 +12,12 @@ from homeassistant.components.select import (
     DOMAIN as SELECT_DOMAIN,
     SERVICE_SELECT_OPTION,
 )
-from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN, EntityCategory
+from homeassistant.const import ATTR_ENTITY_ID, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 
-from .conftest import create_mock_account, setup_integration
+from .conftest import setup_integration
 
 SELECT_ENTITY_ID = "select.test_clean_cycle_wait_time_minutes"
 
@@ -202,58 +202,3 @@ async def test_litterrobot_5_panel_brightness(
         )
 
         assert robot.set_panel_brightness.call_count == count + 1
-
-
-async def test_litterrobot_5_globe_brightness(
-    hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
-) -> None:
-    """Tests the Litter-Robot 5 globe brightness select entity."""
-    entity_id = "select.test_globe_brightness"
-    # A stored brightness of 100 maps to the LR5 "medium" level (the LR5 renders
-    # brightness non-monotonically, so low/medium/high map to 10/100/75).
-    mock_account = create_mock_account(
-        robot_data={
-            "nightLightSettings": {
-                "brightness": 100,
-                "color": "#FFFFFF",
-                "mode": "Auto",
-            }
-        },
-        v5=True,
-    )
-    await setup_integration(hass, mock_account, SELECT_DOMAIN)
-
-    select = hass.states.get(entity_id)
-    assert select
-    assert len(select.attributes[ATTR_OPTIONS]) == 3
-    assert select.state == "medium"
-
-    entity_entry = entity_registry.async_get(entity_id)
-    assert entity_entry
-    assert entity_entry.entity_category is EntityCategory.CONFIG
-
-    robot: LitterRobot5 = mock_account.robots[0]
-
-    # Each option must set the eye-calibrated percentage for that LR5 level.
-    for option, brightness in (("low", 10), ("medium", 100), ("high", 75)):
-        await hass.services.async_call(
-            SELECT_DOMAIN,
-            SERVICE_SELECT_OPTION,
-            {ATTR_ENTITY_ID: entity_id, ATTR_OPTION: option},
-            blocking=True,
-        )
-        robot.set_night_light_brightness.assert_awaited_with(brightness)
-
-    assert robot.set_night_light_brightness.await_count == 3
-
-
-async def test_litterrobot_5_globe_brightness_unmapped(hass: HomeAssistant) -> None:
-    """A brightness with no matching level leaves globe brightness unknown."""
-    # The default LR5 fixture brightness (50) maps to no low/medium/high level.
-    mock_account = create_mock_account(v5=True)
-    await setup_integration(hass, mock_account, SELECT_DOMAIN)
-
-    select = hass.states.get("select.test_globe_brightness")
-    assert select
-    assert select.state == STATE_UNKNOWN


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

None.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds night light support for the Litter-Robot 5 (LR5 Pro):

- A new **`light`** entity for the globe night light, exposing RGB color,
  brightness, and on/off. Color, brightness, and mode are written together
  because the device replaces the entire night light settings object on each
  command.
Scope note: this PR now adds **only** the `light` entity. Two select entities
that were originally included have been split out to follow-ups after review:
a `night_light_preset` colour select (removed in 4e8a4cd) and an LR5
`globe_brightness` level select (removed in 5db092e). Nothing in this PR
duplicates a setting the light entity already exposes.

It also fixes `LitterRobotSelectEntity.current_option` to return `None`
(Unknown) instead of the literal string `"None"` when the current value matches
no option.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#46408
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

