### PR TITLE
Fix Airzone min_temp clamped to cooling floor in double-setpoint mode

### DIFF
--- a/homeassistant/components/airzone/climate.py
+++ b/homeassistant/components/airzone/climate.py
@@ -279,8 +279,11 @@ class AirzoneClimate(AirzoneZoneEntity, ClimateEntity):
             # In double-setpoint mode the device reports minTemp using the cooling
             # floor (coolmintemp), which is higher than the heating floor
             # (heatmintemp).  Use the heating minimum so the heat setpoint is not
-            # artificially clamped.  See HA issues #135149 and #140238.
-            self._attr_min_temp = self.get_airzone_value(AZD_HEAT_TEMP_MIN)
+            # artificially clamped.  Fall back to AZD_TEMP_MIN if heatmintemp is
+            # absent.  See HA issues #135149 and #140238.
+            self._attr_min_temp = self.get_airzone_value(
+                AZD_HEAT_TEMP_MIN
+            ) or self.get_airzone_value(AZD_TEMP_MIN)
         else:
             self._attr_min_temp = self.get_airzone_value(AZD_TEMP_MIN)
         if self.supported_features & ClimateEntityFeature.FAN_MODE:

--- a/homeassistant/components/airzone/climate.py
+++ b/homeassistant/components/airzone/climate.py
@@ -13,6 +13,7 @@ from aioairzone.const import (
     AZD_ACTION,
     AZD_COOL_TEMP_SET,
     AZD_DOUBLE_SET_POINT,
+    AZD_HEAT_TEMP_MIN,
     AZD_HEAT_TEMP_SET,
     AZD_HUMIDITY,
     AZD_MASTER,
@@ -274,7 +275,14 @@ class AirzoneClimate(AirzoneZoneEntity, ClimateEntity):
         else:
             self._attr_hvac_mode = HVACMode.OFF
         self._attr_max_temp = self.get_airzone_value(AZD_TEMP_MAX)
-        self._attr_min_temp = self.get_airzone_value(AZD_TEMP_MIN)
+        if self.get_airzone_value(AZD_DOUBLE_SET_POINT):
+            # In double-setpoint mode the device reports minTemp using the cooling
+            # floor (coolmintemp), which is higher than the heating floor
+            # (heatmintemp).  Use the heating minimum so the heat setpoint is not
+            # artificially clamped.  See HA issues #135149 and #140238.
+            self._attr_min_temp = self.get_airzone_value(AZD_HEAT_TEMP_MIN)
+        else:
+            self._attr_min_temp = self.get_airzone_value(AZD_TEMP_MIN)
         if self.supported_features & ClimateEntityFeature.FAN_MODE:
             self._attr_fan_mode = self._speeds.get(self.get_airzone_value(AZD_SPEED))
         if (

--- a/tests/components/airzone/test_climate.py
+++ b/tests/components/airzone/test_climate.py
@@ -220,7 +220,9 @@ async def test_airzone_create_climates(hass: HomeAssistant) -> None:
         HVACMode.OFF,
     ]
     assert state.attributes.get(ATTR_MAX_TEMP) == 32.2
-    assert state.attributes.get(ATTR_MIN_TEMP) == 10.0  # heat_temp_min (50°F), not cooling floor (64°F)
+    assert (
+        state.attributes.get(ATTR_MIN_TEMP) == 10.0
+    )  # heat_temp_min (50°F), not cooling floor (64°F)
     assert state.attributes.get(ATTR_TARGET_TEMP_STEP) == API_TEMPERATURE_STEP
     assert state.attributes.get(ATTR_TARGET_TEMP_HIGH) == 25.0
     assert state.attributes.get(ATTR_TARGET_TEMP_LOW) == 22.8

--- a/tests/components/airzone/test_climate.py
+++ b/tests/components/airzone/test_climate.py
@@ -220,7 +220,7 @@ async def test_airzone_create_climates(hass: HomeAssistant) -> None:
         HVACMode.OFF,
     ]
     assert state.attributes.get(ATTR_MAX_TEMP) == 32.2
-    assert state.attributes.get(ATTR_MIN_TEMP) == 17.8
+    assert state.attributes.get(ATTR_MIN_TEMP) == 10.0  # heat_temp_min (50°F), not cooling floor (64°F)
     assert state.attributes.get(ATTR_TARGET_TEMP_STEP) == API_TEMPERATURE_STEP
     assert state.attributes.get(ATTR_TARGET_TEMP_HIGH) == 25.0
     assert state.attributes.get(ATTR_TARGET_TEMP_LOW) == 22.8


### PR DESCRIPTION
## Description

In double-setpoint (`double_sp`) mode, the Airzone Aidoo PRO reports `minTemp` using the cooling floor (e.g. 67°F) rather than the heating floor (e.g. 63°F). Home Assistant uses `AZD_TEMP_MIN` (`temp-min`) unconditionally for `min_temp`, so the heat setpoint is artificially clamped to the cooling minimum.

The `aioairzone` coordinator already correctly parses `heatmintemp` into `heat-temp-min` (`AZD_HEAT_TEMP_MIN`). This fix uses it when `double_set_point` is True.

**Reported and confirmed by Airzone engineering** — they acknowledged the API behavior is intentional for Nest compatibility, meaning the fix must live in the HA integration layer.

Fixes #160887 (follow-up to #135149)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] The code change is tested and works locally (verified on Aidoo PRO + Mitsubishi Electric heat pump in dual-setpoint / Auto mode)
- [ ] Tests added (happy to add if a fixture with `double_sp` data is pointed out)
- [x] The changes have no obvious negative impact on other Airzone devices or modes