### PR TITLE
Detect Shelly device replacements by name in the config flow

### DIFF
--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -43,6 +43,7 @@ from .const import (
     BLOCK_WRONG_SLEEP_PERIOD,
     CONF_BLE_SCANNER_MODE,
     CONF_COAP_PORT,
+    CONF_DEVICE_NAME,
     CONF_SLEEP_PERIOD,
     DOMAIN,
     FIRMWARE_UNSUPPORTED_ISSUE_ID,
@@ -144,6 +145,21 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ShellyConfigEntry) -> 
         if options.get(CONF_BLE_SCANNER_MODE) == BLEScannerMode.ACTIVE:
             options[CONF_BLE_SCANNER_MODE] = BLEScannerMode.AUTO
         hass.config_entries.async_update_entry(entry, options=options, minor_version=3)
+
+    if entry.minor_version < 4:
+        # Seed the device name used to detect a replacement device. The device
+        # registry holds the name the integration gave the device, separately from
+        # any user rename, so it is preferred over the entry title, which the user
+        # can have changed and which a dead device never gets to correct. The next
+        # successful setup replaces it with the name the device reports.
+        device = None
+        if entry.unique_id is not None:
+            device = dr.async_get(hass).async_get_device_by_identifier(
+                (DOMAIN, entry.unique_id), entry.entry_id
+            )
+        data = dict(entry.data)
+        data.setdefault(CONF_DEVICE_NAME, (device and device.name) or entry.title)
+        hass.config_entries.async_update_entry(entry, data=data, minor_version=4)
     return True
 
 

--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -44,6 +44,7 @@ from homeassistant.components.bluetooth import (
 from homeassistant.config_entries import (
     SOURCE_BLUETOOTH,
     SOURCE_ZEROCONF,
+    ConfigEntryState,
     ConfigFlow,
     ConfigFlowResult,
     OptionsFlow,
@@ -77,6 +78,7 @@ from .ble_provisioning import (
 )
 from .const import (
     CONF_BLE_SCANNER_MODE,
+    CONF_DEVICE_NAME,
     CONF_GEN,
     CONF_SLEEP_PERIOD,
     CONF_SSID,
@@ -87,6 +89,8 @@ from .const import (
 )
 from .coordinator import ShellyConfigEntry, async_reconnect_soon
 from .utils import (
+    async_can_replace_device,
+    async_replace_device,
     get_block_device_sleep_period,
     get_coap_context,
     get_device_entry_gen,
@@ -215,7 +219,7 @@ class ShellyConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Shelly."""
 
     VERSION = 1
-    MINOR_VERSION = 3
+    MINOR_VERSION = 4
 
     host: str = ""
     port: int = DEFAULT_HTTP_PORT
@@ -232,6 +236,8 @@ class ShellyConfigFlow(ConfigFlow, domain=DOMAIN):
     disable_ble_rpc_after_provision: bool = True
     _discovered_devices: dict[str, DiscoveredDeviceZeroconf | DiscoveredDeviceBluetooth]
     _ble_rpc_device: RpcDevice | None = None
+    _entry_with_name_conflict: ShellyConfigEntry | None = None
+    _name_conflict_data: dict[str, Any] | None = None
 
     @staticmethod
     def _get_ssl_entry_data(port: int, verify_ssl: bool) -> dict[str, bool]:
@@ -460,18 +466,154 @@ class ShellyConfigFlow(ConfigFlow, domain=DOMAIN):
         )
 
         if device_info[CONF_MODEL]:
-            return self.async_create_entry(
-                title=device_info["title"],
-                data={
-                    CONF_HOST: self.host,
-                    CONF_PORT: self.port,
-                    CONF_SLEEP_PERIOD: device_info[CONF_SLEEP_PERIOD],
-                    CONF_MODEL: device_info[CONF_MODEL],
-                    CONF_GEN: device_info[CONF_GEN],
-                    **self._get_ssl_entry_data(self.port, self.verify_ssl),
-                },
-            )
+            return await self._async_create_or_migrate_entry(device_info)
         return self.async_abort(reason="firmware_not_fully_provisioned")
+
+    async def _async_create_or_migrate_entry(
+        self, device_info: dict[str, Any], credentials: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Create the entry, or offer to migrate an entry with the same name."""
+        entry_data: dict[str, Any] = {
+            CONF_HOST: self.host,
+            CONF_PORT: self.port,
+            CONF_SLEEP_PERIOD: device_info[CONF_SLEEP_PERIOD],
+            CONF_MODEL: device_info[CONF_MODEL],
+            CONF_GEN: device_info[CONF_GEN],
+            CONF_DEVICE_NAME: device_info["title"],
+            **self._get_ssl_entry_data(self.port, self.verify_ssl),
+        }
+        if credentials is not None:
+            entry_data |= credentials
+
+        if entry := self._async_find_entry_with_name_conflict(device_info):
+            self._entry_with_name_conflict = entry
+            self._name_conflict_data = entry_data
+            return await self.async_step_name_conflict()
+
+        return self.async_create_entry(title=device_info["title"], data=entry_data)
+
+    @callback
+    def _async_find_entry_with_name_conflict(
+        self, device_info: dict[str, Any]
+    ) -> ShellyConfigEntry | None:
+        """Return a non-working entry of the same name, model and generation."""
+        name = device_info["title"]
+        for entry in self._async_current_entries(include_ignore=False):
+            if entry.disabled_by is not None or self._async_entry_is_working(entry):
+                continue
+            if (
+                entry.data.get(CONF_DEVICE_NAME) == name
+                # CONF_GEN is absent on entries created before it was added,
+                # and those are always gen1.
+                and entry.data.get(CONF_GEN, 1) == device_info[CONF_GEN]
+                and entry.data.get(CONF_MODEL) == device_info[CONF_MODEL]
+            ):
+                return entry
+        return None
+
+    @callback
+    def _async_entry_is_working(self, entry: ShellyConfigEntry) -> bool:
+        """Return True if the entry is loaded and its device is answering."""
+        if entry.state is not ConfigEntryState.LOADED:
+            return False
+        coordinator = entry.runtime_data.rpc or entry.runtime_data.block
+        # `initialized` only tells us the device answered at some point, it is
+        # never cleared again, so the current state comes from the coordinator.
+        return (
+            coordinator is not None
+            and coordinator.device.initialized
+            and coordinator.last_update_success
+        )
+
+    async def async_step_name_conflict(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Offer to migrate the conflicting entry onto the new device."""
+        return self.async_show_menu(
+            step_id="name_conflict",
+            menu_options=["name_conflict_add_new", "name_conflict_migrate"],
+            description_placeholders=self._name_conflict_placeholders(),
+        )
+
+    async def async_step_name_conflict_add_new(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Add the device as a new entry, keeping the existing one."""
+        if TYPE_CHECKING:
+            assert self._name_conflict_data is not None
+
+        # Another entry can have claimed this MAC while the menu was open. Creating
+        # an entry for a unique ID that is taken removes the other one along with
+        # its devices and entities, which is the opposite of what this step offers.
+        self._abort_if_unique_id_configured()
+
+        return self.async_create_entry(
+            title=self._name_conflict_data[CONF_DEVICE_NAME],
+            data=self._name_conflict_data,
+        )
+
+    async def async_step_name_conflict_migrate(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Migrate the existing entry onto the new device."""
+        conflict_entry = self._entry_with_name_conflict
+        if TYPE_CHECKING:
+            assert conflict_entry is not None
+            assert conflict_entry.unique_id is not None
+            assert self._name_conflict_data is not None
+            assert self.unique_id is not None
+
+        entry_id = conflict_entry.entry_id
+        old_mac = conflict_entry.unique_id
+        new_mac = self.unique_id
+        placeholders = self._name_conflict_placeholders()
+
+        if (entry := self.hass.config_entries.async_get_entry(entry_id)) is None:
+            return self.async_abort(
+                reason="name_conflict_entry_removed",
+                description_placeholders=placeholders,
+            )
+        # The menu can stay open for a while, and the old device may come back in
+        # the meantime, so the conditions are checked again before writing.
+        if entry.disabled_by is not None or self._async_entry_is_working(
+            cast(ShellyConfigEntry, entry)
+        ):
+            return self.async_abort(
+                reason="name_conflict_entry_working",
+                description_placeholders=placeholders,
+            )
+        if not async_can_replace_device(self.hass, entry_id, old_mac, new_mac):
+            return self.async_abort(
+                reason="name_conflict_device_in_use",
+                description_placeholders=placeholders,
+            )
+
+        await async_replace_device(self.hass, entry_id, old_mac, new_mac)
+        self.hass.config_entries.async_update_entry(
+            entry, data=self._name_conflict_data, unique_id=new_mac
+        )
+        self.hass.config_entries.async_schedule_reload(entry_id)
+        return self.async_abort(
+            reason="name_conflict_migrated", description_placeholders=placeholders
+        )
+
+    @callback
+    def _name_conflict_placeholders(self) -> dict[str, str]:
+        """Return the placeholders describing the name conflict."""
+        entry = self._entry_with_name_conflict
+        if TYPE_CHECKING:
+            assert entry is not None
+            assert entry.unique_id is not None
+            assert self._name_conflict_data is not None
+            assert self.unique_id is not None
+
+        return {
+            "name": self._name_conflict_data[CONF_DEVICE_NAME],
+            "host": self.host,
+            "existing_title": entry.title,
+            "existing_mac": format_mac(entry.unique_id).upper(),
+            "mac": format_mac(self.unique_id).upper(),
+        }
 
     @override
     async def async_step_user(
@@ -633,17 +775,8 @@ class ShellyConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors["base"] = "unknown"
             else:
                 if device_info[CONF_MODEL]:
-                    return self.async_create_entry(
-                        title=device_info["title"],
-                        data={
-                            **user_input,
-                            CONF_HOST: self.host,
-                            CONF_PORT: self.port,
-                            CONF_SLEEP_PERIOD: device_info[CONF_SLEEP_PERIOD],
-                            CONF_MODEL: device_info[CONF_MODEL],
-                            CONF_GEN: device_info[CONF_GEN],
-                            **self._get_ssl_entry_data(self.port, self.verify_ssl),
-                        },
+                    return await self._async_create_or_migrate_entry(
+                        device_info, user_input
                     )
                 return self.async_abort(reason="firmware_not_fully_provisioned")
         else:
@@ -1077,18 +1210,8 @@ class ShellyConfigFlow(ConfigFlow, domain=DOMAIN):
             assert self.ble_device is not None
         async_clear_address_from_match_history(self.hass, self.ble_device.address)
 
-        # User just provisioned this device - create entry directly without confirmation
-        return self.async_create_entry(
-            title=device_info["title"],
-            data={
-                CONF_HOST: self.host,
-                CONF_PORT: self.port,
-                CONF_SLEEP_PERIOD: device_info[CONF_SLEEP_PERIOD],
-                CONF_MODEL: device_info[CONF_MODEL],
-                CONF_GEN: device_info[CONF_GEN],
-                **self._get_ssl_entry_data(self.port, self.verify_ssl),
-            },
-        )
+        # User just provisioned this device, no confirmation step needed
+        return await self._async_create_or_migrate_entry(device_info)
 
     async def _do_provision(self, password: str) -> None:
         """Provision WiFi credentials to device via BLE."""
@@ -1229,17 +1352,7 @@ class ShellyConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="firmware_not_fully_provisioned")
         model = get_model_name(self.info)
         if user_input is not None:
-            return self.async_create_entry(
-                title=self.device_info["title"],
-                data={
-                    CONF_HOST: self.host,
-                    CONF_PORT: self.port,
-                    CONF_SLEEP_PERIOD: self.device_info[CONF_SLEEP_PERIOD],
-                    CONF_MODEL: self.device_info[CONF_MODEL],
-                    CONF_GEN: self.device_info[CONF_GEN],
-                    **self._get_ssl_entry_data(self.port, self.verify_ssl),
-                },
-            )
+            return await self._async_create_or_migrate_entry(self.device_info)
         self._set_confirm_only()
 
         return self.async_show_form(

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -297,6 +297,8 @@ DEVICES_WITHOUT_FIRMWARE_CHANGELOG = (
 
 CONF_GEN = "gen"
 
+CONF_DEVICE_NAME = "device_name"
+
 VIRTUAL_COMPONENTS = ("boolean", "button", "enum", "number", "text")
 VIRTUAL_COMPONENTS_MAP = {
     "binary_sensor": {"types": ["boolean"], "modes": ["label"]},

--- a/homeassistant/components/shelly/coordinator.py
+++ b/homeassistant/components/shelly/coordinator.py
@@ -72,6 +72,7 @@ from .const import (
 from .utils import (
     async_create_issue_unsupported_firmware,
     async_manage_coiot_issues_task,
+    async_update_entry_device_name,
     get_block_device_sleep_period,
     get_device_entry_gen,
     get_host,
@@ -182,6 +183,7 @@ class ShellyCoordinatorBase[_DeviceT: BlockDevice | RpcDevice](
     def async_setup(self, pending_platforms: list[Platform] | None = None) -> None:
         """Set up the coordinator."""
         self._pending_platforms = pending_platforms
+        async_update_entry_device_name(self.hass, self.config_entry, self.device)
         dev_reg = dr.async_get(self.hass)
         device_entry = dev_reg.async_get_or_create(
             config_entry_id=self.config_entry.entry_id,
@@ -217,6 +219,7 @@ class ShellyCoordinatorBase[_DeviceT: BlockDevice | RpcDevice](
         try:
             await self.device.initialize()
             update_device_fw_info(self.hass, self.device, self.config_entry)
+            async_update_entry_device_name(self.hass, self.config_entry, self.device)
         except (DeviceConnectionError, MacAddressMismatchError) as err:
             LOGGER.debug(
                 "Error connecting to Shelly device %s, error: %r", self.name, err

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -11,6 +11,10 @@
       "invalid_discovery_info": "Invalid Bluetooth discovery information.",
       "ipv6_not_supported": "IPv6 is not supported.",
       "mac_address_mismatch": "[%key:component::shelly::config::error::mac_address_mismatch%]",
+      "name_conflict_device_in_use": "The configuration for `{name}` cannot be migrated, because the Shelly integration already uses the MAC address `{mac}`. Set the device up as a new device instead.",
+      "name_conflict_entry_removed": "The configuration for `{name}` was removed while this dialog was open, so there is nothing left to migrate.",
+      "name_conflict_entry_working": "The configuration of {existing_title} was not migrated, because that device started responding again while this dialog was open. Set the device up as a new device instead.",
+      "name_conflict_migrated": "The configuration for `{name}` has been migrated from the device with MAC address `{existing_mac}` to the device with MAC address `{mac}`.",
       "no_wifi_networks": "No Wi-Fi networks found during scan.",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
       "reauth_unsuccessful": "Re-authentication was unsuccessful, please remove the integration and set it up again.",
@@ -55,6 +59,14 @@
           "password": "Password for the device's web panel.",
           "username": "Username for the device's web panel."
         }
+      },
+      "name_conflict": {
+        "description": "**The device at {host} (MAC address: `{mac}`) reports the name `{name}`, which is already used by another configuration entry: {existing_title} (MAC address: `{existing_mac}`).**\n\nTo continue, please choose one of the following options:\n\n**Add as a new device:** Set this device up as an additional device and leave the existing configuration untouched. Two Shelly devices are allowed to share a name.\n**Migrate configuration to the new device:** If this device replaces the one configured as {existing_title}, move that configuration over to it. Entities, entity IDs, history and automations are kept.",
+        "menu_options": {
+          "name_conflict_add_new": "Add as a new device",
+          "name_conflict_migrate": "Migrate configuration to the new device"
+        },
+        "title": "Possible device replacement"
       },
       "provision_failed": {
         "description": "The device did not connect to {ssid}. This may be due to an incorrect password or the network being out of range. Would you like to try again?"

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -1,6 +1,6 @@
 """Shelly helpers functions."""
 
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Iterator, Mapping
 from ipaddress import IPv4Address, IPv6Address, ip_address
 from typing import TYPE_CHECKING, Any, cast
 
@@ -55,6 +55,7 @@ from .const import (
     COIOT_UNCONFIGURED_ISSUE_ID,
     COMPONENT_ID_PATTERN,
     CONF_COAP_PORT,
+    CONF_DEVICE_NAME,
     CONF_GEN,
     DEVICE_UNIT_MAP,
     DEVICES_WITHOUT_FIRMWARE_CHANGELOG,
@@ -533,6 +534,116 @@ def update_device_fw_info(
         LOGGER.debug("Updating device registry info for %s", entry.title)
 
         dev_reg.async_update_device(device.id, sw_version=shellydevice.firmware_version)
+
+
+@callback
+def async_update_entry_device_name(
+    hass: HomeAssistant, entry: ConfigEntry, device: BlockDevice | RpcDevice
+) -> None:
+    """Store the current device name on the config entry."""
+    if not device.initialized or entry.data.get(CONF_DEVICE_NAME) == device.name:
+        return
+
+    hass.config_entries.async_update_entry(
+        entry, data={**entry.data, CONF_DEVICE_NAME: device.name}
+    )
+
+
+def _device_replacement_updates(
+    dev_reg: dr.DeviceRegistry, entry_id: str, old_mac: str, new_mac: str
+) -> Iterator[tuple[dr.DeviceEntry, set[tuple[str, str]], set[tuple[str, str]]]]:
+    """Yield the devices of a config entry with their migrated registry keys."""
+    old_connection = (CONNECTION_NETWORK_MAC, dr.format_mac(old_mac))
+    new_connection = (CONNECTION_NETWORK_MAC, dr.format_mac(new_mac))
+
+    for device in dr.async_entries_for_config_entry(dev_reg, entry_id):
+        identifiers = {
+            (domain, new_mac + identifier.removeprefix(old_mac))
+            if domain == DOMAIN and identifier.startswith(old_mac)
+            else (domain, identifier)
+            for domain, identifier in device.identifiers
+        }
+        connections = device.connections
+        if old_connection in connections:
+            connections = (connections - {old_connection}) | {new_connection}
+
+        if identifiers != device.identifiers or connections != device.connections:
+            yield device, identifiers, connections
+
+
+@callback
+def async_can_replace_device(
+    hass: HomeAssistant,
+    entry_id: str,
+    old_mac: str,  # bare upper case, as reported by the device
+    new_mac: str,  # bare upper case, as reported by the device
+) -> bool:
+    """Return True if no registry entry the migration needs is already taken."""
+    # Another entry can have claimed the new MAC after this one was offered for
+    # migration. Updating the unique ID would not fail, it is only logged, so the
+    # two entries would silently share one.
+    other_entry = hass.config_entries.async_entry_for_domain_unique_id(DOMAIN, new_mac)
+    if other_entry is not None and other_entry.entry_id != entry_id:
+        return False
+
+    dev_reg = dr.async_get(hass)
+    for device, identifiers, connections in _device_replacement_updates(
+        dev_reg, entry_id, old_mac, new_mac
+    ):
+        # Identifiers and connections are unique per config entry, so the lookups
+        # are scoped the same way the device registry scopes its collision checks.
+        for identifier in identifiers - device.identifiers:
+            other = dev_reg.async_get_device_by_identifier(identifier, entry_id)
+            if other is not None and other.id != device.id:
+                return False
+        for connection in connections - device.connections:
+            other = dev_reg.async_get_device_by_connection(connection, entry_id)
+            if other is not None and other.id != device.id:
+                return False
+
+    ent_reg = er.async_get(hass)
+    for entity in er.async_entries_for_config_entry(ent_reg, entry_id):
+        if not entity.unique_id.startswith(old_mac):
+            continue
+        new_unique_id = new_mac + entity.unique_id.removeprefix(old_mac)
+        if ent_reg.async_get_entity_id(entity.domain, entity.platform, new_unique_id):
+            return False
+
+    return True
+
+
+async def async_replace_device(
+    hass: HomeAssistant,
+    entry_id: str,
+    old_mac: str,  # bare upper case, as reported by the device
+    new_mac: str,  # bare upper case, as reported by the device
+) -> None:
+    """Move the devices and entities of a config entry to a new MAC address."""
+    dev_reg = dr.async_get(hass)
+    for device, identifiers, connections in _device_replacement_updates(
+        dev_reg, entry_id, old_mac, new_mac
+    ):
+        dev_reg.async_update_device(
+            device.id, new_connections=connections, new_identifiers=identifiers
+        )
+
+    @callback
+    def _migrate_unique_id(entity_entry: er.RegistryEntry) -> dict[str, str] | None:
+        """Rewrite the old MAC prefix of an entity unique_id to the new MAC."""
+        if not entity_entry.unique_id.startswith(old_mac):
+            return None
+        return {"new_unique_id": new_mac + entity_entry.unique_id.removeprefix(old_mac)}
+
+    await er.async_migrate_entries(hass, entry_id, _migrate_unique_id)
+
+    # Every issue this integration raises is keyed by the MAC of the device it is
+    # about. The ones raised for the old device are persistent and would never be
+    # deleted again once the entry stops using its MAC, so they go now.
+    issue_reg = ir.async_get(hass)
+    old_suffix = f"_{old_mac}"
+    for domain, issue_id in list(issue_reg.issues):
+        if domain == DOMAIN and issue_id.endswith(old_suffix):
+            ir.async_delete_issue(hass, DOMAIN, issue_id)
 
 
 def brightness_to_percentage(brightness: int) -> int:

--- a/tests/components/shelly/__init__.py
+++ b/tests/components/shelly/__init__.py
@@ -66,7 +66,7 @@ async def init_integration(
         unique_id=MOCK_MAC,
         options=options,
         title="Test name",
-        minor_version=3,
+        minor_version=4,
     )
     entry.add_to_hass(hass)
 

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -6081,6 +6081,7 @@ async def test_name_conflict_migrate_recovered_entry(
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
 
+@pytest.mark.parametrize("ignore_translations_for_mock_domains", ["other_domain"])
 async def test_name_conflict_migrate_deletes_old_issues(
     hass: HomeAssistant,
     issue_registry: ir.IssueRegistry,
@@ -6098,11 +6099,16 @@ async def test_name_conflict_migrate_deletes_old_issues(
         hass,
         DOMAIN,
         old_issue_id,
-        is_fixable=False,
+        is_fixable=True,
         is_persistent=True,
         severity=ir.IssueSeverity.WARNING,
         translation_key="deprecated_firmware",
-        translation_placeholders={"device_name": "Test name", "model": MODEL_PLUS_2PM},
+        translation_placeholders={
+            "device_name": "Test name",
+            "ip_address": "10.10.10.10",
+            "firmware": "20230913-112003/v1.14.0-gcb84623",
+            "ha_version": "2025.6.0",
+        },
     )
     # An issue of another integration that happens to end with the same MAC.
     ir.async_create_issue(

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -11,6 +11,7 @@ from aioshelly.const import (
     DEFAULT_HTTP_PORT,
     DEFAULT_HTTPS_PORT,
     MODEL_1,
+    MODEL_25,
     MODEL_PLUS_2PM,
 )
 from aioshelly.exceptions import (
@@ -20,22 +21,28 @@ from aioshelly.exceptions import (
     InvalidHostError,
     RpcCallError,
 )
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 from zeroconf.asyncio import AsyncServiceInfo
 
 from homeassistant import config_entries
 from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.shelly import MacAddressMismatchError, config_flow
 from homeassistant.components.shelly.const import (
     CONF_BLE_SCANNER_MODE,
+    CONF_DEVICE_NAME,
     CONF_GEN,
     CONF_SLEEP_PERIOD,
     CONF_SSID,
+    DEPRECATED_FIRMWARE_ISSUE_ID,
     DOMAIN,
+    RPC_RECONNECT_INTERVAL,
+    UPDATE_PERIOD_MULTIPLIER,
     BLEScannerMode,
 )
 from homeassistant.components.shelly.coordinator import ENTRY_RELOAD_COOLDOWN
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.config_entries import ConfigEntryState, ConfigFlowResult
 from homeassistant.const import (
     CONF_DEVICE,
     CONF_HOST,
@@ -47,6 +54,15 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import (
+    device_registry as dr,
+    entity_registry as er,
+    issue_registry as ir,
+)
+from homeassistant.helpers.device_registry import (
+    CONNECTION_BLUETOOTH,
+    CONNECTION_NETWORK_MAC,
+)
 from homeassistant.helpers.service_info.zeroconf import (
     ATTR_PROPERTIES_ID,
     ZeroconfServiceInfo,
@@ -54,7 +70,7 @@ from homeassistant.helpers.service_info.zeroconf import (
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
-from . import init_integration
+from . import MOCK_MAC, init_integration, register_entity, register_sub_device
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 from tests.components.bluetooth import (
@@ -72,6 +88,62 @@ async def _async_inject_ble_discovery(
     with patch.object(hass.config_entries.flow, "async_init"):
         inject_bluetooth_service_info_bleak(hass, info)
         await hass.async_block_till_done()
+
+
+# MAC address of the device replacing the one set up with MOCK_MAC.
+NEW_MAC = "AABBCCDDEEFF"
+# A BLU sub-device is keyed by its own BLE address, not by the gateway MAC.
+BLU_ADDR = "11:22:33:44:55:66"
+
+
+def _replacement_info(gen: int) -> dict[str, Any]:
+    """Return the get_info payload of the replacement device."""
+    return {
+        "mac": NEW_MAC,
+        "type": MODEL_1,
+        "model": MODEL_PLUS_2PM,
+        "auth": False,
+        "gen": gen,
+        "port": DEFAULT_HTTP_PORT,
+    }
+
+
+async def _async_run_user_flow(hass: HomeAssistant, gen: int) -> ConfigFlowResult:
+    """Run the user flow for the replacement device at a new host."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+
+    with patch(
+        "homeassistant.components.shelly.config_flow.get_info",
+        return_value=_replacement_info(gen),
+    ):
+        return await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: "2.2.2.2", CONF_PORT: DEFAULT_HTTP_PORT}
+        )
+
+
+async def _async_add_replaced_entry(
+    hass: HomeAssistant,
+    gen: int | None,
+    model: str,
+    data: dict[str, Any] | None = None,
+) -> MockConfigEntry:
+    """Add an unloaded entry for the device that is about to be replaced."""
+    return await init_integration(
+        hass,
+        gen,
+        model=model,
+        skip_setup=True,
+        data={
+            CONF_HOST: "1.1.1.1",
+            CONF_SLEEP_PERIOD: 0,
+            CONF_MODEL: model,
+            CONF_DEVICE_NAME: "Test name",
+            **(data or {}),
+        },
+    )
 
 
 DISCOVERY_INFO = ZeroconfServiceInfo(
@@ -464,6 +536,7 @@ async def test_form(
         CONF_MODEL: model,
         CONF_SLEEP_PERIOD: 0,
         CONF_GEN: gen,
+        CONF_DEVICE_NAME: "Test name",
     }
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
@@ -504,6 +577,7 @@ async def test_form_https_verify_ssl_disabled_by_default(
         CONF_SLEEP_PERIOD: 0,
         CONF_GEN: 2,
         CONF_VERIFY_SSL: False,
+        CONF_DEVICE_NAME: "Test name",
     }
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
@@ -549,6 +623,7 @@ async def test_form_https_verify_ssl_enabled(
         CONF_SLEEP_PERIOD: 0,
         CONF_GEN: 2,
         CONF_VERIFY_SSL: True,
+        CONF_DEVICE_NAME: "Test name",
     }
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
@@ -598,6 +673,7 @@ async def test_form_enhanced_security(
         CONF_SLEEP_PERIOD: 0,
         CONF_GEN: gen,
         CONF_VERIFY_SSL: False,
+        CONF_DEVICE_NAME: "Test name",
     }
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
@@ -636,6 +712,7 @@ async def test_form_enhanced_security_older_firmware(
         CONF_MODEL: MODEL_PLUS_2PM,
         CONF_SLEEP_PERIOD: 0,
         CONF_GEN: 2,
+        CONF_DEVICE_NAME: "Test name",
     }
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
@@ -691,6 +768,7 @@ async def test_user_flow_overrides_existing_discovery(
         CONF_MODEL: MODEL_PLUS_2PM,
         CONF_SLEEP_PERIOD: 0,
         CONF_GEN: 2,
+        CONF_DEVICE_NAME: "Test name",
     }
     assert result["context"]["unique_id"] == "AABBCCDDEEFF"
     assert len(mock_setup.mock_calls) == 1
@@ -748,6 +826,7 @@ async def test_form_gen1_custom_port(
         CONF_MODEL: MODEL_1,
         CONF_SLEEP_PERIOD: 0,
         CONF_GEN: 1,
+        CONF_DEVICE_NAME: "Test name",
     }
     assert result["context"]["unique_id"] == "test-mac"
     assert len(mock_setup.mock_calls) == 1
@@ -821,6 +900,7 @@ async def test_form_auth(
         CONF_GEN: gen,
         CONF_USERNAME: username,
         CONF_PASSWORD: user_input[CONF_PASSWORD],
+        CONF_DEVICE_NAME: "Test name",
     }
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
@@ -873,6 +953,7 @@ async def test_form_errors_get_info(
         CONF_MODEL: MODEL_1,
         CONF_SLEEP_PERIOD: 0,
         CONF_GEN: 1,
+        CONF_DEVICE_NAME: "Test name",
     }
     assert result["context"]["unique_id"] == "test-mac"
     assert len(mock_setup.mock_calls) == 1
@@ -1006,6 +1087,7 @@ async def test_form_errors_test_connection(
         CONF_MODEL: MODEL_1,
         CONF_SLEEP_PERIOD: 0,
         CONF_GEN: 1,
+        CONF_DEVICE_NAME: "Test name",
     }
     assert result["context"]["unique_id"] == "test-mac"
     assert len(mock_setup.mock_calls) == 1
@@ -2143,6 +2225,7 @@ async def test_user_flow_filters_devices_with_active_discovery_flows(
         CONF_SLEEP_PERIOD: 0,
         CONF_MODEL: MODEL_PLUS_2PM,
         CONF_GEN: 2,
+        CONF_DEVICE_NAME: "Test name",
     }
 
 
@@ -2207,6 +2290,7 @@ async def test_form_auth_errors_test_connection_gen1(
         CONF_GEN: 1,
         CONF_USERNAME: "test username",
         CONF_PASSWORD: "test password",
+        CONF_DEVICE_NAME: "Test name",
     }
     assert result["context"]["unique_id"] == "test-mac"
     assert len(mock_setup.mock_calls) == 1
@@ -2273,6 +2357,7 @@ async def test_form_auth_errors_test_connection_gen2(
         CONF_GEN: 2,
         CONF_USERNAME: "admin",
         CONF_PASSWORD: "test password",
+        CONF_DEVICE_NAME: "Test name",
     }
     assert result["context"]["unique_id"] == "test-mac"
     assert len(mock_setup.mock_calls) == 1
@@ -2342,6 +2427,7 @@ async def test_zeroconf(
         CONF_MODEL: model,
         CONF_SLEEP_PERIOD: 0,
         CONF_GEN: gen,
+        CONF_DEVICE_NAME: "Test name",
     }
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
@@ -2407,6 +2493,7 @@ async def test_zeroconf_enhanced_security(
         CONF_MODEL: model,
         CONF_SLEEP_PERIOD: 0,
         CONF_GEN: gen,
+        CONF_DEVICE_NAME: "Test name",
     }
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
@@ -2461,6 +2548,7 @@ async def test_zeroconf_sleeping_device(
         CONF_MODEL: MODEL_1,
         CONF_SLEEP_PERIOD: 600,
         CONF_GEN: 1,
+        CONF_DEVICE_NAME: "Test name",
     }
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
@@ -2667,6 +2755,7 @@ async def test_zeroconf_require_auth(
         CONF_GEN: 1,
         CONF_USERNAME: "test username",
         CONF_PASSWORD: "test password",
+        CONF_DEVICE_NAME: "Test name",
     }
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
@@ -2832,6 +2921,7 @@ async def test_reauth_enhanced_security(
         CONF_USERNAME: "admin",
         CONF_PASSWORD: "test password",
         CONF_VERIFY_SSL: False,
+        CONF_DEVICE_NAME: "Test name",
     }
 
 
@@ -3344,6 +3434,7 @@ async def test_sleeping_device_gen2_with_new_firmware(
         CONF_MODEL: MODEL_PLUS_2PM,
         CONF_SLEEP_PERIOD: 666,
         CONF_GEN: 2,
+        CONF_DEVICE_NAME: "Test name",
     }
 
 
@@ -3378,7 +3469,12 @@ async def test_reconfigure_successful(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
-    assert entry.data == {CONF_HOST: "10.10.10.10", CONF_PORT: 99, CONF_GEN: gen}
+    assert entry.data == {
+        CONF_HOST: "10.10.10.10",
+        CONF_PORT: 99,
+        CONF_GEN: gen,
+        CONF_DEVICE_NAME: "Test name",
+    }
 
 
 @pytest.mark.parametrize("gen", [1, 2, 3])
@@ -3462,7 +3558,12 @@ async def test_reconfigure_with_exception(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
-    assert entry.data == {CONF_HOST: "10.10.10.10", CONF_PORT: 99, CONF_GEN: 2}
+    assert entry.data == {
+        CONF_HOST: "10.10.10.10",
+        CONF_PORT: 99,
+        CONF_GEN: 2,
+        CONF_DEVICE_NAME: "Test name",
+    }
 
 
 async def test_reconfigure_enhanced_security(
@@ -3504,6 +3605,7 @@ async def test_reconfigure_enhanced_security(
         CONF_PORT: DEFAULT_HTTPS_PORT,
         CONF_GEN: 2,
         CONF_VERIFY_SSL: False,
+        CONF_DEVICE_NAME: "Test name",
     }
 
 
@@ -3571,6 +3673,7 @@ async def test_zeroconf_wrong_device_name(
         CONF_MODEL: MODEL_PLUS_2PM,
         CONF_SLEEP_PERIOD: 0,
         CONF_GEN: 2,
+        CONF_DEVICE_NAME: "Test name",
     }
     assert result["result"].unique_id == "test-mac"
     assert len(mock_setup.mock_calls) == 1
@@ -3641,6 +3744,7 @@ async def test_bluetooth_discovery(
         CONF_MODEL: MODEL_PLUS_2PM,
         CONF_SLEEP_PERIOD: 0,
         CONF_GEN: 2,
+        CONF_DEVICE_NAME: "Test name",
     }
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
@@ -4016,6 +4120,7 @@ async def test_bluetooth_wifi_scan_success(
         CONF_MODEL: MODEL_PLUS_2PM,
         CONF_SLEEP_PERIOD: 0,
         CONF_GEN: 2,
+        CONF_DEVICE_NAME: "Test name",
     }
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
@@ -4099,6 +4204,7 @@ async def test_bluetooth_wifi_scan_failure(
         CONF_MODEL: MODEL_PLUS_2PM,
         CONF_SLEEP_PERIOD: 0,
         CONF_GEN: 2,
+        CONF_DEVICE_NAME: "Test name",
     }
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
@@ -4204,6 +4310,7 @@ async def test_bluetooth_wifi_credentials_and_provision_success(
         CONF_MODEL: MODEL_PLUS_2PM,
         CONF_SLEEP_PERIOD: 0,
         CONF_GEN: 2,
+        CONF_DEVICE_NAME: "Test name",
     }
     mock_ble_rpc_device.wifi_setconfig.assert_called_once()
     assert len(mock_setup.mock_calls) == 1
@@ -4301,6 +4408,7 @@ async def test_bluetooth_wifi_provision_failure(
         CONF_MODEL: MODEL_PLUS_2PM,
         CONF_SLEEP_PERIOD: 0,
         CONF_GEN: 2,
+        CONF_DEVICE_NAME: "Test name",
     }
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
@@ -4514,6 +4622,7 @@ async def test_bluetooth_provision_requires_auth(
         CONF_MODEL: MODEL_PLUS_2PM,
         CONF_SLEEP_PERIOD: 0,
         CONF_GEN: 2,
+        CONF_DEVICE_NAME: "Test name",
     }
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
@@ -5599,3 +5708,679 @@ async def test_bluetooth_provision_ble_reconnect_fails_during_ip_fetch(
         # Abort flow to reach terminal state
         hass.config_entries.flow.async_abort(result["flow_id"])
         await hass.async_block_till_done(wait_background_tasks=True)
+
+
+@pytest.mark.parametrize(("gen", "model"), [(1, MODEL_1), (2, MODEL_PLUS_2PM)])
+async def test_name_conflict_migrate(
+    hass: HomeAssistant,
+    gen: int,
+    model: str,
+    mock_block_device: Mock,
+    mock_rpc_device: Mock,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test migrating an entry onto a device that took over its name."""
+    entry = await init_integration(hass, gen, model=model)
+    assert entry.data[CONF_DEVICE_NAME] == "Test name"
+
+    # An energy meter phase sub-device, the three part identifier shape.
+    emeter_device = register_sub_device(device_registry, entry, "em:0-a")
+    emeter_id = register_entity(
+        hass,
+        SENSOR_DOMAIN,
+        "test_em_0_a",
+        "em:0-a-power",
+        entry,
+        device_id=emeter_device.id,
+    )
+    # A BLU sub-device is keyed by its own BLE address and must not be touched.
+    blu_device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, BLU_ADDR)},
+        connections={(CONNECTION_BLUETOOTH, BLU_ADDR)},
+        via_device=(DOMAIN, MOCK_MAC),
+    )
+    blu_entity = entity_registry.async_get_or_create(
+        SENSOR_DOMAIN,
+        DOMAIN,
+        f"{BLU_ADDR}-temperature",
+        suggested_object_id="blu_temperature",
+        config_entry=entry,
+        device_id=blu_device.id,
+    )
+
+    # The device this entry was set up for is gone, so the entry no longer loads.
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await _async_run_user_flow(hass, gen)
+
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "name_conflict"
+    assert result["description_placeholders"] == {
+        "name": "Test name",
+        "host": "2.2.2.2",
+        "existing_title": "Test name",
+        "existing_mac": "12:34:56:78:9A:BC",
+        "mac": "AA:BB:CC:DD:EE:FF",
+    }
+
+    with patch.object(hass.config_entries, "async_schedule_reload") as mock_reload:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"next_step_id": "name_conflict_migrate"}
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "name_conflict_migrated"
+    mock_reload.assert_called_once_with(entry.entry_id)
+
+    # No second entry was created, the existing one was moved over.
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+    assert entry.unique_id == NEW_MAC
+    assert entry.data == {
+        CONF_HOST: "2.2.2.2",
+        CONF_PORT: DEFAULT_HTTP_PORT,
+        CONF_MODEL: model,
+        CONF_SLEEP_PERIOD: 0,
+        CONF_GEN: gen,
+        CONF_DEVICE_NAME: "Test name",
+    }
+
+    # Main device: identifier and network MAC connection rewritten.
+    main_device = device_registry.async_get_device(identifiers={(DOMAIN, NEW_MAC)})
+    assert main_device is not None
+    assert (CONNECTION_NETWORK_MAC, dr.format_mac(NEW_MAC)) in main_device.connections
+    assert (
+        CONNECTION_NETWORK_MAC,
+        dr.format_mac(MOCK_MAC),
+    ) not in main_device.connections
+    assert device_registry.async_get_device(identifiers={(DOMAIN, MOCK_MAC)}) is None
+
+    # Sub-device identifiers rewritten, none left on the old MAC.
+    assert device_registry.async_get(emeter_device.id).identifiers == {
+        (DOMAIN, f"{NEW_MAC}-em:0-a")
+    }
+    for device in dr.async_entries_for_config_entry(device_registry, entry.entry_id):
+        assert not any(
+            identifier.startswith(MOCK_MAC) for _, identifier in device.identifiers
+        )
+
+    # Entity unique_ids rewritten, entity IDs preserved.
+    assert entity_registry.async_get(emeter_id).unique_id == f"{NEW_MAC}-em:0-a-power"
+    for entity in er.async_entries_for_config_entry(entity_registry, entry.entry_id):
+        assert not entity.unique_id.startswith(MOCK_MAC)
+
+    # The BLU sub-device and its entity are untouched.
+    assert device_registry.async_get(blu_device.id) == blu_device
+    assert entity_registry.async_get(blu_entity.entity_id) == blu_entity
+
+
+async def test_name_conflict_migrate_reload(
+    hass: HomeAssistant,
+    mock_rpc_device: Mock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the reload of a migrated entry does not duplicate its entities."""
+    entry = await init_integration(hass, 2, model=MODEL_PLUS_2PM)
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+    entity_ids = {
+        entity.entity_id
+        for entity in er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+    }
+    assert entity_ids
+
+    result = await _async_run_user_flow(hass, 2)
+    assert result["type"] is FlowResultType.MENU
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "name_conflict_migrate"}
+    )
+    # Let the scheduled reload of the migrated entry run for real.
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert result["type"] is FlowResultType.ABORT
+    assert entry.state is ConfigEntryState.LOADED
+    entities = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+    assert {entity.entity_id for entity in entities} == entity_ids
+    for entity in entities:
+        assert entity.unique_id.startswith(NEW_MAC)
+
+
+async def test_name_conflict_migrate_zeroconf(
+    hass: HomeAssistant,
+    mock_rpc_device: Mock,
+) -> None:
+    """Test the migrated entry does not keep the host, port and credentials."""
+    entry = await _async_add_replaced_entry(
+        hass,
+        2,
+        MODEL_PLUS_2PM,
+        data={
+            CONF_HOST: "9.9.9.9",
+            CONF_PORT: 8080,
+            CONF_USERNAME: "admin",
+            CONF_PASSWORD: "test password",
+        },
+    )
+
+    with patch(
+        "homeassistant.components.shelly.config_flow.get_info",
+        return_value=_replacement_info(2),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            data=DISCOVERY_INFO,
+            context={"source": config_entries.SOURCE_ZEROCONF},
+        )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "confirm_discovery"
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    assert result["type"] is FlowResultType.MENU
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "name_conflict_migrate"}
+    )
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "name_conflict_migrated"
+    assert entry.unique_id == NEW_MAC
+    assert entry.data == {
+        CONF_HOST: "1.1.1.1",
+        CONF_PORT: DEFAULT_HTTP_PORT,
+        CONF_MODEL: MODEL_PLUS_2PM,
+        CONF_SLEEP_PERIOD: 0,
+        CONF_GEN: 2,
+        CONF_DEVICE_NAME: "Test name",
+    }
+
+
+async def test_name_conflict_migrate_mac_in_use(
+    hass: HomeAssistant,
+    mock_rpc_device: Mock,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test aborting the migration when another device row holds the new MAC."""
+    entry = await init_integration(hass, 2, model=MODEL_PLUS_2PM)
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+    # Connections are unique per config entry, so the collision the migration has
+    # to avoid is another device row of this same entry holding the new MAC.
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        connections={(CONNECTION_NETWORK_MAC, dr.format_mac(NEW_MAC))},
+    )
+
+    result = await _async_run_user_flow(hass, 2)
+    assert result["type"] is FlowResultType.MENU
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "name_conflict_migrate"}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "name_conflict_device_in_use"
+    assert entry.unique_id == MOCK_MAC
+    assert entry.data[CONF_HOST] == "192.168.1.37"
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+    assert (
+        device_registry.async_get_device(identifiers={(DOMAIN, MOCK_MAC)}) is not None
+    )
+
+
+async def test_name_conflict_migrate_entity_id_in_use(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_rpc_device: Mock,
+) -> None:
+    """Test aborting the migration when a target entity unique ID is taken.
+
+    This is the second guard in `async_can_replace_device`: the devices can move
+    while an entity of the replacement is already registered, which would leave
+    the entry renamed but its entities behind.
+    """
+    entry = await init_integration(hass, 2, model=MODEL_PLUS_2PM)
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+    entity = next(
+        entity
+        for entity in er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+        if entity.unique_id.startswith(MOCK_MAC)
+    )
+    # Something already holds the unique ID this entity would be moved to.
+    other_entry = MockConfigEntry(domain=DOMAIN, unique_id="other")
+    other_entry.add_to_hass(hass)
+    entity_registry.async_get_or_create(
+        entity.domain,
+        entity.platform,
+        NEW_MAC + entity.unique_id.removeprefix(MOCK_MAC),
+        config_entry=other_entry,
+    )
+
+    result = await _async_run_user_flow(hass, 2)
+    assert result["type"] is FlowResultType.MENU
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "name_conflict_migrate"}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "name_conflict_device_in_use"
+    assert entry.unique_id == MOCK_MAC
+    assert entity_registry.async_get(entity.entity_id).unique_id == entity.unique_id
+
+
+async def test_name_conflict_add_new_unique_id_claimed(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_rpc_device: Mock,
+) -> None:
+    """Test the add new path does not replace an entry that claimed the new MAC.
+
+    Creating an entry for a unique ID another entry already has makes Core remove
+    that entry together with its devices and entities, so this path has to abort.
+    """
+    await _async_add_replaced_entry(hass, 2, MODEL_PLUS_2PM)
+
+    result = await _async_run_user_flow(hass, 2)
+    assert result["type"] is FlowResultType.MENU
+
+    # A second flow for the same replacement finished in the meantime.
+    other_entry = MockConfigEntry(domain=DOMAIN, unique_id=NEW_MAC)
+    other_entry.add_to_hass(hass)
+    other_entity = entity_registry.async_get_or_create(
+        SENSOR_DOMAIN, DOMAIN, f"{NEW_MAC}-sensor", config_entry=other_entry
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "name_conflict_add_new"}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert hass.config_entries.async_get_entry(other_entry.entry_id) is not None
+    assert entity_registry.async_get(other_entity.entity_id) is not None
+
+
+async def test_name_conflict_migrate_unique_id_claimed(
+    hass: HomeAssistant,
+    mock_rpc_device: Mock,
+) -> None:
+    """Test aborting when another entry claims the new MAC while the menu is open.
+
+    Updating a config entry to a unique ID another entry already has does not
+    fail, it is only logged, so the two would silently share one.
+    """
+    entry = await _async_add_replaced_entry(hass, 2, MODEL_PLUS_2PM)
+
+    result = await _async_run_user_flow(hass, 2)
+    assert result["type"] is FlowResultType.MENU
+
+    # A second flow for the same replacement finished in the meantime.
+    other_entry = MockConfigEntry(domain=DOMAIN, unique_id=NEW_MAC)
+    other_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "name_conflict_migrate"}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "name_conflict_device_in_use"
+    assert entry.unique_id == MOCK_MAC
+
+
+async def test_name_conflict_migrate_recovered_entry(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_rpc_device: Mock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test aborting when the old device answers again while the menu is open.
+
+    The menu can stay open for a long time, and a device that only lost power
+    comes back within seconds, so the conditions cannot be checked only once.
+    """
+    entry = await init_integration(hass, 2, model=MODEL_PLUS_2PM)
+    assert entry.state is ConfigEntryState.LOADED
+
+    # The device stops answering, but the entry stays loaded.
+    monkeypatch.setattr(mock_rpc_device, "connected", False)
+    monkeypatch.setattr(
+        mock_rpc_device, "initialize", AsyncMock(side_effect=DeviceConnectionError)
+    )
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    coordinator = entry.runtime_data.rpc
+    assert coordinator is not None
+    assert coordinator.last_update_success is False
+
+    # The replacement answers, the coordinator of the existing entry has not
+    # polled again yet, so the menu is offered.
+    monkeypatch.undo()
+    result = await _async_run_user_flow(hass, 2)
+    assert result["type"] is FlowResultType.MENU
+
+    # The old device comes back before the user picks an option.
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert coordinator.last_update_success is True
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "name_conflict_migrate"}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "name_conflict_entry_working"
+    assert entry.unique_id == MOCK_MAC
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+
+
+async def test_name_conflict_migrate_deletes_old_issues(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    mock_rpc_device: Mock,
+) -> None:
+    """Test issues raised for the replaced device are deleted.
+
+    Every issue this integration raises is keyed by the MAC of its device and
+    most of them are persistent, so after the entry stops using the old MAC
+    nothing would ever delete them again.
+    """
+    await _async_add_replaced_entry(hass, 2, MODEL_PLUS_2PM)
+    old_issue_id = DEPRECATED_FIRMWARE_ISSUE_ID.format(unique=MOCK_MAC)
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        old_issue_id,
+        is_fixable=False,
+        is_persistent=True,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="deprecated_firmware",
+        translation_placeholders={"device_name": "Test name", "model": MODEL_PLUS_2PM},
+    )
+    # An issue of another integration that happens to end with the same MAC.
+    ir.async_create_issue(
+        hass,
+        "other_domain",
+        f"unrelated_{MOCK_MAC}",
+        is_fixable=False,
+        is_persistent=True,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="unrelated",
+    )
+
+    result = await _async_run_user_flow(hass, 2)
+    assert result["type"] is FlowResultType.MENU
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "name_conflict_migrate"}
+    )
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert result["reason"] == "name_conflict_migrated"
+    assert issue_registry.async_get_issue(DOMAIN, old_issue_id) is None
+    assert (
+        issue_registry.async_get_issue("other_domain", f"unrelated_{MOCK_MAC}")
+        is not None
+    )
+
+
+async def test_name_conflict_migrate_entry_removed(
+    hass: HomeAssistant,
+    mock_rpc_device: Mock,
+) -> None:
+    """Test aborting the migration when the entry is removed while the menu is open."""
+    entry = await _async_add_replaced_entry(hass, 2, MODEL_PLUS_2PM)
+
+    result = await _async_run_user_flow(hass, 2)
+    assert result["type"] is FlowResultType.MENU
+
+    await hass.config_entries.async_remove(entry.entry_id)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "name_conflict_migrate"}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "name_conflict_entry_removed"
+
+
+async def test_name_conflict_add_new(
+    hass: HomeAssistant,
+    mock_rpc_device: Mock,
+    mock_setup: AsyncMock,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test declining the migration creates a separate entry."""
+    entry = await _async_add_replaced_entry(hass, 2, MODEL_PLUS_2PM)
+
+    result = await _async_run_user_flow(hass, 2)
+    assert result["type"] is FlowResultType.MENU
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "name_conflict_add_new"}
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Test name"
+    assert result["data"] == {
+        CONF_HOST: "2.2.2.2",
+        CONF_PORT: DEFAULT_HTTP_PORT,
+        CONF_MODEL: MODEL_PLUS_2PM,
+        CONF_SLEEP_PERIOD: 0,
+        CONF_GEN: 2,
+        CONF_DEVICE_NAME: "Test name",
+    }
+    assert result["result"].unique_id == NEW_MAC
+    # The existing entry is left alone.
+    assert entry.unique_id == MOCK_MAC
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 2
+
+
+async def test_name_conflict_working_entry(
+    hass: HomeAssistant,
+    mock_rpc_device: Mock,
+) -> None:
+    """Test that an entry whose device still answers is never migrated."""
+    entry = await init_integration(hass, 2, model=MODEL_PLUS_2PM)
+    assert entry.state is ConfigEntryState.LOADED
+
+    result = await _async_run_user_flow(hass, 2)
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert entry.unique_id == MOCK_MAC
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 2
+
+
+async def test_name_conflict_disabled_entry(
+    hass: HomeAssistant,
+    mock_rpc_device: Mock,
+    mock_setup: AsyncMock,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test that a disabled entry is not offered for migration."""
+    entry = await _async_add_replaced_entry(hass, 2, MODEL_PLUS_2PM)
+    await hass.config_entries.async_set_disabled_by(
+        entry.entry_id, config_entries.ConfigEntryDisabler.USER
+    )
+
+    result = await _async_run_user_flow(hass, 2)
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert entry.unique_id == MOCK_MAC
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 2
+
+
+async def test_name_conflict_different_model(
+    hass: HomeAssistant,
+    mock_rpc_device: Mock,
+    mock_setup: AsyncMock,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test that a same-named device of another model is not offered a migration."""
+    # MODEL_25 differs from the model the mocked device reports.
+    entry = await _async_add_replaced_entry(hass, 2, MODEL_25)
+
+    result = await _async_run_user_flow(hass, 2)
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_MODEL] == MODEL_PLUS_2PM
+    assert entry.unique_id == MOCK_MAC
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 2
+
+
+async def test_name_conflict_different_generation(
+    hass: HomeAssistant,
+    mock_rpc_device: Mock,
+    mock_setup: AsyncMock,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test that a same-named device of another generation gets its own entry."""
+    # Same name and same model as the discovered device, but stored as gen1.
+    entry = await _async_add_replaced_entry(hass, 1, MODEL_PLUS_2PM)
+
+    result = await _async_run_user_flow(hass, 2)
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert entry.unique_id == MOCK_MAC
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 2
+
+
+async def test_name_conflict_entry_without_gen(
+    hass: HomeAssistant,
+    mock_block_device: Mock,
+) -> None:
+    """Test a gen1 entry predating CONF_GEN still matches.
+
+    CONF_GEN was added later, so the oldest gen1 entries do not carry it.
+    """
+    entry = await _async_add_replaced_entry(hass, None, MODEL_1)
+    assert CONF_GEN not in entry.data
+
+    result = await _async_run_user_flow(hass, 1)
+
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "name_conflict"
+
+
+@pytest.mark.parametrize(
+    ("gen", "model", "poll_interval"),
+    [
+        (1, MODEL_1, UPDATE_PERIOD_MULTIPLIER * 15),
+        (2, MODEL_PLUS_2PM, RPC_RECONNECT_INTERVAL),
+    ],
+)
+async def test_name_conflict_migrate_loaded_entry(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    gen: int,
+    model: str,
+    poll_interval: float,
+    mock_block_device: Mock,
+    mock_rpc_device: Mock,
+    monkeypatch: pytest.MonkeyPatch,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test migrating an entry that is still loaded while its device is gone.
+
+    A device that dies while Home Assistant keeps running leaves its entry
+    loaded, so the entry can only be recognised as broken by its coordinator.
+    """
+    entry = await init_integration(hass, gen, model=model)
+    assert entry.state is ConfigEntryState.LOADED
+    entity_ids = {
+        entity.entity_id
+        for entity in er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+    }
+    assert entity_ids
+
+    # The device stops answering, but the entry stays loaded. Both mocks are set
+    # up, only the coordinator of the generation under test consumes its own.
+    monkeypatch.setattr(
+        mock_block_device, "update", AsyncMock(side_effect=DeviceConnectionError)
+    )
+    monkeypatch.setattr(mock_rpc_device, "connected", False)
+    monkeypatch.setattr(
+        mock_rpc_device, "initialize", AsyncMock(side_effect=DeviceConnectionError)
+    )
+    freezer.tick(timedelta(seconds=poll_interval))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    coordinator = entry.runtime_data.rpc or entry.runtime_data.block
+    assert entry.state is ConfigEntryState.LOADED
+    # The device stays initialized, only the coordinator knows it is gone.
+    assert coordinator.device.initialized is True
+    assert coordinator.last_update_success is False
+
+    # The replacement hardware at the new address answers; the coordinator of
+    # the existing entry stays failed until its next poll.
+    monkeypatch.undo()
+
+    result = await _async_run_user_flow(hass, gen)
+
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "name_conflict"
+    assert coordinator.last_update_success is False
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "name_conflict_migrate"}
+    )
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "name_conflict_migrated"
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+    assert entry.state is ConfigEntryState.LOADED
+    assert entry.unique_id == NEW_MAC
+
+    # The entity IDs survived the rewrite and no duplicates were created.
+    entities = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+    assert {entity.entity_id for entity in entities} == entity_ids
+    for entity in entities:
+        assert entity.unique_id.startswith(NEW_MAC)
+
+
+@pytest.mark.parametrize(
+    ("elapsed_periods", "expected_update_success", "expected_type"),
+    [
+        (0, True, FlowResultType.CREATE_ENTRY),
+        (UPDATE_PERIOD_MULTIPLIER, False, FlowResultType.MENU),
+    ],
+    ids=["checked_in", "missed_checkin"],
+)
+async def test_name_conflict_sleeping_device(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    elapsed_periods: float,
+    expected_update_success: bool,
+    expected_type: FlowResultType,
+    mock_rpc_device: Mock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test a battery device is only offered for migration once it stops waking up."""
+    sleep_period = 1000
+    monkeypatch.setattr(mock_rpc_device, "connected", False)
+    monkeypatch.setitem(mock_rpc_device.status["sys"], "wakeup_period", sleep_period)
+    entry = await init_integration(
+        hass, 2, model=MODEL_PLUS_2PM, sleep_period=sleep_period
+    )
+
+    # The device checks in, which marks the coordinator as up to date.
+    mock_rpc_device.mock_online()
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert entry.runtime_data.rpc.last_update_success is True
+
+    # Only the missed check-in case moves past the window the device is given.
+    freezer.tick(timedelta(seconds=elapsed_periods * sleep_period))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert entry.runtime_data.rpc.last_update_success is expected_update_success
+
+    result = await _async_run_user_flow(hass, 2)
+
+    assert result["type"] is expected_type

--- a/tests/components/shelly/test_init.py
+++ b/tests/components/shelly/test_init.py
@@ -3,7 +3,7 @@
 import asyncio
 from ipaddress import IPv4Address
 from typing import Any
-from unittest.mock import AsyncMock, Mock, call, patch
+from unittest.mock import AsyncMock, Mock, PropertyMock, call, patch
 
 from aioshelly.block_device import COAP
 from aioshelly.common import ConnectionOptions
@@ -23,6 +23,7 @@ from homeassistant.components.shelly.const import (
     BLOCK_EXPECTED_SLEEP_PERIOD,
     BLOCK_WRONG_SLEEP_PERIOD,
     CONF_BLE_SCANNER_MODE,
+    CONF_DEVICE_NAME,
     CONF_GEN,
     CONF_SLEEP_PERIOD,
     DOMAIN,
@@ -698,7 +699,7 @@ async def test_migrate_ble_scanner_mode(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    assert entry.minor_version == 3
+    assert entry.minor_version == 4
     assert entry.options.get(CONF_BLE_SCANNER_MODE) == expected_mode
 
 
@@ -748,7 +749,7 @@ async def test_migrate_ble_scanner_mode_future_minor_version(
         options={CONF_BLE_SCANNER_MODE: BLEScannerMode.ACTIVE},
         title="Test name",
         version=1,
-        minor_version=4,
+        minor_version=5,
     )
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
@@ -756,7 +757,7 @@ async def test_migrate_ble_scanner_mode_future_minor_version(
 
     assert entry.state is ConfigEntryState.LOADED
     assert entry.version == 1
-    assert entry.minor_version == 4
+    assert entry.minor_version == 5
     assert entry.options[CONF_BLE_SCANNER_MODE] == BLEScannerMode.ACTIVE
 
 
@@ -936,3 +937,140 @@ async def test_rpc_disabled_ble_scanner_does_not_wait_at_startup(
     assert entry.state is ConfigEntryState.LOADED
     block_event.set()
     await hass.async_block_till_done()
+
+
+@pytest.mark.parametrize("gen", [1, 2])
+async def test_device_name_stored_and_refreshed(
+    hass: HomeAssistant,
+    gen: int,
+    mock_block_device: Mock,
+    mock_rpc_device: Mock,
+) -> None:
+    """Test the device name is stored on setup and follows a device rename."""
+    entry = await init_integration(hass, gen)
+
+    assert entry.data[CONF_DEVICE_NAME] == "Test name"
+
+    # Both device types are renamed, only the one of the generation under test
+    # is actually set up.
+    with (
+        patch.object(
+            type(mock_block_device), "name", PropertyMock(return_value="Renamed device")
+        ),
+        patch.object(
+            type(mock_rpc_device), "name", PropertyMock(return_value="Renamed device")
+        ),
+    ):
+        await hass.config_entries.async_reload(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.data[CONF_DEVICE_NAME] == "Renamed device"
+
+
+async def test_sleeping_device_name_stored_when_online(
+    hass: HomeAssistant,
+    mock_rpc_device: Mock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test a sleeping device stores its name once it checks in.
+
+    A sleeping device is not initialized while the entry is set up, so the name
+    is stored by the coordinator when the device connects.
+    """
+    monkeypatch.setattr(mock_rpc_device, "connected", False)
+    monkeypatch.setattr(mock_rpc_device, "initialized", False)
+    monkeypatch.setitem(mock_rpc_device.status["sys"], "wakeup_period", 1000)
+    entry = await init_integration(hass, 2, sleep_period=1000)
+
+    assert CONF_DEVICE_NAME not in entry.data
+
+    monkeypatch.setattr(mock_rpc_device, "initialized", True)
+    mock_rpc_device.mock_online()
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert entry.data[CONF_DEVICE_NAME] == "Test name"
+
+
+@pytest.mark.parametrize(
+    ("data", "expected_name"),
+    [({}, "Old name"), ({CONF_DEVICE_NAME: "Stored name"}, "Stored name")],
+    ids=["seeded_from_title", "existing_value_kept"],
+)
+async def test_migrate_device_name(
+    hass: HomeAssistant,
+    mock_rpc_device: Mock,
+    monkeypatch: pytest.MonkeyPatch,
+    data: dict[str, Any],
+    expected_name: str,
+) -> None:
+    """Test the device name is seeded from the entry title for older entries.
+
+    The device is not reachable, which is the situation the seed exists for:
+    an entry that will never be set up again cannot learn the name from its
+    device.
+    """
+    monkeypatch.setattr(
+        mock_rpc_device, "initialize", AsyncMock(side_effect=DeviceConnectionError)
+    )
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "192.168.1.37",
+            CONF_SLEEP_PERIOD: 0,
+            CONF_MODEL: MODEL_PLUS_2PM,
+            CONF_GEN: 2,
+            **data,
+        },
+        unique_id=MOCK_MAC,
+        title="Old name",
+        minor_version=3,
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+    assert entry.minor_version == 4
+    assert entry.data[CONF_DEVICE_NAME] == expected_name
+
+
+async def test_migrate_device_name_from_device_registry(
+    hass: HomeAssistant,
+    device_registry: DeviceRegistry,
+    mock_rpc_device: Mock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test the seeded device name is taken from the device registry.
+
+    The entry title can have been renamed by the user, and an entry whose device
+    is gone never gets to correct it, so the name the integration gave the device
+    is preferred. It is kept separately from the user's own rename.
+    """
+    monkeypatch.setattr(
+        mock_rpc_device, "initialize", AsyncMock(side_effect=DeviceConnectionError)
+    )
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "192.168.1.37",
+            CONF_SLEEP_PERIOD: 0,
+            CONF_MODEL: MODEL_PLUS_2PM,
+            CONF_GEN: 2,
+        },
+        unique_id=MOCK_MAC,
+        title="Renamed by the user",
+        minor_version=3,
+    )
+    entry.add_to_hass(hass)
+    device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, MOCK_MAC)},
+        name="Reported by the device",
+    )
+    device_registry.async_update_device(device.id, name_by_user="Renamed by the user")
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert entry.minor_version == 4
+    assert entry.data[CONF_DEVICE_NAME] == "Reported by the device"


### PR DESCRIPTION
## Proposed change

When you replace a broken Shelly with a new unit, Home Assistant sets the new one up as a separate device. The old entry stays behind, and every entity ID, history graph and automation that pointed at the old hardware is dead.

This adds the ESPHome name conflict flow to Shelly. When a device is set up and an existing entry has the same device name, the same model and the same generation, and that entry is not currently working, the flow offers two options: add it as a new device, or migrate the existing configuration onto the new hardware. Migrating rewrites the config entry unique ID, the device and sub-device registry rows and every entity unique ID, so entity IDs, history and automations survive the swap.

The device has to be named before it is added to Home Assistant, which the documentation now says. A Shelly with no name reports its host name, which contains its own MAC, so two unnamed devices never match each other.

Before anything is written, the flow checks whether any target device identifier, the target MAC connection or any target entity unique ID is already taken. If so it aborts and nothing is touched, because a partial failure would leave the entry renamed but the registries untouched, which duplicates every entity on the next reload. The device registry lookups are scoped to the config entry, matching how `_validate_connections` and `_validate_identifiers` scope their own collision checks.

## What changed since the first version of this PR

The first version triggered on `MacAddressMismatchError` and raised a repair issue. @thecode pointed out that this is the wrong signal: it exists to protect against devices crossing over after a DHCP reshuffle, and since most users do not assign fixed IP addresses, a replacement device usually appears on a different address and never reaches that code path. That trigger is gone. Detection now happens in the config flow, which is where a replacement actually shows up.

## Testing

The hardware run below was done on the first version of this branch. The rebase onto current `dev` changed the entry data (the SSL keys from #176547 are now carried through the shared helper) and narrowed the registry collision lookups to the config entry, so the numbers describe the same flow but not literally the commit as it stands now.

Two Shelly Plus 2PM (`SNSW-102P16EU`, firmware `1.3.3`, generation 2) on a throwaway Home Assistant instance running this branch. Both units are configured in switch profile, so each one has `switch:0` and `switch:1` and the integration creates two sub-devices per unit.

The replacement run: the first unit was named `Office Light`, set up, and left running. It was then powered off. Home Assistant reported the device as disconnected 67 seconds after the last successful update and started reconnecting in the same moment. The second unit was given the same name and added.

<img width="580" height="420" alt="The name conflict menu on real hardware" src="https://github.com/user-attachments/assets/27a6c546-1306-4a71-9a40-39b3627be14c" />

<img width="580" height="212" alt="Confirmation after the migration" src="https://github.com/user-attachments/assets/087ef6f3-85dd-4ef6-be95-73c15512fd1d" />

Result of the migration:

- The config entry moved from `D0EF76C7A454` to `D0EF76C84F58`. Host, port and credentials are taken from the new device.
- All three device registry rows moved, including both sub-devices (`D0EF76C84F58-switch:0` and `-switch:1`).
- 19 entities: 19 on the new MAC, 0 left on the old one, 0 duplicates.
- The entity IDs are identical to the ones recorded before the swap, line for line.
- History continues on the same entities across the swap.

The guard was checked on hardware as well. With the first unit powered on again, both units online, both named `Office Light` and the same model, no migration is offered and the new unit becomes a separate entry.

Both units report `sys.device.name: null` out of the box and fall back to `shellyplus2pm-<own mac>`, which is the behaviour the unnamed case relies on.

History across the swap, on the same two entities. The gap is the window in which the old unit was off and the replacement had not been added yet:

<img width="1500" height="400" alt="History continues on the same entities across the swap" src="https://github.com/user-attachments/assets/c8ef458e-1de2-4ff0-ad1d-d24693a7d272" />

## Notes on two details

A device that is gone is recognised by `last_update_success` on the coordinator, not by `device.initialized` alone. `initialized` is only ever cleared inside `initialize()`, and the Block coordinator re-enters that method only when a device comes back, so a generation 1 device that dies under a running Home Assistant keeps `initialized == True` indefinitely. Checking it alone would have meant the menu never appears for generation 1 in exactly the scenario this feature is for. `test_name_conflict_migrate_loaded_entry` covers both generations with a loaded entry whose device has stopped answering.

For sleeping devices this works out on its own. A check-in calls `async_set_updated_data`, which resets `last_update_success` and reschedules, so a battery device that wakes on time reads as working and is not offered for migration. Only after it misses its window by the usual 2.2 × wake-up period does the scheduled poll fail and the menu become available. `test_name_conflict_sleeping_device` pins both states.

Entries created before this change carry no device name, so `async_migrate_entry` seeds it once from the entry title at `minor_version` 4. The title is set from the device name at creation but is user-editable, so this is a one-time heuristic; the value is refreshed from the device on the next successful setup. Without it the feature would be invisible on the most likely upgrade path, where the device is already dead by the time the user updates Home Assistant.

## Known limitations and open questions

**Name uniqueness.** An ESPHome node name is the node's identity and unique on the network by construction. A Shelly name is free text typed in the app, and two devices can legitimately share one. The guards are: same model, same generation, the existing entry must not currently be working, and the non-destructive option is listed first. That narrows it but does not close it. If you would rather have a stricter condition, say which and I will change it.

`CONF_DEVICE_NAME` may be redundant. `ShellyCoordinatorBase.async_setup` already writes the same string as the device registry name. I kept an explicit entry key for parity with ESPHome, but reading the registry instead would remove the new constant and the refresh entirely.

Generation 1 is covered by tests only. I have no pair of generation 1 units here, so the hardware run above is generation 2.

If several dead entries share the same name and model, the first match wins. The dialog names the entry and its MAC address, so the choice is visible, but there is no picker.

The reconfigure flow still aborts on a unique ID mismatch rather than offering migration. Discovery normally finds the replacement first, so this seemed like the wrong place for a second entry point, but I can add it.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #125811, #119933, #131307, #132826
- Link to documentation pull request: home-assistant/home-assistant.io#47213
- Link to developer documentation pull request:
- Link to frontend pull request:
- Follows the ESPHome name conflict flow added in #142966.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io
