### PR TITLE
Handle Tankerkoenig API errors in config flow

### DIFF
--- a/homeassistant/components/tankerkoenig/config_flow.py
+++ b/homeassistant/components/tankerkoenig/config_flow.py
@@ -8,6 +8,8 @@ from aiotankerkoenig import (
     Sort,
     Station,
     Tankerkoenig,
+    TankerkoenigConnectionError,
+    TankerkoenigError,
     TankerkoenigInvalidKeyError,
 )
 import voluptuous as vol
@@ -55,6 +57,18 @@ async def async_get_nearby_stations(
     )
 
 
+def _api_error_key(err: TankerkoenigError) -> str:
+    """Return the config flow error key for an API error."""
+    if isinstance(err, TankerkoenigConnectionError):
+        return "cannot_connect"
+
+    # aiotankerkoenig only classifies some API key errors as invalid keys.
+    if isinstance(err, TankerkoenigInvalidKeyError) or "key" in str(err).lower():
+        return "invalid_auth"
+
+    return "cannot_connect"
+
+
 class FlowHandler(ConfigFlow, domain=DOMAIN):
     """Handle a config flow."""
 
@@ -94,10 +108,13 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
         )
         try:
             stations = await async_get_nearby_stations(tankerkoenig, user_input)
-        except TankerkoenigInvalidKeyError:
-            return self._show_form_user(
-                user_input, errors={CONF_API_KEY: "invalid_auth"}
-            )
+        except TankerkoenigError as err:
+            error_key = _api_error_key(err)
+            if error_key == "invalid_auth":
+                return self._show_form_user(
+                    user_input, errors={CONF_API_KEY: error_key}
+                )
+            return self._show_form_user(user_input, errors={"base": error_key})
 
         # no stations found
         if len(stations) == 0:
@@ -153,8 +170,11 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
         )
         try:
             await async_get_nearby_stations(tankerkoenig, user_input)
-        except TankerkoenigInvalidKeyError:
-            return self._show_form_reauth(user_input, {CONF_API_KEY: "invalid_auth"})
+        except TankerkoenigError as err:
+            error_key = _api_error_key(err)
+            if error_key == "invalid_auth":
+                return self._show_form_reauth(user_input, {CONF_API_KEY: error_key})
+            return self._show_form_reauth(user_input, {"base": error_key})
 
         return self.async_update_reload_and_abort(reauth_entry, data=user_input)
 
@@ -260,8 +280,10 @@ class OptionsFlowHandler(OptionsFlowWithReload):
             stations = await async_get_nearby_stations(
                 tankerkoenig, self.config_entry.data
             )
-        except TankerkoenigInvalidKeyError:
-            return self.async_show_form(step_id="init", errors={"base": "invalid_auth"})
+        except TankerkoenigError as err:
+            return self.async_show_form(
+                step_id="init", errors={"base": _api_error_key(err)}
+            )
 
         if stations:
             for station in stations:

--- a/homeassistant/components/tankerkoenig/strings.json
+++ b/homeassistant/components/tankerkoenig/strings.json
@@ -12,6 +12,7 @@
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     },
     "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "no_stations": "Could not find any station in range."
     },
@@ -179,6 +180,7 @@
   },
   "options": {
     "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
     },
     "step": {

--- a/tests/components/tankerkoenig/test_config_flow.py
+++ b/tests/components/tankerkoenig/test_config_flow.py
@@ -2,7 +2,11 @@
 
 from unittest.mock import AsyncMock, patch
 
-from aiotankerkoenig.exceptions import TankerkoenigInvalidKeyError
+from aiotankerkoenig.exceptions import (
+    TankerkoenigConnectionError,
+    TankerkoenigError,
+    TankerkoenigInvalidKeyError,
+)
 
 from homeassistant.components.tankerkoenig.const import CONF_STATIONS, DOMAIN
 from homeassistant.config_entries import SOURCE_USER
@@ -133,6 +137,72 @@ async def test_exception_security(hass: HomeAssistant) -> None:
         assert result["errors"][CONF_API_KEY] == "invalid_auth"
 
 
+async def test_api_rejected_key_error(hass: HomeAssistant) -> None:
+    """Test starting a flow with an API rejected key error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    with patch(
+        "homeassistant.components.tankerkoenig.config_flow.Tankerkoenig.nearby_stations",
+        side_effect=TankerkoenigError(
+            "tankerkoenig.de API responded with an error: Key is disabled",
+            {"response": "Key is disabled"},
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=MOCK_USER_DATA
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "user"
+        assert result["errors"][CONF_API_KEY] == "invalid_auth"
+
+
+async def test_api_connection_error(hass: HomeAssistant) -> None:
+    """Test starting a flow with an API connection error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    with patch(
+        "homeassistant.components.tankerkoenig.config_flow.Tankerkoenig.nearby_stations",
+        side_effect=TankerkoenigConnectionError,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=MOCK_USER_DATA
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "user"
+        assert result["errors"]["base"] == "cannot_connect"
+
+
+async def test_api_error(hass: HomeAssistant) -> None:
+    """Test starting a flow with a generic API error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    with patch(
+        "homeassistant.components.tankerkoenig.config_flow.Tankerkoenig.nearby_stations",
+        side_effect=TankerkoenigError(
+            "tankerkoenig.de API responded with an error: maintenance",
+            {"response": "maintenance"},
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=MOCK_USER_DATA
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "user"
+        assert result["errors"]["base"] == "cannot_connect"
+
+
 async def test_user_no_stations(hass: HomeAssistant) -> None:
     """Test starting a flow by user which does not find any station."""
     result = await hass.config_entries.flow.async_init(
@@ -196,6 +266,30 @@ async def test_reauth(hass: HomeAssistant, config_entry: MockConfigEntry) -> Non
 
     entry = hass.config_entries.async_get_entry(config_entry.entry_id)
     assert entry.data[CONF_API_KEY] == "269534f6-aaaa-bbbb-cccc-yyyyzzzzxxxx"
+
+
+async def test_reauth_connection_error(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
+    """Test re-auth with an API connection error."""
+    config_entry.add_to_hass(hass)
+    result = await config_entry.start_reauth_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    with patch(
+        "homeassistant.components.tankerkoenig.config_flow.Tankerkoenig.nearby_stations",
+        side_effect=TankerkoenigConnectionError,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_API_KEY: "269534f6-aaaa-bbbb-cccc-yyyyzzzzxxxx",
+            },
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "reauth_confirm"
+        assert result["errors"] == {"base": "cannot_connect"}
 
 
 async def test_options_flow(hass: HomeAssistant, tankerkoenig: AsyncMock) -> None:
@@ -270,3 +364,27 @@ async def test_options_flow_error(hass: HomeAssistant) -> None:
         )
         assert result["type"] is FlowResultType.CREATE_ENTRY
         assert not mock_config.options[CONF_SHOW_ON_MAP]
+
+
+async def test_options_flow_api_rejected_key_error(hass: HomeAssistant) -> None:
+    """Test options flow with an API rejected key error."""
+
+    mock_config = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_OPTIONS_DATA,
+        options={CONF_SHOW_ON_MAP: True},
+        unique_id=f"{DOMAIN}_{MOCK_USER_DATA[CONF_LOCATION][CONF_LATITUDE]}_{MOCK_USER_DATA[CONF_LOCATION][CONF_LONGITUDE]}",
+    )
+    mock_config.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.tankerkoenig.config_flow.Tankerkoenig.nearby_stations",
+        side_effect=TankerkoenigError(
+            "tankerkoenig.de API responded with an error: Key is disabled",
+            {"response": "Key is disabled"},
+        ),
+    ):
+        result = await hass.config_entries.options.async_init(mock_config.entry_id)
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "init"
+        assert result["errors"] == {"base": "invalid_auth"}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
None.

## Proposed change
Handle Tankerkoenig API errors while opening the config, reauth, and options flows.

The Tankerkoenig API can reject an API key with a generic `TankerkoenigError` response instead of the more specific `TankerkoenigInvalidKeyError`. When that happens in the options flow today, the exception bubbles up and Home Assistant returns a 500 error instead of showing the form error.

This maps API key rejection responses to `invalid_auth` and connection-style failures to `cannot_connect`, so the flow remains usable and the user can retry or reauthenticate.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #174659
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

Local validation:
- `ruff format --check homeassistant/components/tankerkoenig/config_flow.py tests/components/tankerkoenig/test_config_flow.py`
- `ruff check homeassistant/components/tankerkoenig/config_flow.py tests/components/tankerkoenig/test_config_flow.py`
- `pylint homeassistant/components/tankerkoenig/config_flow.py tests/components/tankerkoenig/test_config_flow.py`
- `python -m script.hassfest --integration-path homeassistant/components/tankerkoenig`
- `PREK_SKIP=no-commit-to-branch,mypy,pylint,gen_requirements_all,hassfest,hassfest-metadata,hassfest-mypy-config,zizmor prek run --files homeassistant/components/tankerkoenig/config_flow.py homeassistant/components/tankerkoenig/strings.json tests/components/tankerkoenig/test_config_flow.py`
- `pytest tests/components/tankerkoenig/test_config_flow.py::test_api_rejected_key_error tests/components/tankerkoenig/test_config_flow.py::test_api_connection_error tests/components/tankerkoenig/test_config_flow.py::test_api_error tests/components/tankerkoenig/test_config_flow.py::test_reauth_connection_error tests/components/tankerkoenig/test_config_flow.py::test_options_flow_api_rejected_key_error -q` passes the test bodies locally on Windows; teardown is blocked by the local translation checker reporting existing Tankerkoenig keys as missing.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr