### PR TITLE
Migrate humidifier entity attributes to StrEnum

### DIFF
--- a/homeassistant/components/humidifier/__init__.py
+++ b/homeassistant/components/humidifier/__init__.py
@@ -47,7 +47,9 @@ from .const import (  # noqa: F401
     SERVICE_SET_HUMIDITY,
     SERVICE_SET_MODE,
     HumidifierAction,
+    HumidifierEntityCapabilityAttribute,
     HumidifierEntityFeature,
+    HumidifierEntityStateAttribute,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -147,10 +149,10 @@ class HumidifierEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_AT
 
     _entity_component_unrecorded_attributes = frozenset(
         {
-            ATTR_MIN_HUMIDITY,
-            ATTR_MAX_HUMIDITY,
-            ATTR_AVAILABLE_MODES,
-            ATTR_TARGET_HUMIDITY_STEP,
+            HumidifierEntityCapabilityAttribute.MIN_HUMIDITY,
+            HumidifierEntityCapabilityAttribute.MAX_HUMIDITY,
+            HumidifierEntityCapabilityAttribute.AVAILABLE_MODES,
+            HumidifierEntityCapabilityAttribute.TARGET_HUMIDITY_STEP,
         }
     )
 
@@ -171,14 +173,18 @@ class HumidifierEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_AT
     def capability_attributes(self) -> dict[str, Any]:
         """Return capability attributes."""
         data: dict[str, Any] = {
-            ATTR_MIN_HUMIDITY: self.min_humidity,
-            ATTR_MAX_HUMIDITY: self.max_humidity,
+            HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: self.min_humidity,
+            HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: self.max_humidity,
         }
         if self.target_humidity_step is not None:
-            data[ATTR_TARGET_HUMIDITY_STEP] = self.target_humidity_step
+            data[HumidifierEntityCapabilityAttribute.TARGET_HUMIDITY_STEP] = (
+                self.target_humidity_step
+            )
 
         if HumidifierEntityFeature.MODES in self.supported_features:
-            data[ATTR_AVAILABLE_MODES] = self.available_modes
+            data[HumidifierEntityCapabilityAttribute.AVAILABLE_MODES] = (
+                self.available_modes
+            )
 
         return data
 
@@ -200,16 +206,20 @@ class HumidifierEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_AT
         data: dict[str, Any] = {}
 
         if self.action is not None:
-            data[ATTR_ACTION] = self.action if self.is_on else HumidifierAction.OFF
+            data[HumidifierEntityStateAttribute.ACTION] = (
+                self.action if self.is_on else HumidifierAction.OFF
+            )
 
         if self.current_humidity is not None:
-            data[ATTR_CURRENT_HUMIDITY] = self.current_humidity
+            data[HumidifierEntityStateAttribute.CURRENT_HUMIDITY] = (
+                self.current_humidity
+            )
 
         if self.target_humidity is not None:
-            data[ATTR_HUMIDITY] = self.target_humidity
+            data[HumidifierEntityStateAttribute.HUMIDITY] = self.target_humidity
 
         if HumidifierEntityFeature.MODES in self.supported_features:
-            data[ATTR_MODE] = self.mode
+            data[HumidifierEntityStateAttribute.MODE] = self.mode
 
         return data
 

--- a/homeassistant/components/humidifier/const.py
+++ b/homeassistant/components/humidifier/const.py
@@ -39,6 +39,24 @@ SERVICE_SET_MODE = "set_mode"
 SERVICE_SET_HUMIDITY = "set_humidity"
 
 
+class HumidifierEntityCapabilityAttribute(StrEnum):
+    """Capability attributes for humidifier entities."""
+
+    MIN_HUMIDITY = "min_humidity"
+    MAX_HUMIDITY = "max_humidity"
+    TARGET_HUMIDITY_STEP = "target_humidity_step"
+    AVAILABLE_MODES = "available_modes"
+
+
+class HumidifierEntityStateAttribute(StrEnum):
+    """State attributes for humidifier entities."""
+
+    ACTION = "action"
+    CURRENT_HUMIDITY = "current_humidity"
+    HUMIDITY = "humidity"
+    MODE = "mode"
+
+
 class HumidifierEntityFeature(IntFlag):
     """Supported features of the humidifier entity."""
 

--- a/tests/components/comelit/snapshots/test_humidifier.ambr
+++ b/tests/components/comelit/snapshots/test_humidifier.ambr
@@ -6,12 +6,12 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'available_modes': list([
+      <HumidifierEntityCapabilityAttribute.AVAILABLE_MODES: 'available_modes'>: list([
         'normal',
         'auto',
       ]),
-      'max_humidity': 90,
-      'min_humidity': 10,
+      <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 90,
+      <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 10,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -46,18 +46,18 @@
 # name: test_all_entities[humidifier.climate0_dehumidifier-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'action': <HumidifierAction.OFF: 'off'>,
-      'available_modes': list([
+      <HumidifierEntityStateAttribute.ACTION: 'action'>: <HumidifierAction.OFF: 'off'>,
+      <HumidifierEntityCapabilityAttribute.AVAILABLE_MODES: 'available_modes'>: list([
         'normal',
         'auto',
       ]),
-      'current_humidity': 65.0,
+      <HumidifierEntityStateAttribute.CURRENT_HUMIDITY: 'current_humidity'>: 65.0,
       'device_class': 'dehumidifier',
       'friendly_name': 'Climate0 Dehumidifier',
-      'humidity': 50.0,
-      'max_humidity': 90,
-      'min_humidity': 10,
-      'mode': 'normal',
+      <HumidifierEntityStateAttribute.HUMIDITY: 'humidity'>: 50.0,
+      <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 90,
+      <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 10,
+      <HumidifierEntityStateAttribute.MODE: 'mode'>: 'normal',
       'supported_features': <HumidifierEntityFeature: 1>,
     }),
     'context': <ANY>,
@@ -75,12 +75,12 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'available_modes': list([
+      <HumidifierEntityCapabilityAttribute.AVAILABLE_MODES: 'available_modes'>: list([
         'normal',
         'auto',
       ]),
-      'max_humidity': 90,
-      'min_humidity': 10,
+      <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 90,
+      <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 10,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -115,18 +115,18 @@
 # name: test_all_entities[humidifier.climate0_humidifier-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'action': <HumidifierAction.IDLE: 'idle'>,
-      'available_modes': list([
+      <HumidifierEntityStateAttribute.ACTION: 'action'>: <HumidifierAction.IDLE: 'idle'>,
+      <HumidifierEntityCapabilityAttribute.AVAILABLE_MODES: 'available_modes'>: list([
         'normal',
         'auto',
       ]),
-      'current_humidity': 65.0,
+      <HumidifierEntityStateAttribute.CURRENT_HUMIDITY: 'current_humidity'>: 65.0,
       'device_class': 'humidifier',
       'friendly_name': 'Climate0 Humidifier',
-      'humidity': 50.0,
-      'max_humidity': 90,
-      'min_humidity': 10,
-      'mode': 'normal',
+      <HumidifierEntityStateAttribute.HUMIDITY: 'humidity'>: 50.0,
+      <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 90,
+      <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 10,
+      <HumidifierEntityStateAttribute.MODE: 'mode'>: 'normal',
       'supported_features': <HumidifierEntityFeature: 1>,
     }),
     'context': <ANY>,

--- a/tests/components/generic_hygrostat/snapshots/test_config_flow.ambr
+++ b/tests/components/generic_hygrostat/snapshots/test_config_flow.ambr
@@ -21,13 +21,13 @@
 # name: test_options[dehumidifier]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'action': <HumidifierAction.OFF: 'off'>,
-      'current_humidity': 10.0,
+      <HumidifierEntityStateAttribute.ACTION: 'action'>: <HumidifierAction.OFF: 'off'>,
+      <HumidifierEntityStateAttribute.CURRENT_HUMIDITY: 'current_humidity'>: 10.0,
       'device_class': 'dehumidifier',
       'friendly_name': 'My hygrostat',
-      'humidity': 100,
-      'max_humidity': 100,
-      'min_humidity': 0,
+      <HumidifierEntityStateAttribute.HUMIDITY: 'humidity'>: 100,
+      <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 100,
+      <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 0,
       'supported_features': <HumidifierEntityFeature: 0>,
     }),
     'context': <ANY>,
@@ -41,13 +41,13 @@
 # name: test_options[humidifier]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'action': <HumidifierAction.OFF: 'off'>,
-      'current_humidity': 10.0,
+      <HumidifierEntityStateAttribute.ACTION: 'action'>: <HumidifierAction.OFF: 'off'>,
+      <HumidifierEntityStateAttribute.CURRENT_HUMIDITY: 'current_humidity'>: 10.0,
       'device_class': 'humidifier',
       'friendly_name': 'My hygrostat',
-      'humidity': 100,
-      'max_humidity': 100,
-      'min_humidity': 0,
+      <HumidifierEntityStateAttribute.HUMIDITY: 'humidity'>: 100,
+      <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 100,
+      <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 0,
       'supported_features': <HumidifierEntityFeature: 0>,
     }),
     'context': <ANY>,

--- a/tests/components/homekit_controller/snapshots/test_init.ambr
+++ b/tests/components/homekit_controller/snapshots/test_init.ambr
@@ -14267,12 +14267,12 @@
             ]),
             'area_id': None,
             'capabilities': dict({
-              'available_modes': list([
+              <HumidifierEntityCapabilityAttribute.AVAILABLE_MODES: 'available_modes'>: list([
                 'normal',
                 'auto',
               ]),
-              'max_humidity': 100,
-              'min_humidity': 0,
+              <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 100,
+              <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 0,
             }),
             'config_entry_id': <ANY>,
             'config_subentry_id': <ANY>,
@@ -14305,17 +14305,17 @@
           }),
           'state': dict({
             'attributes': dict({
-              'available_modes': list([
+              <HumidifierEntityCapabilityAttribute.AVAILABLE_MODES: 'available_modes'>: list([
                 'normal',
                 'auto',
               ]),
-              'current_humidity': 0,
+              <HumidifierEntityStateAttribute.CURRENT_HUMIDITY: 'current_humidity'>: 0,
               'device_class': 'humidifier',
               'friendly_name': 'Humidifier 182A',
-              'humidity': 45,
-              'max_humidity': 100,
-              'min_humidity': 0,
-              'mode': 'normal',
+              <HumidifierEntityStateAttribute.HUMIDITY: 'humidity'>: 45,
+              <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 100,
+              <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 0,
+              <HumidifierEntityStateAttribute.MODE: 'mode'>: 'normal',
               'supported_features': <HumidifierEntityFeature: 1>,
             }),
             'entity_id': 'humidifier.humidifier_182a',
@@ -14538,12 +14538,12 @@
             ]),
             'area_id': None,
             'capabilities': dict({
-              'available_modes': list([
+              <HumidifierEntityCapabilityAttribute.AVAILABLE_MODES: 'available_modes'>: list([
                 'normal',
                 'auto',
               ]),
-              'max_humidity': 80,
-              'min_humidity': 20,
+              <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 80,
+              <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 20,
             }),
             'config_entry_id': <ANY>,
             'config_subentry_id': <ANY>,
@@ -14576,17 +14576,17 @@
           }),
           'state': dict({
             'attributes': dict({
-              'available_modes': list([
+              <HumidifierEntityCapabilityAttribute.AVAILABLE_MODES: 'available_modes'>: list([
                 'normal',
                 'auto',
               ]),
-              'current_humidity': 0,
+              <HumidifierEntityStateAttribute.CURRENT_HUMIDITY: 'current_humidity'>: 0,
               'device_class': 'humidifier',
               'friendly_name': 'Humidifier 182A',
-              'humidity': 45,
-              'max_humidity': 80,
-              'min_humidity': 20,
-              'mode': 'normal',
+              <HumidifierEntityStateAttribute.HUMIDITY: 'humidity'>: 45,
+              <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 80,
+              <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 20,
+              <HumidifierEntityStateAttribute.MODE: 'mode'>: 'normal',
               'supported_features': <HumidifierEntityFeature: 1>,
             }),
             'entity_id': 'humidifier.humidifier_182a',
@@ -24049,12 +24049,12 @@
             ]),
             'area_id': None,
             'capabilities': dict({
-              'available_modes': list([
+              <HumidifierEntityCapabilityAttribute.AVAILABLE_MODES: 'available_modes'>: list([
                 'normal',
                 'auto',
               ]),
-              'max_humidity': 100,
-              'min_humidity': 0,
+              <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 100,
+              <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 0,
             }),
             'config_entry_id': <ANY>,
             'config_subentry_id': <ANY>,
@@ -24087,17 +24087,17 @@
           }),
           'state': dict({
             'attributes': dict({
-              'available_modes': list([
+              <HumidifierEntityCapabilityAttribute.AVAILABLE_MODES: 'available_modes'>: list([
                 'normal',
                 'auto',
               ]),
-              'current_humidity': 45.0,
+              <HumidifierEntityStateAttribute.CURRENT_HUMIDITY: 'current_humidity'>: 45.0,
               'device_class': 'humidifier',
               'friendly_name': 'VOCOlinc-Flowerbud-0d324b',
-              'humidity': 100.0,
-              'max_humidity': 100,
-              'min_humidity': 0,
-              'mode': 'normal',
+              <HumidifierEntityStateAttribute.HUMIDITY: 'humidity'>: 100.0,
+              <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 100,
+              <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 0,
+              <HumidifierEntityStateAttribute.MODE: 'mode'>: 'normal',
               'supported_features': <HumidifierEntityFeature: 1>,
             }),
             'entity_id': 'humidifier.vocolinc_flowerbud_0d324b',

--- a/tests/components/honeywell/snapshots/test_humidity.ambr
+++ b/tests/components/honeywell/snapshots/test_humidity.ambr
@@ -2,12 +2,12 @@
 # name: test_static_attributes[dehumidifier]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_humidity': 50,
+      <HumidifierEntityStateAttribute.CURRENT_HUMIDITY: 'current_humidity'>: 50,
       'device_class': 'dehumidifier',
       'friendly_name': 'device1 Dehumidifier',
-      'humidity': 30,
-      'max_humidity': 55,
-      'min_humidity': 15,
+      <HumidifierEntityStateAttribute.HUMIDITY: 'humidity'>: 30,
+      <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 55,
+      <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 15,
       'supported_features': <HumidifierEntityFeature: 0>,
     }),
     'context': <ANY>,
@@ -21,12 +21,12 @@
 # name: test_static_attributes[humidifier]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_humidity': 50,
+      <HumidifierEntityStateAttribute.CURRENT_HUMIDITY: 'current_humidity'>: 50,
       'device_class': 'humidifier',
       'friendly_name': 'device1 Humidifier',
-      'humidity': 20,
-      'max_humidity': 60,
-      'min_humidity': 10,
+      <HumidifierEntityStateAttribute.HUMIDITY: 'humidity'>: 20,
+      <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 60,
+      <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 10,
       'supported_features': <HumidifierEntityFeature: 0>,
     }),
     'context': <ANY>,

--- a/tests/components/lg_thinq/snapshots/test_humidifier.ambr
+++ b/tests/components/lg_thinq/snapshots/test_humidifier.ambr
@@ -6,16 +6,16 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'available_modes': list([
+      <HumidifierEntityCapabilityAttribute.AVAILABLE_MODES: 'available_modes'>: list([
         'smart_humidity',
         'intensive_dry',
         'rapid_humidity',
         'quiet_humidity',
         'clothes_dry',
       ]),
-      'max_humidity': 70,
-      'min_humidity': 30,
-      'target_humidity_step': 5,
+      <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 70,
+      <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 30,
+      <HumidifierEntityCapabilityAttribute.TARGET_HUMIDITY_STEP: 'target_humidity_step'>: 5,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -50,23 +50,23 @@
 # name: test_humidifier_entities[dehumidifier][humidifier.test_dehumidifier-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'action': <HumidifierAction.DRYING: 'drying'>,
-      'available_modes': list([
+      <HumidifierEntityStateAttribute.ACTION: 'action'>: <HumidifierAction.DRYING: 'drying'>,
+      <HumidifierEntityCapabilityAttribute.AVAILABLE_MODES: 'available_modes'>: list([
         'smart_humidity',
         'intensive_dry',
         'rapid_humidity',
         'quiet_humidity',
         'clothes_dry',
       ]),
-      'current_humidity': 80,
+      <HumidifierEntityStateAttribute.CURRENT_HUMIDITY: 'current_humidity'>: 80,
       'device_class': 'dehumidifier',
       'friendly_name': 'Test dehumidifier',
-      'humidity': 55,
-      'max_humidity': 70,
-      'min_humidity': 30,
-      'mode': 'smart_humidity',
+      <HumidifierEntityStateAttribute.HUMIDITY: 'humidity'>: 55,
+      <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 70,
+      <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 30,
+      <HumidifierEntityStateAttribute.MODE: 'mode'>: 'smart_humidity',
       'supported_features': <HumidifierEntityFeature: 1>,
-      'target_humidity_step': 5,
+      <HumidifierEntityCapabilityAttribute.TARGET_HUMIDITY_STEP: 'target_humidity_step'>: 5,
     }),
     'context': <ANY>,
     'entity_id': 'humidifier.test_dehumidifier',

--- a/tests/components/switchbot_cloud/snapshots/test_humidifier.ambr
+++ b/tests/components/switchbot_cloud/snapshots/test_humidifier.ambr
@@ -6,12 +6,12 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'available_modes': list([
+      <HumidifierEntityCapabilityAttribute.AVAILABLE_MODES: 'available_modes'>: list([
         'normal',
         'auto',
       ]),
-      'max_humidity': 100,
-      'min_humidity': 1,
+      <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 100,
+      <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 1,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -46,17 +46,17 @@
 # name: test_humidifier[device_info0-6][humidifier.humidifier_1-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'available_modes': list([
+      <HumidifierEntityCapabilityAttribute.AVAILABLE_MODES: 'available_modes'>: list([
         'normal',
         'auto',
       ]),
-      'current_humidity': 50,
+      <HumidifierEntityStateAttribute.CURRENT_HUMIDITY: 'current_humidity'>: 50,
       'device_class': 'humidifier',
       'friendly_name': 'humidifier-1',
-      'humidity': 50,
-      'max_humidity': 100,
-      'min_humidity': 1,
-      'mode': 'normal',
+      <HumidifierEntityStateAttribute.HUMIDITY: 'humidity'>: 50,
+      <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 100,
+      <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 1,
+      <HumidifierEntityStateAttribute.MODE: 'mode'>: 'normal',
       'supported_features': <HumidifierEntityFeature: 1>,
     }),
     'context': <ANY>,
@@ -74,7 +74,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'available_modes': list([
+      <HumidifierEntityCapabilityAttribute.AVAILABLE_MODES: 'available_modes'>: list([
         'high',
         'medium',
         'low',
@@ -84,8 +84,8 @@
         'auto',
         'drying_filter',
       ]),
-      'max_humidity': 100,
-      'min_humidity': 0,
+      <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 100,
+      <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 0,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -120,7 +120,7 @@
 # name: test_humidifier[device_info1-7][humidifier.humidifier2_1-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'available_modes': list([
+      <HumidifierEntityCapabilityAttribute.AVAILABLE_MODES: 'available_modes'>: list([
         'high',
         'medium',
         'low',
@@ -130,13 +130,13 @@
         'auto',
         'drying_filter',
       ]),
-      'current_humidity': 50,
+      <HumidifierEntityStateAttribute.CURRENT_HUMIDITY: 'current_humidity'>: 50,
       'device_class': 'humidifier',
       'friendly_name': 'humidifier2-1',
-      'humidity': 50,
-      'max_humidity': 100,
-      'min_humidity': 0,
-      'mode': 'high',
+      <HumidifierEntityStateAttribute.HUMIDITY: 'humidity'>: 50,
+      <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 100,
+      <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 0,
+      <HumidifierEntityStateAttribute.MODE: 'mode'>: 'high',
       'supported_features': <HumidifierEntityFeature: 1>,
     }),
     'context': <ANY>,

--- a/tests/components/tuya/snapshots/test_humidifier.ambr
+++ b/tests/components/tuya/snapshots/test_humidifier.ambr
@@ -6,8 +6,8 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'max_humidity': 100,
-      'min_humidity': 0,
+      <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 100,
+      <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 0,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -42,11 +42,11 @@
 # name: test_platform_setup_and_discovery[humidifier.arida_stavern-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_humidity': 61,
+      <HumidifierEntityStateAttribute.CURRENT_HUMIDITY: 'current_humidity'>: 61,
       'device_class': 'dehumidifier',
       'friendly_name': 'Arida Stavern ',
-      'max_humidity': 100,
-      'min_humidity': 0,
+      <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 100,
+      <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 0,
       'supported_features': <HumidifierEntityFeature: 0>,
     }),
     'context': <ANY>,
@@ -64,8 +64,8 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'max_humidity': 100,
-      'min_humidity': 0,
+      <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 100,
+      <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 0,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -100,11 +100,11 @@
 # name: test_platform_setup_and_discovery[humidifier.d825a_i-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_humidity': 76,
+      <HumidifierEntityStateAttribute.CURRENT_HUMIDITY: 'current_humidity'>: 76,
       'device_class': 'dehumidifier',
       'friendly_name': 'D825A I',
-      'max_humidity': 100,
-      'min_humidity': 0,
+      <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 100,
+      <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 0,
       'supported_features': <HumidifierEntityFeature: 0>,
     }),
     'context': <ANY>,
@@ -122,8 +122,8 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'max_humidity': 80,
-      'min_humidity': 25,
+      <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 80,
+      <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 25,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -160,8 +160,8 @@
     'attributes': ReadOnlyDict({
       'device_class': 'dehumidifier',
       'friendly_name': 'Dehumidifer',
-      'max_humidity': 80,
-      'min_humidity': 25,
+      <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 80,
+      <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 25,
       'supported_features': <HumidifierEntityFeature: 0>,
     }),
     'context': <ANY>,
@@ -179,8 +179,8 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'max_humidity': 70,
-      'min_humidity': 35,
+      <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 70,
+      <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 35,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -215,12 +215,12 @@
 # name: test_platform_setup_and_discovery[humidifier.dehumidifier-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_humidity': 47,
+      <HumidifierEntityStateAttribute.CURRENT_HUMIDITY: 'current_humidity'>: 47,
       'device_class': 'dehumidifier',
       'friendly_name': 'Dehumidifier',
-      'humidity': 50,
-      'max_humidity': 70,
-      'min_humidity': 35,
+      <HumidifierEntityStateAttribute.HUMIDITY: 'humidity'>: 50,
+      <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 70,
+      <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 35,
       'supported_features': <HumidifierEntityFeature: 0>,
     }),
     'context': <ANY>,
@@ -238,8 +238,8 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'max_humidity': 80,
-      'min_humidity': 30,
+      <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 80,
+      <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 30,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -274,12 +274,12 @@
 # name: test_platform_setup_and_discovery[humidifier.deshumidificateur_silencieux_omnidry_20l_avec_mode_linge-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_humidity': 72,
+      <HumidifierEntityStateAttribute.CURRENT_HUMIDITY: 'current_humidity'>: 72,
       'device_class': 'dehumidifier',
       'friendly_name': 'Déshumidificateur Silencieux OmniDry 20L avec Mode Linge',
-      'humidity': 65,
-      'max_humidity': 80,
-      'min_humidity': 30,
+      <HumidifierEntityStateAttribute.HUMIDITY: 'humidity'>: 65,
+      <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 80,
+      <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 30,
       'supported_features': <HumidifierEntityFeature: 0>,
     }),
     'context': <ANY>,
@@ -297,8 +297,8 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'max_humidity': 100,
-      'min_humidity': 0,
+      <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 100,
+      <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 0,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -335,8 +335,8 @@
     'attributes': ReadOnlyDict({
       'device_class': 'humidifier',
       'friendly_name': 'KLARTA HUMEA',
-      'max_humidity': 100,
-      'min_humidity': 0,
+      <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 100,
+      <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 0,
       'supported_features': <HumidifierEntityFeature: 0>,
     }),
     'context': <ANY>,
@@ -354,8 +354,8 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'max_humidity': 80,
-      'min_humidity': 25,
+      <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 80,
+      <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 25,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -390,12 +390,12 @@
 # name: test_platform_setup_and_discovery[humidifier.living_room_dehumidifier-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_humidity': 48,
+      <HumidifierEntityStateAttribute.CURRENT_HUMIDITY: 'current_humidity'>: 48,
       'device_class': 'dehumidifier',
       'friendly_name': 'Living room dehumidifier',
-      'humidity': 47,
-      'max_humidity': 80,
-      'min_humidity': 25,
+      <HumidifierEntityStateAttribute.HUMIDITY: 'humidity'>: 47,
+      <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 80,
+      <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 25,
       'supported_features': <HumidifierEntityFeature: 0>,
     }),
     'context': <ANY>,

--- a/tests/components/vesync/snapshots/test_humidifier.ambr
+++ b/tests/components/vesync/snapshots/test_humidifier.ambr
@@ -336,12 +336,12 @@
       ]),
       'area_id': None,
       'capabilities': dict({
-        'available_modes': list([
+        <HumidifierEntityCapabilityAttribute.AVAILABLE_MODES: 'available_modes'>: list([
           'auto',
           'normal',
         ]),
-        'max_humidity': 80,
-        'min_humidity': 30,
+        <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 80,
+        <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 30,
       }),
       'config_entry_id': <ANY>,
       'config_subentry_id': <ANY>,
@@ -377,16 +377,16 @@
 # name: test_humidifier_state[Humidifier 200s][humidifier.humidifier_200s]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'available_modes': list([
+      <HumidifierEntityCapabilityAttribute.AVAILABLE_MODES: 'available_modes'>: list([
         'auto',
         'normal',
       ]),
-      'current_humidity': 35,
+      <HumidifierEntityStateAttribute.CURRENT_HUMIDITY: 'current_humidity'>: 35,
       'friendly_name': 'Humidifier 200s',
-      'humidity': 40,
-      'max_humidity': 80,
-      'min_humidity': 30,
-      'mode': 'normal',
+      <HumidifierEntityStateAttribute.HUMIDITY: 'humidity'>: 40,
+      <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 80,
+      <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 30,
+      <HumidifierEntityStateAttribute.MODE: 'mode'>: 'normal',
       'supported_features': <HumidifierEntityFeature: 1>,
     }),
     'context': <ANY>,
@@ -438,14 +438,14 @@
       ]),
       'area_id': None,
       'capabilities': dict({
-        'available_modes': list([
+        <HumidifierEntityCapabilityAttribute.AVAILABLE_MODES: 'available_modes'>: list([
           'auto',
           'humidity',
           'normal',
           'sleep',
         ]),
-        'max_humidity': 80,
-        'min_humidity': 30,
+        <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 80,
+        <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 30,
       }),
       'config_entry_id': <ANY>,
       'config_subentry_id': <ANY>,
@@ -481,18 +481,18 @@
 # name: test_humidifier_state[Humidifier 6000s][humidifier.humidifier_6000s]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'available_modes': list([
+      <HumidifierEntityCapabilityAttribute.AVAILABLE_MODES: 'available_modes'>: list([
         'auto',
         'humidity',
         'normal',
         'sleep',
       ]),
-      'current_humidity': 36,
+      <HumidifierEntityStateAttribute.CURRENT_HUMIDITY: 'current_humidity'>: 36,
       'friendly_name': 'Humidifier 6000s',
-      'humidity': 40,
-      'max_humidity': 80,
-      'min_humidity': 30,
-      'mode': 'humidity',
+      <HumidifierEntityStateAttribute.HUMIDITY: 'humidity'>: 40,
+      <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 80,
+      <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 30,
+      <HumidifierEntityStateAttribute.MODE: 'mode'>: 'humidity',
       'supported_features': <HumidifierEntityFeature: 1>,
     }),
     'context': <ANY>,
@@ -544,13 +544,13 @@
       ]),
       'area_id': None,
       'capabilities': dict({
-        'available_modes': list([
+        <HumidifierEntityCapabilityAttribute.AVAILABLE_MODES: 'available_modes'>: list([
           'auto',
           'normal',
           'sleep',
         ]),
-        'max_humidity': 80,
-        'min_humidity': 30,
+        <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 80,
+        <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 30,
       }),
       'config_entry_id': <ANY>,
       'config_subentry_id': <ANY>,
@@ -586,17 +586,17 @@
 # name: test_humidifier_state[Humidifier 600S][humidifier.humidifier_600s]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'available_modes': list([
+      <HumidifierEntityCapabilityAttribute.AVAILABLE_MODES: 'available_modes'>: list([
         'auto',
         'normal',
         'sleep',
       ]),
-      'current_humidity': 35,
+      <HumidifierEntityStateAttribute.CURRENT_HUMIDITY: 'current_humidity'>: 35,
       'friendly_name': 'Humidifier 600S',
-      'humidity': 40,
-      'max_humidity': 80,
-      'min_humidity': 30,
-      'mode': 'normal',
+      <HumidifierEntityStateAttribute.HUMIDITY: 'humidity'>: 40,
+      <HumidifierEntityCapabilityAttribute.MAX_HUMIDITY: 'max_humidity'>: 80,
+      <HumidifierEntityCapabilityAttribute.MIN_HUMIDITY: 'min_humidity'>: 30,
+      <HumidifierEntityStateAttribute.MODE: 'mode'>: 'normal',
       'supported_features': <HumidifierEntityFeature: 1>,
     }),
     'context': <ANY>,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add new `HumidifierEntityCapabilityAttribute` enum for the capability attributes and new `HumidifierEntityStateAttribute` enum for the state attributes of the humidifier entity.

Based on https://github.com/home-assistant/architecture/discussions/1406, linked to epic https://github.com/home-assistant/epics/issues/104

A follow-up PR will formally deprecate the corresponding `ATTR_*` constants.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
