### PR TITLE
Improve tests of sun conditions and triggers

### DIFF
--- a/tests/components/sun/test_condition.py
+++ b/tests/components/sun/test_condition.py
@@ -16,8 +16,11 @@ from homeassistant.util import dt as dt_util
 
 from tests.typing import WebSocketGenerator
 
-# San Diego (default test location) and Longyearbyen, Svalbard (deep polar).
+# San Diego (default test location), Kotzebue, Alaska (just inside the Arctic
+# Circle - brief midnight sun in June) and Longyearbyen, Svalbard (deep polar -
+# long polar night in December).
 _SAN_DIEGO = (32.87336, -117.22743, "US/Pacific")
+_KOTZEBUE = (66.8983, -162.5966, "America/Anchorage")
 _SVALBARD = (78.22, 15.65, "Europe/Oslo")
 
 _TWILIGHT_TYPES = ("any", "civil", "nautical", "astronomical")
@@ -38,8 +41,8 @@ def _find_run_id(traces, trace_type, item_id):
     return None
 
 
-async def assert_automation_condition_trace(hass_ws_client, automation_id, expected):
-    """Test the result of automation condition."""
+async def _get_automation_condition_trace(hass_ws_client, automation_id):
+    """Return the condition trace for a given automation."""
     msg_id = 1
 
     def next_id():
@@ -71,8 +74,25 @@ async def assert_automation_condition_trace(hass_ws_client, automation_id, expec
     assert response["success"]
     trace = response["result"]
     assert len(trace["trace"]["condition/0"]) == 1
-    condition_trace = trace["trace"]["condition/0"][0]["result"]
-    assert condition_trace == expected
+    return trace["trace"]["condition/0"][0]
+
+
+async def assert_automation_condition_trace(hass_ws_client, automation_id, expected):
+    """Test the result of automation condition."""
+    condition_trace = await _get_automation_condition_trace(
+        hass_ws_client, automation_id
+    )
+    assert condition_trace["result"] == expected
+
+
+async def assert_automation_condition_trace_error(
+    hass_ws_client, automation_id, expected
+):
+    """Test the result of automation condition."""
+    condition_trace = await _get_automation_condition_trace(
+        hass_ws_client, automation_id
+    )
+    assert condition_trace["error"] == expected
 
 
 async def test_if_action_before_sunrise_no_offset(
@@ -937,14 +957,14 @@ async def test_if_action_before_sunrise_no_offset_kotzebue(
 ) -> None:
     """Test if action was before sunrise.
 
-    Local timezone: Alaska time
-    Location: Kotzebue, which has a very skewed local timezone with sunrise
-    at 7 AM and sunset at 3AM during summer
-    After sunrise is true from sunrise until midnight, local time.
+    Local timezone: Alaska time (America/Anchorage)
+    Location: Kotzebue, Alaska, whose far-west longitude skews local time by
+    ~3 hours, so in late July sunrise is ~04:48 local. Before sunrise is true
+    from local midnight until sunrise.
     """
     await hass.config.async_set_time_zone("America/Anchorage")
-    hass.config.latitude = 66.5
-    hass.config.longitude = 162.4
+    hass.config.latitude = 66.8983
+    hass.config.longitude = -162.5966
     await async_setup_component(
         hass,
         automation.DOMAIN,
@@ -961,10 +981,9 @@ async def test_if_action_before_sunrise_no_offset_kotzebue(
         },
     )
 
-    # sunrise: 2015-07-24 07:21:12 local, sunset: 2015-07-25 03:13:33 local
-    # sunrise: 2015-07-24 15:21:12 UTC,   sunset: 2015-07-25 11:13:33 UTC
+    # sunrise: 2015-07-24 04:48:24 local = 2015-07-24 12:48:24 UTC
     # now = sunrise + 1s -> 'before sunrise' not true
-    now = datetime(2015, 7, 24, 15, 21, 13, tzinfo=dt_util.UTC)
+    now = datetime(2015, 7, 24, 12, 48, 25, tzinfo=dt_util.UTC)
     with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
@@ -972,11 +991,11 @@ async def test_if_action_before_sunrise_no_offset_kotzebue(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": False, "wanted_time_before": "2015-07-24T15:16:46.975735+00:00"},
+        {"result": False, "wanted_time_before": "2015-07-24T12:48:24.249497+00:00"},
     )
 
     # now = sunrise - 1h -> 'before sunrise' true
-    now = datetime(2015, 7, 24, 14, 21, 12, tzinfo=dt_util.UTC)
+    now = datetime(2015, 7, 24, 11, 48, 24, tzinfo=dt_util.UTC)
     with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
@@ -984,7 +1003,7 @@ async def test_if_action_before_sunrise_no_offset_kotzebue(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": True, "wanted_time_before": "2015-07-24T15:16:46.975735+00:00"},
+        {"result": True, "wanted_time_before": "2015-07-24T12:48:24.249497+00:00"},
     )
 
     # now = local midnight -> 'before sunrise' true
@@ -996,7 +1015,7 @@ async def test_if_action_before_sunrise_no_offset_kotzebue(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": True, "wanted_time_before": "2015-07-24T15:16:46.975735+00:00"},
+        {"result": True, "wanted_time_before": "2015-07-24T12:48:24.249497+00:00"},
     )
 
     # now = local midnight - 1s -> 'before sunrise' not true
@@ -1008,7 +1027,7 @@ async def test_if_action_before_sunrise_no_offset_kotzebue(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": False, "wanted_time_before": "2015-07-23T15:12:19.155123+00:00"},
+        {"result": False, "wanted_time_before": "2015-07-23T12:43:32.413351+00:00"},
     )
 
 
@@ -1019,14 +1038,14 @@ async def test_if_action_after_sunrise_no_offset_kotzebue(
 ) -> None:
     """Test if action was after sunrise.
 
-    Local timezone: Alaska time
-    Location: Kotzebue, which has a very skewed local timezone with sunrise
-    at 7 AM and sunset at 3AM during summer
-    Before sunrise is true from midnight until sunrise, local time.
+    Local timezone: Alaska time (America/Anchorage)
+    Location: Kotzebue, Alaska, whose far-west longitude skews local time by
+    ~3 hours, so in late July sunrise is ~04:48 local. After sunrise is true
+    from sunrise until local midnight.
     """
     await hass.config.async_set_time_zone("America/Anchorage")
-    hass.config.latitude = 66.5
-    hass.config.longitude = 162.4
+    hass.config.latitude = 66.8983
+    hass.config.longitude = -162.5966
     await async_setup_component(
         hass,
         automation.DOMAIN,
@@ -1043,10 +1062,9 @@ async def test_if_action_after_sunrise_no_offset_kotzebue(
         },
     )
 
-    # sunrise: 2015-07-24 07:21:12 local, sunset: 2015-07-25 03:13:33 local
-    # sunrise: 2015-07-24 15:21:12 UTC,   sunset: 2015-07-25 11:13:33 UTC
-    # now = sunrise -> 'after sunrise' true
-    now = datetime(2015, 7, 24, 15, 21, 12, tzinfo=dt_util.UTC)
+    # sunrise: 2015-07-24 04:48:24 local = 2015-07-24 12:48:24 UTC
+    # now = sunrise + 1s -> 'after sunrise' true
+    now = datetime(2015, 7, 24, 12, 48, 25, tzinfo=dt_util.UTC)
     with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
@@ -1054,11 +1072,11 @@ async def test_if_action_after_sunrise_no_offset_kotzebue(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": True, "wanted_time_after": "2015-07-24T15:16:46.975735+00:00"},
+        {"result": True, "wanted_time_after": "2015-07-24T12:48:24.249497+00:00"},
     )
 
     # now = sunrise - 1h -> 'after sunrise' not true
-    now = datetime(2015, 7, 24, 14, 21, 12, tzinfo=dt_util.UTC)
+    now = datetime(2015, 7, 24, 11, 48, 24, tzinfo=dt_util.UTC)
     with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
@@ -1066,7 +1084,7 @@ async def test_if_action_after_sunrise_no_offset_kotzebue(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": False, "wanted_time_after": "2015-07-24T15:16:46.975735+00:00"},
+        {"result": False, "wanted_time_after": "2015-07-24T12:48:24.249497+00:00"},
     )
 
     # now = local midnight -> 'after sunrise' not true
@@ -1078,7 +1096,7 @@ async def test_if_action_after_sunrise_no_offset_kotzebue(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": False, "wanted_time_after": "2015-07-24T15:16:46.975735+00:00"},
+        {"result": False, "wanted_time_after": "2015-07-24T12:48:24.249497+00:00"},
     )
 
     # now = local midnight - 1s -> 'after sunrise' true
@@ -1090,7 +1108,7 @@ async def test_if_action_after_sunrise_no_offset_kotzebue(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": True, "wanted_time_after": "2015-07-23T15:12:19.155123+00:00"},
+        {"result": True, "wanted_time_after": "2015-07-23T12:43:32.413351+00:00"},
     )
 
 
@@ -1099,16 +1117,17 @@ async def test_if_action_before_sunset_no_offset_kotzebue(
     hass_ws_client: WebSocketGenerator,
     service_calls: list[ServiceCall],
 ) -> None:
-    """Test if action was before sunrise.
+    """Test if action was before sunset on a day with two sunsets.
 
-    Local timezone: Alaska time
-    Location: Kotzebue, which has a very skewed local timezone with sunrise
-    at 7 AM and sunset at 3AM during summer
-    Before sunset is true from midnight until sunset, local time.
+    Local timezone: Alaska time (America/Anchorage)
+    Location: Kotzebue, Alaska. On 2015-08-07 (local) the sun sets twice - at
+    00:03 and again at 23:59 - because solar midnight falls near local midnight.
+    The condition tracks the day's (late) sunset, so 'before sunset' stays true
+    across the early sunset and only turns false after the late one.
     """
     await hass.config.async_set_time_zone("America/Anchorage")
-    hass.config.latitude = 66.5
-    hass.config.longitude = 162.4
+    hass.config.latitude = 66.8983
+    hass.config.longitude = -162.5966
     await async_setup_component(
         hass,
         automation.DOMAIN,
@@ -1125,22 +1144,9 @@ async def test_if_action_before_sunset_no_offset_kotzebue(
         },
     )
 
-    # sunrise: 2015-07-24 07:21:12 local, sunset: 2015-07-25 03:13:33 local
-    # sunrise: 2015-07-24 15:21:12 UTC,   sunset: 2015-07-25 11:13:33 UTC
-    # now = sunset + 1s -> 'before sunset' not true
-    now = datetime(2015, 7, 25, 11, 13, 34, tzinfo=dt_util.UTC)
-    with freeze_time(now):
-        hass.bus.async_fire("test_event")
-        await hass.async_block_till_done()
-        assert len(service_calls) == 0
-    await assert_automation_condition_trace(
-        hass_ws_client,
-        "sun",
-        {"result": False, "wanted_time_before": "2015-07-25T11:13:32.501837+00:00"},
-    )
-
-    # now = sunset - 1h-> 'before sunset' true
-    now = datetime(2015, 7, 25, 10, 13, 33, tzinfo=dt_util.UTC)
+    # 2015-08-07 local has two sunsets: 00:03 (08:03 UTC) and 23:59 (08-08 07:59 UTC)
+    # now = local midnight -> 'before sunset' true
+    now = datetime(2015, 8, 7, 8, 0, 0, tzinfo=dt_util.UTC)
     with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
@@ -1148,11 +1154,11 @@ async def test_if_action_before_sunset_no_offset_kotzebue(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": True, "wanted_time_before": "2015-07-25T11:13:32.501837+00:00"},
+        {"result": True, "wanted_time_before": "2015-08-08T07:59:25.982224+00:00"},
     )
 
-    # now = local midnight -> 'before sunrise' true
-    now = datetime(2015, 7, 24, 8, 0, 0, tzinfo=dt_util.UTC)
+    # now = first (early) sunset + 1s -> still 'before sunset' (tracks the late one)
+    now = datetime(2015, 8, 7, 8, 3, 43, tzinfo=dt_util.UTC)
     with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
@@ -1160,19 +1166,31 @@ async def test_if_action_before_sunset_no_offset_kotzebue(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": True, "wanted_time_before": "2015-07-24T11:17:54.446913+00:00"},
+        {"result": True, "wanted_time_before": "2015-08-08T07:59:25.982224+00:00"},
     )
 
-    # now = local midnight - 1s -> 'before sunrise' not true
-    now = datetime(2015, 7, 24, 7, 59, 59, tzinfo=dt_util.UTC)
+    # now = late sunset - 1h -> 'before sunset' true
+    now = datetime(2015, 8, 8, 6, 59, 25, tzinfo=dt_util.UTC)
     with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
-        assert len(service_calls) == 2
+        assert len(service_calls) == 3
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": False, "wanted_time_before": "2015-07-23T11:22:18.467277+00:00"},
+        {"result": True, "wanted_time_before": "2015-08-08T07:59:25.982224+00:00"},
+    )
+
+    # now = late sunset + 1s -> 'before sunset' not true
+    now = datetime(2015, 8, 8, 7, 59, 26, tzinfo=dt_util.UTC)
+    with freeze_time(now):
+        hass.bus.async_fire("test_event")
+        await hass.async_block_till_done()
+        assert len(service_calls) == 3
+    await assert_automation_condition_trace(
+        hass_ws_client,
+        "sun",
+        {"result": False, "wanted_time_before": "2015-08-08T07:59:25.982224+00:00"},
     )
 
 
@@ -1181,16 +1199,17 @@ async def test_if_action_after_sunset_no_offset_kotzebue(
     hass_ws_client: WebSocketGenerator,
     service_calls: list[ServiceCall],
 ) -> None:
-    """Test if action was after sunrise.
+    """Test if action was after sunset on a day with two sunsets.
 
-    Local timezone: Alaska time
-    Location: Kotzebue, which has a very skewed local timezone with sunrise
-    at 7 AM and sunset at 3AM during summer
-    After sunset is true from sunset until midnight, local time.
+    Local timezone: Alaska time (America/Anchorage)
+    Location: Kotzebue, Alaska. On 2015-08-07 (local) the sun sets twice - at
+    00:03 and again at 23:59. The condition tracks the day's (late) sunset, so
+    'after sunset' is false right after the early sunset and only true in the
+    short window after the late sunset before local midnight.
     """
     await hass.config.async_set_time_zone("America/Anchorage")
-    hass.config.latitude = 66.5
-    hass.config.longitude = 162.4
+    hass.config.latitude = 66.8983
+    hass.config.longitude = -162.5966
     await async_setup_component(
         hass,
         automation.DOMAIN,
@@ -1207,10 +1226,33 @@ async def test_if_action_after_sunset_no_offset_kotzebue(
         },
     )
 
-    # sunrise: 2015-07-24 07:21:12 local, sunset: 2015-07-25 03:13:33 local
-    # sunrise: 2015-07-24 15:21:12 UTC,   sunset: 2015-07-25 11:13:33 UTC
-    # now = sunset -> 'after sunset' true
-    now = datetime(2015, 7, 25, 11, 13, 33, tzinfo=dt_util.UTC)
+    # 2015-08-07 local has two sunsets: 00:03 (08:03 UTC) and 23:59 (08-08 07:59 UTC)
+    # now = first (early) sunset + 1s -> 'after sunset' not true (tracks the late one)
+    now = datetime(2015, 8, 7, 8, 4, 0, tzinfo=dt_util.UTC)
+    with freeze_time(now):
+        hass.bus.async_fire("test_event")
+        await hass.async_block_till_done()
+        assert len(service_calls) == 0
+    await assert_automation_condition_trace(
+        hass_ws_client,
+        "sun",
+        {"result": False, "wanted_time_after": "2015-08-08T07:59:25.982224+00:00"},
+    )
+
+    # now = late sunset - 1s -> 'after sunset' not true
+    now = datetime(2015, 8, 8, 7, 59, 25, tzinfo=dt_util.UTC)
+    with freeze_time(now):
+        hass.bus.async_fire("test_event")
+        await hass.async_block_till_done()
+        assert len(service_calls) == 0
+    await assert_automation_condition_trace(
+        hass_ws_client,
+        "sun",
+        {"result": False, "wanted_time_after": "2015-08-08T07:59:25.982224+00:00"},
+    )
+
+    # now = late sunset + 1s -> 'after sunset' true
+    now = datetime(2015, 8, 8, 7, 59, 27, tzinfo=dt_util.UTC)
     with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
@@ -1218,11 +1260,11 @@ async def test_if_action_after_sunset_no_offset_kotzebue(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": True, "wanted_time_after": "2015-07-25T11:13:32.501837+00:00"},
+        {"result": True, "wanted_time_after": "2015-08-08T07:59:25.982224+00:00"},
     )
 
-    # now = sunset - 1s -> 'after sunset' not true
-    now = datetime(2015, 7, 25, 11, 13, 32, tzinfo=dt_util.UTC)
+    # now = local midnight (next day) -> 'after sunset' not true
+    now = datetime(2015, 8, 8, 8, 0, 1, tzinfo=dt_util.UTC)
     with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
@@ -1230,31 +1272,66 @@ async def test_if_action_after_sunset_no_offset_kotzebue(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": False, "wanted_time_after": "2015-07-25T11:13:32.501837+00:00"},
+        {"result": False, "wanted_time_after": "2015-08-09T07:55:10.646523+00:00"},
     )
 
-    # now = local midnight -> 'after sunset' not true
-    now = datetime(2015, 7, 24, 8, 0, 1, tzinfo=dt_util.UTC)
+
+@pytest.mark.parametrize(
+    ("location", "now", "event"),
+    [
+        # Midnight sun at Kotzebue (early June to early July): the sun neither
+        # rises nor sets, so neither a sunrise nor a sunset condition can be met.
+        (_KOTZEBUE, datetime(2015, 6, 15, 12, tzinfo=dt_util.UTC), SUN_EVENT_SUNSET),
+        (_KOTZEBUE, datetime(2015, 6, 15, 12, tzinfo=dt_util.UTC), SUN_EVENT_SUNRISE),
+        # Polar night at Svalbard: the sun neither rises nor sets here either.
+        (_SVALBARD, datetime(2015, 12, 15, 12, tzinfo=dt_util.UTC), SUN_EVENT_SUNSET),
+        (_SVALBARD, datetime(2015, 12, 15, 12, tzinfo=dt_util.UTC), SUN_EVENT_SUNRISE),
+    ],
+)
+async def test_if_action_no_sun_event_in_polar_regions(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    service_calls: list[ServiceCall],
+    location: tuple[float, float, str],
+    now: datetime,
+    event: str,
+) -> None:
+    """Test a sun condition where the requested event never occurs.
+
+    During midnight sun and polar night the sun neither rises nor sets, so
+    ``get_astral_event_date`` returns None for both events. This documents the
+    legacy condition crashing on the missing event (it passes None to
+    ``dt_util.as_local``); the crash fix and the matching "no sunrise/sunset
+    today" results are a follow-up.
+    """
+    latitude, longitude, time_zone = location
+    await hass.config.async_set_time_zone(time_zone)
+    hass.config.latitude = latitude
+    hass.config.longitude = longitude
+    await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "id": "sun",
+                "trigger": {"platform": "event", "event_type": "test_event"},
+                "condition": {
+                    "condition": "sun",
+                    "options": {"after": event},
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
+
     with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
-        assert len(service_calls) == 1
-    await assert_automation_condition_trace(
+        assert len(service_calls) == 0
+    await assert_automation_condition_trace_error(
         hass_ws_client,
         "sun",
-        {"result": False, "wanted_time_after": "2015-07-24T11:17:54.446913+00:00"},
-    )
-
-    # now = local midnight - 1s -> 'after sunset' true
-    now = datetime(2015, 7, 24, 7, 59, 59, tzinfo=dt_util.UTC)
-    with freeze_time(now):
-        hass.bus.async_fire("test_event")
-        await hass.async_block_till_done()
-        assert len(service_calls) == 2
-    await assert_automation_condition_trace(
-        hass_ws_client,
-        "sun",
-        {"result": True, "wanted_time_after": "2015-07-23T11:22:18.467277+00:00"},
+        "'NoneType' object has no attribute 'tzinfo'",
     )
 
 

--- a/tests/components/sun/test_condition.py
+++ b/tests/components/sun/test_condition.py
@@ -88,7 +88,7 @@ async def assert_automation_condition_trace(hass_ws_client, automation_id, expec
 async def assert_automation_condition_trace_error(
     hass_ws_client, automation_id, expected
 ):
-    """Test the result of automation condition."""
+    """Test the error of automation condition."""
     condition_trace = await _get_automation_condition_trace(
         hass_ws_client, automation_id
     )

--- a/tests/components/sun/test_trigger.py
+++ b/tests/components/sun/test_trigger.py
@@ -346,6 +346,12 @@ async def test_dawn_defaults_to_civil(
 _SVALBARD = (78.22, 15.65, "Europe/Oslo")
 _KOTZEBUE = (66.8983, -162.5966, "America/Anchorage")
 
+# A two-sunrise day is the mirror of Kotzebue's two-sunset day: it needs solar
+# noon (not midnight) near local midnight, which no real location has because
+# time zones keep solar noon near local noon. This synthetic location forces it
+# with a polar latitude on a deliberately ~12 h-offset time zone.
+_TWO_SUNRISE_LOCATION = (66.5, -32.5, "America/Anchorage")
+
 
 @pytest.mark.parametrize(
     ("location", "now", "trigger_key", "astral_event", "options", "depression"),
@@ -438,6 +444,41 @@ async def test_two_sunsets_on_one_day_at_kotzebue(
         first = get_astral_event_next(hass, "sunset", now)
         second = get_astral_event_next(hass, "sunset", first)
         # Two sunsets ~24 h apart that share one local calendar day.
+        assert dt_util.as_local(first).date() == dt_util.as_local(second).date()
+        assert timedelta(hours=23) < second - first < timedelta(hours=25)
+
+        freezer.move_to(first + timedelta(seconds=1))
+        async_fire_time_changed(hass, first + timedelta(seconds=1))
+        await hass.async_block_till_done()
+        assert len(service_calls) == 1
+
+        freezer.move_to(second + timedelta(seconds=1))
+        async_fire_time_changed(hass, second + timedelta(seconds=1))
+        await hass.async_block_till_done()
+        assert len(service_calls) == 2
+
+
+async def test_two_sunrises_on_one_day(
+    hass: HomeAssistant, service_calls: list[ServiceCall]
+) -> None:
+    """Test both sunrises fire on a calendar day that has two.
+
+    The mirror of the two-sunset case: a synthetic polar location on a
+    deliberately offset time zone puts solar noon near local midnight, so
+    2015-03-07 (local) has two sunrises ~24 h apart - one just after midnight
+    and one just before - and the scheduler must fire for both.
+    """
+    latitude, longitude, time_zone = _TWO_SUNRISE_LOCATION
+    await hass.config.async_set_time_zone(time_zone)
+    await hass.config.async_update(latitude=latitude, longitude=longitude, elevation=0)
+
+    # 2015-03-07 09:02:36 UTC (00:02 local) and 2015-03-08 08:58:43 UTC (23:58 local)
+    now = datetime(2015, 3, 7, 9, tzinfo=dt_util.UTC)
+    with freeze_time(now) as freezer:
+        await _arm_automation(hass, {"platform": "sun.sunrise"}, {})
+        first = get_astral_event_next(hass, "sunrise", now)
+        second = get_astral_event_next(hass, "sunrise", first)
+        # Two sunrises ~24 h apart that share one local calendar day.
         assert dt_util.as_local(first).date() == dt_util.as_local(second).date()
         assert timedelta(hours=23) < second - first < timedelta(hours=25)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve tests of sun conditions and triggers:
- Use real location for condition tests with Kotzebue as location (Kotzebue is north of the polar circle with very skewed time zone, which exposes some edge cases)
- Add a trigger test for a synthetic location where we get two sunrises in a day (Kotzebue has two sunsets in a day)
- Add a condition test for midnight sun / polar night exposing a crash in the legacy sun condition (to be fixed in a follow-up PR)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
