### PR TITLE
Migrate entity unique_id in Steam integration

### DIFF
--- a/homeassistant/components/steam_online/__init__.py
+++ b/homeassistant/components/steam_online/__init__.py
@@ -1,9 +1,7 @@
 """The Steam integration."""
 
-from typing import TYPE_CHECKING
-
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 
 from .coordinator import SteamConfigEntry, SteamDataUpdateCoordinator
@@ -26,31 +24,20 @@ async def async_unload_entry(hass: HomeAssistant, entry: SteamConfigEntry) -> bo
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
-async def async_migrate_entry(
-    hass: HomeAssistant, config_entry: SteamConfigEntry
-) -> bool:
+async def async_migrate_entry(hass: HomeAssistant, entry: SteamConfigEntry) -> bool:
     """Migrate old entry."""
 
-    if config_entry.version < 2:
+    if entry.version < 2:
         # Migrate entity unique id
 
-        if TYPE_CHECKING:
-            assert config_entry.unique_id
+        @callback
+        def migrate_unique_id(entity_entry: er.RegistryEntry) -> dict[str, str] | None:
+            if entity_entry.unique_id.startswith("sensor.steam_"):
+                new = entity_entry.unique_id.removeprefix("sensor.steam_") + "_account"
+                return {"new_unique_id": new}
+            return None
 
-        ent_reg = er.async_get(hass)
-        for entity_entry in er.async_entries_for_config_entry(
-            ent_reg, config_entry.entry_id
-        ):
-            if not entity_entry.unique_id.startswith("sensor.steam_"):
-                continue
-
-            ent_reg.async_update_entity(
-                entity_entry.entity_id,
-                new_unique_id=(
-                    entity_entry.unique_id.removeprefix("sensor.steam_") + "_account"
-                ),
-            )
-
-        hass.config_entries.async_update_entry(config_entry, version=2)
+        await er.async_migrate_entries(hass, entry.entry_id, migrate_unique_id)
+        hass.config_entries.async_update_entry(entry, version=2)
 
     return True

--- a/homeassistant/components/steam_online/__init__.py
+++ b/homeassistant/components/steam_online/__init__.py
@@ -1,7 +1,10 @@
 """The Steam integration."""
 
+from typing import TYPE_CHECKING
+
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 from .coordinator import SteamConfigEntry, SteamDataUpdateCoordinator
 
@@ -21,3 +24,33 @@ async def async_setup_entry(hass: HomeAssistant, entry: SteamConfigEntry) -> boo
 async def async_unload_entry(hass: HomeAssistant, entry: SteamConfigEntry) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
+async def async_migrate_entry(
+    hass: HomeAssistant, config_entry: SteamConfigEntry
+) -> bool:
+    """Migrate old entry."""
+
+    if config_entry.version < 2:
+        # Migrate entity unique id
+
+        if TYPE_CHECKING:
+            assert config_entry.unique_id
+
+        ent_reg = er.async_get(hass)
+        for entity_entry in er.async_entries_for_config_entry(
+            ent_reg, config_entry.entry_id
+        ):
+            if not entity_entry.unique_id.startswith("sensor.steam_"):
+                continue
+
+            ent_reg.async_update_entity(
+                entity_entry.entity_id,
+                new_unique_id=(
+                    entity_entry.unique_id.removeprefix("sensor.steam_") + "_account"
+                ),
+            )
+
+        hass.config_entries.async_update_entry(config_entry, version=2)
+
+    return True

--- a/homeassistant/components/steam_online/config_flow.py
+++ b/homeassistant/components/steam_online/config_flow.py
@@ -41,6 +41,8 @@ def validate_input(user_input: dict[str, str]) -> dict[str, str | int]:
 class SteamFlowHandler(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Steam."""
 
+    VERSION = 2
+
     @staticmethod
     @callback
     @override
@@ -150,7 +152,7 @@ class SteamOptionsFlowHandler(OptionsFlowWithReload):
             for _id in self.options[CONF_ACCOUNTS]:
                 if _id not in user_input[CONF_ACCOUNTS] and (
                     entity_id := er.async_get(self.hass).async_get_entity_id(
-                        Platform.SENSOR, DOMAIN, f"sensor.steam_{_id}"
+                        Platform.SENSOR, DOMAIN, f"{_id}_account"
                     )
                 ):
                     er.async_get(self.hass).async_remove(entity_id)

--- a/homeassistant/components/steam_online/entity.py
+++ b/homeassistant/components/steam_online/entity.py
@@ -1,5 +1,6 @@
 """Entity classes for the Steam integration."""
 
+from homeassistant.components.sensor import SensorEntityDescription
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -12,9 +13,17 @@ class SteamEntity(CoordinatorEntity[SteamDataUpdateCoordinator]):
 
     _attr_has_entity_name = True
 
-    def __init__(self, coordinator: SteamDataUpdateCoordinator) -> None:
+    def __init__(
+        self,
+        coordinator: SteamDataUpdateCoordinator,
+        steamid: str,
+        description: SensorEntityDescription,
+    ) -> None:
         """Initialize a Steam entity."""
         super().__init__(coordinator)
+        self._steamid = steamid
+        self.entity_description = description
+        self._attr_unique_id = f"{steamid}_{description.key}"
         self._attr_device_info = DeviceInfo(
             configuration_url="https://store.steampowered.com",
             entry_type=DeviceEntryType.SERVICE,

--- a/homeassistant/components/steam_online/sensor.py
+++ b/homeassistant/components/steam_online/sensor.py
@@ -80,10 +80,7 @@ class SteamSensorEntity(SteamEntity, SensorEntity):
         description: SteamSensorEntityDescription,
     ) -> None:
         """Initialize the sensor."""
-        super().__init__(coordinator)
-        self._steamid = steamid
-        self.entity_description = description
-        self._attr_unique_id = f"sensor.steam_{steamid}"
+        super().__init__(coordinator, steamid, description)
         self._attr_name = self.entity_description.name_fn(coordinator.data[steamid])
 
     @property

--- a/tests/components/steam_online/conftest.py
+++ b/tests/components/steam_online/conftest.py
@@ -20,6 +20,7 @@ def mock_config_entry() -> MockConfigEntry:
         data=CONF_DATA,
         options=CONF_OPTIONS,
         unique_id=ACCOUNT_1,
+        version=2,
     )
 
 

--- a/tests/components/steam_online/snapshots/test_sensor.ambr
+++ b/tests/components/steam_online/snapshots/test_sensor.ambr
@@ -32,7 +32,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': <SteamSensor.ACCOUNT: 'account'>,
-    'unique_id': 'sensor.steam_12345678901234567',
+    'unique_id': '12345678901234567_account',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/steam_online/test_init.py
+++ b/tests/components/steam_online/test_init.py
@@ -126,6 +126,8 @@ async def test_migrate_entry(
         original_name=ACCOUNT_NAME_1,
     )
 
+    assert sensor.unique_id == f"sensor.steam_{ACCOUNT_1}"
+
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 

--- a/tests/components/steam_online/test_init.py
+++ b/tests/components/steam_online/test_init.py
@@ -103,7 +103,6 @@ async def test_device_info(
 @pytest.mark.usefixtures("steam_api")
 async def test_migrate_entry(
     hass: HomeAssistant,
-    config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test entry migration."""

--- a/tests/components/steam_online/test_init.py
+++ b/tests/components/steam_online/test_init.py
@@ -7,8 +7,11 @@ import steam.api
 
 from homeassistant.components.steam_online.const import DEFAULT_NAME, DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from . import ACCOUNT_1, ACCOUNT_NAME_1, CONF_DATA, CONF_OPTIONS
 
 from tests.common import MockConfigEntry
 
@@ -95,3 +98,39 @@ async def test_device_info(
     assert device.identifiers == {(DOMAIN, config_entry.entry_id)}
     assert device.manufacturer == DEFAULT_NAME
     assert device.name == DEFAULT_NAME
+
+
+@pytest.mark.usefixtures("steam_api")
+async def test_migrate_entry(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test entry migration."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=CONF_DATA,
+        options=CONF_OPTIONS,
+        unique_id=ACCOUNT_1,
+        version=1,
+    )
+
+    config_entry.add_to_hass(hass)
+
+    assert config_entry.version == 1
+
+    sensor = entity_registry.async_get_or_create(
+        domain=Platform.SENSOR,
+        platform=DOMAIN,
+        unique_id=f"sensor.steam_{ACCOUNT_1}",
+        config_entry=config_entry,
+        original_name=ACCOUNT_NAME_1,
+    )
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.version == 2
+
+    assert (sensor := entity_registry.async_get(sensor.entity_id))
+    assert sensor.unique_id == f"{ACCOUNT_1}_account"


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


Migrates the entity unique id from `sensor.steam_{steamid}` to `"{steamid}_{description.key}"`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
