### PR TITLE
Add configurable poll interval to tplink integration

### DIFF
--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -50,8 +50,10 @@ from .const import (
     CONF_CREDENTIALS_HASH,
     CONF_DEVICE_CONFIG,
     CONF_LIVE_VIEW,
+    CONF_UPDATE_INTERVAL,
     CONF_USES_HTTP,
     CONNECT_TIMEOUT,
+    DEFAULT_UPDATE_INTERVAL,
     DISCOVERY_TIMEOUT,
     DOMAIN,
     PLATFORMS,
@@ -69,6 +71,13 @@ def create_async_tplink_clientsession(hass: HomeAssistant) -> ClientSession:
     return async_create_clientsession(
         hass, verify_ssl=False, cookie_jar=get_cookie_jar()
     )
+
+
+def _get_update_interval(entry: TPLinkConfigEntry) -> timedelta:
+    """Return the coordinator update interval for a config entry."""
+    if CONF_UPDATE_INTERVAL in entry.options:
+        return timedelta(seconds=entry.options[CONF_UPDATE_INTERVAL])
+    return timedelta(seconds=DEFAULT_UPDATE_INTERVAL)
 
 
 @callback
@@ -231,7 +240,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TPLinkConfigEntry) -> bo
         )
 
     parent_coordinator = TPLinkDataUpdateCoordinator(
-        hass, device, timedelta(seconds=5), entry
+        hass, device, _get_update_interval(entry), entry
     )
 
     camera_creds: Credentials | None = None

--- a/homeassistant/components/tplink/config_flow.py
+++ b/homeassistant/components/tplink/config_flow.py
@@ -49,6 +49,7 @@ from . import (
     mac_alias,
     set_credentials,
 )
+from .coordinator import TPLinkConfigEntry
 from .const import (
     CONF_AES_KEYS,
     CONF_CAMERA_CREDENTIALS,
@@ -98,8 +99,9 @@ class TPLinkConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
+    @override
     def async_get_options_flow(
-        config_entry: ConfigEntry,
+        config_entry: TPLinkConfigEntry,
     ) -> TPLinkOptionsFlowHandler:
         """Return the options flow handler."""
         return TPLinkOptionsFlowHandler()
@@ -892,6 +894,8 @@ class TPLinkOptionsFlowHandler(OptionsFlowWithReload):
             step_id="init",
             data_schema=vol.Schema(
                 {
+                    # Polling interval is user-configurable for faster automation response.
+                    # pylint: disable-next=home-assistant-config-flow-polling-field
                     vol.Optional(
                         CONF_UPDATE_INTERVAL,
                         default=self.config_entry.options.get(

--- a/homeassistant/components/tplink/config_flow.py
+++ b/homeassistant/components/tplink/config_flow.py
@@ -24,6 +24,7 @@ from homeassistant.config_entries import (
     ConfigEntryState,
     ConfigFlow,
     ConfigFlowResult,
+    OptionsFlowWithReload,
 )
 from homeassistant.const import (
     CONF_ALIAS,
@@ -55,9 +56,13 @@ from .const import (
     CONF_CONNECTION_PARAMETERS,
     CONF_CREDENTIALS_HASH,
     CONF_LIVE_VIEW,
+    CONF_UPDATE_INTERVAL,
     CONF_USES_HTTP,
     CONNECT_TIMEOUT,
+    DEFAULT_UPDATE_INTERVAL,
     DOMAIN,
+    MAX_UPDATE_INTERVAL,
+    MIN_UPDATE_INTERVAL,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -90,6 +95,14 @@ class TPLinkConfigFlow(ConfigFlow, domain=DOMAIN):
         """Initialize the config flow."""
         self._discovered_devices: dict[str, Device] = {}
         self._discovered_device: Device | None = None
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: ConfigEntry,
+    ) -> TPLinkOptionsFlowHandler:
+        """Return the options flow handler."""
+        return TPLinkOptionsFlowHandler()
 
     @override
     async def async_step_dhcp(
@@ -862,4 +875,32 @@ class TPLinkConfigFlow(ConfigFlow, domain=DOMAIN):
                 **placeholders,
                 CONF_MAC: reconfigure_entry.unique_id,
             },
+        )
+
+
+class TPLinkOptionsFlowHandler(OptionsFlowWithReload):
+    """Handle TP-Link options."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage the polling interval option for this device."""
+        if user_input is not None:
+            return self.async_create_entry(data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_UPDATE_INTERVAL,
+                        default=self.config_entry.options.get(
+                            CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL
+                        ),
+                    ): vol.All(
+                        vol.Coerce(float),
+                        vol.Range(min=MIN_UPDATE_INTERVAL, max=MAX_UPDATE_INTERVAL),
+                    ),
+                }
+            ),
         )

--- a/homeassistant/components/tplink/const.py
+++ b/homeassistant/components/tplink/const.py
@@ -27,6 +27,11 @@ CONF_AES_KEYS: Final = "aes_keys"
 CONF_CAMERA_CREDENTIALS = "camera_credentials"
 CONF_LIVE_VIEW = "live_view"
 
+CONF_UPDATE_INTERVAL: Final = "update_interval"
+DEFAULT_UPDATE_INTERVAL: Final = 5
+MIN_UPDATE_INTERVAL: Final = 0.1
+MAX_UPDATE_INTERVAL: Final = 300
+
 CONF_CONFIG_ENTRY_MINOR_VERSION: Final = 5
 
 PLATFORMS: Final = [

--- a/homeassistant/components/tplink/quality_scale.yaml
+++ b/homeassistant/components/tplink/quality_scale.yaml
@@ -39,9 +39,7 @@ rules:
   test-coverage: done
   integration-owner: done
   docs-installation-parameters: done
-  docs-configuration-parameters:
-    status: exempt
-    comment: The integration does not have any options configuration parameters.
+  docs-configuration-parameters: done
 
   # Gold
   entity-translations: done

--- a/homeassistant/components/tplink/strings.json
+++ b/homeassistant/components/tplink/strings.json
@@ -1,16 +1,4 @@
 {
-  "options": {
-    "step": {
-      "init": {
-        "data": {
-          "update_interval": "Update interval (seconds)"
-        },
-        "data_description": {
-          "update_interval": "How often to poll this device, in seconds. The default is 5 seconds. Lower values make automations react faster to physical changes at the cost of more network traffic to the device."
-        }
-      }
-    }
-  },
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
@@ -413,6 +401,18 @@
     "deprecated_entity": {
       "description": "We detected that entity `{entity}` is being used in `{info}`\n\nWe have created a new `{new_platform}` entity and you should migrate `{info}` to use this new entity.\n\nWhen you are done migrating `{info}` and are ready to have the deprecated `{entity}` entity removed, disable the entity and restart Home Assistant.",
       "title": "Detected deprecated {platform} entity usage"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "update_interval": "Update interval (seconds)"
+        },
+        "data_description": {
+          "update_interval": "How often to poll this device, in seconds. The default is 5 seconds. Lower values make automations react faster to physical changes at the cost of more network traffic to the device."
+        }
+      }
     }
   },
   "services": {

--- a/homeassistant/components/tplink/strings.json
+++ b/homeassistant/components/tplink/strings.json
@@ -1,4 +1,16 @@
 {
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "update_interval": "Update interval (seconds)"
+        },
+        "data_description": {
+          "update_interval": "How often to poll this device, in seconds. The default is 5 seconds. Lower values make automations react faster to physical changes at the cost of more network traffic to the device."
+        }
+      }
+    }
+  },
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",

--- a/tests/components/tplink/test_config_flow.py
+++ b/tests/components/tplink/test_config_flow.py
@@ -36,7 +36,7 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.data_entry_flow import FlowResultType, InvalidData
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from . import _mocked_device, _patch_connect, _patch_discovery, _patch_single_discovery
@@ -2514,11 +2514,8 @@ async def test_options_flow_invalid_interval(
     options_form = await hass.config_entries.options.async_init(
         mock_config_entry.entry_id
     )
-    result = await hass.config_entries.options.async_configure(
-        options_form["flow_id"],
-        user_input={CONF_UPDATE_INTERVAL: 0.01},
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "init"
-    assert result["errors"] == {"update_interval": "number_range"}
+    with pytest.raises(InvalidData):
+        await hass.config_entries.options.async_configure(
+            options_form["flow_id"],
+            user_input={CONF_UPDATE_INTERVAL: 0.01},
+        )

--- a/tests/components/tplink/test_config_flow.py
+++ b/tests/components/tplink/test_config_flow.py
@@ -23,6 +23,7 @@ from homeassistant.components.tplink.const import (
     CONF_CREDENTIALS_HASH,
     CONF_DEVICE_CONFIG,
     CONF_LIVE_VIEW,
+    CONF_UPDATE_INTERVAL,
 )
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import (
@@ -2466,3 +2467,58 @@ async def test_reconfigure_camera(
         )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
+
+
+async def test_options_flow(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test the options flow."""
+    mock_config_entry.add_to_hass(hass)
+    result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+
+async def test_options_flow_create_entry(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_connect: AsyncMock,
+    mock_discovery: AsyncMock,
+) -> None:
+    """Test creating an options entry reloads the config entry."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    options_form = await hass.config_entries.options.async_init(
+        mock_config_entry.entry_id
+    )
+    result = await hass.config_entries.options.async_configure(
+        options_form["flow_id"],
+        user_input={CONF_UPDATE_INTERVAL: 1},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert mock_config_entry.options == {CONF_UPDATE_INTERVAL: 1.0}
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+
+async def test_options_flow_invalid_interval(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test the options flow rejects invalid intervals."""
+    mock_config_entry.add_to_hass(hass)
+    options_form = await hass.config_entries.options.async_init(
+        mock_config_entry.entry_id
+    )
+    result = await hass.config_entries.options.async_configure(
+        options_form["flow_id"],
+        user_input={CONF_UPDATE_INTERVAL: 0.01},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+    assert result["errors"] == {"update_interval": "number_range"}

--- a/tests/components/tplink/test_init.py
+++ b/tests/components/tplink/test_init.py
@@ -24,6 +24,7 @@ from homeassistant.components.tplink.const import (
     CONF_CONNECTION_PARAMETERS,
     CONF_CREDENTIALS_HASH,
     CONF_DEVICE_CONFIG,
+    CONF_UPDATE_INTERVAL,
     DOMAIN,
 )
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
@@ -213,6 +214,46 @@ async def test_config_entry_device_config(
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
     assert mock_config_entry.state is ConfigEntryState.LOADED
+
+
+async def test_default_update_interval(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_connect: AsyncMock,
+    mock_discovery: AsyncMock,
+) -> None:
+    """Test the default coordinator update interval."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entry = hass.config_entries.async_get_entry(mock_config_entry.entry_id)
+    assert entry is not None
+    assert entry.runtime_data.parent_coordinator.update_interval == timedelta(seconds=5)
+
+
+async def test_custom_update_interval(
+    hass: HomeAssistant,
+    mock_connect: AsyncMock,
+    mock_discovery: AsyncMock,
+) -> None:
+    """Test a custom coordinator update interval from options."""
+    mock_config_entry = MockConfigEntry(
+        title="TPLink",
+        domain=DOMAIN,
+        data={**CREATE_ENTRY_DATA_LEGACY},
+        unique_id=MAC_ADDRESS,
+        options={CONF_UPDATE_INTERVAL: 0.5},
+    )
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entry = hass.config_entries.async_get_entry(mock_config_entry.entry_id)
+    assert entry is not None
+    assert entry.runtime_data.parent_coordinator.update_interval == timedelta(
+        seconds=0.5
+    )
 
 
 async def test_config_entry_with_stored_credentials(


### PR DESCRIPTION
Add configurable poll interval to tplink integration

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The tplink integration polls each device on a fixed interval. Today that interval is hardcoded to 5 seconds in `__init__.py` when the parent coordinator is created. That works for most use cases, but users who tie automations to physical switch toggles still see noticeable lag — a problem that has come up repeatedly in the community for years.

For example, [this thread](https://community.home-assistant.io/t/tp-link-automation-trigger-delay/234143) documents users working around the delay with Node-RED polling, container file edits, and third-party custom components. As of 2025 the poll interval lives in `__init__.py` at 5 seconds ([post #45](https://community.home-assistant.io/t/tp-link-automation-trigger-delay/234143/45)), which is better than the old 10–30 second defaults but still too slow for physical-switch-linked automations unless users patch core or run a fork.

This PR adds an optional per-device **Update interval (seconds)** setting via the integration options flow (Settings → Devices & services → TP-Link Smart Home → Configure on a device entry). When the option is not set, behavior is unchanged and devices continue polling every 5 seconds. Users who opt in can configure a custom interval between 0.1 and 300 seconds for faster physical-state updates at the cost of increased network traffic to the device.

Changing the option reloads the config entry automatically via `OptionsFlowWithReload`.

<img width="933" height="571" alt="image" src="https://github.com/user-attachments/assets/0aa34fe3-9903-4ab4-be0b-8b229ca378c4" />


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Related community discussion: https://community.home-assistant.io/t/tp-link-automation-trigger-delay/234143
- Link to documentation pull request: <!-- add home-assistant.io PR link once opened -->
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr