### PR TITLE
Add speech speed option to Fish Audio TTS

### DIFF
--- a/homeassistant/components/fish_audio/config_flow.py
+++ b/homeassistant/components/fish_audio/config_flow.py
@@ -21,6 +21,9 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.selector import (
     LanguageSelector,
     LanguageSelectorConfig,
+    NumberSelector,
+    NumberSelectorConfig,
+    NumberSelectorMode,
     SelectOptionDict,
     SelectSelector,
     SelectSelectorConfig,
@@ -34,13 +37,18 @@ from .const import (
     CONF_LATENCY,
     CONF_SELF_ONLY,
     CONF_SORT_BY,
+    CONF_SPEED,
     CONF_TITLE,
     CONF_USER_ID,
     CONF_VOICE_ID,
+    DEFAULT_SPEED,
     DOMAIN,
     LATENCY_OPTIONS,
+    MAX_SPEED,
+    MIN_SPEED,
     SIGNUP_URL,
     SORT_BY_OPTIONS,
+    SPEED_STEP,
     TTS_SUPPORTED_LANGUAGES,
 )
 from .error import (
@@ -126,6 +134,17 @@ def get_model_selection_schema(
                         for opt in LATENCY_OPTIONS
                     ],
                     mode=SelectSelectorMode.DROPDOWN,
+                )
+            ),
+            vol.Optional(
+                CONF_SPEED,
+                default=options.get(CONF_SPEED, DEFAULT_SPEED),
+            ): NumberSelector(
+                NumberSelectorConfig(
+                    min=MIN_SPEED,
+                    max=MAX_SPEED,
+                    step=SPEED_STEP,
+                    mode=NumberSelectorMode.SLIDER,
                 )
             ),
             # Name field is no longer allowed in config flow schemas

--- a/homeassistant/components/fish_audio/const.py
+++ b/homeassistant/components/fish_audio/const.py
@@ -10,6 +10,7 @@ CONF_BACKEND: Literal["backend"] = "backend"
 CONF_SELF_ONLY: Literal["self_only"] = "self_only"
 CONF_SORT_BY: Literal["sort_by"] = "sort_by"
 CONF_LATENCY: Literal["latency"] = "latency"
+CONF_SPEED: Literal["speed"] = "speed"
 CONF_TITLE: Literal["title"] = "title"
 
 DEVELOPER_ID = "1e9f9baadce144f5b16dd94cbc0314c8"
@@ -30,6 +31,12 @@ TTS_SUPPORTED_LANGUAGES = [
 BACKEND_MODELS = ["s2-pro", "s1", "speech-1.5", "speech-1.6"]
 SORT_BY_OPTIONS = ["task_count", "score", "created_at"]
 LATENCY_OPTIONS = ["normal", "balanced"]
+
+# Speech speed multiplier accepted by the Fish Audio API (1.0 = normal speed).
+DEFAULT_SPEED = 1.0
+MIN_SPEED = 0.5
+MAX_SPEED = 2.0
+SPEED_STEP = 0.05
 
 SIGNUP_URL = "https://fish.audio/"
 BILLING_URL = "https://fish.audio/app/billing/"

--- a/homeassistant/components/fish_audio/strings.json
+++ b/homeassistant/components/fish_audio/strings.json
@@ -65,12 +65,14 @@
             "backend": "AI voice model",
             "latency": "Latency mode",
             "name": "[%key:common::config_flow::data::name%]",
+            "speed": "Speech speed",
             "voice_id": "Voice"
           },
           "data_description": {
             "backend": "Select the AI model that will generate the audio.",
             "latency": "Choose the latency mode: 'normal' for standard processing or 'balanced' for optimized speed.",
             "name": "Enter a unique name for this TTS voice to easily identify it in Home Assistant.",
+            "speed": "Speed of the generated speech. 1.0 is the normal speed; lower values speak slower and higher values speak faster.",
             "voice_id": "Choose from the list of available voices, or manually enter a specific voice ID."
           },
           "description": "Select your preferred voice and the AI model to use for speech synthesis.",

--- a/homeassistant/components/fish_audio/tts.py
+++ b/homeassistant/components/fish_audio/tts.py
@@ -16,7 +16,9 @@ from . import FishAudioConfigEntry
 from .const import (
     CONF_BACKEND,
     CONF_LATENCY,
+    CONF_SPEED,
     CONF_VOICE_ID,
+    DEFAULT_SPEED,
     DOMAIN,
     TTS_SUPPORTED_LANGUAGES,
 )
@@ -50,7 +52,7 @@ class FishAudioTTSEntity(TextToSpeechEntity):
     """Fish Audio TTS entity."""
 
     _attr_has_entity_name = True
-    _attr_supported_options = [CONF_VOICE_ID, CONF_BACKEND, CONF_LATENCY]
+    _attr_supported_options = [CONF_VOICE_ID, CONF_BACKEND, CONF_LATENCY, CONF_SPEED]
 
     def __init__(self, entry: FishAudioConfigEntry, sub_entry: ConfigSubentry) -> None:
         """Initialize the TTS entity."""
@@ -97,6 +99,9 @@ class FishAudioTTSEntity(TextToSpeechEntity):
         latency = options.get(
             CONF_LATENCY, self.sub_entry.data.get(CONF_LATENCY, "balanced")
         )
+        speed = options.get(
+            CONF_SPEED, self.sub_entry.data.get(CONF_SPEED, DEFAULT_SPEED)
+        )
 
         if voice_id is None:
             raise ServiceValidationError("Voice ID not configured")
@@ -108,6 +113,7 @@ class FishAudioTTSEntity(TextToSpeechEntity):
                 text=message,
                 reference_id=voice_id,
                 latency=latency,
+                speed=speed,
                 model=backend,
                 format="mp3",
             )

--- a/homeassistant/components/fish_audio/tts.py
+++ b/homeassistant/components/fish_audio/tts.py
@@ -20,6 +20,8 @@ from .const import (
     CONF_VOICE_ID,
     DEFAULT_SPEED,
     DOMAIN,
+    MAX_SPEED,
+    MIN_SPEED,
     TTS_SUPPORTED_LANGUAGES,
 )
 from .error import UnexpectedError
@@ -59,6 +61,10 @@ class FishAudioTTSEntity(TextToSpeechEntity):
         self.client = entry.runtime_data
         self.sub_entry = sub_entry
         self._attr_unique_id = sub_entry.subentry_id
+        # Configured speed must be a default option so it is part of the TTS cache key.
+        self._attr_default_options = {
+            CONF_SPEED: sub_entry.data.get(CONF_SPEED, DEFAULT_SPEED)
+        }
         title = sub_entry.title
         backend = sub_entry.data[CONF_BACKEND]
         self._attr_name = title
@@ -107,6 +113,10 @@ class FishAudioTTSEntity(TextToSpeechEntity):
             raise ServiceValidationError("Voice ID not configured")
         if backend is None:
             raise ServiceValidationError("Backend model not configured")
+        if not MIN_SPEED <= speed <= MAX_SPEED:
+            raise ServiceValidationError(
+                f"Speed must be between {MIN_SPEED} and {MAX_SPEED}"
+            )
 
         try:
             audio = await self.client.tts.convert(

--- a/tests/components/fish_audio/test_config_flow.py
+++ b/tests/components/fish_audio/test_config_flow.py
@@ -10,6 +10,7 @@ from homeassistant.components.fish_audio.const import (
     CONF_LATENCY,
     CONF_SELF_ONLY,
     CONF_SORT_BY,
+    CONF_SPEED,
     CONF_TITLE,
     CONF_USER_ID,
     CONF_VOICE_ID,
@@ -146,6 +147,7 @@ async def test_subflow_happy_path(
             CONF_VOICE_ID: "voice-alpha",
             CONF_BACKEND: "s1",
             CONF_LATENCY: "balanced",
+            CONF_SPEED: 1.5,
             CONF_NAME: "My Custom Voice",
         },
     )
@@ -155,6 +157,7 @@ async def test_subflow_happy_path(
     assert result["data"][CONF_VOICE_ID] == "voice-alpha"
     assert result["data"][CONF_BACKEND] == "s1"
     assert result["data"][CONF_LATENCY] == "balanced"
+    assert result["data"][CONF_SPEED] == 1.5
     assert result["unique_id"] == "voice-alpha-s1"
 
     entry = hass.config_entries.async_get_entry(mock_config_entry.entry_id)
@@ -250,12 +253,14 @@ async def test_subflow_reconfigure(
             CONF_VOICE_ID: "voice-gamma",
             CONF_BACKEND: "s1",
             CONF_LATENCY: "normal",
+            CONF_SPEED: 1.3,
             CONF_NAME: "Updated Voice",
         },
     )
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
+    assert mock_config_entry.subentries[subentry.subentry_id].data[CONF_SPEED] == 1.3
 
 
 async def test_subflow_reconfigure_already_configured(

--- a/tests/components/fish_audio/test_tts.py
+++ b/tests/components/fish_audio/test_tts.py
@@ -9,14 +9,21 @@ from fishaudio.exceptions import ServerError
 import pytest
 
 from homeassistant.components import tts
-from homeassistant.components.fish_audio.const import CONF_BACKEND, DOMAIN
+from homeassistant.components.fish_audio.const import (
+    CONF_BACKEND,
+    CONF_LATENCY,
+    CONF_SPEED,
+    CONF_VOICE_ID,
+    DEFAULT_SPEED,
+    DOMAIN,
+)
 from homeassistant.components.media_player import (
     ATTR_MEDIA_CONTENT_ID,
     DOMAIN as MP_DOMAIN,
     SERVICE_PLAY_MEDIA,
 )
 from homeassistant.config_entries import ConfigSubentryData
-from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.const import ATTR_ENTITY_ID, CONF_API_KEY
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.core_config import async_process_ha_core_config
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
@@ -174,6 +181,81 @@ async def test_tts_supported_languages(
         "es",
         "ko",
     ]
+
+
+@pytest.mark.parametrize(
+    ("options", "expected_speed"),
+    [
+        pytest.param({}, DEFAULT_SPEED, id="default"),
+        pytest.param({CONF_SPEED: 1.5}, 1.5, id="per_call_faster"),
+        pytest.param({CONF_SPEED: 0.75}, 0.75, id="per_call_slower"),
+    ],
+)
+async def test_tts_speed_option(
+    hass: HomeAssistant,
+    mock_fishaudio_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    options: dict[str, float],
+    expected_speed: float,
+) -> None:
+    """Test the speech speed per-call option is forwarded to the client."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity = hass.data[tts.DOMAIN].get_entity("tts.test_voice_test_voice")
+    assert entity is not None
+
+    await entity.async_get_tts_audio(
+        message="Hello world",
+        language="en",
+        options=options,
+    )
+
+    assert mock_fishaudio_client.tts.convert.call_args.kwargs["speed"] == expected_speed
+
+
+async def test_tts_speed_from_subentry(
+    hass: HomeAssistant,
+    mock_fishaudio_client: AsyncMock,
+) -> None:
+    """Test the configured per-voice speed is used without a per-call option.
+
+    This is the Assist pipeline path, which does not pass per-call options.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_API_KEY: "test-api-key"},
+        unique_id="test_user",
+        subentries_data=[
+            ConfigSubentryData(
+                data={
+                    CONF_VOICE_ID: "voice-123",
+                    CONF_BACKEND: "s1",
+                    CONF_LATENCY: "balanced",
+                    CONF_SPEED: 1.25,
+                },
+                subentry_type="tts",
+                title="Test Voice",
+                subentry_id="test-subentry-id",
+                unique_id="voice-123-s1",
+            )
+        ],
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity = hass.data[tts.DOMAIN].get_entity("tts.test_voice_test_voice")
+    assert entity is not None
+
+    await entity.async_get_tts_audio(
+        message="Hello world",
+        language="en",
+        options={},
+    )
+
+    assert mock_fishaudio_client.tts.convert.call_args.kwargs["speed"] == 1.25
 
 
 # Service-level integration tests

--- a/tests/components/fish_audio/test_tts.py
+++ b/tests/components/fish_audio/test_tts.py
@@ -249,6 +249,9 @@ async def test_tts_speed_from_subentry(
     entity = hass.data[tts.DOMAIN].get_entity("tts.test_voice_test_voice")
     assert entity is not None
 
+    # The configured speed is exposed as a default option so it is part of the cache key.
+    assert entity.default_options == {CONF_SPEED: 1.25}
+
     await entity.async_get_tts_audio(
         message="Hello world",
         language="en",
@@ -256,6 +259,31 @@ async def test_tts_speed_from_subentry(
     )
 
     assert mock_fishaudio_client.tts.convert.call_args.kwargs["speed"] == 1.25
+
+
+@pytest.mark.parametrize("speed", [0.1, 5.0])
+async def test_tts_speed_out_of_range(
+    hass: HomeAssistant,
+    mock_fishaudio_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    speed: float,
+) -> None:
+    """Test an out-of-range per-call speed raises a validation error."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity = hass.data[tts.DOMAIN].get_entity("tts.test_voice_test_voice")
+    assert entity is not None
+
+    with pytest.raises(ServiceValidationError):
+        await entity.async_get_tts_audio(
+            message="Hello world",
+            language="en",
+            options={CONF_SPEED: speed},
+        )
+
+    mock_fishaudio_client.tts.convert.assert_not_called()
 
 
 # Service-level integration tests


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fish Audio voices currently always speak at a fixed rate. This adds a `speed` option that exposes the Fish Audio API's prosody speed.

It can be set per voice in the config subentry, so it also applies to Assist pipelines (the main motivation, e.g. a voice assistant that speaks a little faster), and as a per-call `tts.speak` option following the existing `latency`/`backend` pattern. The default of `1.0` keeps the current behavior.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/46482
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
