### PR TITLE
Handle Speedtest server URL whitespace

### DIFF
--- a/homeassistant/components/speedtestdotnet/coordinator.py
+++ b/homeassistant/components/speedtestdotnet/coordinator.py
@@ -1,8 +1,10 @@
 """Coordinator for speedtestdotnet."""
 
 from datetime import timedelta
+from http.client import InvalidURL
 import logging
 from typing import Any, cast, override
+from urllib.parse import urlsplit, urlunsplit
 
 import speedtest
 
@@ -15,6 +17,20 @@ from .const import CONF_SERVER_ID, DEFAULT_SCAN_INTERVAL, DEFAULT_SERVER, DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 type SpeedTestConfigEntry = ConfigEntry[SpeedTestDataCoordinator]
+
+
+def _normalize_server_url(server: dict[str, Any]) -> None:
+    """Normalize a speedtest server URL."""
+    url_parts = urlsplit(server["url"])
+    server["url"] = urlunsplit(
+        (
+            url_parts.scheme,
+            url_parts.netloc.strip(),
+            url_parts.path,
+            url_parts.query,
+            url_parts.fragment,
+        )
+    )
 
 
 class SpeedTestDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
@@ -45,6 +61,9 @@ class SpeedTestDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         test_servers_list = [
             server for servers in test_servers.values() for server in servers
         ]
+        for server in test_servers_list:
+            _normalize_server_url(server)
+
         for server in sorted(
             test_servers_list,
             key=lambda server: (
@@ -81,5 +100,7 @@ class SpeedTestDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return await self.hass.async_add_executor_job(self.update_data)
         except speedtest.NoMatchedServers as err:
             raise UpdateFailed("Selected server is not found.") from err
+        except InvalidURL as err:
+            raise UpdateFailed(err) from err
         except speedtest.SpeedtestException as err:
             raise UpdateFailed(err) from err

--- a/tests/components/speedtestdotnet/test_init.py
+++ b/tests/components/speedtestdotnet/test_init.py
@@ -1,6 +1,8 @@
 """Tests for SpeedTest integration."""
 
+from copy import deepcopy
 from datetime import timedelta
+from http.client import InvalidURL
 from unittest.mock import MagicMock
 
 import speedtest
@@ -12,13 +14,26 @@ from homeassistant.components.speedtestdotnet.const import (
 )
 from homeassistant.components.speedtestdotnet.coordinator import (
     SpeedTestDataCoordinator,
+    _normalize_server_url,
 )
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
+from . import MOCK_SERVERS
+
 from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+def test_normalize_server_url() -> None:
+    """Test stripping whitespace from a server URL host."""
+    server = deepcopy(MOCK_SERVERS[1][0])
+    server["url"] = "http:// server_1:8080/speedtest/upload.php"
+
+    _normalize_server_url(server)
+
+    assert server["url"] == "http://server_1:8080/speedtest/upload.php"
 
 
 async def test_setup_failed(hass: HomeAssistant, mock_api: MagicMock) -> None:
@@ -108,3 +123,24 @@ async def test_get_best_server_error(hass: HomeAssistant, mock_api: MagicMock) -
     state = hass.states.get("sensor.speedtest_ping")
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
+
+
+async def test_invalid_server_url(hass: HomeAssistant, mock_api: MagicMock) -> None:
+    """Test malformed server URLs do not raise unexpected errors."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert isinstance(entry.runtime_data, SpeedTestDataCoordinator)
+
+    mock_api.return_value.get_best_server.side_effect = InvalidURL(
+        "URL can't contain control characters"
+    )
+    await entry.runtime_data.async_refresh()
+    assert not entry.runtime_data.last_update_success


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
None.

## Proposed change
Normalize Speedtest.net server URLs before selecting the best server.

Some Speedtest server entries can include whitespace in the URL host, which makes `speedtest-cli` raise `http.client.InvalidURL` while testing latency. This strips whitespace from the parsed URL netloc before `get_best_server()` uses the server list, and also converts any remaining `InvalidURL` into `UpdateFailed` so the coordinator marks the update unavailable instead of logging an unexpected exception.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #174561
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

Local validation:
- `ruff format --check homeassistant/components/speedtestdotnet/coordinator.py tests/components/speedtestdotnet/test_init.py`
- `ruff check homeassistant/components/speedtestdotnet/coordinator.py tests/components/speedtestdotnet/test_init.py`
- `pylint homeassistant/components/speedtestdotnet/coordinator.py tests/components/speedtestdotnet/test_init.py`
- `PREK_SKIP=no-commit-to-branch,mypy,pylint,gen_requirements_all,hassfest,hassfest-metadata,hassfest-mypy-config,zizmor prek run --files homeassistant/components/speedtestdotnet/coordinator.py tests/components/speedtestdotnet/test_init.py`
- `python -m script.hassfest --integration-path homeassistant/components/speedtestdotnet`
- `pytest tests/components/speedtestdotnet/test_init.py::test_normalize_server_url tests/components/speedtestdotnet/test_init.py::test_invalid_server_url -q`

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr