### PR TITLE
Migrate lock entity attributes to StrEnum

### DIFF
--- a/homeassistant/components/lock/__init__.py
+++ b/homeassistant/components/lock/__init__.py
@@ -11,7 +11,7 @@ from propcache.api import cached_property
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
+from homeassistant.const import (  # noqa: F401
     ATTR_CODE,
     ATTR_CODE_FORMAT,
     SERVICE_LOCK,
@@ -26,7 +26,7 @@ from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.typing import ConfigType, StateType
 from homeassistant.util.hass_dict import HassKey
 
-from .const import DOMAIN, LockState
+from .const import DOMAIN, LockEntityStateAttribute, LockState
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -52,7 +52,10 @@ class LockEntityFeature(IntFlag):
     OPEN = 1
 
 
-PROP_TO_ATTR = {"changed_by": ATTR_CHANGED_BY, "code_format": ATTR_CODE_FORMAT}
+PROP_TO_ATTR = {
+    "changed_by": LockEntityStateAttribute.CHANGED_BY,
+    "code_format": LockEntityStateAttribute.CODE_FORMAT,
+}
 
 # mypy: disallow-any-generics
 
@@ -245,7 +248,7 @@ class LockEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     @override
     def state_attributes(self) -> dict[str, StateType]:
         """Return the state attributes."""
-        state_attr = {}
+        state_attr: dict[str, StateType] = {}
         for prop, attr in PROP_TO_ATTR.items():
             if (value := getattr(self, prop)) is not None:
                 state_attr[attr] = value

--- a/homeassistant/components/lock/const.py
+++ b/homeassistant/components/lock/const.py
@@ -5,6 +5,13 @@ from enum import StrEnum
 DOMAIN = "lock"
 
 
+class LockEntityStateAttribute(StrEnum):
+    """State attributes for lock entities."""
+
+    CHANGED_BY = "changed_by"
+    CODE_FORMAT = "code_format"
+
+
 class LockState(StrEnum):
     """State of lock entities."""
 

--- a/tests/components/homee/snapshots/test_lock.ambr
+++ b/tests/components/homee/snapshots/test_lock.ambr
@@ -39,7 +39,7 @@
 # name: test_lock_snapshot[lock.test_lock-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'changed_by': 'unknown-5',
+      <LockEntityStateAttribute.CHANGED_BY: 'changed_by'>: 'unknown-5',
       'friendly_name': 'Test Lock',
       'supported_features': <LockEntityFeature: 0>,
     }),

--- a/tests/components/matter/snapshots/test_lock.ambr
+++ b/tests/components/matter/snapshots/test_lock.ambr
@@ -39,7 +39,7 @@
 # name: test_locks[aqara_u200][lock.aqara_smart_lock_u200-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'changed_by': 'Unknown',
+      <LockEntityStateAttribute.CHANGED_BY: 'changed_by'>: 'Unknown',
       'friendly_name': 'Aqara Smart Lock U200',
       'supported_features': <LockEntityFeature: 0>,
     }),
@@ -91,7 +91,7 @@
 # name: test_locks[mock_door_lock][lock.mock_door_lock-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'changed_by': 'Unknown',
+      <LockEntityStateAttribute.CHANGED_BY: 'changed_by'>: 'Unknown',
       'friendly_name': 'Mock Door Lock',
       'supported_features': <LockEntityFeature: 0>,
     }),
@@ -143,7 +143,7 @@
 # name: test_locks[mock_door_lock_with_unbolt][lock.mock_door_lock_with_unbolt-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'changed_by': 'Unknown',
+      <LockEntityStateAttribute.CHANGED_BY: 'changed_by'>: 'Unknown',
       'friendly_name': 'Mock Door Lock with unbolt',
       'supported_features': <LockEntityFeature: 1>,
     }),
@@ -195,7 +195,7 @@
 # name: test_locks[mock_lock][lock.mock_lock-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'changed_by': 'Unknown',
+      <LockEntityStateAttribute.CHANGED_BY: 'changed_by'>: 'Unknown',
       'friendly_name': 'Mock Lock',
       'supported_features': <LockEntityFeature: 1>,
     }),
@@ -247,7 +247,7 @@
 # name: test_locks[secuyou_smart_lock][lock.secuyou_smart_lock-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'changed_by': 'Unknown',
+      <LockEntityStateAttribute.CHANGED_BY: 'changed_by'>: 'Unknown',
       'friendly_name': 'Secuyou Smart Lock',
       'supported_features': <LockEntityFeature: 0>,
     }),

--- a/tests/components/yale_smart_alarm/snapshots/test_lock.ambr
+++ b/tests/components/yale_smart_alarm/snapshots/test_lock.ambr
@@ -39,7 +39,7 @@
 # name: test_lock[load_platforms0][lock.device1-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'code_format': '^\\d{6}$',
+      <LockEntityStateAttribute.CODE_FORMAT: 'code_format'>: '^\\d{6}$',
       'friendly_name': 'Device1',
       'supported_features': <LockEntityFeature: 0>,
     }),
@@ -91,7 +91,7 @@
 # name: test_lock[load_platforms0][lock.device2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'code_format': '^\\d{6}$',
+      <LockEntityStateAttribute.CODE_FORMAT: 'code_format'>: '^\\d{6}$',
       'friendly_name': 'Device2',
       'supported_features': <LockEntityFeature: 0>,
     }),
@@ -143,7 +143,7 @@
 # name: test_lock[load_platforms0][lock.device3-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'code_format': '^\\d{6}$',
+      <LockEntityStateAttribute.CODE_FORMAT: 'code_format'>: '^\\d{6}$',
       'friendly_name': 'Device3',
       'supported_features': <LockEntityFeature: 0>,
     }),
@@ -195,7 +195,7 @@
 # name: test_lock[load_platforms0][lock.device7-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'code_format': '^\\d{6}$',
+      <LockEntityStateAttribute.CODE_FORMAT: 'code_format'>: '^\\d{6}$',
       'friendly_name': 'Device7',
       'supported_features': <LockEntityFeature: 0>,
     }),
@@ -247,7 +247,7 @@
 # name: test_lock[load_platforms0][lock.device8-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'code_format': '^\\d{6}$',
+      <LockEntityStateAttribute.CODE_FORMAT: 'code_format'>: '^\\d{6}$',
       'friendly_name': 'Device8',
       'supported_features': <LockEntityFeature: 0>,
     }),
@@ -299,7 +299,7 @@
 # name: test_lock[load_platforms0][lock.device9-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'code_format': '^\\d{6}$',
+      <LockEntityStateAttribute.CODE_FORMAT: 'code_format'>: '^\\d{6}$',
       'friendly_name': 'Device9',
       'supported_features': <LockEntityFeature: 0>,
     }),


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add new `LockEntityStateAttribute` enum for the state attributes of the lock entity.

Based on https://github.com/home-assistant/architecture/discussions/1406, linked to epic https://github.com/home-assistant/epics/issues/104

A follow-up PR will formally deprecate the corresponding `ATTR_*` constants.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
