### PR TITLE
Add missing scope and authorize param to Dropbox OAuth

### DIFF
--- a/homeassistant/components/dropbox/__init__.py
+++ b/homeassistant/components/dropbox/__init__.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
 )
 
 from .auth import DropboxConfigEntryAuth
-from .const import DATA_BACKUP_AGENT_LISTENERS, DOMAIN
+from .const import DATA_BACKUP_AGENT_LISTENERS, DOMAIN, OAUTH2_SCOPES
 
 type DropboxConfigEntry = ConfigEntry[DropboxAPIClient]
 
@@ -31,6 +31,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: DropboxConfigEntry) -> b
             translation_domain=DOMAIN,
             translation_key="oauth2_implementation_unavailable",
         ) from err
+
+    token = entry.data["token"]
+    if not set(token.get("scope", "").split()).issuperset(OAUTH2_SCOPES):
+        raise ConfigEntryAuthFailed(
+            translation_domain=DOMAIN,
+            translation_key="missing_scopes",
+        )
+    if "refresh_token" not in token:
+        raise ConfigEntryAuthFailed(
+            translation_domain=DOMAIN,
+            translation_key="missing_refresh_token",
+        )
+
     oauth2_session = OAuth2Session(hass, entry, oauth2_implementation)
 
     auth = DropboxConfigEntryAuth(

--- a/homeassistant/components/dropbox/application_credentials.py
+++ b/homeassistant/components/dropbox/application_credentials.py
@@ -1,7 +1,5 @@
 """Application credentials platform for the Dropbox integration."""
 
-from typing import override
-
 from homeassistant.components.application_credentials import ClientCredential
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.config_entry_oauth2_flow import (
@@ -9,14 +7,14 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
     LocalOAuth2ImplementationWithPkce,
 )
 
-from .const import OAUTH2_AUTHORIZE, OAUTH2_SCOPES, OAUTH2_TOKEN
+from .const import OAUTH2_AUTHORIZE, OAUTH2_TOKEN
 
 
 async def async_get_auth_implementation(
     hass: HomeAssistant, auth_domain: str, credential: ClientCredential
 ) -> AbstractOAuth2Implementation:
-    """Return custom auth implementation."""
-    return DropboxOAuth2Implementation(
+    """Return auth implementation."""
+    return LocalOAuth2ImplementationWithPkce(
         hass,
         auth_domain,
         credential.client_id,
@@ -24,21 +22,3 @@ async def async_get_auth_implementation(
         OAUTH2_TOKEN,
         credential.client_secret,
     )
-
-
-class DropboxOAuth2Implementation(LocalOAuth2ImplementationWithPkce):
-    """Custom Dropbox OAuth2 implementation.
-
-    Adds the necessary authorize url parameters.
-    """
-
-    @property
-    @override
-    def extra_authorize_data(self) -> dict:
-        """Extra data that needs to be appended to the authorize url."""
-        data: dict = {
-            "token_access_type": "offline",
-            "scope": " ".join(OAUTH2_SCOPES),
-        }
-        data.update(super().extra_authorize_data)
-        return data

--- a/homeassistant/components/dropbox/config_flow.py
+++ b/homeassistant/components/dropbox/config_flow.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.config_entry_oauth2_flow import AbstractOAuth2FlowHandler
 
 from .auth import DropboxConfigFlowAuth
-from .const import DOMAIN
+from .const import DOMAIN, OAUTH2_SCOPES
 
 
 class DropboxConfigFlow(AbstractOAuth2FlowHandler, domain=DOMAIN):
@@ -25,6 +25,15 @@ class DropboxConfigFlow(AbstractOAuth2FlowHandler, domain=DOMAIN):
     def logger(self) -> logging.Logger:
         """Return logger."""
         return logging.getLogger(__name__)
+
+    @property
+    @override
+    def extra_authorize_data(self) -> dict:
+        """Extra data that needs to be appended to the authorize url."""
+        return {
+            "token_access_type": "offline",
+            "scope": " ".join(OAUTH2_SCOPES),
+        }
 
     @override
     async def async_oauth_create_entry(self, data: dict[str, Any]) -> ConfigFlowResult:

--- a/homeassistant/components/dropbox/config_flow.py
+++ b/homeassistant/components/dropbox/config_flow.py
@@ -60,6 +60,9 @@ class DropboxConfigFlow(AbstractOAuth2FlowHandler, domain=DOMAIN):
         self, entry_data: Mapping[str, Any]
     ) -> ConfigFlowResult:
         """Perform reauth upon an API authentication error."""
+        token = entry_data[CONF_TOKEN]
+        if not set(token.get("scope", "").split()).issuperset(OAUTH2_SCOPES):
+            return await self.async_step_reauth_permissions()
         return await self.async_step_reauth_confirm()
 
     async def async_step_reauth_confirm(
@@ -68,4 +71,12 @@ class DropboxConfigFlow(AbstractOAuth2FlowHandler, domain=DOMAIN):
         """Dialog that informs the user that reauth is required."""
         if user_input is None:
             return self.async_show_form(step_id="reauth_confirm")
+        return await self.async_step_user()
+
+    async def async_step_reauth_permissions(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Dialog that informs the user that additional permissions are required."""
+        if user_input is None:
+            return self.async_show_form(step_id="reauth_permissions")
         return await self.async_step_user()

--- a/homeassistant/components/dropbox/const.py
+++ b/homeassistant/components/dropbox/const.py
@@ -12,6 +12,7 @@ OAUTH2_SCOPES = [
     "account_info.read",
     "files.content.read",
     "files.content.write",
+    "files.metadata.read",
 ]
 
 DATA_BACKUP_AGENT_LISTENERS: HassKey[list[Callable[[], None]]] = HassKey(

--- a/homeassistant/components/dropbox/strings.json
+++ b/homeassistant/components/dropbox/strings.json
@@ -24,10 +24,20 @@
       "reauth_confirm": {
         "description": "The Dropbox integration needs to re-authenticate your account.",
         "title": "[%key:common::config_flow::title::reauth%]"
+      },
+      "reauth_permissions": {
+        "description": "The Dropbox integration requires additional permissions to function correctly.",
+        "title": "[%key:common::config_flow::title::reauth%]"
       }
     }
   },
   "exceptions": {
+    "missing_refresh_token": {
+      "message": "[%key:component::dropbox::config::step::reauth_confirm::description%]"
+    },
+    "missing_scopes": {
+      "message": "[%key:component::dropbox::config::step::reauth_permissions::description%]"
+    },
     "oauth2_implementation_unavailable": {
       "message": "[%key:common::exceptions::oauth2_implementation_unavailable::message%]"
     }

--- a/tests/components/dropbox/test_config_flow.py
+++ b/tests/components/dropbox/test_config_flow.py
@@ -130,6 +130,54 @@ async def test_already_configured(
 
 @pytest.mark.usefixtures("current_request_with_host")
 @pytest.mark.parametrize(
+    ("token", "expected_step"),
+    [
+        (
+            {
+                "access_token": "mock-access-token",
+                "expires_at": 9_999_999_999,
+                "scope": " ".join(OAUTH2_SCOPES),
+            },
+            "reauth_confirm",
+        ),
+        (
+            {
+                "access_token": "mock-access-token",
+                "refresh_token": "mock-refresh-token",
+                "expires_at": 9_999_999_999,
+                "scope": "account_info.read files.content.read files.content.write",
+            },
+            "reauth_permissions",
+        ),
+    ],
+    ids=["missing_refresh_token", "missing_scope"],
+)
+async def test_reauth_confirm_step(
+    hass: HomeAssistant,
+    mock_config_entry,
+    token: dict[str, object],
+    expected_step: str,
+) -> None:
+    """Test reauth shows the correct confirmation step for the broken token."""
+
+    mock_config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        mock_config_entry, data={**mock_config_entry.data, "token": token}
+    )
+
+    result = await mock_config_entry.start_reauth_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == expected_step
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result["type"] is FlowResultType.EXTERNAL_STEP
+    assert result["step_id"] == "auth"
+
+
+@pytest.mark.usefixtures("current_request_with_host")
+@pytest.mark.parametrize(
     (
         "new_account_info",
         "expected_reason",

--- a/tests/components/dropbox/test_init.py
+++ b/tests/components/dropbox/test_init.py
@@ -1,11 +1,13 @@
 """Test the Dropbox integration setup."""
 
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from python_dropbox_api import DropboxAuthException, DropboxUnknownException
 
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.components.dropbox.const import DOMAIN, OAUTH2_SCOPES
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.config_entry_oauth2_flow import (
     ImplementationUnavailableError,
@@ -78,6 +80,46 @@ async def test_setup_entry_implementation_unavailable(
         await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+@pytest.mark.usefixtures("mock_dropbox_client")
+@pytest.mark.parametrize(
+    "token",
+    [
+        {
+            "access_token": "mock-access-token",
+            "expires_at": 9_999_999_999,
+            "scope": " ".join(OAUTH2_SCOPES),
+        },
+        {
+            "access_token": "mock-access-token",
+            "refresh_token": "mock-refresh-token",
+            "expires_at": 9_999_999_999,
+            "scope": "account_info.read files.content.read files.content.write",
+        },
+    ],
+    ids=["missing_refresh_token", "missing_scope"],
+)
+async def test_setup_entry_triggers_reauth(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    token: dict[str, Any],
+) -> None:
+    """Test that a broken token triggers a reauth flow during setup."""
+    mock_config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        mock_config_entry, data={**mock_config_entry.data, "token": token}
+    )
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+
+    flows = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
+    assert len(flows) == 1
+    assert flows[0]["context"]["source"] == SOURCE_REAUTH
+    assert flows[0]["context"]["entry_id"] == mock_config_entry.entry_id
 
 
 @pytest.mark.usefixtures("mock_dropbox_client")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This fixes two issues with the Dropbox integration:
1. We were including `token_access_type=offline` in the authorize URL for the local OAuth implementation, but not for the cloud (account linking service) implementation. This resulted in Dropbox not returning a refresh_token, and the integration therefore failing to authenticate after the short-lived access token expired. To fix this, I moved the extra_authorize_data override from the OAuth implementation to the config flow, where it will apply to both the local and cloud flows.
2. The scope `files.metadata.read`, which the integration requires, was missing from OAUTH2_SCOPES. Users were being granted a token that lacked this scope, which meant that auth would succeed, but some functionality would fail.

I also added logic to initiate reauth if either issue (missing refresh token or missing scope) is detected in the user's existing config entry.

Changes are separated into individual commits for easier reviewing.

This change is necessary in order for the issue in https://github.com/home-assistant/core/pull/174512 to be fully resolved, so it would be great if this could change could be tagged for 2026.7 to be released along with that change. Thank you!

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue:
  - https://github.com/home-assistant/core/issues/172643 (not directly related, but mentioned in the comments)
  - https://github.com/home-assistant/core/pull/174432 (previous attempt at fixing)
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
