### PR TITLE
Proof-of-Concept: Review-Only: Dynamically expose entities for Google Assistant

### DIFF
--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -11,6 +11,10 @@ from aiohttp.web import Request, Response
 import jwt
 
 from homeassistant.components import webhook
+from homeassistant.components.homeassistant.exposed_entities import (
+    async_get_entity_settings,
+    async_listen_entity_updates,
+)
 from homeassistant.components.http import KEY_HASS, HomeAssistantView
 from homeassistant.core import HomeAssistant, callback, split_entity_id
 from homeassistant.exceptions import HomeAssistantError
@@ -98,6 +102,17 @@ class GoogleConfig(AbstractConfig):
         await super().async_initialize()
 
         self.async_enable_local_sdk()
+
+        @callback
+        def _async_exposed_entities_updated() -> None:
+            self.async_schedule_google_sync_all()
+
+        for assistant in ("cloud.google_assistant", "cloud.alexa", "conversation"):
+            self._on_deinitialize.append(
+                async_listen_entity_updates(
+                    self.hass, assistant, _async_exposed_entities_updated
+                )
+            )
 
     @property
     @override
@@ -197,7 +212,16 @@ class GoogleConfig(AbstractConfig):
         # exposed, or if the entity is explicitly exposed
         is_default_exposed = entity_exposed_by_default and explicit_expose is not False
 
-        return is_default_exposed or explicit_expose
+        if is_default_exposed or explicit_expose:
+            return True
+
+        # POC: also expose entities marked exposed to any assistant in the
+        # Voice assistants UI, so users can toggle exposure at runtime.
+        try:
+            settings = async_get_entity_settings(self.hass, entity_id)
+        except HomeAssistantError:
+            return False
+        return any(opts.get("should_expose", False) for opts in settings.values())
 
     @override
     def should_2fa(self, state):


### PR DESCRIPTION
Proof-of-Concept: Review-Only: Dynamically expose entities for Google Assistant with local config

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Google Assistant integration, when not using the Nabu Casa subscription, requires entities to be expose in the YAML. You can expose domains by default, but if you have a large number of entities and want to curate your list, then you must list them individually. The YAML cannot be reloaded at runtime, necessitating a relaunch of Home Assistant to expose new entities.

When using Nabu Casa, it is possible to expose entities at runtime via the Voice Assistants UI in Settings.

This POC enables dynamic configuration of exposed entities for local Google Assistant integrations. This is not yet suitable for merging as instead of introducing UI to expose explicitly for Google Assistant, it piggybacks on the entity being exposed for any existing Assistant (mainly the existing standard Home Assistant voice assistant).

It has been tested to work including:
- Exposing new entities
- Renaming entities
- Adding an Aliase
- Removing an entity

Existing entities in the YAML config continue to be exposed. Note that if an entity in YAML is configured as "expose: false" (to prevent an individual entity from being exposed when the YAML expose by default is enabled), if the entity is exposed via UI, it will still be exposed - the YAML false does not block it. This can be changed.

The purpose of this initial PR is to seek alignment on the usage of the Voice Assistants UI for exposing entities dynamically. If there is overall alignment, the next steps would be to expose a Google Assistant entry in the Voice Assistants settings when the YAML is configured, in a manner similar to how the `cloud.google_assistant` entry shows up when Nabu Casa is enabled. The POC would then be updated to specifically check exposure against that entry, enabling entities to be exposed individually per assistant config.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
