### PR TITLE
Fix async_get_entity_id() params for Alexa Devices

### DIFF
--- a/homeassistant/components/alexa_devices/utils.py
+++ b/homeassistant/components/alexa_devices/utils.py
@@ -28,7 +28,7 @@ async def async_update_unique_id(
     for serial_num in coordinator.data:
         unique_id = f"{serial_num}-{old_key}"
         if entity_id := entity_registry.async_get_entity_id(
-            DOMAIN, platform, unique_id
+            platform, DOMAIN, unique_id
         ):
             _LOGGER.debug("Updating unique_id for %s", entity_id)
             new_unique_id = unique_id.replace(old_key, new_key)
@@ -48,7 +48,7 @@ async def async_remove_entity_from_virtual_group(
 
     for serial_num in coordinator.data:
         unique_id = f"{serial_num}-{key}"
-        entity_id = entity_registry.async_get_entity_id(DOMAIN, platform, unique_id)
+        entity_id = entity_registry.async_get_entity_id(platform, DOMAIN, unique_id)
         is_group = coordinator.data[serial_num].device_family == SPEAKER_GROUP_FAMILY
         if entity_id and is_group:
             entity_registry.async_remove(entity_id)
@@ -70,7 +70,7 @@ async def async_remove_unsupported_notification_sensors(
         ):
             unique_id = f"{serial_num}-{notification_key}"
             entity_id = entity_registry.async_get_entity_id(
-                DOMAIN, SENSOR_DOMAIN, unique_id=unique_id
+                SENSOR_DOMAIN, DOMAIN, unique_id=unique_id
             )
             is_unsupported = not coordinator.data[serial_num].notifications_supported
 

--- a/tests/components/alexa_devices/test_utils.py
+++ b/tests/components/alexa_devices/test_utils.py
@@ -145,8 +145,8 @@ async def test_alexa_dnd_group_removal(
     )
 
     entity = entity_registry.async_get_or_create(
-        DOMAIN,
         SWITCH_DOMAIN,
+        DOMAIN,
         unique_id=f"{TEST_DEVICE_1_SN}-do_not_disturb",
         device_id=device.id,
         config_entry=mock_config_entry,
@@ -184,8 +184,8 @@ async def test_alexa_unsupported_notification_sensor_removal(
     )
 
     entity = entity_registry.async_get_or_create(
-        DOMAIN,
         SENSOR_DOMAIN,
+        DOMAIN,
         unique_id=f"{TEST_DEVICE_1_SN}-Timer",
         device_id=device.id,
         config_entry=mock_config_entry,

--- a/tests/components/alexa_devices/test_utils.py
+++ b/tests/components/alexa_devices/test_utils.py
@@ -107,8 +107,8 @@ async def test_alexa_unique_id_migration(
     )
 
     entity = entity_registry.async_get_or_create(
-        DOMAIN,
         SWITCH_DOMAIN,
+        DOMAIN,
         unique_id=f"{TEST_DEVICE_1_SN}-do_not_disturb",
         device_id=device.id,
         config_entry=mock_config_entry,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix async_get_entity_id() params for Alexa Devices as follow-up of #174532

Note: Looks like we need to fix docstrings also for async_get_or_create()

/cc @arturpragacz

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
