### PR TITLE
Prevent multithreading conflicts with OpenBLAS

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -12,7 +12,7 @@ from .const import REQUIRED_PYTHON_VER, RESTART_EXIT_CODE, __version__
 
 FAULT_LOG_FILENAME = "home-assistant.log.fault"
 
-"""Prevent multithreading conflicts with OpenBLAS"""
+# Prevent multithreading conflicts with OpenBLAS
 os.environ["OPENBLAS_NUM_THREADS"] = "1"
 os.environ["OMP_NUM_THREADS"] = "1"
 

--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -12,10 +12,6 @@ from .const import REQUIRED_PYTHON_VER, RESTART_EXIT_CODE, __version__
 
 FAULT_LOG_FILENAME = "home-assistant.log.fault"
 
-# Prevent multithreading conflicts with OpenBLAS
-os.environ["OPENBLAS_NUM_THREADS"] = "1"
-os.environ["OMP_NUM_THREADS"] = "1"
-
 def validate_os() -> None:
     """Validate that Home Assistant is running in a supported operating system."""
     if not sys.platform.startswith(("darwin", "linux")):

--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -12,6 +12,9 @@ from .const import REQUIRED_PYTHON_VER, RESTART_EXIT_CODE, __version__
 
 FAULT_LOG_FILENAME = "home-assistant.log.fault"
 
+"""Prevent multithreading conflicts with OpenBLAS"""
+os.environ["OPENBLAS_NUM_THREADS"] = "1"
+os.environ["OMP_NUM_THREADS"] = "1"
 
 def validate_os() -> None:
     """Validate that Home Assistant is running in a supported operating system."""

--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -12,6 +12,7 @@ from .const import REQUIRED_PYTHON_VER, RESTART_EXIT_CODE, __version__
 
 FAULT_LOG_FILENAME = "home-assistant.log.fault"
 
+
 def validate_os() -> None:
     """Validate that Home Assistant is running in a supported operating system."""
     if not sys.platform.startswith(("darwin", "linux")):

--- a/homeassistant/runner.py
+++ b/homeassistant/runner.py
@@ -279,6 +279,13 @@ def _enable_posix_spawn() -> None:
 
 def run(runtime_config: RuntimeConfig) -> int:
     """Run Home Assistant."""
+    # Set environment variables to prevent multithreading conflicts with OpenBLAS
+    # See https://github.com/home-assistant/core/issues/174359
+    os.environ["OPENBLAS_NUM_THREADS"] = "1"
+    os.environ["MKL_NUM_THREADS"] = "1"
+    os.environ["NUMEXPR_NUM_THREADS"] = "1"
+    os.environ["OMP_NUM_THREADS"] = "1"
+
     _enable_posix_spawn()
     set_open_file_descriptor_limit()
     asyncio.set_event_loop_policy(HassEventLoopPolicy(runtime_config.debug))  # type: ignore[deprecated]


### PR DESCRIPTION
Set environment variables to prevent multithreading conflicts with OpenBLAS.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change



## Proposed change
Need to set environment variables to prevent a conflict between HA multiprocessing and OpenBLAS multiprocessing.   This is a fix for https://github.com/home-assistant/core/issues/174359 (Note:  fixed reference to issue)

See the issue for details of the bug -- it leads to the creation of "zombie" or "duplicate" threads, one for each cpu core used by HA (minus 1 -- so on an 8 core system, 7 duplicates are created). These have the same thread name as created by HA, but aren't doing useful work.  In most cases I have seen they do not use cpu resources, but in at least one case each of these threads uses 100% of a cpu core.   Examples of threads that are duplicated:  ImportExecutor_0,  SyncWorker_n

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #174359 (Note:  updated/fixed reference to issue)


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
