### PR TITLE
Handle unknown Alexa Drop In option

### DIFF
--- a/homeassistant/components/alexa_devices/select.py
+++ b/homeassistant/components/alexa_devices/select.py
@@ -86,9 +86,12 @@ class AmazonSelectEntity(AmazonEntity, SelectEntity):
     async def async_added_to_hass(self) -> None:
         """Restore last known option."""
         await super().async_added_to_hass()
-        self._attr_current_option = self._device.communication_settings[
+        current_option = self._device.communication_settings[
             self.entity_description.key
-        ].lower()
+        ]
+        self._attr_current_option = (
+            current_option.lower() if current_option is not None else None
+        )
 
     @override
     async def async_select_option(self, option: str) -> None:

--- a/tests/components/alexa_devices/test_select.py
+++ b/tests/components/alexa_devices/test_select.py
@@ -6,11 +6,18 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.alexa_devices.const import DOMAIN as ALEXA_DEVICES_DOMAIN
 from homeassistant.components.select import (
     DOMAIN as SELECT_DOMAIN,
     SERVICE_SELECT_OPTION,
 )
-from homeassistant.const import ATTR_ENTITY_ID, ATTR_OPTION, STATE_UNAVAILABLE, Platform
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ATTR_OPTION,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    Platform,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -80,6 +87,46 @@ async def test_select_dropin_option(
     assert mock_amazon_devices_client.set_dropin_status.call_count == 2
     assert (state := hass.states.get(ENTITY_ID))
     assert state.state == "off"
+
+
+async def test_select_dropin_none_option(
+    hass: HomeAssistant,
+    mock_amazon_devices_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test selecting a drop-in option when the current option is unknown."""
+    device_data = deepcopy(TEST_DEVICE_1)
+    device_data.communication_settings = {
+        "announcements": "ON",
+        "communications": "ON",
+        "dropin": None,
+    }
+    mock_amazon_devices_client.get_devices_data.return_value = {
+        TEST_DEVICE_1_SN: device_data
+    }
+
+    with patch("homeassistant.components.alexa_devices.PLATFORMS", [Platform.SELECT]):
+        await setup_integration(hass, mock_config_entry)
+
+    entity_registry = er.async_get(hass)
+    entity_id = entity_registry.async_get_entity_id(
+        SELECT_DOMAIN, ALEXA_DEVICES_DOMAIN, f"{TEST_DEVICE_1_SN}-dropin"
+    )
+    assert entity_id
+
+    assert (state := hass.states.get(entity_id))
+    assert state.state == STATE_UNKNOWN
+
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {ATTR_ENTITY_ID: entity_id, ATTR_OPTION: "home"},
+        blocking=True,
+    )
+
+    assert mock_amazon_devices_client.set_dropin_status.call_count == 1
+    assert (state := hass.states.get(entity_id))
+    assert state.state == "home"
 
 
 async def test_offline_device(

--- a/tests/components/alexa_devices/test_select.py
+++ b/tests/components/alexa_devices/test_select.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.alexa_devices.const import DOMAIN as ALEXA_DEVICES_DOMAIN
+from homeassistant.components.alexa_devices.const import DOMAIN
 from homeassistant.components.select import (
     DOMAIN as SELECT_DOMAIN,
     SERVICE_SELECT_OPTION,
@@ -110,7 +110,7 @@ async def test_select_dropin_none_option(
 
     entity_registry = er.async_get(hass)
     entity_id = entity_registry.async_get_entity_id(
-        SELECT_DOMAIN, ALEXA_DEVICES_DOMAIN, f"{TEST_DEVICE_1_SN}-dropin"
+        SELECT_DOMAIN, DOMAIN, f"{TEST_DEVICE_1_SN}-dropin"
     )
     assert entity_id
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

None.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Handle Alexa Devices returning `None` for the current Drop In communication setting.

When the API includes the `dropin` communication setting but its value is `None`, the select entity currently calls `.lower()` on `None` during `async_added_to_hass`, which prevents the entity from being added. This keeps the select entity available with an unknown current option, while still allowing users to choose a valid Drop In option.

The regression test covers a device with `dropin: None` and verifies that selecting a valid option still calls the API and updates the entity state.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #174670
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

Validation performed:

- `.venv\Scripts\python.exe -m ruff format homeassistant/components/alexa_devices/select.py tests/components/alexa_devices/test_select.py --check`
- `.venv\Scripts\python.exe -m ruff check homeassistant/components/alexa_devices/select.py tests/components/alexa_devices/test_select.py`
- `git diff --check`
- Targeted local pytest collected and ran `tests/components/alexa_devices/test_select.py::test_select_dropin_none_option`; the test body passed, but this Windows environment failed during teardown in the global translation checker for core select service strings. The PR is opened as a draft so CI can validate in Home Assistant's Linux environment before it is marked ready for review.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr