### PR TITLE
remove enphase_envoy test for to-be-deprecated pyenphase library data

### DIFF
--- a/tests/components/enphase_envoy/conftest.py
+++ b/tests/components/enphase_envoy/conftest.py
@@ -209,29 +209,6 @@ def _load_json_2_meter_data(
             ]
             mocked_data.ctmeters_phases.update({meter: meter_phase_data})
 
-    if item := json_fixture["data"].get("ctmeter_production"):
-        mocked_data.ctmeter_production = EnvoyMeterData(**item)
-    if item := json_fixture["data"].get("ctmeter_consumption"):
-        mocked_data.ctmeter_consumption = EnvoyMeterData(**item)
-    if item := json_fixture["data"].get("ctmeter_storage"):
-        mocked_data.ctmeter_storage = EnvoyMeterData(**item)
-    if item := json_fixture["data"].get("ctmeter_production_phases"):
-        mocked_data.ctmeter_production_phases = {}
-        for sub_item, item_data in item.items():
-            mocked_data.ctmeter_production_phases[sub_item] = EnvoyMeterData(
-                **item_data
-            )
-    if item := json_fixture["data"].get("ctmeter_consumption_phases"):
-        mocked_data.ctmeter_consumption_phases = {}
-        for sub_item, item_data in item.items():
-            mocked_data.ctmeter_consumption_phases[sub_item] = EnvoyMeterData(
-                **item_data
-            )
-    if item := json_fixture["data"].get("ctmeter_storage_phases"):
-        mocked_data.ctmeter_storage_phases = {}
-        for sub_item, item_data in item.items():
-            mocked_data.ctmeter_storage_phases[sub_item] = EnvoyMeterData(**item_data)
-
 
 def _load_json_2_inverter_data(
     mocked_data: EnvoyData, json_fixture: dict[str, Any]

--- a/tests/components/enphase_envoy/test_sensor.py
+++ b/tests/components/enphase_envoy/test_sensor.py
@@ -344,7 +344,7 @@ async def test_sensor_production_ct_data(
     sn = mock_envoy.serial_number
     ENTITY_BASE: str = f"{Platform.SENSOR}.envoy_{sn}"
 
-    data = mock_envoy.data.ctmeter_production
+    data = mock_envoy.data.ctmeters[CtType.PRODUCTION]
 
     CT_PRODUCTION_TARGETS_INT = (len(data.status_flags),)
     for name, target in list(
@@ -397,7 +397,7 @@ async def test_sensor_production_ct_phase_data(
 
     CT_PRODUCTION_NAMES_FLOAT_TARGET = [
         len(phase_data.status_flags)
-        for phase_data in mock_envoy.data.ctmeter_production_phases.values()
+        for phase_data in mock_envoy.data.ctmeters_phases[CtType.PRODUCTION].values()
     ]
 
     for name, target in list(
@@ -412,7 +412,7 @@ async def test_sensor_production_ct_phase_data(
 
     CT_PRODUCTION_NAMES_STR_TARGET = [
         phase_data.metering_status
-        for phase_data in mock_envoy.data.ctmeter_production_phases.values()
+        for phase_data in mock_envoy.data.ctmeters_phases[CtType.PRODUCTION].values()
     ]
 
     for name, target in list(
@@ -459,7 +459,7 @@ async def test_sensor_consumption_ct_data(
     sn = mock_envoy.serial_number
     ENTITY_BASE: str = f"{Platform.SENSOR}.envoy_{sn}"
 
-    data = mock_envoy.data.ctmeter_consumption
+    data = mock_envoy.data.ctmeters[mock_envoy.consumption_meter_type]
 
     CT_CONSUMPTION_TARGETS_FLOAT = (
         data.energy_delivered / 1000000.0,
@@ -527,7 +527,9 @@ async def test_sensor_consumption_ct_phase_data(
                 phase_data.voltage,
                 len(phase_data.status_flags),
             )
-            for phase_data in mock_envoy.data.ctmeter_consumption_phases.values()
+            for phase_data in mock_envoy.data.ctmeters_phases[
+                mock_envoy.consumption_meter_type
+            ].values()
         ]
     )
 
@@ -543,7 +545,9 @@ async def test_sensor_consumption_ct_phase_data(
 
     CT_CONSUMPTION_NAMES_STR_PHASE_TARGET = [
         phase_data.metering_status
-        for phase_data in mock_envoy.data.ctmeter_consumption_phases.values()
+        for phase_data in mock_envoy.data.ctmeters_phases[
+            mock_envoy.consumption_meter_type
+        ].values()
     ]
 
     for name, target in list(
@@ -587,7 +591,7 @@ async def test_sensor_storage_ct_data(
     sn = mock_envoy.serial_number
     ENTITY_BASE: str = f"{Platform.SENSOR}.envoy_{sn}"
 
-    data = mock_envoy.data.ctmeter_storage
+    data = mock_envoy.data.ctmeters[CtType.STORAGE]
 
     CT_STORAGE_TARGETS_FLOAT = (
         data.energy_delivered / 1000000.0,
@@ -650,7 +654,7 @@ async def test_sensor_storage_ct_phase_data(
                 phase_data.voltage,
                 len(phase_data.status_flags),
             )
-            for phase_data in mock_envoy.data.ctmeter_storage_phases.values()
+            for phase_data in mock_envoy.data.ctmeters_phases[CtType.STORAGE].values()
         ]
     )
 
@@ -666,7 +670,7 @@ async def test_sensor_storage_ct_phase_data(
 
     CT_STORAGE_NAMES_STR_PHASE_TARGET = [
         phase_data.metering_status
-        for phase_data in mock_envoy.data.ctmeter_storage_phases.values()
+        for phase_data in mock_envoy.data.ctmeters_phases[CtType.STORAGE].values()
     ]
 
     for name, target in list(
@@ -1351,12 +1355,6 @@ async def test_sensor_missing_data(
     mock_envoy.data.system_production_phases["L2"] = None
     mock_envoy.data.system_consumption_phases["L2"] = None
     mock_envoy.data.system_net_consumption_phases["L2"] = None
-    mock_envoy.data.ctmeter_production = None
-    mock_envoy.data.ctmeter_consumption = None
-    mock_envoy.data.ctmeter_storage = None
-    mock_envoy.data.ctmeter_production_phases = None
-    mock_envoy.data.ctmeter_consumption_phases = None
-    mock_envoy.data.ctmeter_storage_phases = None
     del mock_envoy.data.ctmeters[CtType.NET_CONSUMPTION]
     del mock_envoy.data.ctmeters_phases[CtType.NET_CONSUMPTION][PhaseNames.PHASE_2]
     del mock_envoy.data.ctmeters[CtType.PRODUCTION]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Pyenphase, the library used by the enphase_envoy integration, has refactored it's CT data reporting in v2.4.0 of October 2025. At that time, the existing data structures were maintained for backward compatibility. Current library version in use is v3.0.0 (#174496).

With the recent merge of PR #174524 into dev, the internal refactoring of the HA enphase_envoy integration has completed for above described change and the old data structures are no longer used in production code.

This PR removes any tests for, and replaces usage of, these now obsolete data structures:

- .ctmeter_production --> .ctmeters[CtType.PRODUCTION]
- .ctmeter_consumption --> .ctmeters[mock_envoy.consumption_meter_type]
- .ctmeter_storage --> .ctmeters[CtType.STORAGE]
- .ctmeter_production_phases --> .ctmeters_phases[CtType.PRODUCTION]
- .ctmeter_consumption_phases -->ctmeters_phases[mock_envoy.consumption_meter_type]
- .ctmeter_storage_phases --> .ctmeters_phases[CtType.STORAGE]


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
