### PR TITLE
Migrate alarm control panel entity attributes to StrEnum

### DIFF
--- a/homeassistant/components/alarm_control_panel/__init__.py
+++ b/homeassistant/components/alarm_control_panel/__init__.py
@@ -8,7 +8,7 @@ from propcache.api import cached_property
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
+from homeassistant.const import (  # noqa: F401
     ATTR_CODE,
     ATTR_CODE_FORMAT,
     SERVICE_ALARM_ARM_AWAY,
@@ -28,11 +28,12 @@ from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.hass_dict import HassKey
 
-from .const import (
+from .const import (  # noqa: F401
     ATTR_CHANGED_BY,
     ATTR_CODE_ARM_REQUIRED,
     DOMAIN,
     AlarmControlPanelEntityFeature,
+    AlarmControlPanelEntityStateAttribute,
     AlarmControlPanelState,
     CodeFormat,
 )
@@ -303,9 +304,11 @@ class AlarmControlPanelEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_A
     def state_attributes(self) -> dict[str, Any] | None:
         """Return the state attributes."""
         return {
-            ATTR_CODE_FORMAT: self.code_format,
-            ATTR_CHANGED_BY: self.changed_by,
-            ATTR_CODE_ARM_REQUIRED: self.code_arm_required,
+            AlarmControlPanelEntityStateAttribute.CODE_FORMAT: self.code_format,
+            AlarmControlPanelEntityStateAttribute.CHANGED_BY: self.changed_by,
+            AlarmControlPanelEntityStateAttribute.CODE_ARM_REQUIRED: (
+                self.code_arm_required
+            ),
         }
 
     @override

--- a/homeassistant/components/alarm_control_panel/const.py
+++ b/homeassistant/components/alarm_control_panel/const.py
@@ -9,6 +9,14 @@ ATTR_CHANGED_BY: Final = "changed_by"
 ATTR_CODE_ARM_REQUIRED: Final = "code_arm_required"
 
 
+class AlarmControlPanelEntityStateAttribute(StrEnum):
+    """State attributes for alarm control panel entities."""
+
+    CODE_FORMAT = "code_format"
+    CHANGED_BY = "changed_by"
+    CODE_ARM_REQUIRED = "code_arm_required"
+
+
 class AlarmControlPanelState(StrEnum):
     """Alarm control panel entity states."""
 

--- a/tests/components/bosch_alarm/snapshots/test_alarm_control_panel.ambr
+++ b/tests/components/bosch_alarm/snapshots/test_alarm_control_panel.ambr
@@ -39,9 +39,9 @@
 # name: test_alarm_control_panel[amax_3000-None][alarm_control_panel.area1-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'changed_by': None,
-      'code_arm_required': False,
-      'code_format': None,
+      <AlarmControlPanelEntityStateAttribute.CHANGED_BY: 'changed_by'>: None,
+      <AlarmControlPanelEntityStateAttribute.CODE_ARM_REQUIRED: 'code_arm_required'>: False,
+      <AlarmControlPanelEntityStateAttribute.CODE_FORMAT: 'code_format'>: None,
       'friendly_name': 'Area1',
       'supported_features': <AlarmControlPanelEntityFeature: 3>,
     }),
@@ -93,9 +93,9 @@
 # name: test_alarm_control_panel[b5512-None][alarm_control_panel.area1-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'changed_by': None,
-      'code_arm_required': False,
-      'code_format': None,
+      <AlarmControlPanelEntityStateAttribute.CHANGED_BY: 'changed_by'>: None,
+      <AlarmControlPanelEntityStateAttribute.CODE_ARM_REQUIRED: 'code_arm_required'>: False,
+      <AlarmControlPanelEntityStateAttribute.CODE_FORMAT: 'code_format'>: None,
       'friendly_name': 'Area1',
       'supported_features': <AlarmControlPanelEntityFeature: 3>,
     }),
@@ -147,9 +147,9 @@
 # name: test_alarm_control_panel[solution_3000-None][alarm_control_panel.area1-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'changed_by': None,
-      'code_arm_required': False,
-      'code_format': None,
+      <AlarmControlPanelEntityStateAttribute.CHANGED_BY: 'changed_by'>: None,
+      <AlarmControlPanelEntityStateAttribute.CODE_ARM_REQUIRED: 'code_arm_required'>: False,
+      <AlarmControlPanelEntityStateAttribute.CODE_FORMAT: 'code_format'>: None,
       'friendly_name': 'Area1',
       'supported_features': <AlarmControlPanelEntityFeature: 3>,
     }),

--- a/tests/components/deconz/snapshots/test_alarm_control_panel.ambr
+++ b/tests/components/deconz/snapshots/test_alarm_control_panel.ambr
@@ -39,9 +39,9 @@
 # name: test_alarm_control_panel[sensor_payload0-alarm_system_payload0][alarm_control_panel.keypad-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'changed_by': None,
-      'code_arm_required': True,
-      'code_format': <CodeFormat.NUMBER: 'number'>,
+      <AlarmControlPanelEntityStateAttribute.CHANGED_BY: 'changed_by'>: None,
+      <AlarmControlPanelEntityStateAttribute.CODE_ARM_REQUIRED: 'code_arm_required'>: True,
+      <AlarmControlPanelEntityStateAttribute.CODE_FORMAT: 'code_format'>: <CodeFormat.NUMBER: 'number'>,
       'friendly_name': 'Keypad',
       'supported_features': <AlarmControlPanelEntityFeature: 7>,
     }),

--- a/tests/components/elmax/snapshots/test_alarm_control_panel.ambr
+++ b/tests/components/elmax/snapshots/test_alarm_control_panel.ambr
@@ -39,9 +39,9 @@
 # name: test_alarm_control_panels[alarm_control_panel.direct_panel_https_1_1_1_1_443_api_v2_area_1-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'changed_by': None,
-      'code_arm_required': False,
-      'code_format': <CodeFormat.NUMBER: 'number'>,
+      <AlarmControlPanelEntityStateAttribute.CHANGED_BY: 'changed_by'>: None,
+      <AlarmControlPanelEntityStateAttribute.CODE_ARM_REQUIRED: 'code_arm_required'>: False,
+      <AlarmControlPanelEntityStateAttribute.CODE_FORMAT: 'code_format'>: <CodeFormat.NUMBER: 'number'>,
       'friendly_name': 'Direct Panel https://1.1.1.1:443/api/v2 AREA 1',
       'supported_features': <AlarmControlPanelEntityFeature: 2>,
     }),
@@ -93,9 +93,9 @@
 # name: test_alarm_control_panels[alarm_control_panel.direct_panel_https_1_1_1_1_443_api_v2_area_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'changed_by': None,
-      'code_arm_required': False,
-      'code_format': <CodeFormat.NUMBER: 'number'>,
+      <AlarmControlPanelEntityStateAttribute.CHANGED_BY: 'changed_by'>: None,
+      <AlarmControlPanelEntityStateAttribute.CODE_ARM_REQUIRED: 'code_arm_required'>: False,
+      <AlarmControlPanelEntityStateAttribute.CODE_FORMAT: 'code_format'>: <CodeFormat.NUMBER: 'number'>,
       'friendly_name': 'Direct Panel https://1.1.1.1:443/api/v2 AREA 2',
       'supported_features': <AlarmControlPanelEntityFeature: 2>,
     }),
@@ -147,9 +147,9 @@
 # name: test_alarm_control_panels[alarm_control_panel.direct_panel_https_1_1_1_1_443_api_v2_area_3-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'changed_by': None,
-      'code_arm_required': False,
-      'code_format': <CodeFormat.NUMBER: 'number'>,
+      <AlarmControlPanelEntityStateAttribute.CHANGED_BY: 'changed_by'>: None,
+      <AlarmControlPanelEntityStateAttribute.CODE_ARM_REQUIRED: 'code_arm_required'>: False,
+      <AlarmControlPanelEntityStateAttribute.CODE_FORMAT: 'code_format'>: <CodeFormat.NUMBER: 'number'>,
       'friendly_name': 'Direct Panel https://1.1.1.1:443/api/v2 AREA 3',
       'supported_features': <AlarmControlPanelEntityFeature: 2>,
     }),

--- a/tests/components/homee/snapshots/test_alarm_control_panel.ambr
+++ b/tests/components/homee/snapshots/test_alarm_control_panel.ambr
@@ -39,9 +39,9 @@
 # name: test_alarm_control_panel_snapshot[alarm_control_panel.testhomee_status-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'changed_by': 'user - 4',
-      'code_arm_required': False,
-      'code_format': None,
+      <AlarmControlPanelEntityStateAttribute.CHANGED_BY: 'changed_by'>: 'user - 4',
+      <AlarmControlPanelEntityStateAttribute.CODE_ARM_REQUIRED: 'code_arm_required'>: False,
+      <AlarmControlPanelEntityStateAttribute.CODE_FORMAT: 'code_format'>: None,
       'friendly_name': 'TestHomee Status',
       'supported_features': <AlarmControlPanelEntityFeature: 39>,
     }),

--- a/tests/components/homekit_controller/snapshots/test_init.ambr
+++ b/tests/components/homekit_controller/snapshots/test_init.ambr
@@ -1587,9 +1587,9 @@
           }),
           'state': dict({
             'attributes': dict({
-              'changed_by': None,
-              'code_arm_required': False,
-              'code_format': None,
+              <AlarmControlPanelEntityStateAttribute.CHANGED_BY: 'changed_by'>: None,
+              <AlarmControlPanelEntityStateAttribute.CODE_ARM_REQUIRED: 'code_arm_required'>: False,
+              <AlarmControlPanelEntityStateAttribute.CODE_FORMAT: 'code_format'>: None,
               'friendly_name': 'Aqara-Hub-E1-00A0 Security System',
               'supported_features': <AlarmControlPanelEntityFeature: 7>,
             }),
@@ -1987,9 +1987,9 @@
           }),
           'state': dict({
             'attributes': dict({
-              'changed_by': None,
-              'code_arm_required': False,
-              'code_format': None,
+              <AlarmControlPanelEntityStateAttribute.CHANGED_BY: 'changed_by'>: None,
+              <AlarmControlPanelEntityStateAttribute.CODE_ARM_REQUIRED: 'code_arm_required'>: False,
+              <AlarmControlPanelEntityStateAttribute.CODE_FORMAT: 'code_format'>: None,
               'friendly_name': 'Aqara Hub-1563 Security System',
               'supported_features': <AlarmControlPanelEntityFeature: 7>,
             }),

--- a/tests/components/satel_integra/snapshots/test_alarm_control_panel.ambr
+++ b/tests/components/satel_integra/snapshots/test_alarm_control_panel.ambr
@@ -39,9 +39,9 @@
 # name: test_alarm_control_panel[alarm_control_panel.home-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'changed_by': None,
-      'code_arm_required': True,
-      'code_format': <CodeFormat.NUMBER: 'number'>,
+      <AlarmControlPanelEntityStateAttribute.CHANGED_BY: 'changed_by'>: None,
+      <AlarmControlPanelEntityStateAttribute.CODE_ARM_REQUIRED: 'code_arm_required'>: True,
+      <AlarmControlPanelEntityStateAttribute.CODE_FORMAT: 'code_format'>: <CodeFormat.NUMBER: 'number'>,
       'friendly_name': 'Home',
       'supported_features': <AlarmControlPanelEntityFeature: 3>,
     }),

--- a/tests/components/template/snapshots/test_alarm_control_panel.ambr
+++ b/tests/components/template/snapshots/test_alarm_control_panel.ambr
@@ -2,9 +2,9 @@
 # name: test_setup_config_entry
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'changed_by': None,
-      'code_arm_required': True,
-      'code_format': <CodeFormat.NUMBER: 'number'>,
+      <AlarmControlPanelEntityStateAttribute.CHANGED_BY: 'changed_by'>: None,
+      <AlarmControlPanelEntityStateAttribute.CODE_ARM_REQUIRED: 'code_arm_required'>: True,
+      <AlarmControlPanelEntityStateAttribute.CODE_FORMAT: 'code_format'>: <CodeFormat.NUMBER: 'number'>,
       'friendly_name': 'My template',
       'supported_features': <AlarmControlPanelEntityFeature: 0>,
     }),

--- a/tests/components/totalconnect/snapshots/test_alarm_control_panel.ambr
+++ b/tests/components/totalconnect/snapshots/test_alarm_control_panel.ambr
@@ -39,9 +39,9 @@
 # name: test_entities[alarm_control_panel.test-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'changed_by': None,
-      'code_arm_required': False,
-      'code_format': None,
+      <AlarmControlPanelEntityStateAttribute.CHANGED_BY: 'changed_by'>: None,
+      <AlarmControlPanelEntityStateAttribute.CODE_ARM_REQUIRED: 'code_arm_required'>: False,
+      <AlarmControlPanelEntityStateAttribute.CODE_FORMAT: 'code_format'>: None,
       'friendly_name': 'test',
       'supported_features': <AlarmControlPanelEntityFeature: 7>,
     }),
@@ -93,9 +93,9 @@
 # name: test_entities[alarm_control_panel.test_partition_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'changed_by': None,
-      'code_arm_required': False,
-      'code_format': None,
+      <AlarmControlPanelEntityStateAttribute.CHANGED_BY: 'changed_by'>: None,
+      <AlarmControlPanelEntityStateAttribute.CODE_ARM_REQUIRED: 'code_arm_required'>: False,
+      <AlarmControlPanelEntityStateAttribute.CODE_FORMAT: 'code_format'>: None,
       'friendly_name': 'test Partition 2',
       'supported_features': <AlarmControlPanelEntityFeature: 7>,
     }),

--- a/tests/components/tuya/snapshots/test_alarm_control_panel.ambr
+++ b/tests/components/tuya/snapshots/test_alarm_control_panel.ambr
@@ -39,9 +39,9 @@
 # name: test_platform_setup_and_discovery[alarm_control_panel.c30-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'changed_by': None,
-      'code_arm_required': False,
-      'code_format': None,
+      <AlarmControlPanelEntityStateAttribute.CHANGED_BY: 'changed_by'>: None,
+      <AlarmControlPanelEntityStateAttribute.CODE_ARM_REQUIRED: 'code_arm_required'>: False,
+      <AlarmControlPanelEntityStateAttribute.CODE_FORMAT: 'code_format'>: None,
       'friendly_name': 'C30',
       'supported_features': <AlarmControlPanelEntityFeature: 11>,
     }),
@@ -93,9 +93,9 @@
 # name: test_platform_setup_and_discovery[alarm_control_panel.multifunction_alarm-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'changed_by': None,
-      'code_arm_required': False,
-      'code_format': None,
+      <AlarmControlPanelEntityStateAttribute.CHANGED_BY: 'changed_by'>: None,
+      <AlarmControlPanelEntityStateAttribute.CODE_ARM_REQUIRED: 'code_arm_required'>: False,
+      <AlarmControlPanelEntityStateAttribute.CODE_FORMAT: 'code_format'>: None,
       'friendly_name': 'Multifunction alarm',
       'supported_features': <AlarmControlPanelEntityFeature: 11>,
     }),

--- a/tests/components/yale_smart_alarm/snapshots/test_alarm_control_panel.ambr
+++ b/tests/components/yale_smart_alarm/snapshots/test_alarm_control_panel.ambr
@@ -39,9 +39,9 @@
 # name: test_alarm_control_panel[load_platforms0][alarm_control_panel.test_username-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'changed_by': None,
-      'code_arm_required': False,
-      'code_format': None,
+      <AlarmControlPanelEntityStateAttribute.CHANGED_BY: 'changed_by'>: None,
+      <AlarmControlPanelEntityStateAttribute.CODE_ARM_REQUIRED: 'code_arm_required'>: False,
+      <AlarmControlPanelEntityStateAttribute.CODE_FORMAT: 'code_format'>: None,
       'friendly_name': 'test-username',
       'supported_features': <AlarmControlPanelEntityFeature: 3>,
     }),


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add new `AlarmControlPanelEntityStateAttribute` enum for the state attributes of the alarm control panel entity.

Based on https://github.com/home-assistant/architecture/discussions/1406, linked to epic https://github.com/home-assistant/epics/issues/104

A follow-up PR will formally deprecate the corresponding `ATTR_*` constants.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
