### PR TITLE
Widen the INKBIRD IBS-TH2 active scan window to 30s

### DIFF
--- a/homeassistant/components/inkbird/coordinator.py
+++ b/homeassistant/components/inkbird/coordinator.py
@@ -31,8 +31,9 @@ FALLBACK_POLL_INTERVAL = timedelta(seconds=180)
 
 # IBS-TH2 broadcasts every ~20-30s and only carries sensor data in the scan
 # response, so the default 10s active window misses the device most cycles.
-# 25s covers one full broadcast interval with margin to absorb jitter.
-ACTIVE_SCAN_DURATION = 25.0
+# 30s is the longest active window habluetooth allows (AUTO_WINDOW_MAX_DURATION)
+# and spans a full broadcast interval even at the 30s end of the range.
+ACTIVE_SCAN_DURATION = 30.0
 
 
 class INKBIRDActiveBluetoothProcessorCoordinator(

--- a/tests/components/inkbird/test_sensor.py
+++ b/tests/components/inkbird/test_sensor.py
@@ -23,7 +23,10 @@ from homeassistant.components.inkbird.const import (
     CONF_DEVICE_TYPE,
     DOMAIN,
 )
-from homeassistant.components.inkbird.coordinator import FALLBACK_POLL_INTERVAL
+from homeassistant.components.inkbird.coordinator import (
+    ACTIVE_SCAN_DURATION,
+    FALLBACK_POLL_INTERVAL,
+)
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
@@ -99,6 +102,26 @@ async def test_sensors(hass: HomeAssistant) -> None:
     assert entry.data[CONF_DEVICE_TYPE] == "IBS-TH"
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
+
+
+async def test_active_scan_duration(hass: HomeAssistant) -> None:
+    """Test the scan response only IBS-TH registers a wide active scan window."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="61DE521B-F0BF-9F44-64D4-75BBE1738105",
+        data={CONF_DEVICE_TYPE: "IBS-TH"},
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.bluetooth.update_coordinator.async_register_callback"
+    ) as mock_register_callback:
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert mock_register_callback.call_args.kwargs["scan_duration"] == (
+        ACTIVE_SCAN_DURATION
+    )
 
 
 async def test_device_with_corrupt_name(hass: HomeAssistant) -> None:


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The IBS-TH2 broadcasts on a 30s interval and only carries its sensor data in the scan response, so the 25s active window could fall short of a full broadcast interval and miss the device for long stretches; entities updated rarely or not for days. This widens the window to 30s, the longest habluetooth allows, so it spans a full interval.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #174169
- This PR is related to issue: #174507
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
