### PR TITLE
Don't reauth after reboot

### DIFF
--- a/homeassistant/components/teltonika/coordinator.py
+++ b/homeassistant/components/teltonika/coordinator.py
@@ -1,5 +1,6 @@
 """DataUpdateCoordinator for Teltonika."""
 
+from collections.abc import Awaitable, Callable
 from datetime import timedelta
 import logging
 from typing import TYPE_CHECKING, override
@@ -29,6 +30,11 @@ AUTH_ERROR_CODES = frozenset(
         TeltonikaErrorCode.INVALID_JWT_TOKEN,
     }
 )
+
+
+def _is_auth_error(err: ClientResponseError) -> bool:
+    """Return whether an HTTP error indicates an authentication failure."""
+    return err.status in (401, 403)
 
 
 class TeltonikaDataUpdateCoordinator(DataUpdateCoordinator[dict[str, ModemStatusFull]]):
@@ -63,9 +69,7 @@ class TeltonikaDataUpdateCoordinator(DataUpdateCoordinator[dict[str, ModemStatus
         except TeltonikaAuthenticationError as err:
             raise ConfigEntryAuthFailed(f"Authentication failed: {err}") from err
         except (ClientResponseError, ContentTypeError) as err:
-            if (isinstance(err, ClientResponseError) and err.status in (401, 403)) or (
-                isinstance(err, ContentTypeError) and err.status == 403
-            ):
+            if _is_auth_error(err):
                 raise ConfigEntryAuthFailed(f"Authentication failed: {err}") from err
             raise ConfigEntryNotReady(f"Failed to connect to device: {err}") from err
         except TeltonikaConnectionError as err:
@@ -93,41 +97,63 @@ class TeltonikaDataUpdateCoordinator(DataUpdateCoordinator[dict[str, ModemStatus
     @override
     async def _async_update_data(self) -> dict[str, ModemStatusFull]:
         """Fetch data from Teltonika device."""
-        modems = Modems(self.client.auth)
+        return await self._async_with_reauth(self._async_fetch_modems)
+
+    async def _async_with_reauth[DataT](
+        self, fetch: Callable[[], Awaitable[DataT]]
+    ) -> DataT:
+        """Run a device call, re-authenticating once if the session was rejected.
+
+        After e.g. a device reboot, the session might become invalidated, but still
+        look valid from the timestamp in the JWT. In this case, we try to authenticate
+        again with the same credentials and retry the request. A reauth flow is only
+        started when re-authentication itself is rejected, i.e. the stored
+        credentials are no longer valid.
+        """
         try:
-            # Get modems data using the teltasync library
-            modems_response = await modems.get_status()
-        except TeltonikaAuthenticationError as err:
-            raise ConfigEntryAuthFailed(f"Authentication failed: {err}") from err
-        except (ClientResponseError, ContentTypeError) as err:
-            if (isinstance(err, ClientResponseError) and err.status in (401, 403)) or (
-                isinstance(err, ContentTypeError) and err.status == 403
-            ):
-                raise ConfigEntryAuthFailed(f"Authentication failed: {err}") from err
-            raise UpdateFailed(f"Error communicating with device: {err}") from err
+            return await fetch()
         except TeltonikaConnectionError as err:
             raise UpdateFailed(f"Error communicating with device: {err}") from err
+        except TeltonikaAuthenticationError:
+            self.client.auth.clear_token()
+
+            try:
+                await self.client.auth.authenticate()
+            except TeltonikaAuthenticationError as err:
+                raise ConfigEntryAuthFailed(f"Authentication failed: {err}") from err
+            except TeltonikaConnectionError as err:
+                raise UpdateFailed(f"Error communicating with device: {err}") from err
+
+            try:
+                return await fetch()
+            except (TeltonikaAuthenticationError, TeltonikaConnectionError) as err:
+                raise UpdateFailed(f"Error communicating with device: {err}") from err
+
+    async def _async_fetch_modems(self) -> dict[str, ModemStatusFull]:
+        """Fetch the online modems keyed by id."""
+        modems = Modems(self.client.auth)
+        try:
+            modems_response = await modems.get_status()
+        except (ClientResponseError, ContentTypeError) as err:
+            if _is_auth_error(err):
+                raise TeltonikaAuthenticationError(str(err)) from err
+            raise TeltonikaConnectionError(str(err)) from err
 
         if not modems_response.success:
             if modems_response.errors and any(
                 error.code in AUTH_ERROR_CODES for error in modems_response.errors
             ):
-                raise ConfigEntryAuthFailed(
-                    "Authentication failed: unauthorized access"
-                )
+                raise TeltonikaAuthenticationError("unauthorized access")
 
             error_message = (
                 modems_response.errors[0].error
                 if modems_response.errors
                 else "Unknown API error"
             )
-            raise UpdateFailed(f"Error communicating with device: {error_message}")
+            raise TeltonikaConnectionError(error_message)
 
-        # Return only modems which are online
-        if not modems_response.data:
-            return {}
         return {
             modem.id: modem
-            for modem in modems_response.data
+            for modem in (modems_response.data or [])
             if isinstance(modem, ModemStatusFull)
         }

--- a/tests/components/teltonika/conftest.py
+++ b/tests/components/teltonika/conftest.py
@@ -40,6 +40,9 @@ def mock_teltasync() -> Generator[MagicMock]:
     ):
         shared_client = mock_teltasync_class.return_value
 
+        shared_client.auth.authenticate = AsyncMock()
+        shared_client.auth.clear_token = MagicMock()
+
         device_info = load_json_object_fixture("device_info.json", DOMAIN)
         shared_client.get_device_info.return_value = UnauthorizedStatusData(
             **device_info

--- a/tests/components/teltonika/test_sensor.py
+++ b/tests/components/teltonika/test_sensor.py
@@ -3,11 +3,15 @@
 from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock
 
-from aiohttp import ClientResponseError
+from aiohttp import ClientResponseError, ContentTypeError
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
-from teltasync import TeltonikaAuthenticationError, TeltonikaConnectionError
+from teltasync import (
+    TeltonikaAuthenticationError,
+    TeltonikaConnectionError,
+    TeltonikaInvalidCredentialsError,
+)
 from teltasync.error_codes import TeltonikaErrorCode
 
 from homeassistant.components.teltonika.const import DOMAIN
@@ -28,10 +32,10 @@ async def test_sensors(
     await snapshot_platform(hass, entity_registry, snapshot, init_integration.entry_id)
 
 
+@pytest.mark.usefixtures("init_integration")
 async def test_sensor_modem_removed(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    init_integration: MockConfigEntry,
     mock_modems: MagicMock,
     freezer: FrozenDateTimeFactory,
 ) -> None:
@@ -62,10 +66,10 @@ async def test_sensor_modem_removed(
     assert state.state == "unavailable"
 
 
+@pytest.mark.usefixtures("init_integration")
 async def test_sensor_update_failure_and_recovery(
     hass: HomeAssistant,
     mock_modems: AsyncMock,
-    init_integration: MockConfigEntry,
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test sensor becomes unavailable on update failure and recovers."""
@@ -98,42 +102,166 @@ async def test_sensor_update_failure_and_recovery(
     assert state.state == "-63"
 
 
+def _has_reauth_flow(hass: HomeAssistant) -> bool:
+    """Return whether a reauth flow is in progress for the integration."""
+    return bool(
+        hass.config_entries.flow.async_progress_by_handler(
+            DOMAIN, match_context={"source": SOURCE_REAUTH}
+        )
+    )
+
+
 @pytest.mark.parametrize(
-    ("side_effect", "expect_reauth"),
+    "first_failure",
     [
-        (TeltonikaAuthenticationError("Invalid credentials"), True),
-        (
-            ClientResponseError(
-                request_info=MagicMock(),
-                history=(),
-                status=401,
-                message="Unauthorized",
-                headers={},
-            ),
-            True,
+        TeltonikaAuthenticationError("Session expired"),
+        ClientResponseError(
+            request_info=MagicMock(),
+            history=(),
+            status=401,
+            message="Unauthorized",
+            headers=None,
         ),
-        (
-            ClientResponseError(
-                request_info=MagicMock(),
-                history=(),
-                status=500,
-                message="Server error",
-                headers={},
-            ),
-            False,
+        ClientResponseError(
+            request_info=MagicMock(),
+            history=(),
+            status=403,
+            message="Forbidden",
+            headers=None,
+        ),
+        ContentTypeError(
+            request_info=MagicMock(),
+            history=(),
+            status=403,
+            message="Attempt to decode JSON with unexpected mimetype: text/html",
+            headers=None,
         ),
     ],
-    ids=["auth_exception", "http_auth_error", "http_non_auth_error"],
+    ids=[
+        "auth_exception",
+        "http_401",
+        "http_403",
+        "content_type_403",
+    ],
 )
-async def test_sensor_update_exception_paths(
+@pytest.mark.usefixtures("init_integration")
+async def test_dropped_session_recovers_without_reauth(
     hass: HomeAssistant,
     mock_modems: AsyncMock,
-    init_integration: MockConfigEntry,
+    mock_teltasync_client: MagicMock,
+    freezer: FrozenDateTimeFactory,
+    first_failure: Exception,
+) -> None:
+    """Test a device that drops the session (e.g. on reboot) recovers itself.
+
+    This should not trigger a reauth flow, as the credentials are still valid.
+    Instead, the integration should clear the token, re-authenticate, and retry.
+    """
+    good_response = mock_modems.get_status.return_value
+    mock_modems.get_status.side_effect = [first_failure, good_response]
+
+    freezer.tick(timedelta(seconds=31))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.rutx50_test_internal_modem_rssi")
+    assert state is not None
+    assert state.state == "-63"
+
+    mock_teltasync_client.auth.authenticate.assert_awaited_once()
+    assert _has_reauth_flow(hass) is False
+
+
+@pytest.mark.parametrize(
+    "auth_error",
+    [
+        TeltonikaInvalidCredentialsError("Invalid username or password"),
+        TeltonikaAuthenticationError("Login failed (code 121)"),
+    ],
+    ids=["invalid_credentials", "login_failed_body_error"],
+)
+@pytest.mark.usefixtures("init_integration")
+async def test_failed_reauthentication_triggers_reauth(
+    hass: HomeAssistant,
+    mock_modems: AsyncMock,
+    mock_teltasync_client: MagicMock,
+    freezer: FrozenDateTimeFactory,
+    auth_error: TeltonikaAuthenticationError,
+) -> None:
+    """Test a reauth flow starts when re-authentication is rejected.
+
+    Both an HTTP 401 (``TeltonikaInvalidCredentialsError``) and a body error
+    code such as LOGIN_FAILED (plain ``TeltonikaAuthenticationError``) mean the
+    stored credentials are no longer valid.
+    """
+    mock_modems.get_status.side_effect = TeltonikaAuthenticationError("Session expired")
+    mock_teltasync_client.auth.authenticate.side_effect = auth_error
+
+    freezer.tick(timedelta(seconds=31))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.rutx50_test_internal_modem_rssi")
+    assert state is not None
+    assert state.state == "unavailable"
+
+    assert _has_reauth_flow(hass) is True
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_connection_error_during_reauth_is_transient(
+    hass: HomeAssistant,
+    mock_modems: AsyncMock,
+    mock_teltasync_client: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a connection error while re-authenticating does not start a reauth flow."""
+    mock_modems.get_status.side_effect = TeltonikaAuthenticationError("Session expired")
+    mock_teltasync_client.auth.authenticate.side_effect = TeltonikaConnectionError(
+        "Device still rebooting"
+    )
+
+    freezer.tick(timedelta(seconds=31))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.rutx50_test_internal_modem_rssi")
+    assert state is not None
+    assert state.state == "unavailable"
+
+    assert _has_reauth_flow(hass) is False
+
+
+@pytest.mark.parametrize(
+    "side_effect",
+    [
+        TeltonikaAuthenticationError("Session expired"),
+        ClientResponseError(
+            request_info=MagicMock(),
+            history=(),
+            status=401,
+            message="Unauthorized",
+            headers=None,
+        ),
+        ClientResponseError(
+            request_info=MagicMock(),
+            history=(),
+            status=500,
+            message="Server error",
+            headers=None,
+        ),
+        TeltonikaConnectionError("Connection lost"),
+    ],
+    ids=["persistent_auth", "http_401", "http_500", "connection_error"],
+)
+@pytest.mark.usefixtures("init_integration")
+async def test_persistent_update_error_marks_unavailable_without_reauth(
+    hass: HomeAssistant,
+    mock_modems: AsyncMock,
     freezer: FrozenDateTimeFactory,
     side_effect: Exception,
-    expect_reauth: bool,
 ) -> None:
-    """Test auth and non-auth exceptions during updates."""
+    """Test persistent errors mark entities unavailable without a reauth flow."""
     mock_modems.get_status.side_effect = side_effect
 
     freezer.tick(timedelta(seconds=31))
@@ -144,30 +272,22 @@ async def test_sensor_update_exception_paths(
     assert state is not None
     assert state.state == "unavailable"
 
-    has_reauth = any(
-        flow["handler"] == DOMAIN and flow["context"]["source"] == SOURCE_REAUTH
-        for flow in hass.config_entries.flow.async_progress()
-    )
-    assert has_reauth is expect_reauth
+    assert _has_reauth_flow(hass) is False
 
 
 @pytest.mark.parametrize(
-    ("error_code", "expect_reauth"),
-    [
-        (TeltonikaErrorCode.UNAUTHORIZED_ACCESS, True),
-        (999, False),
-    ],
+    "error_code",
+    [TeltonikaErrorCode.UNAUTHORIZED_ACCESS, 999],
     ids=["api_auth_error", "api_non_auth_error"],
 )
-async def test_sensor_update_unsuccessful_response_paths(
+@pytest.mark.usefixtures("init_integration")
+async def test_unsuccessful_response_marks_unavailable_without_reauth(
     hass: HomeAssistant,
     mock_modems: AsyncMock,
-    init_integration: MockConfigEntry,
     freezer: FrozenDateTimeFactory,
     error_code: int,
-    expect_reauth: bool,
 ) -> None:
-    """Test unsuccessful API response handling."""
+    """Test persistent unsuccessful API responses don't trigger a reauth flow."""
     mock_modems.get_status.side_effect = None
     mock_modems.get_status.return_value = MagicMock(
         success=False,
@@ -183,8 +303,4 @@ async def test_sensor_update_unsuccessful_response_paths(
     assert state is not None
     assert state.state == "unavailable"
 
-    has_reauth = any(
-        flow["handler"] == DOMAIN and flow["context"]["source"] == SOURCE_REAUTH
-        for flow in hass.config_entries.flow.async_progress()
-    )
-    assert has_reauth is expect_reauth
+    assert _has_reauth_flow(hass) is False


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change should fix #174115, by trying to re-authenticate with the same credentials first before triggering a full reauth flow, e.g. after a reboot of the device has reset the JWT validity. To achieve this cleanly, the re-authenticating fetch was extracted from the main `_async_update_data` method.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #174115
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
