### PR TITLE
Migrate siren entity attributes to StrEnum

### DIFF
--- a/homeassistant/components/siren/__init__.py
+++ b/homeassistant/components/siren/__init__.py
@@ -16,12 +16,13 @@ from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.typing import ConfigType, VolDictType
 from homeassistant.util.hass_dict import HassKey
 
-from .const import (
+from .const import (  # noqa: F401
     ATTR_AVAILABLE_TONES,
     ATTR_DURATION,
     ATTR_TONE,
     ATTR_VOLUME_LEVEL,
     DOMAIN,
+    SirenEntityCapabilityAttribute,
     SirenEntityFeature,
 )
 
@@ -154,7 +155,9 @@ CACHED_PROPERTIES_WITH_ATTR_ = {
 class SirenEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     """Representation of a siren device."""
 
-    _entity_component_unrecorded_attributes = frozenset({ATTR_AVAILABLE_TONES})
+    _entity_component_unrecorded_attributes = frozenset(
+        {SirenEntityCapabilityAttribute.AVAILABLE_TONES}
+    )
 
     entity_description: SirenEntityDescription
     _attr_available_tones: list[int | str] | dict[int, str] | None
@@ -169,7 +172,9 @@ class SirenEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
             self.supported_features & SirenEntityFeature.TONES
             and self.available_tones is not None
         ):
-            return {ATTR_AVAILABLE_TONES: self.available_tones}
+            return {
+                SirenEntityCapabilityAttribute.AVAILABLE_TONES: self.available_tones
+            }
 
         return None
 

--- a/homeassistant/components/siren/const.py
+++ b/homeassistant/components/siren/const.py
@@ -1,6 +1,6 @@
 """Constants for the siren component."""
 
-from enum import IntFlag
+from enum import IntFlag, StrEnum
 from typing import Final
 
 DOMAIN: Final = "siren"
@@ -10,6 +10,12 @@ ATTR_TONE: Final = "tone"
 ATTR_AVAILABLE_TONES: Final = "available_tones"
 ATTR_DURATION: Final = "duration"
 ATTR_VOLUME_LEVEL: Final = "volume_level"
+
+
+class SirenEntityCapabilityAttribute(StrEnum):
+    """Capability attributes for siren entities."""
+
+    AVAILABLE_TONES = "available_tones"
 
 
 class SirenEntityFeature(IntFlag):

--- a/tests/components/devolo_home_control/snapshots/test_siren.ambr
+++ b/tests/components/devolo_home_control/snapshots/test_siren.ambr
@@ -2,7 +2,7 @@
 # name: test_siren
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'available_tones': list([
+      <SirenEntityCapabilityAttribute.AVAILABLE_TONES: 'available_tones'>: list([
         0,
       ]),
       'friendly_name': 'Test',
@@ -23,7 +23,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'available_tones': list([
+      <SirenEntityCapabilityAttribute.AVAILABLE_TONES: 'available_tones'>: list([
         0,
       ]),
     }),
@@ -60,7 +60,7 @@
 # name: test_siren_change_default_tone
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'available_tones': list([
+      <SirenEntityCapabilityAttribute.AVAILABLE_TONES: 'available_tones'>: list([
         0,
       ]),
       'friendly_name': 'Test',
@@ -81,7 +81,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'available_tones': list([
+      <SirenEntityCapabilityAttribute.AVAILABLE_TONES: 'available_tones'>: list([
         0,
       ]),
     }),
@@ -118,7 +118,7 @@
 # name: test_siren_switching
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'available_tones': list([
+      <SirenEntityCapabilityAttribute.AVAILABLE_TONES: 'available_tones'>: list([
         0,
       ]),
       'friendly_name': 'Test',
@@ -139,7 +139,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'available_tones': list([
+      <SirenEntityCapabilityAttribute.AVAILABLE_TONES: 'available_tones'>: list([
         0,
       ]),
     }),

--- a/tests/components/ring/snapshots/test_siren.ambr
+++ b/tests/components/ring/snapshots/test_siren.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'available_tones': list([
+      <SirenEntityCapabilityAttribute.AVAILABLE_TONES: 'available_tones'>: list([
         'ding',
         'motion',
       ]),
@@ -45,7 +45,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by Ring.com',
-      'available_tones': list([
+      <SirenEntityCapabilityAttribute.AVAILABLE_TONES: 'available_tones'>: list([
         'ding',
         'motion',
       ]),

--- a/tests/components/tplink/snapshots/test_siren.ambr
+++ b/tests/components/tplink/snapshots/test_siren.ambr
@@ -41,7 +41,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'available_tones': tuple(
+      <SirenEntityCapabilityAttribute.AVAILABLE_TONES: 'available_tones'>: tuple(
         'Foo',
         'Bar',
       ),
@@ -79,7 +79,7 @@
 # name: test_states[siren.hub-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'available_tones': tuple(
+      <SirenEntityCapabilityAttribute.AVAILABLE_TONES: 'available_tones'>: tuple(
         'Foo',
         'Bar',
       ),


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add new `SirenEntityCapabilityAttribute` enum for the capability attributes of the siren entity.

Based on https://github.com/home-assistant/architecture/discussions/1406, linked to epic https://github.com/home-assistant/epics/issues/104

A follow-up PR will formally deprecate the corresponding `ATTR_*` constants.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
