### PR TITLE
Migrate fan entity attributes to StrEnum

### DIFF
--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -29,6 +29,8 @@ from homeassistant.util.percentage import (
     ranged_value_to_percentage,
 )
 
+from .const import FanEntityCapabilityAttribute, FanEntityStateAttribute
+
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "fan"
@@ -202,7 +204,9 @@ CACHED_PROPERTIES_WITH_ATTR_ = {
 class FanEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     """Base class for fan entities."""
 
-    _entity_component_unrecorded_attributes = frozenset({ATTR_PRESET_MODES})
+    _entity_component_unrecorded_attributes = frozenset(
+        {FanEntityCapabilityAttribute.PRESET_MODES}
+    )
 
     entity_description: FanEntityDescription
     _attr_current_direction: str | None = None
@@ -372,14 +376,14 @@ class FanEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     @override
     def capability_attributes(self) -> dict[str, list[str] | None]:
         """Return capability attributes."""
-        attrs = {}
+        attrs: dict[str, list[str] | None] = {}
         supported_features = self.supported_features
 
         if (
             FanEntityFeature.SET_SPEED in supported_features
             or FanEntityFeature.PRESET_MODE in supported_features
         ):
-            attrs[ATTR_PRESET_MODES] = self.preset_modes
+            attrs[FanEntityCapabilityAttribute.PRESET_MODES] = self.preset_modes
 
         return attrs
 
@@ -392,19 +396,19 @@ class FanEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         supported_features = self.supported_features
 
         if FanEntityFeature.DIRECTION in supported_features:
-            data[ATTR_DIRECTION] = self.current_direction
+            data[FanEntityStateAttribute.DIRECTION] = self.current_direction
 
         if FanEntityFeature.OSCILLATE in supported_features:
-            data[ATTR_OSCILLATING] = self.oscillating
+            data[FanEntityStateAttribute.OSCILLATING] = self.oscillating
 
         has_set_speed = FanEntityFeature.SET_SPEED in supported_features
 
         if has_set_speed:
-            data[ATTR_PERCENTAGE] = self.percentage
-            data[ATTR_PERCENTAGE_STEP] = self.percentage_step
+            data[FanEntityStateAttribute.PERCENTAGE] = self.percentage
+            data[FanEntityStateAttribute.PERCENTAGE_STEP] = self.percentage_step
 
         if has_set_speed or FanEntityFeature.PRESET_MODE in supported_features:
-            data[ATTR_PRESET_MODE] = self.preset_mode
+            data[FanEntityStateAttribute.PRESET_MODE] = self.preset_mode
 
         return data
 

--- a/homeassistant/components/fan/const.py
+++ b/homeassistant/components/fan/const.py
@@ -1,0 +1,19 @@
+"""Constants for the fan component."""
+
+from enum import StrEnum
+
+
+class FanEntityCapabilityAttribute(StrEnum):
+    """Capability attributes for fan entities."""
+
+    PRESET_MODES = "preset_modes"
+
+
+class FanEntityStateAttribute(StrEnum):
+    """State attributes for fan entities."""
+
+    DIRECTION = "direction"
+    OSCILLATING = "oscillating"
+    PERCENTAGE = "percentage"
+    PERCENTAGE_STEP = "percentage_step"
+    PRESET_MODE = "preset_mode"

--- a/tests/components/balboa/snapshots/test_fan.ambr
+++ b/tests/components/balboa/snapshots/test_fan.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -42,10 +42,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'FakeSpa Pump 1',
-      'percentage': 0,
-      'percentage_step': 50.0,
-      'preset_mode': None,
-      'preset_modes': None,
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 0,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 50.0,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
       'supported_features': <FanEntityFeature: 49>,
     }),
     'context': <ANY>,

--- a/tests/components/compit/snapshots/test_fan.ambr
+++ b/tests/components/compit/snapshots/test_fan.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -42,10 +42,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Nano Color 2',
-      'percentage': 60,
-      'percentage_step': 20.0,
-      'preset_mode': None,
-      'preset_modes': None,
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 60,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 20.0,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
       'supported_features': <FanEntityFeature: 49>,
     }),
     'context': <ANY>,

--- a/tests/components/deconz/snapshots/test_fan.ambr
+++ b/tests/components/deconz/snapshots/test_fan.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -42,10 +42,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Ceiling fan',
-      'percentage': 100,
-      'percentage_step': 1.0,
-      'preset_mode': None,
-      'preset_modes': None,
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 100,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 1.0,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
       'supported_features': <FanEntityFeature: 49>,
     }),
     'context': <ANY>,

--- a/tests/components/duco/snapshots/test_fan.ambr
+++ b/tests/components/duco/snapshots/test_fan.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': list([
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'auto',
       ]),
     }),
@@ -44,10 +44,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Living',
-      'percentage': None,
-      'percentage_step': 33.333333333333336,
-      'preset_mode': 'auto',
-      'preset_modes': list([
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: None,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 33.333333333333336,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: 'auto',
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'auto',
       ]),
       'supported_features': <FanEntityFeature: 9>,

--- a/tests/components/helty/snapshots/test_fan.ambr
+++ b/tests/components/helty/snapshots/test_fan.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': list([
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'boost',
         'night',
         'free_cooling',
@@ -46,10 +46,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'VMC Soggiorno',
-      'percentage': 25,
-      'percentage_step': 25.0,
-      'preset_mode': None,
-      'preset_modes': list([
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 25,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 25.0,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'boost',
         'night',
         'free_cooling',

--- a/tests/components/homee/snapshots/test_fan.ambr
+++ b/tests/components/homee/snapshots/test_fan.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': list([
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'manual',
         'auto',
         'summer',
@@ -46,10 +46,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Fan',
-      'percentage': 37,
-      'percentage_step': 12.5,
-      'preset_mode': 'manual',
-      'preset_modes': list([
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 37,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 12.5,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: 'manual',
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'manual',
         'auto',
         'summer',

--- a/tests/components/homekit_controller/snapshots/test_init.ambr
+++ b/tests/components/homekit_controller/snapshots/test_init.ambr
@@ -84,7 +84,7 @@
             ]),
             'area_id': None,
             'capabilities': dict({
-              'preset_modes': list([
+              <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
                 'auto',
               ]),
             }),
@@ -120,10 +120,10 @@
           'state': dict({
             'attributes': dict({
               'friendly_name': 'Airversa AP2 1808 AirPurifier',
-              'percentage': 0,
-              'percentage_step': 20.0,
-              'preset_mode': 'auto',
-              'preset_modes': list([
+              <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 0,
+              <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 20.0,
+              <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: 'auto',
+              <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
                 'auto',
               ]),
               'supported_features': <FanEntityFeature: 57>,
@@ -11013,7 +11013,7 @@
             ]),
             'area_id': None,
             'capabilities': dict({
-              'preset_modes': list([
+              <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
               ]),
             }),
             'config_entry_id': <ANY>,
@@ -11048,10 +11048,10 @@
           'state': dict({
             'attributes': dict({
               'friendly_name': 'HAA-C718B3',
-              'percentage': 66,
-              'percentage_step': 33.333333333333336,
-              'preset_mode': None,
-              'preset_modes': list([
+              <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 66,
+              <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 33.333333333333336,
+              <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+              <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
               ]),
               'supported_features': <FanEntityFeature: 49>,
             }),
@@ -11706,7 +11706,7 @@
             ]),
             'area_id': None,
             'capabilities': dict({
-              'preset_modes': list([
+              <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
               ]),
             }),
             'config_entry_id': <ANY>,
@@ -11741,10 +11741,10 @@
           'state': dict({
             'attributes': dict({
               'friendly_name': 'Ceiling Fan',
-              'percentage': 0,
-              'percentage_step': 1.0,
-              'preset_mode': None,
-              'preset_modes': list([
+              <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 0,
+              <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 1.0,
+              <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+              <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
               ]),
               'supported_features': <FanEntityFeature: 49>,
             }),
@@ -11915,7 +11915,7 @@
             ]),
             'area_id': None,
             'capabilities': dict({
-              'preset_modes': list([
+              <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
               ]),
             }),
             'config_entry_id': <ANY>,
@@ -11949,12 +11949,12 @@
           }),
           'state': dict({
             'attributes': dict({
-              'direction': 'forward',
+              <FanEntityStateAttribute.DIRECTION: 'direction'>: 'forward',
               'friendly_name': 'Living Room Fan',
-              'percentage': 0,
-              'percentage_step': 1.0,
-              'preset_mode': None,
-              'preset_modes': list([
+              <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 0,
+              <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 1.0,
+              <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+              <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
               ]),
               'supported_features': <FanEntityFeature: 53>,
             }),
@@ -12117,7 +12117,7 @@
             ]),
             'area_id': None,
             'capabilities': dict({
-              'preset_modes': list([
+              <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
                 'auto',
               ]),
             }),
@@ -12153,11 +12153,11 @@
           'state': dict({
             'attributes': dict({
               'friendly_name': '89 Living Room',
-              'oscillating': False,
-              'percentage': 33,
-              'percentage_step': 33.333333333333336,
-              'preset_mode': None,
-              'preset_modes': list([
+              <FanEntityStateAttribute.OSCILLATING: 'oscillating'>: False,
+              <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 33,
+              <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 33.333333333333336,
+              <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+              <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
                 'auto',
               ]),
               'supported_features': <FanEntityFeature: 59>,
@@ -13183,7 +13183,7 @@
             ]),
             'area_id': None,
             'capabilities': dict({
-              'preset_modes': list([
+              <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
               ]),
             }),
             'config_entry_id': <ANY>,
@@ -13218,10 +13218,10 @@
           'state': dict({
             'attributes': dict({
               'friendly_name': 'Ceiling Fan',
-              'percentage': 0,
-              'percentage_step': 1.0,
-              'preset_mode': None,
-              'preset_modes': list([
+              <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 0,
+              <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 1.0,
+              <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+              <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
               ]),
               'supported_features': <FanEntityFeature: 49>,
             }),
@@ -13392,7 +13392,7 @@
             ]),
             'area_id': None,
             'capabilities': dict({
-              'preset_modes': list([
+              <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
               ]),
             }),
             'config_entry_id': <ANY>,
@@ -13426,13 +13426,13 @@
           }),
           'state': dict({
             'attributes': dict({
-              'direction': 'forward',
+              <FanEntityStateAttribute.DIRECTION: 'direction'>: 'forward',
               'friendly_name': 'Living Room Fan',
-              'oscillating': False,
-              'percentage': 0,
-              'percentage_step': 1.0,
-              'preset_mode': None,
-              'preset_modes': list([
+              <FanEntityStateAttribute.OSCILLATING: 'oscillating'>: False,
+              <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 0,
+              <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 1.0,
+              <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+              <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
               ]),
               'supported_features': <FanEntityFeature: 55>,
             }),
@@ -13607,7 +13607,7 @@
             ]),
             'area_id': None,
             'capabilities': dict({
-              'preset_modes': list([
+              <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
               ]),
             }),
             'config_entry_id': <ANY>,
@@ -13641,13 +13641,13 @@
           }),
           'state': dict({
             'attributes': dict({
-              'direction': 'forward',
+              <FanEntityStateAttribute.DIRECTION: 'direction'>: 'forward',
               'friendly_name': 'Living Room Fan',
-              'oscillating': False,
-              'percentage': 0,
-              'percentage_step': 1.0,
-              'preset_mode': None,
-              'preset_modes': list([
+              <FanEntityStateAttribute.OSCILLATING: 'oscillating'>: False,
+              <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 0,
+              <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 1.0,
+              <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+              <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
               ]),
               'supported_features': <FanEntityFeature: 55>,
             }),
@@ -13819,7 +13819,7 @@
             ]),
             'area_id': None,
             'capabilities': dict({
-              'preset_modes': list([
+              <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
                 'auto',
               ]),
             }),
@@ -13855,11 +13855,11 @@
           'state': dict({
             'attributes': dict({
               'friendly_name': '89 Living Room',
-              'oscillating': False,
-              'percentage': 33,
-              'percentage_step': 33.333333333333336,
-              'preset_mode': None,
-              'preset_modes': list([
+              <FanEntityStateAttribute.OSCILLATING: 'oscillating'>: False,
+              <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 33,
+              <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 33.333333333333336,
+              <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+              <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
                 'auto',
               ]),
               'supported_features': <FanEntityFeature: 59>,
@@ -18468,7 +18468,7 @@
             ]),
             'area_id': None,
             'capabilities': dict({
-              'preset_modes': list([
+              <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
               ]),
             }),
             'config_entry_id': <ANY>,
@@ -18503,10 +18503,10 @@
           'state': dict({
             'attributes': dict({
               'friendly_name': 'Caséta® Wireless Fan Speed Control',
-              'percentage': 0,
-              'percentage_step': 25.0,
-              'preset_mode': None,
-              'preset_modes': list([
+              <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 0,
+              <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 25.0,
+              <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+              <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
               ]),
               'supported_features': <FanEntityFeature: 49>,
             }),
@@ -22377,7 +22377,7 @@
             ]),
             'area_id': None,
             'capabilities': dict({
-              'preset_modes': list([
+              <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
               ]),
             }),
             'config_entry_id': <ANY>,
@@ -22411,12 +22411,12 @@
           }),
           'state': dict({
             'attributes': dict({
-              'direction': 'forward',
+              <FanEntityStateAttribute.DIRECTION: 'direction'>: 'forward',
               'friendly_name': 'SIMPLEconnect Fan-06F674 Hunter Fan',
-              'percentage': 0,
-              'percentage_step': 25.0,
-              'preset_mode': None,
-              'preset_modes': list([
+              <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 0,
+              <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 25.0,
+              <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+              <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
               ]),
               'supported_features': <FanEntityFeature: 53>,
             }),

--- a/tests/components/intelliclima/snapshots/test_fan.ambr
+++ b/tests/components/intelliclima/snapshots/test_fan.ambr
@@ -45,7 +45,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': list([
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'auto',
       ]),
     }),
@@ -83,10 +83,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test VMC',
-      'percentage': 75,
-      'percentage_step': 25.0,
-      'preset_mode': None,
-      'preset_modes': list([
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 75,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 25.0,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'auto',
       ]),
       'supported_features': <FanEntityFeature: 57>,

--- a/tests/components/lg_thinq/snapshots/test_fan.ambr
+++ b/tests/components/lg_thinq/snapshots/test_fan.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -42,10 +42,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test hood Hood',
-      'percentage': 20,
-      'percentage_step': 20.0,
-      'preset_mode': None,
-      'preset_modes': None,
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 20,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 20.0,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
       'supported_features': <FanEntityFeature: 49>,
     }),
     'context': <ANY>,

--- a/tests/components/lutron/snapshots/test_fan.ambr
+++ b/tests/components/lutron/snapshots/test_fan.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -42,10 +42,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Fan',
-      'percentage': 0,
-      'percentage_step': 33.333333333333336,
-      'preset_mode': None,
-      'preset_modes': None,
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 0,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 33.333333333333336,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
       'supported_features': <FanEntityFeature: 49>,
     }),
     'context': <ANY>,

--- a/tests/components/matter/snapshots/test_fan.ambr
+++ b/tests/components/matter/snapshots/test_fan.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': list([
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'low',
         'medium',
         'high',
@@ -47,10 +47,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Longan link HVAC',
-      'percentage': 0,
-      'percentage_step': 1.0,
-      'preset_mode': None,
-      'preset_modes': list([
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 0,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 1.0,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'low',
         'medium',
         'high',
@@ -73,7 +73,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': list([
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'low',
         'medium',
         'high',
@@ -115,13 +115,13 @@
 # name: test_fans[mock_air_purifier][fan.mock_air_purifier-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'direction': 'forward',
+      <FanEntityStateAttribute.DIRECTION: 'direction'>: 'forward',
       'friendly_name': 'Mock Air Purifier',
-      'oscillating': False,
-      'percentage': None,
-      'percentage_step': 10.0,
-      'preset_mode': 'auto',
-      'preset_modes': list([
+      <FanEntityStateAttribute.OSCILLATING: 'oscillating'>: False,
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: None,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 10.0,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: 'auto',
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'low',
         'medium',
         'high',
@@ -146,7 +146,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': list([
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'low',
         'medium',
         'high',
@@ -186,10 +186,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Extractor hood',
-      'percentage': 0,
-      'percentage_step': 1.0,
-      'preset_mode': None,
-      'preset_modes': list([
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 0,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 1.0,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'low',
         'medium',
         'high',
@@ -211,7 +211,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': list([
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'low',
         'medium',
         'high',
@@ -254,10 +254,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mocked Fan Switch',
-      'percentage': 0,
-      'percentage_step': 33.333333333333336,
-      'preset_mode': None,
-      'preset_modes': list([
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 0,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 33.333333333333336,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'low',
         'medium',
         'high',
@@ -282,7 +282,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': list([
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'low',
         'medium',
         'high',
@@ -324,10 +324,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Room AirConditioner',
-      'percentage': 0,
-      'percentage_step': 33.333333333333336,
-      'preset_mode': None,
-      'preset_modes': list([
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 0,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 33.333333333333336,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'low',
         'medium',
         'high',
@@ -351,7 +351,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': list([
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'low',
         'medium',
         'high',
@@ -393,13 +393,13 @@
 # name: test_fans[silabs_fan][fan.sl_fan-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'direction': 'forward',
+      <FanEntityStateAttribute.DIRECTION: 'direction'>: 'forward',
       'friendly_name': 'SL_Fan',
-      'oscillating': False,
-      'percentage': 30,
-      'percentage_step': 10.0,
-      'preset_mode': 'low',
-      'preset_modes': list([
+      <FanEntityStateAttribute.OSCILLATING: 'oscillating'>: False,
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 30,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 10.0,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: 'low',
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'low',
         'medium',
         'high',
@@ -424,7 +424,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': list([
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'low',
         'medium',
         'high',
@@ -464,10 +464,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'SL-RangeHood',
-      'percentage': 0,
-      'percentage_step': 1.0,
-      'preset_mode': None,
-      'preset_modes': list([
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 0,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 1.0,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'low',
         'medium',
         'high',

--- a/tests/components/miele/snapshots/test_fan.ambr
+++ b/tests/components/miele/snapshots/test_fan.ambr
@@ -110,7 +110,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -146,10 +146,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Hood Fan',
-      'percentage': 0,
-      'percentage_step': 25.0,
-      'preset_mode': None,
-      'preset_modes': None,
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 0,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 25.0,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
       'supported_features': <FanEntityFeature: 49>,
     }),
     'context': <ANY>,
@@ -167,7 +167,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -203,10 +203,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Hood Fan',
-      'percentage': 0,
-      'percentage_step': 25.0,
-      'preset_mode': None,
-      'preset_modes': None,
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 0,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 25.0,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
       'supported_features': <FanEntityFeature: 49>,
     }),
     'context': <ANY>,

--- a/tests/components/netatmo/snapshots/test_fan.ambr
+++ b/tests/components/netatmo/snapshots/test_fan.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': list([
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'slow',
         'fast',
       ]),
@@ -46,8 +46,8 @@
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by Netatmo',
       'friendly_name': 'Centralized ventilation controler',
-      'preset_mode': 'slow',
-      'preset_modes': list([
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: 'slow',
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'slow',
         'fast',
       ]),

--- a/tests/components/overkiz/snapshots/test_fan.ambr
+++ b/tests/components/overkiz/snapshots/test_fan.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -42,10 +42,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Living Room Air Inlet',
-      'percentage': 40,
-      'percentage_step': 1.0,
-      'preset_mode': None,
-      'preset_modes': None,
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 40,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 1.0,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
       'supported_features': <FanEntityFeature: 49>,
     }),
     'context': <ANY>,
@@ -63,7 +63,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -99,10 +99,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Living Room Air Outlet',
-      'percentage': 0,
-      'percentage_step': 1.0,
-      'preset_mode': None,
-      'preset_modes': None,
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 0,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 1.0,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
       'supported_features': <FanEntityFeature: 49>,
     }),
     'context': <ANY>,
@@ -120,7 +120,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -156,10 +156,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Living Room Air Transfer',
-      'percentage': 75,
-      'percentage_step': 1.0,
-      'preset_mode': None,
-      'preset_modes': None,
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 75,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 1.0,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
       'supported_features': <FanEntityFeature: 49>,
     }),
     'context': <ANY>,

--- a/tests/components/prana/snapshots/test_fan.ambr
+++ b/tests/components/prana/snapshots/test_fan.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': list([
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'night',
         'boost',
       ]),
@@ -45,10 +45,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'PRANA RECUPERATOR Extract fan',
-      'percentage': 10,
-      'percentage_step': 10.0,
-      'preset_mode': None,
-      'preset_modes': list([
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 10,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 10.0,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'night',
         'boost',
       ]),
@@ -69,7 +69,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': list([
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'night',
         'boost',
       ]),
@@ -108,10 +108,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'PRANA RECUPERATOR Supply fan',
-      'percentage': 10,
-      'percentage_step': 10.0,
-      'preset_mode': None,
-      'preset_modes': list([
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 10,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 10.0,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'night',
         'boost',
       ]),

--- a/tests/components/smartthings/snapshots/test_fan.ambr
+++ b/tests/components/smartthings/snapshots/test_fan.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': list([
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'auto',
         'low',
         'medium',
@@ -48,8 +48,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Air purifier',
-      'preset_mode': 'auto',
-      'preset_modes': list([
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: 'auto',
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'auto',
         'low',
         'medium',
@@ -73,7 +73,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': list([
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'auto',
         'low',
         'medium',
@@ -115,8 +115,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Air filter',
-      'preset_mode': 'auto',
-      'preset_modes': list([
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: 'auto',
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'auto',
         'low',
         'medium',
@@ -140,7 +140,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': list([
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'smart',
       ]),
     }),
@@ -178,10 +178,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Range hood',
-      'percentage': 25,
-      'percentage_step': 25.0,
-      'preset_mode': None,
-      'preset_modes': list([
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 25,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 25.0,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'smart',
       ]),
       'supported_features': <FanEntityFeature: 57>,
@@ -201,7 +201,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': list([
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'auto',
         'low',
         'medium',
@@ -243,10 +243,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Fake fan',
-      'percentage': 2000,
-      'percentage_step': 33.333333333333336,
-      'preset_mode': None,
-      'preset_modes': list([
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 2000,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 33.333333333333336,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'auto',
         'low',
         'medium',
@@ -270,7 +270,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -306,10 +306,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Bedroom Fan',
-      'percentage': 0,
-      'percentage_step': 33.333333333333336,
-      'preset_mode': None,
-      'preset_modes': None,
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 0,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 33.333333333333336,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
       'supported_features': <FanEntityFeature: 49>,
     }),
     'context': <ANY>,

--- a/tests/components/smarty/snapshots/test_fan.ambr
+++ b/tests/components/smarty/snapshots/test_fan.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -42,10 +42,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Title',
-      'percentage': 0,
-      'percentage_step': 33.333333333333336,
-      'preset_mode': None,
-      'preset_modes': None,
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 0,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 33.333333333333336,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
       'supported_features': <FanEntityFeature: 49>,
     }),
     'context': <ANY>,

--- a/tests/components/switchbot_cloud/snapshots/test_fan.ambr
+++ b/tests/components/switchbot_cloud/snapshots/test_fan.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': list([
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'normal',
         'auto',
         'sleep',
