### PR TITLE
Migrate event entity attributes to StrEnum

### DIFF
--- a/homeassistant/components/event/__init__.py
+++ b/homeassistant/components/event/__init__.py
@@ -18,7 +18,14 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import dt as dt_util
 from homeassistant.util.hass_dict import HassKey
 
-from .const import ATTR_EVENT_TYPE, ATTR_EVENT_TYPES, DOMAIN, DoorbellEventType
+from .const import (
+    ATTR_EVENT_TYPE,
+    ATTR_EVENT_TYPES,
+    DOMAIN,
+    DoorbellEventType,
+    EventEntityCapabilityAttribute,
+    EventEntityStateAttribute,
+)
 
 _LOGGER = logging.getLogger(__name__)
 DATA_COMPONENT: HassKey[EntityComponent[EventEntity]] = HassKey(DOMAIN)
@@ -110,7 +117,9 @@ CACHED_PROPERTIES_WITH_ATTR_ = {
 class EventEntity(RestoreEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     """Representation of an Event entity."""
 
-    _entity_component_unrecorded_attributes = frozenset({ATTR_EVENT_TYPES})
+    _entity_component_unrecorded_attributes = frozenset(
+        {EventEntityCapabilityAttribute.EVENT_TYPES}
+    )
 
     entity_description: EventEntityDescription
     _attr_device_class: EventDeviceClass | None
@@ -168,7 +177,7 @@ class EventEntity(RestoreEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_)
     def capability_attributes(self) -> dict[str, list[str]]:
         """Return capability attributes."""
         return {
-            ATTR_EVENT_TYPES: self.event_types,
+            EventEntityCapabilityAttribute.EVENT_TYPES: self.event_types,
         }
 
     @property
@@ -185,7 +194,9 @@ class EventEntity(RestoreEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_)
     @override
     def state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
-        attributes = {ATTR_EVENT_TYPE: self.__last_event_type}
+        attributes: dict[str, Any] = {
+            EventEntityStateAttribute.EVENT_TYPE: self.__last_event_type
+        }
         if last_event_attributes := self.__last_event_attributes:
             attributes |= last_event_attributes
         return attributes

--- a/homeassistant/components/event/const.py
+++ b/homeassistant/components/event/const.py
@@ -7,6 +7,18 @@ ATTR_EVENT_TYPE = "event_type"
 ATTR_EVENT_TYPES = "event_types"
 
 
+class EventEntityCapabilityAttribute(StrEnum):
+    """Capability attributes for event entities."""
+
+    EVENT_TYPES = "event_types"
+
+
+class EventEntityStateAttribute(StrEnum):
+    """State attributes for event entities."""
+
+    EVENT_TYPE = "event_type"
+
+
 class DoorbellEventType(StrEnum):
     """Standard event types for doorbell device class."""
 

--- a/tests/components/alexa_devices/snapshots/test_event.ambr
+++ b/tests/components/alexa_devices/snapshots/test_event.ambr
@@ -43,7 +43,7 @@
 # name: test_all_entities[event.echo_test_voice_event-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',
       ]),
@@ -59,7 +59,7 @@
 # ---
 # name: test_history_event_is_fired
   ReadOnlyDict({
-    'event_type': 'triggered',
+    <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'triggered',
     <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
       'triggered',
     ]),

--- a/tests/components/alexa_devices/snapshots/test_event.ambr
+++ b/tests/components/alexa_devices/snapshots/test_event.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',
       ]),
     }),
@@ -44,7 +44,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',
       ]),
       'friendly_name': 'Echo Test Voice event',
@@ -60,7 +60,7 @@
 # name: test_history_event_is_fired
   ReadOnlyDict({
     'event_type': 'triggered',
-    'event_types': list([
+    <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
       'triggered',
     ]),
     'friendly_name': 'Echo Test Voice event',

--- a/tests/components/backup/snapshots/test_event.ambr
+++ b/tests/components/backup/snapshots/test_event.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'completed',
         'failed',
         'in_progress',
@@ -45,8 +45,8 @@
 # name: test_event_entity[event.backup_automatic_backup-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'completed',
         'failed',
         'in_progress',

--- a/tests/components/balboa/snapshots/test_event.ambr
+++ b/tests/components/balboa/snapshots/test_event.ambr
@@ -60,7 +60,7 @@
 # name: test_events[event.fakespa_fault-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'clock_failed',
         'flow_failed',

--- a/tests/components/balboa/snapshots/test_event.ambr
+++ b/tests/components/balboa/snapshots/test_event.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'clock_failed',
         'flow_failed',
         'gfci_test_failed',
@@ -61,7 +61,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'clock_failed',
         'flow_failed',
         'gfci_test_failed',

--- a/tests/components/bring/snapshots/test_event.ambr
+++ b/tests/components/bring/snapshots/test_event.ambr
@@ -46,7 +46,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'entity_picture': 'https://api.getbring.com/rest/v2/bringusers/profilepictures/9a21fdfc-63a4-441a-afc1-ef3030605a9d',
-      'event_type': 'list_items_changed',
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'list_items_changed',
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'list_items_changed',
         'list_items_added',
@@ -133,7 +133,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'entity_picture': 'https://api.getbring.com/rest/v2/bringusers/profilepictures/9a21fdfc-63a4-441a-afc1-ef3030605a9d',
-      'event_type': 'list_items_changed',
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'list_items_changed',
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'list_items_changed',
         'list_items_added',

--- a/tests/components/bring/snapshots/test_event.ambr
+++ b/tests/components/bring/snapshots/test_event.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'list_items_changed',
         'list_items_added',
         'list_items_removed',
@@ -47,7 +47,7 @@
     'attributes': ReadOnlyDict({
       'entity_picture': 'https://api.getbring.com/rest/v2/bringusers/profilepictures/9a21fdfc-63a4-441a-afc1-ef3030605a9d',
       'event_type': 'list_items_changed',
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'list_items_changed',
         'list_items_added',
         'list_items_removed',
@@ -93,7 +93,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'list_items_changed',
         'list_items_added',
         'list_items_removed',
@@ -134,7 +134,7 @@
     'attributes': ReadOnlyDict({
       'entity_picture': 'https://api.getbring.com/rest/v2/bringusers/profilepictures/9a21fdfc-63a4-441a-afc1-ef3030605a9d',
       'event_type': 'list_items_changed',
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'list_items_changed',
         'list_items_added',
         'list_items_removed',

--- a/tests/components/ecovacs/snapshots/test_event.ambr
+++ b/tests/components/ecovacs/snapshots/test_event.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'finished',
         'finished_with_warnings',
         'manually_stopped',
@@ -46,7 +46,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'event_type': 'finished',
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'finished',
         'finished_with_warnings',
         'manually_stopped',

--- a/tests/components/ecovacs/snapshots/test_event.ambr
+++ b/tests/components/ecovacs/snapshots/test_event.ambr
@@ -45,7 +45,7 @@
 # name: test_last_job[event.ozmo_950_last_job-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'event_type': 'finished',
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'finished',
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'finished',
         'finished_with_warnings',

--- a/tests/components/feedreader/snapshots/test_event.ambr
+++ b/tests/components/feedreader/snapshots/test_event.ambr
@@ -3,8 +3,8 @@
   ReadOnlyDict({
     'content': 'Contenido en español',
     'description': 'Resumen en español',
-    'event_type': 'feedreader',
-    'event_types': list([
+    <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'feedreader',
+    <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
       'feedreader',
     ]),
     'friendly_name': 'Mock Title',
@@ -16,8 +16,8 @@
   ReadOnlyDict({
     'content': 'Contenido 1 en español',
     'description': 'Descripción 1',
-    'event_type': 'feedreader',
-    'event_types': list([
+    <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'feedreader',
+    <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
       'feedreader',
     ]),
     'friendly_name': 'Mock Title',

--- a/tests/components/folder_watcher/snapshots/test_event.ambr
+++ b/tests/components/folder_watcher/snapshots/test_event.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'closed',
         'created',
         'deleted',
@@ -47,8 +47,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'dest_file': 'hello2.txt',
-      'event_type': 'moved',
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'moved',
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'closed',
         'created',
         'deleted',

--- a/tests/components/gentex_homelink/snapshots/test_event.ambr
+++ b/tests/components/gentex_homelink/snapshots/test_event.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'Pressed',
       ]),
     }),
@@ -45,7 +45,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'Pressed',
       ]),
       'friendly_name': 'TestDevice Button 1',
@@ -65,7 +65,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'Pressed',
       ]),
     }),
@@ -104,7 +104,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'Pressed',
       ]),
       'friendly_name': 'TestDevice Button 2',
@@ -124,7 +124,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'Pressed',
       ]),
     }),
@@ -163,7 +163,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'Pressed',
       ]),
       'friendly_name': 'TestDevice Button 3',

--- a/tests/components/gentex_homelink/snapshots/test_event.ambr
+++ b/tests/components/gentex_homelink/snapshots/test_event.ambr
@@ -44,7 +44,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'Pressed',
       ]),
@@ -103,7 +103,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'Pressed',
       ]),
@@ -162,7 +162,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'Pressed',
       ]),

--- a/tests/components/homee/snapshots/test_event.ambr
+++ b/tests/components/homee/snapshots/test_event.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'upper',
         'lower',
         'released',
@@ -47,7 +47,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'upper',
         'lower',
         'released',
@@ -69,7 +69,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'upper',
         'lower',
         'released',
@@ -110,7 +110,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'upper',
         'lower',
         'released',
@@ -132,7 +132,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'released',
         'up',
         'down',
@@ -180,7 +180,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'released',
         'up',
         'down',
@@ -209,7 +209,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'upper',
         'lower',
         'released',
@@ -250,7 +250,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'upper',
         'lower',
         'released',
@@ -272,7 +272,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'upper',
         'lower',
         'released',
@@ -313,7 +313,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'upper',
         'lower',
         'released',
@@ -335,7 +335,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'released',
         'up',
         'down',
@@ -383,7 +383,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'released',
         'up',
         'down',
@@ -412,7 +412,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'upper',
         'lower',
         'released',
@@ -453,7 +453,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'upper',
         'lower',
         'released',
@@ -475,7 +475,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'upper',
         'lower',
         'released',
@@ -516,7 +516,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'upper',
         'lower',
         'released',
@@ -538,7 +538,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'released',
         'up',
         'down',
@@ -586,7 +586,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'released',
         'up',
         'down',
@@ -615,7 +615,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'upper',
         'lower',
         'released',
@@ -656,7 +656,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'upper',
         'lower',
         'released',
@@ -678,7 +678,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'upper',
         'lower',
         'released',
@@ -719,7 +719,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'upper',
         'lower',
         'released',
@@ -741,7 +741,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'released',
         'up',
         'down',
@@ -789,7 +789,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'released',
         'up',
         'down',
@@ -818,7 +818,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'upper',
         'lower',
         'released',
@@ -859,7 +859,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'upper',
         'lower',
         'released',
@@ -881,7 +881,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'upper',
         'lower',
         'released',
@@ -922,7 +922,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'upper',
         'lower',
         'released',
@@ -944,7 +944,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'released',
         'up',
         'down',
@@ -992,7 +992,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'released',
         'up',
         'down',

--- a/tests/components/homee/snapshots/test_event.ambr
+++ b/tests/components/homee/snapshots/test_event.ambr
@@ -46,7 +46,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'upper',
         'lower',
@@ -109,7 +109,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'upper',
         'lower',
@@ -179,7 +179,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'released',
         'up',
@@ -249,7 +249,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'upper',
         'lower',
@@ -312,7 +312,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'upper',
         'lower',
@@ -382,7 +382,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'released',
         'up',
@@ -452,7 +452,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'upper',
         'lower',
@@ -515,7 +515,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'upper',
         'lower',
@@ -585,7 +585,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'released',
         'up',
@@ -655,7 +655,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'upper',
         'lower',
@@ -718,7 +718,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'upper',
         'lower',
@@ -788,7 +788,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'released',
         'up',
@@ -858,7 +858,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'upper',
         'lower',
@@ -921,7 +921,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'upper',
         'lower',
@@ -991,7 +991,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'released',
         'up',

--- a/tests/components/homekit_controller/snapshots/test_init.ambr
+++ b/tests/components/homekit_controller/snapshots/test_init.ambr
@@ -16079,7 +16079,7 @@
             ]),
             'area_id': None,
             'capabilities': dict({
-              'event_types': list([
+              <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
                 'single_press',
               ]),
             }),
@@ -16115,8 +16115,8 @@
           'state': dict({
             'attributes': dict({
               'device_class': 'button',
-              'event_type': None,
-              'event_types': list([
+              <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+              <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
                 'single_press',
               ]),
               'friendly_name': 'Hue dimmer switch Button 1',
@@ -16132,7 +16132,7 @@
             ]),
             'area_id': None,
             'capabilities': dict({
-              'event_types': list([
+              <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
                 'single_press',
               ]),
             }),
@@ -16168,8 +16168,8 @@
           'state': dict({
             'attributes': dict({
               'device_class': 'button',
-              'event_type': None,
-              'event_types': list([
+              <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+              <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
                 'single_press',
               ]),
               'friendly_name': 'Hue dimmer switch Button 2',
@@ -16185,7 +16185,7 @@
             ]),
             'area_id': None,
             'capabilities': dict({
-              'event_types': list([
+              <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
                 'single_press',
               ]),
             }),
@@ -16221,8 +16221,8 @@
           'state': dict({
             'attributes': dict({
               'device_class': 'button',
-              'event_type': None,
-              'event_types': list([
+              <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+              <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
                 'single_press',
               ]),
               'friendly_name': 'Hue dimmer switch Button 3',
@@ -16238,7 +16238,7 @@
             ]),
             'area_id': None,
             'capabilities': dict({
-              'event_types': list([
+              <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
                 'single_press',
               ]),
             }),
@@ -16274,8 +16274,8 @@
           'state': dict({
             'attributes': dict({
               'device_class': 'button',
-              'event_type': None,
-              'event_types': list([
+              <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+              <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
                 'single_press',
               ]),
               'friendly_name': 'Hue dimmer switch Button 4',
@@ -19847,7 +19847,7 @@
             ]),
             'area_id': None,
             'capabilities': dict({
-              'event_types': list([
+              <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
                 'single_press',
                 'double_press',
                 'long_press',
@@ -19885,8 +19885,8 @@
           'state': dict({
             'attributes': dict({
               'device_class': 'doorbell',
-              'event_type': None,
-              'event_types': list([
+              <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+              <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
                 'single_press',
                 'double_press',
                 'long_press',

--- a/tests/components/html5/snapshots/test_event.ambr
+++ b/tests/components/html5/snapshots/test_event.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'clicked',
         'received',
         'closed',
@@ -45,8 +45,8 @@
 # name: test_setup[event.my_desktop-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'clicked',
         'received',
         'closed',

--- a/tests/components/husqvarna_automower/snapshots/test_event.ambr
+++ b/tests/components/husqvarna_automower/snapshots/test_event.ambr
@@ -165,7 +165,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'date_time': HAFakeDatetime(2025, 7, 13, 15, 30, tzinfo=datetime.timezone.utc),
-      'event_type': 'wheel_motor_overloaded_rear_left',
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'wheel_motor_overloaded_rear_left',
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'alarm_mower_in_motion',
         'alarm_mower_lifted',

--- a/tests/components/husqvarna_automower/snapshots/test_event.ambr
+++ b/tests/components/husqvarna_automower/snapshots/test_event.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'alarm_mower_in_motion',
         'alarm_mower_lifted',
         'alarm_mower_stopped',
@@ -166,7 +166,7 @@
     'attributes': ReadOnlyDict({
       'date_time': HAFakeDatetime(2025, 7, 13, 15, 30, tzinfo=datetime.timezone.utc),
       'event_type': 'wheel_motor_overloaded_rear_left',
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'alarm_mower_in_motion',
         'alarm_mower_lifted',
         'alarm_mower_stopped',

--- a/tests/components/knocki/snapshots/test_event.ambr
+++ b/tests/components/knocki/snapshots/test_event.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',
       ]),
     }),
@@ -43,8 +43,8 @@
 # name: test_entities[event.knc1_w_00000214_aaaa-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',
       ]),
       'friendly_name': 'KNC1-W-00000214 Aaaa',

--- a/tests/components/lg_infrared/snapshots/test_event.ambr
+++ b/tests/components/lg_infrared/snapshots/test_event.ambr
@@ -94,7 +94,7 @@
 # name: test_entities[event.lg_tv_received_command-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'aspect',
         'back',

--- a/tests/components/lg_infrared/snapshots/test_event.ambr
+++ b/tests/components/lg_infrared/snapshots/test_event.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'aspect',
         'back',
         'blue',
@@ -95,7 +95,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'aspect',
         'back',
         'blue',

--- a/tests/components/lg_thinq/snapshots/test_event.ambr
+++ b/tests/components/lg_thinq/snapshots/test_event.ambr
@@ -43,7 +43,7 @@
 # name: test_event_entities[air_conditioner][event.test_air_conditioner_notification-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'water_is_full',
       ]),

--- a/tests/components/lg_thinq/snapshots/test_event.ambr
+++ b/tests/components/lg_thinq/snapshots/test_event.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'water_is_full',
       ]),
     }),
@@ -44,7 +44,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'water_is_full',
       ]),
       'friendly_name': 'Test air conditioner Notification',

--- a/tests/components/lutron/snapshots/test_event.ambr
+++ b/tests/components/lutron/snapshots/test_event.ambr
@@ -43,7 +43,7 @@
 # name: test_event_setup[event.test_keypad_test_button-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         <LutronEventType.SINGLE_PRESS: 'single_press'>,
       ]),

--- a/tests/components/lutron/snapshots/test_event.ambr
+++ b/tests/components/lutron/snapshots/test_event.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         <LutronEventType.SINGLE_PRESS: 'single_press'>,
       ]),
     }),
@@ -44,7 +44,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         <LutronEventType.SINGLE_PRESS: 'single_press'>,
       ]),
       'friendly_name': 'Test Keypad Test Button',

--- a/tests/components/matter/snapshots/test_event.ambr
+++ b/tests/components/matter/snapshots/test_event.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'long_press',
@@ -47,8 +47,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'long_press',
@@ -71,7 +71,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'long_press',
@@ -112,8 +112,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'long_press',
@@ -136,7 +136,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'long_press',
@@ -177,8 +177,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'long_press',
@@ -201,7 +201,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'long_press',
@@ -242,8 +242,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'long_press',
@@ -266,7 +266,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'long_press',
@@ -307,8 +307,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'long_press',
@@ -331,7 +331,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'long_press',
@@ -372,8 +372,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'long_press',
@@ -396,7 +396,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'long_press',
@@ -437,8 +437,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'long_press',
@@ -461,7 +461,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'long_press',
@@ -502,8 +502,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'long_press',
@@ -526,7 +526,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'long_press',
@@ -567,8 +567,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'long_press',
@@ -591,7 +591,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'long_press',
@@ -632,8 +632,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'long_press',
@@ -656,7 +656,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'long_press',
@@ -697,8 +697,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'long_press',
@@ -721,7 +721,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'multi_press_3',
@@ -766,8 +766,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'multi_press_3',
@@ -794,7 +794,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'multi_press_3',
@@ -839,8 +839,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'multi_press_3',
@@ -867,7 +867,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'multi_press_3',
@@ -909,8 +909,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'multi_press_3',
@@ -934,7 +934,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'multi_press_3',
@@ -979,8 +979,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'multi_press_3',
@@ -1007,7 +1007,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'multi_press_3',
@@ -1052,8 +1052,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'multi_press_3',
@@ -1080,7 +1080,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'multi_press_3',
@@ -1122,8 +1122,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'multi_press_3',
@@ -1147,7 +1147,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'multi_press_3',
@@ -1192,8 +1192,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'multi_press_3',
@@ -1220,7 +1220,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'multi_press_3',
@@ -1265,8 +1265,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'multi_press_3',
@@ -1293,7 +1293,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'multi_press_3',
@@ -1335,8 +1335,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'multi_press_3',
@@ -1360,7 +1360,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'multi_press_3',
@@ -1404,8 +1404,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'multi_press_3',
@@ -1431,7 +1431,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'multi_press_3',
@@ -1475,8 +1475,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'multi_press_3',
@@ -1502,7 +1502,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'multi_press_3',
@@ -1546,8 +1546,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'multi_press_3',
@@ -1573,7 +1573,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'multi_press_3',
@@ -1617,8 +1617,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'multi_press_3',
@@ -1644,7 +1644,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'multi_press_3',
@@ -1688,8 +1688,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'multi_press_3',
@@ -1715,7 +1715,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'multi_press_3',
@@ -1759,8 +1759,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'multi_press_3',
@@ -1786,7 +1786,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'initial_press',
         'short_release',
         'long_press',
@@ -1827,8 +1827,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'initial_press',
         'short_release',
         'long_press',
@@ -1851,7 +1851,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'long_press',
@@ -1892,8 +1892,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'long_press',
@@ -1916,7 +1916,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'multi_press_3',
@@ -1959,8 +1959,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
         'multi_press_3',
@@ -1985,7 +1985,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'initial_press',
         'short_release',
       ]),
@@ -2024,8 +2024,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'initial_press',
         'short_release',
       ]),

--- a/tests/components/ntfy/snapshots/test_event.ambr
+++ b/tests/components/ntfy/snapshots/test_event.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'Title: Hello',
       ]),
     }),
@@ -51,7 +51,7 @@
       'entity_picture': 'https://example.com/icon.png',
       'event': <Event.MESSAGE: 'message'>,
       'event_type': 'Title: Hello',
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'Title: Hello',
       ]),
       'expires': HAFakeDatetime(2025, 3, 29, 5, 58, 46, tzinfo=datetime.timezone.utc),

--- a/tests/components/ntfy/snapshots/test_event.ambr
+++ b/tests/components/ntfy/snapshots/test_event.ambr
@@ -50,7 +50,7 @@
       'content_type': None,
       'entity_picture': 'https://example.com/icon.png',
       'event': <Event.MESSAGE: 'message'>,
-      'event_type': 'Title: Hello',
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'Title: Hello',
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'Title: Hello',
       ]),

--- a/tests/components/overseerr/snapshots/test_event.ambr
+++ b/tests/components/overseerr/snapshots/test_event.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'pending',
         'approved',
         'available',
@@ -49,8 +49,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'entity_picture': 'https://image.tmdb.org/t/p/w600_and_h900_bestv2/something.jpg',
-      'event_type': 'auto_approved',
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'auto_approved',
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'pending',
         'approved',
         'available',

--- a/tests/components/rfxtrx/snapshots/test_event.ambr
+++ b/tests/components/rfxtrx/snapshots/test_event.ambr
@@ -7,8 +7,8 @@
   +     'Command': 'On',
   +     'Rssi numeric': 5,
         ...
-  -     'event_type': None,
-  +     'event_type': 'on',
+  -     <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+  +     <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'on',
           ...
   -   'state': 'unknown',
   +   'state': '2021-01-09T12:00:00.000+00:00',
@@ -18,7 +18,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'assumed_state': True,
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'off',
         'on',
@@ -43,7 +43,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'assumed_state': True,
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'off',
         'on',
@@ -70,8 +70,8 @@
   +     'Rssi numeric': 8,
   +     'Sensor Status': 'Normal',
         ...
-  -     'event_type': None,
-  +     'event_type': 'normal',
+  -     <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+  +     <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'normal',
           ...
   -   'state': 'unknown',
   +   'state': '2021-01-09T12:00:00.000+00:00',
@@ -81,7 +81,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'assumed_state': True,
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'normal',
         'normal_delayed',

--- a/tests/components/rfxtrx/snapshots/test_event.ambr
+++ b/tests/components/rfxtrx/snapshots/test_event.ambr
@@ -19,7 +19,7 @@
     'attributes': ReadOnlyDict({
       'assumed_state': True,
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'off',
         'on',
         'dim',
@@ -44,7 +44,7 @@
     'attributes': ReadOnlyDict({
       'assumed_state': True,
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'off',
         'on',
         'dim',
@@ -82,7 +82,7 @@
     'attributes': ReadOnlyDict({
       'assumed_state': True,
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'normal',
         'normal_delayed',
         'alarm',

--- a/tests/components/ring/snapshots/test_event.ambr
+++ b/tests/components/ring/snapshots/test_event.ambr
@@ -45,7 +45,7 @@
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by Ring.com',
       'device_class': 'doorbell',
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         <DoorbellEventType.RING: 'ring'>,
       ]),
@@ -105,7 +105,7 @@
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by Ring.com',
       'device_class': 'motion',
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'motion',
       ]),
@@ -165,7 +165,7 @@
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by Ring.com',
       'device_class': 'motion',
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'motion',
       ]),
@@ -225,7 +225,7 @@
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by Ring.com',
       'device_class': 'doorbell',
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         <DoorbellEventType.RING: 'ring'>,
       ]),
@@ -285,7 +285,7 @@
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by Ring.com',
       'device_class': 'button',
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'intercom_unlock',
       ]),
@@ -345,7 +345,7 @@
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by Ring.com',
       'device_class': 'motion',
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'motion',
       ]),

--- a/tests/components/ring/snapshots/test_event.ambr
+++ b/tests/components/ring/snapshots/test_event.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         <DoorbellEventType.RING: 'ring'>,
       ]),
     }),
@@ -46,7 +46,7 @@
       'attribution': 'Data provided by Ring.com',
       'device_class': 'doorbell',
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         <DoorbellEventType.RING: 'ring'>,
       ]),
       'friendly_name': 'Front Door Ding',
@@ -66,7 +66,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'motion',
       ]),
     }),
@@ -106,7 +106,7 @@
       'attribution': 'Data provided by Ring.com',
       'device_class': 'motion',
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'motion',
       ]),
       'friendly_name': 'Front Door Motion',
@@ -126,7 +126,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'motion',
       ]),
     }),
@@ -166,7 +166,7 @@
       'attribution': 'Data provided by Ring.com',
       'device_class': 'motion',
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'motion',
       ]),
       'friendly_name': 'Front Motion',
@@ -186,7 +186,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         <DoorbellEventType.RING: 'ring'>,
       ]),
     }),
@@ -226,7 +226,7 @@
       'attribution': 'Data provided by Ring.com',
       'device_class': 'doorbell',
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         <DoorbellEventType.RING: 'ring'>,
       ]),
       'friendly_name': 'Ingress Ding',
@@ -246,7 +246,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'intercom_unlock',
       ]),
     }),
@@ -286,7 +286,7 @@
       'attribution': 'Data provided by Ring.com',
       'device_class': 'button',
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'intercom_unlock',
       ]),
       'friendly_name': 'Ingress Intercom unlock',
@@ -306,7 +306,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'motion',
       ]),
     }),
@@ -346,7 +346,7 @@
       'attribution': 'Data provided by Ring.com',
       'device_class': 'motion',
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'motion',
       ]),
       'friendly_name': 'Internal Motion',

--- a/tests/components/shelly/snapshots/test_devices.ambr
+++ b/tests/components/shelly/snapshots/test_devices.ambr
@@ -5934,8 +5934,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'btn_down',
         'btn_up',
         'double_push',
@@ -5995,8 +5995,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'btn_down',
         'btn_up',
         'double_push',
@@ -6056,8 +6056,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'btn_down',
         'btn_up',
         'double_push',

--- a/tests/components/shelly/snapshots/test_event.ambr
+++ b/tests/components/shelly/snapshots/test_event.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'input_event',
         'script_start',
       ]),
@@ -44,8 +44,8 @@
 # name: test_rpc_script_1_event[event.test_name_test_script_js-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'input_event',
         'script_start',
       ]),

--- a/tests/components/sleep_as_android/snapshots/test_event.ambr
+++ b/tests/components/sleep_as_android/snapshots/test_event.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'alert_dismiss',
         'alert_start',
         'rescheduled',
@@ -48,8 +48,8 @@
 # name: test_setup[event.sleep_as_android_alarm_clock-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'alert_dismiss',
         'alert_start',
         'rescheduled',
@@ -74,7 +74,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'jet_lag_start',
         'jet_lag_stop',
       ]),
@@ -112,8 +112,8 @@
 # name: test_setup[event.sleep_as_android_jet_lag_prevention-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'jet_lag_start',
         'jet_lag_stop',
       ]),
@@ -134,7 +134,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'start',
         'stop',
         'volume_down',
@@ -173,8 +173,8 @@
 # name: test_setup[event.sleep_as_android_lullaby-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'start',
         'stop',
         'volume_down',
@@ -196,7 +196,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'antisnoring',
         'apnea_alarm',
       ]),
@@ -234,8 +234,8 @@
 # name: test_setup[event.sleep_as_android_sleep_health-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'antisnoring',
         'apnea_alarm',
       ]),
@@ -256,7 +256,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'awake',
         'deep_sleep',
         'light_sleep',
@@ -297,8 +297,8 @@
 # name: test_setup[event.sleep_as_android_sleep_phase-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'awake',
         'deep_sleep',
         'light_sleep',
@@ -322,7 +322,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'paused',
         'resumed',
         'started',
@@ -363,8 +363,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'paused',
         'resumed',
         'started',
@@ -387,7 +387,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'before_smart_period',
         'smart_period',
       ]),
@@ -425,8 +425,8 @@
 # name: test_setup[event.sleep_as_android_smart_wake_up-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'before_smart_period',
         'smart_period',
       ]),
@@ -447,7 +447,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'baby',
         'cough',
         'laugh',
@@ -488,8 +488,8 @@
 # name: test_setup[event.sleep_as_android_sound_recognition-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'baby',
         'cough',
         'laugh',
@@ -513,7 +513,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'wake_up_check',
         'show_skip_next_alarm',
         'time_to_bed_alarm_alert',
@@ -552,8 +552,8 @@
 # name: test_setup[event.sleep_as_android_user_notification-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'event_type': None,
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'wake_up_check',
         'show_skip_next_alarm',
         'time_to_bed_alarm_alert',

--- a/tests/components/smartthings/snapshots/test_event.ambr
+++ b/tests/components/smartthings/snapshots/test_event.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: None,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -43,7 +43,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
-      'event_types': None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: None,
       'friendly_name': 'Dimmer entré 1 1 button1',
     }),
     'context': <ANY>,
@@ -61,7 +61,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: None,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -98,7 +98,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
-      'event_types': None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: None,
       'friendly_name': 'Dimmer entré 1 1 button2',
     }),
     'context': <ANY>,
@@ -116,7 +116,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'pushed',
         'held',
         'down_hold',
@@ -157,7 +157,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'pushed',
         'held',
         'down_hold',
@@ -179,7 +179,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'pushed',
         'held',
         'down_hold',
@@ -220,7 +220,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'pushed',
         'held',
         'down_hold',
@@ -242,7 +242,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'pushed',
         'held',
         'down_hold',
@@ -283,7 +283,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'pushed',
         'held',
         'down_hold',
@@ -305,7 +305,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'pushed',
         'held',
         'down_hold',
@@ -346,7 +346,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'pushed',
         'held',
         'down_hold',
@@ -368,7 +368,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'pushed',
         'held',
         'down_hold',
@@ -409,7 +409,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'pushed',
         'held',
         'down_hold',
@@ -431,7 +431,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'pushed',
         'held',
         'down_hold',
@@ -472,7 +472,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'button',
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'pushed',
         'held',
         'down_hold',

--- a/tests/components/smartthings/snapshots/test_event.ambr
+++ b/tests/components/smartthings/snapshots/test_event.ambr
@@ -42,7 +42,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: None,
       'friendly_name': 'Dimmer entré 1 1 button1',
     }),
@@ -97,7 +97,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: None,
       'friendly_name': 'Dimmer entré 1 1 button2',
     }),
@@ -156,7 +156,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'pushed',
         'held',
@@ -219,7 +219,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'pushed',
         'held',
@@ -282,7 +282,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'pushed',
         'held',
@@ -345,7 +345,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'pushed',
         'held',
@@ -408,7 +408,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'pushed',
         'held',
@@ -471,7 +471,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'pushed',
         'held',

--- a/tests/components/telegram_bot/snapshots/test_event.ambr
+++ b/tests/components/telegram_bot/snapshots/test_event.ambr
@@ -9,7 +9,7 @@
     }),
     'chat_id': 123456,
     'event_type': 'telegram_sent',
-    'event_types': list([
+    <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
       'telegram_attachment',
       'telegram_callback',
       'telegram_command',

--- a/tests/components/telegram_bot/snapshots/test_event.ambr
+++ b/tests/components/telegram_bot/snapshots/test_event.ambr
@@ -8,7 +8,7 @@
       'username': 'mock_bot',
     }),
     'chat_id': 123456,
-    'event_type': 'telegram_sent',
+    <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'telegram_sent',
     <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
       'telegram_attachment',
       'telegram_callback',

--- a/tests/components/template/snapshots/test_event.ambr
+++ b/tests/components/template/snapshots/test_event.ambr
@@ -2,7 +2,7 @@
 # name: test_setup_config_entry
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'event_type': 'single',
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'single',
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'single',
         'double',

--- a/tests/components/template/snapshots/test_event.ambr
+++ b/tests/components/template/snapshots/test_event.ambr
@@ -3,7 +3,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'event_type': 'single',
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'single',
         'double',
         'hold',

--- a/tests/components/togrill/snapshots/test_event.ambr
+++ b/tests/components/togrill/snapshots/test_event.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'probe_acknowledge',
         'device_low_power',
         'device_high_temp',
@@ -55,7 +55,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'probe_acknowledge',
         'device_low_power',
         'device_high_temp',
@@ -86,7 +86,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'probe_acknowledge',
         'device_low_power',
         'device_high_temp',
@@ -135,7 +135,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'probe_acknowledge',
         'device_low_power',
         'device_high_temp',
@@ -166,7 +166,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'probe_acknowledge',
         'device_low_power',
         'device_high_temp',
@@ -215,7 +215,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'probe_acknowledge',
         'device_low_power',
         'device_high_temp',
@@ -246,7 +246,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'probe_acknowledge',
         'device_low_power',
         'device_high_temp',
@@ -295,7 +295,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'probe_acknowledge',
         'device_low_power',
         'device_high_temp',
@@ -326,7 +326,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'probe_acknowledge',
         'device_low_power',
         'device_high_temp',
@@ -375,7 +375,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'probe_acknowledge',
         'device_low_power',
         'device_high_temp',
@@ -406,7 +406,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'probe_acknowledge',
         'device_low_power',
         'device_high_temp',
@@ -455,7 +455,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'probe_acknowledge',
         'device_low_power',
         'device_high_temp',

--- a/tests/components/togrill/snapshots/test_event.ambr
+++ b/tests/components/togrill/snapshots/test_event.ambr
@@ -54,7 +54,7 @@
 # name: test_setup[no_data][event.probe_1_event-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'probe_acknowledge',
         'device_low_power',
@@ -134,7 +134,7 @@
 # name: test_setup[no_data][event.probe_2_event-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'probe_acknowledge',
         'device_low_power',
@@ -214,7 +214,7 @@
 # name: test_setup[non_event_packet][event.probe_1_event-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'probe_acknowledge',
         'device_low_power',
@@ -294,7 +294,7 @@
 # name: test_setup[non_event_packet][event.probe_2_event-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'probe_acknowledge',
         'device_low_power',
@@ -374,7 +374,7 @@
 # name: test_setup[non_known_message][event.probe_1_event-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'probe_acknowledge',
         'device_low_power',
@@ -454,7 +454,7 @@
 # name: test_setup[non_known_message][event.probe_2_event-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'probe_acknowledge',
         'device_low_power',

--- a/tests/components/tuya/snapshots/test_event.ambr
+++ b/tests/components/tuya/snapshots/test_event.ambr
@@ -2,8 +2,8 @@
 # name: test_alarm_message_event[event.intercom_doorbell_message-alarm_message-eyJzb21lIjogImpzb24iLCAicmFuZG9tIjogImRhdGEifQ==-sp_csr2fqitalj5o0tq]
   ReadOnlyDict({
     'device_class': 'doorbell',
-    'event_type': 'triggered',
-    'event_types': list([
+    <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'triggered',
+    <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
       'triggered',
     ]),
     'friendly_name': 'Intercom Doorbell message',
@@ -13,8 +13,8 @@
 # name: test_alarm_message_event[event.intercom_doorbell_picture-doorbell_pic-aHR0cHM6Ly9zb21lLXBpY3R1cmUtdXJsLmNvbS9pbWFnZS5qcGc=-sp_csr2fqitalj5o0tq]
   ReadOnlyDict({
     'device_class': 'doorbell',
-    'event_type': 'triggered',
-    'event_types': list([
+    <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'triggered',
+    <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
       'triggered',
     ]),
     'friendly_name': 'Intercom Doorbell picture',
@@ -28,7 +28,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'click',
         'press',
       ]),
@@ -67,8 +67,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': 'click',
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'click',
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'click',
         'press',
       ]),
@@ -89,7 +89,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'click',
         'press',
       ]),
@@ -128,8 +128,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': 'click',
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'click',
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'click',
         'press',
       ]),
@@ -150,7 +150,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'click',
         'double_click',
         'press',
@@ -190,8 +190,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'button',
-      'event_type': 'press',
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'press',
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'click',
         'double_click',
         'press',
@@ -213,7 +213,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',
       ]),
     }),
@@ -251,8 +251,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'doorbell',
-      'event_type': 'triggered',
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'triggered',
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',
       ]),
       'friendly_name': 'Bürocam Doorbell message',
@@ -273,7 +273,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',
       ]),
     }),
@@ -311,8 +311,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'doorbell',
-      'event_type': 'triggered',
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'triggered',
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',
       ]),
       'friendly_name': 'C9 Doorbell message',
@@ -333,7 +333,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',
       ]),
     }),
@@ -371,8 +371,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'doorbell',
-      'event_type': 'triggered',
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'triggered',
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',
       ]),
       'friendly_name': 'C9 Doorbell picture',
@@ -393,7 +393,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',
       ]),
     }),
@@ -431,8 +431,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'doorbell',
-      'event_type': 'triggered',
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'triggered',
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',
       ]),
       'friendly_name': 'Dolní vchod - západ Doorbell message',
@@ -453,7 +453,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',
       ]),
     }),
@@ -491,8 +491,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'doorbell',
-      'event_type': 'triggered',
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'triggered',
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',
       ]),
       'friendly_name': 'Dolní vchod - západ Doorbell picture',
@@ -513,7 +513,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',
       ]),
     }),
@@ -551,8 +551,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'doorbell',
-      'event_type': 'triggered',
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'triggered',
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',
       ]),
       'friendly_name': 'Garage Camera Doorbell message',
@@ -573,7 +573,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',
       ]),
     }),
@@ -611,8 +611,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'doorbell',
-      'event_type': 'triggered',
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'triggered',
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',
       ]),
       'friendly_name': 'Intercom Doorbell message',
@@ -633,7 +633,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',
       ]),
     }),
@@ -671,8 +671,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'doorbell',
-      'event_type': 'triggered',
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'triggered',
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',
       ]),
       'friendly_name': 'Intercom Doorbell picture',
@@ -693,7 +693,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',
       ]),
     }),
@@ -731,8 +731,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'doorbell',
-      'event_type': 'triggered',
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'triggered',
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',
       ]),
       'friendly_name': 'Mirilla puerta Doorbell message',
@@ -753,7 +753,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',
       ]),
     }),
@@ -791,8 +791,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'doorbell',
-      'event_type': 'triggered',
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'triggered',
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',
       ]),
       'friendly_name': 'Mirilla puerta Doorbell picture',
@@ -813,7 +813,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',
       ]),
     }),
@@ -851,8 +851,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'doorbell',
-      'event_type': 'triggered',
-      'event_types': list([
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: 'triggered',
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'triggered',
       ]),
       'friendly_name': 'Security Camera Doorbell message',

--- a/tests/components/unifi_access/snapshots/test_event.ambr
+++ b/tests/components/unifi_access/snapshots/test_event.ambr
@@ -44,7 +44,7 @@
 # name: test_event_entities[event.back_door_access-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'access_granted',
         'access_denied',
@@ -104,7 +104,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'doorbell',
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         <DoorbellEventType.RING: 'ring'>,
       ]),
@@ -163,7 +163,7 @@
 # name: test_event_entities[event.front_door_access-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'access_granted',
         'access_denied',
@@ -223,7 +223,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'doorbell',
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         <DoorbellEventType.RING: 'ring'>,
       ]),

--- a/tests/components/unifi_access/snapshots/test_event.ambr
+++ b/tests/components/unifi_access/snapshots/test_event.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'access_granted',
         'access_denied',
       ]),
@@ -45,7 +45,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'access_granted',
         'access_denied',
       ]),
@@ -66,7 +66,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         <DoorbellEventType.RING: 'ring'>,
       ]),
     }),
@@ -105,7 +105,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'doorbell',
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         <DoorbellEventType.RING: 'ring'>,
       ]),
       'friendly_name': 'Back Door Doorbell',
@@ -125,7 +125,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'access_granted',
         'access_denied',
       ]),
@@ -164,7 +164,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'access_granted',
         'access_denied',
       ]),
@@ -185,7 +185,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         <DoorbellEventType.RING: 'ring'>,
       ]),
     }),
@@ -224,7 +224,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'doorbell',
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         <DoorbellEventType.RING: 'ring'>,
       ]),
       'friendly_name': 'Front Door Doorbell',

--- a/tests/components/watergate/snapshots/test_event.ambr
+++ b/tests/components/watergate/snapshots/test_event.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'duration_threshold',
       ]),
     }),
@@ -44,7 +44,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'duration_threshold',
       ]),
       'friendly_name': 'Sonic Duration auto shut-off',
@@ -64,7 +64,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'volume_threshold',
       ]),
     }),
@@ -102,7 +102,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'event_type': None,
-      'event_types': list([
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'volume_threshold',
       ]),
       'friendly_name': 'Sonic Volume auto shut-off',

--- a/tests/components/watergate/snapshots/test_event.ambr
+++ b/tests/components/watergate/snapshots/test_event.ambr
@@ -43,7 +43,7 @@
 # name: test_event[event.sonic_duration_auto_shut_off-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'duration_threshold',
       ]),
@@ -101,7 +101,7 @@
 # name: test_event[event.sonic_volume_auto_shut_off-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'event_type': None,
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'volume_threshold',
       ]),


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add new `EventEntityCapabilityAttribute` enum for the capability attributes and new `EventEntityStateAttribute` enum for the state attributes of the event entity.

Based on https://github.com/home-assistant/architecture/discussions/1406, linked to epic https://github.com/home-assistant/epics/issues/104

A follow-up PR will formally deprecate the corresponding `ATTR_*` constants.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
