### PR TITLE
Ignore unknown LinkPlay album art URLs

### DIFF
--- a/homeassistant/components/linkplay/media_player.py
+++ b/homeassistant/components/linkplay/media_player.py
@@ -3,7 +3,7 @@
 
 from datetime import timedelta
 import logging
-from typing import TYPE_CHECKING, Any, override
+from typing import TYPE_CHECKING, Any, Final, override
 
 from linkplay.bridge import LinkPlayBridge
 from linkplay.consts import EqualizerMode, LoopMode, PlayingMode, PlayingStatus
@@ -106,6 +106,7 @@ SEEKABLE_FEATURES: MediaPlayerEntityFeature = (
 RETRY_POLL_MAXIMUM = 3
 SCAN_INTERVAL = timedelta(seconds=5)
 PARALLEL_UPDATES = 1
+UNKNOWN_ALBUM_ART_VALUES: Final = {"", "none", "null", "unknown"}
 
 
 async def async_setup_entry(
@@ -331,7 +332,15 @@ class LinkPlayMediaPlayerEntity(LinkPlayBaseEntity, MediaPlayerEntity):
     def media_image_url(self) -> str | None:
         """Image url of playing media."""
         if self._bridge.player.status in [PlayingStatus.PLAYING, PlayingStatus.PAUSED]:
-            return str(self._bridge.player.album_art)
+            album_art = self._bridge.player.album_art
+            if album_art is None:
+                return None
+
+            album_art_url = str(album_art).strip()
+            if album_art_url.casefold() in UNKNOWN_ALBUM_ART_VALUES:
+                return None
+
+            return album_art_url
         return None
 
     @exception_wrap

--- a/tests/components/linkplay/test_media_player.py
+++ b/tests/components/linkplay/test_media_player.py
@@ -1,0 +1,48 @@
+"""Tests for the LinkPlay media player platform."""
+
+from unittest.mock import MagicMock
+
+from linkplay.consts import PlayingStatus
+import pytest
+
+from homeassistant.components.linkplay.media_player import LinkPlayMediaPlayerEntity
+
+
+def _mock_linkplay_entity(
+    album_art: str | None,
+    status: PlayingStatus = PlayingStatus.PLAYING,
+) -> LinkPlayMediaPlayerEntity:
+    """Create a LinkPlay media player entity with mocked bridge data."""
+    bridge = MagicMock()
+    bridge.device.uuid = "test-uuid"
+    bridge.device.playmode_support = []
+    bridge.player.available_equalizer_modes = []
+    bridge.player.album_art = album_art
+    bridge.player.status = status
+    return LinkPlayMediaPlayerEntity(bridge)
+
+
+@pytest.mark.parametrize(
+    "album_art", [None, "", "   ", "unknown", "Unknown", "none", "null"]
+)
+def test_media_image_url_ignores_unknown_album_art(album_art: str | None) -> None:
+    """Test unknown album art values are not exposed as media image URLs."""
+    entity = _mock_linkplay_entity(album_art)
+
+    assert entity.media_image_url is None
+
+
+def test_media_image_url_returns_album_art_for_playing_media() -> None:
+    """Test album art is exposed while media is playing."""
+    entity = _mock_linkplay_entity("http://example.com/album-art.jpg")
+
+    assert entity.media_image_url == "http://example.com/album-art.jpg"
+
+
+def test_media_image_url_returns_none_when_not_playing() -> None:
+    """Test album art is hidden when media is stopped."""
+    entity = _mock_linkplay_entity(
+        "http://example.com/album-art.jpg", PlayingStatus.STOPPED
+    )
+
+    assert entity.media_image_url is None


### PR DESCRIPTION
## Proposed change
LinkPlay players may report unavailable album art as sentinel values such as `unknown`. The media player entity exposed that sentinel as `media_image_url`, which can make Home Assistant build an invalid artwork URL when the dashboard requests the image.

This normalizes empty/unknown album art values to `None` while preserving real album art URLs for playing or paused media.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #159602
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

## Validation

- `pytest --force-enable-socket tests/components/linkplay/test_media_player.py`
- `ruff check homeassistant/components/linkplay tests/components/linkplay/test_media_player.py`
- `ruff format --check homeassistant/components/linkplay/media_player.py tests/components/linkplay/test_media_player.py`
- `python -m script.hassfest --integration-path homeassistant/components/linkplay`
- `pylint homeassistant/components/linkplay tests/components/linkplay/test_media_player.py`

Existing broader LinkPlay tests were also sampled locally and currently expose unrelated pre-existing translation-check failures for service labels outside this change.