@@ -47,8 +47,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'air-purifier-1',
-      'preset_mode': 'auto',
-      'preset_modes': list([
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: 'auto',
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'normal',
         'auto',
         'sleep',

--- a/tests/components/tplink/snapshots/test_fan.ambr
+++ b/tests/components/tplink/snapshots/test_fan.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -42,10 +42,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'my_device',
-      'percentage': None,
-      'percentage_step': 25.0,
-      'preset_mode': None,
-      'preset_modes': None,
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: None,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 25.0,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
       'supported_features': <FanEntityFeature: 49>,
     }),
     'context': <ANY>,
@@ -63,7 +63,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -99,10 +99,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'my_device my_fan_0',
-      'percentage': None,
-      'percentage_step': 25.0,
-      'preset_mode': None,
-      'preset_modes': None,
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: None,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 25.0,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
       'supported_features': <FanEntityFeature: 49>,
     }),
     'context': <ANY>,
@@ -120,7 +120,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -156,10 +156,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'my_device my_fan_1',
-      'percentage': None,
-      'percentage_step': 25.0,
-      'preset_mode': None,
-      'preset_modes': None,
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: None,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 25.0,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
       'supported_features': <FanEntityFeature: 49>,
     }),
     'context': <ANY>,

--- a/tests/components/tuya/snapshots/test_fan.ambr
+++ b/tests/components/tuya/snapshots/test_fan.ambr
@@ -58,7 +58,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': list([
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'sleep',
       ]),
     }),
@@ -96,8 +96,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Bree',
-      'preset_mode': None,
-      'preset_modes': list([
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'sleep',
       ]),
       'supported_features': <FanEntityFeature: 56>,
@@ -117,7 +117,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -152,12 +152,12 @@
 # name: test_platform_setup_and_discovery[fan.ceiling_fan_light_v2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'direction': 'forward',
+      <FanEntityStateAttribute.DIRECTION: 'direction'>: 'forward',
       'friendly_name': 'ceiling fan/Light v2',
-      'percentage': 21,
-      'percentage_step': 1.0,
-      'preset_mode': None,
-      'preset_modes': None,
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 21,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 1.0,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
       'supported_features': <FanEntityFeature: 53>,
     }),
     'context': <ANY>,
@@ -175,7 +175,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': list([
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'normal',
         'sleep',
         'nature',
@@ -214,12 +214,12 @@
 # name: test_platform_setup_and_discovery[fan.ceiling_fan_with_light-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'direction': 'reverse',
+      <FanEntityStateAttribute.DIRECTION: 'direction'>: 'reverse',
       'friendly_name': 'Ceiling Fan With Light',
-      'percentage': None,
-      'percentage_step': 16.666666666666668,
-      'preset_mode': 'normal',
-      'preset_modes': list([
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: None,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 16.666666666666668,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: 'normal',
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'normal',
         'sleep',
         'nature',
@@ -241,7 +241,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -277,10 +277,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'D825A I',
-      'percentage': 100,
-      'percentage_step': 25.0,
-      'preset_mode': None,
-      'preset_modes': None,
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 100,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 25.0,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
       'supported_features': <FanEntityFeature: 49>,
     }),
     'context': <ANY>,
@@ -298,7 +298,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -334,7 +334,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Dehumidifer',
-      'preset_modes': None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
       'supported_features': <FanEntityFeature: 49>,
     }),
     'context': <ANY>,
@@ -404,7 +404,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -440,10 +440,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Déshumidificateur Silencieux OmniDry 20L avec Mode Linge',
-      'percentage': 50,
-      'percentage_step': 50.0,
-      'preset_mode': None,
-      'preset_modes': None,
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 50,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 50.0,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
       'supported_features': <FanEntityFeature: 49>,
     }),
     'context': <ANY>,
@@ -461,7 +461,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -497,10 +497,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'HL400',
-      'percentage': None,
-      'percentage_step': 33.333333333333336,
-      'preset_mode': None,
-      'preset_modes': None,
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: None,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 33.333333333333336,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
       'supported_features': <FanEntityFeature: 49>,
     }),
     'context': <ANY>,
@@ -570,7 +570,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': list([
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'manual',
         'auto',
         'sleep',
@@ -610,8 +610,8 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Kalado Air Purifier',
-      'preset_mode': 'auto',
-      'preset_modes': list([
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: 'auto',
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'manual',
         'auto',
         'sleep',
@@ -633,7 +633,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -669,10 +669,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Living room dehumidifier',
-      'percentage': 100,
-      'percentage_step': 50.0,
-      'preset_mode': None,
-      'preset_modes': None,
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 100,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 50.0,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
       'supported_features': <FanEntityFeature: 49>,
     }),
     'context': <ANY>,
@@ -690,7 +690,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': list([
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'ordinary',
         'nature',
         'sleep',
@@ -730,11 +730,11 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Tower Fan CA-407G Smart',
-      'oscillating': True,
-      'percentage': 37,
-      'percentage_step': 1.0,
-      'preset_mode': 'ordinary',
-      'preset_modes': list([
+      <FanEntityStateAttribute.OSCILLATING: 'oscillating'>: True,
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 37,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 1.0,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: 'ordinary',
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'ordinary',
         'nature',
         'sleep',

--- a/tests/components/vesync/snapshots/test_fan.ambr
+++ b/tests/components/vesync/snapshots/test_fan.ambr
@@ -40,7 +40,7 @@
       ]),
       'area_id': None,
       'capabilities': dict({
-        'preset_modes': list([
+        <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
           'auto',
           'sleep',
         ]),
@@ -83,10 +83,10 @@
       'display_status': 'on',
       'friendly_name': 'Air Purifier 131s',
       'mode': 'sleep',
-      'percentage': None,
-      'percentage_step': 33.333333333333336,
-      'preset_mode': 'sleep',
-      'preset_modes': list([
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: None,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 33.333333333333336,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: 'sleep',
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'auto',
         'sleep',
       ]),
@@ -141,7 +141,7 @@
       ]),
       'area_id': None,
       'capabilities': dict({
-        'preset_modes': list([
+        <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
           'sleep',
         ]),
       }),
@@ -185,10 +185,10 @@
       'friendly_name': 'Air Purifier 200s',
       'mode': 'manual',
       'night_light': 'off',
-      'percentage': 33,
-      'percentage_step': 33.333333333333336,
-      'preset_mode': None,
-      'preset_modes': list([
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 33,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 33.333333333333336,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'sleep',
       ]),
       'supported_features': <FanEntityFeature: 57>,
@@ -242,7 +242,7 @@
       ]),
       'area_id': None,
       'capabilities': dict({
-        'preset_modes': list([
+        <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
           'auto',
           'sleep',
         ]),
@@ -287,10 +287,10 @@
       'friendly_name': 'Air Purifier 400s',
       'mode': 'manual',
       'night_light': 'off',
-      'percentage': 25,
-      'percentage_step': 25.0,
-      'preset_mode': None,
-      'preset_modes': list([
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 25,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 25.0,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'auto',
         'sleep',
       ]),
@@ -345,7 +345,7 @@
       ]),
       'area_id': None,
       'capabilities': dict({
-        'preset_modes': list([
+        <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
           'auto',
           'sleep',
         ]),
@@ -390,10 +390,10 @@
       'friendly_name': 'Air Purifier 600s',
       'mode': 'manual',
       'night_light': 'off',
-      'percentage': 25,
-      'percentage_step': 25.0,
-      'preset_mode': None,
-      'preset_modes': list([
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 25,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 25.0,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'auto',
         'sleep',
       ]),
@@ -744,7 +744,7 @@
       ]),
       'area_id': None,
       'capabilities': dict({
-        'preset_modes': list([
+        <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
           'auto',
           'normal',
           'sleep',
@@ -789,11 +789,11 @@
       'display_status': 'off',
       'friendly_name': 'SmartTowerFan',
       'mode': <FanModes.NORMAL: 'normal'>,
-      'oscillating': True,
-      'percentage': 0,
-      'percentage_step': 8.333333333333334,
-      'preset_mode': 'normal',
-      'preset_modes': list([
+      <FanEntityStateAttribute.OSCILLATING: 'oscillating'>: True,
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 0,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 8.333333333333334,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: 'normal',
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'auto',
         'normal',
         'sleep',

--- a/tests/components/vicare/snapshots/test_fan.ambr
+++ b/tests/components/vicare/snapshots/test_fan.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': list([
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         <VentilationMode.PERMANENT: 'permanent'>,
         <VentilationMode.VENTILATION: 'ventilation'>,
         <VentilationMode.SENSOR_DRIVEN: 'sensor_driven'>,
@@ -48,10 +48,10 @@
     'attributes': ReadOnlyDict({
       'friendly_name': 'model0 Ventilation',
       'icon': 'mdi:fan',
-      'percentage': 0,
-      'percentage_step': 25.0,
-      'preset_mode': None,
-      'preset_modes': list([
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 0,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 25.0,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         <VentilationMode.PERMANENT: 'permanent'>,
         <VentilationMode.VENTILATION: 'ventilation'>,
         <VentilationMode.SENSOR_DRIVEN: 'sensor_driven'>,
@@ -79,7 +79,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': list([
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         <VentilationMode.PERMANENT: 'permanent'>,
         <VentilationMode.VENTILATION: 'ventilation'>,
         <VentilationMode.SENSOR_DRIVEN: 'sensor_driven'>,
@@ -120,10 +120,10 @@
     'attributes': ReadOnlyDict({
       'friendly_name': 'model1 Ventilation',
       'icon': 'mdi:fan',
-      'percentage': 0,
-      'percentage_step': 25.0,
-      'preset_mode': None,
-      'preset_modes': list([
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 0,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 25.0,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         <VentilationMode.PERMANENT: 'permanent'>,
         <VentilationMode.VENTILATION: 'ventilation'>,
         <VentilationMode.SENSOR_DRIVEN: 'sensor_driven'>,
@@ -150,7 +150,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': list([
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         <VentilationMode.VENTILATION: 'ventilation'>,
         <VentilationMode.STANDBY: 'standby'>,
         <VentilationMode.STANDARD: 'standard'>,
@@ -191,8 +191,8 @@
     'attributes': ReadOnlyDict({
       'friendly_name': 'model2 Ventilation',
       'icon': 'mdi:fan',
-      'preset_mode': None,
-      'preset_modes': list([
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         <VentilationMode.VENTILATION: 'ventilation'>,
         <VentilationMode.STANDBY: 'standby'>,
         <VentilationMode.STANDARD: 'standard'>,

--- a/tests/components/wiz/snapshots/test_fan.ambr
+++ b/tests/components/wiz/snapshots/test_fan.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': list([
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'breeze',
       ]),
     }),
@@ -43,12 +43,12 @@
 # name: test_entity[bulb_type0][fan.mock_title-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'direction': 'forward',
+      <FanEntityStateAttribute.DIRECTION: 'direction'>: 'forward',
       'friendly_name': 'Mock Title',
-      'percentage': 16,
-      'percentage_step': 16.666666666666668,
-      'preset_mode': None,
-      'preset_modes': list([
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 16,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 16.666666666666668,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'breeze',
       ]),
       'supported_features': <FanEntityFeature: 61>,
@@ -68,7 +68,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': list([
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'breeze',
       ]),
     }),
@@ -105,12 +105,12 @@
 # name: test_entity[bulb_type1][fan.mock_title-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'direction': 'forward',
+      <FanEntityStateAttribute.DIRECTION: 'direction'>: 'forward',
       'friendly_name': 'Mock Title',
-      'percentage': 16,
-      'percentage_step': 16.666666666666668,
-      'preset_mode': None,
-      'preset_modes': list([
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 16,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 16.666666666666668,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'breeze',
       ]),
       'supported_features': <FanEntityFeature: 61>,

--- a/tests/components/xiaomi_miio/snapshots/test_fan.ambr
+++ b/tests/components/xiaomi_miio/snapshots/test_fan.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': list([
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'Normal',
         'Nature',
       ]),
@@ -44,13 +44,13 @@
 # name: test_fan_status[dmaker.fan.p18][fan.test_fan-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'direction': None,
+      <FanEntityStateAttribute.DIRECTION: 'direction'>: None,
       'friendly_name': 'test_fan',
-      'oscillating': None,
-      'percentage': None,
-      'percentage_step': 1.0,
-      'preset_mode': None,
-      'preset_modes': list([
+      <FanEntityStateAttribute.OSCILLATING: 'oscillating'>: None,
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: None,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 1.0,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'Normal',
         'Nature',
       ]),
@@ -71,7 +71,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'preset_modes': list([
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'Normal',
         'Nature',
       ]),
@@ -109,13 +109,13 @@
 # name: test_fan_status[dmaker.fan.p5][fan.test_fan-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'direction': None,
+      <FanEntityStateAttribute.DIRECTION: 'direction'>: None,
       'friendly_name': 'test_fan',
-      'oscillating': False,
-      'percentage': None,
-      'percentage_step': 1.0,
-      'preset_mode': 'Nature',
-      'preset_modes': list([
+      <FanEntityStateAttribute.OSCILLATING: 'oscillating'>: False,
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: None,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 1.0,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: 'Nature',
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
         'Normal',
         'Nature',
       ]),

--- a/tests/components/zimi/snapshots/test_fan.ambr
+++ b/tests/components/zimi/snapshots/test_fan.ambr
@@ -3,10 +3,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Fan Controller Test Entity Name',
-      'percentage': 1,
-      'percentage_step': 12.5,
-      'preset_mode': None,
-      'preset_modes': None,
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 1,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 12.5,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: None,
       'supported_features': <FanEntityFeature: 49>,
     }),
     'context': <ANY>,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add new `FanEntityCapabilityAttribute` enum for the capability attributes and new `FanEntityStateAttribute` enum for the state attributes of the fan entity.

Based on https://github.com/home-assistant/architecture/discussions/1406, linked to epic https://github.com/home-assistant/epics/issues/104

A follow-up PR will formally deprecate the corresponding `ATTR_*` constants.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
