### PR TITLE
Always force arm Verisure

### DIFF
--- a/homeassistant/components/verisure/alarm_control_panel.py
+++ b/homeassistant/components/verisure/alarm_control_panel.py
@@ -115,7 +115,8 @@ class VerisureAlarm(
         self._attr_alarm_state = AlarmControlPanelState.ARMING
         self.async_write_ha_state()
         await self._async_set_arm_state(
-            "ARMED_HOME", self.coordinator.verisure.arm_home(code)
+            "ARMED_HOME",
+            self.coordinator.verisure.arm_home(code, force_arm=True),
         )
 
     @override
@@ -124,7 +125,8 @@ class VerisureAlarm(
         self._attr_alarm_state = AlarmControlPanelState.ARMING
         self.async_write_ha_state()
         await self._async_set_arm_state(
-            "ARMED_AWAY", self.coordinator.verisure.arm_away(code)
+            "ARMED_AWAY",
+            self.coordinator.verisure.arm_away(code, force_arm=True),
         )
 
     def _update_alarm_attributes(self) -> None:

--- a/tests/components/verisure/test_alarm_control_panel.py
+++ b/tests/components/verisure/test_alarm_control_panel.py
@@ -1,0 +1,56 @@
+"""Tests for the Verisure alarm control panel."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from homeassistant.components.alarm_control_panel import DOMAIN as ALARM_DOMAIN
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_ALARM_ARM_AWAY,
+    SERVICE_ALARM_ARM_HOME,
+    Platform,
+)
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+ALARM_ENTITY_ID = "alarm_control_panel.verisure_alarm"
+ARM_TRANSACTION = {"data": {"armStateChangeTransactionId": "txn"}}
+POLL_OK = {"data": {"installation": {"armStateChangePollResult": {"result": "OK"}}}}
+
+
+@pytest.mark.parametrize(
+    ("service", "method", "state"),
+    [
+        (SERVICE_ALARM_ARM_AWAY, "arm_away", "armed_away"),
+        (SERVICE_ALARM_ARM_HOME, "arm_home", "armed_home"),
+    ],
+)
+async def test_arm_always_forces(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_verisure: MagicMock,
+    service: str,
+    method: str,
+    state: str,
+) -> None:
+    """Arming always passes force_arm=True to the library."""
+    mock_config_entry.add_to_hass(hass)
+    with patch(
+        "homeassistant.components.verisure.PLATFORMS", [Platform.ALARM_CONTROL_PANEL]
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    mock_verisure.request.side_effect = [ARM_TRANSACTION, POLL_OK]
+
+    await hass.services.async_call(
+        ALARM_DOMAIN,
+        service,
+        {ATTR_ENTITY_ID: ALARM_ENTITY_ID, "code": "1234"},
+        blocking=True,
+    )
+
+    getattr(mock_verisure, method).assert_called_once_with("1234", force_arm=True)
+    assert hass.states.get(ALARM_ENTITY_ID).state == state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The Verisure integration now always force-arms. On arm it sends `forceArm=true`, so the alarm arms even when a device is out of place or reporting a problem (for example an open door or window, or an offline sensor), matching the "Arm anyway" confirmation in the My Verisure app. When nothing needs bypassing it behaves like a normal arm, so no user option is needed.

Previously, arming from Home Assistant would stall on "Arming…" whenever the installation had a device that could not be restored, because the backend waits for an override the integration could not send. The `forceArm` request was confirmed from real My Verisure web traffic.

This uses the `force_arm` parameter added to `vsure` 2.8.0 (#175060).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#46520
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr