### PR TITLE
Handle Yardian device info without yid

### DIFF
--- a/homeassistant/components/yardian/config_flow.py
+++ b/homeassistant/components/yardian/config_flow.py
@@ -60,12 +60,16 @@ class YardianConfigFlow(ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
             else:
-                await self.async_set_unique_id(device_info["yid"])
-                self._abort_if_unique_id_configured()
-                return self.async_create_entry(
-                    data=user_input | device_info,
-                    title=PRODUCT_NAME,
-                )
+                if not (yid := device_info.get("yid")):
+                    _LOGGER.debug("Yardian device info is missing device identifier")
+                    errors["base"] = "invalid_response"
+                else:
+                    await self.async_set_unique_id(yid)
+                    self._abort_if_unique_id_configured()
+                    return self.async_create_entry(
+                        data=user_input | device_info,
+                        title=PRODUCT_NAME,
+                    )
 
         return self.async_show_form(
             step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors

--- a/homeassistant/components/yardian/strings.json
+++ b/homeassistant/components/yardian/strings.json
@@ -6,6 +6,7 @@
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "invalid_response": "The device returned an invalid response",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {

--- a/tests/components/yardian/test_config_flow.py
+++ b/tests/components/yardian/test_config_flow.py
@@ -74,3 +74,36 @@ async def test_form_errors(
     await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
+
+
+async def test_form_missing_yid(
+    hass: HomeAssistant,
+    mock_yardian_client: AsyncMock,
+) -> None:
+    """Test missing device identifier is handled as a form error."""
+    mock_yardian_client.fetch_device_info.return_value = {"name": "fake_name"}
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"host": "fake_host", "access_token": "fake_token"},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_response"}
+
+    mock_yardian_client.fetch_device_info.return_value = {
+        "name": "fake_name",
+        "yid": "fake_yid",
+    }
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"host": "fake_host", "access_token": "fake_token"},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY


### PR DESCRIPTION
## Proposed change

Handle Yardian devices that return device info without a `yid` during config flow setup. Instead of raising `KeyError` and surfacing a 500 response, the flow now reports an invalid device response on the form and lets the user retry.

A regression test verifies that a missing `yid` stays in the form and that the same flow can still create the entry after a valid response.

Fixes #173139

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Documentation (updates to the documentation)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

Validation run locally:

- `pytest --force-enable-socket tests/components/yardian/test_config_flow.py` - 5 passed
- `ruff check homeassistant/components/yardian tests/components/yardian/test_config_flow.py`
- `ruff format --check homeassistant/components/yardian/config_flow.py tests/components/yardian/test_config_flow.py`
- `python -m script.hassfest --integration-path homeassistant/components/yardian`
- `pylint homeassistant/components/yardian tests/components/yardian`

I also ran `pytest --force-enable-socket tests/components/yardian`; all 18 tests passed their assertions, but teardown failed on an existing global translation check for `switch.services.turn_on.name`, unrelated to this config flow change.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.