### PR TITLE
Expose selected state attributes in the logbook

### DIFF
--- a/homeassistant/components/event/__init__.py
+++ b/homeassistant/components/event/__init__.py
@@ -52,7 +52,9 @@ __all__ = [
     "DoorbellEventType",
     "EventDeviceClass",
     "EventEntity",
+    "EventEntityCapabilityAttribute",
     "EventEntityDescription",
+    "EventEntityStateAttribute",
 ]
 
 # mypy: disallow-any-generics

--- a/homeassistant/components/logbook/const.py
+++ b/homeassistant/components/logbook/const.py
@@ -1,7 +1,7 @@
 """Event parser and human readable log generator."""
 
 from homeassistant.components.automation import EVENT_AUTOMATION_TRIGGERED
-from homeassistant.components.event import ATTR_EVENT_TYPE
+from homeassistant.components.event import EventEntityStateAttribute
 from homeassistant.components.script import EVENT_SCRIPT_STARTED
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import EVENT_CALL_SERVICE, EVENT_LOGBOOK_ENTRY
@@ -44,7 +44,7 @@ LOGBOOK_ENTRY_ATTRIBUTES = "attributes"
 LOGBOOK_ENTRY_WHEN = "when"
 
 # State attributes surfaced in logbook entries; extend as needed.
-EXPOSED_STATE_ATTRIBUTES = {ATTR_EVENT_TYPE}
+EXPOSED_STATE_ATTRIBUTES = {EventEntityStateAttribute.EVENT_TYPE}
 
 # Automation events that can affect an entity_id or device_id
 AUTOMATION_EVENTS = {EVENT_AUTOMATION_TRIGGERED, EVENT_SCRIPT_STARTED}

--- a/homeassistant/components/logbook/const.py
+++ b/homeassistant/components/logbook/const.py
@@ -1,6 +1,7 @@
 """Event parser and human readable log generator."""
 
 from homeassistant.components.automation import EVENT_AUTOMATION_TRIGGERED
+from homeassistant.components.event import ATTR_EVENT_TYPE
 from homeassistant.components.script import EVENT_SCRIPT_STARTED
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import EVENT_CALL_SERVICE, EVENT_LOGBOOK_ENTRY
@@ -39,7 +40,11 @@ LOGBOOK_ENTRY_SOURCE = "source"
 LOGBOOK_ENTRY_MESSAGE = "message"
 LOGBOOK_ENTRY_NAME = "name"
 LOGBOOK_ENTRY_STATE = "state"
+LOGBOOK_ENTRY_ATTRIBUTES = "attributes"
 LOGBOOK_ENTRY_WHEN = "when"
+
+# State attributes surfaced in logbook entries; extend as needed.
+EXPOSED_STATE_ATTRIBUTES = {ATTR_EVENT_TYPE}
 
 # Automation events that can affect an entity_id or device_id
 AUTOMATION_EVENTS = {EVENT_AUTOMATION_TRIGGERED, EVENT_SCRIPT_STARTED}

--- a/homeassistant/components/logbook/models.py
+++ b/homeassistant/components/logbook/models.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any, Final, NamedTuple, cast, final
 from propcache.api import cached_property
 from sqlalchemy.engine.row import Row
 
-from homeassistant.components.recorder.db_schema import StateAttributes
 from homeassistant.components.recorder.filters import Filters
 from homeassistant.components.recorder.models import (
     bytes_to_ulid_or_none,
@@ -16,7 +15,7 @@ from homeassistant.components.recorder.models import (
     uuid_hex_to_bytes_or_none,
 )
 from homeassistant.const import ATTR_ICON, EVENT_STATE_CHANGED
-from homeassistant.core import Context, Event, EventStateChangedData, State, callback
+from homeassistant.core import Context, Event, State, callback
 from homeassistant.util.event_type import EventType
 from homeassistant.util.json import json_loads
 from homeassistant.util.ulid import ulid_to_bytes
@@ -131,7 +130,7 @@ class EventAsRow(NamedTuple):
     state: str | None
     entity_id: str | None
     icon: str | None
-    attributes: bytes | str | None
+    attributes: Mapping[str, Any] | None
     context_only: bool | None
 
     # Additional fields for EventAsRow
@@ -163,7 +162,6 @@ def async_event_to_row(event: Event) -> EventAsRow:
     # States are prefiltered so we never get states
     # that are missing new_state or old_state
     # since the logbook does not show these
-    state_changed_event = cast("Event[EventStateChangedData]", event)
     new_state: State = event.data["new_state"]
     # Use the event's context rather than the state's context because
     # State.expire() replaces the context with a copy that loses
@@ -180,9 +178,7 @@ def async_event_to_row(event: Event) -> EventAsRow:
         state=new_state.state,
         entity_id=new_state.entity_id,
         icon=new_state.attributes.get(ATTR_ICON),
-        attributes=StateAttributes.shared_attrs_bytes_from_event(
-            state_changed_event, None
-        ),
+        attributes=new_state.attributes,
         context_only=None,
         data=event.data,
         context=context,

--- a/homeassistant/components/logbook/models.py
+++ b/homeassistant/components/logbook/models.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Final, NamedTuple, cast, final
 from propcache.api import cached_property
 from sqlalchemy.engine.row import Row
 
+from homeassistant.components.recorder.db_schema import StateAttributes
 from homeassistant.components.recorder.filters import Filters
 from homeassistant.components.recorder.models import (
     bytes_to_ulid_or_none,
@@ -15,7 +16,7 @@ from homeassistant.components.recorder.models import (
     uuid_hex_to_bytes_or_none,
 )
 from homeassistant.const import ATTR_ICON, EVENT_STATE_CHANGED
-from homeassistant.core import Context, Event, State, callback
+from homeassistant.core import Context, Event, EventStateChangedData, State, callback
 from homeassistant.util.event_type import EventType
 from homeassistant.util.json import json_loads
 from homeassistant.util.ulid import ulid_to_bytes
@@ -106,10 +107,11 @@ CONTEXT_PARENT_ID_BIN_POS: Final = 6
 STATE_POS: Final = 7
 ENTITY_ID_POS: Final = 8
 ICON_POS: Final = 9
-CONTEXT_ONLY_POS: Final = 10
+ATTRIBUTES_POS: Final = 10
+CONTEXT_ONLY_POS: Final = 11
 # - For EventAsRow, additional fields are:
-DATA_POS: Final = 11
-CONTEXT_POS: Final = 12
+DATA_POS: Final = 12
+CONTEXT_POS: Final = 13
 
 
 @final  # Final to allow direct checking of the type instead of using isinstance
@@ -129,6 +131,7 @@ class EventAsRow(NamedTuple):
     state: str | None
     entity_id: str | None
     icon: str | None
+    attributes: bytes | str | None
     context_only: bool | None
 
     # Additional fields for EventAsRow
@@ -152,6 +155,7 @@ def async_event_to_row(event: Event) -> EventAsRow:
             state=None,
             entity_id=None,
             icon=None,
+            attributes=None,
             context_only=None,
             data=event.data,
             context=context,
@@ -159,6 +163,7 @@ def async_event_to_row(event: Event) -> EventAsRow:
     # States are prefiltered so we never get states
     # that are missing new_state or old_state
     # since the logbook does not show these
+    state_changed_event = cast("Event[EventStateChangedData]", event)
     new_state: State = event.data["new_state"]
     # Use the event's context rather than the state's context because
     # State.expire() replaces the context with a copy that loses
@@ -175,6 +180,9 @@ def async_event_to_row(event: Event) -> EventAsRow:
         state=new_state.state,
         entity_id=new_state.entity_id,
         icon=new_state.attributes.get(ATTR_ICON),
+        attributes=StateAttributes.shared_attrs_bytes_from_event(
+            state_changed_event, None
+        ),
         context_only=None,
         data=event.data,
         context=context,

--- a/homeassistant/components/logbook/processor.py
+++ b/homeassistant/components/logbook/processor.py
@@ -16,6 +16,7 @@ from homeassistant.components.recorder import get_instance
 from homeassistant.components.recorder.filters import Filters
 from homeassistant.components.recorder.models import (
     bytes_to_uuid_hex_or_none,
+    decode_attributes_from_source,
     extract_event_type_ids,
     extract_metadata_ids,
     process_timestamp_to_utc_isoformat,
@@ -53,6 +54,8 @@ from .const import (
     CONTEXT_STATE,
     CONTEXT_USER_ID,
     DOMAIN,
+    EXPOSED_STATE_ATTRIBUTES,
+    LOGBOOK_ENTRY_ATTRIBUTES,
     LOGBOOK_ENTRY_DOMAIN,
     LOGBOOK_ENTRY_ENTITY_ID,
     LOGBOOK_ENTRY_ICON,
@@ -64,6 +67,7 @@ from .const import (
 )
 from .helpers import is_sensor_continuous
 from .models import (
+    ATTRIBUTES_POS,
     CONTEXT_ID_BIN_POS,
     CONTEXT_ONLY_POS,
     CONTEXT_PARENT_ID_BIN_POS,
@@ -294,6 +298,8 @@ def _humanify(
     get_context = context_augmenter.get_context
     context_id_bin: bytes
     data: dict[str, Any]
+    # Decode each shared attribute set only once per run.
+    attr_cache: dict[str, dict[str, Any]] = {}
 
     context_user_ids = logbook_run.context_user_ids
     # Skip the LRU write on one-shot runs — the LogbookRun is discarded.
@@ -337,6 +343,13 @@ def _humanify(
                 data[LOGBOOK_ENTRY_NAME] = entity_name_cache_get(entity_id)
             if icon := row[ICON_POS]:
                 data[LOGBOOK_ENTRY_ICON] = icon
+            attributes = decode_attributes_from_source(row[ATTRIBUTES_POS], attr_cache)
+            if state_attributes := {
+                name: attributes[name]
+                for name in EXPOSED_STATE_ATTRIBUTES
+                if name in attributes
+            }:
+                data[LOGBOOK_ENTRY_ATTRIBUTES] = state_attributes
 
         elif event_type in external_events:
             domain, describe_event = external_events[event_type]

--- a/homeassistant/components/logbook/processor.py
+++ b/homeassistant/components/logbook/processor.py
@@ -1,6 +1,6 @@
 """Event parser and human readable log generator."""
 
-from collections.abc import Callable, Collection, Generator, Sequence
+from collections.abc import Callable, Collection, Generator, Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime as dt
 import logging
@@ -277,6 +277,26 @@ class EventProcessor:
         )
 
 
+def _exposed_state_attributes(
+    row: Row | EventAsRow, attr_cache: dict[str, dict[str, Any]]
+) -> dict[str, Any]:
+    """Return the allowlisted state attributes for a state change row."""
+    # Live rows carry the state's attributes directly; db rows carry the
+    # recorded shared_attrs source that has to be decoded.
+    attributes: Mapping[str, Any] | None
+    if type(row) is EventAsRow:
+        attributes = row[ATTRIBUTES_POS]
+    else:
+        attributes = decode_attributes_from_source(row[ATTRIBUTES_POS], attr_cache)
+    if not attributes:
+        return {}
+    return {
+        name: attributes[name]
+        for name in EXPOSED_STATE_ATTRIBUTES
+        if name in attributes
+    }
+
+
 def _humanify(
     hass: HomeAssistant,
     rows: Generator[EventAsRow] | Sequence[Row] | Result,
@@ -343,13 +363,8 @@ def _humanify(
                 data[LOGBOOK_ENTRY_NAME] = entity_name_cache_get(entity_id)
             if icon := row[ICON_POS]:
                 data[LOGBOOK_ENTRY_ICON] = icon
-            attributes = decode_attributes_from_source(row[ATTRIBUTES_POS], attr_cache)
-            if state_attributes := {
-                name: attributes[name]
-                for name in EXPOSED_STATE_ATTRIBUTES
-                if name in attributes
-            }:
-                data[LOGBOOK_ENTRY_ATTRIBUTES] = state_attributes
+            if exposed := _exposed_state_attributes(row, attr_cache):
+                data[LOGBOOK_ENTRY_ATTRIBUTES] = exposed
 
         elif event_type in external_events:
             domain, describe_event = external_events[event_type]

--- a/homeassistant/components/logbook/processor.py
+++ b/homeassistant/components/logbook/processor.py
@@ -281,8 +281,6 @@ def _exposed_state_attributes(
     row: Row | EventAsRow, attr_cache: dict[str, dict[str, Any]]
 ) -> dict[str, Any]:
     """Return the allowlisted state attributes for a state change row."""
-    # Live rows carry the state's attributes directly; db rows carry the
-    # recorded shared_attrs source that has to be decoded.
     attributes: Mapping[str, Any] | None
     if type(row) is EventAsRow:
         attributes = row[ATTRIBUTES_POS]

--- a/homeassistant/components/logbook/queries/common.py
+++ b/homeassistant/components/logbook/queries/common.py
@@ -14,6 +14,7 @@ from homeassistant.components.recorder.db_schema import (
     EVENTS_CONTEXT_ID_BIN_INDEX,
     OLD_FORMAT_ATTRS_JSON,
     OLD_STATE,
+    SHARED_ATTR_OR_LEGACY_ATTRIBUTES,
     SHARED_ATTRS_JSON,
     SHARED_DATA_OR_LEGACY_EVENT_DATA,
     STATES_CONTEXT_ID_BIN_INDEX,
@@ -65,12 +66,14 @@ STATE_COLUMNS = (
     States.state.label("state"),
     StatesMeta.entity_id.label("entity_id"),
     ICON_OR_OLD_FORMAT_ICON_JSON,
+    SHARED_ATTR_OR_LEGACY_ATTRIBUTES,
 )
 
 STATE_CONTEXT_ONLY_COLUMNS = (
     States.state.label("state"),
     StatesMeta.entity_id.label("entity_id"),
     literal(value=None, type_=sqlalchemy.String).label("icon"),
+    literal(value=None, type_=sqlalchemy.String).label("attributes"),
 )
 
 EVENT_COLUMNS_FOR_STATE_SELECT = (
@@ -93,6 +96,7 @@ EMPTY_STATE_COLUMNS = (
     literal(value=None, type_=sqlalchemy.String).label("state"),
     literal(value=None, type_=sqlalchemy.String).label("entity_id"),
     literal(value=None, type_=sqlalchemy.String).label("icon"),
+    literal(value=None, type_=sqlalchemy.String).label("attributes"),
 )
 
 

--- a/homeassistant/components/recorder/models/__init__.py
+++ b/homeassistant/components/recorder/models/__init__.py
@@ -9,6 +9,7 @@ from .context import (
 from .database import DatabaseEngine, DatabaseOptimizer, UnsupportedDialect
 from .event import extract_event_type_ids
 from .state import LazyState, extract_metadata_ids, row_to_compressed_state
+from .state_attributes import decode_attributes_from_source
 from .statistics import (
     CalendarStatisticPeriod,
     FixedStatisticPeriod,
@@ -44,6 +45,7 @@ __all__ = [
     "bytes_to_ulid_or_none",
     "bytes_to_uuid_hex_or_none",
     "datetime_to_timestamp_or_none",
+    "decode_attributes_from_source",
     "extract_event_type_ids",
     "extract_metadata_ids",
     "process_timestamp",

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -42,6 +42,7 @@ from homeassistant.const import (
     EVENT_LOGBOOK_ENTRY,
     STATE_OFF,
     STATE_ON,
+    STATE_UNKNOWN,
 )
 from homeassistant.core import Context, Event, HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -345,6 +346,7 @@ def create_state_changed_event_from_old_new(
         state=new_state and new_state.get("state"),
         entity_id=entity_id,
         icon=None,
+        attributes=None,
         context_only=False,
         data=None,
         context=None,
@@ -1858,6 +1860,46 @@ async def test_icon_and_state(
 
 
 @pytest.mark.usefixtures("recorder_mock")
+async def test_state_attributes_in_logbook(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
+    """Test state attributes are exposed in the logbook like the history.
+
+    The recorded subset is surfaced, so attributes the recorder excludes
+    (such as supported_features) must not appear.
+    """
+    await asyncio.gather(
+        *[
+            async_setup_component(hass, domain, {})
+            for domain in ("homeassistant", "logbook")
+        ]
+    )
+    await async_recorder_block_till_done(hass)
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+
+    hass.states.async_set("event.doorbell", STATE_UNKNOWN, {"event_type": None})
+    hass.states.async_set(
+        "event.doorbell",
+        "2024-01-01T00:00:00.000+00:00",
+        {"event_type": "ring", "supported_features": 1},
+    )
+    hass.states.async_set(
+        "event.doorbell", "2024-01-01T00:01:00.000+00:00", {"event_type": "motion"}
+    )
+
+    await async_wait_recording_done(hass)
+
+    client = await hass_client()
+    response_json = await _async_fetch_logbook(client)
+
+    entries = [e for e in response_json if e.get("entity_id") == "event.doorbell"]
+    assert len(entries) == 2
+    assert entries[0]["attributes"] == {"event_type": "ring"}
+    assert entries[1]["attributes"] == {"event_type": "motion"}
+
+
+@pytest.mark.usefixtures("recorder_mock")
 async def test_fire_logbook_entries(
     hass: HomeAssistant, hass_client: ClientSessionGenerator
 ) -> None:
@@ -3335,6 +3377,7 @@ async def test_parent_user_attribution_does_not_use_origin_event_fallback(
         state=STATE_ON,
         entity_id="switch.heater",
         icon=None,
+        attributes=None,
         context_only=False,
         data={},
         context=child_context,

--- a/tests/components/logbook/test_models.py
+++ b/tests/components/logbook/test_models.py
@@ -19,6 +19,7 @@ def test_lazy_event_partial_state_context() -> None:
             state="state",
             entity_id="entity_id",
             icon="icon",
+            attributes=None,
             context_only=False,
             data={},
             context=Mock(),

--- a/tests/components/logbook/test_websocket_api.py
+++ b/tests/components/logbook/test_websocket_api.py
@@ -35,6 +35,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_START,
     STATE_OFF,
     STATE_ON,
+    STATE_UNKNOWN,
 )
 from homeassistant.core import Event, HomeAssistant, State, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -1477,6 +1478,64 @@ async def test_subscribe_unsubscribe_logbook_stream(
     assert listeners_without_writes(
         hass.bus.async_listeners()
     ) == listeners_without_writes(init_listeners)
+
+
+@patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)
+async def test_subscribe_logbook_stream_state_attributes(
+    recorder_mock: Recorder, hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
+    """Test the live logbook stream exposes allowlisted state attributes."""
+    now = dt_util.utcnow()
+    await asyncio.gather(
+        *[
+            async_setup_component(hass, domain, {})
+            for domain in ("homeassistant", "logbook")
+        ]
+    )
+    await hass.async_block_till_done()
+
+    hass.states.async_set("binary_sensor.is_light", STATE_ON)
+    hass.states.async_set("binary_sensor.is_light", STATE_OFF)
+    await hass.async_block_till_done()
+    await async_wait_recording_done(hass)
+
+    websocket_client = await hass_ws_client()
+    await websocket_client.send_json(
+        {"id": 7, "type": "logbook/event_stream", "start_time": now.isoformat()}
+    )
+
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
+    assert msg["id"] == 7
+    assert msg["type"] == TYPE_RESULT
+    assert msg["success"]
+
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
+    assert msg["event"]["partial"] is True
+
+    await hass.async_block_till_done()
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
+    assert "partial" not in msg["event"]
+    assert msg["event"]["events"] == []
+
+    hass.states.async_set("event.doorbell", STATE_UNKNOWN, {"event_type": None})
+    hass.states.async_set(
+        "event.doorbell",
+        "2024-01-01T00:00:00.000+00:00",
+        {"event_type": "ring", "supported_features": 1},
+    )
+    await hass.async_block_till_done()
+
+    msg = await asyncio.wait_for(websocket_client.receive_json(), 2)
+    assert msg["id"] == 7
+    assert msg["type"] == "event"
+    assert msg["event"]["events"] == [
+        {
+            "entity_id": "event.doorbell",
+            "state": "2024-01-01T00:00:00.000+00:00",
+            "attributes": {"event_type": "ring"},
+            "when": ANY,
+        }
+    ]
 
 
 @patch("homeassistant.components.logbook.websocket_api.EVENT_COALESCE_TIME", 0)


### PR DESCRIPTION
## Proposed change

Event entities only showed a timestamp in the logbook, with no indication of what happened. Logbook entries now include an `attributes` object carrying a curated allowlist of state attributes (currently `event_type`), decoded from the recorded attributes the same way the history component does, so the list can be extended later without further plumbing.

Feel free to push down if you think we should not add attributes for performance reason even if it's a limited set for now (only `event_type`)

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
