### PR TITLE
Fix notify group default data payload

### DIFF
--- a/homeassistant/components/group/notify.py
+++ b/homeassistant/components/group/notify.py
@@ -10,6 +10,7 @@ import voluptuous as vol
 from homeassistant.components.notify import (
     ATTR_DATA,
     ATTR_MESSAGE,
+    ATTR_TARGET,
     ATTR_TITLE,
     DOMAIN as NOTIFY_DOMAIN,
     PLATFORM_SCHEMA as NOTIFY_PLATFORM_SCHEMA,
@@ -35,6 +36,7 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from .entity import GroupEntity
 
 CONF_SERVICES = "services"
+_SERVICE_DATA_KEYS = {ATTR_DATA, ATTR_MESSAGE, ATTR_TARGET, ATTR_TITLE}
 
 
 def _backward_compat_schema(value: Any | None) -> Any:
@@ -84,6 +86,28 @@ def add_defaults(
     return input_data
 
 
+def _normalize_default_data(default_data: Mapping[str, Any]) -> dict[str, Any]:
+    """Move notify data defaults into the notify data payload."""
+    service_defaults: dict[str, Any] = {}
+    data_defaults: dict[str, Any] = {}
+
+    for key, val in default_data.items():
+        if key in _SERVICE_DATA_KEYS:
+            service_defaults[key] = val
+        else:
+            data_defaults[key] = val
+
+    if data_defaults:
+        if (configured_data := service_defaults.get(ATTR_DATA)) is not None:
+            service_defaults[ATTR_DATA] = add_defaults(
+                deepcopy(configured_data), data_defaults
+            )
+        else:
+            service_defaults[ATTR_DATA] = data_defaults
+
+    return service_defaults
+
+
 async def async_get_service(
     hass: HomeAssistant,
     config: ConfigType,
@@ -111,7 +135,7 @@ class GroupNotifyPlatform(BaseNotificationService):
         for entity in self.entities:
             sending_payload = deepcopy(payload.copy())
             if (default_data := entity.get(ATTR_DATA)) is not None:
-                add_defaults(sending_payload, default_data)
+                add_defaults(sending_payload, _normalize_default_data(default_data))
             tasks.append(
                 asyncio.create_task(
                     self.hass.services.async_call(

--- a/tests/components/group/test_notify.py
+++ b/tests/components/group/test_notify.py
@@ -11,7 +11,9 @@ from homeassistant import config as hass_config
 from homeassistant.components import notify
 from homeassistant.components.group import DOMAIN, SERVICE_RELOAD
 from homeassistant.components.notify import (
+    ATTR_DATA,
     ATTR_MESSAGE,
+    ATTR_TARGET,
     ATTR_TITLE,
     DOMAIN as NOTIFY_DOMAIN,
     SERVICE_SEND_MESSAGE,
@@ -202,6 +204,67 @@ async def test_send_message_with_data(hass: HomeAssistant, tmp_path: Path) -> No
             ),
         ],
         any_order=True,
+    )
+
+
+async def test_send_message_with_default_notify_data(
+    hass: HomeAssistant, tmp_path: Path
+) -> None:
+    """Test sending a message with default notify data to a notify group."""
+    assert await async_setup_component(
+        hass,
+        DOMAIN,
+        {},
+    )
+    await hass.async_block_till_done()
+
+    group_setup = [
+        {
+            "platform": "group",
+            "name": "My notification group",
+            "services": [
+                {
+                    "action": "test_service1",
+                    ATTR_DATA: {
+                        ATTR_TARGET: "unnamed device",
+                        "push": {"sound": "default"},
+                    },
+                },
+            ],
+        }
+    ]
+    send_message_mock = await help_setup_notify(
+        hass, tmp_path, {"service1": 1}, group_setup
+    )
+    assert hass.services.has_service("notify", "my_notification_group")
+
+    await hass.services.async_call(
+        "notify",
+        "my_notification_group",
+        {ATTR_MESSAGE: "Hello"},
+        blocking=True,
+    )
+    send_message_mock.assert_called_once_with(
+        "Hello",
+        {
+            ATTR_TARGET: [1],
+            ATTR_DATA: {"push": {"sound": "default"}},
+        },
+    )
+    send_message_mock.reset_mock()
+
+    await hass.services.async_call(
+        "notify",
+        "my_notification_group",
+        {ATTR_MESSAGE: "Hello", ATTR_DATA: {"push": {"sound": "custom"}}},
+        blocking=True,
+    )
+    send_message_mock.assert_called_once_with(
+        "Hello",
+        {
+            ATTR_TARGET: [1],
+            ATTR_DATA: {"push": {"sound": "custom"}},
+        },
     )
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

None.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Normalize legacy notify group per-target defaults before forwarding them to the underlying notify service.

A legacy notify group can configure default data for a member service. When that default contains notify payload keys such as `push`, the group platform currently forwards those keys as top-level service data. The legacy notify service schema only accepts top-level `message`, `title`, `target`, and `data`, so the call fails before it reaches the target notify platform.

This keeps valid top-level notify service defaults (`title`, `target`, and `data`) at the service level and moves other per-target defaults into the nested notify `data` payload. Explicit data supplied by the service call still takes precedence over configured defaults.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #174525
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

Validation performed:

- `.venv\Scripts\python.exe -m ruff format homeassistant/components/group/notify.py tests/components/group/test_notify.py --check`
- `.venv\Scripts\python.exe -m ruff check homeassistant/components/group/notify.py tests/components/group/test_notify.py`
- Local helper assertion for `_normalize_default_data` with default `push` data and explicit call data precedence.

Targeted local pytest was attempted, but this Windows environment cannot load Home Assistant's test harness without Linux-only modules from `homeassistant.runner` and additional component test dependencies. The PR is opened as a draft so CI and CLA can run before marking it ready for review.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr