### PR TITLE
Check for supported fan speed modes in Synology DSM

### DIFF
--- a/homeassistant/components/synology_dsm/icons.json
+++ b/homeassistant/components/synology_dsm/icons.json
@@ -11,6 +11,7 @@
         "state": {
           "cool": "mdi:fan-speed-2",
           "full_speed": "mdi:fan-speed-3",
+          "low_power": "mdi:fan-chevron-down",
           "quiet": "mdi:fan-speed-1"
         }
       }

--- a/homeassistant/components/synology_dsm/manifest.json
+++ b/homeassistant/components/synology_dsm/manifest.json
@@ -8,7 +8,7 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["synology_dsm"],
-  "requirements": ["py-synologydsm-api==2.10.0"],
+  "requirements": ["py-synologydsm-api==2.10.1"],
   "ssdp": [
     {
       "deviceType": "urn:schemas-upnp-org:device:Basic:1",

--- a/homeassistant/components/synology_dsm/select.py
+++ b/homeassistant/components/synology_dsm/select.py
@@ -15,6 +15,7 @@ from .coordinator import SynologyDSMCentralUpdateCoordinator, SynologyDSMConfigE
 from .entity import SynologyDSMBaseEntity, SynologyDSMEntityDescription
 
 FAN_SPEED_MAP = {
+    FanSpeed.QUIET_STOP: "low_power",
     FanSpeed.QUIET: "quiet",
     FanSpeed.COOL: "cool",
     FanSpeed.FULL: "full_speed",
@@ -47,7 +48,6 @@ class SynologyDSMFanSpeedMode(
 ):
     """Represent a Synology DSM fan speed mode select entity."""
 
-    _attr_options = list(FAN_SPEED_MAP.values())
     entity_description: SynologyDSMSelectEntityDescription
 
     def __init__(
@@ -62,6 +62,11 @@ class SynologyDSMFanSpeedMode(
             translation_key="fan_speed_mode",
             entity_category=EntityCategory.CONFIG,
         )
+        self._attr_options = [
+            val
+            for fs, val in FAN_SPEED_MAP.items()
+            if fs in api.dsm.hardware.supported_fan_speeds
+        ]
         super().__init__(api, coordinator, description)
 
     @property

--- a/homeassistant/components/synology_dsm/strings.json
+++ b/homeassistant/components/synology_dsm/strings.json
@@ -87,6 +87,7 @@
         "state": {
           "cool": "Cool mode",
           "full_speed": "Full-speed mode",
+          "low_power": "Low-Power mode",
           "quiet": "Quiet mode"
         }
       }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1948,7 +1948,7 @@ py-schluter==0.1.7
 py-sucks==0.9.11
 
 # homeassistant.components.synology_dsm
-py-synologydsm-api==2.10.0
+py-synologydsm-api==2.10.1
 
 # homeassistant.components.unifi_access
 py-unifi-access==1.3.0

--- a/tests/components/synology_dsm/common.py
+++ b/tests/components/synology_dsm/common.py
@@ -12,7 +12,16 @@ from .consts import SERIAL
 
 def mock_dsm_hardware(fan_speed: FanSpeed = FanSpeed.COOL) -> Mock:
     """Mock SynologyDSM hardware information."""
-    return AsyncMock(update=AsyncMock(), fan_speed=fan_speed)
+    return AsyncMock(
+        update=AsyncMock(),
+        fan_speed=fan_speed,
+        supported_fan_speeds=[
+            FanSpeed.FULL,
+            FanSpeed.COOL,
+            FanSpeed.QUIET,
+            FanSpeed.QUIET_STOP,
+        ],
+    )
 
 
 def mock_dsm_information(

--- a/tests/components/synology_dsm/snapshots/test_select.ambr
+++ b/tests/components/synology_dsm/snapshots/test_select.ambr
@@ -7,6 +7,7 @@
     'area_id': None,
     'capabilities': dict({
       <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'low_power',
         'quiet',
         'cool',
         'full_speed',
@@ -48,7 +49,68 @@
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Synology',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'nas.meontheinternet.com Fan speed mode',
       <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'low_power',
         'quiet',
+        'cool',
+        'full_speed',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.nas_meontheinternet_com_fan_speed_mode',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'cool',
+  })
+# ---
+# name: test_fan_speed_supported_option[select.nas_meontheinternet_com_fan_speed_mode-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'cool',
+        'full_speed',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'select.nas_meontheinternet_com_fan_speed_mode',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Fan speed mode',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Fan speed mode',
+    'platform': 'synology_dsm',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'fan_speed_mode',
+    'unique_id': 'mySerial_SYNO.Core.Hardware:fan_speed_mode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_fan_speed_supported_option[select.nas_meontheinternet_com_fan_speed_mode-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Synology',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'nas.meontheinternet.com Fan speed mode',
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'cool',
         'full_speed',
       ]),

--- a/tests/components/synology_dsm/test_select.py
+++ b/tests/components/synology_dsm/test_select.py
@@ -2,7 +2,6 @@
 
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
-from pylint_home_assistant.const import Platform
 import pytest
 from synology_dsm.api.core.hardware import FanSpeed
 from syrupy.assertion import SnapshotAssertion
@@ -85,7 +84,12 @@ async def test_fan_speed(
 
 @pytest.mark.parametrize(
     ("fan_speed", "fan_speed_parameter"),
-    [("full_speed", FanSpeed.FULL), ("cool", FanSpeed.COOL), ("quiet", FanSpeed.QUIET)],
+    [
+        ("full_speed", FanSpeed.FULL),
+        ("cool", FanSpeed.COOL),
+        ("quiet", FanSpeed.QUIET),
+        ("low_power", FanSpeed.QUIET_STOP),
+    ],
 )
 async def test_fan_speed_select_option(
     hass: HomeAssistant,
@@ -99,7 +103,7 @@ async def test_fan_speed_select_option(
             "homeassistant.components.synology_dsm.common.SynologyDSM",
             return_value=mock_dsm,
         ),
-        patch("homeassistant.components.synology_dsm.PLATFORMS", [Platform.SELECT]),
+        patch("homeassistant.components.synology_dsm.PLATFORMS", ["select"]),
     ):
         entry = MockConfigEntry(
             domain=DOMAIN,
@@ -127,3 +131,39 @@ async def test_fan_speed_select_option(
         blocking=True,
     )
     assert mock_dsm.hardware.set_fan_speed.call_args[0][0] == fan_speed_parameter
+
+
+async def test_fan_speed_supported_option(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+    mock_dsm: MagicMock,
+) -> None:
+    """Test selecting a fan speed mode option."""
+    with (
+        patch(
+            "homeassistant.components.synology_dsm.common.SynologyDSM",
+            return_value=mock_dsm,
+        ),
+        patch("homeassistant.components.synology_dsm.PLATFORMS", ["select"]),
+    ):
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={
+                CONF_HOST: HOST,
+                CONF_PORT: PORT,
+                CONF_SSL: USE_SSL,
+                CONF_USERNAME: USERNAME,
+                CONF_PASSWORD: PASSWORD,
+                CONF_MAC: MACS[0],
+            },
+            unique_id=SERIAL,
+        )
+        entry.add_to_hass(hass)
+
+        mock_dsm.hardware.supported_fan_speeds = [FanSpeed.FULL, FanSpeed.COOL]
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Release-Notes: https://github.com/mib1185/py-synologydsm-api/releases/tag/v2.10.1
Diff: https://github.com/mib1185/py-synologydsm-api/compare/v2.10.0...v2.10.1
noteworthy changes:
- https://github.com/mib1185/py-synologydsm-api/pull/425

This dependency update is necessary to implement a check for supported fan speed modes in the select entity.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #174885
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/46494
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
