### PR TITLE
Add delegated charging mode to Renault integration

### DIFF
--- a/homeassistant/components/renault/sensor.py
+++ b/homeassistant/components/renault/sensor.py
@@ -321,6 +321,7 @@ SENSOR_TYPES: tuple[RenaultSensorEntityDescription[Any], ...] = (
         options=[
             "always",
             "delayed",
+            "delegated",
             "scheduled",
         ],
         value_lambda=_get_charging_settings_mode_formatted,

--- a/homeassistant/components/renault/strings.json
+++ b/homeassistant/components/renault/strings.json
@@ -157,6 +157,7 @@
         "state": {
           "always": "Always",
           "delayed": "Delayed",
+          "delegated": "Delegated",
           "scheduled": "Scheduled"
         }
       },

--- a/pylint/plugins/pylint_home_assistant/generated/mdi_icons.py
+++ b/pylint/plugins/pylint_home_assistant/generated/mdi_icons.py
@@ -5,7 +5,7 @@ To update, run python3 -m script.hassfest
 
 from typing import Final
 
-FRONTEND_VERSION: Final[str] = "20260527.7"
+FRONTEND_VERSION: Final[str] = "20260624.0"
 
 MDI_ICONS: Final[set[str]] = {
     "ab-testing",

--- a/pylint/plugins/pylint_home_assistant/generated/mdi_icons.py
+++ b/pylint/plugins/pylint_home_assistant/generated/mdi_icons.py
@@ -5,7 +5,7 @@ To update, run python3 -m script.hassfest
 
 from typing import Final
 
-FRONTEND_VERSION: Final[str] = "20260624.0"
+FRONTEND_VERSION: Final[str] = "20260527.7"
 
 MDI_ICONS: Final[set[str]] = {
     "ab-testing",

--- a/tests/components/renault/snapshots/test_sensor.ambr
+++ b/tests/components/renault/snapshots/test_sensor.ambr
@@ -318,6 +318,7 @@
       <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'always',
         'delayed',
+        'delegated',
         'scheduled',
       ]),
     }),
@@ -359,6 +360,7 @@
       <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'always',
         'delayed',
+        'delegated',
         'scheduled',
       ]),
     }),
@@ -1143,6 +1145,7 @@
       <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'always',
         'delayed',
+        'delegated',
         'scheduled',
       ]),
     }),
@@ -1184,6 +1187,7 @@
       <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'always',
         'delayed',
+        'delegated',
         'scheduled',
       ]),
     }),
@@ -2411,6 +2415,7 @@
       <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'always',
         'delayed',
+        'delegated',
         'scheduled',
       ]),
     }),
@@ -2452,6 +2457,7 @@
       <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'always',
         'delayed',
+        'delegated',
         'scheduled',
       ]),
     }),
@@ -3400,6 +3406,7 @@
       <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'always',
         'delayed',
+        'delegated',
         'scheduled',
       ]),
     }),
@@ -3441,6 +3448,7 @@
       <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'always',
         'delayed',
+        'delegated',
         'scheduled',
       ]),
     }),
@@ -4273,6 +4281,7 @@
       <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'always',
         'delayed',
+        'delegated',
         'scheduled',
       ]),
     }),
@@ -4314,6 +4323,7 @@
       <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'always',
         'delayed',
+        'delegated',
         'scheduled',
       ]),
     }),
@@ -5088,6 +5098,7 @@
       <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'always',
         'delayed',
+        'delegated',
         'scheduled',
       ]),
     }),
@@ -5129,6 +5140,7 @@
       <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'always',
         'delayed',
+        'delegated',
         'scheduled',
       ]),
     }),
@@ -5971,6 +5983,7 @@
       <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'always',
         'delayed',
+        'delegated',
         'scheduled',
       ]),
     }),
@@ -6012,6 +6025,7 @@
       <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'always',
         'delayed',
+        'delegated',
         'scheduled',
       ]),
     }),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Renault API now returns `delegated` as a charging settings mode for mobilize vehicles. This value was not in the sensor's options list, causing a `ValueError` when the sensor received this state.

This adds `delegated` to the options list and corresponding translation.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #174618
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr