### PR TITLE
Bump pyintesishome to 2.0.2

### DIFF
--- a/homeassistant/components/intesishome/climate.py
+++ b/homeassistant/components/intesishome/climate.py
@@ -209,7 +209,7 @@ class IntesisAC(ClimateEntity):
     async def async_added_to_hass(self) -> None:
         """Subscribe to event updates."""
         _LOGGER.debug("Added climate device with state: %s", repr(self._ih_device))
-        await self._controller.add_update_callback(self.async_update_callback)
+        self._controller.add_update_callback(self.async_update_callback)
         try:
             await self._controller.connect()
         except IHConnectionError as ex:

--- a/homeassistant/components/intesishome/manifest.json
+++ b/homeassistant/components/intesishome/manifest.json
@@ -6,5 +6,5 @@
   "iot_class": "cloud_push",
   "loggers": ["pyintesishome"],
   "quality_scale": "legacy",
-  "requirements": ["pyintesishome==1.8.8"]
+  "requirements": ["pyintesishome==2.0.2"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2247,7 +2247,7 @@ pyinsteon==1.6.4
 pyintelliclima==0.3.1
 
 # homeassistant.components.intesishome
-pyintesishome==1.8.8
+pyintesishome==2.0.2
 
 # homeassistant.components.ipma
 pyipma==3.0.10


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

Bump `pyintesishome` from 1.8.8 to 2.0.2 for the IntesisHome integration.

`pyintesishome` 2.0.2 includes the upstream fix for `KeyError` in `get_device_property` when a `device_id` is not present in `_devices`. The integration code is also updated for the 2.x callback API, where `add_update_callback` is synchronous and must not be awaited.

Release notes: https://github.com/jnimmo/pyIntesisHome/releases/tag/v2.0.2

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #173153
- This PR is related to issue: #171209
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

Local verification:

- `python -m compileall -q homeassistant\components\intesishome`
- `ruff format --check homeassistant\components\intesishome\climate.py`
- `ruff check homeassistant\components\intesishome\climate.py`
- `python -m script.hassfest --action validate --integration-path homeassistant\components\intesishome --requirements -p manifest,requirements`
- `python -m json.tool homeassistant\components\intesishome\manifest.json`
- `git diff --check`

Notes:

- `python -m script.gen_requirements_all` was attempted locally, but this Windows environment fails while importing `homeassistant.runner` because `fcntl` is unavailable. The generated `requirements_all.txt` entry is included and hassfest requirements validation passes.
- `python -m mypy --config-file mypy.ini homeassistant\components\intesishome\climate.py` was attempted, but this local environment reports existing unrelated errors in `frontend`, `matter`, `stream`, and `tts` while checking one source file.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr