### PR TITLE
Remove name field from `srp_energy` config flow

### DIFF
--- a/homeassistant/components/srp_energy/config_flow.py
+++ b/homeassistant/components/srp_energy/config_flow.py
@@ -11,7 +11,7 @@ from homeassistant.config_entries import (
     ConfigFlow,
     ConfigFlowResult,
 )
-from homeassistant.const import CONF_ID, CONF_NAME, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import CONF_ID, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
@@ -70,7 +70,7 @@ class SRPEnergyConfigFlow(ConfigFlow, domain=DOMAIN):
 
                 if self.source == SOURCE_USER:
                     return self.async_create_entry(
-                        title=user_input[CONF_NAME],
+                        title=user_input[CONF_ID],
                         data=user_input,
                     )
                 return self.async_update_reload_and_abort(
@@ -87,11 +87,6 @@ class SRPEnergyConfigFlow(ConfigFlow, domain=DOMAIN):
                             if self.source == SOURCE_USER
                             else self._get_reconfigure_entry().data[CONF_ID]
                         ),
-                        # Name field is no longer allowed in config flow schemas
-                        # pylint: disable-next=home-assistant-config-flow-name-field
-                        vol.Required(
-                            CONF_NAME, default=self.hass.config.location_name
-                        ): str,
                         vol.Required(CONF_USERNAME): str,
                         vol.Required(CONF_PASSWORD): str,
                         vol.Optional(CONF_IS_TOU, default=False): bool,

--- a/homeassistant/components/srp_energy/const.py
+++ b/homeassistant/components/srp_energy/const.py
@@ -6,7 +6,6 @@ import logging
 LOGGER = logging.getLogger(__package__)
 
 DOMAIN = "srp_energy"
-DEFAULT_NAME = "Home"
 
 CONF_IS_TOU = "is_tou"
 

--- a/tests/components/srp_energy/__init__.py
+++ b/tests/components/srp_energy/__init__.py
@@ -3,17 +3,15 @@
 from typing import Final
 
 from homeassistant.components.srp_energy.const import CONF_IS_TOU
-from homeassistant.const import CONF_ID, CONF_NAME, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import CONF_ID, CONF_PASSWORD, CONF_USERNAME
 
 ACCNT_ID: Final = "123456789"
 ACCNT_IS_TOU: Final = False
 ACCNT_USERNAME: Final = "test_username"
 ACCNT_PASSWORD: Final = "test_password"
-ACCNT_NAME: Final = "Test Home"
 
 
 TEST_CONFIG_HOME: Final[dict[str, str]] = {
-    CONF_NAME: ACCNT_NAME,
     CONF_ID: ACCNT_ID,
     CONF_USERNAME: ACCNT_USERNAME,
     CONF_PASSWORD: ACCNT_PASSWORD,
@@ -21,10 +19,8 @@ TEST_CONFIG_HOME: Final[dict[str, str]] = {
 }
 
 ACCNT_ID_2: Final = "987654321"
-ACCNT_NAME_2: Final = "Test Cabin"
 
 TEST_CONFIG_CABIN: Final[dict[str, str]] = {
-    CONF_NAME: ACCNT_NAME_2,
     CONF_ID: ACCNT_ID_2,
     CONF_USERNAME: ACCNT_USERNAME,
     CONF_PASSWORD: ACCNT_PASSWORD,

--- a/tests/components/srp_energy/test_config_flow.py
+++ b/tests/components/srp_energy/test_config_flow.py
@@ -7,13 +7,7 @@ import pytest
 from homeassistant.components.recorder import Recorder
 from homeassistant.components.srp_energy.const import CONF_IS_TOU, DOMAIN
 from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
-from homeassistant.const import (
-    CONF_ID,
-    CONF_NAME,
-    CONF_PASSWORD,
-    CONF_SOURCE,
-    CONF_USERNAME,
-)
+from homeassistant.const import CONF_ID, CONF_PASSWORD, CONF_SOURCE, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -21,8 +15,6 @@ from . import (
     ACCNT_ID,
     ACCNT_ID_2,
     ACCNT_IS_TOU,
-    ACCNT_NAME,
-    ACCNT_NAME_2,
     ACCNT_PASSWORD,
     ACCNT_USERNAME,
     TEST_CONFIG_CABIN,
@@ -55,7 +47,7 @@ async def test_show_form(
         await hass.async_block_till_done()
 
         assert result["type"] is FlowResultType.CREATE_ENTRY
-        assert result["title"] == ACCNT_NAME
+        assert result["title"] == ACCNT_ID
 
         assert "data" in result
         assert result["data"][CONF_ID] == ACCNT_ID
@@ -172,7 +164,7 @@ async def test_flow_multiple_configs(
 
     # Verify created
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == ACCNT_NAME_2
+    assert result["title"] == ACCNT_ID_2
 
     assert "data" in result
     assert result["data"][CONF_ID] == ACCNT_ID_2
@@ -200,7 +192,6 @@ async def test_reconfigure(
         result["flow_id"],
         {
             CONF_ID: ACCNT_ID,
-            CONF_NAME: ACCNT_NAME + "reconf",
             CONF_USERNAME: ACCNT_USERNAME + "reconf",
             CONF_PASSWORD: ACCNT_PASSWORD + "reconf",
             CONF_IS_TOU: not ACCNT_IS_TOU,
@@ -211,7 +202,6 @@ async def test_reconfigure(
     assert result["reason"] == "reconfigure_successful"
     assert init_integration.data == {
         CONF_ID: ACCNT_ID,
-        CONF_NAME: ACCNT_NAME + "reconf",
         CONF_USERNAME: ACCNT_USERNAME + "reconf",
         CONF_PASSWORD: ACCNT_PASSWORD + "reconf",
         CONF_IS_TOU: not ACCNT_IS_TOU,
@@ -238,7 +228,6 @@ async def test_reconfigure_error(
         result["flow_id"],
         {
             CONF_ID: ACCNT_ID,
-            CONF_NAME: ACCNT_NAME + "reconf",
             CONF_USERNAME: ACCNT_USERNAME + "reconf",
             CONF_PASSWORD: ACCNT_PASSWORD + "reconf",
             CONF_IS_TOU: not ACCNT_IS_TOU,
@@ -254,7 +243,6 @@ async def test_reconfigure_error(
         result["flow_id"],
         {
             CONF_ID: ACCNT_ID,
-            CONF_NAME: ACCNT_NAME + "reconf",
             CONF_USERNAME: ACCNT_USERNAME + "reconf",
             CONF_PASSWORD: ACCNT_PASSWORD + "reconf",
             CONF_IS_TOU: not ACCNT_IS_TOU,
@@ -285,7 +273,6 @@ async def test_reconfigure_unknown_error(
         result["flow_id"],
         {
             CONF_ID: ACCNT_ID,
-            CONF_NAME: ACCNT_NAME + "reconf",
             CONF_USERNAME: ACCNT_USERNAME + "reconf",
             CONF_PASSWORD: ACCNT_PASSWORD + "reconf",
             CONF_IS_TOU: not ACCNT_IS_TOU,


### PR DESCRIPTION
## Proposed change

Remove the `name` field from the `srp_energy` config flow, as required by the
`home-assistant-config-flow-name-field` rule and tracked by the config flow name
field cleanup epic (home-assistant/epics#47). Config flows should not ask users
to name the entry.

New entries are now titled by the SRP account ID (`CONF_ID`), which is the
integration's unique ID. Using the account ID keeps the device name
(`SRP Energy <account id>`, built from the entry title in `sensor.py`) and the
long term statistic names distinct when more than one account is configured, and
it avoids the redundant `SRP Energy SRP Energy` device name that a static title
would produce. The now unused `DEFAULT_NAME` constant is removed.

Existing entries are unaffected: the stored `name` value is no longer read
anywhere, and existing entry titles are preserved.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #168962

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist].
- [x] The code has been formatted using Ruff (`ruff format`).
- [x] Tests have been updated to verify the change works.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
