### PR TITLE
Add Anglian Water reauth flow

### DIFF
--- a/homeassistant/components/anglian_water/__init__.py
+++ b/homeassistant/components/anglian_water/__init__.py
@@ -6,8 +6,10 @@ from pyanglianwater.auth import MSOB2CAuth
 from pyanglianwater.exceptions import (
     ConsentRequiredError,
     ExpiredAccessTokenError,
+    InvalidGrantError,
     SelfAssertedError,
     SmartMeterUnavailableError,
+    TokenRequestError,
 )
 
 from homeassistant.const import (
@@ -41,7 +43,13 @@ async def async_setup_entry(
     )
     try:
         await auth.send_refresh_request()
-    except (ConsentRequiredError, ExpiredAccessTokenError, SelfAssertedError) as err:
+    except (
+        ConsentRequiredError,
+        ExpiredAccessTokenError,
+        InvalidGrantError,
+        SelfAssertedError,
+        TokenRequestError,
+    ) as err:
         raise ConfigEntryAuthFailed from err
 
     _aw = AnglianWater(authenticator=auth)

--- a/homeassistant/components/anglian_water/config_flow.py
+++ b/homeassistant/components/anglian_water/config_flow.py
@@ -1,5 +1,6 @@
 """Config flow for the Anglian Water integration."""
 
+from collections.abc import Mapping
 import logging
 from typing import TYPE_CHECKING, Any, override
 
@@ -7,9 +8,8 @@ from aiohttp import CookieJar
 from pyanglianwater import AnglianWater
 from pyanglianwater.auth import MSOB2CAuth
 from pyanglianwater.exceptions import (
-    ConsentRequiredError,
+    AuthError,
     InvalidAccountIdError,
-    SelfAssertedError,
     SmartMeterUnavailableError,
 )
 import voluptuous as vol
@@ -37,7 +37,7 @@ async def validate_credentials(auth: MSOB2CAuth) -> str | MSOB2CAuth:
     """Validate the provided credentials."""
     try:
         await auth.send_login_request()
-    except ConsentRequiredError, SelfAssertedError:
+    except AuthError:
         return "invalid_auth"
     except Exception:
         _LOGGER.exception("Unexpected exception")
@@ -86,6 +86,17 @@ class AnglianWaterConfigFlow(ConfigFlow, domain=DOMAIN):
         self.accounts: list[selector.SelectOptionDict] = []
         self.user_input: dict[str, Any] | None = None
 
+    def _create_authenticator(self, user_input: dict[str, Any]) -> MSOB2CAuth:
+        """Create an Anglian Water authenticator from user input."""
+        return MSOB2CAuth(
+            username=user_input[CONF_USERNAME],
+            password=user_input[CONF_PASSWORD],
+            session=async_create_clientsession(
+                self.hass,
+                cookie_jar=CookieJar(quote_cookie=False),
+            ),
+        )
+
     @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -93,14 +104,7 @@ class AnglianWaterConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle the initial step."""
         errors: dict[str, str] = {}
         if user_input is not None:
-            self.authenticator = MSOB2CAuth(
-                username=user_input[CONF_USERNAME],
-                password=user_input[CONF_PASSWORD],
-                session=async_create_clientsession(
-                    self.hass,
-                    cookie_jar=CookieJar(quote_cookie=False),
-                ),
-            )
+            self.authenticator = self._create_authenticator(user_input)
             validation_response = await validate_credentials(self.authenticator)
             if isinstance(validation_response, str):
                 errors["base"] = validation_response
@@ -168,4 +172,52 @@ class AnglianWaterConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_create_entry(
             title=user_input[CONF_ACCOUNT_NUMBER],
             data=config_entry_data,
+        )
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Handle reauthentication."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reauthentication confirmation."""
+        errors: dict[str, str] = {}
+        reauth_entry = self._get_reauth_entry()
+
+        if user_input is not None:
+            self.authenticator = self._create_authenticator(user_input)
+            validation_response = await validate_credentials(self.authenticator)
+            if isinstance(validation_response, str):
+                errors["base"] = validation_response
+            else:
+                account_number = str(reauth_entry.data[CONF_ACCOUNT_NUMBER])
+                self.accounts = await get_accounts(self.authenticator)
+                if account_number not in {
+                    account["value"] for account in self.accounts
+                }:
+                    errors["base"] = "wrong_account"
+                else:
+                    validation_result = await validate_account(
+                        self.authenticator,
+                        account_number,
+                    )
+                    if isinstance(validation_result, str):
+                        errors["base"] = validation_result
+                    else:
+                        return self.async_update_reload_and_abort(
+                            reauth_entry,
+                            data_updates={
+                                CONF_USERNAME: user_input[CONF_USERNAME],
+                                CONF_PASSWORD: user_input[CONF_PASSWORD],
+                                CONF_ACCESS_TOKEN: self.authenticator.refresh_token,
+                            },
+                        )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=STEP_USER_DATA_SCHEMA,
+            errors=errors,
         )

--- a/homeassistant/components/anglian_water/quality_scale.yaml
+++ b/homeassistant/components/anglian_water/quality_scale.yaml
@@ -43,7 +43,7 @@ rules:
   integration-owner: done
   log-when-unavailable: done
   parallel-updates: done
-  reauthentication-flow: todo
+  reauthentication-flow: done
   test-coverage: todo
 
   # Gold

--- a/homeassistant/components/anglian_water/strings.json
+++ b/homeassistant/components/anglian_water/strings.json
@@ -1,15 +1,28 @@
 {
   "config": {
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "smart_meter_unavailable": "This account does not have any smart meters associated with it. If this is unexpected, enter your Billing Account Number found at the top of your latest bill.",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
+      "unknown": "[%key:common::config_flow::error::unknown%]",
+      "wrong_account": "You must reauthenticate with an Anglian Water account that includes the originally configured billing account."
     },
     "step": {
+      "reauth_confirm": {
+        "data": {
+          "password": "[%key:common::config_flow::data::password%]",
+          "username": "[%key:common::config_flow::data::username%]"
+        },
+        "data_description": {
+          "password": "Your password",
+          "username": "Username or email used to log in to the Anglian Water website."
+        },
+        "description": "Reauthenticate with your Anglian Water account credentials."
+      },
       "select_account": {
         "data": {
           "account_number": "Billing account number"

--- a/tests/components/anglian_water/test_config_flow.py
+++ b/tests/components/anglian_water/test_config_flow.py
@@ -271,3 +271,80 @@ async def test_account_recover_exception(
     assert result["data"][CONF_ACCESS_TOKEN] == ACCESS_TOKEN
     assert result["data"][CONF_ACCOUNT_NUMBER] == ACCOUNT_NUMBER
     assert result["result"].unique_id == ACCOUNT_NUMBER
+
+
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_reauth_flow(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_anglian_water_authenticator: AsyncMock,
+    mock_anglian_water_client: AsyncMock,
+) -> None:
+    """Test reauthentication updates credentials."""
+    mock_config_entry.add_to_hass(hass)
+    mock_anglian_water_authenticator.refresh_token = "new_token"
+
+    result = await mock_config_entry.start_reauth_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_USERNAME: "new@example.com",
+            CONF_PASSWORD: "new-password",
+        },
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert mock_config_entry.data[CONF_USERNAME] == "new@example.com"
+    assert mock_config_entry.data[CONF_PASSWORD] == "new-password"
+    assert mock_config_entry.data[CONF_ACCESS_TOKEN] == "new_token"
+    mock_anglian_water_client.validate_smart_meter.assert_called_once_with(
+        ACCOUNT_NUMBER
+    )
+
+
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_reauth_flow_wrong_account(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_anglian_water_authenticator: AsyncMock,
+    mock_anglian_water_client: AsyncMock,
+) -> None:
+    """Test reauthentication rejects a different account."""
+    mock_config_entry.add_to_hass(hass)
+    mock_anglian_water_client.api.get_associated_accounts.return_value = {
+        "result": {
+            "active": [
+                {
+                    "account_number": "999999999",
+                    "address": {
+                        "building_name": "",
+                        "company_name": "",
+                        "postcode": "AA1 1AA",
+                    },
+                }
+            ]
+        }
+    }
+
+    result = await mock_config_entry.start_reauth_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_USERNAME: "other@example.com",
+            CONF_PASSWORD: "other-password",
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+    assert result["errors"] == {"base": "wrong_account"}
+    mock_anglian_water_client.validate_smart_meter.assert_not_called()

--- a/tests/components/anglian_water/test_init.py
+++ b/tests/components/anglian_water/test_init.py
@@ -1,0 +1,39 @@
+"""Test the Anglian Water integration setup."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from pyanglianwater.exceptions import InvalidGrantError, TokenRequestError
+import pytest
+
+from homeassistant.components.anglian_water.const import DOMAIN
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.parametrize("exception", [InvalidGrantError, TokenRequestError])
+async def test_auth_error_starts_reauth(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_anglian_water_authenticator: MagicMock,
+    mock_anglian_water_client: AsyncMock,
+    exception: type[Exception],
+) -> None:
+    """Test auth errors during setup start reauthentication."""
+    mock_anglian_water_authenticator.send_refresh_request.side_effect = exception
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+
+    flow = flows[0]
+    assert flow["handler"] == DOMAIN
+    assert flow["step_id"] == "reauth_confirm"
+    assert flow["context"]["source"] == SOURCE_REAUTH
+    assert flow["context"]["entry_id"] == mock_config_entry.entry_id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a reauthentication flow for the Anglian Water integration so expired or rejected refresh tokens can be recovered without deleting and recreating the config entry.

The setup path now treats refresh-token auth failures reported by `pyanglianwater` (`InvalidGrantError`, `TokenRequestError`, and related auth exceptions) as `ConfigEntryAuthFailed`, which lets Home Assistant start the reauth flow. The reauth flow asks for the Anglian Water credentials again, verifies that the authenticated account still includes the originally configured billing account, validates that smart meter access is still available, and then updates the stored credentials and refresh token.

This is related to #174443, which improves Anglian Water exception handling but intentionally leaves the reauth flow as follow-up work. If #174443 lands first, this PR may need a small rebase around the setup exception handling.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #173437
- This PR is related to issue: #174443
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr