### PR TITLE
Add @mosandlt as codeowner for bosch_shc

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -254,8 +254,8 @@ CLAUDE.md @home-assistant/core
 /tests/components/bond/ @bdraco @prystupa @joshs85 @marciogranzotto
 /homeassistant/components/bosch_alarm/ @mag1024 @sanjay900
 /tests/components/bosch_alarm/ @mag1024 @sanjay900
-/homeassistant/components/bosch_shc/ @tschamm
-/tests/components/bosch_shc/ @tschamm
+/homeassistant/components/bosch_shc/ @tschamm @mosandlt
+/tests/components/bosch_shc/ @tschamm @mosandlt
 /homeassistant/components/brands/ @home-assistant/core
 /tests/components/brands/ @home-assistant/core
 /homeassistant/components/braviatv/ @bieniu @Drafteed

--- a/homeassistant/components/bosch_shc/manifest.json
+++ b/homeassistant/components/bosch_shc/manifest.json
@@ -2,7 +2,7 @@
   "domain": "bosch_shc",
   "name": "Bosch SHC",
   "after_dependencies": ["zeroconf"],
-  "codeowners": ["@tschamm"],
+  "codeowners": ["@tschamm", "@mosandlt"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/bosch_shc",
   "integration_type": "hub",


### PR DESCRIPTION
## Proposed change

Adds @mosandlt alongside @tschamm as a code owner of the Bosch SHC integration.

We already co-maintain the upstream library [boschshcpy](https://github.com/tschamm/boschshcpy) (I'm a PyPI co-owner) and the HACS integration [boschshc-hass](https://github.com/tschamm/boschshc-hass), and I'm actively driving the current work to bring the upstream device/platform support into Core (see #174550, #174551, #174556). Becoming a Core code owner lets me help review and maintain `bosch_shc` here too.

Only the integration's `codeowners` is changed; `CODEOWNERS` was regenerated via `python3 -m script.hassfest`.

cc @tschamm — proceeding with your approval as the existing code owner (confirmed in-thread).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
