### PR TITLE
Fix Roborock time entity crash when timer value is missing

### DIFF
--- a/homeassistant/components/roborock/time.py
+++ b/homeassistant/components/roborock/time.py
@@ -30,6 +30,13 @@ _LOGGER = logging.getLogger(__name__)
 PARALLEL_UPDATES = 0
 
 
+def _build_time(hour: int | None, minute: int | None) -> datetime.time | None:
+    """Build a time, returning None when either component is missing."""
+    if hour is None or minute is None:
+        return None
+    return datetime.time(hour=hour, minute=minute)
+
+
 @dataclass(frozen=True, kw_only=True)
 class RoborockTimeDescription(TimeEntityDescription):
     """Class to describe a Roborock time entity."""
@@ -37,7 +44,7 @@ class RoborockTimeDescription(TimeEntityDescription):
     trait: Callable[[Any], Any | None]
     """Function to determine if time entity is supported by the device."""
 
-    get_value: Callable[[Any], datetime.time]
+    get_value: Callable[[Any], datetime.time | None]
     """Function to get the value from the trait."""
 
     update_value: Callable[[Any, datetime.time], Coroutine[Any, Any, None]]
@@ -58,9 +65,7 @@ TIME_DESCRIPTIONS: list[RoborockTimeDescription] = [
                 end_minute=trait.end_minute,
             )
         ),
-        get_value=lambda trait: datetime.time(
-            hour=trait.start_hour, minute=trait.start_minute
-        ),
+        get_value=lambda trait: _build_time(trait.start_hour, trait.start_minute),
         entity_category=EntityCategory.CONFIG,
     ),
     RoborockTimeDescription(
@@ -76,9 +81,7 @@ TIME_DESCRIPTIONS: list[RoborockTimeDescription] = [
                 end_minute=desired_time.minute,
             )
         ),
-        get_value=lambda trait: datetime.time(
-            hour=trait.end_hour, minute=trait.end_minute
-        ),
+        get_value=lambda trait: _build_time(trait.end_hour, trait.end_minute),
         entity_category=EntityCategory.CONFIG,
     ),
     RoborockTimeDescription(
@@ -94,9 +97,7 @@ TIME_DESCRIPTIONS: list[RoborockTimeDescription] = [
                 end_minute=trait.end_minute,
             )
         ),
-        get_value=lambda trait: datetime.time(
-            hour=trait.start_hour, minute=trait.start_minute
-        ),
+        get_value=lambda trait: _build_time(trait.start_hour, trait.start_minute),
         entity_category=EntityCategory.CONFIG,
         entity_registry_enabled_default=False,
     ),
@@ -113,9 +114,7 @@ TIME_DESCRIPTIONS: list[RoborockTimeDescription] = [
                 end_minute=desired_time.minute,
             )
         ),
-        get_value=lambda trait: datetime.time(
-            hour=trait.end_hour, minute=trait.end_minute
-        ),
+        get_value=lambda trait: _build_time(trait.end_hour, trait.end_minute),
         entity_category=EntityCategory.CONFIG,
         entity_registry_enabled_default=False,
     ),

--- a/tests/components/roborock/test_time.py
+++ b/tests/components/roborock/test_time.py
@@ -1,9 +1,10 @@
 """Test Roborock Time platform."""
 
 from collections.abc import Callable
-from datetime import time
+from datetime import time, timedelta
 from typing import Any
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 import roborock
 from roborock.data import DnDTimer, RoborockBaseTimer, ValleyElectricityTimer
@@ -12,11 +13,10 @@ from homeassistant.components.time import SERVICE_SET_VALUE
 from homeassistant.const import STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.entity_component import async_update_entity
 
 from .conftest import FakeDevice
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 @pytest.fixture
@@ -158,6 +158,7 @@ async def test_update_failure(
 )
 async def test_missing_value(
     hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
     setup_entry: MockConfigEntry,
     fake_vacuum: FakeDevice,
     entity_id: str,
@@ -170,7 +171,9 @@ async def test_missing_value(
     assert state.state != STATE_UNKNOWN
 
     setattr(trait(fake_vacuum), missing_attribute, None)
-    await async_update_entity(hass, entity_id)
+    freezer.tick(timedelta(seconds=31))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
     assert state is not None

--- a/tests/components/roborock/test_time.py
+++ b/tests/components/roborock/test_time.py
@@ -9,9 +9,10 @@ import roborock
 from roborock.data import DnDTimer, RoborockBaseTimer, ValleyElectricityTimer
 
 from homeassistant.components.time import SERVICE_SET_VALUE
-from homeassistant.const import Platform
+from homeassistant.const import STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_component import async_update_entity
 
 from .conftest import FakeDevice
 
@@ -127,3 +128,50 @@ async def test_update_failure(
             target={"entity_id": entity_id},
         )
     assert fake_vacuum.v1_properties.dnd.set_dnd_timer.call_count == 1
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+@pytest.mark.parametrize(
+    ("entity_id", "trait", "missing_attribute"),
+    [
+        (
+            "time.roborock_s7_maxv_do_not_disturb_begin",
+            lambda x: x.v1_properties.dnd,
+            "start_hour",
+        ),
+        (
+            "time.roborock_s7_maxv_do_not_disturb_begin",
+            lambda x: x.v1_properties.dnd,
+            "start_minute",
+        ),
+        (
+            "time.roborock_s7_maxv_do_not_disturb_end",
+            lambda x: x.v1_properties.dnd,
+            "end_hour",
+        ),
+        (
+            "time.roborock_s7_maxv_off_peak_start",
+            lambda x: x.v1_properties.valley_electricity_timer,
+            "start_minute",
+        ),
+    ],
+)
+async def test_missing_value(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    fake_vacuum: FakeDevice,
+    entity_id: str,
+    trait: Callable[[FakeDevice], Any],
+    missing_attribute: str,
+) -> None:
+    """Test that a missing time component reports as unknown instead of raising."""
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state != STATE_UNKNOWN
+
+    setattr(trait(fake_vacuum), missing_attribute, None)
+    await async_update_entity(hass, entity_id)
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == STATE_UNKNOWN


### PR DESCRIPTION
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The DnD and valley electricity timer traits can report `None` for their hour/minute components (e.g. before the device has reported a value). The `get_value` lambdas in `time.py` passed these straight into `datetime.time()`, which raised `TypeError: 'NoneType' object cannot be interpreted as an integer` on every state write:

```
File "/usr/src/homeassistant/homeassistant/components/roborock/time.py", line 61, in <lambda>
    get_value=lambda trait: datetime.time(
        hour=trait.start_hour, minute=trait.start_minute
    ),
TypeError: 'NoneType' object cannot be interpreted as an integer
```

This flooded the logs (249 occurrences in the report this was based on). A small `_build_time` helper now returns `None` when either component is missing, so the entity reports `unknown` instead of crashing — `native_value` already declares `time | None`. A parametrized regression test covers the DnD and off-peak entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFFAMdz8zKmJBU9aXQA9V9)_