### PR TITLE
Use async config flow in stiebel_eltron integration

### DIFF
--- a/homeassistant/components/stiebel_eltron/config_flow.py
+++ b/homeassistant/components/stiebel_eltron/config_flow.py
@@ -3,16 +3,28 @@
 import logging
 from typing import Any, override
 
-from pymodbus.client import ModbusTcpClient
-from pystiebeleltron.pystiebeleltron import StiebelEltronAPI
+from pystiebeleltron import StiebelEltronModbusError, get_controller_model
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
-from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
+from homeassistant.const import CONF_HOST, CONF_PORT
 
 from .const import DEFAULT_PORT, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+
+async def check_controller_model(host: str, port: int) -> str | None:
+    """Check if the controller model is valid."""
+    try:
+        await get_controller_model(host, port)
+    except StiebelEltronModbusError:
+        _LOGGER.debug("Cannot connect to Stiebel Eltron device", exc_info=True)
+        return "cannot_connect"
+    except Exception:
+        _LOGGER.exception("Unexpected exception")
+        return "unknown"
+    return None
 
 
 class StiebelEltronConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -30,18 +42,12 @@ class StiebelEltronConfigFlow(ConfigFlow, domain=DOMAIN):
             self._async_abort_entries_match(
                 {CONF_HOST: user_input[CONF_HOST], CONF_PORT: user_input[CONF_PORT]}
             )
-            client = StiebelEltronAPI(
-                ModbusTcpClient(user_input[CONF_HOST], port=user_input[CONF_PORT]), 1
+            error = await check_controller_model(
+                user_input[CONF_HOST], user_input[CONF_PORT]
             )
-            try:
-                success = await self.hass.async_add_executor_job(client.update)
-            except Exception:
-                _LOGGER.exception("Unexpected exception")
-                errors["base"] = "unknown"
+            if error is not None:
+                errors["base"] = error
             else:
-                if not success:
-                    errors["base"] = "cannot_connect"
-            if not errors:
                 return self.async_create_entry(title="Stiebel Eltron", data=user_input)
 
         return self.async_show_form(
@@ -53,29 +59,4 @@ class StiebelEltronConfigFlow(ConfigFlow, domain=DOMAIN):
                 }
             ),
             errors=errors,
-        )
-
-    async def async_step_import(self, user_input: dict[str, Any]) -> ConfigFlowResult:
-        """Handle import."""
-        self._async_abort_entries_match(
-            {CONF_HOST: user_input[CONF_HOST], CONF_PORT: user_input[CONF_PORT]}
-        )
-        client = StiebelEltronAPI(
-            ModbusTcpClient(user_input[CONF_HOST], port=user_input[CONF_PORT]), 1
-        )
-        try:
-            success = await self.hass.async_add_executor_job(client.update)
-        except Exception:
-            _LOGGER.exception("Unexpected exception")
-            return self.async_abort(reason="unknown")
-
-        if not success:
-            return self.async_abort(reason="cannot_connect")
-
-        return self.async_create_entry(
-            title=user_input[CONF_NAME],
-            data={
-                CONF_HOST: user_input[CONF_HOST],
-                CONF_PORT: user_input[CONF_PORT],
-            },
         )

--- a/tests/components/stiebel_eltron/conftest.py
+++ b/tests/components/stiebel_eltron/conftest.py
@@ -16,9 +16,16 @@ from tests.common import MockConfigEntry
 @pytest.fixture(autouse=True)
 def mock_get_controller_model() -> Generator[MagicMock]:
     """Mock the Stiebel Eltron get_controller_model function."""
-    with patch(
-        "homeassistant.components.stiebel_eltron.get_controller_model"
-    ) as mock_get_model:
+    with (
+        patch(
+            "homeassistant.components.stiebel_eltron.get_controller_model",
+            autospec=True,
+        ) as mock_get_model,
+        patch(
+            "homeassistant.components.stiebel_eltron.config_flow.get_controller_model",
+            new=mock_get_model,
+        ),
+    ):
         mock_get_model.return_value = ControllerModel.LWZ
         yield mock_get_model
 
@@ -50,24 +57,6 @@ def mock_lwz_api() -> Generator[MagicMock]:
 
         mock_api_cls.return_value = api_client
         yield api_client
-
-
-@pytest.fixture
-def mock_stiebel_eltron_client() -> Generator[MagicMock]:
-    """Mock a stiebel eltron client."""
-    with patch(
-        "homeassistant.components.stiebel_eltron.config_flow.StiebelEltronAPI"
-    ) as mock_client:
-        client = mock_client.return_value
-        client.update.return_value = True
-        client.get_target_temp = MagicMock(return_value=22.5)
-        client.get_current_temp = MagicMock(return_value=21.0)
-        client.get_current_humidity = MagicMock(return_value=45.0)
-        client.get_filter_alarm_status = MagicMock(return_value=False)
-        client.get_operation = MagicMock(return_value="DAY MODE")
-        client.set_operation = MagicMock()
-        client.set_target_temp = MagicMock()
-        yield client
 
 
 @pytest.fixture

--- a/tests/components/stiebel_eltron/test_config_flow.py
+++ b/tests/components/stiebel_eltron/test_config_flow.py
@@ -2,18 +2,17 @@
 
 from unittest.mock import MagicMock
 
-import pytest
+from pystiebeleltron import ControllerModel, StiebelEltronModbusError
 
 from homeassistant.components.stiebel_eltron.const import DOMAIN
-from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
-from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from tests.common import MockConfigEntry
 
 
-@pytest.mark.usefixtures("mock_stiebel_eltron_client")
 async def test_full_flow(hass: HomeAssistant) -> None:
     """Test the full flow."""
     result = await hass.config_entries.flow.async_init(
@@ -40,14 +39,14 @@ async def test_full_flow(hass: HomeAssistant) -> None:
 
 async def test_form_cannot_connect(
     hass: HomeAssistant,
-    mock_stiebel_eltron_client: MagicMock,
+    mock_get_controller_model: MagicMock,
 ) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    mock_stiebel_eltron_client.update.return_value = False
+    mock_get_controller_model.side_effect = StiebelEltronModbusError
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -60,7 +59,7 @@ async def test_form_cannot_connect(
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "cannot_connect"}
 
-    mock_stiebel_eltron_client.update.return_value = True
+    mock_get_controller_model.side_effect = None
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -75,14 +74,14 @@ async def test_form_cannot_connect(
 
 async def test_form_unknown_exception(
     hass: HomeAssistant,
-    mock_stiebel_eltron_client: MagicMock,
+    mock_get_controller_model: MagicMock,
 ) -> None:
-    """Test we handle cannot connect error."""
+    """Test we handle unknown exception."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    mock_stiebel_eltron_client.update.side_effect = Exception
+    mock_get_controller_model.side_effect = Exception
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -95,7 +94,8 @@ async def test_form_unknown_exception(
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "unknown"}
 
-    mock_stiebel_eltron_client.update.side_effect = None
+    mock_get_controller_model.side_effect = None
+    mock_get_controller_model.return_value = ControllerModel.LWZ  # Valid model (LWZ)
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -122,86 +122,6 @@ async def test_already_configured(
         {
             CONF_HOST: "1.1.1.1",
             CONF_PORT: 502,
-        },
-    )
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
-
-
-@pytest.mark.usefixtures("mock_stiebel_eltron_client")
-async def test_import(hass: HomeAssistant) -> None:
-    """Test import step."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_IMPORT},
-        data={
-            CONF_HOST: "1.1.1.1",
-            CONF_PORT: 502,
-            CONF_NAME: "Stiebel Eltron",
-        },
-    )
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == "Stiebel Eltron"
-    assert result["data"] == {
-        CONF_HOST: "1.1.1.1",
-        CONF_PORT: 502,
-    }
-
-
-async def test_import_cannot_connect(
-    hass: HomeAssistant,
-    mock_stiebel_eltron_client: MagicMock,
-) -> None:
-    """Test we handle cannot connect error."""
-    mock_stiebel_eltron_client.update.return_value = False
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_IMPORT},
-        data={
-            CONF_HOST: "1.1.1.1",
-            CONF_PORT: 502,
-            CONF_NAME: "Stiebel Eltron",
-        },
-    )
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "cannot_connect"
-
-
-async def test_import_unknown_exception(
-    hass: HomeAssistant,
-    mock_stiebel_eltron_client: MagicMock,
-) -> None:
-    """Test we handle cannot connect error."""
-    mock_stiebel_eltron_client.update.side_effect = Exception
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_IMPORT},
-        data={
-            CONF_HOST: "1.1.1.1",
-            CONF_PORT: 502,
-            CONF_NAME: "Stiebel Eltron",
-        },
-    )
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "unknown"
-
-
-async def test_import_already_configured(
-    hass: HomeAssistant, mock_config_entry: MockConfigEntry
-) -> None:
-    """Test we handle already configured."""
-    mock_config_entry.add_to_hass(hass)
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_IMPORT},
-        data={
-            CONF_HOST: "1.1.1.1",
-            CONF_PORT: 502,
-            CONF_NAME: "Stiebel Eltron",
         },
     )
 


### PR DESCRIPTION
## Proposed change

Uses functionality provided by pystiebeleltron instead of calling pymodbus directly.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Follow-up of: #174850 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
