### PR TITLE
Add TP-Link Omada controller diagnostic and update entities

### DIFF
--- a/homeassistant/components/tplink_omada/__init__.py
+++ b/homeassistant/components/tplink_omada/__init__.py
@@ -67,12 +67,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmadaConfigEntry) -> boo
         ) from ex
 
     site_client = await client.get_site_client(OmadaSite("", entry.data[CONF_SITE]))
-    controller = OmadaSiteController(hass, entry, site_client)
+    controller = OmadaSiteController(hass, entry, client, site_client)
     await controller.initialize_first_refresh()
 
     entry.runtime_data = controller
 
-    _remove_old_devices(hass, entry, controller.devices_coordinator.data)
+    _remove_old_devices(
+        hass,
+        entry,
+        controller.devices_coordinator.data,
+        controller.controller_info_coordinator.data.omadac_id,
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -88,6 +93,7 @@ def _remove_old_devices(
     hass: HomeAssistant,
     entry: OmadaConfigEntry,
     omada_devices: dict[str, OmadaListDevice],
+    controller_id: str,
 ) -> None:
     device_registry = dr.async_get(hass)
 
@@ -97,7 +103,7 @@ def _remove_old_devices(
         mac = next(
             (i[1] for i in registered_device.identifiers if i[0] == DOMAIN), None
         )
-        if mac and mac not in omada_devices:
+        if mac and mac not in omada_devices and mac != controller_id:
             device_registry.async_update_device(
                 registered_device.id, remove_config_entry_id=entry.entry_id
             )

--- a/homeassistant/components/tplink_omada/controller.py
+++ b/homeassistant/components/tplink_omada/controller.py
@@ -3,7 +3,7 @@
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING
 
-from tplink_omada_client import OmadaSiteClient
+from tplink_omada_client import OmadaClient, OmadaSiteClient
 from tplink_omada_client.devices import OmadaListDevice, OmadaSwitch
 
 from homeassistant.core import HomeAssistant, callback
@@ -13,6 +13,8 @@ if TYPE_CHECKING:
 
 from .coordinator import (
     OmadaClientsCoordinator,
+    OmadaControllerInfoCoordinator,
+    OmadaControllerUpdateCoordinator,
     OmadaDevicesCoordinator,
     OmadaGatewayCoordinator,
     OmadaSwitchPortCoordinator,
@@ -28,6 +30,7 @@ class OmadaSiteController:
         self,
         hass: HomeAssistant,
         config_entry: OmadaConfigEntry,
+        omada_controller_client: OmadaClient,
         omada_client: OmadaSiteClient,
     ) -> None:
         """Create the controller."""
@@ -36,6 +39,12 @@ class OmadaSiteController:
         self._omada_client = omada_client
 
         self._switch_port_coordinators: dict[str, OmadaSwitchPortCoordinator] = {}
+        self._controller_info_coordinator = OmadaControllerInfoCoordinator(
+            hass, config_entry, omada_controller_client
+        )
+        self._controller_update_coordinator = OmadaControllerUpdateCoordinator(
+            hass, config_entry, omada_controller_client
+        )
         self._devices_coordinator = OmadaDevicesCoordinator(
             hass, config_entry, omada_client
         )
@@ -45,6 +54,7 @@ class OmadaSiteController:
 
     async def initialize_first_refresh(self) -> None:
         """Initialize the all coordinators, and perform first refresh."""
+        await self._controller_info_coordinator.async_config_entry_first_refresh()
         await self._devices_coordinator.async_config_entry_first_refresh()
 
         devices = self._devices_coordinator.data.values()
@@ -105,6 +115,16 @@ class OmadaSiteController:
     def omada_client(self) -> OmadaSiteClient:
         """Get the connected client API for the site to manage."""
         return self._omada_client
+
+    @property
+    def controller_info_coordinator(self) -> OmadaControllerInfoCoordinator:
+        """Gets the coordinator for controller information."""
+        return self._controller_info_coordinator
+
+    @property
+    def controller_update_coordinator(self) -> OmadaControllerUpdateCoordinator:
+        """Gets the coordinator for controller update information."""
+        return self._controller_update_coordinator
 
     def get_switch_port_coordinator(
         self, switch: OmadaSwitch

--- a/homeassistant/components/tplink_omada/controller_entities.py
+++ b/homeassistant/components/tplink_omada/controller_entities.py
@@ -1,0 +1,43 @@
+"""Helpers for TP-Link Omada controller-level entities."""
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .config_flow import CONF_SITE
+from .const import DOMAIN
+
+
+def config_entry_controller_unique_id(config_entry: ConfigEntry) -> str | None:
+    """Return the controller-level unique ID for a site config entry."""
+    unique_id = config_entry.unique_id
+    site_id = config_entry.data.get(CONF_SITE)
+
+    if unique_id is None or not isinstance(site_id, str):
+        return unique_id
+
+    site_suffix = f"_{site_id}"
+    if unique_id.endswith(site_suffix):
+        return unique_id[: -len(site_suffix)]
+
+    return unique_id
+
+
+def config_entry_owns_controller_entities(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> bool:
+    """Return if this site entry should add the controller-level entities."""
+    controller_unique_id = config_entry_controller_unique_id(config_entry)
+    controller_entries = [
+        entry
+        for entry in hass.config_entries.async_entries(
+            DOMAIN, include_ignore=False, include_disabled=False
+        )
+        if config_entry_controller_unique_id(entry) == controller_unique_id
+    ]
+
+    return (
+        config_entry.entry_id
+        == min(
+            controller_entries, key=lambda entry: (entry.created_at, entry.entry_id)
+        ).entry_id
+    )

--- a/homeassistant/components/tplink_omada/coordinator.py
+++ b/homeassistant/components/tplink_omada/coordinator.py
@@ -5,7 +5,13 @@ from datetime import timedelta
 import logging
 from typing import TYPE_CHECKING, NamedTuple, override
 
-from tplink_omada_client import OmadaSiteClient, OmadaSwitchPortDetails
+from tplink_omada_client import (
+    OmadaClient,
+    OmadaControllerInfo,
+    OmadaControllerUpdateInfo,
+    OmadaSiteClient,
+    OmadaSwitchPortDetails,
+)
 from tplink_omada_client.clients import OmadaWirelessClient
 from tplink_omada_client.devices import (
     OmadaFirmwareUpdate,
@@ -28,6 +34,70 @@ POLL_GATEWAY = 300
 POLL_CLIENTS = 300
 POLL_DEVICES = 300
 POLL_UPGRADE = 60
+
+
+class OmadaControllerInfoCoordinator(DataUpdateCoordinator[OmadaControllerInfo]):
+    """Coordinator for synchronizing Omada controller information."""
+
+    config_entry: OmadaConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: OmadaConfigEntry,
+        omada_client: OmadaClient,
+    ) -> None:
+        """Initialize the controller info coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=config_entry,
+            name="Omada API Data - Controller Info",
+            update_interval=timedelta(seconds=POLL_DEVICES),
+        )
+        self.omada_client = omada_client
+
+    @override
+    async def _async_update_data(self) -> OmadaControllerInfo:
+        """Fetch controller information from the API endpoint."""
+        try:
+            async with asyncio.timeout(10):
+                return await self.omada_client.get_controller_info()
+        except OmadaClientException as err:
+            raise UpdateFailed(f"Error communicating with API: {err}") from err
+
+
+class OmadaControllerUpdateCoordinator(
+    DataUpdateCoordinator[OmadaControllerUpdateInfo]
+):
+    """Coordinator for synchronizing Omada controller update information."""
+
+    config_entry: OmadaConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: OmadaConfigEntry,
+        omada_client: OmadaClient,
+    ) -> None:
+        """Initialize the controller update coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=config_entry,
+            name="Omada API Data - Controller Updates",
+            update_interval=timedelta(seconds=POLL_DEVICES),
+        )
+        self.omada_client = omada_client
+
+    @override
+    async def _async_update_data(self) -> OmadaControllerUpdateInfo:
+        """Fetch controller update information from the API endpoint."""
+        try:
+            async with asyncio.timeout(10):
+                return await self.omada_client.check_firmware_updates()
+        except OmadaClientException as err:
+            raise UpdateFailed(f"Error communicating with API: {err}") from err
 
 
 class OmadaCoordinator[_T](DataUpdateCoordinator[dict[str, _T]]):

--- a/homeassistant/components/tplink_omada/sensor.py
+++ b/homeassistant/components/tplink_omada/sensor.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import override
 
+from tplink_omada_client import OmadaControllerInfo
 from tplink_omada_client.definitions import DeviceStatus, DeviceStatusCategory
 from tplink_omada_client.devices import OmadaListDevice
 
@@ -15,12 +16,15 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import PERCENTAGE, EntityCategory
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import OmadaConfigEntry
-from .const import OmadaDeviceStatus
-from .coordinator import OmadaDevicesCoordinator
+from .const import DOMAIN, OmadaDeviceStatus
+from .controller_entities import config_entry_owns_controller_entities
+from .coordinator import OmadaControllerInfoCoordinator, OmadaDevicesCoordinator
 from .entity import OmadaDeviceEntity
 
 PARALLEL_UPDATES = 0
@@ -55,6 +59,13 @@ def _map_device_status(device: OmadaListDevice) -> str | None:
     return display_status.value if display_status else None
 
 
+def _map_controller_status(controller_info: OmadaControllerInfo) -> str:
+    """Map the controller info response to a device status."""
+    if controller_info.configured is False:
+        return OmadaDeviceStatus.DISCONNECTED.value
+    return OmadaDeviceStatus.CONNECTED.value
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: OmadaConfigEntry,
@@ -63,7 +74,18 @@ async def async_setup_entry(
     """Set up sensors."""
     controller = config_entry.runtime_data
 
+    controller_info_coordinator = controller.controller_info_coordinator
     devices_coordinator = controller.devices_coordinator
+
+    _register_controller_device(hass, config_entry, controller_info_coordinator.data)
+
+    if config_entry_owns_controller_entities(hass, config_entry):
+        async_add_entities(
+            [
+                OmadaControllerSensor(controller_info_coordinator, desc)
+                for desc in OMADA_CONTROLLER_SENSORS
+            ]
+        )
 
     async def _create_device_sensor_entities(
         device: OmadaListDevice,
@@ -89,6 +111,75 @@ class OmadaDeviceSensorEntityDescription(SensorEntityDescription):
 
     exists_func: Callable[[OmadaListDevice], bool] = lambda _: True
     update_func: Callable[[OmadaListDevice], StateType]
+
+
+@dataclass(frozen=True, kw_only=True)
+class OmadaControllerSensorEntityDescription(SensorEntityDescription):
+    """Entity description for status from the Omada controller."""
+
+    update_func: Callable[[OmadaControllerInfo], StateType]
+    extra_attributes_func: Callable[[OmadaControllerInfo], dict[str, StateType]] = (
+        lambda _: {}
+    )
+
+
+def _register_controller_device(
+    hass: HomeAssistant,
+    config_entry: OmadaConfigEntry,
+    controller_info: OmadaControllerInfo,
+) -> None:
+    """Register the controller device with the site config entry."""
+    dr.async_get(hass).async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, controller_info.omadac_id)},
+        manufacturer="TP-Link",
+        model="Omada Controller",
+        name="Omada Controller",
+        sw_version=controller_info.controller_version,
+    )
+
+
+def _controller_status_attributes(
+    controller_info: OmadaControllerInfo,
+) -> dict[str, StateType]:
+    """Return attributes for the controller status sensor."""
+    return {
+        "configured": controller_info.configured,
+        "type": controller_info.type,
+        "support_app": controller_info.support_app,
+        "registered_root": controller_info.registered_root,
+        "omadac_category": controller_info.omadac_category,
+        "msp_mode": controller_info.msp_mode,
+        "omada_cloud_url": controller_info.omada_cloud_url,
+    }
+
+
+OMADA_CONTROLLER_SENSORS: list[OmadaControllerSensorEntityDescription] = [
+    OmadaControllerSensorEntityDescription(
+        key="device_status",
+        translation_key="device_status",
+        device_class=SensorDeviceClass.ENUM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        update_func=_map_controller_status,
+        extra_attributes_func=_controller_status_attributes,
+        options=[
+            OmadaDeviceStatus.DISCONNECTED.value,
+            OmadaDeviceStatus.CONNECTED.value,
+        ],
+    ),
+    OmadaControllerSensorEntityDescription(
+        key="version",
+        translation_key="controller_version",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        update_func=lambda controller_info: controller_info.controller_version,
+    ),
+    OmadaControllerSensorEntityDescription(
+        key="api_version",
+        translation_key="controller_api_version",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        update_func=lambda controller_info: controller_info.api_version,
+    ),
+]
 
 
 OMADA_DEVICE_SENSORS: list[OmadaDeviceSensorEntityDescription] = [
@@ -117,6 +208,49 @@ OMADA_DEVICE_SENSORS: list[OmadaDeviceSensorEntityDescription] = [
         update_func=lambda device: device.mem_usage,
     ),
 ]
+
+
+class OmadaControllerSensor(
+    CoordinatorEntity[OmadaControllerInfoCoordinator], SensorEntity
+):
+    """Sensor for a property of the Omada controller."""
+
+    _attr_has_entity_name = True
+    entity_description: OmadaControllerSensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: OmadaControllerInfoCoordinator,
+        entity_description: OmadaControllerSensorEntityDescription,
+    ) -> None:
+        """Initialize the controller sensor."""
+        super().__init__(coordinator)
+        self.entity_description = entity_description
+        self._attr_unique_id = f"{coordinator.data.omadac_id}_{entity_description.key}"
+
+    @property
+    @override
+    def device_info(self) -> dr.DeviceInfo:
+        """Return device info for the Omada controller."""
+        return dr.DeviceInfo(
+            identifiers={(DOMAIN, self.coordinator.data.omadac_id)},
+            manufacturer="TP-Link",
+            model="Omada Controller",
+            name="Omada Controller",
+            sw_version=self.coordinator.data.controller_version,
+        )
+
+    @property
+    @override
+    def extra_state_attributes(self) -> dict[str, StateType]:
+        """Return extra attributes for the sensor."""
+        return self.entity_description.extra_attributes_func(self.coordinator.data)
+
+    @property
+    @override
+    def native_value(self) -> StateType:
+        """Return the state of the sensor."""
+        return self.entity_description.update_func(self.coordinator.data)
 
 
 class OmadaDeviceSensor(OmadaDeviceEntity[OmadaDevicesCoordinator], SensorEntity):

--- a/homeassistant/components/tplink_omada/strings.json
+++ b/homeassistant/components/tplink_omada/strings.json
@@ -67,6 +67,12 @@
       }
     },
     "sensor": {
+      "controller_api_version": {
+        "name": "API version"
+      },
+      "controller_version": {
+        "name": "Version"
+      },
       "cpu_usage": {
         "name": "CPU usage"
       },

--- a/homeassistant/components/tplink_omada/update.py
+++ b/homeassistant/components/tplink_omada/update.py
@@ -1,7 +1,9 @@
 """Support for TPLink Omada device firmware updates."""
 
-from typing import Any, override
+from dataclasses import dataclass
+from typing import Any, cast, override
 
+from tplink_omada_client import OmadaControllerInfo, OmadaControllerUpdateInfo
 from tplink_omada_client.devices import OmadaListDevice
 from tplink_omada_client.exceptions import OmadaClientException, RequestFailed
 
@@ -10,12 +12,20 @@ from homeassistant.components.update import (
     UpdateEntity,
     UpdateEntityFeature,
 )
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import OmadaConfigEntry
-from .coordinator import OmadaFirmwareUpdateCoordinator
+from .const import DOMAIN
+from .controller_entities import config_entry_owns_controller_entities
+from .coordinator import (
+    OmadaControllerUpdateCoordinator,
+    OmadaFirmwareUpdateCoordinator,
+)
 from .entity import OmadaDeviceEntity
 
 PARALLEL_UPDATES = 0
@@ -31,6 +41,17 @@ async def async_setup_entry(
 
     devices = controller.devices_coordinator.data
 
+    if config_entry_owns_controller_entities(hass, config_entry):
+        async_add_entities(
+            [
+                OmadaControllerUpdate(
+                    controller.controller_update_coordinator,
+                    controller.controller_info_coordinator.data,
+                )
+            ]
+        )
+        await controller.controller_update_coordinator.async_request_refresh()
+
     coordinator = OmadaFirmwareUpdateCoordinator(
         hass, config_entry, controller.omada_client, controller.devices_coordinator
     )
@@ -39,6 +60,125 @@ async def async_setup_entry(
         OmadaDeviceUpdate(coordinator, device) for device in devices.values()
     )
     await coordinator.async_request_refresh()
+
+
+@dataclass(frozen=True, kw_only=True)
+class ControllerUpdateDetails:
+    """Controller update data normalized for the update entity."""
+
+    current_version: str
+    latest_version: str
+    release_notes: str | None
+
+
+def _controller_software_update(
+    update_info: OmadaControllerUpdateInfo,
+) -> ControllerUpdateDetails | None:
+    """Return software controller update data when the API provides it."""
+    # The typed software update accessor can replace raw_data access after
+    # tplink-omada-client includes https://github.com/MarkGodwin/tplink-omada-api/pull/83.
+    software_update = update_info.raw_data.get("software")
+
+    if not isinstance(software_update, dict) or not software_update.get("upgrade"):
+        return None
+
+    current_version = software_update.get("currentVersion")
+    if not isinstance(current_version, str):
+        current_version = ""
+
+    latest_version = software_update.get("latestVersion")
+    if not isinstance(latest_version, str):
+        latest_version = current_version
+
+    release_notes = software_update.get("releaseLog")
+    if not isinstance(release_notes, str):
+        release_notes = None
+
+    return ControllerUpdateDetails(
+        current_version=current_version,
+        latest_version=latest_version,
+        release_notes=release_notes,
+    )
+
+
+def _controller_update_details(
+    update_info: OmadaControllerUpdateInfo,
+) -> ControllerUpdateDetails | None:
+    """Return controller update data, preferring software over hardware updates."""
+    if software_update := _controller_software_update(update_info):
+        return software_update
+
+    if hardware_update := update_info.hardware:
+        if hardware_update.upgrade:
+            return ControllerUpdateDetails(
+                current_version=hardware_update.current_version,
+                latest_version=hardware_update.latest_version,
+                release_notes=hardware_update.release_notes,
+            )
+
+    return None
+
+
+class OmadaControllerUpdate(
+    CoordinatorEntity[OmadaControllerUpdateCoordinator],
+    UpdateEntity,
+):
+    """Update status for an Omada controller."""
+
+    _attr_device_class = UpdateDeviceClass.FIRMWARE
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_has_entity_name = True
+    _attr_name = "Firmware"
+    _attr_supported_features = UpdateEntityFeature.RELEASE_NOTES
+
+    def __init__(
+        self,
+        coordinator: OmadaControllerUpdateCoordinator,
+        controller_info: OmadaControllerInfo,
+    ) -> None:
+        """Initialize the controller update entity."""
+        super().__init__(coordinator)
+        self._controller_info = controller_info
+        self._attr_unique_id = f"{controller_info.omadac_id}_controller_firmware"
+
+    @property
+    @override
+    def device_info(self) -> dr.DeviceInfo:
+        """Return device info for the Omada controller."""
+        return dr.DeviceInfo(
+            identifiers={(DOMAIN, self._controller_info.omadac_id)},
+            manufacturer="TP-Link",
+            model="Omada Controller",
+            name="Omada Controller",
+            sw_version=self._controller_info.controller_version,
+        )
+
+    @override
+    def release_notes(self) -> str | None:
+        """Get the release notes for the latest update."""
+        if self.coordinator.data and (
+            update_details := _controller_update_details(self.coordinator.data)
+        ):
+            return update_details.release_notes
+        return None
+
+    @callback
+    @override
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        update_details = (
+            _controller_update_details(self.coordinator.data)
+            if self.coordinator.data
+            else None
+        )
+        if update_details:
+            self._attr_installed_version = update_details.current_version
+            self._attr_latest_version = update_details.latest_version
+        else:
+            self._attr_installed_version = self._controller_info.controller_version
+            self._attr_latest_version = self._controller_info.controller_version
+
+        self.async_write_ha_state()
 
 
 class OmadaDeviceUpdate(
@@ -53,6 +193,7 @@ class OmadaDeviceUpdate(
         | UpdateEntityFeature.RELEASE_NOTES
     )
     _attr_device_class = UpdateDeviceClass.FIRMWARE
+    _attr_name = "Firmware"
 
     def __init__(
         self,
@@ -71,9 +212,10 @@ class OmadaDeviceUpdate(
     def release_notes(self) -> str | None:
         """Get the release notes for the latest update."""
         status = self.coordinator.data[self._mac]
-        if status.firmware:
-            return status.firmware.release_notes
-        return None
+        if not status.firmware:
+            return None
+
+        return cast(str | None, status.firmware.release_notes)
 
     @override
     async def async_install(

--- a/tests/components/tplink_omada/conftest.py
+++ b/tests/components/tplink_omada/conftest.py
@@ -5,7 +5,11 @@ from functools import partial
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from tplink_omada_client import OmadaSite
+from tplink_omada_client import (
+    OmadaControllerInfo,
+    OmadaControllerUpdateInfo,
+    OmadaSite,
+)
 from tplink_omada_client.clients import (
     OmadaConnectedClient,
     OmadaNetworkClient,
@@ -29,6 +33,7 @@ from tests.common import (
     MockConfigEntry,
     async_load_json_array_fixture,
     async_load_json_object_fixture,
+    load_json_object_fixture,
 )
 
 
@@ -188,6 +193,19 @@ def mock_omada_client(mock_omada_site_client: AsyncMock) -> Generator[MagicMock]
         client = client_mock.return_value
 
         client.get_site_client.return_value = mock_omada_site_client
+        client.get_controller_info = AsyncMock(return_value=_get_mock_controller_info())
+        client.check_firmware_updates = AsyncMock(
+            return_value=OmadaControllerUpdateInfo(
+                {
+                    "software": {
+                        "upgrade": True,
+                        "currentVersion": "6.2.10.15",
+                        "latestVersion": "6.2.14.6 Build 20260617091728",
+                        "releaseLog": "New controller software available.",
+                    }
+                }
+            )
+        )
         client.login.return_value = "12345"
         client.get_controller_name.return_value = "OC200"
         client.get_sites.return_value = [OmadaSite("Display Name", "SiteId")]
@@ -206,7 +224,17 @@ def mock_omada_clients_only_client(
         client = client_mock.return_value
 
         client.get_site_client.return_value = mock_omada_clients_only_site_client
+        client.get_controller_info = AsyncMock(return_value=_get_mock_controller_info())
+        client.check_firmware_updates = AsyncMock(
+            return_value=OmadaControllerUpdateInfo({})
+        )
         yield client
+
+
+def _get_mock_controller_info() -> OmadaControllerInfo:
+    """Mock controller information."""
+    controller_info_data = load_json_object_fixture("controller-info.json", DOMAIN)
+    return OmadaControllerInfo(controller_info_data)
 
 
 @pytest.fixture

--- a/tests/components/tplink_omada/fixtures/controller-info.json
+++ b/tests/components/tplink_omada/fixtures/controller-info.json
@@ -1,0 +1,12 @@
+{
+  "controllerVer": "6.2.10.15",
+  "apiVer": "3",
+  "configured": true,
+  "type": 1,
+  "supportApp": true,
+  "omadacId": "2b8ebfe7af51afa2f58844e1f9ba0c04",
+  "registeredRoot": true,
+  "omadacCategory": "advanced",
+  "mspMode": false,
+  "omadaCloudUrl": "https://omada.tplinkcloud.com"
+}

--- a/tests/components/tplink_omada/snapshots/test_sensor.ambr
+++ b/tests/components/tplink_omada/snapshots/test_sensor.ambr
@@ -1,4 +1,171 @@
 # serializer version: 1
+# name: test_entities[sensor.omada_controller_api_version-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.omada_controller_api_version',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'API version',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'API version',
+    'platform': 'tplink_omada',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'controller_api_version',
+    'unique_id': '2b8ebfe7af51afa2f58844e1f9ba0c04_api_version',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[sensor.omada_controller_api_version-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Omada Controller API version',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.omada_controller_api_version',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '3',
+  })
+# ---
+# name: test_entities[sensor.omada_controller_device_status-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'disconnected',
+        'connected',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.omada_controller_device_status',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Device status',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Device status',
+    'platform': 'tplink_omada',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'device_status',
+    'unique_id': '2b8ebfe7af51afa2f58844e1f9ba0c04_device_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[sensor.omada_controller_device_status-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'configured': True,
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Omada Controller Device status',
+      'msp_mode': False,
+      'omada_cloud_url': 'https://omada.tplinkcloud.com',
+      'omadac_category': 'advanced',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'disconnected',
+        'connected',
+      ]),
+      'registered_root': True,
+      'support_app': True,
+      'type': 1,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.omada_controller_device_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'connected',
+  })
+# ---
+# name: test_entities[sensor.omada_controller_version-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.omada_controller_version',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Version',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Version',
+    'platform': 'tplink_omada',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'controller_version',
+    'unique_id': '2b8ebfe7af51afa2f58844e1f9ba0c04_version',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[sensor.omada_controller_version-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Omada Controller Version',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.omada_controller_version',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '6.2.10.15',
+  })
+# ---
 # name: test_entities[sensor.test_poe_switch_cpu_usage-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/tplink_omada/snapshots/test_update.ambr
+++ b/tests/components/tplink_omada/snapshots/test_update.ambr
@@ -1,4 +1,67 @@
 # serializer version: 1
+# name: test_entities[update.omada_controller_firmware-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'update',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'update.omada_controller_firmware',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Firmware',
+    'options': dict({
+    }),
+    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
+    'original_icon': None,
+    'original_name': 'Firmware',
+    'platform': 'tplink_omada',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <UpdateEntityFeature: 16>,
+    'translation_key': None,
+    'unique_id': '2b8ebfe7af51afa2f58844e1f9ba0c04_controller_firmware',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[update.omada_controller_firmware-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <UpdateEntityStateAttribute.AUTO_UPDATE: 'auto_update'>: False,
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'firmware',
+      <UpdateEntityStateAttribute.DISPLAY_PRECISION: 'display_precision'>: 0,
+      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/brands/integration/tplink_omada/icon.png',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Omada Controller Firmware',
+      <UpdateEntityStateAttribute.IN_PROGRESS: 'in_progress'>: False,
+      <UpdateEntityStateAttribute.INSTALLED_VERSION: 'installed_version'>: '6.2.10.15',
+      <UpdateEntityStateAttribute.LATEST_VERSION: 'latest_version'>: '6.2.14.6 Build 20260617091728',
+      <UpdateEntityStateAttribute.RELEASE_SUMMARY: 'release_summary'>: None,
+      <UpdateEntityStateAttribute.RELEASE_URL: 'release_url'>: None,
+      <UpdateEntityStateAttribute.SKIPPED_VERSION: 'skipped_version'>: None,
+      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <UpdateEntityFeature: 16>,
+      <UpdateEntityStateAttribute.TITLE: 'title'>: None,
+      <UpdateEntityStateAttribute.UPDATE_PERCENTAGE: 'update_percentage'>: None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'update.omada_controller_firmware',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
 # name: test_entities[update.test_poe_switch_firmware-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/tplink_omada/test_init.py
+++ b/tests/components/tplink_omada/test_init.py
@@ -91,6 +91,43 @@ async def test_missing_devices_removed_at_startup(
     assert device_registry.async_get(device_entry.id) is None
 
 
+async def test_controller_device_kept_at_startup(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mock_omada_client: MagicMock,
+) -> None:
+    """Test the controller device is kept at startup."""
+    mock_config_entry = MockConfigEntry(
+        title="Test Omada Controller",
+        domain=DOMAIN,
+        data=dict(MOCK_ENTRY_DATA),
+        unique_id="12345_SiteId",
+        version=2,
+    )
+    mock_config_entry.add_to_hass(hass)
+
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={(DOMAIN, "2b8ebfe7af51afa2f58844e1f9ba0c04")},
+        manufacturer="TP-Link",
+        name="Omada Controller",
+        model="Omada Controller",
+    )
+
+    assert device_registry.async_get(device_entry.id) == device_entry
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    device_after = device_registry.async_get(device_entry.id)
+    assert device_after is not None
+    assert device_after.manufacturer == "TP-Link"
+    assert device_after.model == "Omada Controller"
+    assert device_after.name == "Omada Controller"
+    assert device_after.sw_version == "6.2.10.15"
+    assert (DOMAIN, "2b8ebfe7af51afa2f58844e1f9ba0c04") in device_after.identifiers
+
+
 async def test_migrate_entry_v1_to_v2(
     hass: HomeAssistant,
     mock_omada_client: MagicMock,

--- a/tests/components/tplink_omada/test_sensor.py
+++ b/tests/components/tplink_omada/test_sensor.py
@@ -1,23 +1,30 @@
 """Tests for TP-Link Omada sensor entities."""
 
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from tplink_omada_client import OmadaControllerInfo
 from tplink_omada_client.definitions import DeviceStatus, DeviceStatusCategory
 from tplink_omada_client.devices import OmadaListDevice
+from tplink_omada_client.exceptions import OmadaClientException
 
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.components.tplink_omada.config_flow import CONF_SITE
 from homeassistant.components.tplink_omada.const import DOMAIN
 from homeassistant.components.tplink_omada.coordinator import POLL_DEVICES
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.config_entries import ConfigEntryDisabler, ConfigEntryState
+from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant, State
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.common import (
     MockConfigEntry,
     async_fire_time_changed,
     async_load_json_array_fixture,
+    async_load_json_object_fixture,
     snapshot_platform,
 )
 
@@ -50,6 +57,67 @@ async def test_entities(
     await snapshot_platform(hass, entity_registry, snapshot, init_integration.entry_id)
 
 
+@pytest.mark.usefixtures("mock_omada_client")
+async def test_controller_entities_created_once_per_controller(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test controller entities are only created for one site config entry."""
+    second_entry = MockConfigEntry(
+        title="Test Omada Controller (Second)",
+        domain=DOMAIN,
+        data={**mock_config_entry.data, CONF_SITE: "Second"},
+        unique_id="12345_Second",
+        version=2,
+    )
+    disabled_entry = MockConfigEntry(
+        title="Test Omada Controller (Disabled)",
+        domain=DOMAIN,
+        data={**mock_config_entry.data, CONF_SITE: "Disabled"},
+        unique_id="12345_Disabled",
+        version=2,
+        disabled_by=ConfigEntryDisabler.USER,
+    )
+    object.__setattr__(disabled_entry, "created_at", datetime(2024, 1, 1, tzinfo=UTC))
+
+    disabled_entry.add_to_hass(hass)
+    mock_config_entry.add_to_hass(hass)
+    second_entry.add_to_hass(hass)
+
+    with patch("homeassistant.components.tplink_omada.PLATFORMS", ["sensor"]):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert second_entry.state is ConfigEntryState.LOADED
+    assert disabled_entry.state is ConfigEntryState.NOT_LOADED
+
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, "2b8ebfe7af51afa2f58844e1f9ba0c04")}
+    )
+    assert device_entry is not None
+    assert device_entry.config_entries == {
+        mock_config_entry.entry_id,
+        second_entry.entry_id,
+    }
+
+    expected_unique_ids = {
+        "2b8ebfe7af51afa2f58844e1f9ba0c04_api_version",
+        "2b8ebfe7af51afa2f58844e1f9ba0c04_device_status",
+        "2b8ebfe7af51afa2f58844e1f9ba0c04_version",
+    }
+
+    for unique_id in expected_unique_ids:
+        entity_id = entity_registry.async_get_entity_id(
+            SENSOR_DOMAIN, DOMAIN, unique_id
+        )
+        assert entity_id is not None
+        entity_entry = entity_registry.async_get(entity_id)
+        assert entity_entry is not None
+        assert entity_entry.config_entry_id == mock_config_entry.entry_id
+
+
 async def test_device_specific_status(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
@@ -77,6 +145,73 @@ async def test_device_specific_status(
     assert entity and entity.state == "adopt_failed"
 
 
+async def test_controller_status_connected(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test controller status reports connected."""
+    entity = _get_controller_status_state(hass)
+
+    assert entity.state == "connected"
+    assert entity.attributes["configured"] is True
+    assert entity.attributes["type"] == 1
+    assert entity.attributes["support_app"] is True
+    assert "omadac_id" not in entity.attributes
+    assert entity.attributes["registered_root"] is True
+    assert entity.attributes["omadac_category"] == "advanced"
+    assert entity.attributes["msp_mode"] is False
+    assert entity.attributes["omada_cloud_url"] == "https://omada.tplinkcloud.com"
+
+    version_entity = hass.states.get("sensor.omada_controller_version")
+    assert version_entity is not None
+    assert version_entity.state == "6.2.10.15"
+
+    api_version_entity = hass.states.get("sensor.omada_controller_api_version")
+    assert api_version_entity is not None
+    assert api_version_entity.state == "3"
+
+
+async def test_controller_status_disconnected(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_omada_client: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test controller status reports disconnected when it is not configured."""
+    await _set_controller_configured(hass, mock_omada_client, False)
+
+    freezer.tick(POLL_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    entity = _get_controller_status_state(hass)
+    assert entity.state == "disconnected"
+    assert entity.attributes["configured"] is False
+
+
+async def test_controller_status_unavailable(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_omada_client: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test controller sensors are unavailable when controller info cannot update."""
+    mock_omada_client.get_controller_info.side_effect = OmadaClientException()
+
+    freezer.tick(POLL_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert _get_controller_status_state(hass).state == STATE_UNAVAILABLE
+    version_entity = hass.states.get("sensor.omada_controller_version")
+    assert version_entity is not None
+    assert version_entity.state == STATE_UNAVAILABLE
+
+    api_version_entity = hass.states.get("sensor.omada_controller_api_version")
+    assert api_version_entity is not None
+    assert api_version_entity.state == STATE_UNAVAILABLE
+
+
 async def test_device_category_status(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
@@ -102,6 +237,27 @@ async def test_device_category_status(
 
     entity = hass.states.get(entity_id)
     assert entity and entity.state == "pending"
+
+
+def _get_controller_status_state(hass: HomeAssistant) -> State:
+    entity = hass.states.get("sensor.omada_controller_device_status")
+    assert entity is not None
+    return entity
+
+
+async def _set_controller_configured(
+    hass: HomeAssistant,
+    mock_omada_client: MagicMock,
+    configured: bool,
+) -> None:
+    controller_info_data = await async_load_json_object_fixture(
+        hass, "controller-info.json", DOMAIN
+    )
+    controller_info_data["configured"] = configured
+    mock_omada_client.get_controller_info.reset_mock()
+    mock_omada_client.get_controller_info.return_value = OmadaControllerInfo(
+        controller_info_data
+    )
 
 
 async def _set_test_device_status(

--- a/tests/components/tplink_omada/test_update.py
+++ b/tests/components/tplink_omada/test_update.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from tplink_omada_client import OmadaControllerUpdateInfo
 from tplink_omada_client.devices import OmadaListDevice
 from tplink_omada_client.exceptions import OmadaClientException, RequestFailed
 
@@ -100,6 +101,37 @@ async def test_firmware_download_in_progress(
     entity = hass.states.get(entity_id)
     assert entity is not None
     assert entity.attributes.get(ATTR_IN_PROGRESS) is True
+
+
+async def test_controller_hardware_update_fallback(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_omada_client: MagicMock,
+) -> None:
+    """Test controller update entity uses hardware update details as fallback."""
+    mock_omada_client.check_firmware_updates.return_value = OmadaControllerUpdateInfo(
+        {
+            "hardware": {
+                "upgrade": True,
+                "currentVersion": "1.0.0",
+                "latestVersion": "1.0.1",
+                "fwReleaseLog": "Hardware controller update available.",
+            }
+        }
+    )
+    mock_config_entry.add_to_hass(hass)
+
+    with patch("homeassistant.components.tplink_omada.PLATFORMS", [Platform.UPDATE]):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    entity = hass.states.get("update.omada_controller_firmware")
+    assert entity is not None
+    assert entity.state == STATE_ON
+    assert entity.attributes["installed_version"] == "1.0.0"
+    assert entity.attributes["latest_version"] == "1.0.1"
+
+    mock_omada_client.check_firmware_updates.assert_awaited_once()
 
 
 async def test_install_firmware_success(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add diagnostic entities for the TP-Link Omada Controller itself, and expose the controller firmware update entity when Omada reports a controller update.
This uses the controller info support available in tplink-omada-client==1.5.8 through OmadaClient.get_controller_info().
The controller is represented as its own Home Assistant device using the Omada controller ID as the device identifier.
New diagnostic sensor entities:
- Controller device status
- Controller version
- Controller API version

New update entity:
- Controller firmware update

The controller device status is mapped as:

- connected when controller info is available and configured is not explicitly false
- disconnected when controller info is available and configured is false
- unavailable when controller info cannot be refreshed

The controller update entity uses the controller update information already returned by the Omada updateInfo endpoint. For software controllers, it reads the software update payload from the raw response for compatibility with tplink-omada-client==1.5.8. For hardware controllers, it continues to use the typed hardware update data.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/MarkGodwin/tplink-omada-api/issues/75
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->