### PR TITLE
Refactor Roborock time platform to use library property APIs

### DIFF
--- a/homeassistant/components/roborock/time.py
+++ b/homeassistant/components/roborock/time.py
@@ -30,13 +30,6 @@ _LOGGER = logging.getLogger(__name__)
 PARALLEL_UPDATES = 0
 
 
-def _build_time(hour: int | None, minute: int | None) -> datetime.time | None:
-    """Build a time, returning None when either component is missing."""
-    if hour is None or minute is None:
-        return None
-    return datetime.time(hour=hour, minute=minute)
-
-
 @dataclass(frozen=True, kw_only=True)
 class RoborockTimeDescription(TimeEntityDescription):
     """Class to describe a Roborock time entity."""
@@ -65,7 +58,7 @@ TIME_DESCRIPTIONS: list[RoborockTimeDescription] = [
                 end_minute=trait.end_minute,
             )
         ),
-        get_value=lambda trait: _build_time(trait.start_hour, trait.start_minute),
+        get_value=lambda trait: trait.start_time,
         entity_category=EntityCategory.CONFIG,
     ),
     RoborockTimeDescription(
@@ -81,7 +74,7 @@ TIME_DESCRIPTIONS: list[RoborockTimeDescription] = [
                 end_minute=desired_time.minute,
             )
         ),
-        get_value=lambda trait: _build_time(trait.end_hour, trait.end_minute),
+        get_value=lambda trait: trait.end_time,
         entity_category=EntityCategory.CONFIG,
     ),
     RoborockTimeDescription(
@@ -97,7 +90,7 @@ TIME_DESCRIPTIONS: list[RoborockTimeDescription] = [
                 end_minute=trait.end_minute,
             )
         ),
-        get_value=lambda trait: _build_time(trait.start_hour, trait.start_minute),
+        get_value=lambda trait: trait.start_time,
         entity_category=EntityCategory.CONFIG,
         entity_registry_enabled_default=False,
     ),
@@ -114,7 +107,7 @@ TIME_DESCRIPTIONS: list[RoborockTimeDescription] = [
                 end_minute=desired_time.minute,
             )
         ),
-        get_value=lambda trait: _build_time(trait.end_hour, trait.end_minute),
+        get_value=lambda trait: trait.end_time,
         entity_category=EntityCategory.CONFIG,
         entity_registry_enabled_default=False,
     ),

--- a/tests/components/roborock/conftest.py
+++ b/tests/components/roborock/conftest.py
@@ -3,6 +3,7 @@
 import asyncio
 from collections.abc import Callable, Generator
 from copy import deepcopy
+from dataclasses import asdict
 import logging
 import pathlib
 import tempfile
@@ -272,12 +273,9 @@ def make_mock_switch(
     return trait
 
 
-def make_dnd_timer(dataclass_template: RoborockBase) -> AsyncMock:
-    """Make a function for the fake timer trait that emulates the real behavior."""
-    dnd_trait = make_mock_switch(
-        trait_spec=DoNotDisturbTrait,
-        dataclass_template=dataclass_template,
-    )
+def make_dnd_timer(dataclass_template: RoborockBase) -> DoNotDisturbTrait:
+    """Create a DoNotDisturbTrait for testing."""
+    dnd_trait = DoNotDisturbTrait(**asdict(dataclass_template))
 
     async def set_dnd_timer(timer: DnDTimer) -> None:
         dnd_trait.start_hour = timer.start_hour
@@ -286,16 +284,19 @@ def make_dnd_timer(dataclass_template: RoborockBase) -> AsyncMock:
         dnd_trait.end_minute = timer.end_minute
         dnd_trait.enabled = timer.enabled
 
-    dnd_trait.set_dnd_timer = AsyncMock()
-    dnd_trait.set_dnd_timer.side_effect = set_dnd_timer
+    dnd_trait.set_dnd_timer = AsyncMock(side_effect=set_dnd_timer)
+    dnd_trait.enable = AsyncMock(side_effect=lambda: setattr(dnd_trait, "enabled", 1))
+    dnd_trait.disable = AsyncMock(side_effect=lambda: setattr(dnd_trait, "enabled", 0))
+    dnd_trait.refresh = AsyncMock()
     return dnd_trait
 
 
-def make_valley_electric_timer(dataclass_template: RoborockBase) -> AsyncMock:
-    """Make a function for the fake timer trait that emulates the real behavior."""
-    valley_electric_timer_trait = make_mock_switch(
-        trait_spec=ValleyElectricityTimerTrait,
-        dataclass_template=dataclass_template,
+def make_valley_electric_timer(
+    dataclass_template: RoborockBase,
+) -> ValleyElectricityTimerTrait:
+    """Create a ValleyElectricityTimerTrait for testing."""
+    valley_electric_timer_trait = ValleyElectricityTimerTrait(
+        **asdict(dataclass_template)
     )
 
     async def set_timer(timer: ValleyElectricityTimer) -> None:
@@ -305,8 +306,14 @@ def make_valley_electric_timer(dataclass_template: RoborockBase) -> AsyncMock:
         valley_electric_timer_trait.end_minute = timer.end_minute
         valley_electric_timer_trait.enabled = timer.enabled
 
-    valley_electric_timer_trait.set_timer = AsyncMock()
-    valley_electric_timer_trait.set_timer.side_effect = set_timer
+    valley_electric_timer_trait.set_timer = AsyncMock(side_effect=set_timer)
+    valley_electric_timer_trait.enable = AsyncMock(
+        side_effect=lambda: setattr(valley_electric_timer_trait, "enabled", 1)
+    )
+    valley_electric_timer_trait.disable = AsyncMock(
+        side_effect=lambda: setattr(valley_electric_timer_trait, "enabled", 0)
+    )
+    valley_electric_timer_trait.refresh = AsyncMock()
     return valley_electric_timer_trait
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Refactored the Roborock time platform to use the existing `start_time` and `end_time` properties from the `python-roborock` library rather than implementing a redundant custom `_build_time` helper function in Home Assistant. This is an update on the fix in #174873

Additionally, updated the test fixtures in `conftest.py` (`make_dnd_timer` and `make_valley_electric_timer`) to instantiate the actual `DoNotDisturbTrait` and `ValleyElectricityTimerTrait` library classes rather than using a mock switch. This allows properties like `start_time` and `end_time` to evaluate dynamically and correctly during tests. The trait classes are cleanly instantiated using `**asdict(dataclass_template)`.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
