### PR TITLE
Bump ZHA to 2.0.0

### DIFF
--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -314,6 +314,18 @@ class ZHADeviceProxy(EventBase):
         self._unsubs: list[Callable[[], None]] = []
         self._unsubs.append(self.device.on_all_events(self._handle_event_protocol))
 
+    @callback
+    def async_rebind_device(self, device: Device) -> None:
+        """Repoint this proxy to a replacement device object after a re-interview."""
+        for unsub in self._unsubs:
+            unsub()
+
+        self._unsubs.clear()
+
+        self.device = device
+        self._unsubs.append(self.device.on_all_events(self._handle_event_protocol))
+        self._track_firmware_version()
+
     @property
     def device_id(self) -> str:
         """Return the HA device registry device id."""
@@ -728,11 +740,24 @@ class ZHAGatewayProxy(EventBase):
     def handle_device_fully_initialized(self, event: DeviceFullInitEvent) -> None:
         """Handle a device fully initialized event."""
         zha_device = self.gateway.get_device(event.device_info.ieee)
+
+        # If ZHA swaps out the underlying device object, we need to update the proxy to
+        # point to the new one. The replacement is initialized silently
+        # (its entity-added events are suppressed), so we repoint the proxy and re-add
+        # its entities here; the old entities were already removed via teardown events
+        # on the previous object.
+        device_proxy = self.device_proxies.get(zha_device.ieee)
+        swapped_device = (
+            device_proxy is not None and device_proxy.device is not zha_device
+        )
+
         zha_device_proxy = self._async_get_or_create_device_proxy(zha_device)
+        if swapped_device:
+            zha_device_proxy.async_rebind_device(zha_device)
 
         device_info = zha_device_proxy.zha_device_info
         device_info[DEVICE_PAIRING_STATUS] = event.device_info.pairing_status.name
-        if event.new_join:
+        if event.new_join or swapped_device:
             self._create_entity_metadata(zha_device_proxy)
             async_dispatcher_send(self.hass, SIGNAL_ADD_ENTITIES)
         async_dispatcher_send(

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -77,6 +77,8 @@ from zha.zigbee.device import (
     ZHAEvent,
 )
 from zha.zigbee.group import Group, GroupInfo, GroupMember
+import zhaquirks
+import zhaquirks.legacy
 from zigpy.config import (
     CONF_DATABASE,
     CONF_DEVICE,
@@ -1363,6 +1365,10 @@ def create_zha_config(hass: HomeAssistant, ha_zha_data: HAZHAData) -> ZHAData:
     quirks_config: QuirksConfiguration = QuirksConfiguration(
         enabled=ha_zha_data.yaml_config.get(CONF_ENABLE_QUIRKS, True),
         custom_quirks_path=ha_zha_data.yaml_config.get(CONF_CUSTOM_QUIRKS_PATH),
+        setup_function=zhaquirks.setup,
+        uninitialized_packet_handler=(
+            zhaquirks.legacy.handle_message_from_uninitialized_sender
+        ),
     )
     overrides_config: dict[str, DeviceOverridesConfiguration] = {}
     overrides: dict[str, dict[str, Any]] = cast(

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -324,13 +324,14 @@ class ZHADeviceProxy(EventBase):
 
         self.device = device
         self._unsubs.append(self.device.on_all_events(self._handle_event_protocol))
-        self._sync_firmware_version()
+        self.attach_event_handlers()
 
     @callback
-    def _sync_firmware_version(self) -> None:
-        """Sync the device's firmware version into the device registry."""
+    def attach_event_handlers(self) -> None:
+        """Attach event handlers to the ZHA device."""
         device_registry = dr.async_get(self.gateway_proxy.hass)
 
+        # Sync the device's firmware version into the device registry
         def update_sw_version(event: DeviceFirmwareInfoUpdatedEvent) -> None:
             """Update software version in device registry."""
             device_registry.async_update_device(
@@ -914,7 +915,7 @@ class ZHAGatewayProxy(EventBase):
                 sw_version=zha_device.firmware_version,
             )
             zha_device_proxy.device_id = device_registry_device.id
-            zha_device_proxy._sync_firmware_version()
+            zha_device_proxy.attach_event_handlers()
 
         return zha_device_proxy
 

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -324,7 +324,24 @@ class ZHADeviceProxy(EventBase):
 
         self.device = device
         self._unsubs.append(self.device.on_all_events(self._handle_event_protocol))
-        self._track_firmware_version()
+        self._sync_firmware_version()
+
+    @callback
+    def _sync_firmware_version(self) -> None:
+        """Sync the device's firmware version into the device registry."""
+        device_registry = dr.async_get(self.gateway_proxy.hass)
+
+        def update_sw_version(event: DeviceFirmwareInfoUpdatedEvent) -> None:
+            """Update software version in device registry."""
+            device_registry.async_update_device(
+                self.device_id, sw_version=event.new_firmware_version
+            )
+
+        self._unsubs.append(
+            self.device.on_event(
+                DeviceFirmwareInfoUpdatedEvent.event_type, update_sw_version
+            )
+        )
 
     @property
     def device_id(self) -> str:
@@ -897,19 +914,7 @@ class ZHAGatewayProxy(EventBase):
                 sw_version=zha_device.firmware_version,
             )
             zha_device_proxy.device_id = device_registry_device.id
-
-            def update_sw_version(event: DeviceFirmwareInfoUpdatedEvent) -> None:
-                """Update software version in device registry."""
-                device_registry.async_update_device(
-                    device_registry_device.id,
-                    sw_version=event.new_firmware_version,
-                )
-
-            self._unsubs.append(
-                zha_device.on_event(
-                    DeviceFirmwareInfoUpdatedEvent.event_type, update_sw_version
-                )
-            )
+            zha_device_proxy._sync_firmware_version()
 
         return zha_device_proxy
 

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -23,7 +23,7 @@
     "universal_silabs_flasher",
     "serialx"
   ],
-  "requirements": ["zha==1.4.1"],
+  "requirements": ["zha==1.4.1", "zha-quirks==1.2.0"],
   "usb": [
     {
       "description": "*2652*",

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -23,7 +23,7 @@
     "universal_silabs_flasher",
     "serialx"
   ],
-  "requirements": ["zha==1.4.1", "zha-quirks==1.2.0"],
+  "requirements": ["zha==2.0.0", "zha-quirks==2.0.0"],
   "usb": [
     {
       "description": "*2652*",

--- a/homeassistant/components/zha/radio_manager.py
+++ b/homeassistant/components/zha/radio_manager.py
@@ -45,13 +45,18 @@ from .helpers import get_zha_data
 RECOMMENDED_RADIOS = (
     RadioType.ezsp,
     RadioType.znp,
+    RadioType.ziggurat,
     RadioType.deconz,
 )
 
 # Only the common radio types will be autoprobed, ordered by new device popularity.
 # XBee takes too long to probe since it scans through all possible bauds and likely has
 # very few users to begin with.
-AUTOPROBE_RADIOS = RECOMMENDED_RADIOS
+AUTOPROBE_RADIOS = (
+    RadioType.ezsp,
+    RadioType.znp,
+    RadioType.deconz,
+)
 
 CONNECT_DELAY_S = 1.0
 RETRY_DELAY_S = 1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3466,10 +3466,10 @@ zeroconf==0.150.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha-quirks==1.2.0
+zha-quirks==2.0.0
 
 # homeassistant.components.zha
-zha==1.4.1
+zha==2.0.0
 
 # homeassistant.components.zhong_hong
 zhong-hong-hvac==1.0.13

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3466,6 +3466,9 @@ zeroconf==0.150.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
+zha-quirks==1.2.0
+
+# homeassistant.components.zha
 zha==1.4.1
 
 # homeassistant.components.zhong_hong

--- a/tests/components/zha/conftest.py
+++ b/tests/components/zha/conftest.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
 import warnings
 
 import pytest
+from zha.quirks import resolve_zigpy_device
 import zhaquirks
 import zigpy
 from zigpy.application import ControllerApplication
@@ -397,7 +398,7 @@ def zigpy_device_mock(zigpy_app_controller) -> Callable[..., zigpy.device.Device
             device = quirk(zigpy_app_controller, device.ieee, device.nwk, device)
         else:
             # Allow zigpy to apply quirks if we don't pass one explicitly
-            device = zigpy.quirks.get_device(device)
+            device = resolve_zigpy_device(device)
 
         if patch_cluster:
             for endpoint in (ep for epid, ep in device.endpoints.items() if epid):

--- a/tests/components/zha/conftest.py
+++ b/tests/components/zha/conftest.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
 import warnings
 
 import pytest
-from zha.quirks import resolve_zigpy_device
+from zha.quirks import DEVICE_REGISTRY
 import zhaquirks
 import zigpy
 from zigpy.application import ControllerApplication
@@ -19,7 +19,6 @@ import zigpy.device
 import zigpy.group
 import zigpy.profiles
 from zigpy.profiles import zha
-import zigpy.quirks
 import zigpy.state
 import zigpy.types
 import zigpy.util
@@ -398,7 +397,7 @@ def zigpy_device_mock(zigpy_app_controller) -> Callable[..., zigpy.device.Device
             device = quirk(zigpy_app_controller, device.ieee, device.nwk, device)
         else:
             # Allow zigpy to apply quirks if we don't pass one explicitly
-            device = resolve_zigpy_device(device)
+            device = DEVICE_REGISTRY.resolve(device)
 
         if patch_cluster:
             for endpoint in (ep for epid, ep in device.endpoints.items() if epid):

--- a/tests/components/zha/test_dynamic_entities.py
+++ b/tests/components/zha/test_dynamic_entities.py
@@ -6,7 +6,9 @@ from unittest.mock import patch
 import pytest
 from zha.application import Platform as ZhaPlatform
 from zha.application.platforms import PlatformEntity
+from zha.quirks import DEVICE_REGISTRY
 from zha.zigbee.device import DeviceEntityAddedEvent, DeviceEntityRemovedEvent
+from zhaquirks.builder import QuirkBuilder
 from zigpy.device import Device
 from zigpy.profiles import zha
 from zigpy.zcl.clusters import general
@@ -257,3 +259,71 @@ async def test_remove_entity_reference_when_ieee_already_cleared(
     await hass.async_block_till_done()
 
     assert ieee not in gateway_proxy._ha_entity_refs
+
+
+async def test_reinterview_quirk_class_swap_rebinds_proxy(
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
+) -> None:
+    """A re-interview that changes the ZHA `Device` class re-binds the proxy."""
+    await setup_zha()
+    gateway = get_zha_gateway(hass)
+    gateway_proxy = get_zha_gateway_proxy(hass)
+
+    endpoints = {
+        1: {
+            SIG_EP_INPUT: [general.Basic.cluster_id, general.OnOff.cluster_id],
+            SIG_EP_OUTPUT: [],
+            SIG_EP_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+            SIG_EP_PROFILE: zha.PROFILE_ID,
+        }
+    }
+
+    # Join with no matching quirk: resolves to the base `Device` class.
+    zigpy_device = zigpy_device_mock(
+        endpoints,
+        ieee="01:2d:6f:00:0a:90:69:e8",
+        manufacturer="Fake",
+        model="Model_A",
+    )
+    gateway.get_or_create_device(zigpy_device)
+    await gateway.async_device_initialized(zigpy_device)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    proxy = gateway_proxy.get_device_proxy(zigpy_device.ieee)
+    assert proxy is not None
+    original_device = proxy.device
+    assert not original_device.quirk_applied
+
+    switch_id = find_entity_id(Platform.SWITCH, proxy, hass)
+    assert switch_id is not None
+    assert hass.states.get(switch_id).state == STATE_OFF
+
+    with DEVICE_REGISTRY.preserve_state():
+        # Register a v2 quirk for the re-interviewed model -> `QuirkV2Device`.
+        (
+            QuirkBuilder("Fake", "Model_B")
+            .friendly_name(model="Quirk B", manufacturer="Fake")
+            .add_to_registry()
+        )
+
+        reinterviewed = zigpy_device_mock(
+            endpoints,
+            ieee="01:2d:6f:00:0a:90:69:e8",
+            manufacturer="Fake",
+            model="Model_B",
+        )
+        gateway.device_reinterviewed(reinterviewed)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    # The `Device` object was replaced by a quirked one
+    new_device = gateway.get_device(zigpy_device.ieee)
+    assert new_device is not original_device
+    assert new_device.quirk_applied
+
+    # The proxy followed the swap
+    assert proxy.device is new_device
+
+    # And the switch entity was re-materialized on the new object.
+    assert hass.states.get(switch_id).state == STATE_OFF

--- a/tests/components/zha/test_number.py
+++ b/tests/components/zha/test_number.py
@@ -4,10 +4,9 @@ from collections.abc import Callable, Coroutine
 from unittest.mock import call, patch
 
 import pytest
+from zhaquirks.builder import NumberDeviceClass, QuirkBuilder
 from zigpy.device import Device
 from zigpy.profiles import zha
-from zigpy.quirks.v2 import QuirkBuilder
-from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
 from zigpy.typing import UNDEFINED
 from zigpy.zcl.clusters import general
 import zigpy.zcl.foundation as zcl_f

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -4,9 +4,9 @@ from collections.abc import Callable, Coroutine
 from unittest.mock import patch
 
 import pytest
+from zhaquirks.builder import QuirkBuilder
 from zigpy.device import Device
 from zigpy.profiles import zha
-from zigpy.quirks.v2 import QuirkBuilder
 from zigpy.zcl import Cluster
 from zigpy.zcl.clusters import general, homeautomation, hvac, measurement, smartenergy
 from zigpy.zcl.clusters.hvac import Thermostat


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump ZHA to [2.0.0](https://github.com/zigpy/zha/releases/tag/2.0.0) ([diff](https://github.com/zigpy/zha/compare/1.4.1...2.0.0)) and bundle zha-quirks [2.0.0](https://github.com/zigpy/zha-device-handlers/releases/tag/2.0.0) ([diff](https://github.com/zigpy/zha-device-handlers/compare/1.2.0...2.0.0)) (ZHA no longer pins zha-quirks).
The bundled zigpy version is updated to [2.0.0](https://github.com/zigpy/zigpy/releases/tag/2.0.0) ([diff](https://github.com/zigpy/zigpy/compare/1.5.1...2.0.0)).

This is a major release for both projects:

1. Our quirks API is now fully revamped: complex ZHA entities can now be created entirely within with quirks, allowing for faster community support of new devices and new _complex_ devices.
2. Our fully open source host-side Zigbee stack, [Ziggurat](https://github.com/zigpy/ziggurat/), is now in public beta. It replaces the closed-source firmware on any Zigbee adapter with OpenThread RCP ([more info](https://github.com/zigpy/ziggurat/#ziggurat)) and runs inside of a Home Assistant [app](https://github.com/zigpy/addons). Ziggurat is _fast_, 100% open source, written in safe Rust, and lets your Zigbee network benefit from the computing power of a general purpose computer.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
