### PR TITLE
Migrate cover entity attributes to StrEnum

### DIFF
--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -41,6 +41,7 @@ from .const import (
     INTENT_OPEN_COVER,
     CoverDeviceClass,
     CoverEntityFeature,
+    CoverEntityStateAttribute,
     CoverState,
 )
 from .trigger import make_cover_closed_trigger, make_cover_opened_trigger
@@ -260,13 +261,13 @@ class CoverEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         """Return the state attributes."""
         data: dict[str, Any] = {}
 
-        data[ATTR_IS_CLOSED] = self.is_closed
+        data[CoverEntityStateAttribute.IS_CLOSED] = self.is_closed
 
         if (current := self.current_cover_position) is not None:
-            data[ATTR_CURRENT_POSITION] = current
+            data[CoverEntityStateAttribute.CURRENT_POSITION] = current
 
         if (current_tilt := self.current_cover_tilt_position) is not None:
-            data[ATTR_CURRENT_TILT_POSITION] = current_tilt
+            data[CoverEntityStateAttribute.CURRENT_TILT_POSITION] = current_tilt
 
         return data
 

--- a/homeassistant/components/cover/const.py
+++ b/homeassistant/components/cover/const.py
@@ -10,6 +10,15 @@ ATTR_IS_CLOSED = "is_closed"
 ATTR_POSITION = "position"
 ATTR_TILT_POSITION = "tilt_position"
 
+
+class CoverEntityStateAttribute(StrEnum):
+    """State attributes for cover entities."""
+
+    IS_CLOSED = "is_closed"
+    CURRENT_POSITION = "current_position"
+    CURRENT_TILT_POSITION = "current_tilt_position"
+
+
 INTENT_OPEN_COVER = "HassOpenCover"
 INTENT_CLOSE_COVER = "HassCloseCover"
 

--- a/homeassistant/components/water_heater/__init__.py
+++ b/homeassistant/components/water_heater/__init__.py
@@ -30,7 +30,7 @@ from homeassistant.helpers.typing import ConfigType, VolDictType
 from homeassistant.util.hass_dict import HassKey
 from homeassistant.util.unit_conversion import TemperatureConverter
 
-from .const import DOMAIN
+from .const import DOMAIN, WaterHeaterCapabilityAttribute, WaterHeaterStateAttribute
 
 DATA_COMPONENT: HassKey[EntityComponent[WaterHeaterEntity]] = HassKey(DOMAIN)
 ENTITY_ID_FORMAT = DOMAIN + ".{}"
@@ -157,10 +157,10 @@ class WaterHeaterEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
 
     _entity_component_unrecorded_attributes = frozenset(
         {
-            ATTR_OPERATION_LIST,
-            ATTR_MIN_TEMP,
-            ATTR_MAX_TEMP,
-            ATTR_TARGET_TEMP_STEP,
+            WaterHeaterCapabilityAttribute.OPERATION_LIST,
+            WaterHeaterCapabilityAttribute.MIN_TEMP,
+            WaterHeaterCapabilityAttribute.MAX_TEMP,
+            WaterHeaterCapabilityAttribute.TARGET_TEMP_STEP,
         }
     )
 
@@ -201,18 +201,20 @@ class WaterHeaterEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     def capability_attributes(self) -> dict[str, Any]:
         """Return capability attributes."""
         data: dict[str, Any] = {
-            ATTR_MIN_TEMP: show_temp(
+            WaterHeaterCapabilityAttribute.MIN_TEMP: show_temp(
                 self.hass, self.min_temp, self.temperature_unit, self.precision
             ),
-            ATTR_MAX_TEMP: show_temp(
+            WaterHeaterCapabilityAttribute.MAX_TEMP: show_temp(
                 self.hass, self.max_temp, self.temperature_unit, self.precision
             ),
         }
         if target_temperature_step := self.target_temperature_step:
-            data[ATTR_TARGET_TEMP_STEP] = target_temperature_step
+            data[WaterHeaterCapabilityAttribute.TARGET_TEMP_STEP] = (
+                target_temperature_step
+            )
 
         if WaterHeaterEntityFeature.OPERATION_MODE in self.supported_features:
-            data[ATTR_OPERATION_LIST] = self.operation_list
+            data[WaterHeaterCapabilityAttribute.OPERATION_LIST] = self.operation_list
 
         return data
 
@@ -222,25 +224,25 @@ class WaterHeaterEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     def state_attributes(self) -> dict[str, Any]:
         """Return the optional state attributes."""
         data: dict[str, Any] = {
-            ATTR_CURRENT_TEMPERATURE: show_temp(
+            WaterHeaterStateAttribute.CURRENT_TEMPERATURE: show_temp(
                 self.hass,
                 self.current_temperature,
                 self.temperature_unit,
                 self.precision,
             ),
-            ATTR_TEMPERATURE: show_temp(
+            WaterHeaterStateAttribute.TEMPERATURE: show_temp(
                 self.hass,
                 self.target_temperature,
                 self.temperature_unit,
                 self.precision,
             ),
-            ATTR_TARGET_TEMP_HIGH: show_temp(
+            WaterHeaterStateAttribute.TARGET_TEMP_HIGH: show_temp(
                 self.hass,
                 self.target_temperature_high,
                 self.temperature_unit,
                 self.precision,
             ),
-            ATTR_TARGET_TEMP_LOW: show_temp(
+            WaterHeaterStateAttribute.TARGET_TEMP_LOW: show_temp(
                 self.hass,
                 self.target_temperature_low,
                 self.temperature_unit,
@@ -251,11 +253,13 @@ class WaterHeaterEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         supported_features = self.supported_features
 
         if WaterHeaterEntityFeature.OPERATION_MODE in supported_features:
-            data[ATTR_OPERATION_MODE] = self.current_operation
+            data[WaterHeaterStateAttribute.OPERATION_MODE] = self.current_operation
 
         if WaterHeaterEntityFeature.AWAY_MODE in supported_features:
             is_away = self.is_away_mode_on
-            data[ATTR_AWAY_MODE] = STATE_ON if is_away else STATE_OFF
+            data[WaterHeaterStateAttribute.AWAY_MODE] = (
+                STATE_ON if is_away else STATE_OFF
+            )
 
         return data
 

--- a/homeassistant/components/water_heater/__init__.py
+++ b/homeassistant/components/water_heater/__init__.py
@@ -30,7 +30,7 @@ from homeassistant.helpers.typing import ConfigType, VolDictType
 from homeassistant.util.hass_dict import HassKey
 from homeassistant.util.unit_conversion import TemperatureConverter
 
-from .const import DOMAIN, WaterHeaterCapabilityAttribute, WaterHeaterStateAttribute
+from .const import DOMAIN
 
 DATA_COMPONENT: HassKey[EntityComponent[WaterHeaterEntity]] = HassKey(DOMAIN)
 ENTITY_ID_FORMAT = DOMAIN + ".{}"
@@ -157,10 +157,10 @@ class WaterHeaterEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
 
     _entity_component_unrecorded_attributes = frozenset(
         {
-            WaterHeaterCapabilityAttribute.OPERATION_LIST,
-            WaterHeaterCapabilityAttribute.MIN_TEMP,
-            WaterHeaterCapabilityAttribute.MAX_TEMP,
-            WaterHeaterCapabilityAttribute.TARGET_TEMP_STEP,
+            ATTR_OPERATION_LIST,
+            ATTR_MIN_TEMP,
+            ATTR_MAX_TEMP,
+            ATTR_TARGET_TEMP_STEP,
         }
     )
 
@@ -201,20 +201,18 @@ class WaterHeaterEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     def capability_attributes(self) -> dict[str, Any]:
         """Return capability attributes."""
         data: dict[str, Any] = {
-            WaterHeaterCapabilityAttribute.MIN_TEMP: show_temp(
+            ATTR_MIN_TEMP: show_temp(
                 self.hass, self.min_temp, self.temperature_unit, self.precision
             ),
-            WaterHeaterCapabilityAttribute.MAX_TEMP: show_temp(
+            ATTR_MAX_TEMP: show_temp(
                 self.hass, self.max_temp, self.temperature_unit, self.precision
             ),
         }
         if target_temperature_step := self.target_temperature_step:
-            data[WaterHeaterCapabilityAttribute.TARGET_TEMP_STEP] = (
-                target_temperature_step
-            )
+            data[ATTR_TARGET_TEMP_STEP] = target_temperature_step
 
         if WaterHeaterEntityFeature.OPERATION_MODE in self.supported_features:
-            data[WaterHeaterCapabilityAttribute.OPERATION_LIST] = self.operation_list
+            data[ATTR_OPERATION_LIST] = self.operation_list
 
         return data
 
@@ -224,25 +222,25 @@ class WaterHeaterEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     def state_attributes(self) -> dict[str, Any]:
         """Return the optional state attributes."""
         data: dict[str, Any] = {
-            WaterHeaterStateAttribute.CURRENT_TEMPERATURE: show_temp(
+            ATTR_CURRENT_TEMPERATURE: show_temp(
                 self.hass,
                 self.current_temperature,
                 self.temperature_unit,
                 self.precision,
             ),
-            WaterHeaterStateAttribute.TEMPERATURE: show_temp(
+            ATTR_TEMPERATURE: show_temp(
                 self.hass,
                 self.target_temperature,
                 self.temperature_unit,
                 self.precision,
             ),
-            WaterHeaterStateAttribute.TARGET_TEMP_HIGH: show_temp(
+            ATTR_TARGET_TEMP_HIGH: show_temp(
                 self.hass,
                 self.target_temperature_high,
                 self.temperature_unit,
                 self.precision,
             ),
-            WaterHeaterStateAttribute.TARGET_TEMP_LOW: show_temp(
+            ATTR_TARGET_TEMP_LOW: show_temp(
                 self.hass,
                 self.target_temperature_low,
                 self.temperature_unit,
@@ -253,13 +251,11 @@ class WaterHeaterEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         supported_features = self.supported_features
 
         if WaterHeaterEntityFeature.OPERATION_MODE in supported_features:
-            data[WaterHeaterStateAttribute.OPERATION_MODE] = self.current_operation
+            data[ATTR_OPERATION_MODE] = self.current_operation
 
         if WaterHeaterEntityFeature.AWAY_MODE in supported_features:
             is_away = self.is_away_mode_on
-            data[WaterHeaterStateAttribute.AWAY_MODE] = (
-                STATE_ON if is_away else STATE_OFF
-            )
+            data[ATTR_AWAY_MODE] = STATE_ON if is_away else STATE_OFF
 
         return data
 

--- a/homeassistant/components/water_heater/const.py
+++ b/homeassistant/components/water_heater/const.py
@@ -1,6 +1,29 @@
 """Support for water heater devices."""
 
+from enum import StrEnum
+
 DOMAIN = "water_heater"
+
+
+class WaterHeaterCapabilityAttribute(StrEnum):
+    """Capability attributes for water heater devices."""
+
+    MIN_TEMP = "min_temp"
+    MAX_TEMP = "max_temp"
+    TARGET_TEMP_STEP = "target_temp_step"
+    OPERATION_LIST = "operation_list"
+
+
+class WaterHeaterStateAttribute(StrEnum):
+    """State attributes for water heater entities."""
+
+    CURRENT_TEMPERATURE = "current_temperature"
+    TEMPERATURE = "temperature"
+    TARGET_TEMP_HIGH = "target_temp_high"
+    TARGET_TEMP_LOW = "target_temp_low"
+    OPERATION_MODE = "operation_mode"
+    AWAY_MODE = "away_mode"
+
 
 STATE_ECO = "eco"
 STATE_ELECTRIC = "electric"

--- a/homeassistant/components/water_heater/const.py
+++ b/homeassistant/components/water_heater/const.py
@@ -1,29 +1,6 @@
 """Support for water heater devices."""
 
-from enum import StrEnum
-
 DOMAIN = "water_heater"
-
-
-class WaterHeaterCapabilityAttribute(StrEnum):
-    """Capability attributes for water heater devices."""
-
-    MIN_TEMP = "min_temp"
-    MAX_TEMP = "max_temp"
-    TARGET_TEMP_STEP = "target_temp_step"
-    OPERATION_LIST = "operation_list"
-
-
-class WaterHeaterStateAttribute(StrEnum):
-    """State attributes for water heater entities."""
-
-    CURRENT_TEMPERATURE = "current_temperature"
-    TEMPERATURE = "temperature"
-    TARGET_TEMP_HIGH = "target_temp_high"
-    TARGET_TEMP_LOW = "target_temp_low"
-    OPERATION_MODE = "operation_mode"
-    AWAY_MODE = "away_mode"
-
 
 STATE_ECO = "eco"
 STATE_ELECTRIC = "electric"

--- a/tests/components/airtouch5/snapshots/test_cover.ambr
+++ b/tests/components/airtouch5/snapshots/test_cover.ambr
@@ -39,10 +39,10 @@
 # name: test_all_entities[cover.zone_1_damper-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 90,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 90,
       'device_class': 'damper',
       'friendly_name': 'Zone 1 Damper',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 7>,
     }),
     'context': <ANY>,
@@ -93,10 +93,10 @@
 # name: test_all_entities[cover.zone_2_damper-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
       'device_class': 'damper',
       'friendly_name': 'Zone 2 Damper',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 7>,
     }),
     'context': <ANY>,

--- a/tests/components/aladdin_connect/snapshots/test_cover.ambr
+++ b/tests/components/aladdin_connect/snapshots/test_cover.ambr
@@ -41,7 +41,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'garage',
       'friendly_name': 'Test Door',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 3>,
     }),
     'context': <ANY>,

--- a/tests/components/chacon_dio/snapshots/test_cover.ambr
+++ b/tests/components/chacon_dio/snapshots/test_cover.ambr
@@ -39,10 +39,10 @@
 # name: test_entities[cover.shutter_mock_1-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 75,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 75,
       'device_class': 'shutter',
       'friendly_name': 'Shutter mock 1',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,

--- a/tests/components/comelit/snapshots/test_cover.ambr
+++ b/tests/components/comelit/snapshots/test_cover.ambr
@@ -41,7 +41,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'shutter',
       'friendly_name': 'Cover0',
-      'is_closed': None,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: None,
       'supported_features': <CoverEntityFeature: 11>,
     }),
     'context': <ANY>,

--- a/tests/components/control4/snapshots/test_cover.ambr
+++ b/tests/components/control4/snapshots/test_cover.ambr
@@ -39,10 +39,10 @@
 # name: test_cover_entities[cover.test_controller_living_room_shade-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 50,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 50,
       'device_class': 'shade',
       'friendly_name': 'Test Controller Living Room Shade',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,

--- a/tests/components/deconz/snapshots/test_cover.ambr
+++ b/tests/components/deconz/snapshots/test_cover.ambr
@@ -39,10 +39,10 @@
 # name: test_cover[light_payload0][cover.window_covering_device-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
       'device_class': 'shade',
       'friendly_name': 'Window covering device',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -93,11 +93,11 @@
 # name: test_level_controllable_output_cover[light_payload0][cover.vent-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 5,
-      'current_tilt_position': 97,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 5,
+      <CoverEntityStateAttribute.CURRENT_TILT_POSITION: 'current_tilt_position'>: 97,
       'device_class': 'damper',
       'friendly_name': 'Vent',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 255>,
     }),
     'context': <ANY>,
@@ -148,11 +148,11 @@
 # name: test_tilt_cover[light_payload0][cover.covering_device-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 100,
-      'current_tilt_position': 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
+      <CoverEntityStateAttribute.CURRENT_TILT_POSITION: 'current_tilt_position'>: 100,
       'device_class': 'shade',
       'friendly_name': 'Covering device',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 255>,
     }),
     'context': <ANY>,

--- a/tests/components/devolo_home_control/snapshots/test_cover.ambr
+++ b/tests/components/devolo_home_control/snapshots/test_cover.ambr
@@ -2,10 +2,10 @@
 # name: test_cover
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 20,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 20,
       'device_class': 'blind',
       'friendly_name': 'Test',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 7>,
     }),
     'context': <ANY>,

--- a/tests/components/elmax/snapshots/test_cover.ambr
+++ b/tests/components/elmax/snapshots/test_cover.ambr
@@ -39,9 +39,9 @@
 # name: test_covers[cover.direct_panel_https_1_1_1_1_443_api_v2_espan_dom_01-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
       'friendly_name': 'Direct Panel https://1.1.1.1:443/api/v2 ESPAN.DOM.01',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 11>,
     }),
     'context': <ANY>,

--- a/tests/components/fluss/snapshots/test_cover.ambr
+++ b/tests/components/fluss/snapshots/test_cover.ambr
@@ -41,7 +41,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'garage',
       'friendly_name': 'Device 1',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 3>,
     }),
     'context': <ANY>,
@@ -94,7 +94,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'garage',
       'friendly_name': 'Device 2',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 3>,
     }),
     'context': <ANY>,

--- a/tests/components/fritzbox/snapshots/test_cover.ambr
+++ b/tests/components/fritzbox/snapshots/test_cover.ambr
@@ -39,10 +39,10 @@
 # name: test_setup[cover.fake_name-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
       'device_class': 'blind',
       'friendly_name': 'fake_name',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,

--- a/tests/components/homee/snapshots/test_cover.ambr
+++ b/tests/components/homee/snapshots/test_cover.ambr
@@ -41,7 +41,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'shutter',
       'friendly_name': 'No Position',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 11>,
     }),
     'context': <ANY>,
@@ -92,11 +92,11 @@
 # name: test_cover_snapshot[cover.shutter_with_position_and_slats-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 100,
-      'current_tilt_position': 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
+      <CoverEntityStateAttribute.CURRENT_TILT_POSITION: 'current_tilt_position'>: 100,
       'device_class': 'shutter',
       'friendly_name': 'Shutter with position and slats',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 143>,
     }),
     'context': <ANY>,
@@ -147,10 +147,10 @@
 # name: test_cover_snapshot[cover.slats_position-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_tilt_position': 65,
+      <CoverEntityStateAttribute.CURRENT_TILT_POSITION: 'current_tilt_position'>: 65,
       'device_class': 'shutter',
       'friendly_name': 'Slats & Position',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 240>,
     }),
     'context': <ANY>,

--- a/tests/components/homekit_controller/snapshots/test_init.ambr
+++ b/tests/components/homekit_controller/snapshots/test_init.ambr
@@ -11305,9 +11305,9 @@
           }),
           'state': dict({
             'attributes': dict({
-              'current_position': 98,
+              <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 98,
               'friendly_name': 'Family Room North',
-              'is_closed': False,
+              <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
               'supported_features': <CoverEntityFeature: 7>,
             }),
             'entity_id': 'cover.family_room_north',
@@ -11558,9 +11558,9 @@
           }),
           'state': dict({
             'attributes': dict({
-              'current_position': 100,
+              <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
               'friendly_name': 'Kitchen Window',
-              'is_closed': False,
+              <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
               'supported_features': <CoverEntityFeature: 7>,
             }),
             'entity_id': 'cover.kitchen_window',
@@ -12782,9 +12782,9 @@
           }),
           'state': dict({
             'attributes': dict({
-              'current_position': 98,
+              <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 98,
               'friendly_name': 'Family Room North',
-              'is_closed': False,
+              <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
               'supported_features': <CoverEntityFeature: 15>,
             }),
             'entity_id': 'cover.family_room_north',
@@ -13035,9 +13035,9 @@
           }),
           'state': dict({
             'attributes': dict({
-              'current_position': 100,
+              <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
               'friendly_name': 'Kitchen Window',
-              'is_closed': False,
+              <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
               'supported_features': <CoverEntityFeature: 7>,
             }),
             'entity_id': 'cover.kitchen_window',
@@ -21067,9 +21067,9 @@
           }),
           'state': dict({
             'attributes': dict({
-              'current_position': 0,
+              <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
               'friendly_name': 'Master Bath South RYSE Shade',
-              'is_closed': True,
+              <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
               'supported_features': <CoverEntityFeature: 7>,
             }),
             'entity_id': 'cover.master_bath_south_ryse_shade',
@@ -21320,9 +21320,9 @@
           }),
           'state': dict({
             'attributes': dict({
-              'current_position': 100,
+              <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
               'friendly_name': 'RYSE SmartShade RYSE Shade',
-              'is_closed': False,
+              <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
               'supported_features': <CoverEntityFeature: 7>,
             }),
             'entity_id': 'cover.ryse_smartshade_ryse_shade',
@@ -21499,9 +21499,9 @@
           }),
           'state': dict({
             'attributes': dict({
-              'current_position': 100,
+              <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
               'friendly_name': 'BR Left RYSE Shade',
-              'is_closed': False,
+              <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
               'supported_features': <CoverEntityFeature: 7>,
             }),
             'entity_id': 'cover.br_left_ryse_shade',
@@ -21674,9 +21674,9 @@
           }),
           'state': dict({
             'attributes': dict({
-              'current_position': 0,
+              <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
               'friendly_name': 'LR Left RYSE Shade',
-              'is_closed': True,
+              <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
               'supported_features': <CoverEntityFeature: 7>,
             }),
             'entity_id': 'cover.lr_left_ryse_shade',
@@ -21849,9 +21849,9 @@
           }),
           'state': dict({
             'attributes': dict({
-              'current_position': 0,
+              <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
               'friendly_name': 'LR Right RYSE Shade',
-              'is_closed': True,
+              <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
               'supported_features': <CoverEntityFeature: 7>,
             }),
             'entity_id': 'cover.lr_right_ryse_shade',
@@ -22102,9 +22102,9 @@
           }),
           'state': dict({
             'attributes': dict({
-              'current_position': 100,
+              <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
               'friendly_name': 'RZSS RYSE Shade',
-              'is_closed': False,
+              <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
               'supported_features': <CoverEntityFeature: 7>,
             }),
             'entity_id': 'cover.rzss_ryse_shade',
@@ -22598,10 +22598,10 @@
           }),
           'state': dict({
             'attributes': dict({
-              'current_position': 0,
-              'current_tilt_position': 100,
+              <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
+              <CoverEntityStateAttribute.CURRENT_TILT_POSITION: 'current_tilt_position'>: 100,
               'friendly_name': 'VELUX Internal Cover Venetian Blinds',
-              'is_closed': True,
+              <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
               'supported_features': <CoverEntityFeature: 183>,
             }),
             'entity_id': 'cover.velux_internal_cover_venetian_blinds',
@@ -23691,10 +23691,10 @@
           }),
           'state': dict({
             'attributes': dict({
-              'current_position': 0,
+              <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
               'device_class': 'window',
               'friendly_name': 'VELUX Window Roof Window',
-              'is_closed': True,
+              <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
               'supported_features': <CoverEntityFeature: 7>,
             }),
             'entity_id': 'cover.velux_window_roof_window',
@@ -23821,10 +23821,10 @@
           }),
           'state': dict({
             'attributes': dict({
-              'current_position': 0,
+              <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
               'device_class': 'window',
               'friendly_name': 'VELUX Window Roof Window',
-              'is_closed': True,
+              <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
               'supported_features': <CoverEntityFeature: 7>,
             }),
             'entity_id': 'cover.velux_window_roof_window',
@@ -23951,9 +23951,9 @@
           }),
           'state': dict({
             'attributes': dict({
-              'current_position': 0,
+              <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
               'friendly_name': 'VELUX External Cover Awning Blinds',
-              'is_closed': True,
+              <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
               'supported_features': <CoverEntityFeature: 7>,
             }),
             'entity_id': 'cover.velux_external_cover_awning_blinds',

--- a/tests/components/lcn/snapshots/test_cover.ambr
+++ b/tests/components/lcn/snapshots/test_cover.ambr
@@ -41,7 +41,7 @@
     'attributes': ReadOnlyDict({
       'assumed_state': True,
       'friendly_name': 'TestModule Cover_Outputs',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 11>,
     }),
     'context': <ANY>,
@@ -94,7 +94,7 @@
     'attributes': ReadOnlyDict({
       'assumed_state': True,
       'friendly_name': 'TestModule Cover_Relays',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 11>,
     }),
     'context': <ANY>,
@@ -147,7 +147,7 @@
     'attributes': ReadOnlyDict({
       'assumed_state': True,
       'friendly_name': 'TestModule Cover_Relays_BS4',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -200,7 +200,7 @@
     'attributes': ReadOnlyDict({
       'assumed_state': True,
       'friendly_name': 'TestModule Cover_Relays_Module',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,

--- a/tests/components/lutron/snapshots/test_cover.ambr
+++ b/tests/components/lutron/snapshots/test_cover.ambr
@@ -39,9 +39,9 @@
 # name: test_cover_setup[cover.test_area_test_cover-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
       'friendly_name': 'Test Cover',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'lutron_integration_id': 3,
       'supported_features': <CoverEntityFeature: 7>,
     }),

--- a/tests/components/matter/snapshots/test_cover.ambr
+++ b/tests/components/matter/snapshots/test_cover.ambr
@@ -39,10 +39,10 @@
 # name: test_covers[eve_shutter][cover.eve_shutter_switch_20eci1701-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
       'device_class': 'shade',
       'friendly_name': 'Eve Shutter Switch 20ECI1701',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -93,11 +93,11 @@
 # name: test_covers[mock_window_covering_full][cover.mock_full_window_covering-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 100,
-      'current_tilt_position': 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
+      <CoverEntityStateAttribute.CURRENT_TILT_POSITION: 'current_tilt_position'>: 100,
       'device_class': 'awning',
       'friendly_name': 'Mock Full Window Covering',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 143>,
     }),
     'context': <ANY>,
@@ -150,7 +150,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'awning',
       'friendly_name': 'Mock Lift Window Covering',
-      'is_closed': None,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: None,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -201,10 +201,10 @@
 # name: test_covers[mock_window_covering_pa_lift][cover.longan_link_wncv_da01-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 51,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 51,
       'device_class': 'shade',
       'friendly_name': 'Longan link WNCV DA01',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -255,10 +255,10 @@
 # name: test_covers[mock_window_covering_pa_tilt][cover.mock_pa_tilt_window_covering-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_tilt_position': 100,
+      <CoverEntityStateAttribute.CURRENT_TILT_POSITION: 'current_tilt_position'>: 100,
       'device_class': 'blind',
       'friendly_name': 'Mock PA Tilt Window Covering',
-      'is_closed': None,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: None,
       'supported_features': <CoverEntityFeature: 139>,
     }),
     'context': <ANY>,
@@ -311,7 +311,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'blind',
       'friendly_name': 'Mock Tilt Window Covering',
-      'is_closed': None,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: None,
       'supported_features': <CoverEntityFeature: 139>,
     }),
     'context': <ANY>,
@@ -362,10 +362,10 @@
 # name: test_covers[zemismart_mt25b][cover.zemismart_mt25b_roller_motor-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
       'device_class': 'shade',
       'friendly_name': 'Zemismart MT25B Roller Motor',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,

--- a/tests/components/netatmo/snapshots/test_cover.ambr
+++ b/tests/components/netatmo/snapshots/test_cover.ambr
@@ -40,10 +40,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by Netatmo',
-      'current_position': 0,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
       'device_class': 'shutter',
       'friendly_name': 'Bubendorff blind',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -95,10 +95,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by Netatmo',
-      'current_position': 0,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
       'device_class': 'shutter',
       'friendly_name': 'Entrance Blinds',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,

--- a/tests/components/nice_go/snapshots/test_cover.ambr
+++ b/tests/components/nice_go/snapshots/test_cover.ambr
@@ -41,7 +41,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'garage',
       'friendly_name': 'Test Garage 1',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 3>,
     }),
     'context': <ANY>,
@@ -94,7 +94,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'garage',
       'friendly_name': 'Test Garage 2',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 3>,
     }),
     'context': <ANY>,
@@ -147,7 +147,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'gate',
       'friendly_name': 'Test Garage 3',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 3>,
     }),
     'context': <ANY>,
@@ -200,7 +200,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'garage',
       'friendly_name': 'Test Garage 4',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 3>,
     }),
     'context': <ANY>,

--- a/tests/components/nice_go/snapshots/test_init.ambr
+++ b/tests/components/nice_go/snapshots/test_init.ambr
@@ -4,7 +4,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'garage',
       'friendly_name': 'Test Garage 1',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 3>,
     }),
     'context': <ANY>,

--- a/tests/components/niko_home_control/snapshots/test_cover.ambr
+++ b/tests/components/niko_home_control/snapshots/test_cover.ambr
@@ -40,7 +40,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'cover',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 11>,
     }),
     'context': <ANY>,

--- a/tests/components/overkiz/snapshots/test_cover.ambr
+++ b/tests/components/overkiz/snapshots/test_cover.ambr
@@ -39,10 +39,10 @@
 # name: test_cover_entities_snapshot[cloud_nexity_rail_din_europe.json][cover.maple_residence_hallway_shutter-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
       'device_class': 'shutter',
       'friendly_name': 'Hallway Shutter',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -93,10 +93,10 @@
 # name: test_cover_entities_snapshot[cloud_nexity_rail_din_europe.json][cover.maple_residence_hallway_shutter_low_speed-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
       'device_class': 'shutter',
       'friendly_name': 'Hallway Shutter Low speed',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -147,10 +147,10 @@
 # name: test_cover_entities_snapshot[cloud_nexity_rail_din_europe.json][cover.maple_residence_nursery_shutter-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
       'device_class': 'shutter',
       'friendly_name': 'Nursery Shutter',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -201,10 +201,10 @@
 # name: test_cover_entities_snapshot[cloud_nexity_rail_din_europe.json][cover.maple_residence_nursery_shutter_low_speed-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
       'device_class': 'shutter',
       'friendly_name': 'Nursery Shutter Low speed',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -255,10 +255,10 @@
 # name: test_cover_entities_snapshot[cloud_nexity_rail_din_europe.json][cover.maple_residence_office_shutter-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
       'device_class': 'shutter',
       'friendly_name': 'Office Shutter',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -309,10 +309,10 @@
 # name: test_cover_entities_snapshot[cloud_nexity_rail_din_europe.json][cover.maple_residence_office_shutter_low_speed-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
       'device_class': 'shutter',
       'friendly_name': 'Office Shutter Low speed',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -366,7 +366,7 @@
       'assumed_state': True,
       'device_class': 'blind',
       'friendly_name': 'Jaloezie',
-      'is_closed': None,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: None,
       'supported_features': <CoverEntityFeature: 123>,
     }),
     'context': <ANY>,
@@ -420,7 +420,7 @@
       'assumed_state': True,
       'device_class': 'blind',
       'friendly_name': 'Kitchen Sheer Screen',
-      'is_closed': None,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: None,
       'supported_features': <CoverEntityFeature: 123>,
     }),
     'context': <ANY>,
@@ -474,7 +474,7 @@
       'assumed_state': True,
       'device_class': 'shutter',
       'friendly_name': 'Kitchen Shutter',
-      'is_closed': None,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: None,
       'supported_features': <CoverEntityFeature: 11>,
     }),
     'context': <ANY>,
@@ -528,7 +528,7 @@
       'assumed_state': True,
       'device_class': 'blind',
       'friendly_name': 'Office Venetian Blind',
-      'is_closed': None,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: None,
       'supported_features': <CoverEntityFeature: 123>,
     }),
     'context': <ANY>,
@@ -582,7 +582,7 @@
       'assumed_state': True,
       'device_class': 'shutter',
       'friendly_name': 'Patio Shutter',
-      'is_closed': None,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: None,
       'supported_features': <CoverEntityFeature: 11>,
     }),
     'context': <ANY>,
@@ -633,10 +633,10 @@
 # name: test_cover_entities_snapshot[cloud_somfy_tahoma_switch_sc_europe.json][cover.loft_loft_window-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
       'device_class': 'window',
       'friendly_name': 'Loft Window',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -687,10 +687,10 @@
 # name: test_cover_entities_snapshot[cloud_somfy_tahoma_switch_sc_europe.json][cover.loft_studio_window-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
       'device_class': 'window',
       'friendly_name': 'Studio Window',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -741,10 +741,10 @@
 # name: test_cover_entities_snapshot[cloud_somfy_tahoma_switch_sc_europe.json][cover.playroom_laundry_screen-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 50,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 50,
       'device_class': 'blind',
       'friendly_name': 'Laundry Screen',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -795,10 +795,10 @@
 # name: test_cover_entities_snapshot[cloud_somfy_tahoma_switch_sc_europe.json][cover.playroom_pantry_screen-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
       'device_class': 'blind',
       'friendly_name': 'Pantry Screen',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -849,10 +849,10 @@
 # name: test_cover_entities_snapshot[cloud_somfy_tahoma_switch_sc_europe.json][cover.playroom_playroom_screen-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
       'device_class': 'blind',
       'friendly_name': 'Playroom Screen',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -903,10 +903,10 @@
 # name: test_cover_entities_snapshot[cloud_somfy_tahoma_switch_sc_europe.json][cover.playroom_workshop_screen-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
       'device_class': 'blind',
       'friendly_name': 'Workshop Screen',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -957,10 +957,10 @@
 # name: test_cover_entities_snapshot[cloud_somfy_tahoma_switch_sc_europe.json][cover.study_study_screen-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
       'device_class': 'blind',
       'friendly_name': 'Study Screen',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -1011,11 +1011,11 @@
 # name: test_cover_entities_snapshot[cloud_somfy_tahoma_switch_sc_europe.json][cover.veranda_basement_roller_shutter-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 80,
-      'current_tilt_position': 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 80,
+      <CoverEntityStateAttribute.CURRENT_TILT_POSITION: 'current_tilt_position'>: 100,
       'device_class': 'shutter',
       'friendly_name': 'Basement Roller Shutter',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 255>,
     }),
     'context': <ANY>,
@@ -1066,11 +1066,11 @@
 # name: test_cover_entities_snapshot[cloud_somfy_tahoma_switch_sc_europe.json][cover.veranda_veranda_roller_shutter-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
-      'current_tilt_position': 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
+      <CoverEntityStateAttribute.CURRENT_TILT_POSITION: 'current_tilt_position'>: 100,
       'device_class': 'shutter',
       'friendly_name': 'Veranda Roller Shutter',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 255>,
     }),
     'context': <ANY>,
@@ -1121,10 +1121,10 @@
 # name: test_cover_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][cover.dining_room_studio_shutter-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
       'device_class': 'shutter',
       'friendly_name': 'Studio Shutter',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -1175,10 +1175,10 @@
 # name: test_cover_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][cover.garage_dining_room_shutter-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
       'device_class': 'shutter',
       'friendly_name': 'Dining Room Shutter',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -1229,10 +1229,10 @@
 # name: test_cover_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][cover.garage_guest_room_shutter-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
       'device_class': 'shutter',
       'friendly_name': 'Guest Room Shutter',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -1283,10 +1283,10 @@
 # name: test_cover_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][cover.guest_bedroom_kids_room_shutter-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
       'device_class': 'shutter',
       'friendly_name': 'Kids Room Shutter',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -1337,10 +1337,10 @@
 # name: test_cover_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][cover.kids_room_kitchen_shutter-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
       'device_class': 'shutter',
       'friendly_name': 'Kitchen Shutter',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -1391,10 +1391,10 @@
 # name: test_cover_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][cover.kids_room_office_shutter-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
       'device_class': 'shutter',
       'friendly_name': 'Office Shutter',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -1445,10 +1445,10 @@
 # name: test_cover_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][cover.kids_room_patio_shutter-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
       'device_class': 'shutter',
       'friendly_name': 'Patio Shutter',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -1501,7 +1501,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'garage',
       'friendly_name': 'Basement Garage Door',
-      'is_closed': None,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: None,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -1552,10 +1552,10 @@
 # name: test_cover_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][cover.living_room_bedroom_window-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
       'device_class': 'window',
       'friendly_name': 'Bedroom Window',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -1606,10 +1606,10 @@
 # name: test_cover_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][cover.living_room_bioclimatic_pergola-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_tilt_position': 11,
+      <CoverEntityStateAttribute.CURRENT_TILT_POSITION: 'current_tilt_position'>: 11,
       'device_class': 'awning',
       'friendly_name': 'Bioclimatic Pergola',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 128>,
     }),
     'context': <ANY>,
@@ -1662,7 +1662,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'garage',
       'friendly_name': 'Cyclic Garage Door',
-      'is_closed': None,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: None,
       'supported_features': <CoverEntityFeature: 3>,
     }),
     'context': <ANY>,
@@ -1715,7 +1715,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'garage',
       'friendly_name': 'Garage Door',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 11>,
     }),
     'context': <ANY>,
@@ -1768,7 +1768,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'gate',
       'friendly_name': 'Garden Gate',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 11>,
     }),
     'context': <ANY>,
@@ -1819,10 +1819,10 @@
 # name: test_cover_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][cover.living_room_main_garage_door-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
       'device_class': 'garage',
       'friendly_name': 'Main Garage Door',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -1875,7 +1875,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'garage',
       'friendly_name': 'OGP Garage Door',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 11>,
     }),
     'context': <ANY>,
@@ -1928,7 +1928,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'gate',
       'friendly_name': 'OGP Gate',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 11>,
     }),
     'context': <ANY>,
@@ -1981,7 +1981,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'garage',
       'friendly_name': 'Partial Garage Door',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 11>,
     }),
     'context': <ANY>,
@@ -2032,10 +2032,10 @@
 # name: test_cover_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][cover.living_room_pergola_awning-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 20,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 20,
       'device_class': 'awning',
       'friendly_name': 'Pergola Awning',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -2089,7 +2089,7 @@
       'assumed_state': True,
       'device_class': 'garage',
       'friendly_name': 'RTS Garage Door 4T',
-      'is_closed': None,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: None,
       'supported_features': <CoverEntityFeature: 3>,
     }),
     'context': <ANY>,
@@ -2143,7 +2143,7 @@
       'assumed_state': True,
       'device_class': 'gate',
       'friendly_name': 'RTS Gate',
-      'is_closed': None,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: None,
       'supported_features': <CoverEntityFeature: 3>,
     }),
     'context': <ANY>,
@@ -2194,10 +2194,10 @@
 # name: test_cover_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][cover.living_room_side_garage_door-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
       'device_class': 'garage',
       'friendly_name': 'Side Garage Door',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -2250,7 +2250,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'gate',
       'friendly_name': 'Sliding Gate',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 11>,
     }),
     'context': <ANY>,
@@ -2301,10 +2301,10 @@
 # name: test_cover_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][cover.living_room_somfy_pergola-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
       'device_class': 'awning',
       'friendly_name': 'Somfy Pergola',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -2357,7 +2357,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'gate',
       'friendly_name': 'Swinging Gate',
-      'is_closed': None,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: None,
       'supported_features': <CoverEntityFeature: 3>,
     }),
     'context': <ANY>,
@@ -2408,10 +2408,10 @@
 # name: test_cover_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][cover.main_bedroom_bedroom_blinds-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
       'device_class': 'shutter',
       'friendly_name': 'Bedroom Blinds',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -2462,11 +2462,11 @@
 # name: test_cover_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][cover.main_bedroom_bedroom_venetian_blind-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
-      'current_tilt_position': 62,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
+      <CoverEntityStateAttribute.CURRENT_TILT_POSITION: 'current_tilt_position'>: 62,
       'device_class': 'blind',
       'friendly_name': 'Bedroom Venetian Blind',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 143>,
     }),
     'context': <ANY>,
@@ -2517,10 +2517,10 @@
 # name: test_cover_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][cover.office_garden_house_shutter-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
       'device_class': 'shutter',
       'friendly_name': 'Garden House Shutter',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -2571,10 +2571,10 @@
 # name: test_cover_entities_snapshot[cloud_somfy_tahoma_v2_europe.json][cover.reading_nook_living_room_shutter-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
       'device_class': 'shutter',
       'friendly_name': 'Living Room Shutter',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -2625,10 +2625,10 @@
 # name: test_cover_entities_snapshot[local_somfy_connexoon_europe.json][cover.terrace_awning-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
       'device_class': 'awning',
       'friendly_name': 'Terrace Awning',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -2679,11 +2679,11 @@
 # name: test_cover_entities_snapshot[local_somfy_tahoma_switch_europe.json][cover.bathroom_blinds-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
-      'current_tilt_position': 68,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
+      <CoverEntityStateAttribute.CURRENT_TILT_POSITION: 'current_tilt_position'>: 68,
       'device_class': 'blind',
       'friendly_name': 'Bathroom Blinds',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 255>,
     }),
     'context': <ANY>,
@@ -2734,11 +2734,11 @@
 # name: test_cover_entities_snapshot[local_somfy_tahoma_switch_europe.json][cover.bedroom_blinds-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
-      'current_tilt_position': 68,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
+      <CoverEntityStateAttribute.CURRENT_TILT_POSITION: 'current_tilt_position'>: 68,
       'device_class': 'blind',
       'friendly_name': 'Bedroom Blinds',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 255>,
     }),
     'context': <ANY>,
@@ -2789,11 +2789,11 @@
 # name: test_cover_entities_snapshot[local_somfy_tahoma_switch_europe.json][cover.dining_room_blinds-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
-      'current_tilt_position': 69,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
+      <CoverEntityStateAttribute.CURRENT_TILT_POSITION: 'current_tilt_position'>: 69,
       'device_class': 'blind',
       'friendly_name': 'Dining Room Blinds',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 255>,
     }),
     'context': <ANY>,
@@ -2844,11 +2844,11 @@
 # name: test_cover_entities_snapshot[local_somfy_tahoma_switch_europe.json][cover.garage_blinds-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
-      'current_tilt_position': 69,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
+      <CoverEntityStateAttribute.CURRENT_TILT_POSITION: 'current_tilt_position'>: 69,
       'device_class': 'blind',
       'friendly_name': 'Garage Blinds',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 255>,
     }),
     'context': <ANY>,
@@ -2899,11 +2899,11 @@
 # name: test_cover_entities_snapshot[local_somfy_tahoma_switch_europe.json][cover.guest_room_blinds-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
-      'current_tilt_position': 68,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
+      <CoverEntityStateAttribute.CURRENT_TILT_POSITION: 'current_tilt_position'>: 68,
       'device_class': 'blind',
       'friendly_name': 'Guest Room Blinds',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 255>,
     }),
     'context': <ANY>,
@@ -2954,11 +2954,11 @@
 # name: test_cover_entities_snapshot[local_somfy_tahoma_switch_europe.json][cover.hallway_blinds-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
-      'current_tilt_position': 68,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
+      <CoverEntityStateAttribute.CURRENT_TILT_POSITION: 'current_tilt_position'>: 68,
       'device_class': 'blind',
       'friendly_name': 'Hallway Blinds',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 255>,
     }),
     'context': <ANY>,
@@ -3009,11 +3009,11 @@
 # name: test_cover_entities_snapshot[local_somfy_tahoma_switch_europe.json][cover.kitchen_blinds-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
-      'current_tilt_position': 68,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
+      <CoverEntityStateAttribute.CURRENT_TILT_POSITION: 'current_tilt_position'>: 68,
       'device_class': 'blind',
       'friendly_name': 'Kitchen Blinds',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 255>,
     }),
     'context': <ANY>,
@@ -3064,11 +3064,11 @@
 # name: test_cover_entities_snapshot[local_somfy_tahoma_switch_europe.json][cover.living_room_blinds-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
-      'current_tilt_position': 68,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
+      <CoverEntityStateAttribute.CURRENT_TILT_POSITION: 'current_tilt_position'>: 68,
       'device_class': 'blind',
       'friendly_name': 'Living Room Blinds',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 255>,
     }),
     'context': <ANY>,
@@ -3119,11 +3119,11 @@
 # name: test_cover_entities_snapshot[local_somfy_tahoma_switch_europe.json][cover.master_bedroom_blinds-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
-      'current_tilt_position': 68,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
+      <CoverEntityStateAttribute.CURRENT_TILT_POSITION: 'current_tilt_position'>: 68,
       'device_class': 'blind',
       'friendly_name': 'Master Bedroom Blinds',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 255>,
     }),
     'context': <ANY>,
@@ -3174,11 +3174,11 @@
 # name: test_cover_entities_snapshot[local_somfy_tahoma_switch_europe.json][cover.nursery_blinds-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
-      'current_tilt_position': 69,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
+      <CoverEntityStateAttribute.CURRENT_TILT_POSITION: 'current_tilt_position'>: 69,
       'device_class': 'blind',
       'friendly_name': 'Nursery Blinds',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 255>,
     }),
     'context': <ANY>,
@@ -3229,11 +3229,11 @@
 # name: test_cover_entities_snapshot[local_somfy_tahoma_switch_europe.json][cover.office_blinds-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 15,
-      'current_tilt_position': 68,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 15,
+      <CoverEntityStateAttribute.CURRENT_TILT_POSITION: 'current_tilt_position'>: 68,
       'device_class': 'blind',
       'friendly_name': 'Office Blinds',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 255>,
     }),
     'context': <ANY>,
@@ -3284,11 +3284,11 @@
 # name: test_cover_entities_snapshot[local_somfy_tahoma_switch_europe.json][cover.study_blinds-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
-      'current_tilt_position': 72,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
+      <CoverEntityStateAttribute.CURRENT_TILT_POSITION: 'current_tilt_position'>: 72,
       'device_class': 'blind',
       'friendly_name': 'Study Blinds',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 255>,
     }),
     'context': <ANY>,
@@ -3339,10 +3339,10 @@
 # name: test_cover_entities_snapshot[local_somfy_tahoma_switch_europe_2.json][cover.back_door_shutter-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
       'device_class': 'shutter',
       'friendly_name': 'Back Door Shutter',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -3393,10 +3393,10 @@
 # name: test_cover_entities_snapshot[local_somfy_tahoma_switch_europe_2.json][cover.front_door_shutter-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
       'device_class': 'shutter',
       'friendly_name': 'Front Door Shutter',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -3447,10 +3447,10 @@
 # name: test_cover_entities_snapshot[local_somfy_tahoma_switch_europe_2.json][cover.roof_window-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
       'device_class': 'window',
       'friendly_name': 'Roof Window',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -3501,10 +3501,10 @@
 # name: test_cover_entities_snapshot[local_somfy_tahoma_switch_europe_2.json][cover.roof_window_low_speed-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
       'device_class': 'window',
       'friendly_name': 'Roof Window Low speed',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -3558,7 +3558,7 @@
       'assumed_state': True,
       'device_class': 'curtain',
       'friendly_name': 'Attic Curtain',
-      'is_closed': None,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: None,
       'supported_features': <CoverEntityFeature: 11>,
     }),
     'context': <ANY>,
@@ -3609,10 +3609,10 @@
 # name: test_cover_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][cover.conservatory_screen-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 86,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 86,
       'device_class': 'blind',
       'friendly_name': 'Conservatory Screen',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -3663,10 +3663,10 @@
 # name: test_cover_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][cover.library_screen-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 86,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 86,
       'device_class': 'blind',
       'friendly_name': 'Library Screen',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -3717,10 +3717,10 @@
 # name: test_cover_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][cover.patio_window-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
       'device_class': 'window',
       'friendly_name': 'Patio Window',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -3771,10 +3771,10 @@
 # name: test_cover_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][cover.sunroom_shades-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
       'device_class': 'blind',
       'friendly_name': 'Sunroom Shades',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -3825,10 +3825,10 @@
 # name: test_cover_entities_snapshot[local_somfy_tahoma_switch_europe_3.json][cover.terrace_awning-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 86,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 86,
       'device_class': 'blind',
       'friendly_name': 'Terrace Awning',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -3879,10 +3879,10 @@
 # name: test_cover_entities_snapshot[local_somfy_tahoma_v2_europe.json][cover.bedroom_screen-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
       'device_class': 'blind',
       'friendly_name': 'Bedroom Screen',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -3933,10 +3933,10 @@
 # name: test_cover_entities_snapshot[local_somfy_tahoma_v2_europe.json][cover.dining_room_screen-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
       'device_class': 'blind',
       'friendly_name': 'Dining Room Screen',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -3989,7 +3989,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'garage',
       'friendly_name': 'Garage Door Rollixo',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 11>,
     }),
     'context': <ANY>,
@@ -4040,10 +4040,10 @@
 # name: test_cover_entities_snapshot[local_somfy_tahoma_v2_europe.json][cover.garden_pergola-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_tilt_position': 0,
+      <CoverEntityStateAttribute.CURRENT_TILT_POSITION: 'current_tilt_position'>: 0,
       'device_class': 'awning',
       'friendly_name': 'Garden Pergola',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 240>,
     }),
     'context': <ANY>,
@@ -4097,7 +4097,7 @@
       'assumed_state': True,
       'device_class': 'awning',
       'friendly_name': 'Kitchen Pergola',
-      'is_closed': None,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: None,
       'supported_features': <CoverEntityFeature: 11>,
     }),
     'context': <ANY>,
@@ -4151,7 +4151,7 @@
       'assumed_state': True,
       'device_class': 'curtain',
       'friendly_name': 'Living Room Curtain',
-      'is_closed': None,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: None,
       'supported_features': <CoverEntityFeature: 11>,
     }),
     'context': <ANY>,
@@ -4202,11 +4202,11 @@
 # name: test_cover_entities_snapshot[local_somfy_tahoma_v2_europe.json][cover.living_room_venetian_blind-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
-      'current_tilt_position': 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
+      <CoverEntityStateAttribute.CURRENT_TILT_POSITION: 'current_tilt_position'>: 100,
       'device_class': 'blind',
       'friendly_name': 'Living Room Venetian Blind',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 143>,
     }),
     'context': <ANY>,
@@ -4257,10 +4257,10 @@
 # name: test_cover_entities_snapshot[local_somfy_tahoma_v2_europe.json][cover.office_screen-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
       'device_class': 'blind',
       'friendly_name': 'Office Screen',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,

--- a/tests/components/shelly/snapshots/test_devices.ambr
+++ b/tests/components/shelly/snapshots/test_devices.ambr
@@ -7030,7 +7030,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'shutter',
       'friendly_name': 'Test name',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 11>,
     }),
     'context': <ANY>,

--- a/tests/components/slide_local/snapshots/test_cover.ambr
+++ b/tests/components/slide_local/snapshots/test_cover.ambr
@@ -40,10 +40,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'assumed_state': True,
-      'current_position': 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
       'device_class': 'curtain',
       'friendly_name': 'slide bedroom',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,

--- a/tests/components/smartthings/snapshots/test_cover.ambr
+++ b/tests/components/smartthings/snapshots/test_cover.ambr
@@ -39,10 +39,10 @@
 # name: test_all_entities[c2c_shade][cover.curtain_1a-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
       'device_class': 'shade',
       'friendly_name': 'Curtain 1A',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 7>,
     }),
     'context': <ANY>,
@@ -94,10 +94,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'battery_level': 37,
-      'current_position': 32,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 32,
       'device_class': 'shade',
       'friendly_name': 'Kitchen IKEA KADRILJ Window blind',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 7>,
     }),
     'context': <ANY>,

--- a/tests/components/tailwind/snapshots/test_cover.ambr
+++ b/tests/components/tailwind/snapshots/test_cover.ambr
@@ -4,7 +4,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'garage',
       'friendly_name': 'Door 1',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 3>,
     }),
     'context': <ANY>,
@@ -88,7 +88,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'garage',
       'friendly_name': 'Door 2',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 3>,
     }),
     'context': <ANY>,

--- a/tests/components/template/snapshots/test_cover.ambr
+++ b/tests/components/template/snapshots/test_cover.ambr
@@ -2,9 +2,9 @@
 # name: test_setup_config_entry
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
       'friendly_name': 'My template',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 7>,
     }),
     'context': <ANY>,

--- a/tests/components/tesla_fleet/snapshots/test_cover.ambr
+++ b/tests/components/tesla_fleet/snapshots/test_cover.ambr
@@ -41,7 +41,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'door',
       'friendly_name': 'Test Charge port door',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 3>,
     }),
     'context': <ANY>,
@@ -94,7 +94,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'door',
       'friendly_name': 'Test Frunk',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 1>,
     }),
     'context': <ANY>,
@@ -147,7 +147,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'window',
       'friendly_name': 'Test Sunroof',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 11>,
     }),
     'context': <ANY>,
@@ -200,7 +200,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'door',
       'friendly_name': 'Test Trunk',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 3>,
     }),
     'context': <ANY>,
@@ -253,7 +253,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'window',
       'friendly_name': 'Test Windows',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 3>,
     }),
     'context': <ANY>,
@@ -306,7 +306,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'door',
       'friendly_name': 'Test Charge port door',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 3>,
     }),
     'context': <ANY>,
@@ -359,7 +359,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'door',
       'friendly_name': 'Test Frunk',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 1>,
     }),
     'context': <ANY>,
@@ -412,7 +412,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'window',
       'friendly_name': 'Test Sunroof',
-      'is_closed': None,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: None,
       'supported_features': <CoverEntityFeature: 11>,
     }),
     'context': <ANY>,
@@ -465,7 +465,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'door',
       'friendly_name': 'Test Trunk',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 3>,
     }),
     'context': <ANY>,
@@ -518,7 +518,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'window',
       'friendly_name': 'Test Windows',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 3>,
     }),
     'context': <ANY>,
@@ -571,7 +571,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'door',
       'friendly_name': 'Test Charge port door',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 0>,
     }),
     'context': <ANY>,
@@ -624,7 +624,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'door',
       'friendly_name': 'Test Frunk',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 0>,
     }),
     'context': <ANY>,
@@ -677,7 +677,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'window',
       'friendly_name': 'Test Sunroof',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 0>,
     }),
     'context': <ANY>,
@@ -730,7 +730,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'door',
       'friendly_name': 'Test Trunk',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 0>,
     }),
     'context': <ANY>,
@@ -783,7 +783,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'window',
       'friendly_name': 'Test Windows',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 0>,
     }),
     'context': <ANY>,

--- a/tests/components/teslemetry/snapshots/test_cover.ambr
+++ b/tests/components/teslemetry/snapshots/test_cover.ambr
@@ -41,7 +41,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'door',
       'friendly_name': 'Test Charge port door',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 3>,
     }),
     'context': <ANY>,
@@ -94,7 +94,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'door',
       'friendly_name': 'Test Frunk',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 1>,
     }),
     'context': <ANY>,
@@ -147,7 +147,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'window',
       'friendly_name': 'Test Sunroof',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 11>,
     }),
     'context': <ANY>,
@@ -200,7 +200,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'door',
       'friendly_name': 'Test Trunk',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 3>,
     }),
     'context': <ANY>,
@@ -253,7 +253,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'window',
       'friendly_name': 'Test Windows',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 3>,
     }),
     'context': <ANY>,
@@ -306,7 +306,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'door',
       'friendly_name': 'Test Charge port door',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 3>,
     }),
     'context': <ANY>,
@@ -359,7 +359,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'door',
       'friendly_name': 'Test Frunk',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 1>,
     }),
     'context': <ANY>,
@@ -412,7 +412,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'door',
       'friendly_name': 'Test Trunk',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 3>,
     }),
     'context': <ANY>,
@@ -465,7 +465,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'window',
       'friendly_name': 'Test Windows',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 3>,
     }),
     'context': <ANY>,
@@ -518,7 +518,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'door',
       'friendly_name': 'Test Charge port door',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 0>,
     }),
     'context': <ANY>,
@@ -571,7 +571,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'door',
       'friendly_name': 'Test Frunk',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 0>,
     }),
     'context': <ANY>,
@@ -624,7 +624,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'window',
       'friendly_name': 'Test Sunroof',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 0>,
     }),
     'context': <ANY>,
@@ -677,7 +677,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'door',
       'friendly_name': 'Test Trunk',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 0>,
     }),
     'context': <ANY>,
@@ -730,7 +730,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'window',
       'friendly_name': 'Test Windows',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 0>,
     }),
     'context': <ANY>,

--- a/tests/components/tessie/snapshots/test_cover.ambr
+++ b/tests/components/tessie/snapshots/test_cover.ambr
@@ -41,7 +41,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'door',
       'friendly_name': 'Test Charge port door',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 3>,
     }),
     'context': <ANY>,
@@ -94,7 +94,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'door',
       'friendly_name': 'Test Frunk',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 1>,
     }),
     'context': <ANY>,
@@ -147,7 +147,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'window',
       'friendly_name': 'Test Sunroof',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 3>,
     }),
     'context': <ANY>,
@@ -200,7 +200,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'door',
       'friendly_name': 'Test Trunk',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 3>,
     }),
     'context': <ANY>,
@@ -253,7 +253,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'window',
       'friendly_name': 'Test Vent windows',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 3>,
     }),
     'context': <ANY>,

--- a/tests/components/tuya/snapshots/test_cover.ambr
+++ b/tests/components/tuya/snapshots/test_cover.ambr
@@ -39,10 +39,10 @@
 # name: test_platform_setup_and_discovery[cover.bedroom_blinds_curtain-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
       'device_class': 'curtain',
       'friendly_name': 'bedroom blinds Curtain',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -93,10 +93,10 @@
 # name: test_platform_setup_and_discovery[cover.blinds_curtain-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 36,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 36,
       'device_class': 'curtain',
       'friendly_name': 'blinds Curtain',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -147,10 +147,10 @@
 # name: test_platform_setup_and_discovery[cover.dining_1_curtain-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
       'device_class': 'curtain',
       'friendly_name': 'Dining 1 Curtain',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -203,7 +203,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'curtain',
       'friendly_name': 'Estore Sala Curtain',
-      'is_closed': None,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: None,
       'supported_features': <CoverEntityFeature: 11>,
     }),
     'context': <ANY>,
@@ -254,10 +254,10 @@
 # name: test_platform_setup_and_discovery[cover.fenster_kuche_curtain-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
       'device_class': 'curtain',
       'friendly_name': 'Fenster Küche Curtain',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -310,7 +310,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'garage',
       'friendly_name': 'Garage door  Door 1',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 3>,
     }),
     'context': <ANY>,
@@ -363,7 +363,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'curtain',
       'friendly_name': 'Kit-Blinds Curtain',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 11>,
     }),
     'context': <ANY>,
@@ -414,10 +414,10 @@
 # name: test_platform_setup_and_discovery[cover.kitchen_blinds_blind-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
       'device_class': 'blind',
       'friendly_name': 'Kitchen Blinds Blind',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -468,10 +468,10 @@
 # name: test_platform_setup_and_discovery[cover.kitchen_blinds_curtain-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 48,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 48,
       'device_class': 'curtain',
       'friendly_name': 'Kitchen Blinds Curtain',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -522,10 +522,10 @@
 # name: test_platform_setup_and_discovery[cover.lounge_dark_blind_curtain-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
       'device_class': 'curtain',
       'friendly_name': 'Lounge Dark Blind Curtain',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -576,10 +576,10 @@
 # name: test_platform_setup_and_discovery[cover.pergola_curtain-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
       'device_class': 'curtain',
       'friendly_name': 'Pergola Curtain',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -630,10 +630,10 @@
 # name: test_platform_setup_and_discovery[cover.persiana_do_quarto_curtain-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
       'device_class': 'curtain',
       'friendly_name': 'Persiana do Quarto Curtain',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -684,10 +684,10 @@
 # name: test_platform_setup_and_discovery[cover.projector_screen_curtain-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
       'device_class': 'curtain',
       'friendly_name': 'Projector Screen Curtain',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -738,10 +738,10 @@
 # name: test_platform_setup_and_discovery[cover.roller_shutter_living_room_curtain-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 75,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 75,
       'device_class': 'curtain',
       'friendly_name': 'Roller shutter Living Room Curtain',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -792,10 +792,10 @@
 # name: test_platform_setup_and_discovery[cover.tapparelle_studio_curtain-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
       'device_class': 'curtain',
       'friendly_name': 'Tapparelle studio Curtain',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -846,10 +846,10 @@
 # name: test_platform_setup_and_discovery[cover.vividstorm_screen_curtain-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
       'device_class': 'curtain',
       'friendly_name': 'VIVIDSTORM SCREEN Curtain',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,

--- a/tests/components/velbus/snapshots/test_cover.ambr
+++ b/tests/components/velbus/snapshots/test_cover.ambr
@@ -39,9 +39,9 @@
 # name: test_entities[cover.basement_covername-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 50,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 50,
       'friendly_name': 'Basement CoverName',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -94,7 +94,7 @@
     'attributes': ReadOnlyDict({
       'assumed_state': True,
       'friendly_name': 'Basement CoverNameNoPos',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 11>,
     }),
     'context': <ANY>,

--- a/tests/components/velux/snapshots/test_cover.ambr
+++ b/tests/components/velux/snapshots/test_cover.ambr
@@ -39,11 +39,11 @@
 # name: test_blind_entity_setup[mock_blind][cover.test_blind-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 60,
-      'current_tilt_position': 75,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 60,
+      <CoverEntityStateAttribute.CURRENT_TILT_POSITION: 'current_tilt_position'>: 75,
       'device_class': 'blind',
       'friendly_name': 'Test Blind',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 255>,
     }),
     'context': <ANY>,
@@ -94,10 +94,10 @@
 # name: test_cover_entity_setup[mock_cover_type-Awning][cover.test_awning-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 70,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 70,
       'device_class': 'awning',
       'friendly_name': 'Test Awning',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -148,10 +148,10 @@
 # name: test_cover_entity_setup[mock_cover_type-DualRollerShutter][cover.test_dualrollershutter-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 70,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 70,
       'device_class': 'shutter',
       'friendly_name': 'Test DualRollerShutter',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -202,10 +202,10 @@
 # name: test_cover_entity_setup[mock_cover_type-DualRollerShutter][cover.test_dualrollershutter_lower_shutter-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 70,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 70,
       'device_class': 'shutter',
       'friendly_name': 'Test DualRollerShutter Lower shutter',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -256,10 +256,10 @@
 # name: test_cover_entity_setup[mock_cover_type-DualRollerShutter][cover.test_dualrollershutter_upper_shutter-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 70,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 70,
       'device_class': 'shutter',
       'friendly_name': 'Test DualRollerShutter Upper shutter',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -310,10 +310,10 @@
 # name: test_cover_entity_setup[mock_cover_type-GarageDoor][cover.test_garagedoor-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 70,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 70,
       'device_class': 'garage',
       'friendly_name': 'Test GarageDoor',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -364,10 +364,10 @@
 # name: test_cover_entity_setup[mock_cover_type-Gate][cover.test_gate-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 70,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 70,
       'device_class': 'gate',
       'friendly_name': 'Test Gate',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -418,10 +418,10 @@
 # name: test_cover_entity_setup[mock_cover_type-RollerShutter][cover.test_rollershutter-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 70,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 70,
       'device_class': 'shutter',
       'friendly_name': 'Test RollerShutter',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -472,10 +472,10 @@
 # name: test_cover_entity_setup[mock_cover_type-Window][cover.test_window-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 70,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 70,
       'device_class': 'window',
       'friendly_name': 'Test Window',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,

--- a/tests/components/wmspro/snapshots/test_cover.ambr
+++ b/tests/components/wmspro/snapshots/test_cover.ambr
@@ -34,10 +34,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by WMS WebControl pro API',
-      'current_position': 0,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
       'device_class': 'awning',
       'friendly_name': 'Markise',
-      'is_closed': True,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,

--- a/tests/components/zimi/snapshots/test_cover.ambr
+++ b/tests/components/zimi/snapshots/test_cover.ambr
@@ -2,10 +2,10 @@
 # name: test_cover_entity
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_position': 0,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
       'device_class': 'garage',
       'friendly_name': 'Cover Controller Test Entity Name',
-      'is_closed': False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add new `CoverEntityStateAttribute` enum for the state attributes of the cover entity.

Based on https://github.com/home-assistant/architecture/discussions/1406, linked to epic https://github.com/home-assistant/epics/issues/104

A follow-up PR will formally deprecate the corresponding `ATTR_*` constants.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
