### PR TITLE
Migrate vacuum entity attributes to StrEnum

### DIFF
--- a/homeassistant/components/vacuum/__init__.py
+++ b/homeassistant/components/vacuum/__init__.py
@@ -34,7 +34,14 @@ from homeassistant.helpers.frame import ReportBehavior, report_usage
 from homeassistant.helpers.icon import icon_for_battery_level
 from homeassistant.helpers.typing import ConfigType
 
-from .const import DATA_COMPONENT, DOMAIN, VacuumActivity, VacuumEntityFeature
+from .const import (
+    DATA_COMPONENT,
+    DOMAIN,
+    VacuumActivity,
+    VacuumEntityCapabilityAttribute,
+    VacuumEntityFeature,
+    VacuumEntityStateAttribute,
+)
 from .websocket import async_register_websocket_handlers
 
 _LOGGER = logging.getLogger(__name__)
@@ -313,7 +320,7 @@ class StateVacuumEntity(
     def capability_attributes(self) -> dict[str, Any] | None:
         """Return capability attributes."""
         if VacuumEntityFeature.FAN_SPEED in self.supported_features:
-            return {ATTR_FAN_SPEED_LIST: self.fan_speed_list}
+            return {VacuumEntityCapabilityAttribute.FAN_SPEED_LIST: self.fan_speed_list}
         return None
 
     @cached_property
@@ -337,11 +344,11 @@ class StateVacuumEntity(
             if self.__vacuum_legacy_battery_feature is False:
                 self._report_deprecated_battery_feature()
                 self.__vacuum_legacy_battery_feature = True
-            data[ATTR_BATTERY_LEVEL] = self.battery_level
-            data[ATTR_BATTERY_ICON] = self.battery_icon
+            data[VacuumEntityStateAttribute.BATTERY_LEVEL] = self.battery_level
+            data[VacuumEntityStateAttribute.BATTERY_ICON] = self.battery_icon
 
         if VacuumEntityFeature.FAN_SPEED in supported_features:
-            data[ATTR_FAN_SPEED] = self.fan_speed
+            data[VacuumEntityStateAttribute.FAN_SPEED] = self.fan_speed
 
         return data
 

--- a/homeassistant/components/vacuum/__init__.py
+++ b/homeassistant/components/vacuum/__init__.py
@@ -344,8 +344,8 @@ class StateVacuumEntity(
             if self.__vacuum_legacy_battery_feature is False:
                 self._report_deprecated_battery_feature()
                 self.__vacuum_legacy_battery_feature = True
-            data[VacuumEntityStateAttribute.BATTERY_LEVEL] = self.battery_level
-            data[VacuumEntityStateAttribute.BATTERY_ICON] = self.battery_icon
+            data[ATTR_BATTERY_LEVEL] = self.battery_level
+            data[ATTR_BATTERY_ICON] = self.battery_icon
 
         if VacuumEntityFeature.FAN_SPEED in supported_features:
             data[VacuumEntityStateAttribute.FAN_SPEED] = self.fan_speed

--- a/homeassistant/components/vacuum/const.py
+++ b/homeassistant/components/vacuum/const.py
@@ -34,8 +34,6 @@ class VacuumEntityCapabilityAttribute(StrEnum):
 class VacuumEntityStateAttribute(StrEnum):
     """State attributes for vacuum entities."""
 
-    BATTERY_LEVEL = "battery_level"
-    BATTERY_ICON = "battery_icon"
     FAN_SPEED = "fan_speed"
 
 

--- a/homeassistant/components/vacuum/const.py
+++ b/homeassistant/components/vacuum/const.py
@@ -25,6 +25,20 @@ class VacuumActivity(StrEnum):
     ERROR = "error"
 
 
+class VacuumEntityCapabilityAttribute(StrEnum):
+    """Capability attributes for vacuum devices."""
+
+    FAN_SPEED_LIST = "fan_speed_list"
+
+
+class VacuumEntityStateAttribute(StrEnum):
+    """State attributes for vacuum entities."""
+
+    BATTERY_LEVEL = "battery_level"
+    BATTERY_ICON = "battery_icon"
+    FAN_SPEED = "fan_speed"
+
+
 class VacuumEntityFeature(IntFlag):
     """Supported features of the vacuum entity."""
 

--- a/tests/components/miele/snapshots/test_vacuum.ambr
+++ b/tests/components/miele/snapshots/test_vacuum.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'fan_speed_list': list([
+      <VacuumEntityCapabilityAttribute.FAN_SPEED_LIST: 'fan_speed_list'>: list([
         'normal',
         'turbo',
         'silent',
@@ -45,8 +45,8 @@
 # name: test_sensor_states[platforms0-vacuum_device.json][vacuum.robot_vacuum_cleaner-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'fan_speed': 'normal',
-      'fan_speed_list': list([
+      <VacuumEntityStateAttribute.FAN_SPEED: 'fan_speed'>: 'normal',
+      <VacuumEntityCapabilityAttribute.FAN_SPEED_LIST: 'fan_speed_list'>: list([
         'normal',
         'turbo',
         'silent',
@@ -69,7 +69,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'fan_speed_list': list([
+      <VacuumEntityCapabilityAttribute.FAN_SPEED_LIST: 'fan_speed_list'>: list([
         'normal',
         'turbo',
         'silent',
@@ -108,8 +108,8 @@
 # name: test_vacuum_states_api_push[platforms0-vacuum_device.json][vacuum.robot_vacuum_cleaner-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'fan_speed': 'normal',
-      'fan_speed_list': list([
+      <VacuumEntityStateAttribute.FAN_SPEED: 'fan_speed'>: 'normal',
+      <VacuumEntityCapabilityAttribute.FAN_SPEED_LIST: 'fan_speed_list'>: list([
         'normal',
         'turbo',
         'silent',

--- a/tests/components/roborock/snapshots/test_vacuum.ambr
+++ b/tests/components/roborock/snapshots/test_vacuum.ambr
@@ -32,7 +32,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'fan_speed_list': list([
+      <VacuumEntityCapabilityAttribute.FAN_SPEED_LIST: 'fan_speed_list'>: list([
         'off',
         'quiet',
         'balanced',
@@ -74,8 +74,8 @@
 # name: test_vacuum_state[vacuum.roborock_q10_s5-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'fan_speed': 'balanced',
-      'fan_speed_list': list([
+      <VacuumEntityStateAttribute.FAN_SPEED: 'fan_speed'>: 'balanced',
+      <VacuumEntityCapabilityAttribute.FAN_SPEED_LIST: 'fan_speed_list'>: list([
         'off',
         'quiet',
         'balanced',
@@ -101,7 +101,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'fan_speed_list': list([
+      <VacuumEntityCapabilityAttribute.FAN_SPEED_LIST: 'fan_speed_list'>: list([
         'quiet',
         'balanced',
         'turbo',
@@ -142,8 +142,8 @@
 # name: test_vacuum_state[vacuum.roborock_q7-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'fan_speed': None,
-      'fan_speed_list': list([
+      <VacuumEntityStateAttribute.FAN_SPEED: 'fan_speed'>: None,
+      <VacuumEntityCapabilityAttribute.FAN_SPEED_LIST: 'fan_speed_list'>: list([
         'quiet',
         'balanced',
         'turbo',
@@ -168,7 +168,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'fan_speed_list': list([
+      <VacuumEntityCapabilityAttribute.FAN_SPEED_LIST: 'fan_speed_list'>: list([
         'gentle',
         'off',
         'quiet',
@@ -214,8 +214,8 @@
 # name: test_vacuum_state[vacuum.roborock_s7_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'fan_speed': 'balanced',
-      'fan_speed_list': list([
+      <VacuumEntityStateAttribute.FAN_SPEED: 'fan_speed'>: 'balanced',
+      <VacuumEntityCapabilityAttribute.FAN_SPEED_LIST: 'fan_speed_list'>: list([
         'gentle',
         'off',
         'quiet',
@@ -245,7 +245,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'fan_speed_list': list([
+      <VacuumEntityCapabilityAttribute.FAN_SPEED_LIST: 'fan_speed_list'>: list([
         'gentle',
         'off',
         'quiet',
@@ -291,8 +291,8 @@
 # name: test_vacuum_state[vacuum.roborock_s7_maxv-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'fan_speed': 'balanced',
-      'fan_speed_list': list([
+      <VacuumEntityStateAttribute.FAN_SPEED: 'fan_speed'>: 'balanced',
+      <VacuumEntityCapabilityAttribute.FAN_SPEED_LIST: 'fan_speed_list'>: list([
         'gentle',
         'off',
         'quiet',

--- a/tests/components/smartthings/snapshots/test_vacuum.ambr
+++ b/tests/components/smartthings/snapshots/test_vacuum.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'fan_speed_list': list([
+      <VacuumEntityCapabilityAttribute.FAN_SPEED_LIST: 'fan_speed_list'>: list([
         'normal',
         'maximum',
         'smart',
@@ -46,8 +46,8 @@
 # name: test_all_entities[da_rvc_map_01011][vacuum.robot_vacuum-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'fan_speed': 'maximum',
-      'fan_speed_list': list([
+      <VacuumEntityStateAttribute.FAN_SPEED: 'fan_speed'>: 'maximum',
+      <VacuumEntityCapabilityAttribute.FAN_SPEED_LIST: 'fan_speed_list'>: list([
         'normal',
         'maximum',
         'smart',
@@ -71,7 +71,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'fan_speed_list': list([
+      <VacuumEntityCapabilityAttribute.FAN_SPEED_LIST: 'fan_speed_list'>: list([
         'normal',
         'maximum',
         'smart',
@@ -111,8 +111,8 @@
 # name: test_all_entities[da_rvc_normal_000001][vacuum.theater_robot_vacuum_1-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'fan_speed': 'smart',
-      'fan_speed_list': list([
+      <VacuumEntityStateAttribute.FAN_SPEED: 'fan_speed'>: 'smart',
+      <VacuumEntityCapabilityAttribute.FAN_SPEED_LIST: 'fan_speed_list'>: list([
         'normal',
         'maximum',
         'smart',

--- a/tests/components/tplink/snapshots/test_vacuum.ambr
+++ b/tests/components/tplink/snapshots/test_vacuum.ambr
@@ -41,7 +41,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'fan_speed_list': list([
+      <VacuumEntityCapabilityAttribute.FAN_SPEED_LIST: 'fan_speed_list'>: list([
         'quiet',
         'max',
       ]),
@@ -81,8 +81,8 @@
     'attributes': ReadOnlyDict({
       'battery_icon': 'mdi:battery-charging-100',
       'battery_level': 100,
-      'fan_speed': 'max',
-      'fan_speed_list': list([
+      <VacuumEntityStateAttribute.FAN_SPEED: 'fan_speed'>: 'max',
+      <VacuumEntityCapabilityAttribute.FAN_SPEED_LIST: 'fan_speed_list'>: list([
         'quiet',
         'max',
       ]),

--- a/tests/components/tuya/snapshots/test_vacuum.ambr
+++ b/tests/components/tuya/snapshots/test_vacuum.ambr
@@ -57,7 +57,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'fan_speed_list': list([
+      <VacuumEntityCapabilityAttribute.FAN_SPEED_LIST: 'fan_speed_list'>: list([
         'gentle',
         'normal',
         'strong',
@@ -96,8 +96,8 @@
 # name: test_platform_setup_and_discovery[vacuum.v20-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'fan_speed': 'strong',
-      'fan_speed_list': list([
+      <VacuumEntityStateAttribute.FAN_SPEED: 'fan_speed'>: 'strong',
+      <VacuumEntityCapabilityAttribute.FAN_SPEED_LIST: 'fan_speed_list'>: list([
         'gentle',
         'normal',
         'strong',


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add new `VacuumEntityCapabilityAttribute` enum for the capability attributes and new `VacuumEntityStateAttribute` enum for the state attributes of the vacuum entity.

Based on https://github.com/home-assistant/architecture/discussions/1406, linked to epic https://github.com/home-assistant/epics/issues/104

A follow-up PR will formally deprecate the corresponding `ATTR_*` constants.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
