### PR TITLE
Add number platform to bosch_shc

### DIFF
--- a/homeassistant/components/bosch_shc/__init__.py
+++ b/homeassistant/components/bosch_shc/__init__.py
@@ -17,6 +17,7 @@ from .const import CONF_SSL_CERTIFICATE, CONF_SSL_KEY, DOMAIN
 PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.COVER,
+    Platform.NUMBER,
     Platform.SENSOR,
     Platform.SWITCH,
 ]

--- a/homeassistant/components/bosch_shc/number.py
+++ b/homeassistant/components/bosch_shc/number.py
@@ -1,0 +1,262 @@
+"""Platform for number integration."""
+
+from typing import override
+
+from boschshcpy import SHCDevice
+from boschshcpy.models_impl import SHCMicromoduleRelay
+
+from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberMode
+from homeassistant.const import EntityCategory, UnitOfTemperature, UnitOfTime
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import BoschConfigEntry
+from .entity import SHCEntity
+
+PARALLEL_UPDATES = 1
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: BoschConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the SHC number platform."""
+    session = config_entry.runtime_data
+    parent_id = session.information.unique_id
+    entities: list[NumberEntity] = []
+
+    for device in (
+        *session.device_helper.thermostats,
+        *session.device_helper.roomthermostats,
+    ):
+        entities.append(
+            SHCThermostatOffsetNumber(
+                device=device,
+                parent_id=parent_id,
+                entry_id=config_entry.entry_id,
+            )
+        )
+        if (
+            getattr(device, "supports_display_configuration", False)
+            and device.display_brightness is not None
+        ):
+            entities.append(
+                SHCDisplayBrightnessNumber(
+                    device=device,
+                    parent_id=parent_id,
+                    entry_id=config_entry.entry_id,
+                )
+            )
+        if (
+            getattr(device, "supports_display_configuration", False)
+            and device.display_on_time is not None
+        ):
+            entities.append(
+                SHCDisplayOnTimeNumber(
+                    device=device,
+                    parent_id=parent_id,
+                    entry_id=config_entry.entry_id,
+                )
+            )
+
+    entities.extend(
+        SHCImpulseLengthNumber(
+            device=device,
+            parent_id=parent_id,
+            entry_id=config_entry.entry_id,
+        )
+        for device in session.device_helper.micromodule_impulse_relays
+        if device.impulse_length is not None
+    )
+
+    async_add_entities(entities)
+
+
+class SHCThermostatOffsetNumber(SHCEntity, NumberEntity):
+    """Number entity for TRV / wall-thermostat temperature offset."""
+
+    _attr_device_class = NumberDeviceClass.TEMPERATURE
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_mode = NumberMode.BOX
+    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+    _attr_translation_key = "thermostat_offset"
+
+    def __init__(self, device: SHCDevice, parent_id: str, entry_id: str) -> None:
+        """Initialize the thermostat offset number."""
+        super().__init__(device, parent_id, entry_id)
+        self._attr_unique_id = f"{device.serial}_offset"
+
+    @property
+    @override
+    def native_value(self) -> float:
+        """Return the current offset."""
+        return self._device.offset
+
+    @property
+    @override
+    def native_step(self) -> float:
+        """Return the step size."""
+        return self._device.step_size
+
+    @property
+    @override
+    def native_min_value(self) -> float:
+        """Return the minimum offset."""
+        return self._device.min_offset
+
+    @property
+    @override
+    def native_max_value(self) -> float:
+        """Return the maximum offset."""
+        return self._device.max_offset
+
+    @override
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the temperature offset, clamped to the device range."""
+        clamped = max(self.native_min_value, min(self.native_max_value, value))
+        await self.hass.async_add_executor_job(setattr, self._device, "offset", clamped)
+
+
+class SHCImpulseLengthNumber(SHCEntity, NumberEntity):
+    """Number entity for the impulse length of a Micromodule Relay in impulse mode.
+
+    The lib stores impulse_length in tenths of seconds (units of 100 ms).
+    We expose it in seconds (range 1-60 s, step 0.1 s) for user-friendly display.
+    """
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_mode = NumberMode.BOX
+    _attr_native_max_value = 60.0
+    _attr_native_min_value = 1.0
+    _attr_native_step = 0.1
+    _attr_native_unit_of_measurement = UnitOfTime.SECONDS
+    _attr_translation_key = "impulse_length"
+
+    def __init__(
+        self, device: SHCMicromoduleRelay, parent_id: str, entry_id: str
+    ) -> None:
+        """Initialize the impulse-length number."""
+        super().__init__(device, parent_id, entry_id)
+        self._attr_unique_id = f"{device.serial}_impulse_length"
+
+    @property
+    @override
+    def native_value(self) -> float | None:
+        """Return the impulse length in seconds."""
+        raw = self._device.impulse_length
+        return None if raw is None else raw / 10.0
+
+    @override
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the impulse length (converted from seconds to tenths of seconds)."""
+        clamped = max(
+            self._attr_native_min_value, min(self._attr_native_max_value, value)
+        )
+        raw = round(clamped * 10)
+        await self.hass.async_add_executor_job(
+            setattr, self._device, "impulse_length", raw
+        )
+
+
+class SHCDisplayBrightnessNumber(SHCEntity, NumberEntity):
+    """Number entity for the display brightness of a TRV Gen2 or Room Thermostat 2."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_mode = NumberMode.SLIDER
+    _attr_native_step = 1.0
+    _attr_translation_key = "display_brightness"
+
+    def __init__(self, device: SHCDevice, parent_id: str, entry_id: str) -> None:
+        """Initialize the display-brightness number."""
+        super().__init__(device, parent_id, entry_id)
+        self._attr_unique_id = f"{device.serial}_display_brightness"
+
+    @property
+    @override
+    def native_min_value(self) -> float:
+        """Return minimum brightness from the device."""
+        val = getattr(
+            getattr(self._device, "_display_config_service", None),
+            "display_brightness_min",
+            None,
+        )
+        return float(val) if val is not None else 0.0
+
+    @property
+    @override
+    def native_max_value(self) -> float:
+        """Return maximum brightness from the device."""
+        val = getattr(
+            getattr(self._device, "_display_config_service", None),
+            "display_brightness_max",
+            None,
+        )
+        return float(val) if val is not None else 100.0
+
+    @property
+    @override
+    def native_value(self) -> float | None:
+        """Return the current display brightness."""
+        val = self._device.display_brightness
+        return None if val is None else float(val)
+
+    @override
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the display brightness."""
+        clamped = int(max(self.native_min_value, min(self.native_max_value, value)))
+        await self.hass.async_add_executor_job(
+            setattr, self._device, "display_brightness", clamped
+        )
+
+
+class SHCDisplayOnTimeNumber(SHCEntity, NumberEntity):
+    """Number entity for display on-time of a TRV Gen2 or Room Thermostat 2."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_mode = NumberMode.BOX
+    _attr_native_step = 1.0
+    _attr_native_unit_of_measurement = UnitOfTime.SECONDS
+    _attr_translation_key = "display_on_time"
+
+    def __init__(self, device: SHCDevice, parent_id: str, entry_id: str) -> None:
+        """Initialize the display-on-time number."""
+        super().__init__(device, parent_id, entry_id)
+        self._attr_unique_id = f"{device.serial}_display_on_time"
+
+    @property
+    @override
+    def native_min_value(self) -> float:
+        """Return minimum on-time from the device."""
+        val = getattr(
+            getattr(self._device, "_display_config_service", None),
+            "display_on_time_min",
+            None,
+        )
+        return float(val) if val is not None else 0.0
+
+    @property
+    @override
+    def native_max_value(self) -> float:
+        """Return maximum on-time from the device."""
+        val = getattr(
+            getattr(self._device, "_display_config_service", None),
+            "display_on_time_max",
+            None,
+        )
+        return float(val) if val is not None else 3600.0
+
+    @property
+    @override
+    def native_value(self) -> float | None:
+        """Return the current display on-time in seconds."""
+        val = self._device.display_on_time
+        return None if val is None else float(val)
+
+    @override
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the display on-time in seconds."""
+        clamped = int(max(self.native_min_value, min(self.native_max_value, value)))
+        await self.hass.async_add_executor_job(
+            setattr, self._device, "display_on_time", clamped
+        )

--- a/homeassistant/components/bosch_shc/strings.json
+++ b/homeassistant/components/bosch_shc/strings.json
@@ -44,6 +44,20 @@
     }
   },
   "entity": {
+    "number": {
+      "display_brightness": {
+        "name": "Display brightness"
+      },
+      "display_on_time": {
+        "name": "Display on-time"
+      },
+      "impulse_length": {
+        "name": "Impulse length"
+      },
+      "thermostat_offset": {
+        "name": "Temperature offset"
+      }
+    },
     "sensor": {
       "air_quality": {
         "name": "Air quality"

--- a/tests/components/bosch_shc/test_number.py
+++ b/tests/components/bosch_shc/test_number.py
@@ -1,0 +1,370 @@
+"""Tests for the Bosch SHC number platform."""
+
+from unittest.mock import MagicMock, patch
+
+from homeassistant.components.number import (
+    ATTR_VALUE,
+    DOMAIN as NUMBER_DOMAIN,
+    SERVICE_SET_VALUE,
+)
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+DOMAIN = "bosch_shc"
+
+MOCK_ENTRY_DATA = {
+    "host": "1.2.3.4",
+    "ssl_certificate": "/fake/cert.pem",
+    "ssl_key": "/fake/key.pem",
+    "hostname": "shc012345",
+    "token": "token:shc012345",
+}
+
+
+def _make_mock_session(
+    thermostats=None,
+    roomthermostats=None,
+    micromodule_impulse_relays=None,
+):
+    """Build a minimal mock SHCSession."""
+    session = MagicMock()
+    session.information.unique_id = "shc-test-uid"
+    session.information.version = "9.99"
+    session.information.updateState.name = "UP_TO_DATE"
+    session.scenarios = []
+    session.device_helper.thermostats = thermostats or []
+    session.device_helper.roomthermostats = roomthermostats or []
+    session.device_helper.micromodule_impulse_relays = micromodule_impulse_relays or []
+    # Other device_helper properties used by other platforms
+    session.device_helper.shutter_contacts = []
+    session.device_helper.shutter_contacts2 = []
+    session.device_helper.shutter_controls = []
+    session.device_helper.micromodule_shutter_controls = []
+    session.device_helper.micromodule_blinds = []
+    session.device_helper.micromodule_relays = []
+    session.device_helper.micromodule_light_controls = []
+    session.device_helper.micromodule_light_attached = []
+    session.device_helper.light_switches_bsm = []
+    session.device_helper.climate_controls = []
+    session.device_helper.wallthermostats = []
+    session.device_helper.motion_detectors = []
+    session.device_helper.motion_detectors2 = []
+    session.device_helper.smart_plugs = []
+    session.device_helper.smart_plugs_compact = []
+    session.device_helper.smoke_detectors = []
+    session.device_helper.twinguards = []
+    session.device_helper.universal_switches = []
+    session.device_helper.camera_eyes = []
+    session.device_helper.camera_360 = []
+    session.device_helper.camera_outdoor_gen2 = []
+    session.device_helper.heating_circuits = []
+    return session
+
+
+def _make_mock_device(serial="device-serial-1", device_id="device-id-1"):
+    """Build a minimal mock SHCDevice."""
+    device = MagicMock()
+    device.serial = serial
+    device.id = device_id
+    device.root_device_id = device_id
+    device.name = "Test Device"
+    device.manufacturer = "Bosch"
+    device.device_model = "TEST_MODEL"
+    device.status = "AVAILABLE"
+    device.deleted = False
+    device.device_services = []
+    return device
+
+
+async def _setup_entry(hass: HomeAssistant, session: MagicMock) -> MockConfigEntry:
+    """Create and set up a mock config entry with the given session."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=1,
+        data=MOCK_ENTRY_DATA,
+        unique_id="shc012345",
+        title="Test SHC",
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.bosch_shc.SHCSession",
+            return_value=session,
+        ),
+        patch(
+            "homeassistant.components.bosch_shc.async_get_instance",
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    return entry
+
+
+async def _set_value(hass: HomeAssistant, entity_id: str, value: float) -> None:
+    """Call the set_value service for the given number entity."""
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: value},
+        blocking=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Thermostat temperature offset
+# ---------------------------------------------------------------------------
+
+
+async def test_thermostat_offset_created(hass: HomeAssistant) -> None:
+    """Thermostat offset number created for every thermostat."""
+    device = _make_mock_device(serial="trv-1", device_id="trv-id-1")
+    device.offset = 0.5
+    device.step_size = 0.5
+    device.min_offset = -5.0
+    device.max_offset = 5.0
+    device.supports_display_configuration = False
+
+    session = _make_mock_session(thermostats=[device])
+    entry = await _setup_entry(hass, session)
+    assert entry.state.value == "loaded"
+
+    state = hass.states.get("number.test_device_temperature_offset")
+    assert state is not None
+    assert float(state.state) == 0.5
+
+
+async def test_thermostat_offset_set_value(hass: HomeAssistant) -> None:
+    """Setting offset calls setattr on the device."""
+    device = _make_mock_device(serial="trv-1", device_id="trv-id-1")
+    device.offset = 0.0
+    device.step_size = 0.5
+    device.min_offset = -5.0
+    device.max_offset = 5.0
+    device.supports_display_configuration = False
+
+    session = _make_mock_session(thermostats=[device])
+    await _setup_entry(hass, session)
+
+    await _set_value(hass, "number.test_device_temperature_offset", 1.5)
+
+    assert device.offset == 1.5
+
+
+async def test_thermostat_offset_clamped_to_max(hass: HomeAssistant) -> None:
+    """Setting a value above max is clamped to max_offset."""
+    device = _make_mock_device(serial="trv-1", device_id="trv-id-1")
+    device.offset = 0.0
+    device.step_size = 0.5
+    device.min_offset = -5.0
+    device.max_offset = 5.0
+    device.supports_display_configuration = False
+
+    session = _make_mock_session(thermostats=[device])
+    await _setup_entry(hass, session)
+
+    await _set_value(hass, "number.test_device_temperature_offset", 10.0)
+
+    assert device.offset == 5.0
+
+
+async def test_thermostat_offset_for_roomthermostat(hass: HomeAssistant) -> None:
+    """Thermostat offset number also created for roomthermostats."""
+    device = _make_mock_device(serial="rt2-1", device_id="rt2-id-1")
+    device.offset = -0.5
+    device.step_size = 0.5
+    device.min_offset = -5.0
+    device.max_offset = 5.0
+    device.supports_display_configuration = False
+
+    session = _make_mock_session(roomthermostats=[device])
+    entry = await _setup_entry(hass, session)
+    assert entry.state.value == "loaded"
+
+    state = hass.states.get("number.test_device_temperature_offset")
+    assert state is not None
+    assert float(state.state) == -0.5
+
+
+# ---------------------------------------------------------------------------
+# Impulse relay length
+# ---------------------------------------------------------------------------
+
+
+async def test_impulse_length_created(hass: HomeAssistant) -> None:
+    """Impulse-length number created when impulse_length is not None."""
+    device = _make_mock_device(serial="relay-1", device_id="relay-id-1")
+    device.impulse_length = 20  # 20 tenths = 2.0 s
+
+    session = _make_mock_session(micromodule_impulse_relays=[device])
+    entry = await _setup_entry(hass, session)
+    assert entry.state.value == "loaded"
+
+    state = hass.states.get("number.test_device_impulse_length")
+    assert state is not None
+    assert float(state.state) == 2.0
+
+
+async def test_impulse_length_set_value(hass: HomeAssistant) -> None:
+    """Setting impulse length converts seconds to tenths of seconds."""
+    device = _make_mock_device(serial="relay-1", device_id="relay-id-1")
+    device.impulse_length = 20
+
+    session = _make_mock_session(micromodule_impulse_relays=[device])
+    await _setup_entry(hass, session)
+
+    await _set_value(hass, "number.test_device_impulse_length", 3.5)
+
+    assert device.impulse_length == 35
+
+
+async def test_impulse_length_skipped_when_none(hass: HomeAssistant) -> None:
+    """Impulse-length number not created when impulse_length is None."""
+    device = _make_mock_device(serial="relay-2", device_id="relay-id-2")
+    device.impulse_length = None
+
+    session = _make_mock_session(micromodule_impulse_relays=[device])
+    await _setup_entry(hass, session)
+
+    assert hass.states.get("number.test_device_impulse_length") is None
+
+
+# ---------------------------------------------------------------------------
+# Display brightness
+# ---------------------------------------------------------------------------
+
+
+async def test_display_brightness_created(hass: HomeAssistant) -> None:
+    """Display brightness number created when supported and not None."""
+    device = _make_mock_device(serial="trv-gen2-1", device_id="trv-gen2-id-1")
+    device.offset = 0.0
+    device.step_size = 0.5
+    device.min_offset = -5.0
+    device.max_offset = 5.0
+    device.supports_display_configuration = True
+    device.display_brightness = 50
+    device.display_on_time = None
+    svc = MagicMock()
+    svc.display_brightness_min = 0
+    svc.display_brightness_max = 100
+    device._display_config_service = svc
+
+    session = _make_mock_session(thermostats=[device])
+    entry = await _setup_entry(hass, session)
+    assert entry.state.value == "loaded"
+
+    state = hass.states.get("number.test_device_display_brightness")
+    assert state is not None
+    assert float(state.state) == 50.0
+
+
+async def test_display_brightness_set_value(hass: HomeAssistant) -> None:
+    """Setting display brightness calls setattr on the device."""
+    device = _make_mock_device(serial="trv-gen2-1", device_id="trv-gen2-id-1")
+    device.offset = 0.0
+    device.step_size = 0.5
+    device.min_offset = -5.0
+    device.max_offset = 5.0
+    device.supports_display_configuration = True
+    device.display_brightness = 50
+    device.display_on_time = None
+    svc = MagicMock()
+    svc.display_brightness_min = 0
+    svc.display_brightness_max = 100
+    device._display_config_service = svc
+
+    session = _make_mock_session(thermostats=[device])
+    await _setup_entry(hass, session)
+
+    await _set_value(hass, "number.test_device_display_brightness", 75.0)
+
+    assert device.display_brightness == 75
+
+
+async def test_display_brightness_skipped_when_none(hass: HomeAssistant) -> None:
+    """Display brightness number not created when display_brightness is None."""
+    device = _make_mock_device(serial="trv-gen2-2", device_id="trv-gen2-id-2")
+    device.offset = 0.0
+    device.step_size = 0.5
+    device.min_offset = -5.0
+    device.max_offset = 5.0
+    device.supports_display_configuration = True
+    device.display_brightness = None
+    device.display_on_time = None
+
+    session = _make_mock_session(thermostats=[device])
+    await _setup_entry(hass, session)
+
+    assert hass.states.get("number.test_device_display_brightness") is None
+
+
+# ---------------------------------------------------------------------------
+# Display on-time
+# ---------------------------------------------------------------------------
+
+
+async def test_display_on_time_created(hass: HomeAssistant) -> None:
+    """Display on-time number created when supported and not None."""
+    device = _make_mock_device(serial="trv-gen2-3", device_id="trv-gen2-id-3")
+    device.offset = 0.0
+    device.step_size = 0.5
+    device.min_offset = -5.0
+    device.max_offset = 5.0
+    device.supports_display_configuration = True
+    device.display_brightness = None
+    device.display_on_time = 30
+    svc = MagicMock()
+    svc.display_on_time_min = 0
+    svc.display_on_time_max = 3600
+    device._display_config_service = svc
+
+    session = _make_mock_session(thermostats=[device])
+    entry = await _setup_entry(hass, session)
+    assert entry.state.value == "loaded"
+
+    state = hass.states.get("number.test_device_display_on_time")
+    assert state is not None
+    assert float(state.state) == 30.0
+
+
+async def test_display_on_time_set_value(hass: HomeAssistant) -> None:
+    """Setting display on-time calls setattr on the device."""
+    device = _make_mock_device(serial="trv-gen2-3", device_id="trv-gen2-id-3")
+    device.offset = 0.0
+    device.step_size = 0.5
+    device.min_offset = -5.0
+    device.max_offset = 5.0
+    device.supports_display_configuration = True
+    device.display_brightness = None
+    device.display_on_time = 30
+    svc = MagicMock()
+    svc.display_on_time_min = 0
+    svc.display_on_time_max = 3600
+    device._display_config_service = svc
+
+    session = _make_mock_session(thermostats=[device])
+    await _setup_entry(hass, session)
+
+    await _set_value(hass, "number.test_device_display_on_time", 60.0)
+
+    assert device.display_on_time == 60
+
+
+async def test_display_on_time_skipped_when_none(hass: HomeAssistant) -> None:
+    """Display on-time number not created when display_on_time is None."""
+    device = _make_mock_device(serial="trv-gen2-4", device_id="trv-gen2-id-4")
+    device.offset = 0.0
+    device.step_size = 0.5
+    device.min_offset = -5.0
+    device.max_offset = 5.0
+    device.supports_display_configuration = True
+    device.display_brightness = None
+    device.display_on_time = None
+
+    session = _make_mock_session(thermostats=[device])
+    await _setup_entry(hass, session)
+
+    assert hass.states.get("number.test_device_display_on_time") is None

--- a/tests/components/bosch_shc/test_number.py
+++ b/tests/components/bosch_shc/test_number.py
@@ -154,23 +154,6 @@ async def test_thermostat_offset_set_value(hass: HomeAssistant) -> None:
     assert device.offset == 1.5
 
 
-async def test_thermostat_offset_clamped_to_max(hass: HomeAssistant) -> None:
-    """Setting a value above max is clamped to max_offset."""
-    device = _make_mock_device(serial="trv-1", device_id="trv-id-1")
-    device.offset = 0.0
-    device.step_size = 0.5
-    device.min_offset = -5.0
-    device.max_offset = 5.0
-    device.supports_display_configuration = False
-
-    session = _make_mock_session(thermostats=[device])
-    await _setup_entry(hass, session)
-
-    await _set_value(hass, "number.test_device_temperature_offset", 10.0)
-
-    assert device.offset == 5.0
-
-
 async def test_thermostat_offset_for_roomthermostat(hass: HomeAssistant) -> None:
     """Thermostat offset number also created for roomthermostats."""
     device = _make_mock_device(serial="rt2-1", device_id="rt2-id-1")


### PR DESCRIPTION
## Proposed change

Adds the \`number\` platform to the \`bosch_shc\` integration with four entity types:

| Entity | Device(s) | Description |
|--------|-----------|-------------|
| Temperature offset | TRV / Room Thermostat | Calibration offset (°C); min/max/step from device |
| Impulse length | Micromodule Relay (impulse mode) | Impulse duration in seconds (lib stores in 100 ms units) |
| Display brightness | TRV Gen2 / Room Thermostat 2 | Display backlight level (SLIDER; min/max from device) |
| Display on-time | TRV Gen2 / Room Thermostat 2 | Display stay-on duration in seconds |

All entities:
- are \`EntityCategory.CONFIG\`
- use \`hass.async_add_executor_job\` for writes (sync \`SHCSession\`)
- are \`getattr\`-guarded for optional device capabilities

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

Part of the incremental sync of HACS [boschshc-hass](https://github.com/tschamm/boschshc-hass) platforms into HA Core. See tracking issue: [tschamm/boschshc-hass#341](https://github.com/tschamm/boschshc-hass/issues/341)

Not included in this PR (require additional lib changes or are very recent/hardware-rare):
- Heating circuit eco/comfort setpoints (no sync model setter in boschshcpy 0.3.5)
- Smart plug energy-saving mode numbers
- Outdoor siren config numbers (added in boschshcpy 0.3.10, not yet in Core pin)

- Link to documentation pull request: home-assistant/home-assistant.io#46451

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist](https://developers.home-assistant.io/docs/development_checklist/)
- [x] I have followed the [translation requirements](https://developers.home-assistant.io/docs/internationalization/core)
- [x] The code has been formatted using Ruff (\`ruff format homeassistant tests\`)
- [x] Tests have been added to verify that the new code works.

If user-facing strings are changed, tests for the entity translation strings are added.