### PR TITLE
Use translated message when Matter Server add-on is not ready

### DIFF
--- a/homeassistant/components/matter/__init__.py
+++ b/homeassistant/components/matter/__init__.py
@@ -410,5 +410,8 @@ def _get_addon_manager(hass: HomeAssistant) -> AddonManager:
     """
     addon_manager: AddonManager = get_addon_manager(hass)
     if addon_manager.task_in_progress():
-        raise ConfigEntryNotReady
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN,
+            translation_key="addon_not_ready",
+        )
     return addon_manager

--- a/homeassistant/components/matter/__init__.py
+++ b/homeassistant/components/matter/__init__.py
@@ -389,11 +389,17 @@ async def _async_ensure_addon_running(
             addon_info.options,
             catch_error=True,
         )
-        raise ConfigEntryNotReady
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN,
+            translation_key="addon_not_installed",
+        )
 
     if addon_state is AddonState.NOT_RUNNING:
         addon_manager.async_schedule_start_addon(catch_error=True)
-        raise ConfigEntryNotReady
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN,
+            translation_key="addon_not_running",
+        )
 
 
 @callback

--- a/homeassistant/components/matter/strings.json
+++ b/homeassistant/components/matter/strings.json
@@ -704,6 +704,9 @@
     "addon_not_installed": {
       "message": "The Matter Server app is not installed yet."
     },
+    "addon_not_ready": {
+      "message": "The Matter Server app is not ready yet."
+    },
     "addon_not_running": {
       "message": "The Matter Server app is not running yet."
     },

--- a/homeassistant/components/matter/strings.json
+++ b/homeassistant/components/matter/strings.json
@@ -702,10 +702,10 @@
   },
   "exceptions": {
     "addon_not_installed": {
-      "message": "The Matter Server app is not installed."
+      "message": "The Matter Server app is not installed yet."
     },
     "addon_not_running": {
-      "message": "The Matter Server app is not running."
+      "message": "The Matter Server app is not running yet."
     },
     "credential_type_not_supported": {
       "message": "The lock does not support credential type `{credential_type}`."

--- a/homeassistant/components/matter/strings.json
+++ b/homeassistant/components/matter/strings.json
@@ -701,6 +701,12 @@
     }
   },
   "exceptions": {
+    "addon_not_installed": {
+      "message": "The Matter Server app is not installed."
+    },
+    "addon_not_running": {
+      "message": "The Matter Server app is not running."
+    },
     "credential_type_not_supported": {
       "message": "The lock does not support credential type `{credential_type}`."
     },

--- a/tests/components/matter/test_init.py
+++ b/tests/components/matter/test_init.py
@@ -357,6 +357,7 @@ async def test_start_addon(
     await hass.async_block_till_done()
 
     assert entry.state is ConfigEntryState.SETUP_RETRY
+    assert entry.error_reason_translation_key == "addon_not_running"
     assert addon_info.call_count == 1
     assert install_addon.call_count == 0
     assert start_addon.call_count == 1
@@ -384,6 +385,7 @@ async def test_install_addon(
     await hass.async_block_till_done()
 
     assert entry.state is ConfigEntryState.SETUP_RETRY
+    assert entry.error_reason_translation_key == "addon_not_installed"
     assert addon_store_info.call_count == 2
     assert install_addon.call_count == 1
     assert install_addon.call_args == call("core_matter_server")

--- a/tests/components/matter/test_init.py
+++ b/tests/components/matter/test_init.py
@@ -325,6 +325,7 @@ async def test_raise_addon_task_in_progress(
     await asyncio.sleep(0.05)
 
     assert entry.state is ConfigEntryState.SETUP_RETRY
+    assert entry.error_reason_translation_key == "addon_not_ready"
     assert install_addon.call_count == 1
     assert start_addon.call_count == 0
 


### PR DESCRIPTION
## Breaking change


## Proposed change

When the Matter integration is configured to use the add-on and the Matter Server add-on is not running (e.g. while it restarts) or not yet installed, setup raised a bare `ConfigEntryNotReady`. Because the exception carried no message, the retry reason surfaced to the user as "Failed setup, will retry: None".

This adds translatable exception strings (`addon_not_running` / `addon_not_installed`) and passes `translation_domain`/`translation_key` to `ConfigEntryNotReady`, so the retry reason is localized and meaningful instead of `None`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
