### PR TITLE
Fix Roborock number entity crash when volume is None

### DIFF
--- a/homeassistant/components/roborock/number.py
+++ b/homeassistant/components/roborock/number.py
@@ -35,7 +35,7 @@ class RoborockNumberDescription(NumberEntityDescription):
     trait: Callable[[PropertiesApi], Any | None]
     """Function to determine if number entity is supported by the device."""
 
-    get_value: Callable[[Any], float]
+    get_value: Callable[[Any], float | None]
     """Function to get the value from the trait."""
 
     set_value: Callable[[Any, float], Coroutine[Any, Any, None]]
@@ -51,7 +51,9 @@ NUMBER_DESCRIPTIONS: list[RoborockNumberDescription] = [
         native_unit_of_measurement=PERCENTAGE,
         entity_category=EntityCategory.CONFIG,
         trait=lambda api: api.sound_volume,
-        get_value=lambda trait: float(trait.volume),
+        get_value=lambda trait: (
+            float(trait.volume) if trait.volume is not None else None
+        ),
         set_value=lambda trait, value: trait.set_volume(int(value)),
     )
 ]

--- a/tests/components/roborock/test_number.py
+++ b/tests/components/roborock/test_number.py
@@ -4,9 +4,10 @@ import pytest
 from roborock.exceptions import RoborockTimeout
 
 from homeassistant.components.number import ATTR_VALUE, SERVICE_SET_VALUE
-from homeassistant.const import Platform
+from homeassistant.const import STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_component import async_update_entity
 
 from .conftest import FakeDevice
 
@@ -47,6 +48,22 @@ async def test_update_sound_volume(
     state = hass.states.get("number.roborock_s7_maxv_volume")
     assert state is not None
     assert state.state == "3.0"
+
+
+async def test_volume_unknown_value(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    fake_vacuum: FakeDevice,
+) -> None:
+    """Test the entity reports unknown when the trait value is None."""
+    assert fake_vacuum.v1_properties is not None
+    fake_vacuum.v1_properties.sound_volume.volume = None
+
+    await async_update_entity(hass, "number.roborock_s7_maxv_volume")
+
+    state = hass.states.get("number.roborock_s7_maxv_volume")
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
 
 
 async def test_volume_update_failed(


### PR DESCRIPTION
## Breaking change

## Proposed change

The Roborock volume number entity called `float()` directly on the trait value:

```python
get_value=lambda trait: float(trait.volume),
```

When the device reports no volume (`trait.volume` is `None`), this raised `TypeError: float() argument must be a string or a real number, not 'NoneType'` on every state write. Because the entity is polled, the error repeated continuously (hundreds of occurrences seen in the wild):

```
File "homeassistant/components/roborock/number.py", line 54, in <lambda>
    get_value=lambda trait: float(trait.volume),
TypeError: float() argument must be a string or a real number, not 'NoneType'
```

This change returns `None` when the trait value is `None`, so the entity reports an unknown state instead of crashing. The `get_value` type annotation is updated to `Callable[[Any], float | None]` to match `native_value`'s declared return type. A test was added covering the `None` case.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015muhdayAokSd8W9u2QYVJk)_