### PR TITLE
mqtt: Fix cover state stuck on open/closed after stopped

### DIFF
--- a/homeassistant/components/mqtt/cover.py
+++ b/homeassistant/components/mqtt/cover.py
@@ -238,6 +238,7 @@ class MqttCover(MqttEntity, CoverEntity):
     _entity_id_format: str = cover.ENTITY_ID_FORMAT
     _optimistic: bool
     _tilt_optimistic: bool
+    _awaiting_position_update_after_stopped: bool
     _tilt_closed_percentage: int
     _tilt_open_percentage: int
     _pos_range: tuple[int, int]
@@ -252,6 +253,7 @@ class MqttCover(MqttEntity, CoverEntity):
     @override
     def _setup_from_config(self, config: ConfigType) -> None:
         """Set up cover from config."""
+        self._awaiting_position_update_after_stopped = False
         self._pos_range = (config[CONF_POSITION_CLOSED] + 1, config[CONF_POSITION_OPEN])
         self._tilt_range = (config[CONF_TILT_MIN] + 1, config[CONF_TILT_MAX])
         self._tilt_closed_percentage = ranged_value_to_percentage(
@@ -378,8 +380,12 @@ class MqttCover(MqttEntity, CoverEntity):
             _LOGGER.debug("Ignoring empty state message from '%s'", msg.topic)
             return
 
+        self._awaiting_position_update_after_stopped = False
         state: str | None
         if payload == self._config[CONF_STATE_STOPPED]:
+            self._awaiting_position_update_after_stopped = (
+                self._config.get(CONF_GET_POSITION_TOPIC) is not None
+            )
             if self._config.get(CONF_GET_POSITION_TOPIC) is not None:
                 state = (
                     CoverState.CLOSED
@@ -455,6 +461,13 @@ class MqttCover(MqttEntity, CoverEntity):
                 if self.current_cover_position == 0
                 else CoverState.OPEN
             )
+        elif self._awaiting_position_update_after_stopped:
+            self._update_state(
+                CoverState.CLOSED
+                if self.current_cover_position == 0
+                else CoverState.OPEN
+            )
+            self._awaiting_position_update_after_stopped = False
 
     @callback
     @override

--- a/tests/components/mqtt/test_cover.py
+++ b/tests/components/mqtt/test_cover.py
@@ -2927,6 +2927,102 @@ async def test_set_state_via_position_using_stopped_state(
                 cover.DOMAIN: {
                     "name": "test",
                     "state_topic": "state-topic",
+                    "position_topic": "get-position-topic",
+                    "position_open": 100,
+                    "position_closed": 0,
+                    "state_open": "OPEN",
+                    "state_closed": "CLOSE",
+                    "state_stopped": "STOPPED",
+                    "command_topic": "command-topic",
+                    "qos": 0,
+                }
+            }
+        }
+    ],
+)
+async def test_set_state_via_position_using_stopped_state_out_of_order(
+    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+) -> None:
+    """Test state reconciliation when stopped arrives before position update."""
+    await mqtt_mock_entry()
+
+    async_fire_mqtt_message(hass, "state-topic", "OPEN")
+
+    state = hass.states.get("cover.test")
+    assert state.state == CoverState.OPEN
+
+    async_fire_mqtt_message(hass, "get-position-topic", "100")
+
+    state = hass.states.get("cover.test")
+    assert state.state == CoverState.OPEN
+
+    async_fire_mqtt_message(hass, "state-topic", "STOPPED")
+
+    state = hass.states.get("cover.test")
+    assert state.state == CoverState.OPEN
+
+    async_fire_mqtt_message(hass, "get-position-topic", "0")
+
+    state = hass.states.get("cover.test")
+    assert state.state == CoverState.CLOSED
+
+
+@pytest.mark.parametrize(
+    "hass_config",
+    [
+        {
+            DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
+                    "position_topic": "get-position-topic",
+                    "position_open": 100,
+                    "position_closed": 0,
+                    "state_open": "OPEN",
+                    "state_closed": "CLOSE",
+                    "state_stopped": "STOPPED",
+                    "command_topic": "command-topic",
+                    "qos": 0,
+                }
+            }
+        }
+    ],
+)
+async def test_set_state_via_position_using_stopped_state_out_of_order_open(
+    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+) -> None:
+    """Test state reconciliation when stopped arrives before open position update."""
+    await mqtt_mock_entry()
+
+    async_fire_mqtt_message(hass, "state-topic", "CLOSE")
+
+    state = hass.states.get("cover.test")
+    assert state.state == CoverState.CLOSED
+
+    async_fire_mqtt_message(hass, "get-position-topic", "0")
+
+    state = hass.states.get("cover.test")
+    assert state.state == CoverState.CLOSED
+
+    async_fire_mqtt_message(hass, "state-topic", "STOPPED")
+
+    state = hass.states.get("cover.test")
+    assert state.state == CoverState.CLOSED
+
+    async_fire_mqtt_message(hass, "get-position-topic", "100")
+
+    state = hass.states.get("cover.test")
+    assert state.state == CoverState.OPEN
+
+
+@pytest.mark.parametrize(
+    "hass_config",
+    [
+        {
+            DOMAIN: {
+                cover.DOMAIN: {
+                    "name": "test",
+                    "state_topic": "state-topic",
                     "command_topic": "command-topic",
                     "set_position_topic": "set-position-topic",
                     "position_topic": "get-position-topic",


### PR DESCRIPTION
When both state_topic and position_topic are configured with a state_stopped payload, the open/closed state was derived from the current (possibly stale) position at the moment STOPPED arrived. If the final position update arrived after STOPPED, the state was never reconciled and remained stuck.

After a STOPPED message, the next position update now sets the definitive open/closed state.

Fixes #174146

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
