### PR TITLE
Fix Duco ventilation state select not being created for valve nodes

### DIFF
--- a/homeassistant/components/duco/select.py
+++ b/homeassistant/components/duco/select.py
@@ -34,6 +34,10 @@ SUPPORTED_SELECT_NODE_TYPES = {
     NodeType.VLVVOC,
     NodeType.VLVCO2,
     NodeType.VLVCO2RH,
+    NodeType.EAV,
+    NodeType.EAVRH,
+    NodeType.EAVVOC,
+    NodeType.EAVCO2,
 }
 
 

--- a/homeassistant/components/duco/select.py
+++ b/homeassistant/components/duco/select.py
@@ -27,6 +27,15 @@ _LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 1
 
+SUPPORTED_SELECT_NODE_TYPES = {
+    NodeType.BOX,
+    NodeType.VLV,
+    NodeType.VLVRH,
+    NodeType.VLVVOC,
+    NodeType.VLVCO2,
+    NodeType.VLVCO2RH,
+}
+
 
 def _get_ventilation_options(action: ActionItem) -> tuple[str, ...] | None:
     """Return ventilation options advertised by a node action."""
@@ -71,7 +80,9 @@ async def async_setup_entry(
             if node.node_id in known_nodes:
                 continue
 
-            if node.general.node_type is not NodeType.BOX:
+            # Duco advertises SetVentilationState broadly, so keep the select
+            # limited to the box and known valve node families.
+            if node.general.node_type not in SUPPORTED_SELECT_NODE_TYPES:
                 continue
 
             options = options_by_node.get(node.node_id)

--- a/tests/components/duco/test_select.py
+++ b/tests/components/duco/test_select.py
@@ -125,6 +125,8 @@ async def test_select_entity_created_with_dynamic_options(
 @pytest.mark.parametrize(
     "valve_node_type",
     [
+        pytest.param(NodeType.VLV, id="vlv"),
+        pytest.param(NodeType.VLVVOC, id="vlvvoc"),
         pytest.param(NodeType.EAV, id="eav"),
         pytest.param(NodeType.EAVRH, id="eavrh"),
         pytest.param(NodeType.EAVVOC, id="eavvoc"),

--- a/tests/components/duco/test_select.py
+++ b/tests/components/duco/test_select.py
@@ -28,10 +28,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
 from . import setup_platform_integration
+from .conftest import load_nodes_fixture
 
 from tests.common import MockConfigEntry
 
 _SELECT_ENTITY = "select.living_ventilation_state"
+_VALVE_SELECT_ENTITY = "select.bedroom_valve_ventilation_state"
 _UNSUPPORTED_SELECT_ENTITY = "select.office_co2_ventilation_state"
 
 
@@ -120,20 +122,36 @@ async def test_select_entity_created_with_dynamic_options(
     assert hass.states.get(_UNSUPPORTED_SELECT_ENTITY) is None
 
 
-async def test_select_ignores_non_box_nodes_even_when_actions_exist(
+async def test_select_creates_entities_for_controllable_valve_nodes(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_duco_client: AsyncMock,
 ) -> None:
-    """Test select discovery ignores non-box nodes that expose the same action."""
+    """Test select discovery includes valve nodes when they advertise control."""
+    mock_nodes = [
+        *load_nodes_fixture("nodes.json"),
+        *load_nodes_fixture("sensor_nodes.json"),
+    ]
+    mock_duco_client.async_get_nodes.return_value = mock_nodes
     mock_duco_client.async_get_node_actions.return_value = _build_multi_node_actions(
-        [1, 2, 50, 113],
+        [node.node_id for node in mock_nodes],
         options=["AUTO", "CNT1", "CNT2", "CNT3", "MAN1", "MAN2", "MAN3"],
     )
 
     await setup_platform_integration(hass, mock_config_entry, [Platform.SELECT])
 
     assert hass.states.get(_SELECT_ENTITY) is not None
+    valve_state = hass.states.get(_VALVE_SELECT_ENTITY)
+    assert valve_state is not None
+    assert valve_state.attributes[ATTR_OPTIONS] == [
+        "AUTO",
+        "CNT1",
+        "CNT2",
+        "CNT3",
+        "MAN1",
+        "MAN2",
+        "MAN3",
+    ]
     assert hass.states.get(_UNSUPPORTED_SELECT_ENTITY) is None
 
 

--- a/tests/components/duco/test_select.py
+++ b/tests/components/duco/test_select.py
@@ -28,7 +28,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
 from . import setup_platform_integration
-from .conftest import load_nodes_fixture
 
 from tests.common import MockConfigEntry
 
@@ -126,15 +125,12 @@ async def test_select_creates_entities_for_controllable_valve_nodes(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_duco_client: AsyncMock,
+    mock_sensor_nodes: list[Node],
 ) -> None:
     """Test select discovery includes valve nodes when they advertise control."""
-    mock_nodes = [
-        *load_nodes_fixture("nodes.json"),
-        *load_nodes_fixture("sensor_nodes.json"),
-    ]
-    mock_duco_client.async_get_nodes.return_value = mock_nodes
+    mock_duco_client.async_get_nodes.return_value = mock_sensor_nodes
     mock_duco_client.async_get_node_actions.return_value = _build_multi_node_actions(
-        [node.node_id for node in mock_nodes],
+        [node.node_id for node in mock_sensor_nodes],
         options=["AUTO", "CNT1", "CNT2", "CNT3", "MAN1", "MAN2", "MAN3"],
     )
 

--- a/tests/components/duco/test_select.py
+++ b/tests/components/duco/test_select.py
@@ -13,6 +13,7 @@ from duco_connectivity import (
     Node,
     NodeActionItemList,
     NodeListActionItemList,
+    NodeType,
     VentilationState,
 )
 import pytest
@@ -121,16 +122,33 @@ async def test_select_entity_created_with_dynamic_options(
     assert hass.states.get(_UNSUPPORTED_SELECT_ENTITY) is None
 
 
+@pytest.mark.parametrize(
+    "valve_node_type",
+    [
+        pytest.param(NodeType.EAV, id="eav"),
+        pytest.param(NodeType.EAVRH, id="eavrh"),
+        pytest.param(NodeType.EAVVOC, id="eavvoc"),
+        pytest.param(NodeType.EAVCO2, id="eavco2"),
+    ],
+)
 async def test_select_creates_entities_for_controllable_valve_nodes(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_duco_client: AsyncMock,
     mock_sensor_nodes: list[Node],
+    valve_node_type: NodeType,
 ) -> None:
     """Test select discovery includes valve nodes when they advertise control."""
-    mock_duco_client.async_get_nodes.return_value = mock_sensor_nodes
+    mock_nodes = [
+        replace(
+            mock_sensor_nodes[0],
+            general=replace(mock_sensor_nodes[0].general, node_type=valve_node_type),
+        ),
+        *mock_sensor_nodes[1:],
+    ]
+    mock_duco_client.async_get_nodes.return_value = mock_nodes
     mock_duco_client.async_get_node_actions.return_value = _build_multi_node_actions(
-        [node.node_id for node in mock_sensor_nodes],
+        [node.node_id for node in mock_nodes],
         options=["AUTO", "CNT1", "CNT2", "CNT3", "MAN1", "MAN2", "MAN3"],
     )
 

--- a/tests/components/duco/test_select.py
+++ b/tests/components/duco/test_select.py
@@ -126,7 +126,10 @@ async def test_select_entity_created_with_dynamic_options(
     "valve_node_type",
     [
         pytest.param(NodeType.VLV, id="vlv"),
+        pytest.param(NodeType.VLVRH, id="vlvrh"),
         pytest.param(NodeType.VLVVOC, id="vlvvoc"),
+        pytest.param(NodeType.VLVCO2, id="vlvco2"),
+        pytest.param(NodeType.VLVCO2RH, id="vlvco2rh"),
         pytest.param(NodeType.EAV, id="eav"),
         pytest.param(NodeType.EAVRH, id="eavrh"),
         pytest.param(NodeType.EAVVOC, id="eavvoc"),


### PR DESCRIPTION
> [!IMPORTANT]
> This PR fixes an overly restrictive node-type filter on already shipped Duco select functionality. Because follow-up hardware validation showed the current implementation does not expose the existing ventilation-state select on supported valve nodes, could this PR be considered for the next milestone as a bugfix?

## Proposed change
This PR fixes the Duco ventilation-state select so it is also created for supported valve node families.

The select platform already exists in the integration, but the initial implementation limited entity creation to the box node only. Follow-up hardware validation showed that supported valve node families expose and honor the same ventilation-state control, so the box-only filter was too restrictive.

This change keeps the entity creation explicitly type-gated and expands that gate only to the known valve node families. That fixes the missing select entities on supported hardware without exposing the select on unrelated node types that also broadly advertise the action metadata.

Because this corrects an overly narrow filter on already shipped functionality, I think this fits best as a bugfix rather than a new feature. If merged in time, it may be suitable for the next release milestone.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr