### PR TITLE
Add repair when IPv6 is disabled for Matter

### DIFF
--- a/homeassistant/components/matter/__init__.py
+++ b/homeassistant/components/matter/__init__.py
@@ -4,6 +4,7 @@ import asyncio
 from functools import cache
 from typing import TYPE_CHECKING
 
+from aiohasupervisor.models import InterfaceMethod
 from matter_server.client import MatterClient
 from matter_server.client.exceptions import (
     CannotConnect,
@@ -15,13 +16,20 @@ from matter_server.client.exceptions import (
 from matter_server.common.errors import MatterError, NodeNotExists
 from yarl import URL
 
-from homeassistant.components.hassio import AddonError, AddonManager, AddonState
+from homeassistant.components.hassio import (
+    AddonError,
+    AddonManager,
+    AddonState,
+    SupervisorError,
+    get_supervisor_client,
+)
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_URL, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.hassio import is_hassio
 from homeassistant.helpers.issue_registry import (
     IssueSeverity,
     async_create_issue,
@@ -122,6 +130,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: MatterConfigEntry) -> bo
 
     async_delete_issue(hass, DOMAIN, "server_version_version_too_old")
     async_delete_issue(hass, DOMAIN, "server_version_version_too_new")
+
+    await _async_check_ipv6_enabled(hass)
 
     ble_proxy: MatterBleProxy | None = None
 
@@ -250,6 +260,53 @@ def _derive_ble_proxy_url(matter_ws_url: str) -> str | None:
     else:
         return None
     return str(parsed.with_path(new_path))
+
+
+async def _async_check_ipv6_enabled(hass: HomeAssistant) -> None:
+    """Raise a repair issue when IPv6 is disabled in Supervisor network settings.
+
+    Matter relies on IPv6 to communicate with devices. On Supervised/HAOS
+    installations the host network IPv6 method can be disabled per interface,
+    which silently breaks Matter, so we surface a repair pointing the user at
+    the network settings.
+    """
+    if not is_hassio(hass):
+        return
+
+    client = get_supervisor_client(hass)
+    try:
+        network_info = await client.network.info()
+    except SupervisorError as err:
+        LOGGER.debug("Failed to fetch Supervisor network info: %s", err)
+        return
+
+    connected_interfaces = [
+        interface
+        for interface in network_info.interfaces
+        if interface.enabled and interface.connected
+    ]
+    # Without a connected interface we can't tell whether IPv6 is disabled or
+    # the network is simply not up yet, so avoid raising a false repair.
+    if not connected_interfaces:
+        return
+
+    if any(
+        interface.ipv6 is not None
+        and interface.ipv6.method is not InterfaceMethod.DISABLED
+        for interface in connected_interfaces
+    ):
+        async_delete_issue(hass, DOMAIN, "ipv6_disabled")
+        return
+
+    async_create_issue(
+        hass,
+        DOMAIN,
+        "ipv6_disabled",
+        is_fixable=False,
+        severity=IssueSeverity.WARNING,
+        translation_key="ipv6_disabled",
+        learn_more_url="homeassistant://config/network",
+    )
 
 
 async def _client_listen(

--- a/homeassistant/components/matter/strings.json
+++ b/homeassistant/components/matter/strings.json
@@ -722,7 +722,7 @@
   },
   "issues": {
     "ipv6_disabled": {
-      "description": "Matter requires IPv6 to communicate with your devices, but IPv6 is disabled on your network interface. Matter will not work reliably until you enable IPv6 in the network settings. Select \"Learn more\" to open them.",
+      "description": "Matter relies on IPv6 to communicate with some devices, but IPv6 is disabled on all of your connected network interfaces. Locally connected Wi-Fi and Ethernet devices may still work, but features such as using an external Thread border router need IPv6 enabled. Select \"Learn more\" to open the network settings.",
       "title": "IPv6 is disabled but required by Matter"
     },
     "server_version_version_too_new": {

--- a/homeassistant/components/matter/strings.json
+++ b/homeassistant/components/matter/strings.json
@@ -721,6 +721,10 @@
     }
   },
   "issues": {
+    "ipv6_disabled": {
+      "description": "Matter requires IPv6 to communicate with your devices, but IPv6 is disabled on your network interface. Matter will not work reliably until you enable IPv6 in the network settings. Select \"Learn more\" to open them.",
+      "title": "IPv6 is disabled but required by Matter"
+    },
     "server_version_version_too_new": {
       "description": "The version of the Matter Server you are currently running is too new for this version of Home Assistant. Please update Home Assistant or downgrade the Matter Server to an older version to fix this issue.",
       "title": "Older version of Matter Server needed"

--- a/tests/components/matter/test_init.py
+++ b/tests/components/matter/test_init.py
@@ -5,7 +5,7 @@ from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 from aiohasupervisor import SupervisorError
-from aiohasupervisor.models import PartialBackupOptions
+from aiohasupervisor.models import InterfaceMethod, PartialBackupOptions
 from matter_server.client.exceptions import (
     CannotConnect,
     NotConnected,
@@ -548,6 +548,197 @@ async def test_issue_registry_invalid_version(
 
     assert entry.state is ConfigEntryState.LOADED
     assert not issue_registry.async_get_issue(DOMAIN, issue_raised)
+
+
+def _mock_network_interface(
+    *, enabled: bool, connected: bool, ipv6_method: InterfaceMethod | None
+) -> MagicMock:
+    """Build a mock Supervisor network interface."""
+    interface = MagicMock()
+    interface.enabled = enabled
+    interface.connected = connected
+    interface.ipv6 = None if ipv6_method is None else MagicMock(method=ipv6_method)
+    return interface
+
+
+@pytest.mark.parametrize(
+    ("interfaces", "issue_expected"),
+    [
+        pytest.param(
+            [
+                _mock_network_interface(
+                    enabled=True, connected=True, ipv6_method=InterfaceMethod.DISABLED
+                )
+            ],
+            True,
+            id="ipv6_disabled",
+        ),
+        pytest.param(
+            [_mock_network_interface(enabled=True, connected=True, ipv6_method=None)],
+            True,
+            id="no_ipv6_config",
+        ),
+        pytest.param(
+            [
+                _mock_network_interface(
+                    enabled=True, connected=True, ipv6_method=InterfaceMethod.AUTO
+                )
+            ],
+            False,
+            id="ipv6_auto",
+        ),
+        pytest.param(
+            [
+                _mock_network_interface(
+                    enabled=True, connected=True, ipv6_method=InterfaceMethod.STATIC
+                )
+            ],
+            False,
+            id="ipv6_static",
+        ),
+        pytest.param(
+            [
+                _mock_network_interface(
+                    enabled=True, connected=True, ipv6_method=InterfaceMethod.DISABLED
+                ),
+                _mock_network_interface(
+                    enabled=True, connected=True, ipv6_method=InterfaceMethod.AUTO
+                ),
+            ],
+            False,
+            id="ipv6_enabled_on_secondary_interface",
+        ),
+        pytest.param(
+            [
+                _mock_network_interface(
+                    enabled=True, connected=False, ipv6_method=InterfaceMethod.DISABLED
+                )
+            ],
+            False,
+            id="no_connected_interface",
+        ),
+    ],
+)
+async def test_ipv6_disabled_repair(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    issue_registry: ir.IssueRegistry,
+    interfaces: list[MagicMock],
+    issue_expected: bool,
+) -> None:
+    """Test repair issue when IPv6 is disabled in Supervisor network settings."""
+    supervisor_client = MagicMock()
+    supervisor_client.network.info = AsyncMock(
+        return_value=MagicMock(interfaces=interfaces)
+    )
+
+    entry = MockConfigEntry(domain=DOMAIN, data={"url": "ws://localhost:5580/ws"})
+    entry.add_to_hass(hass)
+
+    with (
+        patch("homeassistant.components.matter.is_hassio", return_value=True),
+        patch(
+            "homeassistant.components.matter.get_supervisor_client",
+            return_value=supervisor_client,
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    issue = issue_registry.async_get_issue(DOMAIN, "ipv6_disabled")
+    assert (issue is not None) is issue_expected
+
+
+async def test_ipv6_repair_not_raised_without_supervisor(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test the IPv6 repair is skipped when not running on Supervisor."""
+    with patch(
+        "homeassistant.components.matter.get_supervisor_client"
+    ) as get_supervisor_client:
+        entry = MockConfigEntry(domain=DOMAIN, data={"url": "ws://localhost:5580/ws"})
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    get_supervisor_client.assert_not_called()
+    assert not issue_registry.async_get_issue(DOMAIN, "ipv6_disabled")
+
+
+async def test_ipv6_repair_supervisor_error(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test the IPv6 repair handles Supervisor errors gracefully."""
+    supervisor_client = MagicMock()
+    supervisor_client.network.info = AsyncMock(side_effect=SupervisorError("boom"))
+
+    entry = MockConfigEntry(domain=DOMAIN, data={"url": "ws://localhost:5580/ws"})
+    entry.add_to_hass(hass)
+
+    with (
+        patch("homeassistant.components.matter.is_hassio", return_value=True),
+        patch(
+            "homeassistant.components.matter.get_supervisor_client",
+            return_value=supervisor_client,
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert not issue_registry.async_get_issue(DOMAIN, "ipv6_disabled")
+
+
+async def test_ipv6_repair_resolves_on_reload(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test the IPv6 repair is removed once IPv6 is enabled again."""
+    supervisor_client = MagicMock()
+    supervisor_client.network.info = AsyncMock(
+        return_value=MagicMock(
+            interfaces=[
+                _mock_network_interface(
+                    enabled=True, connected=True, ipv6_method=InterfaceMethod.DISABLED
+                )
+            ]
+        )
+    )
+
+    entry = MockConfigEntry(domain=DOMAIN, data={"url": "ws://localhost:5580/ws"})
+    entry.add_to_hass(hass)
+
+    with (
+        patch("homeassistant.components.matter.is_hassio", return_value=True),
+        patch(
+            "homeassistant.components.matter.get_supervisor_client",
+            return_value=supervisor_client,
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert issue_registry.async_get_issue(DOMAIN, "ipv6_disabled")
+
+        supervisor_client.network.info.return_value = MagicMock(
+            interfaces=[
+                _mock_network_interface(
+                    enabled=True, connected=True, ipv6_method=InterfaceMethod.AUTO
+                )
+            ]
+        )
+        await hass.config_entries.async_reload(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert not issue_registry.async_get_issue(DOMAIN, "ipv6_disabled")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Matter relies on IPv6 to communicate with devices. On Supervised/HAOS installations the host network IPv6 method can be disabled per interface in Supervisor's network settings, which silently breaks Matter with no obvious indication to the user.

This adds a check during Matter setup that inspects the Supervisor network information and raises a repair issue when none of the connected interfaces have IPv6 enabled. The repair points the user to the network settings via the "Learn more" button. Once IPv6 is enabled on integration load, the issue is automatically being dismissed. The check is gated on Supervisor being available, so it is a no-op on Home Assistant Container or standalone Core installations.

Note: Strictly speaking, IPv6 set to "Automatic" is only required when a third-party Thread border router is in play. To learn the routes to the Thread network offered by another Thread BR the system running Home Assistant must implement the IPv6 Neighbor discovery protocol, specifically process the router advertisements. On Home Assistant OS this is taken care of by NetworkManager, which enables IPv6 NDP RA only if the setting is "Auto" or "Shared" (the latter is not exposed through Supervisor). The "Disabled" setting still assigns link-local addresses, which is all what is needed to reach Wi-Fi/Ethernet Matter devices on the same network. A local Thread border router has IPv6 enabled by default and is reachable by the Matter server even if other network interfaces have IPv6 disabled. That said, it is still a good idea to keep IPv6 enabled in case an external Thread border router comes into play later, which is why this is surfaced as a repair rather than enforced; users who are sure they don't need it can simply ignore it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #164532
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
