### PR TITLE
Fix Duco ventilation sensors not being created for valve nodes

### DIFF
--- a/homeassistant/components/duco/const.py
+++ b/homeassistant/components/duco/const.py
@@ -2,9 +2,23 @@
 
 from datetime import timedelta
 
+from duco_connectivity.models import NodeType
+
 from homeassistant.const import Platform
 
 DOMAIN = "duco"
 PLATFORMS = [Platform.FAN, Platform.SELECT, Platform.SENSOR]
 SCAN_INTERVAL = timedelta(seconds=10)
 BOX_NODE_ID = 1
+VENTILATION_CAPABLE_NODE_TYPES: tuple[NodeType, ...] = (
+    NodeType.BOX,
+    NodeType.VLV,
+    NodeType.VLVRH,
+    NodeType.VLVVOC,
+    NodeType.VLVCO2,
+    NodeType.VLVCO2RH,
+    NodeType.EAV,
+    NodeType.EAVRH,
+    NodeType.EAVVOC,
+    NodeType.EAVCO2,
+)

--- a/homeassistant/components/duco/select.py
+++ b/homeassistant/components/duco/select.py
@@ -10,7 +10,6 @@ from duco_connectivity import (
     KnownActionName,
     Node,
     NodeListActionItemList,
-    NodeType,
     VentilationState,
 )
 
@@ -19,26 +18,13 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
+from .const import DOMAIN, VENTILATION_CAPABLE_NODE_TYPES
 from .coordinator import DucoConfigEntry, DucoCoordinator
 from .entity import DucoEntity
 
 _LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 1
-
-SUPPORTED_SELECT_NODE_TYPES = {
-    NodeType.BOX,
-    NodeType.VLV,
-    NodeType.VLVRH,
-    NodeType.VLVVOC,
-    NodeType.VLVCO2,
-    NodeType.VLVCO2RH,
-    NodeType.EAV,
-    NodeType.EAVRH,
-    NodeType.EAVVOC,
-    NodeType.EAVCO2,
-}
 
 
 def _get_ventilation_options(action: ActionItem) -> tuple[str, ...] | None:
@@ -86,7 +72,7 @@ async def async_setup_entry(
 
             # Duco advertises SetVentilationState broadly, so keep the select
             # limited to the box and known valve node families.
-            if node.general.node_type not in SUPPORTED_SELECT_NODE_TYPES:
+            if node.general.node_type not in VENTILATION_CAPABLE_NODE_TYPES:
                 continue
 
             options = options_by_node.get(node.node_id)

--- a/homeassistant/components/duco/sensor.py
+++ b/homeassistant/components/duco/sensor.py
@@ -25,7 +25,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util import dt as dt_util
 
-from .const import BOX_NODE_ID, DOMAIN
+from .const import BOX_NODE_ID, DOMAIN, VENTILATION_CAPABLE_NODE_TYPES
 from .coordinator import DucoConfigEntry, DucoCoordinator
 from .entity import DucoEntity
 
@@ -65,7 +65,7 @@ SENSOR_DESCRIPTIONS: tuple[DucoSensorEntityDescription, ...] = (
             if node.ventilation and node.ventilation.state != VentilationState.UNKNOWN
             else None
         ),
-        node_types=(NodeType.BOX,),
+        node_types=VENTILATION_CAPABLE_NODE_TYPES,
     ),
     DucoSensorEntityDescription(
         key="target_flow_level",
@@ -76,7 +76,7 @@ SENSOR_DESCRIPTIONS: tuple[DucoSensorEntityDescription, ...] = (
         value_fn=lambda node: (
             node.ventilation.flow_lvl_tgt if node.ventilation else None
         ),
-        node_types=(NodeType.BOX,),
+        node_types=VENTILATION_CAPABLE_NODE_TYPES,
     ),
     DucoSensorEntityDescription(
         key="time_state_end",
@@ -89,7 +89,7 @@ SENSOR_DESCRIPTIONS: tuple[DucoSensorEntityDescription, ...] = (
             if node.ventilation and node.ventilation.time_state_end != 0
             else None
         ),
-        node_types=(NodeType.BOX,),
+        node_types=VENTILATION_CAPABLE_NODE_TYPES,
     ),
     DucoSensorEntityDescription(
         key="co2",

--- a/tests/components/duco/snapshots/test_sensor.ambr
+++ b/tests/components/duco/snapshots/test_sensor.ambr
@@ -217,6 +217,206 @@
     'state': '88',
   })
 # ---
+# name: test_sensor_entities_state[sensor.bedroom_valve_state_end_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.bedroom_valve_state_end_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'State end time',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'State end time',
+    'platform': 'duco',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'time_state_end',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_60_time_state_end',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_entities_state[sensor.bedroom_valve_state_end_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bedroom valve State end time',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_valve_state_end_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensor_entities_state[sensor.bedroom_valve_target_flow_level-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.bedroom_valve_target_flow_level',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Target flow level',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Target flow level',
+    'platform': 'duco',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'target_flow_level',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_60_target_flow_level',
+    'unit_of_measurement': <UnitOfRatio.PERCENTAGE: '%'>,
+  })
+# ---
+# name: test_sensor_entities_state[sensor.bedroom_valve_target_flow_level-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bedroom valve Target flow level',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfRatio.PERCENTAGE: '%'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_valve_target_flow_level',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensor_entities_state[sensor.bedroom_valve_ventilation_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'auto',
+        'aut1',
+        'aut2',
+        'aut3',
+        'man1',
+        'man2',
+        'man3',
+        'empt',
+        'cnt1',
+        'cnt2',
+        'cnt3',
+        '-',
+        'man1x2',
+        'man2x2',
+        'man3x2',
+        'man1x3',
+        'man2x3',
+        'man3x3',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.bedroom_valve_ventilation_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Ventilation state',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Ventilation state',
+    'platform': 'duco',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'ventilation_state',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_60_ventilation_state',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_entities_state[sensor.bedroom_valve_ventilation_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bedroom valve Ventilation state',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'auto',
+        'aut1',
+        'aut2',
+        'aut3',
+        'man1',
+        'man2',
+        'man3',
+        'empt',
+        'cnt1',
+        'cnt2',
+        'cnt3',
+        '-',
+        'man1x2',
+        'man2x2',
+        'man3x2',
+        'man1x3',
+        'man2x3',
+        'man3x3',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bedroom_valve_ventilation_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'auto',
+  })
+# ---
 # name: test_sensor_entities_state[sensor.hall_valve_carbon_dioxide-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -324,6 +524,206 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '76',
+  })
+# ---
+# name: test_sensor_entities_state[sensor.hall_valve_state_end_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.hall_valve_state_end_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'State end time',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'State end time',
+    'platform': 'duco',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'time_state_end',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_61_time_state_end',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_entities_state[sensor.hall_valve_state_end_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Hall valve State end time',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.hall_valve_state_end_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensor_entities_state[sensor.hall_valve_target_flow_level-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.hall_valve_target_flow_level',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Target flow level',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Target flow level',
+    'platform': 'duco',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'target_flow_level',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_61_target_flow_level',
+    'unit_of_measurement': <UnitOfRatio.PERCENTAGE: '%'>,
+  })
+# ---
+# name: test_sensor_entities_state[sensor.hall_valve_target_flow_level-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Hall valve Target flow level',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfRatio.PERCENTAGE: '%'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.hall_valve_target_flow_level',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensor_entities_state[sensor.hall_valve_ventilation_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'auto',
+        'aut1',
+        'aut2',
+        'aut3',
+        'man1',
+        'man2',
+        'man3',
+        'empt',
+        'cnt1',
+        'cnt2',
+        'cnt3',
+        '-',
+        'man1x2',
+        'man2x2',
+        'man3x2',
+        'man1x3',
+        'man2x3',
+        'man3x3',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.hall_valve_ventilation_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Ventilation state',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Ventilation state',
+    'platform': 'duco',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'ventilation_state',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_61_ventilation_state',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_entities_state[sensor.hall_valve_ventilation_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Hall valve Ventilation state',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'auto',
+        'aut1',
+        'aut2',
+        'aut3',
+        'man1',
+        'man2',
+        'man3',
+        'empt',
+        'cnt1',
+        'cnt2',
+        'cnt3',
+        '-',
+        'man1x2',
+        'man2x2',
+        'man3x2',
+        'man1x3',
+        'man2x3',
+        'man3x3',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.hall_valve_ventilation_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'auto',
   })
 # ---
 # name: test_sensor_entities_state[sensor.kitchen_rh_humidity-entry]
@@ -1070,5 +1470,205 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '92',
+  })
+# ---
+# name: test_sensor_entities_state[sensor.study_valve_state_end_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.study_valve_state_end_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'State end time',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'State end time',
+    'platform': 'duco',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'time_state_end',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_62_time_state_end',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_entities_state[sensor.study_valve_state_end_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Study valve State end time',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.study_valve_state_end_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensor_entities_state[sensor.study_valve_target_flow_level-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.study_valve_target_flow_level',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Target flow level',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Target flow level',
+    'platform': 'duco',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'target_flow_level',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_62_target_flow_level',
+    'unit_of_measurement': <UnitOfRatio.PERCENTAGE: '%'>,
+  })
+# ---
+# name: test_sensor_entities_state[sensor.study_valve_target_flow_level-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Study valve Target flow level',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfRatio.PERCENTAGE: '%'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.study_valve_target_flow_level',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensor_entities_state[sensor.study_valve_ventilation_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'auto',
+        'aut1',
+        'aut2',
+        'aut3',
+        'man1',
+        'man2',
+        'man3',
+        'empt',
+        'cnt1',
+        'cnt2',
+        'cnt3',
+        '-',
+        'man1x2',
+        'man2x2',
+        'man3x2',
+        'man1x3',
+        'man2x3',
+        'man3x3',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.study_valve_ventilation_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Ventilation state',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Ventilation state',
+    'platform': 'duco',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'ventilation_state',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_62_ventilation_state',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_entities_state[sensor.study_valve_ventilation_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Study valve Ventilation state',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'auto',
+        'aut1',
+        'aut2',
+        'aut3',
+        'man1',
+        'man2',
+        'man3',
+        'empt',
+        'cnt1',
+        'cnt2',
+        'cnt3',
+        '-',
+        'man1x2',
+        'man2x2',
+        'man3x2',
+        'man1x3',
+        'man2x3',
+        'man3x3',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.study_valve_ventilation_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'auto',
   })
 # ---

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -1,5 +1,6 @@
 """Tests for the Duco sensor platform."""
 
+from dataclasses import replace
 import logging
 from unittest.mock import AsyncMock
 
@@ -27,6 +28,62 @@ from . import setup_platform_integration
 from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
 
 FILTER_REMAINING_ENTITY_ID = "sensor.living_filter_remaining"
+
+
+@pytest.mark.parametrize(
+    "ventilation_node_type",
+    [
+        pytest.param(NodeType.BOX, id="box"),
+        pytest.param(NodeType.VLV, id="vlv"),
+        pytest.param(NodeType.VLVRH, id="vlvrh"),
+        pytest.param(NodeType.VLVVOC, id="vlvvoc"),
+        pytest.param(NodeType.VLVCO2, id="vlvco2"),
+        pytest.param(NodeType.VLVCO2RH, id="vlvco2rh"),
+        pytest.param(NodeType.EAV, id="eav"),
+        pytest.param(NodeType.EAVRH, id="eavrh"),
+        pytest.param(NodeType.EAVVOC, id="eavvoc"),
+        pytest.param(NodeType.EAVCO2, id="eavco2"),
+    ],
+)
+async def test_ventilation_related_sensors_created_for_supported_node_types(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_duco_client: AsyncMock,
+    mock_sensor_nodes: list[Node],
+    ventilation_node_type: NodeType,
+) -> None:
+    """Test ventilation-related sensors are created for supported node families."""
+    supported_node = replace(
+        mock_sensor_nodes[0],
+        general=replace(mock_sensor_nodes[0].general, node_type=ventilation_node_type),
+        ventilation=replace(
+            mock_sensor_nodes[0].ventilation,
+            flow_lvl_tgt=42,
+            time_state_end=1700000400,
+        ),
+    )
+    mock_duco_client.async_get_nodes.return_value = [
+        supported_node,
+        *mock_sensor_nodes[1:],
+    ]
+
+    await setup_platform_integration(hass, mock_config_entry, [Platform.SENSOR])
+
+    state = hass.states.get("sensor.living_ventilation_state")
+    assert state is not None
+    assert state.state == "auto"
+
+    state = hass.states.get("sensor.living_target_flow_level")
+    assert state is not None
+    assert state.state == "42"
+
+    state = hass.states.get("sensor.living_state_end_time")
+    assert state is not None
+    assert state.state == "2023-11-14T22:20:00+00:00"
+
+    assert hass.states.get("sensor.office_co2_ventilation_state") is None
+    assert hass.states.get("sensor.office_co2_target_flow_level") is None
+    assert hass.states.get("sensor.office_co2_state_end_time") is None
 
 
 @pytest.fixture


### PR DESCRIPTION
> [!IMPORTANT]
> This PR fixes another overly restrictive node-type filter on already shipped Duco functionality. Because follow-up hardware validation showed the current implementation still does not expose the existing ventilation-related sensors on supported valve nodes, could this PR also be considered for the next milestone as a bugfix?

## Proposed change
This PR is a follow-up to #174901, which fixed the Duco ventilation-state `select` platform for supported valve node families.

The same BOX-only restriction was still present in the sensor platform for the existing ventilation-related sensors:

- `ventilation_state`
- `target_flow_level`
- `time_state_end`

That left the integration functionally inconsistent: supported `VLV*` and `EAV*` valve node families could get the ventilation-state `select`, but not the matching readback sensors that expose the same ventilation state metadata.

This change keeps the implementation narrow and aligned with the merged select fix by:

- moving the supported ventilation-capable node families into one shared constant
- reusing that allowlist in both the select and sensor platforms
- expanding the three existing ventilation-related sensors to the same supported valve families
- adding a parametrized regression test plus updated sensor snapshots

Because this corrects another overly narrow filter on already shipped functionality, I think this fits best as a bugfix rather than a new feature. If merged in time, it may be suitable for the next release milestone.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #174901
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr