### PR TITLE
Add face (recognized person) detection event to UniFi Protect

### DIFF
--- a/homeassistant/components/unifiprotect/const.py
+++ b/homeassistant/components/unifiprotect/const.py
@@ -88,6 +88,7 @@ EVENT_TYPE_FINGERPRINT_NOT_IDENTIFIED: Final = "not_identified"
 EVENT_TYPE_NFC_SCANNED: Final = "scanned"
 EVENT_TYPE_VEHICLE_DETECTED: Final = "detected"
 EVENT_TYPE_PACKAGE_DETECTED: Final = "detected"
+EVENT_TYPE_FACE_DETECTED: Final = "detected"
 
 # Delay in seconds before firing vehicle event after last thumbnail
 VEHICLE_EVENT_DELAY_SECONDS: Final = 3

--- a/homeassistant/components/unifiprotect/event.py
+++ b/homeassistant/components/unifiprotect/event.py
@@ -20,6 +20,7 @@ from homeassistant.helpers.event import async_call_at
 from . import Bootstrap
 from .const import (
     ATTR_EVENT_ID,
+    EVENT_TYPE_FACE_DETECTED,
     EVENT_TYPE_FINGERPRINT_IDENTIFIED,
     EVENT_TYPE_FINGERPRINT_NOT_IDENTIFIED,
     EVENT_TYPE_NFC_SCANNED,
@@ -184,19 +185,28 @@ class ProtectDeviceFingerprintEventEntity(
             self.async_write_ha_state()
 
 
-class ProtectDeviceVehicleEventEntity(
+class ProtectDeviceSmartDetectThumbnailEventEntity(
     EventEntityMixin, ProtectDeviceEntity, EventEntity
 ):
-    """A UniFi Protect vehicle detection event entity.
+    """Base for smart-detect event entities that resolve a name from thumbnails.
 
-    Vehicle detection events use a delayed firing mechanism to allow time for
-    the best thumbnail (with license plate recognition data) to arrive. The
-    timer is extended each time new thumbnails arrive for the same event. If
-    a new event arrives while a timer is pending, the old event fires immediately
-    with its stored thumbnails, then a new timer starts for the new event.
+    Some smart-detect object types carry a recognized name on a thumbnail that
+    arrives slightly after the initial detection (the license plate for
+    vehicles, the recognized person for faces). A delayed firing mechanism
+    allows time for the best thumbnail to arrive; the timer is extended each
+    time new thumbnails arrive for the same event. If a new event arrives while
+    a timer is pending, the old event fires immediately with its stored
+    thumbnails, then a new timer starts for the new event.
+
+    Subclasses set ``_smart_detect_object_type`` (the thumbnail ``type`` to
+    match), ``_event_type`` (the fired event state) and ``_detected_name_key``
+    (the event-data key for the recognized name).
     """
 
     entity_description: ProtectEventEntityDescription
+    _smart_detect_object_type: str
+    _event_type: str
+    _detected_name_key: str
     _thumbnail_timer_cancel: CALLBACK_TYPE | None = None
     _latest_event_id: str | None = None
     _latest_thumbnails: list[EventDetectedThumbnail] | None = None
@@ -231,20 +241,20 @@ class ProtectDeviceVehicleEventEntity(
             return
 
         if self._latest_event_id:
-            self._fire_vehicle_event(self._latest_event_id, self._latest_thumbnails)
+            self._fire_event(self._latest_event_id, self._latest_thumbnails)
 
-    @staticmethod
-    def _get_vehicle_thumbnails(event: Event) -> list[EventDetectedThumbnail]:
-        """Get vehicle thumbnails from event."""
+    def _get_thumbnails(self, event: Event) -> list[EventDetectedThumbnail]:
+        """Get thumbnails of this entity's object type from the event."""
         if event.metadata and event.metadata.detected_thumbnails:
             return [
-                t for t in event.metadata.detected_thumbnails if t.type == "vehicle"
+                t
+                for t in event.metadata.detected_thumbnails
+                if t.type == self._smart_detect_object_type
             ]
         return []
 
-    @staticmethod
     def _build_event_data(
-        event_id: str, thumbnails: list[EventDetectedThumbnail]
+        self, event_id: str, thumbnails: list[EventDetectedThumbnail]
     ) -> dict[str, Any]:
         """Build event data dictionary from thumbnails."""
         event_data: dict[str, Any] = {
@@ -262,11 +272,12 @@ class ProtectDeviceVehicleEventEntity(
         if thumbnail.clock_best_wall is not None:
             event_data["clock_best_wall"] = thumbnail.clock_best_wall.isoformat()
 
-        # License plate from group.matched_name (UFP 6.0+) or name field (older)
+        # Recognized name from group.matched_name (UFP 6.0+) or name field
+        # (older): the license plate for vehicles, the person for faces.
         if thumbnail.group and thumbnail.group.matched_name:
-            event_data["license_plate"] = thumbnail.group.matched_name
+            event_data[self._detected_name_key] = thumbnail.group.matched_name
         elif thumbnail.name:
-            event_data["license_plate"] = thumbnail.name
+            event_data[self._detected_name_key] = thumbnail.name
 
         # Add all thumbnail attributes as dict
         if thumbnail.attributes:
@@ -275,10 +286,10 @@ class ProtectDeviceVehicleEventEntity(
         return event_data
 
     @callback
-    def _fire_vehicle_event(
+    def _fire_event(
         self, event_id: str, thumbnails: list[EventDetectedThumbnail] | None = None
     ) -> None:
-        """Fire the vehicle detection event with best available thumbnail.
+        """Fire the detection event with the best available thumbnail.
 
         Args:
             event_id: The event ID to include in the fired event data.
@@ -290,7 +301,7 @@ class ProtectDeviceVehicleEventEntity(
             event = self.entity_description.get_event_obj(self.device)
             if not event or event.id != event_id:
                 return
-            thumbnails = self._get_vehicle_thumbnails(event)
+            thumbnails = self._get_thumbnails(event)
 
         if not thumbnails:
             return
@@ -305,7 +316,7 @@ class ProtectDeviceVehicleEventEntity(
         self._fired_event_id = event_id
         self._fired_event_data = event_data
 
-        self._trigger_event(EVENT_TYPE_VEHICLE_DETECTED, event_data)
+        self._trigger_event(self._event_type, event_data)
         self.async_write_ha_state()
 
     @callback
@@ -327,11 +338,11 @@ class ProtectDeviceVehicleEventEntity(
             self._event = event
             self._event_end = event.end if event else None
 
-        # Process vehicle detection events with thumbnails
+        # Process detection events with thumbnails
         if (
             event
             and event.type is EventType.SMART_DETECT
-            and (thumbnails := self._get_vehicle_thumbnails(event))
+            and (thumbnails := self._get_thumbnails(event))
         ):
             # Skip if same event with same data (no changes)
             if (
@@ -345,7 +356,7 @@ class ProtectDeviceVehicleEventEntity(
             # Fire the old event immediately since it has completed
             if self._latest_event_id and self._latest_event_id != event.id:
                 # Only fire if we haven't already (shouldn't happen, but defensive)
-                self._fire_vehicle_event(self._latest_event_id, self._latest_thumbnails)
+                self._fire_event(self._latest_event_id, self._latest_thumbnails)
                 self._cancel_thumbnail_timer()
 
             # Store event data and extend/start the timer
@@ -358,6 +369,26 @@ class ProtectDeviceVehicleEventEntity(
             # Only schedule if no timer running; existing timer will re-arm
             if self._thumbnail_timer_cancel is None:
                 self._async_set_thumbnail_timer()
+
+
+class ProtectDeviceVehicleEventEntity(ProtectDeviceSmartDetectThumbnailEventEntity):
+    """A UniFi Protect vehicle (license-plate) detection event entity."""
+
+    _smart_detect_object_type = "vehicle"
+    _event_type = EVENT_TYPE_VEHICLE_DETECTED
+    _detected_name_key = "license_plate"
+
+
+class ProtectDeviceFaceEventEntity(ProtectDeviceSmartDetectThumbnailEventEntity):
+    """A UniFi Protect face (recognized-person) detection event entity.
+
+    Fires when a recognized face is detected, carrying the enrolled person's
+    name (from the Protect AI Key face recognition) under ``detected_person``.
+    """
+
+    _smart_detect_object_type = "face"
+    _event_type = EVENT_TYPE_FACE_DETECTED
+    _detected_name_key = "detected_person"
 
 
 class ProtectDeviceSmartDetectEventEntity(
@@ -438,6 +469,14 @@ EVENT_DESCRIPTIONS: tuple[ProtectEventEntityDescription, ...] = (
         ufp_obj_type=SmartDetectObjectType.PACKAGE,
         event_types=[EVENT_TYPE_PACKAGE_DETECTED],
         entity_class=ProtectDeviceSmartDetectEventEntity,
+    ),
+    ProtectEventEntityDescription(
+        key="face",
+        translation_key="face",
+        ufp_required_field="feature_flags.has_smart_detect",
+        ufp_event_obj="last_smart_detect_event",
+        event_types=[EVENT_TYPE_FACE_DETECTED],
+        entity_class=ProtectDeviceFaceEventEntity,
     ),
 )
 

--- a/homeassistant/components/unifiprotect/icons.json
+++ b/homeassistant/components/unifiprotect/icons.json
@@ -178,6 +178,9 @@
       "doorbell": {
         "default": "mdi:doorbell-video"
       },
+      "face": {
+        "default": "mdi:face-recognition"
+      },
       "fingerprint": {
         "default": "mdi:fingerprint"
       },

--- a/homeassistant/components/unifiprotect/strings.json
+++ b/homeassistant/components/unifiprotect/strings.json
@@ -278,6 +278,16 @@
           }
         }
       },
+      "face": {
+        "name": "Face",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "detected": "Detected"
+            }
+          }
+        }
+      },
       "fingerprint": {
         "name": "Fingerprint",
         "state_attributes": {

--- a/tests/components/unifiprotect/test_event.py
+++ b/tests/components/unifiprotect/test_event.py
@@ -56,11 +56,11 @@ async def test_camera_remove(
 
     ufp.api.bootstrap.nvr.system_info.ustorage = None
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.EVENT, 5, 5)
+    assert_entity_counts(hass, Platform.EVENT, 6, 6)
     await remove_entities(hass, ufp, [doorbell, unadopted_camera])
     assert_entity_counts(hass, Platform.EVENT, 0, 0)
     await adopt_devices(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.EVENT, 5, 5)
+    assert_entity_counts(hass, Platform.EVENT, 6, 6)
 
 
 async def test_doorbell_ring(
@@ -84,7 +84,7 @@ async def test_doorbell_ring(
     )
 
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.EVENT, 5, 5)
+    assert_entity_counts(hass, Platform.EVENT, 6, 6)
     events: list[HAEvent] = []
 
     @callback
@@ -172,7 +172,7 @@ async def test_package_detected(
     )
 
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.EVENT, 5, 5)
+    assert_entity_counts(hass, Platform.EVENT, 6, 6)
     events: list[HAEvent] = []
 
     @callback
@@ -313,7 +313,7 @@ async def test_doorbell_nfc_scanned(
     """Test a doorbell NFC scanned event."""
 
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.EVENT, 5, 5)
+    assert_entity_counts(hass, Platform.EVENT, 6, 6)
     events: list[HAEvent] = []
 
     @callback
@@ -388,7 +388,7 @@ async def test_doorbell_nfc_scanned_ulpusr_deactivated(
     """Test a doorbell NFC scanned event."""
 
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.EVENT, 5, 5)
+    assert_entity_counts(hass, Platform.EVENT, 6, 6)
     events: list[HAEvent] = []
 
     @callback
@@ -464,7 +464,7 @@ async def test_doorbell_nfc_scanned_no_ulpusr(
     """Test a doorbell NFC scanned event."""
 
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.EVENT, 5, 5)
+    assert_entity_counts(hass, Platform.EVENT, 6, 6)
     events: list[HAEvent] = []
 
     @callback
@@ -532,7 +532,7 @@ async def test_doorbell_nfc_scanned_no_keyring(
     """Test a doorbell NFC scanned event."""
 
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.EVENT, 5, 5)
+    assert_entity_counts(hass, Platform.EVENT, 6, 6)
     events: list[HAEvent] = []
 
     @callback
@@ -593,7 +593,7 @@ async def test_doorbell_fingerprint_identified(
     """Test a doorbell fingerprint identified event."""
 
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.EVENT, 5, 5)
+    assert_entity_counts(hass, Platform.EVENT, 6, 6)
     events: list[HAEvent] = []
 
     @callback
@@ -661,7 +661,7 @@ async def test_doorbell_fingerprint_identified_user_deactivated(
     """Test a doorbell fingerprint identified event."""
 
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.EVENT, 5, 5)
+    assert_entity_counts(hass, Platform.EVENT, 6, 6)
     events: list[HAEvent] = []
 
     @callback
@@ -730,7 +730,7 @@ async def test_doorbell_fingerprint_identified_no_user(
     """Test a doorbell fingerprint identified event."""
 
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.EVENT, 5, 5)
+    assert_entity_counts(hass, Platform.EVENT, 6, 6)
     events: list[HAEvent] = []
 
     @callback
@@ -791,7 +791,7 @@ async def test_doorbell_fingerprint_not_identified(
     """Test a doorbell fingerprint identified event."""
 
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.EVENT, 5, 5)
+    assert_entity_counts(hass, Platform.EVENT, 6, 6)
     events: list[HAEvent] = []
 
     @callback
@@ -849,7 +849,7 @@ async def test_vehicle_detection_basic(
     """Test basic vehicle detection event with thumbnails."""
 
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.EVENT, 5, 5)
+    assert_entity_counts(hass, Platform.EVENT, 6, 6)
     events: list[HAEvent] = []
 
     @callback
@@ -913,6 +913,156 @@ async def test_vehicle_detection_basic(
     unsub()
 
 
+async def test_face_detection_basic(
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+    doorbell: Camera,
+    unadopted_camera: Camera,
+    fixed_now: datetime,
+) -> None:
+    """Test a face detection event with no recognized person."""
+
+    await init_entry(hass, ufp, [doorbell, unadopted_camera])
+    assert_entity_counts(hass, Platform.EVENT, 6, 6)
+    events: list[HAEvent] = []
+
+    @callback
+    def _capture_event(event: HAEvent) -> None:
+        events.append(event)
+
+    _, entity_id = await ids_from_device_description(
+        hass, Platform.EVENT, doorbell, EVENT_DESCRIPTIONS[5]
+    )
+
+    unsub = async_track_state_change_event(hass, entity_id, _capture_event)
+
+    event = Event(
+        model=ModelType.EVENT,
+        id="test_face_event_id",
+        type=EventType.SMART_DETECT,
+        start=fixed_now - timedelta(seconds=1),
+        end=None,
+        score=100,
+        smart_detect_types=[],
+        smart_detect_event_ids=[],
+        camera_id=doorbell.id,
+        api=ufp.api,
+        metadata={
+            "detected_thumbnails": [
+                {
+                    "type": "face",
+                    "confidence": 88,
+                    "clock_best_wall": fixed_now,
+                    "cropped_id": "test_thumb_id",
+                }
+            ]
+        },
+    )
+
+    new_camera = doorbell.model_copy()
+    new_camera.last_smart_detect_event_id = "test_face_event_id"
+    ufp.api.bootstrap.cameras = {new_camera.id: new_camera}
+    ufp.api.bootstrap.events = {event.id: event}
+
+    mock_msg = Mock()
+    mock_msg.changed_data = {}
+    mock_msg.new_obj = event
+    ufp.ws_msg(mock_msg)
+
+    # Wait for the timer
+    await asyncio.sleep(TEST_VEHICLE_EVENT_DELAY * 2)
+    await hass.async_block_till_done()
+
+    # Should have received a face detection event with no recognized person
+    assert len(events) == 1
+    state = events[0].data["new_state"]
+    assert state
+    assert state.attributes[ATTR_ATTRIBUTION] == DEFAULT_ATTRIBUTION
+    assert state.attributes[ATTR_EVENT_ID] == "test_face_event_id"
+    assert state.attributes["confidence"] == 88
+    assert "clock_best_wall" in state.attributes
+    assert "detected_person" not in state.attributes
+
+    unsub()
+
+
+async def test_face_detection_with_recognized_person(
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+    doorbell: Camera,
+    unadopted_camera: Camera,
+    fixed_now: datetime,
+) -> None:
+    """Test a face detection event with a recognized person (UFP 6.0+ format)."""
+
+    await init_entry(hass, ufp, [doorbell, unadopted_camera])
+    assert_entity_counts(hass, Platform.EVENT, 6, 6)
+    events: list[HAEvent] = []
+
+    @callback
+    def _capture_event(event: HAEvent) -> None:
+        events.append(event)
+
+    _, entity_id = await ids_from_device_description(
+        hass, Platform.EVENT, doorbell, EVENT_DESCRIPTIONS[5]
+    )
+
+    unsub = async_track_state_change_event(hass, entity_id, _capture_event)
+
+    # Face thumbnail with the recognized person in group.matched_name (UFP 6.0+)
+    event = Event(
+        model=ModelType.EVENT,
+        id="test_face_person_event_id",
+        type=EventType.SMART_DETECT,
+        start=fixed_now - timedelta(seconds=1),
+        end=None,
+        score=100,
+        smart_detect_types=[],
+        smart_detect_event_ids=[],
+        camera_id=doorbell.id,
+        api=ufp.api,
+        metadata={
+            "detected_thumbnails": [
+                {
+                    "type": "face",
+                    "confidence": 97,
+                    "clock_best_wall": fixed_now,
+                    "cropped_id": "test_thumb_id",
+                    "group": {
+                        "id": "face_group_1",
+                        "matched_name": "Nate",
+                        "confidence": 96,
+                    },
+                }
+            ]
+        },
+    )
+
+    new_camera = doorbell.model_copy()
+    new_camera.last_smart_detect_event_id = "test_face_person_event_id"
+    ufp.api.bootstrap.cameras = {new_camera.id: new_camera}
+    ufp.api.bootstrap.events = {event.id: event}
+
+    mock_msg = Mock()
+    mock_msg.changed_data = {}
+    mock_msg.new_obj = event
+    ufp.ws_msg(mock_msg)
+
+    # Wait for the timer
+    await asyncio.sleep(TEST_VEHICLE_EVENT_DELAY * 2)
+    await hass.async_block_till_done()
+
+    # Should have received a face detection event with the recognized person
+    assert len(events) == 1
+    state = events[0].data["new_state"]
+    assert state
+    assert state.attributes[ATTR_EVENT_ID] == "test_face_person_event_id"
+    assert state.attributes["confidence"] == 97
+    assert state.attributes["detected_person"] == "Nate"
+
+    unsub()
+
+
 async def test_vehicle_detection_with_lpr_ufp6(
     hass: HomeAssistant,
     ufp: MockUFPFixture,
@@ -923,7 +1073,7 @@ async def test_vehicle_detection_with_lpr_ufp6(
     """Test vehicle detection with license plate recognition (UFP 6.0+ format)."""
 
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.EVENT, 5, 5)
+    assert_entity_counts(hass, Platform.EVENT, 6, 6)
     events: list[HAEvent] = []
 
     @callback
@@ -1007,7 +1157,7 @@ async def test_vehicle_detection_with_lpr_legacy(
     """Test vehicle detection with license plate recognition (legacy format)."""
 
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.EVENT, 5, 5)
+    assert_entity_counts(hass, Platform.EVENT, 6, 6)
     events: list[HAEvent] = []
 
     @callback
@@ -1080,7 +1230,7 @@ async def test_vehicle_detection_multiple_thumbnails(
     """Test vehicle detection with multiple thumbnails - should pick best LPR."""
 
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.EVENT, 5, 5)
+    assert_entity_counts(hass, Platform.EVENT, 6, 6)
     events: list[HAEvent] = []
 
     @callback
@@ -1181,7 +1331,7 @@ async def test_vehicle_detection_no_thumbnails(
     """Test vehicle detection event without thumbnails - should not fire."""
 
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.EVENT, 5, 5)
+    assert_entity_counts(hass, Platform.EVENT, 6, 6)
     events: list[HAEvent] = []
 
     @callback
@@ -1239,7 +1389,7 @@ async def test_vehicle_detection_timer_reset_on_new_thumbnail(
     """Test that timer resets when new thumbnails arrive for same event."""
 
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.EVENT, 5, 5)
+    assert_entity_counts(hass, Platform.EVENT, 6, 6)
     events: list[HAEvent] = []
 
     @callback
@@ -1350,7 +1500,7 @@ async def test_vehicle_detection_new_event_cancels_timer(
     """Test that new event cancels timer for previous event."""
 
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.EVENT, 5, 5)
+    assert_entity_counts(hass, Platform.EVENT, 6, 6)
     events: list[HAEvent] = []
 
     @callback
@@ -1477,7 +1627,7 @@ async def test_vehicle_detection_timer_cleanup_on_remove(
     """Test that pending timer is cancelled when entity is removed."""
 
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.EVENT, 5, 5)
+    assert_entity_counts(hass, Platform.EVENT, 6, 6)
 
     _, entity_id = await ids_from_device_description(
         hass, Platform.EVENT, doorbell, EVENT_DESCRIPTIONS[3]
@@ -1542,7 +1692,7 @@ async def test_vehicle_detection_refire_on_lpr_data(
     """Test that event refires when LPR data arrives after initial detection."""
 
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.EVENT, 5, 5)
+    assert_entity_counts(hass, Platform.EVENT, 6, 6)
     events: list[HAEvent] = []
 
     @callback
@@ -1653,7 +1803,7 @@ async def test_vehicle_detection_no_refire_same_data(
     """Test that event does NOT refire when same data arrives again."""
 
     await init_entry(hass, ufp, [doorbell, unadopted_camera])
-    assert_entity_counts(hass, Platform.EVENT, 5, 5)
+    assert_entity_counts(hass, Platform.EVENT, 6, 6)
     events: list[HAEvent] = []
 
     @callback


### PR DESCRIPTION
## Proposed change

Adds a **Face** event entity to UniFi Protect cameras that support smart detection. It fires when a face is detected and includes the **recognized person's name** (from the Protect AI Key face recognition) under `detected_person`, along with `confidence` and the best detection-frame timestamp.

Today the integration surfaces smart-detect object *types* (person/vehicle/face) but not the recognized identity — even though `uiprotect` already parses it (`Event.metadata.detected_thumbnails[].name`, or `group.matched_name` on UFP 6.0+). This exposes it so users can automate on *who* was seen (e.g. notify, or set a house mode, when a known person is recognized).

Implementation mirrors the existing **vehicle** event entity: the recognized name arrives on a detection thumbnail slightly after the initial event, so the vehicle best-thumbnail timer logic is generalized into a shared `ProtectDeviceSmartDetectThumbnailEventEntity` base, with thin `Vehicle` (→ `license_plate`) and `Face` (→ `detected_person`) subclasses. The vehicle entity's behavior is unchanged; `uiprotect` already models the data, so no library bump is required.

Verified against a real deployment with AI Key face recognition: recognized faces populate `detected_thumbnails[].name`/`group.matched_name`; unmatched faces leave it empty (event still fires, without `detected_person`).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- `uiprotect` already exposes the recognized name; no requirement bump.
- The new event entity is gated on `feature_flags.has_smart_detect` (same as the vehicle entity).

## Checklist

- [x] The code change is tested and works locally. (`tests/components/unifiprotect` passes in full; `hassfest` and `ruff` pass.)
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist].
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`).
- [x] Tests have been added to verify that the new code works: `test_face_detection_basic`, `test_face_detection_with_recognized_person`.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
