### PR TITLE
Migrate select entity attributes to StrEnum

### DIFF
--- a/homeassistant/components/select/__init__.py
+++ b/homeassistant/components/select/__init__.py
@@ -25,6 +25,7 @@ from .const import (
     SERVICE_SELECT_LAST,
     SERVICE_SELECT_NEXT,
     SERVICE_SELECT_PREVIOUS,
+    SelectEntityCapabilityAttribute,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -121,7 +122,9 @@ CACHED_PROPERTIES_WITH_ATTR_ = {
 class SelectEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     """Representation of a Select entity."""
 
-    _entity_component_unrecorded_attributes = frozenset({ATTR_OPTIONS})
+    _entity_component_unrecorded_attributes = frozenset(
+        {SelectEntityCapabilityAttribute.OPTIONS}
+    )
 
     entity_description: SelectEntityDescription
     _attr_current_option: str | None = None
@@ -133,7 +136,7 @@ class SelectEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     def capability_attributes(self) -> dict[str, Any]:
         """Return capability attributes."""
         return {
-            ATTR_OPTIONS: self.options,
+            SelectEntityCapabilityAttribute.OPTIONS: self.options,
         }
 
     @property

--- a/homeassistant/components/select/const.py
+++ b/homeassistant/components/select/const.py
@@ -1,6 +1,15 @@
 """Provides the constants needed for the component."""
 
+from enum import StrEnum
+
 DOMAIN = "select"
+
+
+class SelectEntityCapabilityAttribute(StrEnum):
+    """Capability attributes for select entities."""
+
+    OPTIONS = "options"
+
 
 ATTR_CYCLE = "cycle"
 ATTR_OPTIONS = "options"

--- a/tests/components/airgradient/snapshots/test_select.ambr
+++ b/tests/components/airgradient/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '1',
         '8',
         '30',
@@ -49,7 +49,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Airgradient CO2 automatic baseline duration',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '1',
         '8',
         '30',
@@ -73,7 +73,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'cloud',
         'local',
       ]),
@@ -112,7 +112,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Airgradient Configuration source',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'cloud',
         'local',
       ]),
@@ -132,7 +132,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'ugm3',
         'us_aqi',
       ]),
@@ -171,7 +171,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Airgradient Display PM standard',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'ugm3',
         'us_aqi',
       ]),
@@ -191,7 +191,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'c',
         'f',
       ]),
@@ -230,7 +230,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Airgradient Display temperature unit',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'c',
         'f',
       ]),
@@ -250,7 +250,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'co2',
         'pm',
@@ -290,7 +290,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Airgradient LED bar mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'co2',
         'pm',
@@ -311,7 +311,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '12',
         '60',
         '120',
@@ -353,7 +353,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Airgradient NOx index learning offset',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '12',
         '60',
         '120',
@@ -376,7 +376,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '12',
         '60',
         '120',
@@ -418,7 +418,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Airgradient VOC index learning offset',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '12',
         '60',
         '120',
@@ -441,7 +441,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '1',
         '8',
         '30',
@@ -484,7 +484,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Airgradient CO2 automatic baseline duration',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '1',
         '8',
         '30',
@@ -508,7 +508,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'cloud',
         'local',
       ]),
@@ -547,7 +547,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Airgradient Configuration source',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'cloud',
         'local',
       ]),
@@ -567,7 +567,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '12',
         '60',
         '120',
@@ -609,7 +609,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Airgradient NOx index learning offset',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '12',
         '60',
         '120',
@@ -632,7 +632,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '12',
         '60',
         '120',
@@ -674,7 +674,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Airgradient VOC index learning offset',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '12',
         '60',
         '120',

--- a/tests/components/alexa_devices/snapshots/test_select.ambr
+++ b/tests/components/alexa_devices/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'all',
         'home',
         'off',
@@ -46,7 +46,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Echo Test Drop In',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'all',
         'home',
         'off',

--- a/tests/components/aosmith/snapshots/test_select.ambr
+++ b/tests/components/aosmith/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'level1',
         'level2',
@@ -47,7 +47,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'My water heater Hot Water+ level',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'level1',
         'level2',

--- a/tests/components/balboa/snapshots/test_select.ambr
+++ b/tests/components/balboa/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'low',
         'high',
       ]),
@@ -45,7 +45,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'FakeSpa Temperature range',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'low',
         'high',
       ]),

--- a/tests/components/cambridge_audio/snapshots/test_select.ambr
+++ b/tests/components/cambridge_audio/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Speaker A',
         'Speaker B',
         'Headphones',
@@ -46,7 +46,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Cambridge Audio CXNv2 Audio output',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Speaker A',
         'Speaker B',
         'Headphones',
@@ -67,7 +67,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'amplifier',
         'receiver',
         'off',
@@ -107,7 +107,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Cambridge Audio CXNv2 Control Bus mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'amplifier',
         'receiver',
         'off',
@@ -128,7 +128,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'bright',
         'dim',
         'off',
@@ -168,7 +168,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Cambridge Audio CXNv2 Display brightness',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'bright',
         'dim',
         'off',

--- a/tests/components/casper_glow/snapshots/test_select.ambr
+++ b/tests/components/casper_glow/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '15',
         '30',
         '45',
@@ -48,7 +48,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Jar Dimming time',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '15',
         '30',
         '45',

--- a/tests/components/compit/snapshots/test_select.ambr
+++ b/tests/components/compit/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'auto',
         'on',
@@ -46,7 +46,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Nano Color 2 Bypass',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'auto',
         'on',
@@ -67,7 +67,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'polish',
         'english',
       ]),
@@ -106,7 +106,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Nano Color 2 Language',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'polish',
         'english',
       ]),
@@ -126,7 +126,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'disabled',
         'eco',
         'hybrid',
@@ -166,7 +166,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'R 900 Operating mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'disabled',
         'eco',
         'hybrid',

--- a/tests/components/deconz/snapshots/test_select.ambr
+++ b/tests/components/deconz/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'leftright',
         'undirected',
       ]),
@@ -45,7 +45,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Aqara FP1 Device Mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'leftright',
         'undirected',
       ]),
@@ -65,7 +65,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'High',
         'Medium',
         'Low',
@@ -105,7 +105,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Aqara FP1 Sensitivity',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'High',
         'Medium',
         'Low',
@@ -126,7 +126,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'far',
         'medium',
         'near',
@@ -166,7 +166,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Aqara FP1 Trigger Distance',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'far',
         'medium',
         'near',
@@ -187,7 +187,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'leftright',
         'undirected',
       ]),
@@ -226,7 +226,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Aqara FP1 Device Mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'leftright',
         'undirected',
       ]),
@@ -246,7 +246,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'High',
         'Medium',
         'Low',
@@ -286,7 +286,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Aqara FP1 Sensitivity',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'High',
         'Medium',
         'Low',
@@ -307,7 +307,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'far',
         'medium',
         'near',
@@ -347,7 +347,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Aqara FP1 Trigger Distance',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'far',
         'medium',
         'near',
@@ -368,7 +368,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'leftright',
         'undirected',
       ]),
@@ -407,7 +407,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Aqara FP1 Device Mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'leftright',
         'undirected',
       ]),
@@ -427,7 +427,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'High',
         'Medium',
         'Low',
@@ -467,7 +467,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Aqara FP1 Sensitivity',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'High',
         'Medium',
         'Low',
@@ -488,7 +488,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'far',
         'medium',
         'near',
@@ -528,7 +528,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Aqara FP1 Trigger Distance',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'far',
         'medium',
         'near',
@@ -549,7 +549,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'auto',
         'speed_1',
@@ -593,7 +593,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'IKEA Starkvind Fan Mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'auto',
         'speed_1',

--- a/tests/components/ecovacs/snapshots/test_select.ambr
+++ b/tests/components/ecovacs/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Map 2',
         '1',
       ]),
@@ -45,7 +45,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'X8 PRO OMNI Active map',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Map 2',
         '1',
       ]),
@@ -65,7 +65,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'auto',
         'smart',
       ]),
@@ -104,7 +104,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'X8 PRO OMNI Auto-empty frequency',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'auto',
         'smart',
       ]),
@@ -124,7 +124,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'mop',
         'mop_after_vacuum',
         'vacuum',
@@ -165,7 +165,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'X8 PRO OMNI Work mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'mop',
         'mop_after_vacuum',
         'vacuum',
@@ -187,7 +187,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Map 2',
         '1',
       ]),
@@ -226,7 +226,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Dusty Active map',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Map 2',
         '1',
       ]),
@@ -246,7 +246,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'auto',
         'smart',
       ]),
@@ -285,7 +285,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Dusty Auto-empty frequency',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'auto',
         'smart',
       ]),
@@ -305,7 +305,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'low',
         'medium',
         'high',
@@ -345,7 +345,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Dusty Water flow level',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'low',
         'medium',
         'high',
@@ -366,7 +366,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Map 2',
         '1',
       ]),
@@ -405,7 +405,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Ozmo 950 Active map',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Map 2',
         '1',
       ]),
@@ -425,7 +425,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'low',
         'medium',
         'high',
@@ -466,7 +466,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Ozmo 950 Water flow level',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'low',
         'medium',
         'high',

--- a/tests/components/eheimdigital/snapshots/test_select.ambr
+++ b/tests/components/eheimdigital/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'manual',
         'pulse',
         'bio',
@@ -46,7 +46,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock classicVARIO Filter mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'manual',
         'pulse',
         'bio',
@@ -67,7 +67,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '400',
         '440',
         '480',
@@ -119,7 +119,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock filter Constant flow speed',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '400',
         '440',
         '480',
@@ -153,7 +153,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '400',
         '440',
         '480',
@@ -205,7 +205,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock filter Day speed',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '400',
         '440',
         '480',
@@ -239,7 +239,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'manual',
         'constant_flow',
         'pulse',
@@ -280,7 +280,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock filter Filter mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'manual',
         'constant_flow',
         'pulse',
@@ -302,7 +302,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '400',
         '440',
         '480',
@@ -354,7 +354,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock filter High pulse speed',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '400',
         '440',
         '480',
@@ -388,7 +388,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '400',
         '440',
         '480',
@@ -440,7 +440,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock filter Low pulse speed',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '400',
         '440',
         '480',
@@ -474,7 +474,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '35',
         '37.5',
         '40.5',
@@ -526,7 +526,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock filter Manual speed',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '35',
         '37.5',
         '40.5',
@@ -560,7 +560,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '400',
         '440',
         '480',
@@ -612,7 +612,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock filter Night speed',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '400',
         '440',
         '480',
@@ -646,7 +646,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'constant',
         'daycycle',
       ]),
@@ -685,7 +685,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock reeflex Operation mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'constant',
         'daycycle',
       ]),

--- a/tests/components/enphase_envoy/snapshots/test_select.ambr
+++ b/tests/components/enphase_envoy/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'backup',
         'self_consumption',
         'savings',
@@ -46,7 +46,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Envoy 1234 Storage mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'backup',
         'self_consumption',
         'savings',
@@ -67,7 +67,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'backup',
         'self_consumption',
         'savings',
@@ -107,7 +107,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Enpower 654321 Storage mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'backup',
         'self_consumption',
         'savings',
@@ -128,7 +128,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'powered',
         'not_powered',
         'schedule',
@@ -169,7 +169,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'NC1 Fixture Generator action',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'powered',
         'not_powered',
         'schedule',
@@ -191,7 +191,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'powered',
         'not_powered',
         'schedule',
@@ -232,7 +232,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'NC1 Fixture Grid action',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'powered',
         'not_powered',
         'schedule',
@@ -254,7 +254,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'powered',
         'not_powered',
         'schedule',
@@ -295,7 +295,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'NC1 Fixture Microgrid action',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'powered',
         'not_powered',
         'schedule',
@@ -317,7 +317,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'standard',
         'battery',
       ]),
@@ -356,7 +356,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'NC1 Fixture Mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'standard',
         'battery',
       ]),
@@ -376,7 +376,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'powered',
         'not_powered',
         'schedule',
@@ -417,7 +417,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'NC2 Fixture Generator action',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'powered',
         'not_powered',
         'schedule',
@@ -439,7 +439,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'powered',
         'not_powered',
         'schedule',
@@ -480,7 +480,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'NC2 Fixture Grid action',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'powered',
         'not_powered',
         'schedule',
@@ -502,7 +502,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'powered',
         'not_powered',
         'schedule',
@@ -543,7 +543,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'NC2 Fixture Microgrid action',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'powered',
         'not_powered',
         'schedule',
@@ -565,7 +565,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'standard',
         'battery',
       ]),
@@ -604,7 +604,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'NC2 Fixture Mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'standard',
         'battery',
       ]),
@@ -624,7 +624,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'powered',
         'not_powered',
         'schedule',
@@ -665,7 +665,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'NC3 Fixture Generator action',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'powered',
         'not_powered',
         'schedule',
@@ -687,7 +687,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'powered',
         'not_powered',
         'schedule',
@@ -728,7 +728,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'NC3 Fixture Grid action',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'powered',
         'not_powered',
         'schedule',
@@ -750,7 +750,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'powered',
         'not_powered',
         'schedule',
@@ -791,7 +791,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'NC3 Fixture Microgrid action',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'powered',
         'not_powered',
         'schedule',
@@ -813,7 +813,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'standard',
         'battery',
       ]),
@@ -852,7 +852,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'NC3 Fixture Mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'standard',
         'battery',
       ]),

--- a/tests/components/gardena_bluetooth/snapshots/test_select.ambr
+++ b/tests/components/gardena_bluetooth/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'position_1',
         'position_2',
         'position_3',
@@ -48,7 +48,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Title Active position',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'position_1',
         'position_2',
         'position_3',
@@ -71,7 +71,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'active',
         'manual_mode',
         'pre_winter',
@@ -112,7 +112,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Title Operation mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'active',
         'manual_mode',
         'pre_winter',
@@ -134,7 +134,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'preview',
         'setup_mode',
         'rest',
@@ -179,7 +179,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Title Watering',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'preview',
         'setup_mode',
         'rest',

--- a/tests/components/hdfury/snapshots/test_select.ambr
+++ b/tests/components/hdfury/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -49,7 +49,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'HDFury VRROOM-02 Operation mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -73,7 +73,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -115,7 +115,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'HDFury VRROOM-02 Port select TX0',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -138,7 +138,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -180,7 +180,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'HDFury VRROOM-02 Port select TX1',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',

--- a/tests/components/homee/snapshots/test_select.ambr
+++ b/tests/components/homee/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'target',
         'current',
       ]),
@@ -45,7 +45,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Select Displayed temperature',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'target',
         'current',
       ]),
@@ -65,7 +65,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'level1',
         'level2',
@@ -105,7 +105,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Select Repeater mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'level1',
         'level2',

--- a/tests/components/homekit_controller/snapshots/test_init.ambr
+++ b/tests/components/homekit_controller/snapshots/test_init.ambr
@@ -139,7 +139,7 @@
             ]),
             'area_id': None,
             'capabilities': dict({
-              'options': list([
+              <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
                 'automatic',
                 'manual',
               ]),
@@ -176,7 +176,7 @@
           'state': dict({
             'attributes': dict({
               'friendly_name': 'Airversa AP2 1808 Air Purifier Mode',
-              'options': list([
+              <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
                 'automatic',
                 'manual',
               ]),
@@ -3813,7 +3813,7 @@
             ]),
             'area_id': None,
             'capabilities': dict({
-              'options': list([
+              <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
                 'home',
                 'sleep',
                 'away',
@@ -3851,7 +3851,7 @@
           'state': dict({
             'attributes': dict({
               'friendly_name': 'HomeW Current Mode',
-              'options': list([
+              <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
                 'home',
                 'sleep',
                 'away',
@@ -3868,7 +3868,7 @@
             ]),
             'area_id': None,
             'capabilities': dict({
-              'options': list([
+              <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
                 'celsius',
                 'fahrenheit',
               ]),
@@ -3905,7 +3905,7 @@
           'state': dict({
             'attributes': dict({
               'friendly_name': 'HomeW Temperature Display Units',
-              'options': list([
+              <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
                 'celsius',
                 'fahrenheit',
               ]),
@@ -7226,7 +7226,7 @@
             ]),
             'area_id': None,
             'capabilities': dict({
-              'options': list([
+              <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
                 'home',
                 'sleep',
                 'away',
@@ -7264,7 +7264,7 @@
           'state': dict({
             'attributes': dict({
               'friendly_name': 'Thermostat Current Mode',
-              'options': list([
+              <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
                 'home',
                 'sleep',
                 'away',
@@ -7281,7 +7281,7 @@
             ]),
             'area_id': None,
             'capabilities': dict({
-              'options': list([
+              <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
                 'celsius',
                 'fahrenheit',
               ]),
@@ -7318,7 +7318,7 @@
           'state': dict({
             'attributes': dict({
               'friendly_name': 'Thermostat Temperature Display Units',
-              'options': list([
+              <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
                 'celsius',
                 'fahrenheit',
               ]),
@@ -8257,7 +8257,7 @@
             ]),
             'area_id': None,
             'capabilities': dict({
-              'options': list([
+              <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
                 'home',
                 'sleep',
                 'away',
@@ -8295,7 +8295,7 @@
           'state': dict({
             'attributes': dict({
               'friendly_name': 'HomeW Current Mode',
-              'options': list([
+              <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
                 'home',
                 'sleep',
                 'away',
@@ -8312,7 +8312,7 @@
             ]),
             'area_id': None,
             'capabilities': dict({
-              'options': list([
+              <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
                 'celsius',
                 'fahrenheit',
               ]),
@@ -8349,7 +8349,7 @@
           'state': dict({
             'attributes': dict({
               'friendly_name': 'HomeW Temperature Display Units',
-              'options': list([
+              <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
                 'celsius',
                 'fahrenheit',
               ]),
@@ -8744,7 +8744,7 @@
             ]),
             'area_id': None,
             'capabilities': dict({
-              'options': list([
+              <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
                 'celsius',
                 'fahrenheit',
               ]),
@@ -8781,7 +8781,7 @@
           'state': dict({
             'attributes': dict({
               'friendly_name': 'HomeW Temperature Display Units',
-              'options': list([
+              <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
                 'celsius',
                 'fahrenheit',
               ]),
@@ -9546,7 +9546,7 @@
             ]),
             'area_id': None,
             'capabilities': dict({
-              'options': list([
+              <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
                 'home',
                 'sleep',
                 'away',
@@ -9584,7 +9584,7 @@
           'state': dict({
             'attributes': dict({
               'friendly_name': 'My ecobee Current Mode',
-              'options': list([
+              <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
                 'home',
                 'sleep',
                 'away',
@@ -9601,7 +9601,7 @@
             ]),
             'area_id': None,
             'capabilities': dict({
-              'options': list([
+              <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
                 'celsius',
                 'fahrenheit',
               ]),
@@ -9638,7 +9638,7 @@
           'state': dict({
             'attributes': dict({
               'friendly_name': 'My ecobee Temperature Display Units',
-              'options': list([
+              <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
                 'celsius',
                 'fahrenheit',
               ]),
@@ -10207,7 +10207,7 @@
             ]),
             'area_id': None,
             'capabilities': dict({
-              'options': list([
+              <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
                 'celsius',
                 'fahrenheit',
               ]),
@@ -10244,7 +10244,7 @@
           'state': dict({
             'attributes': dict({
               'friendly_name': 'Eve Degree AA11 Temperature Display Units',
-              'options': list([
+              <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
                 'celsius',
                 'fahrenheit',
               ]),
@@ -12173,7 +12173,7 @@
             ]),
             'area_id': None,
             'capabilities': dict({
-              'options': list([
+              <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
                 'celsius',
                 'fahrenheit',
               ]),
@@ -12210,7 +12210,7 @@
           'state': dict({
             'attributes': dict({
               'friendly_name': '89 Living Room Temperature Display Units',
-              'options': list([
+              <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
                 'celsius',
                 'fahrenheit',
               ]),
@@ -13875,7 +13875,7 @@
             ]),
             'area_id': None,
             'capabilities': dict({
-              'options': list([
+              <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
                 'celsius',
                 'fahrenheit',
               ]),
@@ -13912,7 +13912,7 @@
           'state': dict({
             'attributes': dict({
               'friendly_name': '89 Living Room Temperature Display Units',
-              'options': list([
+              <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
                 'celsius',
                 'fahrenheit',
               ]),
@@ -18040,7 +18040,7 @@
             ]),
             'area_id': None,
             'capabilities': dict({
-              'options': list([
+              <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
                 'celsius',
                 'fahrenheit',
               ]),
@@ -18077,7 +18077,7 @@
           'state': dict({
             'attributes': dict({
               'friendly_name': 'Lennox Temperature Display Units',
-              'options': list([
+              <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
                 'celsius',
                 'fahrenheit',
               ]),
@@ -19239,7 +19239,7 @@
             ]),
             'area_id': None,
             'capabilities': dict({
-              'options': list([
+              <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
                 'celsius',
                 'fahrenheit',
               ]),
@@ -19276,7 +19276,7 @@
           'state': dict({
             'attributes': dict({
               'friendly_name': 'Mysa-85dda9 Temperature Display Units',
-              'options': list([
+              <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
                 'celsius',
                 'fahrenheit',
               ]),

--- a/tests/components/homewizard/snapshots/test_select.ambr
+++ b/tests/components/homewizard/snapshots/test_select.ambr
@@ -3,7 +3,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device Battery group charging strategy',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'standby',
         'to_full',
         'zero',
@@ -24,7 +24,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'standby',
         'to_full',
         'zero',

--- a/tests/components/hr_energy_qube/snapshots/test_select.ambr
+++ b/tests/components/hr_energy_qube/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'block',
         'plus',
@@ -47,7 +47,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Qube heat pump Smart grid ready mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'block',
         'plus',

--- a/tests/components/imeon_inverter/snapshots/test_select.ambr
+++ b/tests/components/imeon_inverter/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'smart_grid',
         'backup',
         'on_grid',
@@ -47,7 +47,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Imeon inverter Inverter mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'smart_grid',
         'backup',
         'on_grid',

--- a/tests/components/indevolt/snapshots/test_select.ambr
+++ b/tests/components/indevolt/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'self_consumed_prioritized',
         'real_time_control',
         'charge_discharge_schedule',
@@ -46,7 +46,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'BK1600 Energy mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'self_consumed_prioritized',
         'real_time_control',
         'charge_discharge_schedule',
@@ -67,7 +67,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'self_consumed_prioritized',
         'real_time_control',
         'charge_discharge_schedule',
@@ -107,7 +107,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'CMS-SF2000 Energy mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'self_consumed_prioritized',
         'real_time_control',
         'charge_discharge_schedule',

--- a/tests/components/intelliclima/snapshots/test_select.ambr
+++ b/tests/components/intelliclima/snapshots/test_select.ambr
@@ -45,7 +45,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'forward',
         'reverse',
         'alternate',
@@ -86,7 +86,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test VMC Fan direction mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'forward',
         'reverse',
         'alternate',

--- a/tests/components/iron_os/snapshots/test_select.ambr
+++ b/tests/components/iron_os/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'slow',
         'medium',
@@ -47,7 +47,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Pinecil Animation speed',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'slow',
         'medium',
@@ -69,7 +69,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'seconds_1',
         'seconds_2',
@@ -113,7 +113,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Pinecil Boot logo duration',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'seconds_1',
         'seconds_2',
@@ -138,7 +138,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'boost_only',
         'full_locking',
@@ -178,7 +178,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Pinecil Button locking mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'boost_only',
         'full_locking',
@@ -199,7 +199,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'right_handed',
         'left_handed',
         'auto',
@@ -239,7 +239,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Pinecil Display orientation mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'right_handed',
         'left_handed',
         'auto',
@@ -260,7 +260,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'on',
         'safe',
@@ -300,7 +300,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Pinecil Power Delivery 3.1 EPR',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'on',
         'safe',
@@ -321,7 +321,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'no_battery',
         'battery_3s',
         'battery_4s',
@@ -363,7 +363,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Pinecil Power source',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'no_battery',
         'battery_3s',
         'battery_4s',
@@ -386,7 +386,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'slow',
         'fast',
       ]),
@@ -425,7 +425,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Pinecil Scrolling speed',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'slow',
         'fast',
       ]),
@@ -445,7 +445,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'auto',
         'ts100_long',
         'pine_short',
@@ -486,7 +486,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Pinecil Soldering tip type',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'auto',
         'ts100_long',
         'pine_short',
@@ -508,7 +508,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'disabled',
         'soldering',
         'sleeping',
@@ -549,7 +549,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Pinecil Start-up behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'disabled',
         'soldering',
         'sleeping',
@@ -571,7 +571,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'celsius',
         'fahrenheit',
       ]),
@@ -610,7 +610,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Pinecil Temperature display unit',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'celsius',
         'fahrenheit',
       ]),

--- a/tests/components/lamarzocco/snapshots/test_bluetooth.ambr
+++ b/tests/components/lamarzocco/snapshots/test_bluetooth.ambr
@@ -235,7 +235,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'MR012345 Steam level',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '1',
         '2',
         '3',

--- a/tests/components/lamarzocco/snapshots/test_select.ambr
+++ b/tests/components/lamarzocco/snapshots/test_select.ambr
@@ -3,7 +3,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'LM012345 Brew by weight dose mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'continuous',
         'dose1',
         'dose2',
@@ -24,7 +24,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'continuous',
         'dose1',
         'dose2',
@@ -64,7 +64,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'GS012345 Prebrew/-infusion mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'disabled',
         'prebrew',
         'preinfusion',
@@ -85,7 +85,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'disabled',
         'prebrew',
         'preinfusion',
@@ -125,7 +125,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'MR012345 Prebrew/-infusion mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'disabled',
         'prebrew',
         'preinfusion',
@@ -146,7 +146,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'disabled',
         'prebrew',
         'preinfusion',
@@ -186,7 +186,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'LM012345 Prebrew/-infusion mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'disabled',
         'prebrew',
         'preinfusion',
@@ -207,7 +207,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'disabled',
         'prebrew',
         'preinfusion',
@@ -247,7 +247,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'GS012345 Smart standby mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_on',
         'last_brewing',
       ]),
@@ -267,7 +267,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_on',
         'last_brewing',
       ]),
@@ -306,7 +306,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'MR012345 Steam level',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '1',
         '2',
         '3',
@@ -327,7 +327,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '1',
         '2',
         '3',

--- a/tests/components/lektrico/snapshots/test_select.ambr
+++ b/tests/components/lektrico/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'disabled',
         'power',
         'hybrid',
@@ -47,7 +47,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': '1p7k_500006 Load balancing mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'disabled',
         'power',
         'hybrid',

--- a/tests/components/letpot/snapshots/test_select.ambr
+++ b/tests/components/letpot/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'low',
         'high',
       ]),
@@ -45,7 +45,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Garden Light brightness',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'low',
         'high',
       ]),
@@ -65,7 +65,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'flower',
         'vegetable',
       ]),
@@ -104,7 +104,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Garden Light mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'flower',
         'vegetable',
       ]),
@@ -124,7 +124,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'flower',
         'vegetable',
       ]),
@@ -163,7 +163,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Garden Light mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'flower',
         'vegetable',
       ]),
@@ -183,7 +183,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'fahrenheit',
         'celsius',
       ]),
@@ -222,7 +222,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Garden Temperature unit on display',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'fahrenheit',
         'celsius',
       ]),

--- a/tests/components/liebherr/snapshots/test_select.ambr
+++ b/tests/components/liebherr/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'on',
         'max_ice',
@@ -46,7 +46,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Fridge Bottom zone IceMaker',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'on',
         'max_ice',
@@ -67,7 +67,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'zero_zero',
         'zero_minus_two',
         'minus_two_minus_two',
@@ -108,7 +108,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Fridge Top zone BioFresh-Plus',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'zero_zero',
         'zero_minus_two',
         'minus_two_minus_two',
@@ -130,7 +130,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'low',
         'medium',
@@ -171,7 +171,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Fridge Top zone HydroBreeze',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'low',
         'medium',
@@ -193,7 +193,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'low',
         'medium',
@@ -234,7 +234,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Single Zone Fridge HydroBreeze',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'low',
         'medium',
@@ -256,7 +256,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'on',
       ]),
@@ -295,7 +295,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Single Zone Fridge IceMaker',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'on',
       ]),

--- a/tests/components/lutron/snapshots/test_select.ambr
+++ b/tests/components/lutron/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'on',
         'slow_flash',
@@ -47,7 +47,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Keypad Test Button LED',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'on',
         'slow_flash',

--- a/tests/components/matter/snapshots/test_select.ambr
+++ b/tests/components/matter/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Celsius',
         'Fahrenheit',
       ]),
@@ -45,7 +45,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Floor Heating Thermostat Temperature display mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Celsius',
         'Fahrenheit',
       ]),
@@ -65,7 +65,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'normal',
         'no_remote_lock_unlock',
       ]),
@@ -104,7 +104,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Aqara Smart Lock U200 Operating mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'normal',
         'no_remote_lock_unlock',
       ]),
@@ -124,7 +124,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Dark',
         'Medium',
         'Light',
@@ -164,7 +164,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Color Temperature Light Lighting',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Dark',
         'Medium',
         'Light',
@@ -185,7 +185,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -226,7 +226,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Color Temperature Light Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -248,7 +248,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Vacuum & Mop',
         'Vacuum-Only',
         'Mop after Vacuum',
@@ -288,7 +288,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'ecodeebot Clean mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Vacuum & Mop',
         'Vacuum-Only',
         'Mop after Vacuum',
@@ -309,7 +309,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Auto Mop & Vacuum',
         'Auto Vacuum',
         'Auto Deep Mop & Vacuum',
@@ -354,7 +354,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': '2BAVS-AB6031X-44PE Clean mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Auto Mop & Vacuum',
         'Auto Vacuum',
         'Auto Deep Mop & Vacuum',
@@ -380,7 +380,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -421,7 +421,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Eve Energy 20ECN4101 Power-on behavior (bottom)',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -443,7 +443,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -484,7 +484,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Eve Energy 20ECN4101 Power-on behavior (top)',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -506,7 +506,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -547,7 +547,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Eve Energy Plug Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -569,7 +569,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -610,7 +610,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Eve Energy Plug Patched Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -632,7 +632,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Celsius',
         'Fahrenheit',
       ]),
@@ -671,7 +671,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Eve Thermo 20EBP1701 Temperature display mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Celsius',
         'Fahrenheit',
       ]),
@@ -691,7 +691,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Celsius',
         'Fahrenheit',
       ]),
@@ -730,7 +730,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Eve Thermo 20ECD1701 Temperature display mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Celsius',
         'Fahrenheit',
       ]),
@@ -750,7 +750,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Dark',
         'Medium',
         'Light',
@@ -790,7 +790,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Extended Color Light Lighting',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Dark',
         'Medium',
         'Light',
@@ -811,7 +811,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -852,7 +852,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Extended Color Light Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -874,7 +874,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'No Delay',
         '300ms',
         '400ms',
@@ -919,7 +919,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'White Series OnOff Switch Button Press Delay',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'No Delay',
         '300ms',
         '400ms',
@@ -945,7 +945,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Instant',
         '500ms',
         '800ms',
@@ -997,7 +997,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'White Series OnOff Switch Dimming Speed',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Instant',
         '500ms',
         '800ms',
@@ -1030,7 +1030,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Red',
         'Orange',
         'Lemon',
@@ -1080,7 +1080,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'White Series OnOff Switch LED Color',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Red',
         'Orange',
         'Lemon',
@@ -1111,7 +1111,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Solid',
         'Fast Blink',
         'Slow Blink',
@@ -1165,7 +1165,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'White Series OnOff Switch LED Effect',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Solid',
         'Fast Blink',
         'Slow Blink',
@@ -1200,7 +1200,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Local Protection Disable',
         'Local Protection Enable',
       ]),
@@ -1239,7 +1239,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'White Series OnOff Switch Local Protection',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Local Protection Disable',
         'Local Protection Enable',
       ]),
@@ -1259,7 +1259,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Local Timer Disable',
         'Local Timer Enable',
       ]),
@@ -1298,7 +1298,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'White Series OnOff Switch Local Timer',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Local Timer Disable',
         'Local Timer Enable',
       ]),
@@ -1318,7 +1318,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -1359,7 +1359,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'White Series OnOff Switch Power-on behavior (Load Control)',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -1381,7 +1381,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -1422,7 +1422,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'White Series OnOff Switch Power-on behavior (RGB Indicator)',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -1444,7 +1444,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Smart Bulb Disable',
         'Smart Bulb Enable',
       ]),
@@ -1483,7 +1483,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'White Series OnOff Switch Smart Bulb Mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Smart Bulb Disable',
         'Smart Bulb Enable',
       ]),
@@ -1503,7 +1503,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'On/Off+Single',
         'On/Off+AUX',
         'Dimmer+Single',
@@ -1544,7 +1544,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'White Series OnOff Switch Switch Mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'On/Off+Single',
         'On/Off+AUX',
         'Dimmer+Single',
@@ -1566,7 +1566,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Leading',
         'Trailing',
       ]),
@@ -1605,7 +1605,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Inovelli Dimming Edge',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Leading',
         'Trailing',
       ]),
@@ -1625,7 +1625,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Instant',
         '500ms',
         '800ms',
@@ -1677,7 +1677,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Inovelli Dimming Speed',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Instant',
         '500ms',
         '800ms',
@@ -1710,7 +1710,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Red',
         'Orange',
         'Lemon',
@@ -1760,7 +1760,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Inovelli LED Color',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Red',
         'Orange',
         'Lemon',
@@ -1791,7 +1791,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -1832,7 +1832,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Inovelli Power-on behavior (1)',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -1854,7 +1854,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -1895,7 +1895,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Inovelli Power-on behavior (6)',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -1917,7 +1917,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Relay Click Enable',
         'Relay Click Disable',
       ]),
@@ -1956,7 +1956,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Inovelli Relay',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Relay Click Enable',
         'Relay Click Disable',
       ]),
@@ -1976,7 +1976,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Smart Bulb Disable',
         'Smart Bulb Enable',
       ]),
@@ -2015,7 +2015,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Inovelli Smart Bulb Mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Smart Bulb Disable',
         'Smart Bulb Enable',
       ]),
@@ -2035,7 +2035,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'OnOff+Single',
         'OnOff+Dumb',
         'OnOff+AUX',
@@ -2079,7 +2079,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Inovelli Switch Mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'OnOff+Single',
         'OnOff+Dumb',
         'OnOff+AUX',
@@ -2104,7 +2104,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Celsius',
         'Fahrenheit',
       ]),
@@ -2143,7 +2143,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Longan link HVAC Temperature display mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Celsius',
         'Fahrenheit',
       ]),
@@ -2163,7 +2163,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Low',
         'Medium',
         'High',
@@ -2203,7 +2203,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Cooktop Temperature level',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Low',
         'Medium',
         'High',
@@ -2224,7 +2224,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Red',
         'Orange',
         'Lemon',
@@ -2274,7 +2274,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Dimmable Light LED Color',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Red',
         'Orange',
         'Lemon',
@@ -2305,7 +2305,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -2346,7 +2346,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Dimmable Light Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -2368,7 +2368,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -2409,7 +2409,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Dimmable Plugin Unit Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -2431,7 +2431,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'normal',
         'no_remote_lock_unlock',
       ]),
@@ -2470,7 +2470,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Door Lock Operating mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'normal',
         'no_remote_lock_unlock',
       ]),
@@ -2490,7 +2490,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -2531,7 +2531,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Door Lock Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -2553,7 +2553,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'silent',
         'low',
         'medium',
@@ -2594,7 +2594,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Door Lock Sound volume',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'silent',
         'low',
         'medium',
@@ -2616,7 +2616,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'normal',
         'no_remote_lock_unlock',
       ]),
@@ -2655,7 +2655,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Door Lock with unbolt Operating mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'normal',
         'no_remote_lock_unlock',
       ]),
@@ -2675,7 +2675,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -2716,7 +2716,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Door Lock with unbolt Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -2738,7 +2738,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'silent',
         'low',
         'medium',
@@ -2779,7 +2779,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Door Lock with unbolt Sound volume',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'silent',
         'low',
         'medium',
@@ -2801,7 +2801,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Low',
         'Medium',
         'High',
@@ -2841,7 +2841,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Laundrydryer Temperature level',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Low',
         'Medium',
         'High',
@@ -2862,7 +2862,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'normal',
         'no_remote_lock_unlock',
       ]),
@@ -2901,7 +2901,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Lock Operating mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'normal',
         'no_remote_lock_unlock',
       ]),
@@ -2921,7 +2921,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'silent',
         'low',
         'medium',
@@ -2962,7 +2962,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Lock Sound volume',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'silent',
         'low',
         'medium',
@@ -2984,7 +2984,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '100',
         '200',
         '300',
@@ -3031,7 +3031,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Microwave Oven Power level (W)',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '100',
         '200',
         '300',
@@ -3059,7 +3059,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -3100,7 +3100,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Mounted dimmable load control Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -3122,7 +3122,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -3163,7 +3163,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock OnOffPluginUnit Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -3185,7 +3185,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -3226,7 +3226,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock OnOff Light Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -3248,7 +3248,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -3289,7 +3289,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock OnOff Light Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -3311,7 +3311,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -3352,7 +3352,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Light Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -3374,7 +3374,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Bake',
         'Convection',
         'Grill',
@@ -3420,7 +3420,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Oven Mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Bake',
         'Convection',
         'Grill',
@@ -3447,7 +3447,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Low',
         'Medium',
         'High',
@@ -3487,7 +3487,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Oven Temperature level',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Low',
         'Medium',
         'High',
@@ -3508,7 +3508,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'normal',
         'minimum',
         'maximum',
@@ -3549,7 +3549,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Pump mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'normal',
         'minimum',
         'maximum',
@@ -3571,7 +3571,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -3612,7 +3612,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock SwitchUnit Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -3634,7 +3634,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Celsius',
         'Fahrenheit',
       ]),
@@ -3673,7 +3673,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Thermostat Temperature display mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Celsius',
         'Fahrenheit',
       ]),
@@ -3693,7 +3693,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Quick',
         'Auto',
         'Deep Clean',
@@ -3735,7 +3735,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Vacuum Clean mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Quick',
         'Auto',
         'Deep Clean',
@@ -3758,7 +3758,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -3799,7 +3799,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'D215S Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -3821,7 +3821,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Quiet, Vacuum Only',
         'Auto, Vacuum Only',
         'Deep Clean, Vacuum Only',
@@ -3867,7 +3867,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Robotic Vacuum Cleaner Clean mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Quiet, Vacuum Only',
         'Auto, Vacuum Only',
         'Deep Clean, Vacuum Only',
@@ -3894,7 +3894,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'normal',
         'privacy',
         'no_remote_lock_unlock',
@@ -3934,7 +3934,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Secuyou Smart Lock Operating mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'normal',
         'privacy',
         'no_remote_lock_unlock',
@@ -3955,7 +3955,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'No energy management (forecast only)',
         'Device optimizes (no local or grid control)',
         'Optimized within building',
@@ -3997,7 +3997,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'evse Energy management mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'No energy management (forecast only)',
         'Device optimizes (no local or grid control)',
         'Optimized within building',
@@ -4020,7 +4020,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Manual',
         'Auto-scheduled',
         'Solar',
@@ -4061,7 +4061,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'evse Mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Manual',
         'Auto-scheduled',
         'Solar',
@@ -4083,7 +4083,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'normal',
       ]),
@@ -4122,7 +4122,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'LaundryWasher Number of rinses',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'normal',
       ]),
@@ -4142,7 +4142,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Off',
         'Low',
         'Medium',
@@ -4183,7 +4183,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'LaundryWasher Spin speed',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Off',
         'Low',
         'Medium',
@@ -4205,7 +4205,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Cold',
         'Colors',
         'Whites',
@@ -4245,7 +4245,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'LaundryWasher Temperature level',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Cold',
         'Colors',
         'Whites',
@@ -4266,7 +4266,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -4307,7 +4307,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'SL-RangeHood Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -4329,7 +4329,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Normal',
         'Rapid Cool',
         'Rapid Freeze',
@@ -4369,7 +4369,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Refrigerator Mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Normal',
         'Rapid Cool',
         'Rapid Freeze',
@@ -4390,7 +4390,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'No energy management (forecast only)',
         'Device optimizes (no local or grid control)',
         'Optimized within building',
@@ -4432,7 +4432,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Water Heater Energy management mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'No energy management (forecast only)',
         'Device optimizes (no local or grid control)',
         'Optimized within building',
@@ -4455,7 +4455,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Quick',
         'Auto',
         'Deep Clean',
@@ -4497,7 +4497,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'K11+ Clean mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Quick',
         'Auto',
         'Deep Clean',
@@ -4520,7 +4520,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',
@@ -4561,7 +4561,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'YNDX-00540 Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'toggle',

--- a/tests/components/miele/snapshots/test_select.ambr
+++ b/tests/components/miele/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'normal',
         'sabbath',
       ]),
@@ -45,7 +45,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Freezer Mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'normal',
         'sabbath',
       ]),
@@ -65,7 +65,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'normal',
         'sabbath',
       ]),
@@ -104,7 +104,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Refrigerator Mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'normal',
         'sabbath',
       ]),

--- a/tests/components/music_assistant/snapshots/test_select.ambr
+++ b/tests/components/music_assistant/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'audio_sync_translation',
         'balanced_translation',
         'lip_sync_translation',
@@ -46,7 +46,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Player 1 Link audio delay',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'audio_sync_translation',
         'balanced_translation',
         'lip_sync_translation',

--- a/tests/components/myneomitis/snapshots/test_select.ambr
+++ b/tests/components/myneomitis/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'comfort',
         'eco',
         'antifrost',
@@ -53,7 +53,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Pilote Device',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'comfort',
         'eco',
         'antifrost',
@@ -81,7 +81,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'auto',
@@ -121,7 +121,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Relais Device',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
         'auto',
@@ -142,7 +142,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'heating',
         'cooling',
       ]),
@@ -181,7 +181,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'UFH Device',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'heating',
         'cooling',
       ]),

--- a/tests/components/myuplink/snapshots/test_select.ambr
+++ b/tests/components/myuplink/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Smart control',
         'Economy',
         'Normal',
@@ -47,7 +47,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Gotham City comfort mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Smart control',
         'Economy',
         'Normal',
@@ -69,7 +69,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Smart control',
         'Economy',
         'Normal',
@@ -110,7 +110,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Gotham City comfort mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Smart control',
         'Economy',
         'Normal',

--- a/tests/components/netatmo/snapshots/test_select.ambr
+++ b/tests/components/netatmo/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Default',
         'Winter',
       ]),
@@ -46,7 +46,7 @@
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by Netatmo',
       'friendly_name': 'MYHOME',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Default',
         'Winter',
       ]),

--- a/tests/components/nintendo_parental_controls/snapshots/test_select.ambr
+++ b/tests/components/nintendo_parental_controls/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'daily',
         'each_day_of_the_week',
       ]),
@@ -45,7 +45,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Home Assistant Test Restriction mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'daily',
         'each_day_of_the_week',
       ]),

--- a/tests/components/nobo_hub/snapshots/test_select.ambr
+++ b/tests/components/nobo_hub/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Default',
       ]),
     }),
@@ -44,7 +44,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Living room Week profile',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Default',
       ]),
     }),
@@ -63,7 +63,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'away',
         'comfort',
@@ -105,7 +105,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'nobo_hub__override',
       'friendly_name': 'My Eco Hub Global override',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'away',
         'comfort',

--- a/tests/components/ohme/snapshots/test_select.ambr
+++ b/tests/components/ohme/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'smart_charge',
         'max_charge',
         'paused',
@@ -46,7 +46,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Ohme Home Pro Charge mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'smart_charge',
         'max_charge',
         'paused',
@@ -67,7 +67,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Nissan Leaf',
         'Tesla Model 3',
       ]),
@@ -106,7 +106,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Ohme Home Pro Vehicle',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Nissan Leaf',
         'Tesla Model 3',
       ]),

--- a/tests/components/onewire/snapshots/test_select.ambr
+++ b/tests/components/onewire/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '9',
         '10',
         '11',
@@ -48,7 +48,7 @@
     'attributes': ReadOnlyDict({
       'device_file': '/28.111111111111/tempres',
       'friendly_name': '28.111111111111 Temperature resolution',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '9',
         '10',
         '11',

--- a/tests/components/openrgb/snapshots/test_select.ambr
+++ b/tests/components/openrgb/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -43,7 +43,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Computer Profile',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
       ]),
     }),
     'context': <ANY>,

--- a/tests/components/ouman_eh_800/snapshots/test_select.ambr
+++ b/tests/components/ouman_eh_800/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'automatic',
         'temperature_drop',
         'big_temperature_drop',
@@ -49,7 +49,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Heating circuit 1 Patterilämmitys Operation mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'automatic',
         'temperature_drop',
         'big_temperature_drop',
@@ -73,7 +73,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'home',
         'away',
         'off',
@@ -113,7 +113,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Ouman EH-800 Home/Away mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'home',
         'away',
         'off',
@@ -134,7 +134,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'auto',
         'stop',
         'run',
@@ -174,7 +174,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Ouman EH-800 Pump summer stop',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'auto',
         'stop',
         'run',
@@ -195,7 +195,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'automatic',
         'temperature_drop',
         'big_temperature_drop',
@@ -238,7 +238,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Heating circuit 1 Patterilämmitys Operation mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'automatic',
         'temperature_drop',
         'big_temperature_drop',
@@ -262,7 +262,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'automatic',
         'temperature_drop',
         'big_temperature_drop',
@@ -305,7 +305,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Heating circuit 2 Lattialämmitys Operation mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'automatic',
         'temperature_drop',
         'big_temperature_drop',
@@ -329,7 +329,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'home',
         'away',
         'off',
@@ -369,7 +369,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Ouman EH-800 Home/Away mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'home',
         'away',
         'off',
@@ -390,7 +390,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'home',
         'away',
         'off',
@@ -430,7 +430,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Ouman EH-800 Home/Away mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'home',
         'away',
         'off',
@@ -451,7 +451,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'auto',
         'on',
         'off',
@@ -491,7 +491,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Ouman EH-800 Relay control',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'auto',
         'on',
         'off',
@@ -512,7 +512,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'home',
         'away',
         'off',
@@ -552,7 +552,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Ouman EH-800 Home/Away mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'home',
         'away',
         'off',
@@ -573,7 +573,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'auto',
         'on',
         'off',
@@ -613,7 +613,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Ouman EH-800 Relay control',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'auto',
         'on',
         'off',
@@ -634,7 +634,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'home',
         'away',
         'off',
@@ -674,7 +674,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Ouman EH-800 Home/Away mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'home',
         'away',
         'off',
@@ -695,7 +695,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'auto',
         'on',
         'off',
@@ -735,7 +735,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Ouman EH-800 Relay control',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'auto',
         'on',
         'off',
@@ -756,7 +756,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'home',
         'away',
         'off',
@@ -796,7 +796,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Ouman EH-800 Home/Away mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'home',
         'away',
         'off',
@@ -817,7 +817,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'auto',
         'on',
         'off',
@@ -857,7 +857,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Ouman EH-800 Relay control',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'auto',
         'on',
         'off',
@@ -878,7 +878,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'automatic',
         'temperature_drop',
         'big_temperature_drop',
@@ -921,7 +921,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Heating circuit 1 Patterilämmitys Operation mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'automatic',
         'temperature_drop',
         'big_temperature_drop',
@@ -945,7 +945,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'automatic',
         'temperature_drop',
         'big_temperature_drop',
@@ -988,7 +988,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Heating circuit 2 Lattialämmitys Operation mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'automatic',
         'temperature_drop',
         'big_temperature_drop',
@@ -1012,7 +1012,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'home',
         'away',
         'off',
@@ -1052,7 +1052,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Ouman EH-800 Home/Away mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'home',
         'away',
         'off',

--- a/tests/components/overkiz/snapshots/test_select.ambr
+++ b/tests/components/overkiz/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <OverkizCommandParam.OPEN: 'open'>,
         <OverkizCommandParam.PEDESTRIAN: 'pedestrian'>,
         <OverkizCommandParam.CLOSED: 'closed'>,
@@ -46,7 +46,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Garden Gate Position',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <OverkizCommandParam.OPEN: 'open'>,
         <OverkizCommandParam.PEDESTRIAN: 'pedestrian'>,
         <OverkizCommandParam.CLOSED: 'closed'>,
@@ -67,7 +67,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <OverkizCommandParam.OPEN: 'open'>,
         <OverkizCommandParam.PARTIAL: 'partial'>,
         <OverkizCommandParam.CLOSED: 'closed'>,
@@ -107,7 +107,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Partial Garage Door Position',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <OverkizCommandParam.OPEN: 'open'>,
         <OverkizCommandParam.PARTIAL: 'partial'>,
         <OverkizCommandParam.CLOSED: 'closed'>,
@@ -128,7 +128,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <OverkizCommandParam.OPEN: 'open'>,
         <OverkizCommandParam.PEDESTRIAN: 'pedestrian'>,
         <OverkizCommandParam.CLOSED: 'closed'>,
@@ -168,7 +168,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Sliding Gate Position',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <OverkizCommandParam.OPEN: 'open'>,
         <OverkizCommandParam.PEDESTRIAN: 'pedestrian'>,
         <OverkizCommandParam.CLOSED: 'closed'>,
@@ -189,7 +189,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '',
         'A',
         'B',
@@ -234,7 +234,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Protexiom Active zones',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '',
         'A',
         'B',
@@ -260,7 +260,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <OverkizCommandParam.STANDARD: 'standard'>,
         <OverkizCommandParam.HIGHEST: 'highest'>,
       ]),
@@ -299,7 +299,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Siren Memorized simple volume',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <OverkizCommandParam.STANDARD: 'standard'>,
         <OverkizCommandParam.HIGHEST: 'highest'>,
       ]),

--- a/tests/components/peblar/snapshots/test_select.ambr
+++ b/tests/components/peblar/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'default',
         'fast_solar',
         'pure_solar',
@@ -48,7 +48,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Peblar EV Charger Smart charging',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'default',
         'fast_solar',
         'pure_solar',

--- a/tests/components/plugwise/snapshots/test_select.ambr
+++ b/tests/components/plugwise/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'away',
         'full',
         'vacation',
@@ -46,7 +46,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Adam Gateway mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'away',
         'full',
         'vacation',
@@ -67,7 +67,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'bleeding_cold',
         'heating',
         'off',
@@ -109,7 +109,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Adam Regulation mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'bleeding_cold',
         'heating',
         'off',
@@ -132,7 +132,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Badkamer',
         'Vakantie',
         'Weekschema',
@@ -174,7 +174,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Bathroom Thermostat schedule',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Badkamer',
         'Vakantie',
         'Weekschema',
@@ -197,7 +197,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'active',
         'off',
         'passive',
@@ -237,7 +237,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Bathroom Zone profile',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'active',
         'off',
         'passive',
@@ -258,7 +258,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Badkamer',
         'Vakantie',
         'Weekschema',
@@ -300,7 +300,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Living room Thermostat schedule',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Badkamer',
         'Vakantie',
         'Weekschema',
@@ -323,7 +323,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'active',
         'off',
         'passive',
@@ -363,7 +363,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Living room Zone profile',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'active',
         'off',
         'passive',
@@ -384,7 +384,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'CV Roan',
         'Bios Schema met Film Avond',
         'GF7  Woonkamer',
@@ -427,7 +427,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Badkamer Thermostat schedule',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'CV Roan',
         'Bios Schema met Film Avond',
         'GF7  Woonkamer',
@@ -451,7 +451,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'CV Roan',
         'Bios Schema met Film Avond',
         'GF7  Woonkamer',
@@ -494,7 +494,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Bios Thermostat schedule',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'CV Roan',
         'Bios Schema met Film Avond',
         'GF7  Woonkamer',
@@ -518,7 +518,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'CV Roan',
         'Bios Schema met Film Avond',
         'GF7  Woonkamer',
@@ -561,7 +561,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Jessie Thermostat schedule',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'CV Roan',
         'Bios Schema met Film Avond',
         'GF7  Woonkamer',
@@ -585,7 +585,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'CV Roan',
         'Bios Schema met Film Avond',
         'GF7  Woonkamer',
@@ -628,7 +628,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Woonkamer Thermostat schedule',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'CV Roan',
         'Bios Schema met Film Avond',
         'GF7  Woonkamer',

--- a/tests/components/pooldose/snapshots/test_select.ambr
+++ b/tests/components/pooldose/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'proportional',
         'on_off',
@@ -47,7 +47,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Pool Device Chlorine dosing method',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'proportional',
         'on_off',
@@ -69,7 +69,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'low',
         'high',
       ]),
@@ -108,7 +108,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Pool Device Chlorine dosing set',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'low',
         'high',
       ]),
@@ -128,7 +128,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR: 'm³/h'>,
         <UnitOfVolumeFlowRate.LITERS_PER_SECOND: 'L/s'>,
       ]),
@@ -167,7 +167,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Pool Device Flow rate unit',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR: 'm³/h'>,
         <UnitOfVolumeFlowRate.LITERS_PER_SECOND: 'L/s'>,
       ]),
@@ -187,7 +187,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'proportional',
         'on_off',
@@ -228,7 +228,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Pool Device ORP dosing method',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'proportional',
         'on_off',
@@ -250,7 +250,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'low',
         'high',
       ]),
@@ -289,7 +289,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Pool Device ORP dosing set',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'low',
         'high',
       ]),
@@ -309,7 +309,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'proportional',
         'on_off',
@@ -350,7 +350,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Pool Device pH dosing method',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'proportional',
         'on_off',
@@ -372,7 +372,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'alcalyne',
         'acid',
       ]),
@@ -411,7 +411,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Pool Device pH dosing set',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'alcalyne',
         'acid',
       ]),
@@ -431,7 +431,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <UnitOfVolume.LITERS: 'L'>,
         <UnitOfVolume.CUBIC_METERS: 'm³'>,
       ]),
@@ -470,7 +470,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Pool Device Water meter unit',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <UnitOfVolume.LITERS: 'L'>,
         <UnitOfVolume.CUBIC_METERS: 'm³'>,
       ]),

--- a/tests/components/qbus/snapshots/test_select.ambr
+++ b/tests/components/qbus/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         'Here comes',
         'the hotstepper',
@@ -54,7 +54,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'CTD 000001 Stepper',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         'Here comes',
         'the hotstepper',

--- a/tests/components/rainmachine/snapshots/test_select.ambr
+++ b/tests/components/rainmachine/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0°C',
         '2°C',
         '5°C',
@@ -47,7 +47,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': '12345 Freeze protection temperature',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0°C',
         '2°C',
         '5°C',

--- a/tests/components/renault/snapshots/test_select.ambr
+++ b/tests/components/renault/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'always',
         'always_charging',
         'schedule_mode',
@@ -47,7 +47,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'REG-ZOE-40 Charge mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'always',
         'always_charging',
         'schedule_mode',
@@ -69,7 +69,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'always',
         'always_charging',
         'schedule_mode',
@@ -110,7 +110,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'REG-ZOE-40 Charge mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'always',
         'always_charging',
         'schedule_mode',
@@ -132,7 +132,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'always',
         'always_charging',
         'schedule_mode',
@@ -173,7 +173,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'REG-ZOE-40 Charge mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'always',
         'always_charging',
         'schedule_mode',

--- a/tests/components/russound_rio/snapshots/test_select.ambr
+++ b/tests/components/russound_rio/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'on',
         'master',
@@ -46,7 +46,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Backyard Party mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'on',
         'master',
@@ -67,7 +67,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'on',
         'master',
@@ -107,7 +107,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Bedroom Party mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'on',
         'master',
@@ -128,7 +128,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'on',
         'master',
@@ -168,7 +168,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Party mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'on',
         'master',
@@ -189,7 +189,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'on',
         'master',
@@ -229,7 +229,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Living Room Party mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'on',
         'master',

--- a/tests/components/sensibo/snapshots/test_select.ambr
+++ b/tests/components/sensibo/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
       ]),
@@ -45,7 +45,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Hallway Light',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
       ]),
@@ -65,7 +65,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'dim',
         'off',
@@ -105,7 +105,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Light',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'dim',
         'off',

--- a/tests/components/shelly/snapshots/test_devices.ambr
+++ b/tests/components/shelly/snapshots/test_devices.ambr
@@ -381,7 +381,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'hall',
         'bedroom',
         'living_room',
@@ -425,7 +425,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test name Mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'hall',
         'bedroom',
         'living_room',

--- a/tests/components/smartthings/snapshots/test_select.ambr
+++ b/tests/components/smartthings/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'high',
       ]),
@@ -45,7 +45,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Air purifier Lamp',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'high',
       ]),
@@ -65,7 +65,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '180',
         '300',
         '500',
@@ -106,7 +106,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Clim Salon Dust filter alarm threshold',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '180',
         '300',
         '500',
@@ -128,7 +128,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '180',
         '300',
         '500',
@@ -169,7 +169,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Aire Dormitorio Principal Dust filter alarm threshold',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '180',
         '300',
         '500',
@@ -191,7 +191,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'low',
         'high',
@@ -231,7 +231,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Microwave Lamp',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'low',
         'high',
@@ -252,7 +252,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'high',
       ]),
@@ -291,7 +291,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Oven Lamp',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'high',
       ]),
@@ -311,7 +311,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'high',
       ]),
@@ -350,7 +350,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen oven Lamp',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'high',
       ]),
@@ -370,7 +370,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'extra_high',
       ]),
@@ -409,7 +409,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Vulcan Lamp',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'extra_high',
       ]),
@@ -429,7 +429,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'high',
       ]),
@@ -468,7 +468,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Four Lamp',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'high',
       ]),
@@ -488,7 +488,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'vacuum',
         'mop',
         'vacuum_and_mop_together',
@@ -529,7 +529,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Robot Vacuum Cleaning type',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'vacuum',
         'mop',
         'vacuum_and_mop_together',
@@ -551,7 +551,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'area_then_walls',
         'walls_first',
         'quick_clean_zigzag_pattern',
@@ -591,7 +591,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Robot Vacuum Driving mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'area_then_walls',
         'walls_first',
         'quick_clean_zigzag_pattern',
@@ -612,7 +612,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
       ]),
@@ -651,7 +651,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Robot Vacuum Lamp',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
       ]),
@@ -671,7 +671,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'low',
         'medium',
         'high',
@@ -711,7 +711,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Robot Vacuum Sound detection sensitivity',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'low',
         'medium',
         'high',
@@ -732,7 +732,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'mute',
         'tone',
         'voice',
@@ -772,7 +772,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Robot Vacuum Sound mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'mute',
         'tone',
         'voice',
@@ -793,7 +793,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'high',
         'moderate_high',
         'medium',
@@ -835,7 +835,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Robot Vacuum Water level',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'high',
         'moderate_high',
         'medium',
@@ -858,7 +858,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
       ]),
@@ -897,7 +897,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Stick vacuum Lamp',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'on',
         'off',
       ]),
@@ -917,7 +917,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'stop',
         'run',
         'pause',
@@ -957,7 +957,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Dishwasher',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'stop',
         'run',
         'pause',
@@ -978,7 +978,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'lower',
         'all',
@@ -1018,7 +1018,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Dishwasher Selected zone',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'lower',
         'all',
@@ -1039,7 +1039,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'left',
       ]),
@@ -1078,7 +1078,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Dishwasher Zone booster',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'left',
       ]),
@@ -1098,7 +1098,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'stop',
         'run',
         'pause',
@@ -1138,7 +1138,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Dishwasher 1',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'stop',
         'run',
         'pause',
@@ -1159,7 +1159,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'lower',
         'all',
       ]),
@@ -1198,7 +1198,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Dishwasher 1 Selected zone',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'lower',
         'all',
       ]),
@@ -1218,7 +1218,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'stop',
         'run',
         'pause',
@@ -1258,7 +1258,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'AirDresser',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'stop',
         'run',
         'pause',
@@ -1279,7 +1279,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'stop',
         'run',
         'pause',
@@ -1319,7 +1319,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Dryer',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'stop',
         'run',
         'pause',
@@ -1340,7 +1340,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'stop',
         'run',
         'pause',
@@ -1380,7 +1380,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Seca-Roupa',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'stop',
         'run',
         'pause',
@@ -1401,7 +1401,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'stop',
         'run',
         'pause',
@@ -1441,7 +1441,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Trockner',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'stop',
         'run',
         'pause',
@@ -1462,7 +1462,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'stop',
         'run',
         'pause',
@@ -1502,7 +1502,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Washer',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'stop',
         'run',
         'pause',
@@ -1523,7 +1523,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'extra_light',
         'light',
@@ -1566,7 +1566,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Washer Soil level',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'extra_light',
         'light',
@@ -1590,7 +1590,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'rinse_hold',
         'no_spin',
         'low',
@@ -1633,7 +1633,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Washer Spin level',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'rinse_hold',
         'no_spin',
         'low',
@@ -1657,7 +1657,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'tap_cold',
         'cold',
@@ -1700,7 +1700,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Washer Water temperature',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'tap_cold',
         'cold',
@@ -1724,7 +1724,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'stop',
         'run',
         'pause',
@@ -1764,7 +1764,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Washing Machine',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'stop',
         'run',
         'pause',
@@ -1785,7 +1785,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'rinse_hold',
         'no_spin',
         '400',
@@ -1829,7 +1829,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Washing Machine Spin level',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'rinse_hold',
         'no_spin',
         '400',
@@ -1854,7 +1854,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'cold',
         '20',
@@ -1898,7 +1898,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Washing Machine Water temperature',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'cold',
         '20',
@@ -1923,7 +1923,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'stop',
         'run',
         'pause',
@@ -1963,7 +1963,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Machine à Laver',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'stop',
         'run',
         'pause',
@@ -1984,7 +1984,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'less',
         'standard',
@@ -2025,7 +2025,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Machine à Laver Detergent dispense amount',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'less',
         'standard',
@@ -2047,7 +2047,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'less',
         'standard',
@@ -2088,7 +2088,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Machine à Laver Flexible compartment dispense amount',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'less',
         'standard',
@@ -2110,7 +2110,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'rinse_hold',
         'no_spin',
         '400',
@@ -2154,7 +2154,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Machine à Laver Spin level',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'rinse_hold',
         'no_spin',
         '400',
@@ -2179,7 +2179,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'cold',
         '20',
@@ -2223,7 +2223,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Machine à Laver Water temperature',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'cold',
         '20',
@@ -2248,7 +2248,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'run',
         'pause',
         'stop',
@@ -2288,7 +2288,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Washer 1',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'run',
         'pause',
         'stop',
@@ -2309,7 +2309,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'run',
         'pause',
         'stop',
@@ -2349,7 +2349,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Washer 2',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'run',
         'pause',
         'stop',

--- a/tests/components/synology_dsm/snapshots/test_select.ambr
+++ b/tests/components/synology_dsm/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'quiet',
         'cool',
         'full_speed',
@@ -47,7 +47,7 @@
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by Synology',
       'friendly_name': 'nas.meontheinternet.com Fan speed mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'quiet',
         'cool',
         'full_speed',

--- a/tests/components/template/snapshots/test_select.ambr
+++ b/tests/components/template/snapshots/test_select.ambr
@@ -3,7 +3,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'My template',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'on',
         'auto',

--- a/tests/components/tesla_fleet/snapshots/test_select.ambr
+++ b/tests/components/tesla_fleet/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <EnergyExportMode.NEVER: 'never'>,
         <EnergyExportMode.BATTERY_OK: 'battery_ok'>,
         <EnergyExportMode.PV_ONLY: 'pv_only'>,
@@ -46,7 +46,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Energy Site Allow export',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <EnergyExportMode.NEVER: 'never'>,
         <EnergyExportMode.BATTERY_OK: 'battery_ok'>,
         <EnergyExportMode.PV_ONLY: 'pv_only'>,
@@ -67,7 +67,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <EnergyOperationMode.AUTONOMOUS: 'autonomous'>,
         <EnergyOperationMode.BACKUP: 'backup'>,
         <EnergyOperationMode.SELF_CONSUMPTION: 'self_consumption'>,
@@ -107,7 +107,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Energy Site Operation mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <EnergyOperationMode.AUTONOMOUS: 'autonomous'>,
         <EnergyOperationMode.BACKUP: 'backup'>,
         <EnergyOperationMode.SELF_CONSUMPTION: 'self_consumption'>,
@@ -128,7 +128,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'low',
         'medium',
@@ -169,7 +169,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Seat heater front left',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'low',
         'medium',
@@ -191,7 +191,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'low',
         'medium',
@@ -232,7 +232,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Seat heater front right',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'low',
         'medium',
@@ -254,7 +254,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'low',
         'medium',
@@ -295,7 +295,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Seat heater rear center',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'low',
         'medium',
@@ -317,7 +317,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'low',
         'medium',
@@ -358,7 +358,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Seat heater rear left',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'low',
         'medium',
@@ -380,7 +380,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'low',
         'medium',
@@ -421,7 +421,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Seat heater rear right',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'low',
         'medium',
@@ -443,7 +443,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'low',
         'medium',
@@ -484,7 +484,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Seat heater third row left',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'low',
         'medium',
@@ -506,7 +506,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'low',
         'medium',
@@ -547,7 +547,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Seat heater third row right',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'low',
         'medium',
@@ -569,7 +569,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'low',
         'high',
@@ -609,7 +609,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Steering wheel heater',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'low',
         'high',

--- a/tests/components/teslemetry/snapshots/test_select.ambr
+++ b/tests/components/teslemetry/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <EnergyExportMode.NEVER: 'never'>,
         <EnergyExportMode.BATTERY_OK: 'battery_ok'>,
         <EnergyExportMode.PV_ONLY: 'pv_only'>,
@@ -46,7 +46,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Energy Site Allow export',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <EnergyExportMode.NEVER: 'never'>,
         <EnergyExportMode.BATTERY_OK: 'battery_ok'>,
         <EnergyExportMode.PV_ONLY: 'pv_only'>,
@@ -67,7 +67,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <EnergyOperationMode.AUTONOMOUS: 'autonomous'>,
         <EnergyOperationMode.BACKUP: 'backup'>,
         <EnergyOperationMode.SELF_CONSUMPTION: 'self_consumption'>,
@@ -107,7 +107,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Energy Site Operation mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <EnergyOperationMode.AUTONOMOUS: 'autonomous'>,
         <EnergyOperationMode.BACKUP: 'backup'>,
         <EnergyOperationMode.SELF_CONSUMPTION: 'self_consumption'>,
@@ -128,7 +128,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'low',
         'medium',
@@ -169,7 +169,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Seat heater front left',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'low',
         'medium',
@@ -191,7 +191,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'low',
         'medium',
@@ -232,7 +232,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Seat heater front right',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'low',
         'medium',
@@ -254,7 +254,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'low',
         'medium',
@@ -295,7 +295,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Seat heater rear center',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'low',
         'medium',
@@ -317,7 +317,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'low',
         'medium',
@@ -358,7 +358,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Seat heater rear left',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'low',
         'medium',
@@ -380,7 +380,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'low',
         'medium',
@@ -421,7 +421,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Seat heater rear right',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'low',
         'medium',
@@ -443,7 +443,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'low',
         'high',
@@ -483,7 +483,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Steering wheel heater',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'off',
         'low',
         'high',

--- a/tests/components/tessie/snapshots/test_select.ambr
+++ b/tests/components/tessie/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <EnergyExportMode.NEVER: 'never'>,
         <EnergyExportMode.BATTERY_OK: 'battery_ok'>,
         <EnergyExportMode.PV_ONLY: 'pv_only'>,
@@ -46,7 +46,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Energy Site Allow export',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <EnergyExportMode.NEVER: 'never'>,
         <EnergyExportMode.BATTERY_OK: 'battery_ok'>,
         <EnergyExportMode.PV_ONLY: 'pv_only'>,
@@ -67,7 +67,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <EnergyOperationMode.AUTONOMOUS: 'autonomous'>,
         <EnergyOperationMode.BACKUP: 'backup'>,
         <EnergyOperationMode.SELF_CONSUMPTION: 'self_consumption'>,
@@ -107,7 +107,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Energy Site Operation mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <EnergyOperationMode.AUTONOMOUS: 'autonomous'>,
         <EnergyOperationMode.BACKUP: 'backup'>,
         <EnergyOperationMode.SELF_CONSUMPTION: 'self_consumption'>,
@@ -128,7 +128,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <TessieSeatCoolerOptions.OFF: 'off'>,
         <TessieSeatCoolerOptions.LOW: 'low'>,
         <TessieSeatCoolerOptions.MEDIUM: 'medium'>,
@@ -169,7 +169,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Seat cooler left',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <TessieSeatCoolerOptions.OFF: 'off'>,
         <TessieSeatCoolerOptions.LOW: 'low'>,
         <TessieSeatCoolerOptions.MEDIUM: 'medium'>,
@@ -191,7 +191,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <TessieSeatCoolerOptions.OFF: 'off'>,
         <TessieSeatCoolerOptions.LOW: 'low'>,
         <TessieSeatCoolerOptions.MEDIUM: 'medium'>,
@@ -232,7 +232,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Seat cooler right',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <TessieSeatCoolerOptions.OFF: 'off'>,
         <TessieSeatCoolerOptions.LOW: 'low'>,
         <TessieSeatCoolerOptions.MEDIUM: 'medium'>,
@@ -254,7 +254,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <TessieSeatHeaterOptions.OFF: 'off'>,
         <TessieSeatHeaterOptions.LOW: 'low'>,
         <TessieSeatHeaterOptions.MEDIUM: 'medium'>,
@@ -295,7 +295,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Seat heater left',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <TessieSeatHeaterOptions.OFF: 'off'>,
         <TessieSeatHeaterOptions.LOW: 'low'>,
         <TessieSeatHeaterOptions.MEDIUM: 'medium'>,
@@ -317,7 +317,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <TessieSeatHeaterOptions.OFF: 'off'>,
         <TessieSeatHeaterOptions.LOW: 'low'>,
         <TessieSeatHeaterOptions.MEDIUM: 'medium'>,
@@ -358,7 +358,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Seat heater rear center',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <TessieSeatHeaterOptions.OFF: 'off'>,
         <TessieSeatHeaterOptions.LOW: 'low'>,
         <TessieSeatHeaterOptions.MEDIUM: 'medium'>,
@@ -380,7 +380,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <TessieSeatHeaterOptions.OFF: 'off'>,
         <TessieSeatHeaterOptions.LOW: 'low'>,
         <TessieSeatHeaterOptions.MEDIUM: 'medium'>,
@@ -421,7 +421,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Seat heater rear left',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <TessieSeatHeaterOptions.OFF: 'off'>,
         <TessieSeatHeaterOptions.LOW: 'low'>,
         <TessieSeatHeaterOptions.MEDIUM: 'medium'>,
@@ -443,7 +443,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <TessieSeatHeaterOptions.OFF: 'off'>,
         <TessieSeatHeaterOptions.LOW: 'low'>,
         <TessieSeatHeaterOptions.MEDIUM: 'medium'>,
@@ -484,7 +484,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Seat heater rear right',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <TessieSeatHeaterOptions.OFF: 'off'>,
         <TessieSeatHeaterOptions.LOW: 'low'>,
         <TessieSeatHeaterOptions.MEDIUM: 'medium'>,
@@ -506,7 +506,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <TessieSeatHeaterOptions.OFF: 'off'>,
         <TessieSeatHeaterOptions.LOW: 'low'>,
         <TessieSeatHeaterOptions.MEDIUM: 'medium'>,
@@ -547,7 +547,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Seat heater right',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <TessieSeatHeaterOptions.OFF: 'off'>,
         <TessieSeatHeaterOptions.LOW: 'low'>,
         <TessieSeatHeaterOptions.MEDIUM: 'medium'>,
@@ -566,7 +566,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Seat heater left',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         <TessieSeatHeaterOptions.OFF: 'off'>,
         <TessieSeatHeaterOptions.LOW: 'low'>,
         <TessieSeatHeaterOptions.MEDIUM: 'medium'>,

--- a/tests/components/togrill/snapshots/test_select.ambr
+++ b/tests/components/togrill/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'beef',
         'veal',
@@ -59,7 +59,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Probe 1 Grill type',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'beef',
         'veal',
@@ -93,7 +93,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'rare',
         'medium_rare',
@@ -136,7 +136,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Probe 1 Taste',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'rare',
         'medium_rare',
@@ -160,7 +160,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'beef',
         'veal',
@@ -213,7 +213,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Probe 2 Grill type',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'beef',
         'veal',
@@ -247,7 +247,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'rare',
         'medium_rare',
@@ -290,7 +290,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Probe 2 Taste',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'rare',
         'medium_rare',
@@ -314,7 +314,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'beef',
         'veal',
@@ -367,7 +367,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Probe 1 Grill type',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'beef',
         'veal',
@@ -401,7 +401,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'rare',
         'medium_rare',
@@ -444,7 +444,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Probe 1 Taste',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'rare',
         'medium_rare',
@@ -468,7 +468,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'beef',
         'veal',
@@ -521,7 +521,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Probe 2 Grill type',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'beef',
         'veal',
@@ -555,7 +555,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'rare',
         'medium_rare',
@@ -598,7 +598,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Probe 2 Taste',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'rare',
         'medium_rare',
@@ -622,7 +622,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'beef',
         'veal',
@@ -675,7 +675,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Probe 1 Grill type',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'beef',
         'veal',
@@ -709,7 +709,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'rare',
         'medium_rare',
@@ -752,7 +752,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Probe 1 Taste',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'rare',
         'medium_rare',
@@ -776,7 +776,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'beef',
         'veal',
@@ -829,7 +829,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Probe 2 Grill type',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'beef',
         'veal',
@@ -863,7 +863,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'rare',
         'medium_rare',
@@ -906,7 +906,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Probe 2 Taste',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'rare',
         'medium_rare',

--- a/tests/components/tplink/snapshots/test_select.ambr
+++ b/tests/components/tplink/snapshots/test_select.ambr
@@ -41,7 +41,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Doorbell Ring 1',
         'Doorbell Ring 2',
         'Doorbell Ring 3',
@@ -97,7 +97,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'my_device Alarm sound',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Doorbell Ring 1',
         'Doorbell Ring 2',
         'Doorbell Ring 3',
@@ -134,7 +134,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'low',
         'normal',
         'high',
@@ -174,7 +174,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'my_device Alarm volume',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'low',
         'normal',
         'high',
@@ -195,7 +195,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Off',
         'Preset 1',
         'Preset 2',
@@ -235,7 +235,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'my_device Light preset',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Off',
         'Preset 1',
         'Preset 2',

--- a/tests/components/tuya/snapshots/test_select.ambr
+++ b/tests/components/tuya/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'relay',
         'pos',
         'none',
@@ -46,7 +46,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': '3DPrinter Indicator light mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'relay',
         'pos',
         'none',
@@ -67,7 +67,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -107,7 +107,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': '3DPrinter Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -128,7 +128,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -168,7 +168,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': '4-433 Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -189,7 +189,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -229,7 +229,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': '6294HA Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -250,7 +250,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'low',
         'middle',
         'high',
@@ -291,7 +291,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'AQI Volume',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'low',
         'middle',
         'high',
@@ -313,7 +313,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '1h',
         '2h',
         '3h',
@@ -353,7 +353,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Arida Stavern  Countdown',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '1h',
         '2h',
         '3h',
@@ -374,7 +374,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '40',
         '50',
       ]),
@@ -413,7 +413,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Arida Stavern  Target humidity',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '40',
         '50',
       ]),
@@ -433,7 +433,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'relay',
         'pos',
         'none',
@@ -473,7 +473,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Aubess Cooker Indicator light mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'relay',
         'pos',
         'none',
@@ -494,7 +494,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -534,7 +534,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Aubess Cooker Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -555,7 +555,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'relay',
         'pos',
         'none',
@@ -595,7 +595,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Aubess Washing Machine Indicator light mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'relay',
         'pos',
         'none',
@@ -616,7 +616,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -656,7 +656,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Aubess Washing Machine Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -677,7 +677,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'cancel',
         '24h',
         '48h',
@@ -718,7 +718,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'balkonbewässerung Weather delay',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'cancel',
         '24h',
         '48h',
@@ -740,7 +740,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'relay',
         'pos',
@@ -780,7 +780,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'bathroom light Indicator light mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'relay',
         'pos',
@@ -801,7 +801,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -841,7 +841,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'bathroom light Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -862,7 +862,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'morning',
         'night',
       ]),
@@ -901,7 +901,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'blinds Mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'morning',
         'night',
       ]),
@@ -921,7 +921,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'cancel',
         '1h',
         '2h',
@@ -964,7 +964,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Bree Countdown',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'cancel',
         '1h',
         '2h',
@@ -988,7 +988,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -1028,7 +1028,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Bürocam Anti-flicker',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -1049,7 +1049,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -1089,7 +1089,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Bürocam Motion detection sensitivity',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -1110,7 +1110,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -1150,7 +1150,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Bürocam Night vision',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -1171,7 +1171,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '1',
         '2',
       ]),
@@ -1210,7 +1210,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Bürocam Record mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '1',
         '2',
       ]),
@@ -1230,7 +1230,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
       ]),
@@ -1269,7 +1269,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Bürocam Sound detection sensitivity',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
       ]),
@@ -1289,7 +1289,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
       ]),
@@ -1328,7 +1328,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'C9 IPC mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
       ]),
@@ -1348,7 +1348,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -1388,7 +1388,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'C9 Motion detection sensitivity',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -1409,7 +1409,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '1',
         '2',
       ]),
@@ -1448,7 +1448,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'C9 Record mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '1',
         '2',
       ]),
@@ -1468,7 +1468,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -1508,7 +1508,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'CAM GARAGE Motion detection sensitivity',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -1529,7 +1529,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -1569,7 +1569,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'CAM GARAGE Night vision',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -1590,7 +1590,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '1',
         '2',
       ]),
@@ -1629,7 +1629,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'CAM GARAGE Record mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '1',
         '2',
       ]),
@@ -1649,7 +1649,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
       ]),
@@ -1688,7 +1688,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'CAM GARAGE Sound detection sensitivity',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
       ]),
@@ -1708,7 +1708,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -1748,7 +1748,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'CAM PORCH Motion detection sensitivity',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -1769,7 +1769,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '1',
         '2',
       ]),
@@ -1808,7 +1808,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'CAM PORCH Record mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '1',
         '2',
       ]),
@@ -1828,7 +1828,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
       ]),
@@ -1867,7 +1867,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'CAM PORCH Sound detection sensitivity',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
       ]),
@@ -1887,7 +1887,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'self_powered',
         'time_of_use',
       ]),
@@ -1926,7 +1926,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'CBE Pro 2 Inverter work mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'self_powered',
         'time_of_use',
       ]),
@@ -1946,7 +1946,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'cancel',
         '1h',
         '2h',
@@ -1988,7 +1988,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Ceiling Fan With Light Countdown',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'cancel',
         '1h',
         '2h',
@@ -2011,7 +2011,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'cancel',
         '1h',
         '2h',
@@ -2052,7 +2052,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'D825A I Countdown',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'cancel',
         '1h',
         '2h',
@@ -2074,7 +2074,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '40',
         '45',
         '50',
@@ -2114,7 +2114,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'D825A I Target humidity',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '40',
         '45',
         '50',
@@ -2135,7 +2135,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'cancel',
         '1h',
         '2h',
@@ -2176,7 +2176,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Dehumidifer Countdown',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'cancel',
         '1h',
         '2h',
@@ -2198,7 +2198,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'cancel',
         '1h',
         '2h',
@@ -2239,7 +2239,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Dehumidifier Countdown',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'cancel',
         '1h',
         '2h',
@@ -2261,7 +2261,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'relay',
         'pos',
         'none',
@@ -2301,7 +2301,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Dehumidifier  Indicator light mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'relay',
         'pos',
         'none',
@@ -2322,7 +2322,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -2362,7 +2362,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Dehumidifier  Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -2383,7 +2383,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'cancel',
         '1h',
         '2h',
@@ -2424,7 +2424,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Déshumidificateur Silencieux OmniDry 20L avec Mode Linge Countdown',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'cancel',
         '1h',
         '2h',
@@ -2446,7 +2446,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'forward',
         'back',
       ]),
@@ -2485,7 +2485,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Dining 1 Motor mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'forward',
         'back',
       ]),
@@ -2505,7 +2505,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -2545,7 +2545,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Dolní vchod - západ Anti-flicker',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -2566,7 +2566,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
       ]),
@@ -2605,7 +2605,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Dolní vchod - západ IPC mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
       ]),
@@ -2625,7 +2625,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'relay',
         'pos',
         'none',
@@ -2665,7 +2665,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Elivco Kitchen Socket Indicator light mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'relay',
         'pos',
         'none',
@@ -2686,7 +2686,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -2726,7 +2726,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Elivco Kitchen Socket Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -2747,7 +2747,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'relay',
         'pos',
         'none',
@@ -2787,7 +2787,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Elivco TV Indicator light mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'relay',
         'pos',
         'none',
@@ -2808,7 +2808,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -2848,7 +2848,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Elivco TV Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -2869,7 +2869,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'relay',
         'pos',
         'none',
@@ -2909,7 +2909,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Framboisier Indicator light mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'relay',
         'pos',
         'none',
@@ -2930,7 +2930,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -2970,7 +2970,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Framboisier Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -2991,7 +2991,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -3031,7 +3031,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Framboisiers Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -3052,7 +3052,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -3092,7 +3092,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Garage Camera Motion detection sensitivity',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -3113,7 +3113,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '1',
         '2',
       ]),
@@ -3152,7 +3152,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Garage Camera Record mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '1',
         '2',
       ]),
@@ -3172,7 +3172,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'cancel',
         '24h',
         '48h',
@@ -3213,7 +3213,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Garden Valve Yard Weather delay',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'cancel',
         '24h',
         '48h',
@@ -3235,7 +3235,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'relay',
         'pos',
         'none',
@@ -3275,7 +3275,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'HA Socket Delta Test Indicator light mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'relay',
         'pos',
         'none',
@@ -3296,7 +3296,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -3336,7 +3336,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'HA Socket Delta Test Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -3357,7 +3357,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'random',
         'smart',
         'wall_follow',
@@ -3398,7 +3398,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Hoover Mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'random',
         'smart',
         'wall_follow',
@@ -3420,7 +3420,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -3460,7 +3460,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Ineox SP2 Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -3481,7 +3481,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -3521,7 +3521,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Intercom Motion detection sensitivity',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -3542,7 +3542,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '1',
         '2',
         '3',
@@ -3585,7 +3585,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'ION1000PRO Countdown',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '1',
         '2',
         '3',
@@ -3609,7 +3609,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '1',
         '2',
         '3',
@@ -3652,7 +3652,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'ION1000PRO Countdown',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '1',
         '2',
         '3',
@@ -3676,7 +3676,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -3716,7 +3716,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Jardim frontal  Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -3737,7 +3737,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -3777,7 +3777,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'jardin Fraises Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -3798,7 +3798,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'relay',
         'pos',
         'none',
@@ -3838,7 +3838,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': '接HA双向计量插座 Indicator light mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'relay',
         'pos',
         'none',
@@ -3859,7 +3859,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -3899,7 +3899,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': '接HA双向计量插座 Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -3920,7 +3920,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'cancel',
         '1h',
         '2h',
@@ -3963,7 +3963,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kalado Air Purifier Countdown',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'cancel',
         '1h',
         '2h',
@@ -3987,7 +3987,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'forward',
         'back',
       ]),
@@ -4026,7 +4026,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen Blinds Motor mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'forward',
         'back',
       ]),
@@ -4046,7 +4046,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'level_1',
         'level_2',
         'level_3',
@@ -4092,7 +4092,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'KLARTA HUMEA Spraying level',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'level_1',
         'level_2',
         'level_3',
@@ -4119,7 +4119,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'relay',
         'pos',
@@ -4159,7 +4159,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Lave linge Indicator light mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'relay',
         'pos',
@@ -4180,7 +4180,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -4220,7 +4220,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Lave linge Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -4241,7 +4241,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'cancel',
         '1h',
         '2h',
@@ -4282,7 +4282,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Living room dehumidifier Countdown',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'cancel',
         '1h',
         '2h',
@@ -4304,7 +4304,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'level_1',
         'level_2',
         'level_3',
@@ -4345,7 +4345,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'mesa Level',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'level_1',
         'level_2',
         'level_3',
@@ -4367,7 +4367,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'up',
         'down',
         'stop',
@@ -4407,7 +4407,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'mesa Up/Down',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'up',
         'down',
         'stop',
@@ -4428,7 +4428,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -4468,7 +4468,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mirilla puerta Anti-flicker',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -4489,7 +4489,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
       ]),
@@ -4528,7 +4528,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mirilla puerta IPC mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
       ]),
@@ -4548,7 +4548,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'relay',
         'pos',
         'none',
@@ -4588,7 +4588,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Office Indicator light mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'relay',
         'pos',
         'none',
@@ -4609,7 +4609,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -4649,7 +4649,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Office Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -4670,7 +4670,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'forward',
         'back',
       ]),
@@ -4709,7 +4709,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Persiana do Quarto Motor mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'forward',
         'back',
       ]),
@@ -4729,7 +4729,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'forward',
         'back',
       ]),
@@ -4768,7 +4768,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Projector Screen Motor mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'forward',
         'back',
       ]),
@@ -4788,7 +4788,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -4828,7 +4828,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Puerta Casa  Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -4849,7 +4849,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'relay',
         'pos',
@@ -4889,7 +4889,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Raspy4 - Home Assistant Indicator light mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'relay',
         'pos',
@@ -4910,7 +4910,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -4950,7 +4950,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Raspy4 - Home Assistant Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -4971,7 +4971,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -5011,7 +5011,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Seating side 6-ch Smart Switch  Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -5032,7 +5032,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -5072,7 +5072,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Security Camera Motion detection sensitivity',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -5093,7 +5093,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -5133,7 +5133,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Security Camera Night vision',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -5154,7 +5154,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '1',
         '2',
       ]),
@@ -5193,7 +5193,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Security Camera Record mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '1',
         '2',
       ]),
@@ -5213,7 +5213,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
       ]),
@@ -5252,7 +5252,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Security Camera Sound detection sensitivity',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
       ]),
@@ -5272,7 +5272,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'relay',
         'pos',
@@ -5312,7 +5312,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Security Light Indicator light mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'relay',
         'pos',
@@ -5333,7 +5333,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -5373,7 +5373,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Security Light Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -5394,7 +5394,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -5434,7 +5434,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Server Fan Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -5455,7 +5455,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'alarm_sound',
         'alarm_light',
         'alarm_sound_light',
@@ -5496,7 +5496,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Siren Siren mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'alarm_sound',
         'alarm_light',
         'alarm_sound_light',
@@ -5518,7 +5518,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'low',
         'middle',
         'high',
@@ -5559,7 +5559,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Siren veranda  Volume',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'low',
         'middle',
         'high',
@@ -5581,7 +5581,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'low',
         'middle',
         'high',
@@ -5622,7 +5622,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Siren Volume',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'low',
         'middle',
         'high',
@@ -5644,7 +5644,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '85',
         '90',
       ]),
@@ -5683,7 +5683,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Smart Kettle Quick heat temperature',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '85',
         '90',
       ]),
@@ -5703,7 +5703,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'setting_quick',
         'boiling_quick',
         'temp_setting',
@@ -5744,7 +5744,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Smart Kettle Work mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'setting_quick',
         'boiling_quick',
         'temp_setting',
@@ -5766,7 +5766,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'smart',
         'interim',
       ]),
@@ -5805,7 +5805,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Smart Odor Eliminator-Pro Odor elimination mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'smart',
         'interim',
       ]),
@@ -5825,7 +5825,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'cancel',
         '24h',
         '48h',
@@ -5866,7 +5866,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Smart Water Timer Weather delay',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'cancel',
         '24h',
         '48h',
@@ -5888,7 +5888,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -5928,7 +5928,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Socket3 Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -5949,7 +5949,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'relay',
         'pos',
         'none',
@@ -5989,7 +5989,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Socket4 Indicator light mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'relay',
         'pos',
         'none',
@@ -6010,7 +6010,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -6050,7 +6050,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Socket4 Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -6071,7 +6071,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'relay',
         'pos',
         'none',
@@ -6111,7 +6111,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Spot 1 Indicator light mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'relay',
         'pos',
         'none',
@@ -6132,7 +6132,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -6172,7 +6172,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Spot 1 Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -6193,7 +6193,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'level_1',
         'level_2',
         'level_3',
@@ -6241,7 +6241,7 @@
     'attributes': ReadOnlyDict({
       'friendly_name': 'Sunbeam Bedding Level',
       'icon': 'mdi:thermometer-lines',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'level_1',
         'level_2',
         'level_3',
@@ -6269,7 +6269,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'level_1',
         'level_2',
         'level_3',
@@ -6317,7 +6317,7 @@
     'attributes': ReadOnlyDict({
       'friendly_name': 'Sunbeam Bedding Level 1',
       'icon': 'mdi:thermometer-lines',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'level_1',
         'level_2',
         'level_3',
@@ -6345,7 +6345,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'level_1',
         'level_2',
         'level_3',
@@ -6393,7 +6393,7 @@
     'attributes': ReadOnlyDict({
       'friendly_name': 'Sunbeam Bedding Level 2',
       'icon': 'mdi:thermometer-lines',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'level_1',
         'level_2',
         'level_3',
@@ -6421,7 +6421,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'smart',
         'zone',
         'pose',
@@ -6462,7 +6462,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'V20 Mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'smart',
         'zone',
         'pose',
@@ -6484,7 +6484,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'low',
         'middle',
         'high',
@@ -6524,7 +6524,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'V20 Water tank adjustment',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'low',
         'middle',
         'high',
@@ -6545,7 +6545,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'cancel',
         '24h',
         '48h',
@@ -6586,7 +6586,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Valve Controller 2 Weather delay',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'cancel',
         '24h',
         '48h',
@@ -6608,7 +6608,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'forward',
         'back',
       ]),
@@ -6647,7 +6647,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'VIVIDSTORM SCREEN Motor mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'forward',
         'back',
       ]),
@@ -6667,7 +6667,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'relay',
         'pos',
         'none',
@@ -6707,7 +6707,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'wallwasher front Indicator light mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'relay',
         'pos',
         'none',
@@ -6728,7 +6728,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -6768,7 +6768,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'wallwasher front Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -6789,7 +6789,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'relay',
         'pos',
         'none',
@@ -6829,7 +6829,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Weihnachtsmann  Indicator light mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'relay',
         'pos',
         'none',
@@ -6850,7 +6850,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -6890,7 +6890,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Weihnachtsmann  Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -6911,7 +6911,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',
@@ -6951,7 +6951,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Wi-Fi hub Power-on behavior',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'power_off',
         'power_on',
         'last',

--- a/tests/components/twinkly/snapshots/test_select.ambr
+++ b/tests/components/twinkly/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'color',
         'demo',
         'effect',
@@ -50,7 +50,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Tree 1 Mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'color',
         'demo',
         'effect',

--- a/tests/components/unifi_access/snapshots/test_select.ambr
+++ b/tests/components/unifi_access/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'keep_lock',
         'keep_unlock',
         'custom',
@@ -47,7 +47,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Back Door Lock rule',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'keep_lock',
         'keep_unlock',
         'custom',
@@ -69,7 +69,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'keep_lock',
         'keep_unlock',
         'custom',
@@ -110,7 +110,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Front Door Lock rule',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'keep_lock',
         'keep_unlock',
         'custom',

--- a/tests/components/velbus/snapshots/test_select.ambr
+++ b/tests/components/velbus/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'summer',
         'winter',
@@ -47,7 +47,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kitchen select',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'summer',
         'winter',

--- a/tests/components/vicare/snapshots/test_select.ambr
+++ b/tests/components/vicare/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'efficient_with_min_comfort',
         'efficient',
         'off',
@@ -46,7 +46,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'model0 DHW operating mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'efficient_with_min_comfort',
         'efficient',
         'off',

--- a/tests/components/vistapool/snapshots/test_select.ambr
+++ b/tests/components/vistapool/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'slow',
         'medium',
         'high',
@@ -46,7 +46,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'My Pool Filtration timer speed 1',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'slow',
         'medium',
         'high',
@@ -67,7 +67,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'slow',
         'medium',
         'high',
@@ -107,7 +107,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'My Pool Filtration timer speed 2',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'slow',
         'medium',
         'high',
@@ -128,7 +128,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'slow',
         'medium',
         'high',
@@ -168,7 +168,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'My Pool Filtration timer speed 3',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'slow',
         'medium',
         'high',
@@ -189,7 +189,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'manual',
         'auto',
         'heat',
@@ -231,7 +231,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'My Pool Pump mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'manual',
         'auto',
         'heat',
@@ -254,7 +254,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'slow',
         'medium',
         'high',
@@ -294,7 +294,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'My Pool Pump speed',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'slow',
         'medium',
         'high',

--- a/tests/components/whirlpool/snapshots/test_select.ambr
+++ b/tests/components/whirlpool/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '-4',
         '-2',
         '0',
@@ -48,7 +48,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Beer fridge Temperature level',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '-4',
         '-2',
         '0',

--- a/tests/components/wled/snapshots/test_select.ambr
+++ b/tests/components/wled/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '* Color 1',
         '* Color Gradient',
         '* Colors 1&2',
@@ -114,7 +114,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'WLED RGB Light Color palette',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '* Color 1',
         '* Color Gradient',
         '* Colors 1&2',
@@ -203,7 +203,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -243,7 +243,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'WLED RGB Light Live override',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '0',
         '1',
         '2',
@@ -264,7 +264,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -301,7 +301,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'WLED RGB Light Playlist',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
       ]),
     }),
     'context': <ANY>,
@@ -319,7 +319,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -356,7 +356,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'WLED RGB Light Preset',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
       ]),
     }),
     'context': <ANY>,
@@ -374,7 +374,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '* Color 1',
         '* Color Gradient',
         '* Colors 1&2',
@@ -482,7 +482,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'WLED RGB Light Segment 1 color palette',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '* Color 1',
         '* Color Gradient',
         '* Colors 1&2',

--- a/tests/components/yale_smart_alarm/snapshots/test_select.ambr
+++ b/tests/components/yale_smart_alarm/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'high',
         'low',
         'off',
@@ -46,7 +46,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device1 Volume',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'high',
         'low',
         'off',
@@ -67,7 +67,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'high',
         'low',
         'off',
@@ -107,7 +107,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device2 Volume',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'high',
         'low',
         'off',
@@ -128,7 +128,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'high',
         'low',
         'off',
@@ -168,7 +168,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device3 Volume',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'high',
         'low',
         'off',
@@ -189,7 +189,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'high',
         'low',
         'off',
@@ -229,7 +229,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device7 Volume',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'high',
         'low',
         'off',
@@ -250,7 +250,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'high',
         'low',
         'off',
@@ -290,7 +290,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device8 Volume',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'high',
         'low',
         'off',
@@ -311,7 +311,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'high',
         'low',
         'off',
@@ -351,7 +351,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Device9 Volume',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'high',
         'low',
         'off',

--- a/tests/components/yoto/snapshots/test_select.ambr
+++ b/tests/components/yoto/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'orange_peel',
         'tambourine_red',
         'lilac',
@@ -51,7 +51,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Nursery Yoto Day mode color',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'orange_peel',
         'tambourine_red',
         'lilac',
@@ -77,7 +77,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'orange_peel',
         'tambourine_red',
         'lilac',
@@ -122,7 +122,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Nursery Yoto Night mode color',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'orange_peel',
         'tambourine_red',
         'lilac',

--- a/tests/components/zinvolt/snapshots/test_select.ambr
+++ b/tests/components/zinvolt/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'dynamic',
         'self_use',
         'fast_discharge',
@@ -48,7 +48,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Zinvolt Batterij Mode',
-      'options': list([
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'dynamic',
         'self_use',
         'fast_discharge',


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add new `SelectEntityCapabilityAttribute` enum for the capability attributes of the select entity. There are no state_attribute so no need to create `SelectEntityStateAttribute` enum.

Based on https://github.com/home-assistant/architecture/discussions/1406, linked to epic https://github.com/home-assistant/epics/issues/104

A follow-up PR will formally deprecate the ATTR_OPTIONS constant.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
