### PR TITLE
Adds the switch platform for the Imou integration

### DIFF
--- a/homeassistant/components/imou/const.py
+++ b/homeassistant/components/imou/const.py
@@ -28,7 +28,14 @@ CONF_APP_SECRET = "app_secret"
 
 PARAM_STATUS = "status"
 PARAM_STATE = "state"
+PARAM_MOTION_DETECT = "motion_detect"
 PARAM_HEADER_DETECT = "header_detect"
+PARAM_WHITE_LIGHT = "white_light"
+PARAM_CLOSE_CAMERA = "close_camera"
+PARAM_AB_ALARM_SOUND = "ab_alarm_sound"
+PARAM_AUDIO_ENCODE_CONTROL = "audio_encode_control"
+PARAM_LIGHT = "light"
+PARAM_PLUG_SWITCH = "switch"
 
 # How long each PTZ button press moves the camera, in milliseconds (Imou cloud API).
 PTZ_MOVE_DURATION_MS = 500

--- a/homeassistant/components/imou/const.py
+++ b/homeassistant/components/imou/const.py
@@ -36,4 +36,4 @@ PTZ_MOVE_DURATION_MS = 500
 # Upper bound for a full coordinator refresh (device list + status for all devices).
 UPDATE_TIMEOUT = 300
 
-PLATFORMS = [Platform.BUTTON, Platform.CAMERA]
+PLATFORMS = [Platform.BUTTON, Platform.CAMERA, Platform.SWITCH]

--- a/homeassistant/components/imou/icons.json
+++ b/homeassistant/components/imou/icons.json
@@ -13,6 +13,29 @@
       "ptz_up": {
         "default": "mdi:arrow-up-bold"
       }
+    },
+    "switch": {
+      "motion_detect": {
+        "default": "mdi:motion-sensor"
+      },
+      "header_detect": {
+        "default": "mdi:run"
+      },
+      "white_light": {
+        "default": "mdi:light-flood-down"
+      },
+      "close_camera": {
+        "default": "mdi:camera-off"
+      },
+      "ab_alarm_sound": {
+        "default": "mdi:home-sound-in"
+      },
+      "audio_encode_control": {
+        "default": "mdi:audio-input-rca"
+      },
+      "light": {
+        "default": "mdi:lightbulb-on"
+      }
     }
   }
 }

--- a/homeassistant/components/imou/icons.json
+++ b/homeassistant/components/imou/icons.json
@@ -15,26 +15,26 @@
       }
     },
     "switch": {
-      "motion_detect": {
-        "default": "mdi:motion-sensor"
-      },
-      "header_detect": {
-        "default": "mdi:run"
-      },
-      "white_light": {
-        "default": "mdi:light-flood-down"
-      },
-      "close_camera": {
-        "default": "mdi:camera-off"
-      },
       "ab_alarm_sound": {
         "default": "mdi:home-sound-in"
       },
       "audio_encode_control": {
         "default": "mdi:audio-input-rca"
       },
+      "close_camera": {
+        "default": "mdi:camera-off"
+      },
+      "header_detect": {
+        "default": "mdi:run"
+      },
       "light": {
         "default": "mdi:lightbulb-on"
+      },
+      "motion_detect": {
+        "default": "mdi:motion-sensor"
+      },
+      "white_light": {
+        "default": "mdi:light-flood-down"
       }
     }
   }

--- a/homeassistant/components/imou/strings.json
+++ b/homeassistant/components/imou/strings.json
@@ -55,19 +55,19 @@
         "name": "Abnormal sound alarm"
       },
       "audio_encode_control": {
-        "name": "Audio encode control"
+        "name": "Audio recording"
       },
       "close_camera": {
-        "name": "Close camera"
+        "name": "Privacy mode"
       },
       "header_detect": {
-        "name": "Human detect"
+        "name": "Human detection"
       },
       "light": {
-        "name": "Light"
+        "name": "Indicator light"
       },
       "motion_detect": {
-        "name": "Motion detect"
+        "name": "Motion detection"
       },
       "switch": {
         "name": "Plug switch"

--- a/homeassistant/components/imou/strings.json
+++ b/homeassistant/components/imou/strings.json
@@ -49,6 +49,32 @@
       "camera_sd": {
         "name": "Live view SD"
       }
+    },
+    "switch": {
+      "motion_detect": {
+        "name": "Motion detect"
+      },
+      "header_detect": {
+        "name": "Human detect"
+      },
+      "white_light": {
+        "name": "White light"
+      },
+      "close_camera": {
+        "name": "Close camera"
+      },
+      "ab_alarm_sound": {
+        "name": "Abnormal sound alarm"
+      },
+      "audio_encode_control": {
+        "name": "Audio encode control"
+      },
+      "light": {
+        "name": "Light"
+      },
+      "switch": {
+        "name": "Plug switch"
+      }
     }
   },
   "selector": {

--- a/homeassistant/components/imou/strings.json
+++ b/homeassistant/components/imou/strings.json
@@ -51,29 +51,29 @@
       }
     },
     "switch": {
-      "motion_detect": {
-        "name": "Motion detect"
-      },
-      "header_detect": {
-        "name": "Human detect"
-      },
-      "white_light": {
-        "name": "White light"
-      },
-      "close_camera": {
-        "name": "Close camera"
-      },
       "ab_alarm_sound": {
         "name": "Abnormal sound alarm"
       },
       "audio_encode_control": {
         "name": "Audio encode control"
       },
+      "close_camera": {
+        "name": "Close camera"
+      },
+      "header_detect": {
+        "name": "Human detect"
+      },
       "light": {
         "name": "Light"
       },
+      "motion_detect": {
+        "name": "Motion detect"
+      },
       "switch": {
         "name": "Plug switch"
+      },
+      "white_light": {
+        "name": "White light"
       }
     }
   },

--- a/homeassistant/components/imou/switch.py
+++ b/homeassistant/components/imou/switch.py
@@ -96,6 +96,7 @@ class ImouSwitch(ImouEntity, SwitchEntity):
             self._attr_device_class = device_class
 
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return True if the switch is on."""
         return self.device.switches[self._entity_type][PARAM_STATE]

--- a/homeassistant/components/imou/switch.py
+++ b/homeassistant/components/imou/switch.py
@@ -94,8 +94,7 @@ class ImouSwitch(ImouEntity, SwitchEntity):
     ) -> None:
         """Initialize the Imou switch entity."""
         super().__init__(coordinator, entity_type, device)
-        if device_class := SWITCH_DEVICE_CLASS.get(entity_type):
-            self._attr_device_class = device_class
+        self._attr_device_class = SWITCH_DEVICE_CLASS.get(entity_type)
 
     @property
     @override
@@ -121,7 +120,6 @@ class ImouSwitch(ImouEntity, SwitchEntity):
                 self._entity_type,
                 enable,
             )
-            self.device.switches[self._entity_type][PARAM_STATE] = enable
-            self.async_write_ha_state()
         except ImouException as e:
             raise HomeAssistantError(str(e)) from e
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/imou/switch.py
+++ b/homeassistant/components/imou/switch.py
@@ -10,14 +10,13 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import PARAM_STATE, imou_device_identifier
+from .const import PARAM_HEADER_DETECT, PARAM_STATE, imou_device_identifier
 from .coordinator import ImouConfigEntry, ImouDataUpdateCoordinator
 from .entity import ImouEntity
 
 PARALLEL_UPDATES = 0
 
 PARAM_MOTION_DETECT = "motion_detect"
-PARAM_HEADER_DETECT = "header_detect"
 PARAM_WHITE_LIGHT = "white_light"
 PARAM_CLOSE_CAMERA = "close_camera"
 PARAM_AB_ALARM_SOUND = "ab_alarm_sound"

--- a/homeassistant/components/imou/switch.py
+++ b/homeassistant/components/imou/switch.py
@@ -1,0 +1,124 @@
+"""Support for Imou switch controls."""
+
+from typing import Any, override
+
+from pyimouapi.exceptions import ImouException
+from pyimouapi.ha_device import ImouHaDevice
+
+from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import PARAM_STATE, imou_device_identifier
+from .coordinator import ImouConfigEntry, ImouDataUpdateCoordinator
+from .entity import ImouEntity
+
+PARALLEL_UPDATES = 0
+
+PARAM_MOTION_DETECT = "motion_detect"
+PARAM_HEADER_DETECT = "header_detect"
+PARAM_WHITE_LIGHT = "white_light"
+PARAM_CLOSE_CAMERA = "close_camera"
+PARAM_AB_ALARM_SOUND = "ab_alarm_sound"
+PARAM_AUDIO_ENCODE_CONTROL = "audio_encode_control"
+PARAM_LIGHT = "light"
+PARAM_PLUG_SWITCH = "switch"
+
+SWITCH_TYPES = (
+    PARAM_MOTION_DETECT,
+    PARAM_HEADER_DETECT,
+    PARAM_WHITE_LIGHT,
+    PARAM_CLOSE_CAMERA,
+    PARAM_AB_ALARM_SOUND,
+    PARAM_AUDIO_ENCODE_CONTROL,
+    PARAM_LIGHT,
+    PARAM_PLUG_SWITCH,
+)
+
+SWITCH_DEVICE_CLASS: dict[str, SwitchDeviceClass] = {
+    PARAM_LIGHT: SwitchDeviceClass.SWITCH,
+    PARAM_PLUG_SWITCH: SwitchDeviceClass.SWITCH,
+}
+
+
+def _iter_switches(
+    coordinator: ImouDataUpdateCoordinator,
+) -> list[tuple[str, ImouHaDevice]]:
+    """Return (switch_type, device) pairs for supported switches."""
+    return [
+        (switch_type, device)
+        for device in coordinator.devices
+        for switch_type in device.switches
+        if switch_type in SWITCH_TYPES
+    ]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ImouConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Imou switch entities."""
+    coordinator = entry.runtime_data
+
+    def _add_switches(new_devices: list[ImouHaDevice]) -> None:
+        device_keys = {imou_device_identifier(device) for device in new_devices}
+        async_add_entities(
+            ImouSwitch(coordinator, switch_type, device)
+            for switch_type, device in _iter_switches(coordinator)
+            if imou_device_identifier(device) in device_keys
+        )
+
+    coordinator.new_device_callbacks.append(_add_switches)
+
+    @callback
+    def _remove_new_device_callback() -> None:
+        if _add_switches in coordinator.new_device_callbacks:
+            coordinator.new_device_callbacks.remove(_add_switches)
+
+    entry.async_on_unload(_remove_new_device_callback)
+    _add_switches(coordinator.devices)
+
+
+class ImouSwitch(ImouEntity, SwitchEntity):
+    """Imou switch entity."""
+
+    def __init__(
+        self,
+        coordinator: ImouDataUpdateCoordinator,
+        entity_type: str,
+        device: ImouHaDevice,
+    ) -> None:
+        """Initialize the Imou switch entity."""
+        super().__init__(coordinator, entity_type, device)
+        if device_class := SWITCH_DEVICE_CLASS.get(entity_type):
+            self._attr_device_class = device_class
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True if the switch is on."""
+        return self.device.switches[self._entity_type][PARAM_STATE]
+
+    @override
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the switch on."""
+        await self._async_switch_operation(True)
+
+    @override
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the switch off."""
+        await self._async_switch_operation(False)
+
+    async def _async_switch_operation(self, enable: bool) -> None:
+        """Call the vendor library to change switch state."""
+        try:
+            await self.coordinator.device_manager.async_switch_operation(
+                self.device,
+                self._entity_type,
+                enable,
+            )
+            self.device.switches[self._entity_type][PARAM_STATE] = enable
+            self.async_write_ha_state()
+        except ImouException as e:
+            raise HomeAssistantError(str(e)) from e

--- a/homeassistant/components/imou/switch.py
+++ b/homeassistant/components/imou/switch.py
@@ -10,29 +10,32 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import PARAM_HEADER_DETECT, PARAM_STATE, imou_device_identifier
+from .const import (
+    PARAM_AB_ALARM_SOUND,
+    PARAM_AUDIO_ENCODE_CONTROL,
+    PARAM_CLOSE_CAMERA,
+    PARAM_HEADER_DETECT,
+    PARAM_LIGHT,
+    PARAM_MOTION_DETECT,
+    PARAM_PLUG_SWITCH,
+    PARAM_STATE,
+    PARAM_WHITE_LIGHT,
+    imou_device_identifier,
+)
 from .coordinator import ImouConfigEntry, ImouDataUpdateCoordinator
 from .entity import ImouEntity
 
 PARALLEL_UPDATES = 0
 
-PARAM_MOTION_DETECT = "motion_detect"
-PARAM_WHITE_LIGHT = "white_light"
-PARAM_CLOSE_CAMERA = "close_camera"
-PARAM_AB_ALARM_SOUND = "ab_alarm_sound"
-PARAM_AUDIO_ENCODE_CONTROL = "audio_encode_control"
-PARAM_LIGHT = "light"
-PARAM_PLUG_SWITCH = "switch"
-
 SWITCH_TYPES = (
-    PARAM_MOTION_DETECT,
-    PARAM_HEADER_DETECT,
-    PARAM_WHITE_LIGHT,
-    PARAM_CLOSE_CAMERA,
     PARAM_AB_ALARM_SOUND,
     PARAM_AUDIO_ENCODE_CONTROL,
+    PARAM_CLOSE_CAMERA,
+    PARAM_HEADER_DETECT,
     PARAM_LIGHT,
+    PARAM_MOTION_DETECT,
     PARAM_PLUG_SWITCH,
+    PARAM_WHITE_LIGHT,
 )
 
 SWITCH_DEVICE_CLASS: dict[str, SwitchDeviceClass] = {

--- a/tests/components/imou/const.py
+++ b/tests/components/imou/const.py
@@ -32,6 +32,12 @@ CONFIG_ENTRY_DATA = {
 }
 
 UNKNOWN_BUTTON_KEY = "legacy_unknown_button"
+UNKNOWN_SWITCH_KEY = "legacy_unknown_switch"
+
+DEFAULT_SWITCHES = {
+    "motion_detect": {PARAM_STATE: False},
+    "header_detect": {PARAM_STATE: True},
+}
 
 
 def create_online_device(

--- a/tests/components/imou/const.py
+++ b/tests/components/imou/const.py
@@ -11,14 +11,12 @@ from homeassistant.components.imou.const import (
     CONF_API_URL,
     CONF_APP_ID,
     CONF_APP_SECRET,
-    PARAM_STATE,
-    PARAM_STATUS,
-)
-from homeassistant.components.imou.switch import (
     PARAM_HEADER_DETECT,
     PARAM_LIGHT,
     PARAM_MOTION_DETECT,
     PARAM_PLUG_SWITCH,
+    PARAM_STATE,
+    PARAM_STATUS,
 )
 
 TEST_APP_ID = "test_app_id"

--- a/tests/components/imou/const.py
+++ b/tests/components/imou/const.py
@@ -14,6 +14,12 @@ from homeassistant.components.imou.const import (
     PARAM_STATE,
     PARAM_STATUS,
 )
+from homeassistant.components.imou.switch import (
+    PARAM_HEADER_DETECT,
+    PARAM_LIGHT,
+    PARAM_MOTION_DETECT,
+    PARAM_PLUG_SWITCH,
+)
 
 TEST_APP_ID = "test_app_id"
 TEST_APP_SECRET = "test_app_secret"
@@ -35,8 +41,10 @@ UNKNOWN_BUTTON_KEY = "legacy_unknown_button"
 UNKNOWN_SWITCH_KEY = "legacy_unknown_switch"
 
 DEFAULT_SWITCHES = {
-    "motion_detect": {PARAM_STATE: False},
-    "header_detect": {PARAM_STATE: True},
+    PARAM_MOTION_DETECT: {PARAM_STATE: False},
+    PARAM_HEADER_DETECT: {PARAM_STATE: True},
+    PARAM_LIGHT: {PARAM_STATE: False},
+    PARAM_PLUG_SWITCH: {PARAM_STATE: True},
 }
 
 

--- a/tests/components/imou/snapshots/test_switch.ambr
+++ b/tests/components/imou/snapshots/test_switch.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_switch_entities_snapshot[imou_mock_devices0][switch.device_1_human_detect-entry]
+# name: test_switch_entities_snapshot[imou_mock_devices0][switch.device_1_human_detection-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -13,7 +13,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': None,
-    'entity_id': 'switch.device_1_human_detect',
+    'entity_id': 'switch.device_1_human_detection',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -21,12 +21,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Human detect',
+    'object_id_base': 'Human detection',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Human detect',
+    'original_name': 'Human detection',
     'platform': 'imou',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -36,20 +36,20 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_switch_entities_snapshot[imou_mock_devices0][switch.device_1_human_detect-state]
+# name: test_switch_entities_snapshot[imou_mock_devices0][switch.device_1_human_detection-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Device 1 Human detect',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Device 1 Human detection',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.device_1_human_detect',
+    'entity_id': 'switch.device_1_human_detection',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
   })
 # ---
-# name: test_switch_entities_snapshot[imou_mock_devices0][switch.device_1_light-entry]
+# name: test_switch_entities_snapshot[imou_mock_devices0][switch.device_1_indicator_light-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -63,7 +63,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': None,
-    'entity_id': 'switch.device_1_light',
+    'entity_id': 'switch.device_1_indicator_light',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -71,12 +71,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Light',
+    'object_id_base': 'Indicator light',
     'options': dict({
     }),
     'original_device_class': <SwitchDeviceClass.SWITCH: 'switch'>,
     'original_icon': None,
-    'original_name': 'Light',
+    'original_name': 'Indicator light',
     'platform': 'imou',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -86,21 +86,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_switch_entities_snapshot[imou_mock_devices0][switch.device_1_light-state]
+# name: test_switch_entities_snapshot[imou_mock_devices0][switch.device_1_indicator_light-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'switch',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Device 1 Light',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Device 1 Indicator light',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.device_1_light',
+    'entity_id': 'switch.device_1_indicator_light',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
   })
 # ---
-# name: test_switch_entities_snapshot[imou_mock_devices0][switch.device_1_motion_detect-entry]
+# name: test_switch_entities_snapshot[imou_mock_devices0][switch.device_1_motion_detection-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -114,7 +114,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': None,
-    'entity_id': 'switch.device_1_motion_detect',
+    'entity_id': 'switch.device_1_motion_detection',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -122,12 +122,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Motion detect',
+    'object_id_base': 'Motion detection',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Motion detect',
+    'original_name': 'Motion detection',
     'platform': 'imou',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -137,13 +137,13 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_switch_entities_snapshot[imou_mock_devices0][switch.device_1_motion_detect-state]
+# name: test_switch_entities_snapshot[imou_mock_devices0][switch.device_1_motion_detection-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Device 1 Motion detect',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Device 1 Motion detection',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.device_1_motion_detect',
+    'entity_id': 'switch.device_1_motion_detection',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/imou/snapshots/test_switch.ambr
+++ b/tests/components/imou/snapshots/test_switch.ambr
@@ -1,0 +1,101 @@
+# serializer version: 1
+# name: test_switch_entities_snapshot[imou_mock_devices0][switch.device_1_human_detect-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.device_1_human_detect',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Human detect',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Human detect',
+    'platform': 'imou',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'header_detect',
+    'unique_id': 'd1$header_detect',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_entities_snapshot[imou_mock_devices0][switch.device_1_human_detect-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Device 1 Human detect',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.device_1_human_detect',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switch_entities_snapshot[imou_mock_devices0][switch.device_1_motion_detect-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.device_1_motion_detect',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Motion detect',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Motion detect',
+    'platform': 'imou',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'motion_detect',
+    'unique_id': 'd1$motion_detect',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_entities_snapshot[imou_mock_devices0][switch.device_1_motion_detect-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Device 1 Motion detect',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.device_1_motion_detect',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/imou/snapshots/test_switch.ambr
+++ b/tests/components/imou/snapshots/test_switch.ambr
@@ -49,6 +49,57 @@
     'state': 'on',
   })
 # ---
+# name: test_switch_entities_snapshot[imou_mock_devices0][switch.device_1_light-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.device_1_light',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Light',
+    'options': dict({
+    }),
+    'original_device_class': <SwitchDeviceClass.SWITCH: 'switch'>,
+    'original_icon': None,
+    'original_name': 'Light',
+    'platform': 'imou',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'light',
+    'unique_id': 'd1$light',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_entities_snapshot[imou_mock_devices0][switch.device_1_light-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'switch',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Device 1 Light',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.device_1_light',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_switch_entities_snapshot[imou_mock_devices0][switch.device_1_motion_detect-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -97,5 +148,56 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
+  })
+# ---
+# name: test_switch_entities_snapshot[imou_mock_devices0][switch.device_1_plug_switch-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.device_1_plug_switch',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Plug switch',
+    'options': dict({
+    }),
+    'original_device_class': <SwitchDeviceClass.SWITCH: 'switch'>,
+    'original_icon': None,
+    'original_name': 'Plug switch',
+    'platform': 'imou',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'switch',
+    'unique_id': 'd1$switch',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_entities_snapshot[imou_mock_devices0][switch.device_1_plug_switch-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'switch',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Device 1 Plug switch',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.device_1_plug_switch',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
   })
 # ---

--- a/tests/components/imou/test_switch.py
+++ b/tests/components/imou/test_switch.py
@@ -85,7 +85,7 @@ async def test_setup_ignores_unknown_switch_types(
     """Unknown switch keys from the API are not turned into entities."""
     registry = er.async_get(hass)
     entries = er.async_entries_for_config_entry(registry, mock_config_entry.entry_id)
-    switch_entries = [entry for entry in entries if entry.domain == "switch"]
+    switch_entries = [entry for entry in entries if entry.domain == SWITCH_DOMAIN]
     assert len(switch_entries) == 1
     assert switch_entries[0].translation_key == PARAM_MOTION_DETECT
 

--- a/tests/components/imou/test_switch.py
+++ b/tests/components/imou/test_switch.py
@@ -30,6 +30,14 @@ from .const import DEFAULT_SWITCHES, UNKNOWN_SWITCH_KEY, create_online_device
 
 from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
 
+
+async def _apply_switch_operation(
+    device: ImouHaDevice, switch_type: str, enable: bool
+) -> None:
+    """Simulate the vendor API updating switch state after a command."""
+    device.switches[switch_type][PARAM_STATE] = enable
+
+
 SWITCH_MOCK_DEVICES = [
     create_online_device(
         "d1",
@@ -91,6 +99,7 @@ async def test_turn_on_via_service(
     init_integration: MagicMock,
 ) -> None:
     """Turning on a switch calls the vendor library through the coordinator."""
+    init_integration.async_switch_operation.side_effect = _apply_switch_operation
     motion_entry = next(
         entry
         for entry in er.async_entries_for_config_entry(
@@ -123,6 +132,7 @@ async def test_turn_off_via_service(
     init_integration: MagicMock,
 ) -> None:
     """Turning off a switch calls the vendor library through the coordinator."""
+    init_integration.async_switch_operation.side_effect = _apply_switch_operation
     header_entry = next(
         entry
         for entry in er.async_entries_for_config_entry(

--- a/tests/components/imou/test_switch.py
+++ b/tests/components/imou/test_switch.py
@@ -1,0 +1,251 @@
+"""Tests for Imou switch platform."""
+
+from unittest.mock import MagicMock
+
+from freezegun.api import FrozenDateTimeFactory
+from pyimouapi.exceptions import ImouException
+from pyimouapi.ha_device import DeviceStatus, ImouHaDevice
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.imou.const import PARAM_STATE, PARAM_STATUS
+from homeassistant.components.imou.coordinator import SCAN_INTERVAL
+from homeassistant.components.imou.switch import (
+    PARAM_HEADER_DETECT,
+    PARAM_MOTION_DETECT,
+)
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_UNAVAILABLE,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from .const import DEFAULT_SWITCHES, UNKNOWN_SWITCH_KEY, create_online_device
+
+from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
+
+SWITCH_MOCK_DEVICES = [
+    create_online_device(
+        "d1",
+        "Device 1",
+        button_keys=(),
+        switches=DEFAULT_SWITCHES,
+    ),
+]
+
+
+@pytest.mark.parametrize("imou_mock_devices", [SWITCH_MOCK_DEVICES], indirect=True)
+@pytest.mark.usefixtures("init_integration")
+async def test_switch_entities_snapshot(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Snapshot switch entities created from the mock device list."""
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    "imou_mock_devices",
+    [
+        [
+            create_online_device(
+                "d1",
+                "Device 1",
+                button_keys=(),
+                switches={
+                    UNKNOWN_SWITCH_KEY: {PARAM_STATE: False},
+                    PARAM_MOTION_DETECT: {PARAM_STATE: False},
+                },
+            )
+        ]
+    ],
+    indirect=True,
+)
+@pytest.mark.usefixtures("init_integration")
+async def test_setup_ignores_unknown_switch_types(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Unknown switch keys from the API are not turned into entities."""
+    registry = er.async_get(hass)
+    entries = er.async_entries_for_config_entry(registry, mock_config_entry.entry_id)
+    switch_entries = [entry for entry in entries if entry.domain == "switch"]
+    assert len(switch_entries) == 1
+    assert switch_entries[0].translation_key == PARAM_MOTION_DETECT
+
+
+@pytest.mark.parametrize("imou_mock_devices", [SWITCH_MOCK_DEVICES], indirect=True)
+@pytest.mark.usefixtures("init_integration")
+async def test_turn_on_via_service(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    init_integration: MagicMock,
+) -> None:
+    """Turning on a switch calls the vendor library through the coordinator."""
+    motion_entry = next(
+        entry
+        for entry in er.async_entries_for_config_entry(
+            entity_registry, mock_config_entry.entry_id
+        )
+        if entry.unique_id == "d1$motion_detect"
+    )
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: motion_entry.entity_id},
+        blocking=True,
+    )
+
+    init_integration.async_switch_operation.assert_awaited_once()
+    call = init_integration.async_switch_operation.await_args
+    assert call is not None
+    assert call.args[1] == PARAM_MOTION_DETECT
+    assert call.args[2] is True
+    assert hass.states.get(motion_entry.entity_id).state == "on"
+
+
+@pytest.mark.parametrize("imou_mock_devices", [SWITCH_MOCK_DEVICES], indirect=True)
+@pytest.mark.usefixtures("init_integration")
+async def test_turn_off_via_service(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    init_integration: MagicMock,
+) -> None:
+    """Turning off a switch calls the vendor library through the coordinator."""
+    header_entry = next(
+        entry
+        for entry in er.async_entries_for_config_entry(
+            entity_registry, mock_config_entry.entry_id
+        )
+        if entry.unique_id == "d1$header_detect"
+    )
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: header_entry.entity_id},
+        blocking=True,
+    )
+
+    init_integration.async_switch_operation.assert_awaited_once()
+    call = init_integration.async_switch_operation.await_args
+    assert call is not None
+    assert call.args[1] == PARAM_HEADER_DETECT
+    assert call.args[2] is False
+    assert hass.states.get(header_entry.entity_id).state == "off"
+
+
+@pytest.mark.parametrize("imou_mock_devices", [SWITCH_MOCK_DEVICES], indirect=True)
+@pytest.mark.usefixtures("init_integration")
+async def test_turn_on_service_propagates_api_error(
+    hass: HomeAssistant,
+    init_integration: MagicMock,
+) -> None:
+    """Imou API errors from async_switch_operation surface to the service call."""
+    init_integration.async_switch_operation.side_effect = ImouException("cloud failure")
+
+    entity_id = hass.states.async_all("switch")[0].entity_id
+
+    with pytest.raises(HomeAssistantError, match="cloud failure"):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
+
+
+@pytest.mark.parametrize(
+    "imou_mock_devices",
+    [
+        [
+            create_online_device(
+                "d1",
+                "Device 1",
+                button_keys=(),
+                switches={PARAM_MOTION_DETECT: {PARAM_STATE: False}},
+            )
+        ]
+    ],
+    indirect=True,
+)
+@pytest.mark.usefixtures("init_integration")
+async def test_turn_off_unavailable_offline_device_via_service(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_imou_ha_device_manager: MagicMock,
+    init_integration: MagicMock,
+) -> None:
+    """Turning off an offline device does not call the vendor library."""
+    motion_entry = next(
+        entry
+        for entry in er.async_entries_for_config_entry(
+            entity_registry, mock_config_entry.entry_id
+        )
+        if entry.unique_id == "d1$motion_detect"
+    )
+
+    async def set_device_offline(device: ImouHaDevice) -> None:
+        device._sensors[PARAM_STATUS] = {PARAM_STATE: DeviceStatus.OFFLINE.value}
+
+    mock_imou_ha_device_manager.async_update_device_status.side_effect = (
+        set_device_offline
+    )
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert hass.states.get(motion_entry.entity_id).state == STATE_UNAVAILABLE
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: motion_entry.entity_id},
+        blocking=True,
+    )
+
+    init_integration.async_switch_operation.assert_not_called()
+
+
+@pytest.mark.parametrize("imou_mock_devices", [SWITCH_MOCK_DEVICES], indirect=True)
+@pytest.mark.usefixtures("init_integration")
+async def test_entities_removed_when_device_leaves_account(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_imou_ha_device_manager: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Switch entities are removed when the device is no longer on the account."""
+    motion_entry = next(
+        entry
+        for entry in er.async_entries_for_config_entry(
+            entity_registry, mock_config_entry.entry_id
+        )
+        if entry.unique_id == "d1$motion_detect"
+    )
+    assert hass.states.get(motion_entry.entity_id).state != STATE_UNAVAILABLE
+
+    mock_imou_ha_device_manager.async_get_devices.return_value = []
+
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert (
+        er.async_entries_for_config_entry(entity_registry, mock_config_entry.entry_id)
+        == []
+    )
+    assert hass.states.get(motion_entry.entity_id) is None

--- a/tests/components/imou/test_switch.py
+++ b/tests/components/imou/test_switch.py
@@ -8,12 +8,13 @@ from pyimouapi.ha_device import DeviceStatus, ImouHaDevice
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.imou.const import PARAM_STATE, PARAM_STATUS
-from homeassistant.components.imou.coordinator import SCAN_INTERVAL
-from homeassistant.components.imou.switch import (
+from homeassistant.components.imou.const import (
     PARAM_HEADER_DETECT,
     PARAM_MOTION_DETECT,
+    PARAM_STATE,
+    PARAM_STATUS,
 )
+from homeassistant.components.imou.coordinator import SCAN_INTERVAL
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,


### PR DESCRIPTION
## Proposed change

Adds the switch platform to the Imou integration. Supported devices expose switch entities for cloud-reported toggles such as motion detect, human detect, white light, close camera, abnormal sound alarm, audio encode control, and IoT light/plug switches.

The implementation follows the existing button and camera platform patterns (`SWITCH_TYPES` whitelist, `new_device_callbacks`, `PARALLEL_UPDATES = 0`) and uses `pyimouapi` `async_switch_operation` (already pinned at 1.2.8).

## Type of change

- [x] New feature (which adds functionality to an existing integration)

## Additional information

- This PR fixes or closes issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/46487
- Library: [pyimouapi](https://github.com/Imou-OpenPlatform/Py-Imou-Open-Api) — no version bump required

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io