### PR TITLE
ring: clear stale GCM credentials when listener fails to start

### DIFF
--- a/homeassistant/components/ring/coordinator.py
+++ b/homeassistant/components/ring/coordinator.py
@@ -25,7 +25,7 @@ from homeassistant.helpers.update_coordinator import (
     UpdateFailed,
 )
 
-from .const import DOMAIN, SCAN_INTERVAL
+from .const import CONF_LISTEN_CREDENTIALS, DOMAIN, SCAN_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -182,6 +182,21 @@ class RingListenCoordinator(BaseDataUpdateCoordinatorProtocol):
                 "Ring event listener failed to start after %s seconds",
                 self.start_timeout,
             )
+            # Clear stale GCM credentials so the next reload attempts fresh registration.
+            # Credentials become invalid after an abrupt HA shutdown (SIGKILL), causing
+            # PHONE_REGISTRATION_ERROR on every subsequent start until manually cleared.
+            if CONF_LISTEN_CREDENTIALS in self.config_entry.data:
+                self.logger.warning(
+                    "Clearing stale Ring listen credentials to force re-registration"
+                )
+                self.hass.config_entries.async_update_entry(
+                    self.config_entry,
+                    data={
+                        k: v
+                        for k, v in self.config_entry.data.items()
+                        if k != CONF_LISTEN_CREDENTIALS
+                    },
+                )
         self._listen_callback_id = self.event_listener.add_notification_callback(
             self._on_event
         )

--- a/homeassistant/components/ring/coordinator.py
+++ b/homeassistant/components/ring/coordinator.py
@@ -197,6 +197,9 @@ class RingListenCoordinator(BaseDataUpdateCoordinatorProtocol):
                         if k != CONF_LISTEN_CREDENTIALS
                     },
                 )
+                self.hass.config_entries.async_schedule_reload(
+                    self.config_entry.entry_id
+                )
         self._listen_callback_id = self.event_listener.add_notification_callback(
             self._on_event
         )

--- a/tests/components/ring/test_init.py
+++ b/tests/components/ring/test_init.py
@@ -521,6 +521,11 @@ async def test_no_listen_start(
     assert "Ring event listener failed to start after 10 seconds" in [
         record.message for record in caplog.records if record.levelname == "WARNING"
     ]
+    # No stale credentials to clear, so no reload should have happened.
+    assert CONF_LISTEN_CREDENTIALS not in mock_entry.data
+    assert "Clearing stale Ring listen credentials" not in caplog.text
+    assert mock_entry.state is ConfigEntryState.LOADED
+    assert mock_ring_event_listener_class.call_count == 1
 
 
 async def test_listen_start_failure_clears_stale_credentials(
@@ -564,39 +569,6 @@ async def test_listen_start_failure_clears_stale_credentials(
     # async_block_till_done returns the entry has actually been set up again.
     assert mock_entry.state is ConfigEntryState.LOADED
     assert mock_ring_event_listener_class.call_count == 2
-
-
-async def test_listen_start_failure_without_credentials_no_reload(
-    hass: HomeAssistant,
-    caplog: pytest.LogCaptureFixture,
-    entity_registry: er.EntityRegistry,
-    mock_ring_event_listener_class: type[RingEventListener],
-    mock_ring_client: Ring,
-) -> None:
-    """Test no reload is scheduled when listener fails but no stale credentials exist."""
-    mock_entry = MockConfigEntry(
-        domain=DOMAIN,
-        version=1,
-        data={"username": "foo", "token": {}},
-    )
-    mock_entry.add_to_hass(hass)
-    entity_registry.async_get_or_create(
-        domain=BINARY_SENSOR_DOMAIN,
-        platform=DOMAIN,
-        unique_id=f"{FRONT_DOOR_DEVICE_ID}-motion",
-        suggested_object_id=f"{FRONT_DOOR_DEVICE_ID}_motion",
-        config_entry=mock_entry,
-    )
-    mock_ring_event_listener_class.return_value.started = False
-
-    await hass.config_entries.async_setup(mock_entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert CONF_LISTEN_CREDENTIALS not in mock_entry.data
-    assert "Clearing stale Ring listen credentials" not in caplog.text
-    # No reload should have happened, so the listener was only constructed once.
-    assert mock_entry.state is ConfigEntryState.LOADED
-    assert mock_ring_event_listener_class.call_count == 1
 
 
 @pytest.mark.usefixtures("mock_setup_entry")

--- a/tests/components/ring/test_init.py
+++ b/tests/components/ring/test_init.py
@@ -553,17 +553,17 @@ async def test_listen_start_failure_clears_stale_credentials(
     )
     mock_ring_event_listener_class.return_value.started = False
 
-    with patch.object(
-        hass.config_entries, "async_schedule_reload"
-    ) as mock_schedule_reload:
-        await hass.config_entries.async_setup(mock_entry.entry_id)
-        await hass.async_block_till_done()
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
 
     assert CONF_LISTEN_CREDENTIALS not in mock_entry.data
     assert "Clearing stale Ring listen credentials to force re-registration" in [
         record.message for record in caplog.records if record.levelname == "WARNING"
     ]
-    mock_schedule_reload.assert_called_once_with(mock_entry.entry_id)
+    # The reload is scheduled as a task rather than patched, so by the time
+    # async_block_till_done returns the entry has actually been set up again.
+    assert mock_entry.state is ConfigEntryState.LOADED
+    assert mock_ring_event_listener_class.call_count == 2
 
 
 async def test_listen_start_failure_without_credentials_no_reload(
@@ -589,15 +589,14 @@ async def test_listen_start_failure_without_credentials_no_reload(
     )
     mock_ring_event_listener_class.return_value.started = False
 
-    with patch.object(
-        hass.config_entries, "async_schedule_reload"
-    ) as mock_schedule_reload:
-        await hass.config_entries.async_setup(mock_entry.entry_id)
-        await hass.async_block_till_done()
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
 
     assert CONF_LISTEN_CREDENTIALS not in mock_entry.data
     assert "Clearing stale Ring listen credentials" not in caplog.text
-    mock_schedule_reload.assert_not_called()
+    # No reload should have happened, so the listener was only constructed once.
+    assert mock_entry.state is ConfigEntryState.LOADED
+    assert mock_ring_event_listener_class.call_count == 1
 
 
 @pytest.mark.usefixtures("mock_setup_entry")

--- a/tests/components/ring/test_init.py
+++ b/tests/components/ring/test_init.py
@@ -523,6 +523,83 @@ async def test_no_listen_start(
     ]
 
 
+async def test_listen_start_failure_clears_stale_credentials(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    entity_registry: er.EntityRegistry,
+    mock_ring_event_listener_class: type[RingEventListener],
+    mock_ring_client: Ring,
+) -> None:
+    """Test stale GCM credentials are cleared and reload scheduled when listener fails."""
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=1,
+        data={
+            "username": "foo",
+            "token": {},
+            CONF_LISTEN_CREDENTIALS: {
+                "android_id": "stale-id",
+                "security_token": "stale-token",
+            },
+        },
+    )
+    mock_entry.add_to_hass(hass)
+    entity_registry.async_get_or_create(
+        domain=BINARY_SENSOR_DOMAIN,
+        platform=DOMAIN,
+        unique_id=f"{FRONT_DOOR_DEVICE_ID}-motion",
+        suggested_object_id=f"{FRONT_DOOR_DEVICE_ID}_motion",
+        config_entry=mock_entry,
+    )
+    mock_ring_event_listener_class.return_value.started = False
+
+    with patch.object(
+        hass.config_entries, "async_schedule_reload"
+    ) as mock_schedule_reload:
+        await hass.config_entries.async_setup(mock_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert CONF_LISTEN_CREDENTIALS not in mock_entry.data
+    assert "Clearing stale Ring listen credentials to force re-registration" in [
+        record.message for record in caplog.records if record.levelname == "WARNING"
+    ]
+    mock_schedule_reload.assert_called_once_with(mock_entry.entry_id)
+
+
+async def test_listen_start_failure_without_credentials_no_reload(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    entity_registry: er.EntityRegistry,
+    mock_ring_event_listener_class: type[RingEventListener],
+    mock_ring_client: Ring,
+) -> None:
+    """Test no reload is scheduled when listener fails but no stale credentials exist."""
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=1,
+        data={"username": "foo", "token": {}},
+    )
+    mock_entry.add_to_hass(hass)
+    entity_registry.async_get_or_create(
+        domain=BINARY_SENSOR_DOMAIN,
+        platform=DOMAIN,
+        unique_id=f"{FRONT_DOOR_DEVICE_ID}-motion",
+        suggested_object_id=f"{FRONT_DOOR_DEVICE_ID}_motion",
+        config_entry=mock_entry,
+    )
+    mock_ring_event_listener_class.return_value.started = False
+
+    with patch.object(
+        hass.config_entries, "async_schedule_reload"
+    ) as mock_schedule_reload:
+        await hass.config_entries.async_setup(mock_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert CONF_LISTEN_CREDENTIALS not in mock_entry.data
+    assert "Clearing stale Ring listen credentials" not in caplog.text
+    mock_schedule_reload.assert_not_called()
+
+
 @pytest.mark.usefixtures("mock_setup_entry")
 async def test_migrate_create_device_id(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture


### PR DESCRIPTION
## Proposed change

When Home Assistant shuts down abruptly (SIGKILL, OOM, power loss), the GCM `android_id`/`security_token` stored in the Ring config entry become invalid. On the next boot, the Ring event listener fails to start with `PHONE_REGISTRATION_ERROR` and stays dead indefinitely — doorbell events (dings, motion) are never delivered.

The current workaround requires the user to remove the Ring device from the app and re-add it, which is disruptive.

This change detects the listener start failure **at setup/reload time** and removes the stale `listen_token` from the config entry. The next time the integration reloads (which happens automatically after the credentials are updated), a fresh GCM registration is performed and the listener starts successfully.

Note this only covers the startup-time failure path (`_async_start_listen()` returning `started=False`). It does not address the listener becoming unhealthy *after* it has already started successfully at runtime — that would need separate ongoing health/restart handling.

### How it works

In `_async_start_listen()`, when `event_listener.started is False`, we now also check if `CONF_LISTEN_CREDENTIALS` is present in the config entry. If so, we remove it via `async_update_entry`, which triggers an integration reload with fresh credentials.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Additional information

- Related to #157764 and #173299 — this PR fixes the boot-time `PHONE_REGISTRATION_ERROR` case (listener never starts). It does not fully resolve either issue where the listener degrades at runtime after initially working, since that path never goes through `_async_start_listen()` again until a reload is triggered some other way.

## Checklist

- [x] The code change is tested and works locally
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR
- [x] I have followed the [development checklist](https://developers.home-assistant.io/docs/development_checklist/)
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works