### PR TITLE
Source UniFi Protect light auto-shutoff duration from the public API

### DIFF
--- a/homeassistant/components/unifiprotect/entity.py
+++ b/homeassistant/components/unifiprotect/entity.py
@@ -296,9 +296,9 @@ class BaseProtectEntity(Entity):
         )
         # Not every entity carries an entity_description (e.g. cameras), so getattr.
         description = getattr(self, "entity_description", None)
-        if (
-            isinstance(description, ProtectEntityDescription)
-            and description.ufp_public_value is not None
+        if isinstance(description, ProtectEntityDescription) and (
+            description.ufp_public_value is not None
+            or description.ufp_public_value_fn is not None
         ):
             self._ufp_uses_public = True
             self._ufp_public_obj = self.data.async_get_public_device(self.device)
@@ -423,6 +423,8 @@ class ProtectEntityDescription(EntityDescription, Generic[T]):  # noqa: UP046
     ufp_value: str | None = None
     ufp_value_fn: Callable[[T], Any] | None = None
     ufp_public_value: str | None = None
+    # Callable variant of ``ufp_public_value`` for public values needing a transform.
+    ufp_public_value_fn: Callable[[PublicDeviceModel], Any] | None = None
     ufp_enabled: str | None = None
     ufp_perm: PermRequired | None = None
 
@@ -443,10 +445,13 @@ class ProtectEntityDescription(EntityDescription, Generic[T]):  # noqa: UP046
     def get_value(self, obj: T, public_obj: PublicDeviceModel | None = None) -> Any:
         """Return the value, reading from the public object when migrated.
 
-        A migrated description sets ``ufp_public_value`` and drops the private
-        ``ufp_value``: the value comes only from the public object, or ``None``
-        when it is absent (the entity is then marked unavailable).
+        A migrated description sets ``ufp_public_value`` (or ``ufp_public_value_fn``)
+        and drops the private ``ufp_value``: the value comes only from the public
+        object, or ``None`` when it is absent (the entity is then marked
+        unavailable).
         """
+        if (fn := self.ufp_public_value_fn) is not None:
+            return None if public_obj is None else fn(public_obj)
         if (getter := self.get_ufp_public_value) is not None:
             return None if public_obj is None else getter(public_obj)
         return self.get_ufp_value(obj)

--- a/homeassistant/components/unifiprotect/number.py
+++ b/homeassistant/components/unifiprotect/number.py
@@ -4,9 +4,10 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
-from typing import override
+from typing import cast, override
 
 from uiprotect.data import Camera, Chime, Light, ModelType, ProtectAdoptableDeviceModel
+from uiprotect.data.public_devices import PublicDeviceModel, PublicLight
 
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
 from homeassistant.const import PERCENTAGE, EntityCategory, UnitOfTime
@@ -40,12 +41,14 @@ class ProtectNumberEntityDescription(
     ufp_step: int | float
 
 
-def _get_pir_duration(obj: Light) -> int:
-    return int(obj.light_device_settings.pir_duration.total_seconds())
+def _get_pir_duration_public(obj: PublicDeviceModel) -> int | None:
+    # Public API reports the PIR auto-shutoff duration in milliseconds.
+    duration = cast(PublicLight, obj).light_device_settings.pir_duration
+    return None if duration is None else round(duration / 1000)
 
 
 async def _set_pir_duration(obj: Light, value: float) -> None:
-    await obj.set_duration(timedelta(seconds=value))
+    await obj.set_duration_public(timedelta(seconds=value))
 
 
 def _get_chime_duration(obj: Camera) -> int:
@@ -178,7 +181,7 @@ LIGHT_NUMBERS: tuple[ProtectNumberEntityDescription, ...] = (
         ufp_min=15,
         ufp_max=900,
         ufp_step=15,
-        ufp_value_fn=_get_pir_duration,
+        ufp_public_value_fn=_get_pir_duration_public,
         ufp_set_method_fn=_set_pir_duration,
         ufp_perm=PermRequired.WRITE,
     ),

--- a/tests/components/unifiprotect/conftest.py
+++ b/tests/components/unifiprotect/conftest.py
@@ -193,6 +193,8 @@ def mock_ufp_client(bootstrap: Bootstrap):
     client.public_bootstrap.sirens = {}
     client.public_bootstrap.arm_profiles = {}
     client.public_bootstrap.arm_mode = None
+    # No paired public device by default; tests opt in via setup_public_* helpers.
+    client.public_bootstrap.get = Mock(return_value=None)
 
     async def get_camera_rtsps_streams(
         camera_id: str, *args: Any, **kwargs: Any

--- a/tests/components/unifiprotect/test_number.py
+++ b/tests/components/unifiprotect/test_number.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 from unittest.mock import AsyncMock, Mock
 
 import pytest
-from uiprotect.data import Camera, Chime, IRLEDMode, Light, RingSetting
+from uiprotect.data import Camera, Chime, DeviceState, IRLEDMode, Light, RingSetting
 
 from homeassistant.components.unifiprotect.const import DEFAULT_ATTRIBUTION
 from homeassistant.components.unifiprotect.number import (
@@ -12,7 +12,13 @@ from homeassistant.components.unifiprotect.number import (
     LIGHT_NUMBERS,
     ProtectNumberEntityDescription,
 )
-from homeassistant.const import ATTR_ATTRIBUTION, ATTR_ENTITY_ID, Platform
+from homeassistant.const import (
+    ATTR_ATTRIBUTION,
+    ATTR_ENTITY_ID,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    Platform,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -23,7 +29,10 @@ from .utils import (
     assert_entity_counts,
     ids_from_device_description,
     init_entry,
+    make_public_light,
+    public_device_ws_message,
     remove_entities,
+    setup_public_light,
 )
 
 
@@ -61,6 +70,7 @@ async def test_number_setup_light(
 ) -> None:
     """Test number entity setup for light devices."""
 
+    setup_public_light(ufp)
     await init_entry(hass, ufp, [light])
     assert_entity_counts(hass, Platform.NUMBER, 2, 2)
 
@@ -171,8 +181,9 @@ async def test_number_light_sensitivity(
 async def test_number_light_duration(
     hass: HomeAssistant, ufp: MockUFPFixture, light: Light
 ) -> None:
-    """Test auto-shutoff duration number entity for lights."""
+    """Test auto-shutoff duration number entity for lights (public API)."""
 
+    setup_public_light(ufp)
     await init_entry(hass, ufp, [light])
     assert_entity_counts(hass, Platform.NUMBER, 2, 2)
 
@@ -182,7 +193,9 @@ async def test_number_light_duration(
         hass, Platform.NUMBER, light, description
     )
 
-    with patch_ufp_method(light, "set_duration", new_callable=AsyncMock) as mock_method:
+    with patch_ufp_method(
+        light, "set_duration_public", new_callable=AsyncMock
+    ) as mock_method:
         await hass.services.async_call(
             "number",
             "set_value",
@@ -191,6 +204,79 @@ async def test_number_light_duration(
         )
 
         mock_method.assert_called_once_with(timedelta(seconds=15.0))
+
+
+async def test_number_light_duration_public_value(
+    hass: HomeAssistant, ufp: MockUFPFixture, light: Light
+) -> None:
+    """Duration reads from the public object (ms) and refreshes on a public WS update."""
+
+    setup_public_light(ufp)
+    await init_entry(hass, ufp, [light])
+
+    _, entity_id = await ids_from_device_description(
+        hass, Platform.NUMBER, light, LIGHT_NUMBERS[1]
+    )
+
+    # A public value the private fixture (45 s) would not produce proves the source.
+    public = make_public_light(light, pir_duration_ms=30000)
+    ufp.devices_ws_subscription(public_device_ws_message(public))
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == "30"
+
+
+async def test_number_light_duration_unavailable_without_public(
+    hass: HomeAssistant, ufp: MockUFPFixture, light: Light
+) -> None:
+    """The migrated duration number is unavailable without a public object."""
+
+    await init_entry(hass, ufp, [light])
+
+    _, entity_id = await ids_from_device_description(
+        hass, Platform.NUMBER, light, LIGHT_NUMBERS[1]
+    )
+    assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
+
+
+async def test_number_light_duration_unavailable_on_public_disconnect(
+    hass: HomeAssistant, ufp: MockUFPFixture, light: Light
+) -> None:
+    """Duration availability follows the public object's connection state."""
+
+    setup_public_light(ufp)
+    await init_entry(hass, ufp, [light])
+
+    _, entity_id = await ids_from_device_description(
+        hass, Platform.NUMBER, light, LIGHT_NUMBERS[1]
+    )
+    assert hass.states.get(entity_id).state != STATE_UNAVAILABLE
+
+    public = make_public_light(light, state=DeviceState.DISCONNECTED)
+    ufp.devices_ws_subscription(public_device_ws_message(public))
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
+
+
+async def test_number_light_duration_none(
+    hass: HomeAssistant, ufp: MockUFPFixture, light: Light
+) -> None:
+    """A light that does not report a public duration leaves the number unknown."""
+
+    setup_public_light(ufp)
+    await init_entry(hass, ufp, [light])
+
+    _, entity_id = await ids_from_device_description(
+        hass, Platform.NUMBER, light, LIGHT_NUMBERS[1]
+    )
+
+    public = make_public_light(light)
+    public.light_device_settings.pir_duration = None
+    ufp.devices_ws_subscription(public_device_ws_message(public))
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == STATE_UNKNOWN
 
 
 @pytest.mark.parametrize("description", CAMERA_NUMBERS)

--- a/tests/components/unifiprotect/utils.py
+++ b/tests/components/unifiprotect/utils.py
@@ -12,6 +12,7 @@ from uiprotect.data import (
     DeviceState,
     Event,
     EventType,
+    Light,
     ModelType,
     ProtectAdoptableDeviceModel,
     ProtectModelWithId,
@@ -21,6 +22,8 @@ from uiprotect.data import (
 )
 from uiprotect.data.bootstrap import ProtectDeviceRef
 from uiprotect.data.public_devices import (
+    PublicLight,
+    PublicLightDeviceSettings,
     PublicSensor,
     PublicWirelessBatteryStatus,
     PublicWirelessConnectionState,
@@ -249,6 +252,37 @@ def make_public_sensor(
     return public
 
 
+def make_public_light(
+    light: Light,
+    *,
+    state: DeviceState | None = None,
+    pir_duration_ms: int | None = None,
+) -> Mock:
+    """Build a public-API light for the migrated PIR auto-shutoff duration number.
+
+    ``light_device_settings`` mirrors the private fixture (the public API reports
+    ``pir_duration`` in milliseconds); ``pir_duration_ms`` overrides it so a test
+    can assert a value the private object would not produce.
+    """
+    lds = light.light_device_settings
+    public = Mock(spec=PublicLight)
+    public.id = light.id
+    public.mac = light.mac
+    public.model = ModelType.LIGHT
+    public.state = DeviceState[light.state.name] if state is None else state
+    public.light_device_settings = PublicLightDeviceSettings(
+        is_indicator_enabled=lds.is_indicator_enabled,
+        led_level=lds.led_level,
+        pir_duration=(
+            round(lds.pir_duration.total_seconds() * 1000)
+            if pir_duration_ms is None
+            else pir_duration_ms
+        ),
+        pir_sensitivity=lds.pir_sensitivity,
+    )
+    return public
+
+
 def setup_public_sensor(ufp: MockUFPFixture) -> None:
     """Expose private sensors over the public API via a real ``PublicBootstrap``.
 
@@ -270,6 +304,33 @@ def setup_public_sensor(ufp: MockUFPFixture) -> None:
             and (private := ufp.api.bootstrap.sensors.get(obj_id)) is not None
         ):
             public_bootstrap.sensors[obj_id] = make_public_sensor(private)
+        return public_bootstrap.get(model, obj_id)
+
+    pb.get = _get
+    ufp.api.has_public_bootstrap = True
+    ufp.api.public_bootstrap = pb
+
+
+def setup_public_light(ufp: MockUFPFixture) -> None:
+    """Expose private lights over the public API via a real ``PublicBootstrap``.
+
+    Mirrors ``setup_public_sensor`` for ``ModelType.LIGHT`` so the migrated
+    FloodLight duration number reads from the public object.
+    """
+    public_bootstrap = PublicBootstrap()
+    pb = Mock(spec=PublicBootstrap)
+    pb.lights = public_bootstrap.lights
+    pb.relays = {}
+    pb.sirens = {}
+    pb.arm_mode = None
+    pb.arm_profiles = {}
+
+    def _get(model: ModelType, obj_id: str) -> ProtectModelWithId | None:
+        if (
+            model is ModelType.LIGHT
+            and (private := ufp.api.bootstrap.lights.get(obj_id)) is not None
+        ):
+            public_bootstrap.lights[obj_id] = make_public_light(private)
         return public_bootstrap.get(model, obj_id)
 
     pb.get = _get


### PR DESCRIPTION
## Proposed change

Add `ufp_public_value_fn` to `ProtectEntityDescription`: a callable variant of the
existing `ufp_public_value` attribute-path, for public-API values that need a
transform rather than a plain attribute read. It is wired through `get_value`
(precedence: function → path → private) and treated like `ufp_public_value` for the
public websocket subscription and availability.

Its first user migrates the UP FloodLight auto-shutoff **duration** number to the
public API: the value is read from `PublicLight.light_device_settings.pir_duration`
(reported in milliseconds, converted to seconds) and writes go through
`set_duration_public`. This continues the integration's move to the public API
(after battery #174229 and camera streams #174369); the remaining FloodLight
entities follow in separate PRs.

The test default for `public_bootstrap.get` now returns `None` (no paired public
object unless a test opts in via the `setup_public_*` helpers), matching real
behavior instead of returning a stale mock.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
