### PR TITLE
Bump boschshcpy to 0.3.5

### DIFF
--- a/homeassistant/components/bosch_shc/manifest.json
+++ b/homeassistant/components/bosch_shc/manifest.json
@@ -8,7 +8,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["boschshcpy"],
-  "requirements": ["boschshcpy==0.2.111"],
+  "requirements": ["boschshcpy==0.3.5"],
   "zeroconf": [
     {
       "name": "bosch shc*",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -702,7 +702,7 @@ bond-async==0.2.1
 bosch-alarm-mode2==0.4.10
 
 # homeassistant.components.bosch_shc
-boschshcpy==0.2.111
+boschshcpy==0.3.5
 
 # homeassistant.components.amazon_polly
 # homeassistant.components.route53


### PR DESCRIPTION
## Proposed change

Standalone dependency bump for the `bosch_shc` integration: `boschshcpy` 0.2.111 → 0.3.5.

The existing integration works unchanged against the new library version (the config-flow tests pass as-is). This is the isolated first step of bringing the upstream device/platform support into Core incrementally — the full reference delta lives in #174493 and follows as per-platform PRs on top of this bump (#174551 climate, #174556 light).

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- boschshcpy changelog / release notes: https://github.com/tschamm/boschshcpy/releases (0.2.111 → 0.3.5)

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
