### PR TITLE
Rename "advanced" setup/migration strategy ids to "manual" in ZHA

### DIFF
--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -70,13 +70,13 @@ DECONZ_DOMAIN = "deconz"
 # For the fast path, we automatically migrate everything
 # and restore the most recent backup
 MIGRATION_STRATEGY_RECOMMENDED = "migration_strategy_recommended"
-MIGRATION_STRATEGY_ADVANCED = "migration_strategy_advanced"
+MIGRATION_STRATEGY_MANUAL = "migration_strategy_manual"
 
 # Similarly, setup follows the same approach: we create a new network
 SETUP_STRATEGY_RECOMMENDED = "setup_strategy_recommended"
-SETUP_STRATEGY_ADVANCED = "setup_strategy_advanced"
+SETUP_STRATEGY_MANUAL = "setup_strategy_manual"
 
-# For the advanced paths, we allow users to pick how to form a network: form a brand new
+# For the manual paths, we allow users to pick how to form a network: form a brand new
 # network, use the settings currently on the stick, restore from a database backup, or
 # restore from a JSON backup
 FORMATION_STRATEGY = "formation_strategy"
@@ -340,8 +340,8 @@ class BaseZhaFlow(ConfigEntryBaseFlow):
             # Fast path: automatically form a new network
             return await self.async_step_setup_strategy_recommended()
         if self._flow_strategy == ZigbeeFlowStrategy.ADVANCED:
-            # Advanced path: let the user choose
-            return await self.async_step_setup_strategy_advanced()
+            # Manual path: let the user choose
+            return await self.async_step_setup_strategy_manual()
 
         # Allow onboarding for new users to just create a new network automatically
         if (
@@ -355,7 +355,7 @@ class BaseZhaFlow(ConfigEntryBaseFlow):
             step_id="choose_setup_strategy",
             menu_options=[
                 SETUP_STRATEGY_RECOMMENDED,
-                SETUP_STRATEGY_ADVANCED,
+                SETUP_STRATEGY_MANUAL,
             ],
         )
 
@@ -365,10 +365,10 @@ class BaseZhaFlow(ConfigEntryBaseFlow):
         """Recommended setup strategy: form a brand-new network."""
         return await self.async_step_form_new_network()
 
-    async def async_step_setup_strategy_advanced(
+    async def async_step_setup_strategy_manual(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Advanced setup strategy: let the user choose."""
+        """Manual setup strategy: let the user choose."""
         return await self.async_step_choose_formation_strategy()
 
     async def async_step_choose_migration_strategy(
@@ -379,13 +379,13 @@ class BaseZhaFlow(ConfigEntryBaseFlow):
             # Fast path: automatically migrate everything
             return await self.async_step_migration_strategy_recommended()
         if self._flow_strategy == ZigbeeFlowStrategy.ADVANCED:
-            # Advanced path: let the user choose
-            return await self.async_step_migration_strategy_advanced()
+            # Manual path: let the user choose
+            return await self.async_step_migration_strategy_manual()
         return self.async_show_menu(
             step_id="choose_migration_strategy",
             menu_options=[
                 MIGRATION_STRATEGY_RECOMMENDED,
-                MIGRATION_STRATEGY_ADVANCED,
+                MIGRATION_STRATEGY_MANUAL,
             ],
         )
 
@@ -512,10 +512,10 @@ class BaseZhaFlow(ConfigEntryBaseFlow):
             description_placeholders={"device_path": self._radio_mgr.device_path},
         )
 
-    async def async_step_migration_strategy_advanced(
+    async def async_step_migration_strategy_manual(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Advanced migration strategy: let the user choose."""
+        """Manual migration strategy: let the user choose."""
         return await self.async_step_choose_formation_strategy()
 
     async def async_step_choose_formation_strategy(

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -51,11 +51,11 @@
       "choose_migration_strategy": {
         "description": "Choose how you want to migrate your Zigbee network backup from your old adapter to a new one.",
         "menu_option_descriptions": {
-          "migration_strategy_advanced": "This will let you restore a specific network backup or upload your own.",
+          "migration_strategy_manual": "This will let you restore a specific network backup or upload your own.",
           "migration_strategy_recommended": "This is the quickest option to migrate to a new adapter."
         },
         "menu_options": {
-          "migration_strategy_advanced": "Migrate manually",
+          "migration_strategy_manual": "Migrate manually",
           "migration_strategy_recommended": "Migrate automatically (recommended)"
         },
         "title": "Migrate to a new adapter"
@@ -70,11 +70,11 @@
       "choose_setup_strategy": {
         "description": "Choose how you want to set up Zigbee. Automatic setup is recommended unless you are restoring your network from a backup or setting up an adapter with nonstandard settings.",
         "menu_option_descriptions": {
-          "setup_strategy_advanced": "This will let you restore from a backup.",
+          "setup_strategy_manual": "This will let you restore from a backup.",
           "setup_strategy_recommended": "This is the quickest option to create a new network and get started."
         },
         "menu_options": {
-          "setup_strategy_advanced": "Set up manually",
+          "setup_strategy_manual": "Set up manually",
           "setup_strategy_recommended": "Set up automatically (recommended)"
         },
         "title": "Set up Zigbee"
@@ -2260,11 +2260,11 @@
       "choose_migration_strategy": {
         "description": "[%key:component::zha::config::step::choose_migration_strategy::description%]",
         "menu_option_descriptions": {
-          "migration_strategy_advanced": "[%key:component::zha::config::step::choose_migration_strategy::menu_option_descriptions::migration_strategy_advanced%]",
+          "migration_strategy_manual": "[%key:component::zha::config::step::choose_migration_strategy::menu_option_descriptions::migration_strategy_manual%]",
           "migration_strategy_recommended": "[%key:component::zha::config::step::choose_migration_strategy::menu_option_descriptions::migration_strategy_recommended%]"
         },
         "menu_options": {
-          "migration_strategy_advanced": "[%key:component::zha::config::step::choose_migration_strategy::menu_options::migration_strategy_advanced%]",
+          "migration_strategy_manual": "[%key:component::zha::config::step::choose_migration_strategy::menu_options::migration_strategy_manual%]",
           "migration_strategy_recommended": "[%key:component::zha::config::step::choose_migration_strategy::menu_options::migration_strategy_recommended%]"
         },
         "title": "[%key:component::zha::config::step::choose_migration_strategy::title%]"

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -772,7 +772,7 @@ async def test_multiple_zha_entries_aborts(hass: HomeAssistant, mock_app) -> Non
 
     result_recommended = await hass.config_entries.flow.async_configure(
         result_confirm["flow_id"],
-        user_input={"next_step_id": config_flow.MIGRATION_STRATEGY_ADVANCED},
+        user_input={"next_step_id": config_flow.MIGRATION_STRATEGY_MANUAL},
     )
 
     result_reuse = await hass.config_entries.flow.async_configure(
@@ -1669,7 +1669,7 @@ def advanced_pick_radio(hass: HomeAssistant) -> Generator[RadioPicker]:
 
         advanced_strategy_result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            user_input={"next_step_id": config_flow.SETUP_STRATEGY_ADVANCED},
+            user_input={"next_step_id": config_flow.SETUP_STRATEGY_MANUAL},
         )
 
         assert advanced_strategy_result["type"] is FlowResultType.MENU
@@ -2372,7 +2372,7 @@ async def test_options_flow_defaults(
 
     result6 = await hass.config_entries.options.async_configure(
         result5["flow_id"],
-        user_input={"next_step_id": config_flow.MIGRATION_STRATEGY_ADVANCED},
+        user_input={"next_step_id": config_flow.MIGRATION_STRATEGY_MANUAL},
     )
     await hass.async_block_till_done()
 
@@ -3018,7 +3018,7 @@ async def test_migrate_setup_options_with_ignored_discovery(
     assert confirm_result["step_id"] == "choose_setup_strategy"
     assert confirm_result["menu_options"] == [
         "setup_strategy_recommended",
-        "setup_strategy_advanced",
+        "setup_strategy_manual",
     ]
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Rename the `setup_strategy_advanced` and `migration_strategy_advanced` menu options (and their constants and step methods) to `*_manual`, matching the user-facing labels. This is a follow up to #175094, where I previously only changed the user-facing string. This PR cleans up the rest. I didn't realize this was wanted before (https://github.com/home-assistant/core/pull/174056#discussion_r3427566705), but I think it makes sense.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes 
- This PR is related to issue: #174036, #173016
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
