### PR TITLE
Keep downloaded translations consistent with the building branch

### DIFF
--- a/script/translations/download.py
+++ b/script/translations/download.py
@@ -3,11 +3,13 @@
 
 import json
 from pathlib import Path
+import string
 import subprocess
 from typing import Any
 
 from .const import CLI_2_DOCKER_IMAGE, CORE_PROJECT_ID, INTEGRATIONS_DIR
 from .error import ExitApp
+from .upload import generate_upload_data
 from .util import (
     flatten_translations,
     get_lokalise_token,
@@ -64,21 +66,47 @@ def save_json(filename: Path, data: list | dict) -> None:
     filename.write_text(json.dumps(data, sort_keys=True, indent=4), encoding="utf-8")
 
 
+def _placeholder_names(value: str) -> set[str]:
+    """Return the placeholder names a translation string references."""
+    try:
+        return {
+            field_name
+            for _, field_name, _, _ in string.Formatter().parse(value)
+            if field_name
+        }
+    except ValueError:
+        # Non str.format strings can't be introspected; impose no constraint.
+        return set()
+
+
 def filter_translations(translations: dict[str, Any], strings: dict[str, Any]) -> None:
-    """Remove translations that are not in the original strings."""
+    """Remove translations that are missing from or incompatible with strings."""
     for key in list(translations.keys()):
         if key not in strings:
             translations.pop(key)
             continue
 
-        if isinstance(translations[key], dict):
-            if not isinstance(strings[key], dict):
+        value = translations[key]
+        source = strings[key]
+
+        if isinstance(value, dict):
+            if not isinstance(source, dict):
                 translations.pop(key)
                 continue
-            filter_translations(translations[key], strings[key])
-            if not translations[key]:
+            filter_translations(value, source)
+            if not value:
                 translations.pop(key)
-                continue
+            continue
+
+        # Drop a translation referencing a placeholder the source does not
+        # define: it raises at format time, and happens when Lokalise (sourced
+        # from dev) serves a renamed placeholder the branch's strings.json lacks.
+        if (
+            isinstance(value, str)
+            and isinstance(source, str)
+            and not _placeholder_names(value) <= _placeholder_names(source)
+        ):
+            translations.pop(key)
 
 
 def save_language_translations(lang: str, translations: dict[str, Any]) -> None:
@@ -144,6 +172,11 @@ def run() -> None:
     DOWNLOAD_DIR.mkdir(parents=True, exist_ok=True)
 
     run_download_docker()
+
+    # English is this checkout's strings.json, not a Lokalise round-trip, so a
+    # release build ships the English that matches its own code rather than the
+    # dev source the single Lokalise project always tracks.
+    save_json(DOWNLOAD_DIR / "en.json", generate_upload_data())
 
     delete_old_translations()
 

--- a/script/translations/download.py
+++ b/script/translations/download.py
@@ -79,8 +79,15 @@ def _placeholder_names(value: str) -> set[str]:
         return set()
 
 
-def filter_translations(translations: dict[str, Any], strings: dict[str, Any]) -> None:
-    """Remove translations that are missing from or incompatible with strings."""
+def filter_translations(
+    translations: dict[str, Any], strings: dict[str, Any], prefix: str = ""
+) -> list[str]:
+    """Remove translations that are missing from or incompatible with strings.
+
+    Returns the keys of translations dropped for referencing a placeholder the
+    source string does not define, so the caller can surface the drift.
+    """
+    incompatible: list[str] = []
     for key in list(translations.keys()):
         if key not in strings:
             translations.pop(key)
@@ -88,12 +95,13 @@ def filter_translations(translations: dict[str, Any], strings: dict[str, Any]) -
 
         value = translations[key]
         source = strings[key]
+        path = f"{prefix}{key}"
 
         if isinstance(value, dict):
             if not isinstance(source, dict):
                 translations.pop(key)
                 continue
-            filter_translations(value, source)
+            incompatible.extend(filter_translations(value, source, f"{path}::"))
             if not value:
                 translations.pop(key)
             continue
@@ -107,6 +115,9 @@ def filter_translations(translations: dict[str, Any], strings: dict[str, Any]) -
             and not _placeholder_names(value) <= _placeholder_names(source)
         ):
             translations.pop(key)
+            incompatible.append(path)
+
+    return incompatible
 
 
 def save_language_translations(lang: str, translations: dict[str, Any]) -> None:
@@ -147,8 +158,18 @@ def save_language_translations(lang: str, translations: dict[str, Any]) -> None:
         component_translations = substitute_references(
             component_translations, flattened_translations, fail_on_missing=False
         )
+        # Resolve the source the same way so referenced common strings expose
+        # their placeholders (e.g. ``[%key:...reauth%]`` -> ``... {name}``); a
+        # raw reference would otherwise look placeholder-less.
+        strings = substitute_references(
+            strings, flattened_translations, fail_on_missing=False
+        )
 
-        filter_translations(component_translations, strings)
+        for incompatible in filter_translations(component_translations, strings):
+            print(
+                f"Dropping {lang} translation {component}::{incompatible}, it uses a"
+                " placeholder the source string does not define"
+            )
 
         save_json(path, component_translations)
 

--- a/tests/scripts/test_translations_download.py
+++ b/tests/scripts/test_translations_download.py
@@ -1,0 +1,100 @@
+"""Tests for the translation download script."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from script.translations import download
+from script.translations.download import _placeholder_names, filter_translations
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("no placeholders", set()),
+        ("{name} ({host})", {"name", "host"}),
+        ("{name:>10}", {"name"}),
+        # ICU / non str.format strings impose no constraint instead of raising.
+        ("{count, plural, one {x} other {y}}", set()),
+    ],
+)
+def test_placeholder_names(value: str, expected: set[str]) -> None:
+    """Placeholder names are extracted, malformed strings yield no constraint."""
+    assert _placeholder_names(value) == expected
+
+
+def test_filter_translations_drops_keys_missing_from_strings() -> None:
+    """A translation key absent from the strings is removed."""
+    translations = {"title": "Title", "stale": "Gone"}
+    filter_translations(translations, {"title": "Title"})
+    assert translations == {"title": "Title"}
+
+
+def test_filter_translations_drops_incompatible_placeholder() -> None:
+    """A translation referencing an undefined placeholder is dropped.
+
+    Guards the release-pipeline case where the branch strings.json still uses
+    the old placeholder while the downloaded translation uses a renamed one.
+    """
+    translations = {"config": {"flow_title": "{name} ({host})", "kept": "{host}"}}
+    strings = {"config": {"flow_title": "{site} ({host})", "kept": "{host}"}}
+    filter_translations(translations, strings)
+    assert translations == {"config": {"kept": "{host}"}}
+
+
+@pytest.mark.parametrize(
+    ("value", "source"),
+    [
+        ("{name} ({host})", "{name} ({host})"),
+        # A subset of the source placeholders is allowed.
+        ("{host}", "{name} ({host})"),
+        ("plain", "{name}"),
+    ],
+)
+def test_filter_translations_keeps_compatible_placeholders(
+    value: str, source: str
+) -> None:
+    """Translations whose placeholders the source defines are kept."""
+    translations = {"flow_title": value}
+    filter_translations(translations, {"flow_title": source})
+    assert translations == {"flow_title": value}
+
+
+def test_filter_translations_prunes_emptied_branches() -> None:
+    """A dict left empty after filtering is removed."""
+    translations = {"config": {"flow_title": "{name}"}}
+    filter_translations(translations, {"config": {"flow_title": "{site}"}})
+    assert translations == {}
+
+
+def test_filter_translations_drops_dict_over_non_dict_source() -> None:
+    """A nested translation whose source is not a dict is removed."""
+    translations = {"config": {"nested": "value"}}
+    filter_translations(translations, {"config": "scalar"})
+    assert translations == {}
+
+
+def test_run_sources_english_from_strings(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The build replaces the Lokalise English with the checkout's strings.json.
+
+    English is the source of truth in strings.json, so a release build must ship
+    it rather than the dev-sourced English the single Lokalise project tracks.
+    """
+    monkeypatch.setattr(download, "DOWNLOAD_DIR", tmp_path)
+
+    def _fake_docker() -> None:
+        # Lokalise serves dev-sourced English, here with a drifted placeholder.
+        download.save_json(tmp_path / "en.json", {"component": {"x": {"t": "{name}"}}})
+
+    strings_english = {"component": {"x": {"t": "{site}"}}}
+    monkeypatch.setattr(download, "run_download_docker", _fake_docker)
+    monkeypatch.setattr(download, "generate_upload_data", lambda: strings_english)
+    monkeypatch.setattr(download, "delete_old_translations", lambda: None)
+    monkeypatch.setattr(download, "save_integrations_translations", lambda: None)
+
+    download.run()
+
+    assert json.loads((tmp_path / "en.json").read_text()) == strings_english

--- a/tests/scripts/test_translations_download.py
+++ b/tests/scripts/test_translations_download.py
@@ -39,8 +39,9 @@ def test_filter_translations_drops_incompatible_placeholder() -> None:
     """
     translations = {"config": {"flow_title": "{name} ({host})", "kept": "{host}"}}
     strings = {"config": {"flow_title": "{site} ({host})", "kept": "{host}"}}
-    filter_translations(translations, strings)
+    dropped = filter_translations(translations, strings)
     assert translations == {"config": {"kept": "{host}"}}
+    assert dropped == ["config::flow_title"]
 
 
 @pytest.mark.parametrize(
@@ -98,3 +99,30 @@ def test_run_sources_english_from_strings(
     download.run()
 
     assert json.loads((tmp_path / "en.json").read_text()) == strings_english
+
+
+def test_save_language_resolves_referenced_source_placeholders(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A translation using a placeholder from a referenced common string is kept.
+
+    The source value is a ``[%key:...%]`` reference; it must be resolved before
+    its placeholders are compared, otherwise every key referencing a
+    placeholder-bearing common string would be dropped.
+    """
+    captured: dict = {}
+    monkeypatch.setattr(download, "save_json", lambda path, data: captured.update(data))
+    monkeypatch.setattr(
+        download, "load_json_from_path", lambda path: {"title": "[%key:common::x%]"}
+    )
+    monkeypatch.setattr(download.Path, "is_dir", lambda self: True)
+    monkeypatch.setattr(download.Path, "exists", lambda self: True)
+    monkeypatch.setattr(download.Path, "mkdir", lambda self, **kwargs: None)
+
+    translations = {
+        "component": {"demo": {"title": "Translated {name}"}},
+        "common": {"x": "Source {name}"},
+    }
+    download.save_language_translations("de", translations)
+
+    assert captured == {"title": "Translated {name}"}


### PR DESCRIPTION
## Proposed change

Surfaced by #174348: a UniFi config flow placeholder was renamed (`{site}` →
`{name}`) in #173931 on `dev`. That `strings.json` change was uploaded to
Lokalise (the upload workflow runs on `dev` pushes) and downloaded into the
`2026.6.4` stable build's translation files, but #173931 was not cherry-picked
to the release branch, so the stable code still provided a `{site}` placeholder
— and the frontend raised `formatjs Error: MISSING_VALUE` for `{name}`.

The root cause is structural: translations are downloaded at build time from a
single Lokalise project sourced only from `dev`, and the download is not
committed — every build, including a stable patch build, fetches the latest from
that one project. So translation files are not subject to the cherry-pick
discipline that controls a release branch's code, and a stable build can ship
translations that no longer match its own `strings.json`. A renamed placeholder
is the visible case, but the inconsistency is general and affects every language
(the English `en.json` drifts the same way).

This keeps the shipped translations consistent with the branch being built:

- English is regenerated from this checkout's `strings.json` (reusing
  `generate_upload_data`, as `develop.py` already does) instead of the Lokalise
  round-trip, so the source language always matches the release's own code.
- `filter_translations` now also drops a translation whose placeholders are not
  a subset of the source string's, so an incompatible non-English translation
  falls back to that correct English instead of raising.

It does not freeze translations to the branch, so newer translations still reach
patch releases; only the incompatible (renamed-placeholder) string is dropped.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #174348
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
