### PR TITLE
Create Anthropic client in executor

### DIFF
--- a/homeassistant/components/anthropic/__init__.py
+++ b/homeassistant/components/anthropic/__init__.py
@@ -29,6 +29,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: AnthropicConfigEntry) -> bool:
     """Set up Anthropic from a config entry."""
     coordinator = AnthropicCoordinator(hass, entry)
+    await coordinator.async_setup()
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator
     LOGGER.debug("Available models: %s", coordinator.data)

--- a/homeassistant/components/anthropic/config_flow.py
+++ b/homeassistant/components/anthropic/config_flow.py
@@ -28,7 +28,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv, llm
-from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.helpers.selector import (
     NumberSelector,
     NumberSelectorConfig,
@@ -66,7 +65,7 @@ from .const import (
     TOOL_SEARCH_UNSUPPORTED_MODELS,
     PromptCaching,
 )
-from .coordinator import model_alias
+from .coordinator import async_create_client, model_alias
 
 if TYPE_CHECKING:
     from . import AnthropicConfigEntry
@@ -95,9 +94,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> None:
 
     Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
     """
-    client = anthropic.AsyncAnthropic(
-        api_key=data[CONF_API_KEY], http_client=get_async_client(hass)
-    )
+    client = await async_create_client(hass, data[CONF_API_KEY])
     await client.models.list(timeout=10.0)
 
 
@@ -549,9 +546,8 @@ class ConversationSubentryFlowHandler(ConfigSubentryFlow):
         location_data: dict[str, str] = {}
         zone_home = self.hass.states.get(ENTITY_ID_HOME)
         if zone_home is not None:
-            client = anthropic.AsyncAnthropic(
-                api_key=self._get_entry().data[CONF_API_KEY],
-                http_client=get_async_client(self.hass),
+            client = await async_create_client(
+                self.hass, self._get_entry().data[CONF_API_KEY]
             )
             location_schema = vol.Schema(
                 {

--- a/homeassistant/components/anthropic/coordinator.py
+++ b/homeassistant/components/anthropic/coordinator.py
@@ -1,6 +1,7 @@
 """Coordinator for the Anthropic integration."""
 
 import datetime
+from functools import partial
 from typing import override
 
 import anthropic
@@ -20,6 +21,19 @@ UPDATE_INTERVAL_DISCONNECTED = datetime.timedelta(minutes=1)
 type AnthropicConfigEntry = ConfigEntry[AnthropicCoordinator]
 
 
+async def async_create_client(
+    hass: HomeAssistant, api_key: str
+) -> anthropic.AsyncAnthropic:
+    """Create an Anthropic client."""
+    return await hass.async_add_executor_job(
+        partial(
+            anthropic.AsyncAnthropic,
+            api_key=api_key,
+            http_client=get_async_client(hass),
+        )
+    )
+
+
 @callback
 def model_alias(model_id: str) -> str:
     """Resolve alias from versioned model name."""
@@ -33,10 +47,12 @@ def model_alias(model_id: str) -> str:
 class AnthropicCoordinator(DataUpdateCoordinator[list[anthropic.types.ModelInfo]]):
     """Coordinator using different intervals after success and failure."""
 
-    client: anthropic.AsyncAnthropic
+    _config_entry: AnthropicConfigEntry
+    _client: anthropic.AsyncAnthropic | None = None
 
     def __init__(self, hass: HomeAssistant, config_entry: AnthropicConfigEntry) -> None:
         """Initialize the coordinator."""
+        self._config_entry = config_entry
         super().__init__(
             hass,
             LOGGER,
@@ -46,8 +62,18 @@ class AnthropicCoordinator(DataUpdateCoordinator[list[anthropic.types.ModelInfo]
             update_method=self.async_update_data,
             always_update=False,
         )
-        self.client = anthropic.AsyncAnthropic(
-            api_key=config_entry.data[CONF_API_KEY], http_client=get_async_client(hass)
+
+    @property
+    def client(self) -> anthropic.AsyncAnthropic:
+        """Return the Anthropic client."""
+        if self._client is None:
+            raise RuntimeError("Anthropic client is not set up")
+        return self._client
+
+    async def async_setup(self) -> None:
+        """Set up the coordinator."""
+        self._client = await async_create_client(
+            self.hass, self._config_entry.data[CONF_API_KEY]
         )
 
     @callback

--- a/tests/components/anthropic/test_coordinator.py
+++ b/tests/components/anthropic/test_coordinator.py
@@ -1,5 +1,6 @@
 """Tests for the Anthropic integration."""
 
+from functools import partial
 from unittest.mock import AsyncMock, patch
 
 from anthropic import APITimeoutError, AuthenticationError, RateLimitError
@@ -11,6 +12,7 @@ from homeassistant.components.anthropic.const import DOMAIN
 from homeassistant.components.anthropic.coordinator import (
     UPDATE_INTERVAL_CONNECTED,
     UPDATE_INTERVAL_DISCONNECTED,
+    AnthropicCoordinator,
 )
 from homeassistant.config_entries import SOURCE_REAUTH
 from homeassistant.core import Context, HomeAssistant
@@ -18,6 +20,36 @@ from homeassistant.helpers import intent
 from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+async def test_client_setup_uses_executor(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the Anthropic client is created in the executor."""
+    client = object()
+
+    with (
+        patch.object(
+            hass, "async_add_executor_job", wraps=hass.async_add_executor_job
+        ) as mock_add_executor_job,
+        patch(
+            "homeassistant.components.anthropic.coordinator.anthropic.AsyncAnthropic",
+            return_value=client,
+        ) as mock_client,
+    ):
+        coordinator = AnthropicCoordinator(hass, mock_config_entry)
+        mock_client.assert_not_called()
+        await coordinator.async_setup()
+
+    mock_add_executor_job.assert_called_once()
+    create_client = mock_add_executor_job.call_args.args[0]
+    assert isinstance(create_client, partial)
+    assert create_client.func is mock_client
+    assert create_client.keywords is not None
+    assert create_client.keywords["api_key"] == "bla"
+    assert "http_client" in create_client.keywords
+    assert coordinator.client is client
 
 
 @patch("anthropic.resources.models.AsyncModels.list", new_callable=AsyncMock)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
None.

## Proposed change
Create the Anthropic `AsyncAnthropic` client in the executor before the first coordinator refresh. The Anthropic SDK constructor can synchronously inspect its credential/config files even when Home Assistant passes an explicit API key, which can trigger Home Assistant's blocking call detector.

This adds a shared `async_create_client` helper and uses it from the coordinator setup and config flow paths that validate the API key or request location data.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #174672
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

Local validation:
- `ruff format --check homeassistant/components/anthropic/__init__.py homeassistant/components/anthropic/config_flow.py homeassistant/components/anthropic/coordinator.py tests/components/anthropic/test_coordinator.py`
- `ruff check homeassistant/components/anthropic/__init__.py homeassistant/components/anthropic/config_flow.py homeassistant/components/anthropic/coordinator.py tests/components/anthropic/test_coordinator.py`
- `pylint tests/components/anthropic/test_coordinator.py`
- `pytest tests/components/anthropic/test_coordinator.py::test_client_setup_uses_executor -q` passes the test body locally on Windows, but teardown is blocked by the local Windows test harness translation setup (`homeassistant` service translation lookup) after using local `fcntl`/`resource` stubs.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr