### PR TITLE
bluetooth: prioritize recent advertisements during history replay

### DIFF
--- a/homeassistant/components/bluetooth/__init__.py
+++ b/homeassistant/components/bluetooth/__init__.py
@@ -94,7 +94,7 @@ from .const import (
 )
 from .manager import HomeAssistantBluetoothManager
 from .match import BluetoothCallbackMatcher, IntegrationMatcher
-from .models import BluetoothCallback, BluetoothChange
+from .models import BluetoothCallback, BluetoothCallbackReplay, BluetoothChange
 from .storage import BluetoothStorage
 from .util import adapter_title, resolve_scanning_mode
 
@@ -109,6 +109,7 @@ __all__ = [
     "BaseHaScanner",
     "BluetoothCallback",
     "BluetoothCallbackMatcher",
+    "BluetoothCallbackReplay",
     "BluetoothChange",
     "BluetoothReachabilityIntent",
     "BluetoothScannerDevice",

--- a/homeassistant/components/bluetooth/api.py
+++ b/homeassistant/components/bluetooth/api.py
@@ -26,7 +26,12 @@ from homeassistant.helpers.singleton import singleton
 from .const import DATA_MANAGER
 from .manager import HomeAssistantBluetoothManager
 from .match import BluetoothCallbackMatcher
-from .models import BluetoothCallback, BluetoothChange, ProcessAdvertisementCallback
+from .models import (
+    BluetoothCallback,
+    BluetoothCallbackReplay,
+    BluetoothChange,
+    ProcessAdvertisementCallback,
+)
 
 if TYPE_CHECKING:
     from bleak.backends.device import BLEDevice
@@ -143,6 +148,7 @@ def async_register_callback(
     *,
     scan_interval: float | None = None,
     scan_duration: float | None = None,
+    replay: BluetoothCallbackReplay = BluetoothCallbackReplay.OLDEST_FIRST,
 ) -> Callable[[], None]:
     """Register to receive a callback on bluetooth change.
 
@@ -155,10 +161,13 @@ def async_register_callback(
     values. Without an address in the matcher the active-scan request
     is skipped; the callback itself still fires normally.
 
+    ``replay`` controls which cached advertisements are replayed to the
+    callback on registration; defaults to OLDEST_FIRST.
+
     Returns a callback that can be used to cancel the registration.
     """
     return _get_manager(hass).async_register_callback(
-        callback, match_dict, mode, scan_interval, scan_duration
+        callback, match_dict, mode, scan_interval, scan_duration, replay
     )
 
 

--- a/homeassistant/components/bluetooth/manager.py
+++ b/homeassistant/components/bluetooth/manager.py
@@ -1,9 +1,10 @@
 """The bluetooth integration."""
 
-from collections.abc import Callable, Iterable
+from collections.abc import Callable
 from functools import partial
 import itertools
 import logging
+from operator import attrgetter
 from typing import override
 
 from bleak_retry_connector import BleakSlotManager
@@ -54,7 +55,12 @@ from .match import (
     IntegrationMatcher,
     ble_device_matches,
 )
-from .models import BluetoothCallback, BluetoothChange, BluetoothServiceInfoBleak
+from .models import (
+    BluetoothCallback,
+    BluetoothCallbackReplay,
+    BluetoothChange,
+    BluetoothServiceInfoBleak,
+)
 from .storage import BluetoothStorage
 from .util import async_load_history_from_system
 
@@ -212,6 +218,7 @@ class HomeAssistantBluetoothManager(BluetoothManager):
         mode: BluetoothScanningMode = BluetoothScanningMode.ACTIVE,
         scan_interval: float | None = None,
         scan_duration: float | None = None,
+        replay: BluetoothCallbackReplay = BluetoothCallbackReplay.OLDEST_FIRST,
     ) -> Callable[[], None]:
         """Register a callback."""
         callback_matcher = BluetoothCallbackMatcherWithCallback(callback=callback)
@@ -245,16 +252,37 @@ class HomeAssistantBluetoothManager(BluetoothManager):
             if cancel_active_scan is not None:
                 cancel_active_scan()
 
+        if replay is not BluetoothCallbackReplay.DISABLED:
+            self._async_replay_history_for_callback(
+                connectable, callback, callback_matcher, replay
+            )
+        return _async_remove_callback
+
+    @hass_callback
+    def _async_replay_history_for_callback(
+        self,
+        connectable: bool,
+        callback: BluetoothCallback,
+        callback_matcher: BluetoothCallbackMatcherWithCallback,
+        replay: BluetoothCallbackReplay,
+    ) -> None:
+        """Replay history for a callback."""
         # If we have history for the subscriber, we can trigger the callback
         # immediately with the last packet so the subscriber can see the
         # device.
         history = self._connectable_history if connectable else self._all_history
-        service_infos: Iterable[BluetoothServiceInfoBleak] = []
+        service_infos: list[BluetoothServiceInfoBleak] = []
         if (address := callback_matcher.get(ADDRESS)) is not None:
             if service_info := history.get(address):
                 service_infos = [service_info]
         else:
-            service_infos = history.values()
+            # Sort by time explicitly; dict insertion order is not guaranteed
+            # to match advertisement time after history is loaded from storage.
+            service_infos = sorted(
+                history.values(),
+                key=attrgetter("time"),
+                reverse=replay is BluetoothCallbackReplay.NEWEST_FIRST,
+            )
 
         for service_info in service_infos:
             if ble_device_matches(callback_matcher, service_info):
@@ -262,8 +290,6 @@ class HomeAssistantBluetoothManager(BluetoothManager):
                     callback(service_info, BluetoothChange.ADVERTISEMENT)
                 except Exception:
                     _LOGGER.exception("Error in bluetooth callback")
-
-        return _async_remove_callback
 
     @hass_callback
     @override

--- a/homeassistant/components/bluetooth/models.py
+++ b/homeassistant/components/bluetooth/models.py
@@ -1,10 +1,18 @@
 """Models for bluetooth."""
 
 from collections.abc import Callable
-from enum import Enum
+from enum import Enum, auto
 
 from home_assistant_bluetooth import BluetoothServiceInfoBleak
 
 BluetoothChange = Enum("BluetoothChange", "ADVERTISEMENT")
 type BluetoothCallback = Callable[[BluetoothServiceInfoBleak, BluetoothChange], None]
 type ProcessAdvertisementCallback = Callable[[BluetoothServiceInfoBleak], bool]
+
+
+class BluetoothCallbackReplay(Enum):
+    """Controls how history is replayed when a callback is registered."""
+
+    OLDEST_FIRST = auto()
+    NEWEST_FIRST = auto()
+    DISABLED = auto()

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -16,6 +16,7 @@ import pytest
 
 from homeassistant.components import bluetooth
 from homeassistant.components.bluetooth import (
+    BluetoothCallbackReplay,
     BluetoothChange,
     BluetoothScanningMode,
     BluetoothServiceInfo,
@@ -45,6 +46,7 @@ from homeassistant.components.bluetooth.match import (
     MANUFACTURER_ID,
     SERVICE_DATA_UUID,
     SERVICE_UUID,
+    BluetoothCallbackMatcher,
 )
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
@@ -1501,6 +1503,113 @@ async def test_register_callbacks(
     assert service_info.source == SOURCE_LOCAL
     assert service_info.manufacturer == "Nordic Semiconductor ASA"
     assert service_info.manufacturer_id == 89
+
+
+@pytest.mark.parametrize(
+    ("devices", "matcher", "replay", "expected_addresses"),
+    [
+        pytest.param(
+            [
+                ("AA:BB:CC:DD:EE:01", "older", 1000.0),
+                ("AA:BB:CC:DD:EE:02", "newer", 2000.0),
+            ],
+            None,
+            BluetoothCallbackReplay.OLDEST_FIRST,
+            ["AA:BB:CC:DD:EE:01", "AA:BB:CC:DD:EE:02"],
+            id="oldest-first",
+        ),
+        pytest.param(
+            [
+                ("AA:BB:CC:DD:EE:01", "older", 1000.0),
+                ("AA:BB:CC:DD:EE:02", "newer", 2000.0),
+            ],
+            None,
+            BluetoothCallbackReplay.NEWEST_FIRST,
+            ["AA:BB:CC:DD:EE:02", "AA:BB:CC:DD:EE:01"],
+            id="newest-first",
+        ),
+        pytest.param(
+            [
+                ("AA:BB:CC:DD:EE:01", "target", 1000.0),
+                ("AA:BB:CC:DD:EE:02", "other", 2000.0),
+                ("AA:BB:CC:DD:EE:03", "target", 3000.0),
+            ],
+            {LOCAL_NAME: "target"},
+            BluetoothCallbackReplay.NEWEST_FIRST,
+            ["AA:BB:CC:DD:EE:03", "AA:BB:CC:DD:EE:01"],
+            id="newest-first-with-filter",
+        ),
+        pytest.param(
+            [
+                ("AA:BB:CC:DD:EE:01", "older", 1000.0),
+                ("AA:BB:CC:DD:EE:02", "newer", 2000.0),
+            ],
+            None,
+            BluetoothCallbackReplay.DISABLED,
+            [],
+            id="disabled",
+        ),
+        pytest.param(
+            [
+                ("AA:BB:CC:DD:EE:01", "target", 1000.0),
+                ("AA:BB:CC:DD:EE:02", "other", 2000.0),
+            ],
+            {ADDRESS: "AA:BB:CC:DD:EE:01"},
+            BluetoothCallbackReplay.NEWEST_FIRST,
+            ["AA:BB:CC:DD:EE:01"],
+            id="newest-first-address-match",
+        ),
+        pytest.param(
+            [
+                ("AA:BB:CC:DD:EE:01", "newer", 2000.0),
+                ("AA:BB:CC:DD:EE:02", "older", 1000.0),
+            ],
+            None,
+            BluetoothCallbackReplay.OLDEST_FIRST,
+            ["AA:BB:CC:DD:EE:02", "AA:BB:CC:DD:EE:01"],
+            id="oldest-first-out-of-order-insertion",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("enable_bluetooth", "mock_bleak_scanner_start")
+async def test_register_callbacks_history_replay_order(
+    hass: HomeAssistant,
+    devices: list[tuple[str, str, float]],
+    matcher: BluetoothCallbackMatcher | None,
+    replay: BluetoothCallbackReplay,
+    expected_addresses: list[str],
+) -> None:
+    """History replay respects the replay order kwarg."""
+    mock_bt = []
+    replayed: list[BluetoothServiceInfo] = []
+
+    with patch(
+        "homeassistant.components.bluetooth.async_get_bluetooth", return_value=mock_bt
+    ):
+        await async_setup_with_default_adapter(hass)
+
+    with patch.object(hass.config_entries.flow, "async_init"):
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+
+        for address, name, adv_time in devices:
+            device = generate_ble_device(address, name)
+            adv = generate_advertisement_data(local_name=name)
+            inject_advertisement_with_time_and_source_connectable(
+                hass, device, adv, adv_time, SOURCE_LOCAL, True
+            )
+
+        def _subscriber(
+            service_info: BluetoothServiceInfo, change: BluetoothChange
+        ) -> None:
+            replayed.append(service_info)
+
+        cancel = bluetooth.async_register_callback(
+            hass, _subscriber, matcher, BluetoothScanningMode.ACTIVE, replay=replay
+        )
+        cancel()
+
+    assert [si.address for si in replayed] == expected_addresses
 
 
 @pytest.mark.usefixtures("enable_bluetooth")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Make history replay order opt-in via a new `replay` kwarg. Existing consumers use OLDEST_FIRST which is how it was originally intended. We do not rely on insertion order anymore.
    
* OLDEST_FIRST (default): Delivers in the order of oldest first. Originally it was insertion-order. It was more a maybe oldest first.
* NEWEST_FIRST: delivers the freshest advertisement first, useful for consumers that want to act on current device state immediately.
* DISABLED: skips replay entirely, useful for consumers that only care about live advertisements.

The matter ble implementation will use NEWEST_FIRST.

Tests implemented by Claude Code.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to PR: https://github.com/home-assistant/core/pull/173488
- Developer documentation PR: https://github.com/home-assistant/developers.home-assistant/pull/3210

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
