### PR TITLE
Add sensor entities for multiple RoomIQ sensors

### DIFF
--- a/homeassistant/components/nexia/__init__.py
+++ b/homeassistant/components/nexia/__init__.py
@@ -64,7 +64,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: NexiaConfigEntry) -> boo
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     if nexia_home.any_room_iq_monitors():
         # To avoid initially presenting stale data, manually refresh
-        await coordinator.async_refresh()
+        await coordinator.async_config_entry_first_refresh()
 
     return True
 

--- a/homeassistant/components/nexia/__init__.py
+++ b/homeassistant/components/nexia/__init__.py
@@ -62,6 +62,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: NexiaConfigEntry) -> boo
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    if nexia_home.any_room_iq_monitors():
+        # To avoid initially presenting stale data, manually refresh
+        await coordinator.async_refresh()
 
     return True
 

--- a/homeassistant/components/nexia/__init__.py
+++ b/homeassistant/components/nexia/__init__.py
@@ -6,6 +6,7 @@ import aiohttp
 from nexia.const import BRAND_NEXIA
 from nexia.home import NexiaHome
 from nexia.thermostat import NexiaThermostat
+from nexia.zone import NexiaThermostatZone
 
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
@@ -88,6 +89,10 @@ async def async_remove_config_entry_device(
         for zone_id in thermostat.get_zone_ids():
             if zone_id in dev_ids:
                 return False
+            zone: NexiaThermostatZone = thermostat.get_zone_by_id(zone_id)
+            for room_iq_sensor in zone.get_sensors():
+                if str(room_iq_sensor.id) in dev_ids:
+                    return False
     return True
 
 

--- a/homeassistant/components/nexia/__init__.py
+++ b/homeassistant/components/nexia/__init__.py
@@ -67,7 +67,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: NexiaConfigEntry) -> boo
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     if nexia_home.any_room_iq_monitors():
         # To avoid initially presenting stale data, manually refresh
-        await coordinator.async_refresh()
+        await coordinator.async_config_entry_first_refresh()
 
     return True
 

--- a/homeassistant/components/nexia/__init__.py
+++ b/homeassistant/components/nexia/__init__.py
@@ -65,6 +65,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: NexiaConfigEntry) -> boo
     _preregister_devices(hass, entry, nexia_home)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    if nexia_home.any_room_iq_monitors():
+        # To avoid initially presenting stale data, manually refresh
+        await coordinator.async_refresh()
 
     return True
 

--- a/homeassistant/components/nexia/__init__.py
+++ b/homeassistant/components/nexia/__init__.py
@@ -6,6 +6,7 @@ import aiohttp
 from nexia.const import BRAND_NEXIA
 from nexia.home import NexiaHome
 from nexia.thermostat import NexiaThermostat
+from nexia.zone import NexiaThermostatZone
 
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
@@ -111,6 +112,10 @@ async def async_remove_config_entry_device(
         for zone_id in thermostat.get_zone_ids():
             if zone_id in dev_ids:
                 return False
+            zone: NexiaThermostatZone = thermostat.get_zone_by_id(zone_id)
+            for room_iq_sensor in zone.get_sensors():
+                if str(room_iq_sensor.id) in dev_ids:
+                    return False
     return True
 
 

--- a/homeassistant/components/nexia/entity.py
+++ b/homeassistant/components/nexia/entity.py
@@ -161,8 +161,10 @@ class NexiaRoomIQEntity(NexiaThermostatZoneEntity):
         if sensor.has_online:
             dev_info = DeviceInfo(
                 identifiers={(DOMAIN, str(sensor.id))},
+                model=None,  # not reported
                 name=sensor.name,
                 suggested_area=sensor.name,
+                sw_version=None,  # not reported
                 via_device=(DOMAIN, zone.zone_id),  # type: ignore[typeddict-item] # until fix issue #139773
             )
         super().__init__(coordinator, zone, f"{sensor.id}-{key}", dev_info)

--- a/homeassistant/components/nexia/entity.py
+++ b/homeassistant/components/nexia/entity.py
@@ -161,8 +161,7 @@ class NexiaRoomIQEntity(NexiaThermostatZoneEntity):
         if sensor.has_online:
             dev_info = DeviceInfo(
                 identifiers={(DOMAIN, str(sensor.id))},
-                translation_key="room_iq_sensor",
-                translation_placeholders={"sensor_name": sensor.name},
+                name=sensor.name,
                 suggested_area=sensor.name,
                 via_device=(DOMAIN, zone.zone_id),  # type: ignore[typeddict-item] # until fix issue #139773
             )

--- a/homeassistant/components/nexia/entity.py
+++ b/homeassistant/components/nexia/entity.py
@@ -153,7 +153,7 @@ class NexiaRoomIQEntity(NexiaThermostatZoneEntity):
         coordinator: NexiaDataUpdateCoordinator,
         zone: NexiaThermostatZone,
         sensor: NexiaSensor,
-        unique_id: str,
+        key: str,
     ) -> None:
         """Initialize the entity."""
         # online sensors are separate devices
@@ -165,5 +165,6 @@ class NexiaRoomIQEntity(NexiaThermostatZoneEntity):
                 suggested_area=sensor.name,
                 via_device=(DOMAIN, zone.zone_id),  # type: ignore[typeddict-item] # until fix issue #139773
             )
-        super().__init__(coordinator, zone, unique_id, dev_info)
+        super().__init__(coordinator, zone, f"{sensor.id}-{key}", dev_info)
+        self._attr_translation_key = key
         self._sensor_id = sensor.id

--- a/homeassistant/components/nexia/entity.py
+++ b/homeassistant/components/nexia/entity.py
@@ -156,9 +156,9 @@ class NexiaRoomIQEntity(NexiaThermostatZoneEntity):
         key: str,
     ) -> None:
         """Initialize the entity."""
-        # online sensors are separate devices
         dev_info: DeviceInfo | None = None
         if sensor.has_online:
+            # has_online indicates the RoomIQ sensor connects remotely
             dev_info = DeviceInfo(
                 identifiers={(DOMAIN, str(sensor.id))},
                 model=None,  # not reported

--- a/homeassistant/components/nexia/entity.py
+++ b/homeassistant/components/nexia/entity.py
@@ -2,6 +2,7 @@
 
 from typing import TYPE_CHECKING, override
 
+from nexia.sensor import NexiaSensor
 from nexia.thermostat import NexiaThermostat
 from nexia.zone import NexiaThermostatZone
 
@@ -102,19 +103,23 @@ class NexiaThermostatZoneEntity(NexiaThermostatEntity):
         coordinator: NexiaDataUpdateCoordinator,
         zone: NexiaThermostatZone,
         unique_id: str,
+        dev_info: DeviceInfo | None = None,
     ) -> None:
         """Initialize the entity."""
         super().__init__(coordinator, zone.thermostat, unique_id)
         self._zone = zone
-        zone_name = self._zone.get_name()
         if TYPE_CHECKING:
             assert self._attr_device_info is not None
-        self._attr_device_info |= {
-            ATTR_IDENTIFIERS: {(DOMAIN, zone.zone_id)},  # type: ignore[arg-type] # until fix issue #139773
-            ATTR_NAME: zone_name,
-            ATTR_SUGGESTED_AREA: zone_name,
-            ATTR_VIA_DEVICE: (DOMAIN, zone.thermostat.thermostat_id),  # type: ignore[typeddict-item] # until fix issue #139773
-        }
+        if dev_info is not None:
+            self._attr_device_info |= dev_info
+        else:
+            zone_name = self._zone.get_name()
+            self._attr_device_info |= {
+                ATTR_IDENTIFIERS: {(DOMAIN, zone.zone_id)},  # type: ignore[arg-type] # until fix issue #139773
+                ATTR_NAME: zone_name,
+                ATTR_SUGGESTED_AREA: zone_name,
+                ATTR_VIA_DEVICE: (DOMAIN, zone.thermostat.thermostat_id),  # type: ignore[typeddict-item] # until fix issue #139773
+            }
         self._zone_signal = f"{SIGNAL_ZONE_UPDATE}-{zone.zone_id}"
 
     @override
@@ -138,3 +143,28 @@ class NexiaThermostatZoneEntity(NexiaThermostatEntity):
         Update a single zone.
         """
         async_dispatcher_send(self.hass, self._zone_signal)
+
+
+class NexiaRoomIQEntity(NexiaThermostatZoneEntity):
+    """Base class for RoomIQ sensor entities."""
+
+    def __init__(
+        self,
+        coordinator: NexiaDataUpdateCoordinator,
+        zone: NexiaThermostatZone,
+        sensor: NexiaSensor,
+        unique_id: str,
+    ) -> None:
+        """Initialize the entity."""
+        # online sensors are separate devices
+        dev_info: DeviceInfo | None = None
+        if sensor.has_online:
+            dev_info = DeviceInfo(
+                identifiers={(DOMAIN, str(sensor.id))},
+                translation_key="room_iq_sensor",
+                translation_placeholders={"sensor_name": sensor.name},
+                suggested_area=sensor.name,
+                via_device=(DOMAIN, zone.zone_id),  # type: ignore[typeddict-item] # until fix issue #139773
+            )
+        super().__init__(coordinator, zone, unique_id, dev_info)
+        self._sensor_id = sensor.id

--- a/homeassistant/components/nexia/entity.py
+++ b/homeassistant/components/nexia/entity.py
@@ -2,6 +2,7 @@
 
 from typing import TYPE_CHECKING, override
 
+from nexia.sensor import NexiaSensor
 from nexia.thermostat import NexiaThermostat
 from nexia.zone import NexiaThermostatZone
 
@@ -99,21 +100,26 @@ class NexiaThermostatZoneEntity(NexiaThermostatEntity):
         coordinator: NexiaDataUpdateCoordinator,
         zone: NexiaThermostatZone,
         unique_id: str,
+        dev_info: DeviceInfo | None = None,
     ) -> None:
         """Initialize the entity."""
         super().__init__(coordinator, zone.thermostat, unique_id)
         self._zone = zone
         if TYPE_CHECKING:
             assert self._attr_device_info is not None
-        self._attr_device_info |= {
-            ATTR_IDENTIFIERS: {(DOMAIN, zone.zone_id)},  # type: ignore[arg-type] # until fix issue #139773
-            ATTR_NAME: zone.get_name(),
-            "via_device_id": dr.async_get_device_id_by_identifier(
-                self.coordinator.hass,
-                (DOMAIN, zone.thermostat.thermostat_id),  # type: ignore[arg-type] # until fix issue #139773
-                config_entry_id=self.coordinator.config_entry.entry_id,
-            ),
-        }
+        if dev_info is not None:
+            self._attr_device_info |= dev_info
+        else:
+            zone_name = self._zone.get_name()
+            self._attr_device_info |= {
+                ATTR_IDENTIFIERS: {(DOMAIN, zone.zone_id)},  # type: ignore[arg-type] # until fix issue #139773
+                ATTR_NAME: zone.get_name(),
+                "via_device_id": dr.async_get_device_id_by_identifier(
+                    self.coordinator.hass,
+                    (DOMAIN, zone.thermostat.thermostat_id),  # type: ignore[arg-type] # until fix issue #139773
+                    config_entry_id=self.coordinator.config_entry.entry_id,
+                ),
+            }
         self._zone_signal = f"{SIGNAL_ZONE_UPDATE}-{zone.zone_id}"
 
     @override
@@ -137,3 +143,28 @@ class NexiaThermostatZoneEntity(NexiaThermostatEntity):
         Update a single zone.
         """
         async_dispatcher_send(self.hass, self._zone_signal)
+
+
+class NexiaRoomIQEntity(NexiaThermostatZoneEntity):
+    """Base class for RoomIQ sensor entities."""
+
+    def __init__(
+        self,
+        coordinator: NexiaDataUpdateCoordinator,
+        zone: NexiaThermostatZone,
+        sensor: NexiaSensor,
+        unique_id: str,
+    ) -> None:
+        """Initialize the entity."""
+        # online sensors are separate devices
+        dev_info: DeviceInfo | None = None
+        if sensor.has_online:
+            dev_info = DeviceInfo(
+                identifiers={(DOMAIN, str(sensor.id))},
+                translation_key="room_iq_sensor",
+                translation_placeholders={"sensor_name": sensor.name},
+                suggested_area=sensor.name,
+                via_device=(DOMAIN, zone.zone_id),  # type: ignore[typeddict-item] # until fix issue #139773
+            )
+        super().__init__(coordinator, zone, unique_id, dev_info)
+        self._sensor_id = sensor.id

--- a/homeassistant/components/nexia/entity.py
+++ b/homeassistant/components/nexia/entity.py
@@ -165,7 +165,11 @@ class NexiaRoomIQEntity(NexiaThermostatZoneEntity):
                 name=sensor.name,
                 suggested_area=sensor.name,
                 sw_version=None,  # not reported
-                via_device=(DOMAIN, zone.zone_id),  # type: ignore[typeddict-item] # until fix issue #139773
+                via_device_id=dr.async_get_device_id_by_identifier(
+                    coordinator.hass,
+                    (DOMAIN, zone.zone_id),  # type: ignore[arg-type] # until fix issue #139773
+                    config_entry_id=coordinator.config_entry.entry_id,
+                ),
             )
         super().__init__(coordinator, zone, f"{sensor.id}-{key}", dev_info)
         self._attr_translation_key = key

--- a/homeassistant/components/nexia/entity.py
+++ b/homeassistant/components/nexia/entity.py
@@ -110,7 +110,6 @@ class NexiaThermostatZoneEntity(NexiaThermostatEntity):
         if dev_info is not None:
             self._attr_device_info |= dev_info
         else:
-            zone_name = self._zone.get_name()
             self._attr_device_info |= {
                 ATTR_IDENTIFIERS: {(DOMAIN, zone.zone_id)},  # type: ignore[arg-type] # until fix issue #139773
                 ATTR_NAME: zone.get_name(),

--- a/homeassistant/components/nexia/sensor.py
+++ b/homeassistant/components/nexia/sensor.py
@@ -1,5 +1,7 @@
 """Support for Nexia / Trane XL Thermostats."""
 
+from collections.abc import Callable
+from dataclasses import dataclass
 from typing import override
 
 from nexia.const import UNIT_CELSIUS
@@ -10,6 +12,7 @@ from nexia.zone import NexiaThermostatZone
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
+    SensorEntityDescription,
     SensorStateClass,
 )
 from homeassistant.const import PERCENTAGE, UnitOfTemperature
@@ -22,6 +25,17 @@ from .types import NexiaConfigEntry
 from .util import percent_conv
 
 
+@dataclass(frozen=True, kw_only=True)
+class NexiaRoomIQSensorEntityDescription(SensorEntityDescription):
+    """Describes the sensor entity for a Nexia RoomIQ sensor."""
+
+    available_fn: Callable[[NexiaSensor], bool]
+    value_fn: Callable[[NexiaSensor], int | float]
+    include_fn: Callable[[NexiaSensor], bool] = lambda s: True
+    state_class = SensorStateClass.MEASUREMENT
+    entity_registry_enabled_default = False
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: NexiaConfigEntry,
@@ -32,7 +46,6 @@ async def async_setup_entry(
     coordinator = config_entry.runtime_data
     nexia_home = coordinator.nexia_home
     entities: list[NexiaThermostatEntity] = []
-    room_iq_sensor_enabled_default = False
 
     # Thermostat / System Sensors
     for thermostat_id in nexia_home.get_thermostat_ids():
@@ -189,50 +202,39 @@ async def async_setup_entry(
 
             # RoomIQ sensors
             if len(zone_sensors := zone.get_sensors()) > 1:
-                for room_iq_sensor in zone_sensors:
+                room_iq_descriptions = (
                     # Temperature
-                    entities.append(
-                        NexiaRoomIQSensor(
-                            coordinator,
-                            zone,
-                            room_iq_sensor,
-                            "temperature",
-                            "temperature_valid",
-                            "room_iq_temperature",
-                            SensorDeviceClass.TEMPERATURE,
-                            unit,
-                            room_iq_sensor_enabled_default,
-                        )
-                    )
+                    NexiaRoomIQSensorEntityDescription(
+                        key="room_iq_temperature",
+                        available_fn=lambda s: s.temperature_valid,
+                        value_fn=lambda s: s.temperature,
+                        device_class=SensorDeviceClass.TEMPERATURE,
+                        native_unit_of_measurement=unit,
+                    ),
                     # Relative humidity
-                    entities.append(
-                        NexiaRoomIQSensor(
-                            coordinator,
-                            zone,
-                            room_iq_sensor,
-                            "humidity",
-                            "humidity_valid",
-                            "room_iq_humidity",
-                            SensorDeviceClass.HUMIDITY,
-                            PERCENTAGE,
-                            room_iq_sensor_enabled_default,
-                        )
-                    )
+                    NexiaRoomIQSensorEntityDescription(
+                        key="room_iq_humidity",
+                        available_fn=lambda s: s.humidity_valid,
+                        value_fn=lambda s: s.humidity,
+                        device_class=SensorDeviceClass.HUMIDITY,
+                        native_unit_of_measurement=PERCENTAGE,
+                    ),
                     # Battery level
-                    if room_iq_sensor.has_battery:
-                        entities.append(
-                            NexiaRoomIQSensor(
-                                coordinator,
-                                zone,
-                                room_iq_sensor,
-                                "battery_level",
-                                "battery_valid",
-                                "room_iq_battery",
-                                SensorDeviceClass.BATTERY,
-                                PERCENTAGE,
-                                room_iq_sensor_enabled_default,
-                            )
-                        )
+                    NexiaRoomIQSensorEntityDescription(
+                        key="room_iq_battery",
+                        available_fn=lambda s: bool(s.battery_valid),
+                        value_fn=lambda s: s.battery_level or 0,
+                        include_fn=lambda s: s.has_battery,
+                        device_class=SensorDeviceClass.BATTERY,
+                        native_unit_of_measurement=PERCENTAGE,
+                    ),
+                )
+                entities.extend(
+                    NexiaRoomIQSensor(coordinator, zone, room_iq_sensor, description)
+                    for room_iq_sensor in zone_sensors
+                    for description in room_iq_descriptions
+                    if description.include_fn(room_iq_sensor)
+                )
 
     async_add_entities(entities)
 
@@ -321,42 +323,34 @@ class NexiaThermostatZoneSensor(NexiaThermostatZoneEntity, SensorEntity):
 class NexiaRoomIQSensor(NexiaRoomIQEntity, SensorEntity):
     """Provides Nexia RoomIQ sensor support."""
 
+    entity_description: NexiaRoomIQSensorEntityDescription
+
     def __init__(
         self,
         coordinator: NexiaDataUpdateCoordinator,
         zone: NexiaThermostatZone,
         sensor: NexiaSensor,
-        sensor_field: str,
-        field_valid: str,
-        translation_key: str,
-        sensor_class: SensorDeviceClass,
-        sensor_unit: str,
-        sensor_enabled_default: bool,
+        description: NexiaRoomIQSensorEntityDescription,
     ) -> None:
-        """Initialize the RoomIQ sensor."""
-        super().__init__(coordinator, zone, sensor, f"{sensor.id}_{sensor_field}")
-        self._field = sensor_field
-        self._field_valid = field_valid
-        if translation_key is not None:
-            self._attr_translation_key = translation_key
-        self._attr_device_class = sensor_class
-        self._attr_native_unit_of_measurement = sensor_unit
-        self._attr_state_class = SensorStateClass.MEASUREMENT
-        self._attr_entity_registry_enabled_default = sensor_enabled_default
+        """Initialize the sensor entity for a Nexia RoomIQ sensor."""
+        super().__init__(coordinator, zone, sensor, description.key)
+        self.entity_description = description
 
     @property
     @override
     def available(self) -> bool:
         """Return if the state is available."""
         room_iq_sensor = self._zone.get_sensor_by_id(self._sensor_id)
-        return super().available and getattr(room_iq_sensor, self._field_valid)
+        return super().available and self.entity_description.available_fn(
+            room_iq_sensor
+        )
 
     @property
     @override
     def native_value(self) -> int | float:
         """Return the state of the RoomIQ sensor."""
         room_iq_sensor = self._zone.get_sensor_by_id(self._sensor_id)
-        val = getattr(room_iq_sensor, self._field)
+        val = self.entity_description.value_fn(room_iq_sensor)
         if isinstance(val, float):
             val = round(val, 1)
         return val

--- a/homeassistant/components/nexia/sensor.py
+++ b/homeassistant/components/nexia/sensor.py
@@ -350,10 +350,7 @@ class NexiaRoomIQSensor(NexiaRoomIQEntity, SensorEntity):
     def native_value(self) -> int | float:
         """Return the state of the RoomIQ sensor."""
         room_iq_sensor = self._zone.get_sensor_by_id(self._sensor_id)
-        val = self.entity_description.value_fn(room_iq_sensor)
-        if isinstance(val, float):
-            val = round(val, 1)
-        return val
+        return self.entity_description.value_fn(room_iq_sensor)
 
     @override
     async def async_added_to_hass(self) -> None:

--- a/homeassistant/components/nexia/sensor.py
+++ b/homeassistant/components/nexia/sensor.py
@@ -3,7 +3,9 @@
 from typing import override
 
 from nexia.const import UNIT_CELSIUS
+from nexia.sensor import NexiaSensor
 from nexia.thermostat import NexiaThermostat
+from nexia.zone import NexiaThermostatZone
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -14,7 +16,8 @@ from homeassistant.const import PERCENTAGE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .entity import NexiaThermostatEntity, NexiaThermostatZoneEntity
+from .coordinator import NexiaDataUpdateCoordinator
+from .entity import NexiaRoomIQEntity, NexiaThermostatEntity, NexiaThermostatZoneEntity
 from .types import NexiaConfigEntry
 from .util import percent_conv
 
@@ -29,6 +32,7 @@ async def async_setup_entry(
     coordinator = config_entry.runtime_data
     nexia_home = coordinator.nexia_home
     entities: list[NexiaThermostatEntity] = []
+    room_iq_sensor_enabled_default = False
 
     # Thermostat / System Sensors
     for thermostat_id in nexia_home.get_thermostat_ids():
@@ -183,6 +187,53 @@ async def async_setup_entry(
                 )
             )
 
+            # RoomIQ sensors
+            if len(zone_sensors := zone.get_sensors()) > 1:
+                for room_iq_sensor in zone_sensors:
+                    # Temperature
+                    entities.append(
+                        NexiaRoomIQSensor(
+                            coordinator,
+                            zone,
+                            room_iq_sensor,
+                            "temperature",
+                            "temperature_valid",
+                            "room_iq_temperature",
+                            SensorDeviceClass.TEMPERATURE,
+                            unit,
+                            room_iq_sensor_enabled_default,
+                        )
+                    )
+                    # Relative humidity
+                    entities.append(
+                        NexiaRoomIQSensor(
+                            coordinator,
+                            zone,
+                            room_iq_sensor,
+                            "humidity",
+                            "humidity_valid",
+                            "room_iq_humidity",
+                            SensorDeviceClass.HUMIDITY,
+                            PERCENTAGE,
+                            room_iq_sensor_enabled_default,
+                        )
+                    )
+                    # Battery level
+                    if room_iq_sensor.has_battery:
+                        entities.append(
+                            NexiaRoomIQSensor(
+                                coordinator,
+                                zone,
+                                room_iq_sensor,
+                                "battery_level",
+                                "battery_valid",
+                                "room_iq_battery",
+                                SensorDeviceClass.BATTERY,
+                                PERCENTAGE,
+                                room_iq_sensor_enabled_default,
+                            )
+                        )
+
     async_add_entities(entities)
 
 
@@ -265,3 +316,59 @@ class NexiaThermostatZoneSensor(NexiaThermostatZoneEntity, SensorEntity):
         if isinstance(val, float):
             val = round(val, 1)
         return val
+
+
+class NexiaRoomIQSensor(NexiaRoomIQEntity, SensorEntity):
+    """Provides Nexia RoomIQ sensor support."""
+
+    def __init__(
+        self,
+        coordinator: NexiaDataUpdateCoordinator,
+        zone: NexiaThermostatZone,
+        sensor: NexiaSensor,
+        sensor_field: str,
+        field_valid: str,
+        translation_key: str,
+        sensor_class: SensorDeviceClass,
+        sensor_unit: str,
+        sensor_enabled_default: bool,
+    ) -> None:
+        """Initialize the RoomIQ sensor."""
+        super().__init__(coordinator, zone, sensor, f"{sensor.id}_{sensor_field}")
+        self._field = sensor_field
+        self._field_valid = field_valid
+        if translation_key is not None:
+            self._attr_translation_key = translation_key
+        self._attr_device_class = sensor_class
+        self._attr_native_unit_of_measurement = sensor_unit
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_entity_registry_enabled_default = sensor_enabled_default
+
+    @property
+    @override
+    def available(self) -> bool:
+        """Return if the state is available."""
+        room_iq_sensor = self._zone.get_sensor_by_id(self._sensor_id)
+        return super().available and getattr(room_iq_sensor, self._field_valid)
+
+    @property
+    @override
+    def native_value(self) -> int | float:
+        """Return the state of the RoomIQ sensor."""
+        room_iq_sensor = self._zone.get_sensor_by_id(self._sensor_id)
+        val = getattr(room_iq_sensor, self._field)
+        if isinstance(val, float):
+            val = round(val, 1)
+        return val
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Register this RoomIQ entity."""
+        self._zone.add_room_iq_monitor(self.entity_id)
+        await super().async_added_to_hass()
+
+    @override
+    async def async_will_remove_from_hass(self) -> None:
+        """Unregister this RoomIQ entity."""
+        await super().async_will_remove_from_hass()
+        self._zone.remove_room_iq_monitor(self.entity_id)

--- a/homeassistant/components/nexia/sensor.py
+++ b/homeassistant/components/nexia/sensor.py
@@ -341,8 +341,10 @@ class NexiaRoomIQSensor(NexiaRoomIQEntity, SensorEntity):
         except KeyError:
             # RoomIQ sensor no longer present
             return False
-        return super().available and self.entity_description.available_fn(
-            room_iq_sensor
+        return (
+            super().available
+            and (not room_iq_sensor.has_online or bool(room_iq_sensor.connected))
+            and self.entity_description.available_fn(room_iq_sensor)
         )
 
     @property

--- a/homeassistant/components/nexia/sensor.py
+++ b/homeassistant/components/nexia/sensor.py
@@ -200,10 +200,8 @@ async def async_setup_entry(
                 )
             )
 
-            # RoomIQ sensors
             if len(zone_sensors := zone.get_sensors()) > 1:
                 room_iq_descriptions = (
-                    # Temperature
                     NexiaRoomIQSensorEntityDescription(
                         key="room_iq_temperature",
                         available_fn=lambda s: s.temperature_valid,
@@ -211,7 +209,6 @@ async def async_setup_entry(
                         device_class=SensorDeviceClass.TEMPERATURE,
                         native_unit_of_measurement=unit,
                     ),
-                    # Relative humidity
                     NexiaRoomIQSensorEntityDescription(
                         key="room_iq_humidity",
                         available_fn=lambda s: s.humidity_valid,
@@ -219,7 +216,6 @@ async def async_setup_entry(
                         device_class=SensorDeviceClass.HUMIDITY,
                         native_unit_of_measurement=PERCENTAGE,
                     ),
-                    # Battery level
                     NexiaRoomIQSensorEntityDescription(
                         key="room_iq_battery",
                         available_fn=lambda s: bool(s.battery_valid),
@@ -340,7 +336,11 @@ class NexiaRoomIQSensor(NexiaRoomIQEntity, SensorEntity):
     @override
     def available(self) -> bool:
         """Return if the state is available."""
-        room_iq_sensor = self._zone.get_sensor_by_id(self._sensor_id)
+        try:
+            room_iq_sensor = self._zone.get_sensor_by_id(self._sensor_id)
+        except KeyError:
+            # RoomIQ sensor no longer present
+            return False
         return super().available and self.entity_description.available_fn(
             room_iq_sensor
         )

--- a/homeassistant/components/nexia/sensor.py
+++ b/homeassistant/components/nexia/sensor.py
@@ -30,7 +30,7 @@ class NexiaRoomIQSensorEntityDescription(SensorEntityDescription):
     """Describes the sensor entity for a Nexia RoomIQ sensor."""
 
     available_fn: Callable[[NexiaSensor], bool]
-    value_fn: Callable[[NexiaSensor], int | float]
+    value_fn: Callable[[NexiaSensor], int | float | None]
     include_fn: Callable[[NexiaSensor], bool] = lambda s: True
     state_class = SensorStateClass.MEASUREMENT
     entity_registry_enabled_default = False
@@ -219,7 +219,7 @@ async def async_setup_entry(
                     NexiaRoomIQSensorEntityDescription(
                         key="room_iq_battery",
                         available_fn=lambda s: bool(s.battery_valid),
-                        value_fn=lambda s: s.battery_level or 0,
+                        value_fn=lambda s: s.battery_level,
                         include_fn=lambda s: s.has_battery,
                         device_class=SensorDeviceClass.BATTERY,
                         native_unit_of_measurement=PERCENTAGE,
@@ -349,9 +349,12 @@ class NexiaRoomIQSensor(NexiaRoomIQEntity, SensorEntity):
 
     @property
     @override
-    def native_value(self) -> int | float:
+    def native_value(self) -> int | float | None:
         """Return the state of the RoomIQ sensor."""
-        room_iq_sensor = self._zone.get_sensor_by_id(self._sensor_id)
+        try:
+            room_iq_sensor = self._zone.get_sensor_by_id(self._sensor_id)
+        except KeyError:
+            return None
         return self.entity_description.value_fn(room_iq_sensor)
 
     @override

--- a/homeassistant/components/nexia/sensor.py
+++ b/homeassistant/components/nexia/sensor.py
@@ -339,7 +339,6 @@ class NexiaRoomIQSensor(NexiaRoomIQEntity, SensorEntity):
         try:
             room_iq_sensor = self._zone.get_sensor_by_id(self._sensor_id)
         except KeyError:
-            # RoomIQ sensor no longer present
             return False
         return (
             super().available

--- a/homeassistant/components/nexia/strings.json
+++ b/homeassistant/components/nexia/strings.json
@@ -18,11 +18,6 @@
       }
     }
   },
-  "device": {
-    "room_iq_sensor": {
-      "name": "{sensor_name} RoomIQ"
-    }
-  },
   "entity": {
     "binary_sensor": {
       "blower_active": {

--- a/homeassistant/components/nexia/strings.json
+++ b/homeassistant/components/nexia/strings.json
@@ -18,6 +18,11 @@
       }
     }
   },
+  "device": {
+    "room_iq_sensor": {
+      "name": "{sensor_name} RoomIQ"
+    }
+  },
   "entity": {
     "binary_sensor": {
       "blower_active": {
@@ -50,6 +55,15 @@
       },
       "requested_compressor_speed": {
         "name": "Requested compressor speed"
+      },
+      "room_iq_battery": {
+        "name": "RoomIQ battery"
+      },
+      "room_iq_humidity": {
+        "name": "RoomIQ humidity"
+      },
+      "room_iq_temperature": {
+        "name": "RoomIQ temperature"
       },
       "system_status": {
         "name": "System status"

--- a/tests/components/nexia/conftest.py
+++ b/tests/components/nexia/conftest.py
@@ -21,7 +21,7 @@ def create_mock_sensor(
     sensor_id: int,
     name: str,
     weight: float = 1.0,
-    temperature=72.5,
+    temperature: float = 72.5,
     humidity: int = 45,
     connected: bool | None = None,
     battery_level: int | None = None,

--- a/tests/components/nexia/conftest.py
+++ b/tests/components/nexia/conftest.py
@@ -21,8 +21,10 @@ def create_mock_sensor(
     sensor_id: int,
     name: str,
     weight: float = 1.0,
-    temperature: int = 72,
+    temperature=72.5,
     humidity: int = 45,
+    connected: bool | None = None,
+    battery_level: int | None = None,
 ) -> NonCallableMock[NexiaSensor]:
     """Create a mock NexiaSensor."""
     sensor = NonCallableMock(NexiaSensor)
@@ -30,9 +32,14 @@ def create_mock_sensor(
     sensor.name = name
     sensor.weight = weight
     sensor.temperature = temperature
+    sensor.temperature_valid = True
     sensor.humidity = humidity
-    sensor.has_online = False
-    sensor.has_battery = False
+    sensor.humidity_valid = True
+    sensor.has_online = connected is not None
+    sensor.connected = connected
+    sensor.has_battery = battery_level is not None
+    sensor.battery_level = battery_level
+    sensor.battery_valid = battery_level is not None
 
     return sensor
 
@@ -67,7 +74,11 @@ def create_mock_zone(
     zone.get_preset.return_value = preset
     zone.get_presets.return_value = presets or ["None", "Home", "Away", "Sleep"]
     zone.get_requested_mode.return_value = requested_mode
-    zone.get_sensors.return_value = sensors or []
+    _sensors = sensors or []
+    zone.get_sensors.return_value = _sensors
+    zone.get_sensor_by_id.side_effect = lambda sid: next(
+        s for s in _sensors if s.id == sid
+    )
     zone.get_setpoint_status.return_value = setpoint_status
     zone.get_status.return_value = status
     zone.get_temperature.return_value = temperature
@@ -76,6 +87,9 @@ def create_mock_zone(
     zone.is_native_zone.return_value = True
     zone.load_current_sensor_state.return_value = True
     zone.select_room_iq_sensors.return_value = True
+    zone.has_room_iq_monitor.side_effect = lambda: (
+        zone.add_room_iq_monitor.call_count > zone.remove_room_iq_monitor.call_count
+    )
 
     return zone
 
@@ -166,16 +180,13 @@ def create_mock_thermostat(
 
     thermostat = NonCallableMock(NexiaThermostat)
     thermostat.thermostat_id = thermostat_id
+    thermostat.zones = zones or []
     thermostat.get_name.return_value = name
-
-    if zones is not None:
-        zone_ids = [z.zone_id for z in zones]
-        thermostat.get_zone_ids.return_value = zone_ids
-        thermostat.get_zone_by_id.side_effect = lambda zid: next(
-            z for z in zones if z.zone_id == zid
-        )
-    else:
-        thermostat.get_zone_ids.return_value = []
+    zone_ids = [z.zone_id for z in thermostat.zones]
+    thermostat.get_zone_ids.return_value = zone_ids
+    thermostat.get_zone_by_id.side_effect = lambda zid: next(
+        z for z in thermostat.zones if z.zone_id == zid
+    )
     thermostat.get_air_cleaner_mode.side_effect = lambda: state_data.air_cleaner_mode
     thermostat.get_current_compressor_speed.return_value = current_compressor_speed
     thermostat.get_deadband.return_value = deadband
@@ -276,6 +287,9 @@ def create_mock_nexia_home(
     nexia_home.get_thermostat_by_id.side_effect = lambda tid: next(
         t for t in _thermostats if t.thermostat_id == tid
     )
+    nexia_home.any_room_iq_monitors.side_effect = lambda: any(
+        any(zone.has_room_iq_monitor() for zone in t.zones) for t in _thermostats
+    )
 
     _automations = automations or []
     automation_ids = [a.automation_id for a in _automations]
@@ -349,13 +363,14 @@ def mock_nexia_home() -> NonCallableMock[NexiaHome]:
     )
     zone.thermostat = thermostat4
 
-    sensor1 = create_mock_sensor(sensor_id=1, name="Center", weight=0.5)
-    sensor2 = create_mock_sensor(sensor_id=2, name="Upstairs", weight=0.5)
+    sensor1 = create_mock_sensor(1, "Center", 0.5, temperature=77)
+    sensor2 = create_mock_sensor(2, "Upstairs", 0.5, connected=True, battery_level=93)
+    sensor3 = create_mock_sensor(3, "Downstairs", 0.0, connected=True)
+    sensor3.temperature_valid = False
     zone = create_mock_zone(
-        zone_id=500, name="Center NativeZone", sensors=[sensor1, sensor2]
+        zone_id=500, name="Zone3", sensors=[sensor1, sensor2, sensor3]
     )
     zone.get_active_sensor_ids.return_value = {1, 2}
-    zone.get_sensor_by_id.side_effect = lambda sid: {1: sensor1, 2: sensor2}[sid]
     thermostat5 = create_mock_thermostat(
         thermostat_id=2000004,
         name="Center NativeZone",

--- a/tests/components/nexia/conftest.py
+++ b/tests/components/nexia/conftest.py
@@ -76,9 +76,8 @@ def create_mock_zone(
     zone.get_requested_mode.return_value = requested_mode
     _sensors = sensors or []
     zone.get_sensors.return_value = _sensors
-    zone.get_sensor_by_id.side_effect = lambda sid: next(
-        s for s in _sensors if s.id == sid
-    )
+    sensor_by_id = {sensor.id: sensor for sensor in _sensors}
+    zone.get_sensor_by_id.side_effect = sensor_by_id.__getitem__
     zone.get_setpoint_status.return_value = setpoint_status
     zone.get_status.return_value = status
     zone.get_temperature.return_value = temperature
@@ -352,7 +351,10 @@ def mock_nexia_home() -> NonCallableMock[NexiaHome]:
     )
     zone.thermostat = thermostat3
 
-    zone = create_mock_zone(zone_id=400, name="Kitchen", temperature=77)
+    sensor1 = create_mock_sensor(401, "Kitchen", 1.0, temperature=77)
+    zone = create_mock_zone(
+        zone_id=400, name="Kitchen", sensors=[sensor1], temperature=77
+    )
     thermostat4 = create_mock_thermostat(
         thermostat_id=2000003,
         name="Kitchen",

--- a/tests/components/nexia/conftest.py
+++ b/tests/components/nexia/conftest.py
@@ -365,14 +365,14 @@ def mock_nexia_home() -> NonCallableMock[NexiaHome]:
     )
     zone.thermostat = thermostat4
 
-    sensor1 = create_mock_sensor(1, "Center", 0.5, temperature=77)
-    sensor2 = create_mock_sensor(2, "Upstairs", 0.5, connected=True, battery_level=93)
-    sensor3 = create_mock_sensor(3, "Downstairs", 0.0, connected=True)
+    sensor1 = create_mock_sensor(501, "Center", 0.5, temperature=77)
+    sensor2 = create_mock_sensor(502, "Upstairs", 0.5, connected=True, battery_level=93)
+    sensor3 = create_mock_sensor(503, "Downstairs", 0.0, connected=True)
     sensor3.temperature_valid = False
     zone = create_mock_zone(
         zone_id=500, name="Zone3", sensors=[sensor1, sensor2, sensor3]
     )
-    zone.get_active_sensor_ids.return_value = {1, 2}
+    zone.get_active_sensor_ids.return_value = {501, 502}
     thermostat5 = create_mock_thermostat(
         thermostat_id=2000004,
         name="Center NativeZone",

--- a/tests/components/nexia/test_init.py
+++ b/tests/components/nexia/test_init.py
@@ -40,11 +40,15 @@ async def test_device_remove_devices(
     await async_setup_component(hass, "config", {})
     config_entry = await setup_integration(hass, patch_nexia_home)
     entry_id = config_entry.entry_id
+    client = await hass_ws_client(hass)
+
+    entity = entity_registry.entities["sensor.upstairs_upstairs_roomiq_temperature"]
+    live_room_iq_device_entry = device_registry.async_get(entity.device_id)
+    response = await client.remove_device(live_room_iq_device_entry.id, entry_id)
+    assert not response["success"]
 
     entity = entity_registry.entities["sensor.nick_office_nick_office_temperature"]
-
     live_zone_device_entry = device_registry.async_get(entity.device_id)
-    client = await hass_ws_client(hass)
     response = await client.remove_device(live_zone_device_entry.id, entry_id)
     assert not response["success"]
 

--- a/tests/components/nexia/test_init.py
+++ b/tests/components/nexia/test_init.py
@@ -41,11 +41,15 @@ async def test_device_remove_devices(
     """Test we can only remove a device that no longer exists."""
     await async_setup_component(hass, "config", {})
     config_entry = await setup_integration(hass, patch_nexia_home)
+    client = await hass_ws_client(hass)
+
+    entity = entity_registry.entities["sensor.upstairs_upstairs_roomiq_temperature"]
+    live_room_iq_device_entry = device_registry.async_get(entity.device_id)
+    response = await client.remove_device(live_room_iq_device_entry.id)
+    assert not response["success"]
 
     entity = entity_registry.entities["sensor.nick_office_nick_office_temperature"]
-
     live_zone_device_entry = device_registry.async_get(entity.device_id)
-    client = await hass_ws_client(hass)
     response = await client.remove_device(live_zone_device_entry.id)
     assert not response["success"]
 

--- a/tests/components/nexia/test_init.py
+++ b/tests/components/nexia/test_init.py
@@ -137,3 +137,10 @@ async def test_device_via_device_links(
     assert zone_device is not None
     assert zone_device.via_device_id == thermostat_device.id
     assert zone_device.area_id == "center_nativezone"
+
+    sensor_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "2"),
+        config_entry.entry_id,
+    )
+    assert sensor_device is not None
+    assert sensor_device.via_device_id == zone_device.id

--- a/tests/components/nexia/test_init.py
+++ b/tests/components/nexia/test_init.py
@@ -136,11 +136,12 @@ async def test_device_via_device_links(
     )
     assert zone_device is not None
     assert zone_device.via_device_id == thermostat_device.id
-    assert zone_device.area_id == "center_nativezone"
+    assert zone_device.area_id == "zone3"
 
     sensor_device = device_registry.async_get_device_by_identifier(
-        (DOMAIN, "2"),
+        (DOMAIN, "502"),
         config_entry.entry_id,
     )
     assert sensor_device is not None
     assert sensor_device.via_device_id == zone_device.id
+    assert sensor_device.area_id == "upstairs"

--- a/tests/components/nexia/test_sensor.py
+++ b/tests/components/nexia/test_sensor.py
@@ -6,6 +6,7 @@ from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import PERCENTAGE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceRegistry
 from homeassistant.helpers.entity_registry import EntityRegistry
 
 from .conftest import setup_integration
@@ -154,6 +155,7 @@ async def test_room_iq_sensors(
     hass: HomeAssistant,
     patch_nexia_home: NexiaHome,
     entity_registry: EntityRegistry,
+    device_registry: DeviceRegistry,
 ) -> None:
     """Test NexiaRoomIQSensor."""
 
@@ -173,6 +175,15 @@ async def test_room_iq_sensors(
 
     state = hass.states.get("sensor.zone3_zone3_roomiq_temperature")
     assert state is not None
+
+    # Verify embedded RoomIQ sensor shows thermostat's model and firmware version
+    entry = entity_registry.async_get(state.entity_id)
+    device = device_registry.async_get(entry.device_id)
+    assert device is not None
+    assert device.model == "XL1050"
+    assert device.sw_version == "5.9.1"
+
+    # Verify states
     assert state.state == "25.0"
     assert state.attributes["device_class"] == SensorDeviceClass.TEMPERATURE
     assert state.attributes["friendly_name"] == "Zone3 RoomIQ temperature"
@@ -190,6 +201,15 @@ async def test_room_iq_sensors(
 
     state = hass.states.get("sensor.upstairs_upstairs_roomiq_temperature")
     assert state is not None
+
+    # Verify online RoomIQ sensor shows no model nor firmware version
+    entry = entity_registry.async_get(state.entity_id)
+    device = device_registry.async_get(entry.device_id)
+    assert device is not None
+    assert device.model is None
+    assert device.sw_version is None
+
+    # Verify states
     assert state.state == "22.5"
     assert state.attributes["device_class"] == SensorDeviceClass.TEMPERATURE
     assert state.attributes["friendly_name"] == "Upstairs RoomIQ temperature"

--- a/tests/components/nexia/test_sensor.py
+++ b/tests/components/nexia/test_sensor.py
@@ -188,28 +188,28 @@ async def test_room_iq_sensors(
     state = hass.states.get("sensor.zone3_zone3_roomiq_battery")
     assert state is None
 
-    state = hass.states.get("sensor.upstairs_upstairs_roomiq_roomiq_temperature")
+    state = hass.states.get("sensor.upstairs_upstairs_roomiq_temperature")
     assert state is not None
     assert state.state == "22.5"
     assert state.attributes["device_class"] == SensorDeviceClass.TEMPERATURE
-    assert state.attributes["friendly_name"] == "Upstairs RoomIQ RoomIQ temperature"
+    assert state.attributes["friendly_name"] == "Upstairs RoomIQ temperature"
     assert state.attributes["unit_of_measurement"] == UnitOfTemperature.CELSIUS
 
-    state = hass.states.get("sensor.upstairs_upstairs_roomiq_roomiq_humidity")
+    state = hass.states.get("sensor.upstairs_upstairs_roomiq_humidity")
     assert state is not None
     assert state.state == "45"
     assert state.attributes["device_class"] == SensorDeviceClass.HUMIDITY
-    assert state.attributes["friendly_name"] == "Upstairs RoomIQ RoomIQ humidity"
+    assert state.attributes["friendly_name"] == "Upstairs RoomIQ humidity"
     assert state.attributes["unit_of_measurement"] == PERCENTAGE
 
-    state = hass.states.get("sensor.upstairs_upstairs_roomiq_roomiq_battery")
+    state = hass.states.get("sensor.upstairs_upstairs_roomiq_battery")
     assert state is not None
     assert state.state == "93"
     assert state.attributes["device_class"] == SensorDeviceClass.BATTERY
-    assert state.attributes["friendly_name"] == "Upstairs RoomIQ RoomIQ battery"
+    assert state.attributes["friendly_name"] == "Upstairs RoomIQ battery"
     assert state.attributes["unit_of_measurement"] == PERCENTAGE
 
-    state = hass.states.get("sensor.downstairs_downstairs_roomiq_roomiq_temperature")
+    state = hass.states.get("sensor.downstairs_downstairs_roomiq_temperature")
     assert state is not None
     assert state.state == "unavailable"
 

--- a/tests/components/nexia/test_sensor.py
+++ b/tests/components/nexia/test_sensor.py
@@ -253,3 +253,22 @@ async def test_room_iq_sensor_no_longer_present(
     state = hass.states.get("sensor.upstairs_upstairs_roomiq_humidity")
     assert state is not None
     assert state.state == "unavailable"
+
+
+async def test_1_room_iq_sensor(
+    hass: HomeAssistant, patch_nexia_home: NexiaHome, entity_registry: EntityRegistry
+) -> None:
+    """Test one-RoomIQ sensor case."""
+    zone = patch_nexia_home.get_thermostat_by_id(2000003).get_zone_by_id(400)
+    assert len(zone.get_sensors()) == 1
+
+    config_entry = await setup_integration(hass, patch_nexia_home)
+
+    for entry in entity_registry.entities.values():
+        if entry.disabled_by is not None:
+            entity_registry.async_update_entity(entry.entity_id, disabled_by=None)
+    await hass.config_entries.async_reload(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.kitchen_kitchen_roomiq_temperature")
+    assert state is None

--- a/tests/components/nexia/test_sensor.py
+++ b/tests/components/nexia/test_sensor.py
@@ -161,12 +161,10 @@ async def test_room_iq_sensors(
 
     config_entry = await setup_integration(hass, patch_nexia_home)
 
-    # Verify disabled by default
     assert patch_nexia_home.any_room_iq_monitors() is False
     state = hass.states.get("sensor.zone3_zone3_roomiq_temperature")
     assert state is None
 
-    # Enable all disabled entities
     for entry in entity_registry.entities.values():
         if entry.disabled_by is not None:
             entity_registry.async_update_entity(entry.entity_id, disabled_by=None)
@@ -176,14 +174,12 @@ async def test_room_iq_sensors(
     state = hass.states.get("sensor.zone3_zone3_roomiq_temperature")
     assert state is not None
 
-    # Verify embedded RoomIQ sensor shows thermostat's model and firmware version
     entry = entity_registry.async_get(state.entity_id)
     device = device_registry.async_get(entry.device_id)
     assert device is not None
     assert device.model == "XL1050"
     assert device.sw_version == "5.9.1"
 
-    # Verify states
     assert state.state == "25.0"
     assert state.attributes["device_class"] == SensorDeviceClass.TEMPERATURE
     assert state.attributes["friendly_name"] == "Zone3 RoomIQ temperature"
@@ -202,14 +198,12 @@ async def test_room_iq_sensors(
     state = hass.states.get("sensor.upstairs_upstairs_roomiq_temperature")
     assert state is not None
 
-    # Verify online RoomIQ sensor shows no model nor firmware version
     entry = entity_registry.async_get(state.entity_id)
     device = device_registry.async_get(entry.device_id)
     assert device is not None
     assert device.model is None
     assert device.sw_version is None
 
-    # Verify states
     assert state.state == "22.5"
     assert state.attributes["device_class"] == SensorDeviceClass.TEMPERATURE
     assert state.attributes["friendly_name"] == "Upstairs RoomIQ temperature"
@@ -233,10 +227,8 @@ async def test_room_iq_sensors(
     assert state is not None
     assert state.state == "unavailable"
 
-    # Verify sensors are registered
     assert patch_nexia_home.any_room_iq_monitors() is True
 
-    # Unload should trigger registration removal
     await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
     assert config_entry.state is ConfigEntryState.NOT_LOADED

--- a/tests/components/nexia/test_sensor.py
+++ b/tests/components/nexia/test_sensor.py
@@ -222,6 +222,16 @@ async def test_room_iq_sensors(
     assert state.attributes["friendly_name"] == "Upstairs RoomIQ humidity"
     assert state.attributes["unit_of_measurement"] == PERCENTAGE
 
+    # Verify RoomIQ sensor no longer present
+    entity = hass.data["sensor"].get_entity("sensor.upstairs_upstairs_roomiq_humidity")
+    assert entity is not None
+    entity._zone.get_sensor_by_id.side_effect = KeyError
+    entity.async_write_ha_state()
+
+    state = hass.states.get("sensor.upstairs_upstairs_roomiq_humidity")
+    assert state is not None
+    assert state.state == "unavailable"
+
     state = hass.states.get("sensor.upstairs_upstairs_roomiq_battery")
     assert state is not None
     assert state.state == "93"

--- a/tests/components/nexia/test_sensor.py
+++ b/tests/components/nexia/test_sensor.py
@@ -2,8 +2,11 @@
 
 from nexia.home import NexiaHome
 
+from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import PERCENTAGE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_registry import EntityRegistry
 
 from .conftest import setup_integration
 
@@ -145,3 +148,76 @@ async def test_create_sensors(hass: HomeAssistant, patch_nexia_home: NexiaHome) 
     assert all(
         state.attributes[key] == value for key, value in expected_attributes.items()
     )
+
+
+async def test_room_iq_sensors(
+    hass: HomeAssistant,
+    patch_nexia_home: NexiaHome,
+    entity_registry: EntityRegistry,
+) -> None:
+    """Test NexiaRoomIQSensor."""
+
+    config_entry = await setup_integration(hass, patch_nexia_home)
+
+    # Verify disabled by default
+    assert patch_nexia_home.any_room_iq_monitors() is False
+    state = hass.states.get("sensor.zone3_zone3_roomiq_temperature")
+    assert state is None
+
+    # Enable all disabled entities
+    for entry in entity_registry.entities.values():
+        if entry.disabled_by is not None:
+            entity_registry.async_update_entity(entry.entity_id, disabled_by=None)
+    await hass.config_entries.async_reload(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.zone3_zone3_roomiq_temperature")
+    assert state is not None
+    assert state.state == "25.0"
+    assert state.attributes["device_class"] == SensorDeviceClass.TEMPERATURE
+    assert state.attributes["friendly_name"] == "Zone3 RoomIQ temperature"
+    assert state.attributes["unit_of_measurement"] == UnitOfTemperature.CELSIUS
+
+    state = hass.states.get("sensor.zone3_zone3_roomiq_humidity")
+    assert state is not None
+    assert state.state == "45"
+    assert state.attributes["device_class"] == SensorDeviceClass.HUMIDITY
+    assert state.attributes["friendly_name"] == "Zone3 RoomIQ humidity"
+    assert state.attributes["unit_of_measurement"] == PERCENTAGE
+
+    state = hass.states.get("sensor.zone3_zone3_roomiq_battery")
+    assert state is None
+
+    state = hass.states.get("sensor.upstairs_upstairs_roomiq_roomiq_temperature")
+    assert state is not None
+    assert state.state == "22.5"
+    assert state.attributes["device_class"] == SensorDeviceClass.TEMPERATURE
+    assert state.attributes["friendly_name"] == "Upstairs RoomIQ RoomIQ temperature"
+    assert state.attributes["unit_of_measurement"] == UnitOfTemperature.CELSIUS
+
+    state = hass.states.get("sensor.upstairs_upstairs_roomiq_roomiq_humidity")
+    assert state is not None
+    assert state.state == "45"
+    assert state.attributes["device_class"] == SensorDeviceClass.HUMIDITY
+    assert state.attributes["friendly_name"] == "Upstairs RoomIQ RoomIQ humidity"
+    assert state.attributes["unit_of_measurement"] == PERCENTAGE
+
+    state = hass.states.get("sensor.upstairs_upstairs_roomiq_roomiq_battery")
+    assert state is not None
+    assert state.state == "93"
+    assert state.attributes["device_class"] == SensorDeviceClass.BATTERY
+    assert state.attributes["friendly_name"] == "Upstairs RoomIQ RoomIQ battery"
+    assert state.attributes["unit_of_measurement"] == PERCENTAGE
+
+    state = hass.states.get("sensor.downstairs_downstairs_roomiq_roomiq_temperature")
+    assert state is not None
+    assert state.state == "unavailable"
+
+    # Verify sensors are registered
+    assert patch_nexia_home.any_room_iq_monitors() is True
+
+    # Unload should trigger registration removal
+    await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
+    assert patch_nexia_home.any_room_iq_monitors() is False

--- a/tests/components/nexia/test_sensor.py
+++ b/tests/components/nexia/test_sensor.py
@@ -222,16 +222,6 @@ async def test_room_iq_sensors(
     assert state.attributes["friendly_name"] == "Upstairs RoomIQ humidity"
     assert state.attributes["unit_of_measurement"] == PERCENTAGE
 
-    # Verify RoomIQ sensor no longer present
-    entity = hass.data["sensor"].get_entity("sensor.upstairs_upstairs_roomiq_humidity")
-    assert entity is not None
-    entity._zone.get_sensor_by_id.side_effect = KeyError
-    entity.async_write_ha_state()
-
-    state = hass.states.get("sensor.upstairs_upstairs_roomiq_humidity")
-    assert state is not None
-    assert state.state == "unavailable"
-
     state = hass.states.get("sensor.upstairs_upstairs_roomiq_battery")
     assert state is not None
     assert state.state == "93"
@@ -251,3 +241,23 @@ async def test_room_iq_sensors(
     await hass.async_block_till_done()
     assert config_entry.state is ConfigEntryState.NOT_LOADED
     assert patch_nexia_home.any_room_iq_monitors() is False
+
+
+async def test_room_iq_sensor_no_longer_present(
+    hass: HomeAssistant, patch_nexia_home: NexiaHome, entity_registry: EntityRegistry
+) -> None:
+    """Test RoomIQ sensor no longer present."""
+    zone = patch_nexia_home.get_thermostat_by_id(2000004).get_zone_by_id(500)
+    zone.get_sensor_by_id.side_effect = KeyError
+
+    config_entry = await setup_integration(hass, patch_nexia_home)
+    entry = entity_registry.async_get("sensor.upstairs_upstairs_roomiq_humidity")
+    assert entry is not None
+    assert entry.disabled_by is not None
+    entity_registry.async_update_entity(entry.entity_id, disabled_by=None)
+    await hass.config_entries.async_reload(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.upstairs_upstairs_roomiq_humidity")
+    assert state is not None
+    assert state.state == "unavailable"

--- a/tests/components/nexia/test_sensor.py
+++ b/tests/components/nexia/test_sensor.py
@@ -1,5 +1,7 @@
 """Tests for the nexia sensor platform."""
 
+from unittest.mock import NonCallableMock
+
 from nexia.home import NexiaHome
 import pytest
 
@@ -155,13 +157,14 @@ async def test_create_sensors(hass: HomeAssistant, patch_nexia_home: NexiaHome) 
 
 
 async def test_room_iq_sensor_disabled_by_default(
-    hass: HomeAssistant, patch_nexia_home: NexiaHome
+    hass: HomeAssistant, patch_nexia_home: NonCallableMock[NexiaHome]
 ) -> None:
     """Test NexiaRoomIQSensor is disabled by default."""
 
     await setup_integration(hass, patch_nexia_home)
 
     assert patch_nexia_home.any_room_iq_monitors() is False
+    assert patch_nexia_home.update.await_count == 1
     state = hass.states.get("sensor.zone3_zone3_roomiq_temperature")
     assert state is None
 
@@ -169,7 +172,7 @@ async def test_room_iq_sensor_disabled_by_default(
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_room_iq_sensors(
     hass: HomeAssistant,
-    patch_nexia_home: NexiaHome,
+    patch_nexia_home: NonCallableMock[NexiaHome],
     entity_registry: EntityRegistry,
     device_registry: DeviceRegistry,
 ) -> None:
@@ -177,6 +180,8 @@ async def test_room_iq_sensors(
 
     await setup_integration(hass, patch_nexia_home)
 
+    assert patch_nexia_home.any_room_iq_monitors() is True
+    assert patch_nexia_home.update.await_count == 2
     state = hass.states.get("sensor.zone3_zone3_roomiq_temperature")
     assert state is not None
 

--- a/tests/components/nexia/test_sensor.py
+++ b/tests/components/nexia/test_sensor.py
@@ -1,6 +1,7 @@
 """Tests for the nexia sensor platform."""
 
 from nexia.home import NexiaHome
+import pytest
 
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.config_entries import ConfigEntryState
@@ -151,6 +152,19 @@ async def test_create_sensors(hass: HomeAssistant, patch_nexia_home: NexiaHome) 
     )
 
 
+async def test_room_iq_sensor_disabled_by_default(
+    hass: HomeAssistant, patch_nexia_home: NexiaHome
+) -> None:
+    """Test NexiaRoomIQSensor is disabled by default."""
+
+    await setup_integration(hass, patch_nexia_home)
+
+    assert patch_nexia_home.any_room_iq_monitors() is False
+    state = hass.states.get("sensor.zone3_zone3_roomiq_temperature")
+    assert state is None
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_room_iq_sensors(
     hass: HomeAssistant,
     patch_nexia_home: NexiaHome,
@@ -159,17 +173,7 @@ async def test_room_iq_sensors(
 ) -> None:
     """Test NexiaRoomIQSensor."""
 
-    config_entry = await setup_integration(hass, patch_nexia_home)
-
-    assert patch_nexia_home.any_room_iq_monitors() is False
-    state = hass.states.get("sensor.zone3_zone3_roomiq_temperature")
-    assert state is None
-
-    for entry in entity_registry.entities.values():
-        if entry.disabled_by is not None:
-            entity_registry.async_update_entity(entry.entity_id, disabled_by=None)
-    await hass.config_entries.async_reload(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await setup_integration(hass, patch_nexia_home)
 
     state = hass.states.get("sensor.zone3_zone3_roomiq_temperature")
     assert state is not None
@@ -227,6 +231,15 @@ async def test_room_iq_sensors(
     assert state is not None
     assert state.state == "unavailable"
 
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_any_room_iq_monitors(
+    hass: HomeAssistant, patch_nexia_home: NexiaHome
+) -> None:
+    """Test any_room_iq_monitors after unload."""
+
+    config_entry = await setup_integration(hass, patch_nexia_home)
+
     assert patch_nexia_home.any_room_iq_monitors() is True
 
     await hass.config_entries.async_unload(config_entry.entry_id)
@@ -235,40 +248,30 @@ async def test_room_iq_sensors(
     assert patch_nexia_home.any_room_iq_monitors() is False
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_room_iq_sensor_no_longer_present(
-    hass: HomeAssistant, patch_nexia_home: NexiaHome, entity_registry: EntityRegistry
+    hass: HomeAssistant, patch_nexia_home: NexiaHome
 ) -> None:
     """Test RoomIQ sensor no longer present."""
     zone = patch_nexia_home.get_thermostat_by_id(2000004).get_zone_by_id(500)
     zone.get_sensor_by_id.side_effect = KeyError
 
-    config_entry = await setup_integration(hass, patch_nexia_home)
-    entry = entity_registry.async_get("sensor.upstairs_upstairs_roomiq_humidity")
-    assert entry is not None
-    assert entry.disabled_by is not None
-    entity_registry.async_update_entity(entry.entity_id, disabled_by=None)
-    await hass.config_entries.async_reload(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await setup_integration(hass, patch_nexia_home)
 
     state = hass.states.get("sensor.upstairs_upstairs_roomiq_humidity")
     assert state is not None
     assert state.state == "unavailable"
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_1_room_iq_sensor(
-    hass: HomeAssistant, patch_nexia_home: NexiaHome, entity_registry: EntityRegistry
+    hass: HomeAssistant, patch_nexia_home: NexiaHome
 ) -> None:
     """Test one-RoomIQ sensor case."""
     zone = patch_nexia_home.get_thermostat_by_id(2000003).get_zone_by_id(400)
     assert len(zone.get_sensors()) == 1
 
-    config_entry = await setup_integration(hass, patch_nexia_home)
-
-    for entry in entity_registry.entities.values():
-        if entry.disabled_by is not None:
-            entity_registry.async_update_entity(entry.entity_id, disabled_by=None)
-    await hass.config_entries.async_reload(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await setup_integration(hass, patch_nexia_home)
 
     state = hass.states.get("sensor.kitchen_kitchen_roomiq_temperature")
     assert state is None

--- a/tests/components/nexia/test_sensor.py
+++ b/tests/components/nexia/test_sensor.py
@@ -3,10 +3,12 @@
 from nexia.home import NexiaHome
 import pytest
 
-from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.components.nexia import DOMAIN
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import PERCENTAGE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_platform
 from homeassistant.helpers.device_registry import DeviceRegistry
 from homeassistant.helpers.entity_registry import EntityRegistry
 
@@ -261,6 +263,17 @@ async def test_room_iq_sensor_no_longer_present(
     state = hass.states.get("sensor.upstairs_upstairs_roomiq_humidity")
     assert state is not None
     assert state.state == "unavailable"
+
+    platforms = entity_platform.async_get_platforms(hass, DOMAIN)
+    entity: SensorEntity | None = None
+    for platform in platforms:
+        if state.entity_id in platform.entities:
+            entity = platform.entities[state.entity_id]
+            break
+
+    assert isinstance(entity, SensorEntity) is True
+    # call entity directly since state machine seems to guard against this case
+    assert entity.native_value is None
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")

--- a/tests/components/nexia/test_sensor.py
+++ b/tests/components/nexia/test_sensor.py
@@ -278,10 +278,9 @@ async def test_room_iq_sensor_no_longer_present(
     assert state.state == "unavailable"
 
     def get_sensor_raise_from_native_value(sensor_id: int) -> NexiaSensor:
-        caller_frame = inspect.stack()[4]
-
-        if caller_frame.function == "native_value":
-            raise KeyError
+        for caller_frame in inspect.stack():
+            if caller_frame.function == "native_value":
+                raise KeyError
 
         return get_item(sensor_id)
 

--- a/tests/components/nexia/test_sensor.py
+++ b/tests/components/nexia/test_sensor.py
@@ -1,20 +1,27 @@
 """Tests for the nexia sensor platform."""
 
+from datetime import timedelta
+import inspect
 from unittest.mock import NonCallableMock
 
+from freezegun.api import FrozenDateTimeFactory
 from nexia.home import NexiaHome
+from nexia.sensor import NexiaSensor
 import pytest
 
-from homeassistant.components.nexia import DOMAIN
-from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
+from homeassistant.components.nexia.coordinator import (
+    DEFAULT_UPDATE_RATE as COORDINATOR_UPDATE_RATE,
+)
+from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import PERCENTAGE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_platform
 from homeassistant.helpers.device_registry import DeviceRegistry
 from homeassistant.helpers.entity_registry import EntityRegistry
 
 from .conftest import setup_integration
+
+from tests.common import async_fire_time_changed
 
 
 async def test_create_sensors(hass: HomeAssistant, patch_nexia_home: NexiaHome) -> None:
@@ -257,10 +264,11 @@ async def test_any_room_iq_monitors(
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_room_iq_sensor_no_longer_present(
-    hass: HomeAssistant, patch_nexia_home: NexiaHome
+    hass: HomeAssistant, patch_nexia_home: NexiaHome, freezer: FrozenDateTimeFactory
 ) -> None:
     """Test RoomIQ sensor no longer present."""
     zone = patch_nexia_home.get_thermostat_by_id(2000004).get_zone_by_id(500)
+    get_item = zone.get_sensor_by_id.side_effect
     zone.get_sensor_by_id.side_effect = KeyError
 
     await setup_integration(hass, patch_nexia_home)
@@ -269,16 +277,26 @@ async def test_room_iq_sensor_no_longer_present(
     assert state is not None
     assert state.state == "unavailable"
 
-    platforms = entity_platform.async_get_platforms(hass, DOMAIN)
-    entity: SensorEntity | None = None
-    for platform in platforms:
-        if state.entity_id in platform.entities:
-            entity = platform.entities[state.entity_id]
-            break
+    def get_sensor_raise_from_native_value(sensor_id: int) -> NexiaSensor:
+        caller_frame = inspect.stack()[4]
 
-    assert isinstance(entity, SensorEntity) is True
-    # call entity directly since state machine seems to guard against this case
-    assert entity.native_value is None
+        if caller_frame.function == "native_value":
+            raise KeyError
+
+        return get_item(sensor_id)
+
+    # The state machine won't call NexiaRoomIQSensor.native_value() when unavailable, so only
+    # raise when called from native_value() & return something new to coordinator so it updates
+    zone.get_sensor_by_id.side_effect = get_sensor_raise_from_native_value
+    patch_nexia_home.update.return_value = {"key": "different value"}
+
+    freezer.tick(timedelta(seconds=COORDINATOR_UPDATE_RATE))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.upstairs_upstairs_roomiq_humidity")
+    assert state is not None
+    assert state.state == "unknown"
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")

--- a/tests/components/nexia/test_switch.py
+++ b/tests/components/nexia/test_switch.py
@@ -39,9 +39,9 @@ async def test_nexia_sensor_switch(
 
     await setup_integration(hass, patch_nexia_home)
 
-    sw1_id = f"{Platform.SWITCH}.center_nativezone_center_nativezone_include_center"
+    sw1_id = f"{Platform.SWITCH}.zone3_zone3_include_center"
     sw1 = {ATTR_ENTITY_ID: sw1_id}
-    sw2_id = f"{Platform.SWITCH}.center_nativezone_center_nativezone_include_upstairs"
+    sw2_id = f"{Platform.SWITCH}.zone3_zone3_include_upstairs"
     sw2 = {ATTR_ENTITY_ID: sw2_id}
 
     # Switch starts out on


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
With this change, the nexia integration creates entities corresponding to the RoomIQ sensors reported by the nexia library:

- temperature
- humidity
- battery level, if sensor has battery

These entities are created in a zone only when more than 1 RoomIQ sensor is present in that zone. When enabled, these entities register with the nexia library to monitor RoomIQ sensor state updates. This causes each Nexia Home update to also fetch the current RoomIQ sensor states for this zone, adding 5–40 seconds of latency and additional network traffic. To avoid silently doing so, these entities are disabled by default.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/46491
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
