### PR TITLE
Rename "advanced_settings" section to "additional_settings" in Autoskope

### DIFF
--- a/homeassistant/components/autoskope/config_flow.py
+++ b/homeassistant/components/autoskope/config_flow.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.selector import (
     TextSelectorType,
 )
 
-from .const import DEFAULT_HOST, DOMAIN, SECTION_ADVANCED_SETTINGS
+from .const import DEFAULT_HOST, DOMAIN, SECTION_ADDITIONAL_SETTINGS
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
@@ -25,7 +25,7 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
         vol.Required(CONF_PASSWORD): TextSelector(
             TextSelectorConfig(type=TextSelectorType.PASSWORD)
         ),
-        vol.Required(SECTION_ADVANCED_SETTINGS): section(
+        vol.Required(SECTION_ADDITIONAL_SETTINGS): section(
             vol.Schema(
                 {
                     vol.Required(CONF_HOST, default=DEFAULT_HOST): TextSelector(
@@ -79,7 +79,7 @@ class AutoskopeConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
         if user_input is not None:
             username = user_input[CONF_USERNAME].lower()
-            host = user_input[SECTION_ADVANCED_SETTINGS][CONF_HOST].lower()
+            host = user_input[SECTION_ADDITIONAL_SETTINGS][CONF_HOST].lower()
 
             try:
                 cv.url(host)

--- a/homeassistant/components/autoskope/const.py
+++ b/homeassistant/components/autoskope/const.py
@@ -5,5 +5,5 @@ from datetime import timedelta
 DOMAIN = "autoskope"
 
 DEFAULT_HOST = "https://portal.autoskope.de"
-SECTION_ADVANCED_SETTINGS = "advanced_settings"
+SECTION_ADDITIONAL_SETTINGS = "additional_settings"
 UPDATE_INTERVAL = timedelta(seconds=60)

--- a/homeassistant/components/autoskope/strings.json
+++ b/homeassistant/components/autoskope/strings.json
@@ -31,7 +31,7 @@
         },
         "description": "Enter your Autoskope credentials.",
         "sections": {
-          "advanced_settings": {
+          "additional_settings": {
             "data": {
               "host": "API endpoint"
             },

--- a/tests/components/autoskope/test_config_flow.py
+++ b/tests/components/autoskope/test_config_flow.py
@@ -8,7 +8,7 @@ import pytest
 from homeassistant.components.autoskope.const import (
     DEFAULT_HOST,
     DOMAIN,
-    SECTION_ADVANCED_SETTINGS,
+    SECTION_ADDITIONAL_SETTINGS,
 )
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
@@ -20,7 +20,7 @@ from tests.common import MockConfigEntry
 USER_INPUT = {
     CONF_USERNAME: "test_user",
     CONF_PASSWORD: "test_password",
-    SECTION_ADVANCED_SETTINGS: {
+    SECTION_ADDITIONAL_SETTINGS: {
         CONF_HOST: DEFAULT_HOST,
     },
 }
@@ -102,7 +102,7 @@ async def test_flow_invalid_url(
         {
             CONF_USERNAME: "test_user",
             CONF_PASSWORD: "test_password",
-            SECTION_ADVANCED_SETTINGS: {
+            SECTION_ADDITIONAL_SETTINGS: {
                 CONF_HOST: "not-a-valid-url",
             },
         },
@@ -151,7 +151,7 @@ async def test_custom_host(
         {
             CONF_USERNAME: "test_user",
             CONF_PASSWORD: "test_password",
-            SECTION_ADVANCED_SETTINGS: {
+            SECTION_ADDITIONAL_SETTINGS: {
                 CONF_HOST: "https://custom.autoskope.server",
             },
         },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Rename the section `advanced_settings` to `additional_settings`. This is a follow up to #174630, where I previously only changed the user-facing string. This PR cleans up the rest. I didn't realize this was wanted before (https://github.com/home-assistant/core/pull/174056#discussion_r3427566705), but I think it makes sense.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes 
- This PR is related to issue: #174043, #173016
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
