### PR TITLE
Periodically refresh Whirlpool state as a push fallback

### DIFF
--- a/homeassistant/components/whirlpool/__init__.py
+++ b/homeassistant/components/whirlpool/__init__.py
@@ -1,5 +1,6 @@
 """The Whirlpool Appliances integration."""
 
+from datetime import datetime, timedelta
 import logging
 
 from aiohttp import ClientError
@@ -12,6 +13,7 @@ from homeassistant.const import CONF_PASSWORD, CONF_REGION, CONF_USERNAME, Platf
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.event import async_track_time_interval
 
 from .const import BRANDS_CONF_MAP, CONF_BRAND, DOMAIN, REGIONS_CONF_MAP
 
@@ -24,6 +26,13 @@ PLATFORMS = [
     Platform.SELECT,
     Platform.SENSOR,
 ]
+
+# State normally arrives over a push connection, but that connection can drop
+# silently and stop delivering updates, leaving entities stale while commands
+# still work. Periodically re-fetch state as a fallback so entities recover on
+# their own; this also re-evaluates each appliance's availability through
+# Appliance.get_online().
+STATE_REFRESH_INTERVAL = timedelta(minutes=5)
 
 type WhirlpoolConfigEntry = ConfigEntry[AppliancesManager]
 
@@ -63,6 +72,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: WhirlpoolConfigEntry) ->
     await appliances_manager.connect()
 
     entry.runtime_data = appliances_manager
+
+    async def _async_refresh_data(_now: datetime) -> None:
+        """Re-fetch appliance state as a fallback for missed push updates."""
+        try:
+            await appliances_manager.fetch_all_data()
+        except (ClientError, TimeoutError) as err:
+            _LOGGER.debug("Periodic data refresh failed: %s", err)
+
+    entry.async_on_unload(
+        async_track_time_interval(hass, _async_refresh_data, STATE_REFRESH_INTERVAL)
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True

--- a/tests/components/whirlpool/test_init.py
+++ b/tests/components/whirlpool/test_init.py
@@ -1,5 +1,6 @@
 """Test the Whirlpool Sixth Sense init."""
 
+from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import aiohttp
@@ -7,14 +8,16 @@ import pytest
 from whirlpool.auth import AccountLockedError
 from whirlpool.backendselector import Brand, Region
 
+from homeassistant.components.whirlpool import STATE_REFRESH_INTERVAL
 from homeassistant.components.whirlpool.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_PASSWORD, CONF_REGION, CONF_USERNAME
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 
 from . import init_integration, init_integration_with_entry
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 async def test_setup(
@@ -146,3 +149,36 @@ async def test_unload_entry(hass: HomeAssistant) -> None:
 
     assert entry.state is ConfigEntryState.NOT_LOADED
     assert not hass.data.get(DOMAIN)
+
+
+async def test_periodic_data_refresh(
+    hass: HomeAssistant, mock_appliances_manager_api: MagicMock
+) -> None:
+    """Test appliance data is re-fetched periodically as a push fallback."""
+    await init_integration(hass)
+    manager = mock_appliances_manager_api.return_value
+    manager.fetch_all_data.assert_not_called()
+
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + STATE_REFRESH_INTERVAL + timedelta(seconds=1)
+    )
+    await hass.async_block_till_done()
+    manager.fetch_all_data.assert_called_once()
+
+
+async def test_periodic_data_refresh_stops_after_unload(
+    hass: HomeAssistant, mock_appliances_manager_api: MagicMock
+) -> None:
+    """Test the periodic refresh is cancelled when the entry is unloaded."""
+    entry = await init_integration(hass)
+    manager = mock_appliances_manager_api.return_value
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+    manager.fetch_all_data.reset_mock()
+
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + STATE_REFRESH_INTERVAL + timedelta(seconds=1)
+    )
+    await hass.async_block_till_done()
+    manager.fetch_all_data.assert_not_called()


### PR DESCRIPTION
## Proposed change

The Whirlpool integration receives appliance state over a push connection (the cloud event stream). In practice that connection can drop **silently**: it stops delivering updates while outbound commands (over REST) keep working, so entities freeze at their last-known values — e.g. an oven keeps showing `cooking` and its last target temperature long after it has finished, and because no update arrives, `get_online()` is never re-read so the entity is not marked unavailable either.

This adds a low-frequency fallback: every 5 minutes the integration re-fetches state via `AppliancesManager.fetch_all_data()`. That call re-reads each appliance over REST and fires the attribute callbacks, so it both refreshes entity state and re-evaluates availability through `Appliance.get_online()`. Push remains the primary, real-time path — this only backstops missed/dropped updates — and the interval is unregistered on unload via `entry.async_on_unload`.

Reproduced and verified on a real Whirlpool double oven (Home Assistant 2026.6.4): after the event stream silently stopped, the entities recovered to the correct live state within the refresh interval.

> Note for reviewers: a cleaner long-term fix would be for `whirlpool-sixth-sense` to surface a "connection lost" signal (it already has a connection-up callback used to refresh on reconnect), so the integration could mark entities unavailable immediately instead of polling. Happy to pursue that in the library and switch this over if preferred.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
