### PR TITLE
Bump uiprotect to 15.0.0

### DIFF
--- a/homeassistant/components/unifiprotect/manifest.json
+++ b/homeassistant/components/unifiprotect/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "loggers": ["uiprotect"],
   "quality_scale": "platinum",
-  "requirements": ["uiprotect==14.0.0"]
+  "requirements": ["uiprotect==14.3.0"]
 }

--- a/homeassistant/components/unifiprotect/manifest.json
+++ b/homeassistant/components/unifiprotect/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "loggers": ["uiprotect"],
   "quality_scale": "platinum",
-  "requirements": ["uiprotect==14.3.0"]
+  "requirements": ["uiprotect==15.0.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3245,7 +3245,7 @@ uasiren==0.0.1
 uhooapi==1.2.8
 
 # homeassistant.components.unifiprotect
-uiprotect==14.0.0
+uiprotect==14.3.0
 
 # homeassistant.components.landisgyr_heat_meter
 ultraheat-api==0.6.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3245,7 +3245,7 @@ uasiren==0.0.1
 uhooapi==1.2.8
 
 # homeassistant.components.unifiprotect
-uiprotect==14.3.0
+uiprotect==15.0.0
 
 # homeassistant.components.landisgyr_heat_meter
 ultraheat-api==0.6.1


### PR DESCRIPTION
## Proposed change

Bump uiprotect from 14.0.0 to 15.0.0.

Changes since 14.0.0:
- **14.1.0** — Add `Chime.set_repeat_times_for_camera_public` (uilibs/uiprotect#1036)
- **14.1.1** — Add missing `IRLEDMode` value `customFilterOnly` (uilibs/uiprotect#1046); migrate chime + viewer-liveview CLI write paths to the public API
- **14.2.0** — Add public-API sensor setters (`PATCH /v1/sensors/{id}`), incl. granular single-value setters (uilibs/uiprotect#1049)
- **14.3.0** — Add `Viewer.set_liveview_public` + `set_name_public` (uilibs/uiprotect#1050)
- **15.0.0** — Expose `LinkStation.last_event` as a `datetime` (uilibs/uiprotect#1052) — breaking type change (`int` → `datetime`); no current integration code reads this field, so no effect on Home Assistant

Full diff: https://github.com/uilibs/uiprotect/compare/v14.0.0...v15.0.0

These additions back upcoming public-API migrations in the integration
(camera IR "custom filter only" mode, capability-driven sensor writes, the
viewer liveview select, and alarm-hub support).

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
