### PR TITLE
Handle Freebox host list timeouts

### DIFF
--- a/homeassistant/components/freebox/router.py
+++ b/homeassistant/components/freebox/router.py
@@ -77,6 +77,8 @@ async def get_hosts_list_if_supported(
             fbx_devices.extend(
                 await fbx_api.lan.get_hosts_list(interface["name"]) or []
             )
+    except TimeoutError:
+        _LOGGER.debug("Timed out while updating Freebox host list")
     except HttpRequestError as err:
         if (
             (matcher := re.search(r"Request failed \(APIResponse: (.+)\)", str(err)))

--- a/tests/components/freebox/test_router.py
+++ b/tests/components/freebox/test_router.py
@@ -54,6 +54,18 @@ async def test_get_hosts_list_if_supported_bridge(
     assert fbx_devices == []
 
 
+async def test_get_hosts_list_if_supported_timeout(
+    router: Mock,
+) -> None:
+    """Timeouts during host list updates are retried on the next update."""
+    router().lan.get_hosts_list.side_effect = TimeoutError
+
+    supports_hosts, fbx_devices = await get_hosts_list_if_supported(router())
+
+    assert supports_hosts is True
+    assert fbx_devices == []
+
+
 async def test_get_hosts_list_if_supported_bridge_error(
     mock_router_bridge_mode_error: Mock,
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
None.

## Proposed change
Handle timeouts while Freebox updates the LAN host list.

A timeout while calling `lan.get_hosts_list()` currently bubbles out of `get_hosts_list_if_supported()`, which can leave the periodic Freebox update task with an unhandled exception. A timeout is transient and should not disable host list support permanently, so this keeps `supports_hosts` enabled and skips the host list for the current update. The next scheduled update will retry normally.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #174517
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

Local validation:
- `ruff format --check homeassistant/components/freebox/router.py tests/components/freebox/test_router.py`
- `ruff check homeassistant/components/freebox/router.py tests/components/freebox/test_router.py`
- `pylint homeassistant/components/freebox/router.py tests/components/freebox/test_router.py`
- `PREK_SKIP=no-commit-to-branch,mypy,pylint,gen_requirements_all,hassfest,hassfest-metadata,hassfest-mypy-config,zizmor prek run --files homeassistant/components/freebox/router.py tests/components/freebox/test_router.py`
- `python -m script.hassfest --integration-path homeassistant/components/freebox`
- `pytest tests/components/freebox/test_router.py -q`

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr