### PR TITLE
Drive the UniFi Protect doorbell ring event from the public events websocket

### DIFF
--- a/homeassistant/components/unifiprotect/data.py
+++ b/homeassistant/components/unifiprotect/data.py
@@ -8,7 +8,7 @@ from functools import partial
 import logging
 from typing import TYPE_CHECKING, Any, cast
 
-from uiprotect import EventChange, ProtectApiClient, ProtectEvent, ProtectEventChannel
+from uiprotect import EventChange, ProtectApiClient, ProtectEvent
 from uiprotect.api import RTSPSStreams
 from uiprotect.data import (
     NVR,
@@ -91,7 +91,7 @@ class ProtectData:
         self._siren_subscriptions: defaultdict[str, set[Callable[[Siren], None]]] = (
             defaultdict(set)
         )
-        self._smart_detect_subscriptions: defaultdict[
+        self._public_event_subscriptions: defaultdict[
             str, set[Callable[[ProtectEvent], None]]
         ] = defaultdict(set)
         self._public_subscriptions: defaultdict[
@@ -260,24 +260,20 @@ class ProtectData:
     def _async_process_public_event(
         self, event: ProtectEvent, change: EventChange
     ) -> None:
-        """Process a smart-detect event from the public events websocket.
+        """Dispatch a public events websocket event to per-device subscribers.
 
-        Only the start of a detection is dispatched; the per-camera entities
-        filter by object type. The camera is resolved by ``device_id`` (the
+        Only the start of an event is dispatched; the per-device entities filter
+        by event (and object) type. The device is resolved by ``device_id`` (the
         stable cross-API join key), not the public ``device_mac``, so the
         dispatch key comes from the same store the entities derive
         ``self.device.mac`` from and matches without assuming both mac strings
         are byte-identical.
         """
-        if (
-            change is not EventChange.STARTED
-            or event.channel is not ProtectEventChannel.DETECTION
-            or not event.smart_detect_types
-        ):
+        if change is not EventChange.STARTED:
             return
         device = self.api.bootstrap.get_device_from_id(event.device_id)
         if device is None or not (
-            subscriptions := self._smart_detect_subscriptions.get(device.mac)
+            subscriptions := self._public_event_subscriptions.get(device.mac)
         ):
             return
         for update_callback in subscriptions:
@@ -548,21 +544,21 @@ class ProtectData:
             del self._siren_subscriptions[mac]
 
     @callback
-    def async_subscribe_smart_detect(
+    def async_subscribe_public_event(
         self, mac: str, update_callback: Callable[[ProtectEvent], None]
     ) -> CALLBACK_TYPE:
-        """Add a callback subscriber for public smart-detect events by camera mac."""
-        self._smart_detect_subscriptions[mac].add(update_callback)
-        return partial(self._async_unsubscribe_smart_detect, mac, update_callback)
+        """Add a callback subscriber for public events by device mac."""
+        self._public_event_subscriptions[mac].add(update_callback)
+        return partial(self._async_unsubscribe_public_event, mac, update_callback)
 
     @callback
-    def _async_unsubscribe_smart_detect(
+    def _async_unsubscribe_public_event(
         self, mac: str, update_callback: Callable[[ProtectEvent], None]
     ) -> None:
-        """Remove a smart-detect callback subscriber."""
-        self._smart_detect_subscriptions[mac].remove(update_callback)
-        if not self._smart_detect_subscriptions[mac]:
-            del self._smart_detect_subscriptions[mac]
+        """Remove a public event callback subscriber."""
+        self._public_event_subscriptions[mac].remove(update_callback)
+        if not self._public_event_subscriptions[mac]:
+            del self._public_event_subscriptions[mac]
 
     @callback
     def async_subscribe_public(

--- a/homeassistant/components/unifiprotect/data.py
+++ b/homeassistant/components/unifiprotect/data.py
@@ -92,7 +92,7 @@ class ProtectData:
             defaultdict(set)
         )
         self._public_event_subscriptions: defaultdict[
-            str, set[Callable[[ProtectEvent], None]]
+            tuple[str, EventType], set[Callable[[ProtectEvent], None]]
         ] = defaultdict(set)
         self._public_subscriptions: defaultdict[
             str, set[Callable[[PublicDeviceModel | None], None]]
@@ -210,9 +210,11 @@ class ProtectData:
         Must run *after* ``update_public()`` has primed the public bootstrap;
         the setup flow guarantees this (a failed prime aborts setup), and
         ``subscribe_events()`` raises otherwise. This is the source of truth for
-        smart-detect events (e.g. package) that the private API only surfaces as
-        the unhandled ``smartDetectObject`` model. uiprotect owns websocket
-        reconnection and keeps the callback attached, so this is a one-shot.
+        the event entities driven off the public websocket: the doorbell ring,
+        and the smart-detect events (e.g. package) that the private API only
+        surfaces as the unhandled ``smartDetectObject`` model. uiprotect owns
+        websocket reconnection and keeps the callback attached, so this is a
+        one-shot.
         """
         self._unsubs.append(self.api.subscribe_events(self._async_process_public_event))
 
@@ -260,20 +262,23 @@ class ProtectData:
     def _async_process_public_event(
         self, event: ProtectEvent, change: EventChange
     ) -> None:
-        """Dispatch a public events websocket event to per-device subscribers.
+        """Dispatch a public events websocket event to its subscribers.
 
-        Only the start of an event is dispatched; the per-device entities filter
-        by event (and object) type. The device is resolved by ``device_id`` (the
-        stable cross-API join key), not the public ``device_mac``, so the
-        dispatch key comes from the same store the entities derive
-        ``self.device.mac`` from and matches without assuming both mac strings
-        are byte-identical.
+        Only the start of an event is dispatched, routed to the subscribers that
+        registered for this device and event type; an entity that cares about a
+        sub-type (e.g. a smart-detect object type) filters further itself. The
+        device is resolved by ``device_id`` (the stable cross-API join key), not
+        the public ``device_mac``, so the key comes from the same store the
+        entities derive ``self.device.mac`` from and matches without assuming
+        both mac strings are byte-identical.
         """
         if change is not EventChange.STARTED:
             return
         device = self.api.bootstrap.get_device_from_id(event.device_id)
         if device is None or not (
-            subscriptions := self._public_event_subscriptions.get(device.mac)
+            subscriptions := self._public_event_subscriptions.get(
+                (device.mac, event.type)
+            )
         ):
             return
         for update_callback in subscriptions:
@@ -545,20 +550,26 @@ class ProtectData:
 
     @callback
     def async_subscribe_public_event(
-        self, mac: str, update_callback: Callable[[ProtectEvent], None]
+        self,
+        mac: str,
+        event_type: EventType,
+        update_callback: Callable[[ProtectEvent], None],
     ) -> CALLBACK_TYPE:
-        """Add a callback subscriber for public events by device mac."""
-        self._public_event_subscriptions[mac].add(update_callback)
-        return partial(self._async_unsubscribe_public_event, mac, update_callback)
+        """Add a callback subscriber for public events of a type by device mac."""
+        key = (mac, event_type)
+        self._public_event_subscriptions[key].add(update_callback)
+        return partial(self._async_unsubscribe_public_event, key, update_callback)
 
     @callback
     def _async_unsubscribe_public_event(
-        self, mac: str, update_callback: Callable[[ProtectEvent], None]
+        self,
+        key: tuple[str, EventType],
+        update_callback: Callable[[ProtectEvent], None],
     ) -> None:
         """Remove a public event callback subscriber."""
-        self._public_event_subscriptions[mac].remove(update_callback)
-        if not self._public_event_subscriptions[mac]:
-            del self._public_event_subscriptions[mac]
+        self._public_event_subscriptions[key].remove(update_callback)
+        if not self._public_event_subscriptions[key]:
+            del self._public_event_subscriptions[key]
 
     @callback
     def async_subscribe_public(

--- a/homeassistant/components/unifiprotect/event.py
+++ b/homeassistant/components/unifiprotect/event.py
@@ -80,6 +80,7 @@ class ProtectDeviceRingEventEntity(EventEntityMixin, ProtectDeviceEntity, EventE
 
     entity_description: ProtectEventEntityDescription
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Subscribe to public ring events for this doorbell."""
         await super().async_added_to_hass()
@@ -375,6 +376,7 @@ class ProtectDeviceSmartDetectEventEntity(
 
     entity_description: ProtectEventEntityDescription
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Subscribe to public smart-detect events for this camera."""
         await super().async_added_to_hass()

--- a/homeassistant/components/unifiprotect/event.py
+++ b/homeassistant/components/unifiprotect/event.py
@@ -85,15 +85,14 @@ class ProtectDeviceRingEventEntity(EventEntityMixin, ProtectDeviceEntity, EventE
         await super().async_added_to_hass()
         self.async_on_remove(
             self.data.async_subscribe_public_event(
-                self.device.mac, self._async_ring_event
+                self.device.mac, EventType.RING, self._async_ring_event
             )
         )
 
     @callback
     def _async_ring_event(self, event: ProtectEvent) -> None:
-        if event.type is EventType.RING:
-            self._trigger_event(DoorbellEventType.RING, {ATTR_EVENT_ID: event.id})
-            self.async_write_ha_state()
+        self._trigger_event(DoorbellEventType.RING, {ATTR_EVENT_ID: event.id})
+        self.async_write_ha_state()
 
 
 class ProtectDeviceNFCEventEntity(EventEntityMixin, ProtectDeviceEntity, EventEntity):
@@ -381,7 +380,7 @@ class ProtectDeviceSmartDetectEventEntity(
         await super().async_added_to_hass()
         self.async_on_remove(
             self.data.async_subscribe_public_event(
-                self.device.mac, self._async_smart_detect_event
+                self.device.mac, EventType.SMART_DETECT, self._async_smart_detect_event
             )
         )
 

--- a/homeassistant/components/unifiprotect/event.py
+++ b/homeassistant/components/unifiprotect/event.py
@@ -76,27 +76,22 @@ class ProtectEventEntityDescription(ProtectEventMixin, EventEntityDescription):
 
 
 class ProtectDeviceRingEventEntity(EventEntityMixin, ProtectDeviceEntity, EventEntity):
-    """A UniFi Protect event entity."""
+    """A UniFi Protect doorbell ring event entity driven by the public events WS."""
 
     entity_description: ProtectEventEntityDescription
 
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to public ring events for this doorbell."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self.data.async_subscribe_public_event(
+                self.device.mac, self._async_ring_event
+            )
+        )
+
     @callback
-    @override
-    def _async_update_device_from_protect(self, device: ProtectDeviceType) -> None:
-        description = self.entity_description
-
-        prev_event = self._event
-        prev_event_end = self._event_end
-        super()._async_update_device_from_protect(device)
-        if event := description.get_event_obj(device):
-            self._event = event
-            self._event_end = event.end if event else None
-
-        if (
-            event
-            and not self._event_already_ended(prev_event, prev_event_end)
-            and event.type is EventType.RING
-        ):
+    def _async_ring_event(self, event: ProtectEvent) -> None:
+        if event.type is EventType.RING:
             self._trigger_event(DoorbellEventType.RING, {ATTR_EVENT_ID: event.id})
             self.async_write_ha_state()
 
@@ -385,7 +380,7 @@ class ProtectDeviceSmartDetectEventEntity(
         """Subscribe to public smart-detect events for this camera."""
         await super().async_added_to_hass()
         self.async_on_remove(
-            self.data.async_subscribe_smart_detect(
+            self.data.async_subscribe_public_event(
                 self.device.mac, self._async_smart_detect_event
             )
         )
@@ -405,7 +400,6 @@ EVENT_DESCRIPTIONS: tuple[ProtectEventEntityDescription, ...] = (
         translation_key="doorbell",
         device_class=EventDeviceClass.DOORBELL,
         ufp_required_field="feature_flags.is_doorbell",
-        ufp_event_obj="last_ring_event",
         event_types=[DoorbellEventType.RING],
         entity_class=ProtectDeviceRingEventEntity,
     ),

--- a/tests/components/unifiprotect/test_event.py
+++ b/tests/components/unifiprotect/test_event.py
@@ -70,7 +70,18 @@ async def test_doorbell_ring(
     unadopted_camera: Camera,
     fixed_now: datetime,
 ) -> None:
-    """Test a doorbell ring event."""
+    """Test a doorbell ring event fired from the public events websocket."""
+
+    # Ring is delivered over the public events websocket, which is only
+    # subscribed once update_public() has primed the public bootstrap.
+    ufp.api.has_public_bootstrap = True
+    ufp.api.public_bootstrap = Mock(
+        spec=PublicBootstrap,
+        relays={},
+        sirens={},
+        arm_mode=None,
+        arm_profiles={},
+    )
 
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
     assert_entity_counts(hass, Platform.EVENT, 5, 5)
@@ -85,95 +96,58 @@ async def test_doorbell_ring(
     )
 
     unsub = async_track_state_change_event(hass, entity_id, _capture_event)
-    event = Event(
-        model=ModelType.EVENT,
-        id="test_event_id",
-        type=EventType.RING,
-        start=fixed_now - timedelta(seconds=1),
-        end=None,
-        score=100,
-        smart_detect_types=[],
-        smart_detect_event_ids=[],
-        camera_id=doorbell.id,
-        api=ufp.api,
+
+    ufp.events_msg(
+        ProtectEvent(
+            id="test_ring_event",
+            type=EventType.RING,
+            channel=ProtectEventChannel.DETECTION,
+            device_id=doorbell.id,
+            device_mac=doorbell.mac,
+            start=fixed_now - timedelta(seconds=1),
+            end=fixed_now,
+        ),
+        EventChange.STARTED,
     )
-
-    new_camera = doorbell.model_copy()
-    new_camera.last_ring_event_id = "test_event_id"
-    ufp.api.bootstrap.cameras = {new_camera.id: new_camera}
-    ufp.api.bootstrap.events = {event.id: event}
-
-    mock_msg = Mock()
-    mock_msg.changed_data = {}
-    mock_msg.new_obj = event
-    ufp.ws_msg(mock_msg)
-
     await hass.async_block_till_done()
 
     assert len(events) == 1
     state = events[0].data["new_state"]
     assert state
-    timestamp = state.state
     assert state.attributes[ATTR_ATTRIBUTION] == DEFAULT_ATTRIBUTION
-    assert state.attributes[ATTR_EVENT_ID] == "test_event_id"
+    assert state.attributes[ATTR_EVENT_ID] == "test_ring_event"
 
-    event = Event(
-        model=ModelType.EVENT,
-        id="test_event_id",
-        type=EventType.RING,
-        start=fixed_now - timedelta(seconds=1),
-        end=fixed_now + timedelta(seconds=1),
-        score=50,
-        smart_detect_types=[],
-        smart_detect_event_ids=[],
-        camera_id=doorbell.id,
-        api=ufp.api,
+    # A non-ring event on the same camera must not fire the doorbell entity.
+    ufp.events_msg(
+        ProtectEvent(
+            id="test_motion_event",
+            type=EventType.MOTION,
+            channel=ProtectEventChannel.DETECTION,
+            device_id=doorbell.id,
+            device_mac=doorbell.mac,
+            start=fixed_now,
+            end=None,
+        ),
+        EventChange.STARTED,
     )
-
-    new_camera = doorbell.model_copy()
-    ufp.api.bootstrap.cameras = {new_camera.id: new_camera}
-    ufp.api.bootstrap.events = {event.id: event}
-
-    mock_msg = Mock()
-    mock_msg.changed_data = {}
-    mock_msg.new_obj = event
-    ufp.ws_msg(mock_msg)
-
     await hass.async_block_till_done()
+    assert len(events) == 1
 
-    # Event is already seen and has end, should now be off
-    state = hass.states.get(entity_id)
-    assert state
-    assert state.state == timestamp
-
-    # Now send an event that has an end right away
-    event = Event(
-        model=ModelType.EVENT,
-        id="new_event_id",
-        type=EventType.RING,
-        start=fixed_now - timedelta(seconds=1),
-        end=fixed_now + timedelta(seconds=1),
-        score=80,
-        smart_detect_types=[SmartDetectObjectType.PACKAGE],
-        smart_detect_event_ids=[],
-        camera_id=doorbell.id,
-        api=ufp.api,
+    # Only the start of an event is dispatched; an update must be ignored.
+    ufp.events_msg(
+        ProtectEvent(
+            id="test_ring_event",
+            type=EventType.RING,
+            channel=ProtectEventChannel.DETECTION,
+            device_id=doorbell.id,
+            device_mac=doorbell.mac,
+            start=fixed_now - timedelta(seconds=1),
+            end=fixed_now,
+        ),
+        EventChange.UPDATED,
     )
-
-    new_camera = doorbell.model_copy()
-    ufp.api.bootstrap.cameras = {new_camera.id: new_camera}
-    ufp.api.bootstrap.events = {event.id: event}
-
-    mock_msg = Mock()
-    mock_msg.changed_data = {}
-    mock_msg.new_obj = event
-
-    ufp.ws_msg(mock_msg)
     await hass.async_block_till_done()
-
-    state = hass.states.get(entity_id)
-    assert state
-    assert state.state == timestamp
+    assert len(events) == 1
     unsub()
 
 

--- a/tests/components/unifiprotect/test_event.py
+++ b/tests/components/unifiprotect/test_event.py
@@ -282,6 +282,24 @@ async def test_package_detected(
     await hass.async_block_till_done()
     assert len(events) == 2
 
+    # A non-smart-detect event that happens to carry a matching object type is
+    # routed by type, so it must not reach the smart-detect entity.
+    ufp.events_msg(
+        ProtectEvent(
+            id="test_ring_with_package_types",
+            type=EventType.RING,
+            channel=ProtectEventChannel.DETECTION,
+            device_id=doorbell.id,
+            device_mac=doorbell.mac,
+            start=fixed_now,
+            end=fixed_now,
+            smart_detect_types=(SmartDetectObjectType.PACKAGE,),
+        ),
+        EventChange.STARTED,
+    )
+    await hass.async_block_till_done()
+    assert len(events) == 2
+
     unsub()
 
 


### PR DESCRIPTION
## Proposed change

Migrate the UniFi Protect **doorbell ring** event entity to the public events
websocket.

The public smart-detect subscription is generalized into a per-device public
event subscription: `ProtectData.async_subscribe_public_event(mac, callback)`.
`_async_process_public_event` now relays every *started* public event to that
device's subscribers (resolved by `device_id`, the stable cross-API join key)
instead of pre-filtering to smart-detect detections; each entity filters by the
event type it cares about. This mirrors how the existing package smart-detect
event entity already consumes the public events websocket.

The doorbell ring event entity now fires on a public `RING` event rather than
reading the private `last_ring_event`. Availability stays on the private device,
as for the other event entities. No user-facing behaviour changes.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
