### PR TITLE
Add walk_checker helper to deduplicate pylint rule tests

### DIFF
--- a/tests/pylint/__init__.py
+++ b/tests/pylint/__init__.py
@@ -2,7 +2,19 @@
 
 import contextlib
 
+from astroid import nodes
+from pylint.checkers import BaseChecker
 from pylint.testutils.unittest_linter import UnittestLinter
+from pylint.utils.ast_walker import ASTWalker
+
+
+def walk_checker(
+    linter: UnittestLinter, checker: BaseChecker, node: nodes.NodeNG
+) -> None:
+    """Run the given checker over the parsed node."""
+    walker = ASTWalker(linter)
+    walker.add_checker(checker)
+    walker.walk(node)
 
 
 @contextlib.contextmanager

--- a/tests/pylint/actions/test_service_registration.py
+++ b/tests/pylint/actions/test_service_registration.py
@@ -2,13 +2,12 @@
 
 import astroid
 from pylint.testutils import UnittestLinter
-from pylint.utils.ast_walker import ASTWalker
 from pylint_home_assistant.checkers.actions.service_registration import (
     ServiceRegistrationChecker,
 )
 import pytest
 
-from tests.pylint import assert_no_messages
+from tests.pylint import assert_no_messages, walk_checker
 
 
 @pytest.fixture(name="registration_checker")
@@ -68,11 +67,9 @@ def test_no_warning(
 ) -> None:
     """Test cases that should not trigger a warning."""
     root_node = astroid.parse(code, module_name)
-    walker = ASTWalker(linter)
-    walker.add_checker(registration_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, registration_checker, root_node)
 
 
 def test_hass_services_register_flagged(
@@ -87,9 +84,7 @@ async def async_setup_entry(hass, entry):
 """,
         "homeassistant.components.test_integration",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(registration_checker)
-    walker.walk(root_node)
+    walk_checker(linter, registration_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -108,9 +103,7 @@ async def async_setup_entry(hass, entry):
 """,
         "homeassistant.components.test_integration",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(registration_checker)
-    walker.walk(root_node)
+    walk_checker(linter, registration_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -128,9 +121,7 @@ async def async_setup_entry(hass, entry):
 """,
         "homeassistant.components.test_integration",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(registration_checker)
-    walker.walk(root_node)
+    walk_checker(linter, registration_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -148,9 +139,7 @@ async def async_setup_entry(hass, entry):
 """,
         "homeassistant.components.test_integration",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(registration_checker)
-    walker.walk(root_node)
+    walk_checker(linter, registration_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -170,9 +159,7 @@ async def async_setup_entry(hass, entry):
 """,
         "homeassistant.components.test_integration",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(registration_checker)
-    walker.walk(root_node)
+    walk_checker(linter, registration_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 3
@@ -193,9 +180,7 @@ async def async_setup_entry(hass, entry):
 """,
         "homeassistant.components.test_integration",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(registration_checker)
-    walker.walk(root_node)
+    walk_checker(linter, registration_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -219,8 +204,6 @@ async def async_setup_entry(hass, entry):
 """,
         "homeassistant.components.test_integration",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(registration_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, registration_checker, root_node)

--- a/tests/pylint/actions/test_swallowed_exceptions.py
+++ b/tests/pylint/actions/test_swallowed_exceptions.py
@@ -2,13 +2,12 @@
 
 import astroid
 from pylint.testutils import UnittestLinter
-from pylint.utils.ast_walker import ASTWalker
 from pylint_home_assistant.checkers.actions.swallowed_exceptions import (
     SwallowedActionExceptionsChecker,
 )
 import pytest
 
-from tests.pylint import assert_no_messages
+from tests.pylint import assert_no_messages, walk_checker
 
 
 @pytest.fixture(name="error_propagation_checker")
@@ -129,11 +128,9 @@ def test_no_warning(
 ) -> None:
     """Test cases that should not trigger a warning."""
     root_node = astroid.parse(code, "homeassistant.components.test_integration.switch")
-    walker = ASTWalker(linter)
-    walker.add_checker(error_propagation_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, error_propagation_checker, root_node)
 
 
 def test_log_only_flagged(
@@ -152,9 +149,7 @@ class MySwitch(SwitchEntity):
 """,
         "homeassistant.components.test_integration.switch",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(error_propagation_checker)
-    walker.walk(root_node)
+    walk_checker(linter, error_propagation_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -179,9 +174,7 @@ class MySwitch(SwitchEntity):
 """,
         "homeassistant.components.test_integration.switch",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(error_propagation_checker)
-    walker.walk(root_node)
+    walk_checker(linter, error_propagation_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -203,9 +196,7 @@ class MySwitch(SwitchEntity):
 """,
         "homeassistant.components.test_integration.switch",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(error_propagation_checker)
-    walker.walk(root_node)
+    walk_checker(linter, error_propagation_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -229,9 +220,7 @@ class MySwitch(SwitchEntity):
 """,
         "homeassistant.components.test_integration.switch",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(error_propagation_checker)
-    walker.walk(root_node)
+    walk_checker(linter, error_propagation_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -255,9 +244,7 @@ class MySwitch(SwitchEntity):
 """,
         "homeassistant.components.test_integration.switch",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(error_propagation_checker)
-    walker.walk(root_node)
+    walk_checker(linter, error_propagation_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -280,9 +267,7 @@ class MySwitch(SwitchEntity):
 """,
         "homeassistant.components.test_integration.switch",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(error_propagation_checker)
-    walker.walk(root_node)
+    walk_checker(linter, error_propagation_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -304,9 +289,7 @@ class MySwitch(SwitchEntity):
 """,
         "homeassistant.components.test_integration.switch",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(error_propagation_checker)
-    walker.walk(root_node)
+    walk_checker(linter, error_propagation_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -334,9 +317,7 @@ class MySwitch(SwitchEntity):
 """,
         "homeassistant.components.test_integration.switch",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(error_propagation_checker)
-    walker.walk(root_node)
+    walk_checker(linter, error_propagation_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 2
@@ -356,9 +337,7 @@ class MySwitch(SwitchEntity):
 """,
         "homeassistant.components.test_integration.switch",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(error_propagation_checker)
-    walker.walk(root_node)
+    walk_checker(linter, error_propagation_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -379,11 +358,9 @@ class MySwitch(SwitchEntity):
 """,
         "homeassistant.components.test_integration.switch",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(error_propagation_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, error_propagation_checker, root_node)
 
 
 def test_decorator_swallows_flagged(
@@ -408,9 +385,7 @@ class MySwitch(SwitchEntity):
 """,
         "homeassistant.components.test_integration.switch",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(error_propagation_checker)
-    walker.walk(root_node)
+    walk_checker(linter, error_propagation_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -441,9 +416,7 @@ class MySwitch(SwitchEntity):
 """,
         "homeassistant.components.test_integration.switch",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(error_propagation_checker)
-    walker.walk(root_node)
+    walk_checker(linter, error_propagation_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -471,11 +444,9 @@ class MySwitch(SwitchEntity):
 """,
         "homeassistant.components.test_integration.switch",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(error_propagation_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, error_propagation_checker, root_node)
 
 
 def test_custom_service_method_flagged(
@@ -502,9 +473,7 @@ class MyFan(FanEntity):
 """,
         "homeassistant.components.test_integration.fan",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(error_propagation_checker)
-    walker.walk(root_node)
+    walk_checker(linter, error_propagation_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -535,11 +504,9 @@ class MyFan(FanEntity):
 """,
         "homeassistant.components.test_integration.fan",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(error_propagation_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, error_propagation_checker, root_node)
 
 
 def test_unregistered_custom_method_ignored(
@@ -558,11 +525,9 @@ class MyFan(FanEntity):
 """,
         "homeassistant.components.test_integration.fan",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(error_propagation_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, error_propagation_checker, root_node)
 
 
 def test_standalone_service_handler_flagged(
@@ -583,9 +548,7 @@ async def _handle_do_thing(call):
 """,
         "homeassistant.components.test_integration.services",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(error_propagation_checker)
-    walker.walk(root_node)
+    walk_checker(linter, error_propagation_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -610,9 +573,7 @@ async def _handle_reset(call):
 """,
         "homeassistant.components.test_integration.services",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(error_propagation_checker)
-    walker.walk(root_node)
+    walk_checker(linter, error_propagation_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -637,11 +598,9 @@ async def _handle_do_thing(call):
 """,
         "homeassistant.components.test_integration.services",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(error_propagation_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, error_propagation_checker, root_node)
 
 
 def test_not_integration_module_ignored(
@@ -660,8 +619,6 @@ class MySwitch(SwitchEntity):
 """,
         "tests.components.test_integration.test_switch",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(error_propagation_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, error_propagation_checker, root_node)

--- a/tests/pylint/config_flow/test_no_name.py
+++ b/tests/pylint/config_flow/test_no_name.py
@@ -8,10 +8,9 @@ from pathlib import Path
 import astroid
 from pylint.checkers import BaseChecker
 from pylint.testutils.unittest_linter import UnittestLinter
-from pylint.utils.ast_walker import ASTWalker
 import pytest
 
-from tests.pylint import assert_no_messages
+from tests.pylint import assert_no_messages, walk_checker
 
 
 @pytest.mark.parametrize(
@@ -62,11 +61,9 @@ def test_enforce_config_flow_no_name(
 ) -> None:
     """Good test cases."""
     root_node = astroid.parse(code, module_name)
-    walker = ASTWalker(linter)
-    walker.add_checker(enforce_config_flow_no_name_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, enforce_config_flow_no_name_checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -110,10 +107,8 @@ def test_enforce_config_flow_no_name_bad(
 ) -> None:
     """Bad test cases."""
     root_node = astroid.parse(code, module_name)
-    walker = ASTWalker(linter)
-    walker.add_checker(enforce_config_flow_no_name_checker)
 
-    walker.walk(root_node)
+    walk_checker(linter, enforce_config_flow_no_name_checker, root_node)
     messages = linter.release_messages()
     assert len(messages) == 1
     assert messages[0].msg_id == "home-assistant-config-flow-name-field"
@@ -134,11 +129,9 @@ def test_enforce_config_flow_no_name_subentry_flow(
             )
     """
     root_node = astroid.parse(code, "homeassistant.components.test.config_flow")
-    walker = ASTWalker(linter)
-    walker.add_checker(enforce_config_flow_no_name_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, enforce_config_flow_no_name_checker, root_node)
 
 
 def test_enforce_config_flow_no_name_helper_integration(
@@ -160,11 +153,8 @@ def test_enforce_config_flow_no_name_helper_integration(
     root_node = astroid.parse(code, "homeassistant.components.my_helper.config_flow")
     root_node.file = str(integration_dir / "config_flow.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(enforce_config_flow_no_name_checker)
-
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, enforce_config_flow_no_name_checker, root_node)
 
 
 def test_enforce_config_flow_no_name_non_helper_integration(
@@ -184,10 +174,7 @@ def test_enforce_config_flow_no_name_non_helper_integration(
     root_node = astroid.parse(code, "homeassistant.components.my_device.config_flow")
     root_node.file = str(integration_dir / "config_flow.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(enforce_config_flow_no_name_checker)
-
-    walker.walk(root_node)
+    walk_checker(linter, enforce_config_flow_no_name_checker, root_node)
     messages = linter.release_messages()
     assert len(messages) == 1
     assert messages[0].msg_id == "home-assistant-config-flow-name-field"

--- a/tests/pylint/config_flow/test_no_polling.py
+++ b/tests/pylint/config_flow/test_no_polling.py
@@ -3,10 +3,9 @@
 import astroid
 from pylint.checkers import BaseChecker
 from pylint.testutils.unittest_linter import UnittestLinter
-from pylint.utils.ast_walker import ASTWalker
 import pytest
 
-from tests.pylint import assert_no_messages
+from tests.pylint import assert_no_messages, walk_checker
 
 
 @pytest.mark.parametrize(
@@ -71,11 +70,9 @@ def test_enforce_config_flow_no_polling(
 ) -> None:
     """Good test cases."""
     root_node = astroid.parse(code, module_name)
-    walker = ASTWalker(linter)
-    walker.add_checker(enforce_config_flow_no_polling_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, enforce_config_flow_no_polling_checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -133,10 +130,8 @@ def test_enforce_config_flow_no_polling_bad(
 ) -> None:
     """Bad test cases."""
     root_node = astroid.parse(code, module_name)
-    walker = ASTWalker(linter)
-    walker.add_checker(enforce_config_flow_no_polling_checker)
 
-    walker.walk(root_node)
+    walk_checker(linter, enforce_config_flow_no_polling_checker, root_node)
     messages = linter.release_messages()
     assert len(messages) == 1
     assert messages[0].msg_id == "home-assistant-config-flow-polling-field"

--- a/tests/pylint/config_flow/test_unique_id_no_ip.py
+++ b/tests/pylint/config_flow/test_unique_id_no_ip.py
@@ -3,10 +3,9 @@
 import astroid
 from pylint.checkers import BaseChecker
 from pylint.testutils.unittest_linter import UnittestLinter
-from pylint.utils.ast_walker import ASTWalker
 import pytest
 
-from tests.pylint import assert_no_messages
+from tests.pylint import assert_no_messages, walk_checker
 
 
 @pytest.mark.parametrize(
@@ -64,11 +63,9 @@ def test_enforce_unique_id_no_ip(
 ) -> None:
     """Good test cases."""
     root_node = astroid.parse(code, module_name)
-    walker = ASTWalker(linter)
-    walker.add_checker(enforce_config_entry_unique_id_no_ip_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, enforce_config_entry_unique_id_no_ip_checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -121,10 +118,8 @@ def test_enforce_unique_id_no_ip_bad_call(
 ) -> None:
     """Bad async_set_unique_id call test cases."""
     root_node = astroid.parse(code, module_name)
-    walker = ASTWalker(linter)
-    walker.add_checker(enforce_config_entry_unique_id_no_ip_checker)
 
-    walker.walk(root_node)
+    walk_checker(linter, enforce_config_entry_unique_id_no_ip_checker, root_node)
     messages = linter.release_messages()
     assert len(messages) == 1
     assert messages[0].msg_id == "home-assistant-unique-id-ip-based"
@@ -182,10 +177,8 @@ def test_enforce_unique_id_no_ip_bad_call_variable(
 ) -> None:
     """Bad async_set_unique_id call test cases."""
     root_node = astroid.parse(code, module_name)
-    walker = ASTWalker(linter)
-    walker.add_checker(enforce_config_entry_unique_id_no_ip_checker)
 
-    walker.walk(root_node)
+    walk_checker(linter, enforce_config_entry_unique_id_no_ip_checker, root_node)
     messages = linter.release_messages()
     assert len(messages) == 1
     assert messages[0].msg_id == "home-assistant-unique-id-ip-based"

--- a/tests/pylint/quality_scale/test_config_entry_unloading.py
+++ b/tests/pylint/quality_scale/test_config_entry_unloading.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import astroid
 from pylint.testutils import MessageTest, UnittestLinter
-from pylint.utils.ast_walker import ASTWalker
 from pylint_home_assistant.checkers.quality_scale.config_entry_unloading import (
     ConfigEntryUnloadingChecker,
 )
@@ -12,7 +11,7 @@ from pylint_home_assistant.helpers.quality_scale import clear_quality_scale_cach
 import pytest
 import yaml
 
-from tests.pylint import assert_adds_messages, assert_no_messages
+from tests.pylint import assert_adds_messages, assert_no_messages, walk_checker
 
 
 @pytest.fixture(name="unloading_checker")
@@ -56,11 +55,8 @@ async def async_unload_entry(hass, entry):
     )
     root_node.file = str(integration_dir / "__init__.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(unloading_checker)
-
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, unloading_checker, root_node)
 
 
 def test_unload_entry_missing_fires(
@@ -81,9 +77,6 @@ async def async_setup_entry(hass, entry):
     )
     root_node.file = str(integration_dir / "__init__.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(unloading_checker)
-
     with assert_adds_messages(
         linter,
         MessageTest(
@@ -93,7 +86,7 @@ async def async_setup_entry(hass, entry):
             col_offset=0,
         ),
     ):
-        walker.walk(root_node)
+        walk_checker(linter, unloading_checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -146,8 +139,5 @@ async def async_setup_entry(hass, entry):
     )
     root_node.file = str(integration_dir / "__init__.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(unloading_checker)
-
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, unloading_checker, root_node)

--- a/tests/pylint/quality_scale/test_diagnostics.py
+++ b/tests/pylint/quality_scale/test_diagnostics.py
@@ -4,13 +4,12 @@ from pathlib import Path
 
 import astroid
 from pylint.testutils import MessageTest, UnittestLinter
-from pylint.utils.ast_walker import ASTWalker
 from pylint_home_assistant.checkers.quality_scale.diagnostics import DiagnosticsChecker
 from pylint_home_assistant.helpers.quality_scale import clear_quality_scale_cache
 import pytest
 import yaml
 
-from tests.pylint import assert_adds_messages, assert_no_messages
+from tests.pylint import assert_adds_messages, assert_no_messages, walk_checker
 
 
 @pytest.fixture(name="diagnostics_checker")
@@ -75,11 +74,8 @@ def test_diagnostics_present(
     root_node = astroid.parse(code, "homeassistant.components.test_int.diagnostics")
     root_node.file = str(integration_dir / "diagnostics.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(diagnostics_checker)
-
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, diagnostics_checker, root_node)
 
 
 def test_diagnostics_missing_fires(
@@ -100,9 +96,6 @@ async def async_setup(hass, config):
     )
     root_node.file = str(integration_dir / "diagnostics.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(diagnostics_checker)
-
     with assert_adds_messages(
         linter,
         MessageTest(
@@ -112,7 +105,7 @@ async def async_setup(hass, config):
             col_offset=0,
         ),
     ):
-        walker.walk(root_node)
+        walk_checker(linter, diagnostics_checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -165,8 +158,5 @@ async def async_setup(hass, config):
     )
     root_node.file = str(integration_dir / "diagnostics.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(diagnostics_checker)
-
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, diagnostics_checker, root_node)

--- a/tests/pylint/quality_scale/test_entity_unique_id.py
+++ b/tests/pylint/quality_scale/test_entity_unique_id.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import astroid
 from astroid import nodes
 from pylint.testutils import MessageTest, UnittestLinter
-from pylint.utils.ast_walker import ASTWalker
 from pylint_home_assistant.checkers.quality_scale.entity_unique_id import (
     EntityUniqueIdChecker,
 )
@@ -15,7 +14,7 @@ from pylint_home_assistant.helpers.quality_scale import clear_quality_scale_cach
 import pytest
 import yaml
 
-from tests.pylint import assert_adds_messages, assert_no_messages
+from tests.pylint import assert_adds_messages, assert_no_messages, walk_checker
 
 
 @pytest.fixture(name="entity_unique_id_checker")
@@ -258,10 +257,8 @@ def test_handled(
     _create_quality_scale(integration_dir, {"entity-unique-id": "done"})
 
     root_node = _parse(code, integration_dir)
-    walker = ASTWalker(linter)
-    walker.add_checker(entity_unique_id_checker)
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, entity_unique_id_checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -351,10 +348,8 @@ def test_ancestor_satisfies_rule(
     astroid.parse(ancestor_code, "homeassistant.components.test_integration.eui_entity")
     root_node = _parse(sensor_code, integration_dir)
 
-    walker = ASTWalker(linter)
-    walker.add_checker(entity_unique_id_checker)
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, entity_unique_id_checker, root_node)
 
 
 def test_missing_fires(
@@ -377,10 +372,8 @@ class MySensor(Entity):
     )
 
     class_node = next(root_node.nodes_of_class(nodes.ClassDef))
-    walker = ASTWalker(linter)
-    walker.add_checker(entity_unique_id_checker)
     with assert_adds_messages(linter, _expect_missing(class_node)):
-        walker.walk(root_node)
+        walk_checker(linter, entity_unique_id_checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -444,10 +437,8 @@ def test_conditional_self_assignment_fires(
         for cls in root_node.nodes_of_class(nodes.ClassDef)
         if cls.name == class_name
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(entity_unique_id_checker)
     with assert_adds_messages(linter, _expect_missing(class_node)):
-        walker.walk(root_node)
+        walk_checker(linter, entity_unique_id_checker, root_node)
 
 
 def test_explicit_none_class_body_fires(
@@ -470,10 +461,8 @@ class MySensor(Entity):
     )
 
     class_node = next(root_node.nodes_of_class(nodes.ClassDef))
-    walker = ASTWalker(linter)
-    walker.add_checker(entity_unique_id_checker)
     with assert_adds_messages(linter, _expect_missing(class_node)):
-        walker.walk(root_node)
+        walk_checker(linter, entity_unique_id_checker, root_node)
 
 
 def test_subclass_nullifies_ancestor_value(
@@ -510,10 +499,8 @@ class MySensor(TestIntegrationBaseEntity):
         for cls in root_node.nodes_of_class(nodes.ClassDef)
         if cls.name == "MySensor"
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(entity_unique_id_checker)
     with assert_adds_messages(linter, _expect_missing(class_node)):
-        walker.walk(root_node)
+        walk_checker(linter, entity_unique_id_checker, root_node)
 
 
 def test_explicit_none_self_assign_fires(
@@ -537,10 +524,8 @@ class MySensor(Entity):
     )
 
     class_node = next(root_node.nodes_of_class(nodes.ClassDef))
-    walker = ASTWalker(linter)
-    walker.add_checker(entity_unique_id_checker)
     with assert_adds_messages(linter, _expect_missing(class_node)):
-        walker.walk(root_node)
+        walk_checker(linter, entity_unique_id_checker, root_node)
 
 
 def test_bare_annotation_only_fires(
@@ -563,10 +548,8 @@ class MySensor(Entity):
     )
 
     class_node = next(root_node.nodes_of_class(nodes.ClassDef))
-    walker = ASTWalker(linter)
-    walker.add_checker(entity_unique_id_checker)
     with assert_adds_messages(linter, _expect_missing(class_node)):
-        walker.walk(root_node)
+        walk_checker(linter, entity_unique_id_checker, root_node)
 
 
 def test_entity_default_does_not_satisfy(
@@ -596,10 +579,8 @@ class MySensor(Entity):
     )
 
     class_node = next(root_node.nodes_of_class(nodes.ClassDef))
-    walker = ASTWalker(linter)
-    walker.add_checker(entity_unique_id_checker)
     with assert_adds_messages(linter, _expect_missing(class_node)):
-        walker.walk(root_node)
+        walk_checker(linter, entity_unique_id_checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -638,10 +619,8 @@ def test_class_not_subject_to_rule(
 
     root_node = _parse(code, integration_dir)
 
-    walker = ASTWalker(linter)
-    walker.add_checker(entity_unique_id_checker)
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, entity_unique_id_checker, root_node)
 
 
 def test_leaf_class_still_fires(
@@ -671,10 +650,8 @@ class SomethingUnrelated:
         for cls in root_node.nodes_of_class(nodes.ClassDef)
         if cls.name == "LonelySensor"
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(entity_unique_id_checker)
     with assert_adds_messages(linter, _expect_missing(class_node)):
-        walker.walk(root_node)
+        walk_checker(linter, entity_unique_id_checker, root_node)
 
 
 def test_dict_status_done_fires(
@@ -700,10 +677,8 @@ class MySensor(Entity):
     )
 
     class_node = next(root_node.nodes_of_class(nodes.ClassDef))
-    walker = ASTWalker(linter)
-    walker.add_checker(entity_unique_id_checker)
     with assert_adds_messages(linter, _expect_missing(class_node)):
-        walker.walk(root_node)
+        walk_checker(linter, entity_unique_id_checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -773,10 +748,8 @@ class MySensor(Entity):
 """
     root_node = _parse(code, integration_dir, module_name, file_name)
 
-    walker = ASTWalker(linter)
-    walker.add_checker(entity_unique_id_checker)
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, entity_unique_id_checker, root_node)
 
 
 def _find_attr_value_node(
@@ -848,10 +821,8 @@ def test_static_class_body_string_in_multi_entry_fires(
 
     root_node = _parse(code, integration_dir)
     value_node = _find_attr_value_node(root_node)
-    walker = ASTWalker(linter)
-    walker.add_checker(entity_unique_id_checker)
     with assert_adds_messages(linter, _expect_static(value_node, "MySensor")):
-        walker.walk(root_node)
+        walk_checker(linter, entity_unique_id_checker, root_node)
 
 
 def test_static_class_body_string_no_manifest_fires(
@@ -875,10 +846,8 @@ class MySensor(Entity):
     )
 
     value_node = _find_attr_value_node(root_node)
-    walker = ASTWalker(linter)
-    walker.add_checker(entity_unique_id_checker)
     with assert_adds_messages(linter, _expect_static(value_node, "MySensor")):
-        walker.walk(root_node)
+        walk_checker(linter, entity_unique_id_checker, root_node)
 
 
 _STATIC_CLASS_BODY_STRING = """
@@ -946,7 +915,5 @@ def test_static_rule_does_not_warn(
     _create_quality_scale(integration_dir, {"entity-unique-id": rule_status})
 
     root_node = _parse(code, integration_dir)
-    walker = ASTWalker(linter)
-    walker.add_checker(entity_unique_id_checker)
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, entity_unique_id_checker, root_node)

--- a/tests/pylint/quality_scale/test_has_entity_name.py
+++ b/tests/pylint/quality_scale/test_has_entity_name.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import astroid
 from astroid import nodes
 from pylint.testutils import MessageTest, UnittestLinter
-from pylint.utils.ast_walker import ASTWalker
 from pylint_home_assistant.checkers.quality_scale.has_entity_name import (
     HasEntityNameChecker,
 )
@@ -13,7 +12,7 @@ from pylint_home_assistant.helpers.quality_scale import clear_quality_scale_cach
 import pytest
 import yaml
 
-from tests.pylint import assert_adds_messages, assert_no_messages
+from tests.pylint import assert_adds_messages, assert_no_messages, walk_checker
 
 
 @pytest.fixture(name="has_entity_name_checker")
@@ -145,10 +144,8 @@ def test_handled(
     _create_quality_scale(integration_dir, {"has-entity-name": "done"})
 
     root_node = _parse(code, integration_dir)
-    walker = ASTWalker(linter)
-    walker.add_checker(has_entity_name_checker)
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, has_entity_name_checker, root_node)
 
 
 def test_ancestor_class_level(
@@ -180,10 +177,8 @@ class MySensor(TestIntegrationBaseEntity):
         integration_dir,
     )
 
-    walker = ASTWalker(linter)
-    walker.add_checker(has_entity_name_checker)
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, has_entity_name_checker, root_node)
 
 
 def test_ancestor_self_assign(
@@ -216,10 +211,8 @@ class MySensor(TestIntegrationBaseEntity):
         integration_dir,
     )
 
-    walker = ASTWalker(linter)
-    walker.add_checker(has_entity_name_checker)
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, has_entity_name_checker, root_node)
 
 
 def test_missing_fires(
@@ -242,10 +235,8 @@ class MySensor(Entity):
     )
 
     class_node = next(root_node.nodes_of_class(nodes.ClassDef))
-    walker = ASTWalker(linter)
-    walker.add_checker(has_entity_name_checker)
     with assert_adds_messages(linter, _expect_missing(class_node)):
-        walker.walk(root_node)
+        walk_checker(linter, has_entity_name_checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -333,10 +324,8 @@ def test_conditional_self_assignment_fires(
         for cls in root_node.nodes_of_class(nodes.ClassDef)
         if cls.name == class_name
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(has_entity_name_checker)
     with assert_adds_messages(linter, _expect_missing(class_node)):
-        walker.walk(root_node)
+        walk_checker(linter, has_entity_name_checker, root_node)
 
 
 def test_explicit_false_fires(
@@ -359,10 +348,8 @@ class MySensor(Entity):
     )
 
     class_node = next(root_node.nodes_of_class(nodes.ClassDef))
-    walker = ASTWalker(linter)
-    walker.add_checker(has_entity_name_checker)
     with assert_adds_messages(linter, _expect_missing(class_node)):
-        walker.walk(root_node)
+        walk_checker(linter, has_entity_name_checker, root_node)
 
 
 def test_generic_subscript_base_sets_flag(
@@ -394,10 +381,8 @@ class MySensor(TestIntegrationGenericBase[int]):
         integration_dir,
     )
 
-    walker = ASTWalker(linter)
-    walker.add_checker(has_entity_name_checker)
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, has_entity_name_checker, root_node)
 
 
 def test_two_level_subscript_chain(
@@ -438,10 +423,8 @@ class MyLight(TestIntegrationLightBase):
         file_name="light.py",
     )
 
-    walker = ASTWalker(linter)
-    walker.add_checker(has_entity_name_checker)
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, has_entity_name_checker, root_node)
 
 
 def test_entity_description_fallback(
@@ -471,10 +454,8 @@ class MyEntity(Entity):
         integration_dir,
     )
 
-    walker = ASTWalker(linter)
-    walker.add_checker(has_entity_name_checker)
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, has_entity_name_checker, root_node)
 
 
 def test_entity_description_subscripted_annotation(
@@ -504,10 +485,8 @@ class MyEntity[T](Entity):
         integration_dir,
     )
 
-    walker = ASTWalker(linter)
-    walker.add_checker(has_entity_name_checker)
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, has_entity_name_checker, root_node)
 
 
 def test_entity_description_without_flag_still_fires(
@@ -542,10 +521,8 @@ class MyEntity(Entity):
         for cls in root_node.nodes_of_class(nodes.ClassDef)
         if cls.name == "MyEntity"
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(has_entity_name_checker)
     with assert_adds_messages(linter, _expect_missing(class_node)):
-        walker.walk(root_node)
+        walk_checker(linter, has_entity_name_checker, root_node)
 
 
 def test_entity_description_set_in_ancestor(
@@ -585,10 +562,8 @@ class MySensor(TestIntegrationBaseEntity):
         integration_dir,
     )
 
-    walker = ASTWalker(linter)
-    walker.add_checker(has_entity_name_checker)
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, has_entity_name_checker, root_node)
 
 
 def test_mixin_subclassed_in_same_module_ignored(
@@ -613,10 +588,8 @@ class ActualEntity(MyClimateMixin):
         integration_dir,
     )
 
-    walker = ASTWalker(linter)
-    walker.add_checker(has_entity_name_checker)
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, has_entity_name_checker, root_node)
 
 
 def test_subclassed_via_subscript_ignored(
@@ -641,10 +614,8 @@ class ConcreteEntity(GenericBase[int]):
         integration_dir,
     )
 
-    walker = ASTWalker(linter)
-    walker.add_checker(has_entity_name_checker)
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, has_entity_name_checker, root_node)
 
 
 def test_leaf_class_still_fires(
@@ -674,10 +645,8 @@ class SomethingUnrelated:
         for cls in root_node.nodes_of_class(nodes.ClassDef)
         if cls.name == "LonelySensor"
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(has_entity_name_checker)
     with assert_adds_messages(linter, _expect_missing(class_node)):
-        walker.walk(root_node)
+        walk_checker(linter, has_entity_name_checker, root_node)
 
 
 def test_non_entity_class_ignored(
@@ -697,10 +666,8 @@ class NotAnEntity:
         integration_dir,
     )
 
-    walker = ASTWalker(linter)
-    walker.add_checker(has_entity_name_checker)
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, has_entity_name_checker, root_node)
 
 
 def test_dict_status_done_fires(
@@ -726,10 +693,8 @@ class MySensor(Entity):
     )
 
     class_node = next(root_node.nodes_of_class(nodes.ClassDef))
-    walker = ASTWalker(linter)
-    walker.add_checker(has_entity_name_checker)
     with assert_adds_messages(linter, _expect_missing(class_node)):
-        walker.walk(root_node)
+        walk_checker(linter, has_entity_name_checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -799,7 +764,5 @@ class MySensor(Entity):
 """
     root_node = _parse(code, integration_dir, module_name, file_name)
 
-    walker = ASTWalker(linter)
-    walker.add_checker(has_entity_name_checker)
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, has_entity_name_checker, root_node)

--- a/tests/pylint/quality_scale/test_parallel_updates.py
+++ b/tests/pylint/quality_scale/test_parallel_updates.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import astroid
 from pylint.testutils import MessageTest, UnittestLinter
-from pylint.utils.ast_walker import ASTWalker
 from pylint_home_assistant.checkers.quality_scale.parallel_updates import (
     ParallelUpdatesChecker,
 )
@@ -12,7 +11,7 @@ from pylint_home_assistant.helpers.quality_scale import clear_quality_scale_cach
 import pytest
 import yaml
 
-from tests.pylint import assert_adds_messages, assert_no_messages
+from tests.pylint import assert_adds_messages, assert_no_messages, walk_checker
 
 
 @pytest.fixture(name="parallel_updates_checker")
@@ -61,11 +60,8 @@ def test_parallel_updates_present(
     root_node = astroid.parse("PARALLEL_UPDATES = 1\n", module_name)
     root_node.file = str(integration_dir / "sensor.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(parallel_updates_checker)
-
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, parallel_updates_checker, root_node)
 
 
 def test_parallel_updates_zero(
@@ -82,11 +78,8 @@ def test_parallel_updates_zero(
     )
     root_node.file = str(integration_dir / "sensor.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(parallel_updates_checker)
-
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, parallel_updates_checker, root_node)
 
 
 def test_parallel_updates_annotated_assignment(
@@ -104,11 +97,8 @@ def test_parallel_updates_annotated_assignment(
     )
     root_node.file = str(integration_dir / "sensor.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(parallel_updates_checker)
-
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, parallel_updates_checker, root_node)
 
 
 def test_parallel_updates_missing_fires(
@@ -126,9 +116,6 @@ def test_parallel_updates_missing_fires(
     )
     root_node.file = str(integration_dir / "sensor.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(parallel_updates_checker)
-
     with assert_adds_messages(
         linter,
         MessageTest(
@@ -138,7 +125,7 @@ def test_parallel_updates_missing_fires(
             col_offset=0,
         ),
     ):
-        walker.walk(root_node)
+        walk_checker(linter, parallel_updates_checker, root_node)
 
 
 def test_parallel_updates_missing_status_done_dict(
@@ -159,9 +146,6 @@ def test_parallel_updates_missing_status_done_dict(
     )
     root_node.file = str(integration_dir / "sensor.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(parallel_updates_checker)
-
     with assert_adds_messages(
         linter,
         MessageTest(
@@ -171,7 +155,7 @@ def test_parallel_updates_missing_status_done_dict(
             col_offset=0,
         ),
     ):
-        walker.walk(root_node)
+        walk_checker(linter, parallel_updates_checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -231,8 +215,5 @@ def test_parallel_updates_not_fired(
     )
     root_node.file = str(integration_dir / "sensor.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(parallel_updates_checker)
-
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, parallel_updates_checker, root_node)

--- a/tests/pylint/quality_scale/test_reauthentication_flow.py
+++ b/tests/pylint/quality_scale/test_reauthentication_flow.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import astroid
 from pylint.testutils import MessageTest, UnittestLinter
-from pylint.utils.ast_walker import ASTWalker
 from pylint_home_assistant.checkers.quality_scale.reauthentication_flow import (
     ReauthenticationFlowChecker,
 )
@@ -12,7 +11,7 @@ from pylint_home_assistant.helpers.quality_scale import clear_quality_scale_cach
 import pytest
 import yaml
 
-from tests.pylint import assert_adds_messages, assert_no_messages
+from tests.pylint import assert_adds_messages, assert_no_messages, walk_checker
 
 
 @pytest.fixture(name="reauth_checker")
@@ -54,11 +53,8 @@ class MyConfigFlow(ConfigFlow, domain=DOMAIN):
     )
     root_node.file = str(integration_dir / "config_flow.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(reauth_checker)
-
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, reauth_checker, root_node)
 
 
 def test_reauth_missing_fires(
@@ -80,9 +76,6 @@ class MyConfigFlow(ConfigFlow, domain=DOMAIN):
     )
     root_node.file = str(integration_dir / "config_flow.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(reauth_checker)
-
     with assert_adds_messages(
         linter,
         MessageTest(
@@ -92,7 +85,7 @@ class MyConfigFlow(ConfigFlow, domain=DOMAIN):
             col_offset=0,
         ),
     ):
-        walker.walk(root_node)
+        walk_checker(linter, reauth_checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -146,8 +139,5 @@ class MyConfigFlow(ConfigFlow, domain=DOMAIN):
     )
     root_node.file = str(integration_dir / "config_flow.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(reauth_checker)
-
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, reauth_checker, root_node)

--- a/tests/pylint/test_class_module.py
+++ b/tests/pylint/test_class_module.py
@@ -5,10 +5,9 @@ from pylint.checkers import BaseChecker
 from pylint.interfaces import UNDEFINED
 from pylint.testutils import MessageTest
 from pylint.testutils.unittest_linter import UnittestLinter
-from pylint.utils.ast_walker import ASTWalker
 import pytest
 
-from . import assert_adds_messages, assert_no_messages
+from . import assert_adds_messages, assert_no_messages, walk_checker
 
 
 @pytest.mark.parametrize(
@@ -54,11 +53,9 @@ def test_enforce_class_module_good(
 ) -> None:
     """Good test cases."""
     root_node = astroid.parse(code, path)
-    walker = ASTWalker(linter)
-    walker.add_checker(enforce_class_module_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, enforce_class_module_checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -90,11 +87,9 @@ def test_enforce_class_platform_good(
         pass
     """
     root_node = astroid.parse(code, path)
-    walker = ASTWalker(linter)
-    walker.add_checker(enforce_class_module_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, enforce_class_module_checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -128,8 +123,6 @@ def test_enforce_class_module_bad_simple(
     """,
         path,
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(enforce_class_module_checker)
 
     with assert_adds_messages(
         linter,
@@ -154,7 +147,7 @@ def test_enforce_class_module_bad_simple(
             end_col_offset=35,
         ),
     ):
-        walker.walk(root_node)
+        walk_checker(linter, enforce_class_module_checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -185,8 +178,6 @@ def test_enforce_class_module_bad_nested(
     """,
         path,
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(enforce_class_module_checker)
 
     with assert_adds_messages(
         linter,
@@ -211,7 +202,7 @@ def test_enforce_class_module_bad_nested(
             end_col_offset=21,
         ),
     ):
-        walker.walk(root_node)
+        walk_checker(linter, enforce_class_module_checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -236,11 +227,9 @@ def test_enforce_entity_good(
         pass
     """
     root_node = astroid.parse(code, path)
-    walker = ASTWalker(linter)
-    walker.add_checker(enforce_class_module_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, enforce_class_module_checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -265,8 +254,6 @@ def test_enforce_entity_bad(
         pass
     """
     root_node = astroid.parse(code, path)
-    walker = ASTWalker(linter)
-    walker.add_checker(enforce_class_module_checker)
 
     with assert_adds_messages(
         linter,
@@ -281,4 +268,4 @@ def test_enforce_entity_bad(
             end_col_offset=18,
         ),
     ):
-        walker.walk(root_node)
+        walk_checker(linter, enforce_class_module_checker, root_node)

--- a/tests/pylint/test_decorator.py
+++ b/tests/pylint/test_decorator.py
@@ -5,10 +5,9 @@ from pylint.checkers import BaseChecker
 from pylint.interfaces import UNDEFINED
 from pylint.testutils import MessageTest
 from pylint.testutils.unittest_linter import UnittestLinter
-from pylint.utils.ast_walker import ASTWalker
 import pytest
 
-from . import assert_adds_messages, assert_no_messages
+from . import assert_adds_messages, assert_no_messages, walk_checker
 
 
 def test_good_callback(linter: UnittestLinter, decorator_checker: BaseChecker) -> None:
@@ -24,11 +23,9 @@ def test_good_callback(linter: UnittestLinter, decorator_checker: BaseChecker) -
     """
 
     root_node = astroid.parse(code)
-    walker = ASTWalker(linter)
-    walker.add_checker(decorator_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, decorator_checker, root_node)
 
 
 def test_bad_callback(linter: UnittestLinter, decorator_checker: BaseChecker) -> None:
@@ -44,8 +41,6 @@ def test_bad_callback(linter: UnittestLinter, decorator_checker: BaseChecker) ->
     """
 
     root_node = astroid.parse(code)
-    walker = ASTWalker(linter)
-    walker.add_checker(decorator_checker)
 
     with assert_adds_messages(
         linter,
@@ -60,7 +55,7 @@ def test_bad_callback(linter: UnittestLinter, decorator_checker: BaseChecker) ->
             end_col_offset=15,
         ),
     ):
-        walker.walk(root_node)
+        walk_checker(linter, decorator_checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -110,11 +105,9 @@ def test_good_fixture(
     """
 
     root_node = astroid.parse(code, path)
-    walker = ASTWalker(linter)
-    walker.add_checker(decorator_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, decorator_checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -146,8 +139,6 @@ def test_bad_fixture_session_scope(
     """
 
     root_node = astroid.parse(code, path)
-    walker = ASTWalker(linter)
-    walker.add_checker(decorator_checker)
 
     with assert_adds_messages(
         linter,
@@ -162,7 +153,7 @@ def test_bad_fixture_session_scope(
             end_col_offset=32,
         ),
     ):
-        walker.walk(root_node)
+        walk_checker(linter, decorator_checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -193,8 +184,6 @@ def test_bad_fixture_package_scope(
     """
 
     root_node = astroid.parse(code, path)
-    walker = ASTWalker(linter)
-    walker.add_checker(decorator_checker)
 
     with assert_adds_messages(
         linter,
@@ -209,7 +198,7 @@ def test_bad_fixture_package_scope(
             end_col_offset=32,
         ),
     ):
-        walker.walk(root_node)
+        walk_checker(linter, decorator_checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -247,8 +236,6 @@ def test_bad_fixture_autouse(
     """
 
     root_node = astroid.parse(code, path)
-    walker = ASTWalker(linter)
-    walker.add_checker(decorator_checker)
 
     with assert_adds_messages(
         linter,
@@ -263,4 +250,4 @@ def test_bad_fixture_autouse(
             end_col_offset=17 + len(keywords),
         ),
     ):
-        walker.walk(root_node)
+        walk_checker(linter, decorator_checker, root_node)

--- a/tests/pylint/test_determinism.py
+++ b/tests/pylint/test_determinism.py
@@ -2,11 +2,10 @@
 
 import astroid
 from pylint.testutils import UnittestLinter
-from pylint.utils.ast_walker import ASTWalker
 from pylint_home_assistant.checkers.test_determinism import HassTestDeterminismChecker
 import pytest
 
-from . import assert_no_messages
+from . import assert_no_messages, walk_checker
 
 
 @pytest.fixture(name="determinism_checker")
@@ -144,11 +143,9 @@ def test_no_warning(
 ) -> None:
     """Test cases that should not trigger a warning."""
     root_node = astroid.parse(code, module_name)
-    walker = ASTWalker(linter)
-    walker.add_checker(determinism_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, determinism_checker, root_node)
 
 
 def test_if_statement_flagged(
@@ -167,9 +164,7 @@ def test_sensor_value(hass) -> None:
 """,
         "tests.components.test_integration.test_sensor",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(determinism_checker)
-    walker.walk(root_node)
+    walk_checker(linter, determinism_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -193,9 +188,7 @@ def test_something(hass) -> None:
 """,
         "tests.components.test_integration.test_init",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(determinism_checker)
-    walker.walk(root_node)
+    walk_checker(linter, determinism_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 2
@@ -216,9 +209,7 @@ async def test_something(hass) -> None:
 """,
         "tests.components.test_integration.test_init",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(determinism_checker)
-    walker.walk(root_node)
+    walk_checker(linter, determinism_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -241,9 +232,7 @@ def test_something(state) -> None:
 """,
         "tests.components.test_integration.test_init",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(determinism_checker)
-    walker.walk(root_node)
+    walk_checker(linter, determinism_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1

--- a/tests/pylint/test_domain_constant.py
+++ b/tests/pylint/test_domain_constant.py
@@ -2,11 +2,10 @@
 
 import astroid
 from pylint.testutils import UnittestLinter
-from pylint.utils.ast_walker import ASTWalker
 from pylint_home_assistant.checkers.domain_constant import DomainConstantChecker
 import pytest
 
-from . import assert_no_messages
+from . import assert_no_messages, walk_checker
 
 
 @pytest.fixture(name="domain_constant_checker")
@@ -221,11 +220,9 @@ def test_no_warning(
 ) -> None:
     """Test cases that should not trigger a warning."""
     root_node = astroid.parse(code, "tests.components.test_integration.test_init")
-    walker = ASTWalker(linter)
-    walker.add_checker(domain_constant_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, domain_constant_checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -255,9 +252,7 @@ def test_domain_argument_flagged(
 ) -> None:
     """Test that non-domain arguments are flagged."""
     root_node = astroid.parse(code, "tests.components.test_integration.test_init")
-    walker = ASTWalker(linter)
-    walker.add_checker(domain_constant_checker)
-    walker.walk(root_node)
+    walk_checker(linter, domain_constant_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -276,8 +271,6 @@ async_setup_component(hass, OTHER, {})
 """,
         "homeassistant.components.test_integration",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(domain_constant_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, domain_constant_checker, root_node)

--- a/tests/pylint/test_duplicate_const.py
+++ b/tests/pylint/test_duplicate_const.py
@@ -2,11 +2,10 @@
 
 import astroid
 from pylint.testutils import UnittestLinter
-from pylint.utils.ast_walker import ASTWalker
 from pylint_home_assistant.checkers.duplicate_const import DuplicateConstChecker
 import pytest
 
-from . import assert_no_messages
+from . import assert_no_messages, walk_checker
 
 # Pre-load homeassistant.const so astroid can resolve it.
 astroid.MANAGER.ast_from_module_name("homeassistant.const")
@@ -64,11 +63,9 @@ def test_no_warning(
 ) -> None:
     """Test cases that should not trigger a warning."""
     root_node = astroid.parse(code, "homeassistant.components.test_integration.const")
-    walker = ASTWalker(linter)
-    walker.add_checker(duplicate_const_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, duplicate_const_checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -121,9 +118,7 @@ def test_duplicate_const_flagged(
 ) -> None:
     """Test that duplicate constants are flagged."""
     root_node = astroid.parse(code, "homeassistant.components.test_integration.const")
-    walker = ASTWalker(linter)
-    walker.add_checker(duplicate_const_checker)
-    walker.walk(root_node)
+    walk_checker(linter, duplicate_const_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -142,8 +137,6 @@ CONF_HOST = "host"
 """,
         "tests.components.test_integration.test_const",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(duplicate_const_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, duplicate_const_checker, root_node)

--- a/tests/pylint/test_entity_description_defaults.py
+++ b/tests/pylint/test_entity_description_defaults.py
@@ -2,13 +2,12 @@
 
 import astroid
 from pylint.testutils import UnittestLinter
-from pylint.utils.ast_walker import ASTWalker
 from pylint_home_assistant.checkers.entity_description_defaults import (
     EntityDescriptionDefaultsChecker,
 )
 import pytest
 
-from . import assert_no_messages
+from . import assert_no_messages, walk_checker
 
 # Pre-load EntityDescription so astroid can resolve it in parsed snippets.
 # This avoids depending on component-level imports which may not be
@@ -75,11 +74,9 @@ def test_no_warning(
 ) -> None:
     """Test cases that should not trigger a warning."""
     root_node = astroid.parse(code, "homeassistant.components.test_integration.sensor")
-    walker = ASTWalker(linter)
-    walker.add_checker(defaults_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, defaults_checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -161,9 +158,7 @@ def test_redundant_default_flagged(
 ) -> None:
     """Test that redundant defaults are flagged."""
     root_node = astroid.parse(code, "homeassistant.components.test_integration.sensor")
-    walker = ASTWalker(linter)
-    walker.add_checker(defaults_checker)
-    walker.walk(root_node)
+    walk_checker(linter, defaults_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -185,11 +180,9 @@ JobDescription(icon=None)
 """,
         "homeassistant.components.test_integration.sensor",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(defaults_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, defaults_checker, root_node)
 
 
 def test_local_entity_description_name_ignored(
@@ -209,11 +202,9 @@ MyDescription(entity_registry_enabled_default=True)
 """,
         "homeassistant.components.test_integration.sensor",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(defaults_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, defaults_checker, root_node)
 
 
 def test_aliased_description_flagged(
@@ -230,9 +221,7 @@ Alias(key="temperature", icon=None)
 """,
         "homeassistant.components.test_integration.sensor",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(defaults_checker)
-    walker.walk(root_node)
+    walk_checker(linter, defaults_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -256,8 +245,6 @@ EntityDescription(
 """,
         "tests.components.test_integration.test_sensor",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(defaults_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, defaults_checker, root_node)

--- a/tests/pylint/test_entity_unique_id_format.py
+++ b/tests/pylint/test_entity_unique_id_format.py
@@ -6,14 +6,13 @@ from pathlib import Path
 import astroid
 from astroid import nodes
 from pylint.testutils import MessageTest, UnittestLinter
-from pylint.utils.ast_walker import ASTWalker
 from pylint_home_assistant.checkers.entity_unique_id_format import (
     EntityUniqueIdFormatChecker,
 )
 from pylint_home_assistant.helpers.integration import clear_caches
 import pytest
 
-from . import assert_adds_messages, assert_no_messages
+from . import assert_adds_messages, assert_no_messages, walk_checker
 
 
 @pytest.fixture(name="checker")
@@ -181,10 +180,8 @@ def test_redundant_domain_fires(
 
     root_node = _parse(code, integration_dir)
     value_node = _find_attr_value_node(root_node)
-    walker = ASTWalker(linter)
-    walker.add_checker(checker)
     with assert_adds_messages(linter, _expect_redundant_domain(value_node, "MySensor")):
-        walker.walk(root_node)
+        walk_checker(linter, checker, root_node)
 
 
 def test_redundant_domain_fires_in_both_branches(
@@ -223,14 +220,12 @@ class MySensor(Entity):
         )
     ]
     assert len(value_nodes) == 2
-    walker = ASTWalker(linter)
-    walker.add_checker(checker)
     with assert_adds_messages(
         linter,
         _expect_redundant_domain(value_nodes[0], "MySensor"),
         _expect_redundant_domain(value_nodes[1], "MySensor"),
     ):
-        walker.walk(root_node)
+        walk_checker(linter, checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -280,10 +275,8 @@ def test_redundant_domain_does_not_fire(
     integration_dir = _make_integration(tmp_path)
 
     root_node = _parse(code, integration_dir)
-    walker = ASTWalker(linter)
-    walker.add_checker(checker)
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -370,9 +363,7 @@ def test_redundant_domain_literal_fires(
     integration_dir = _make_integration(tmp_path, domain="myhub")
 
     root_node = _parse(code, integration_dir)
-    walker = ASTWalker(linter)
-    walker.add_checker(checker)
-    walker.walk(root_node)
+    walk_checker(linter, checker, root_node)
     messages = linter.release_messages()
     assert len(messages) == 1
     assert messages[0].msg_id == "home-assistant-entity-unique-id-redundant-domain"
@@ -410,9 +401,7 @@ class MySensor(Entity):
 """,
         integration_dir,
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(checker)
-    walker.walk(root_node)
+    walk_checker(linter, checker, root_node)
     messages = linter.release_messages()
     assert len(messages) == (1 if fires else 0)
 
@@ -492,10 +481,8 @@ def test_redundant_domain_literal_does_not_fire_on_word_substrings(
     integration_dir = _make_integration(tmp_path, domain="myhub")
 
     root_node = _parse(code, integration_dir)
-    walker = ASTWalker(linter)
-    walker.add_checker(checker)
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -539,12 +526,10 @@ def test_redundant_domain_fires_in_unique_id_property(
 
     root_node = _parse(code, integration_dir)
     return_node = next(root_node.nodes_of_class(nodes.Return))
-    walker = ASTWalker(linter)
-    walker.add_checker(checker)
     with assert_adds_messages(
         linter, _expect_redundant_domain(return_node.value, "MySensor")
     ):
-        walker.walk(root_node)
+        walk_checker(linter, checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -591,10 +576,8 @@ def test_out_of_scope_ignored(
     root_node = _parse(
         code, integration_dir, module_name=module_name, file_name=file_name
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(checker)
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -640,10 +623,8 @@ class MyEntity(Entity):
         file_name=file_name,
     )
     value_node = _find_attr_value_node(root_node)
-    walker = ASTWalker(linter)
-    walker.add_checker(checker)
     with assert_adds_messages(linter, _expect_redundant_domain(value_node, "MyEntity")):
-        walker.walk(root_node)
+        walk_checker(linter, checker, root_node)
 
 
 def test_same_module_mixin_base_fires(
@@ -674,9 +655,7 @@ class MyConcreteSensor(MyBaseSensor):
         integration_dir,
     )
     value_node = _find_attr_value_node(root_node)
-    walker = ASTWalker(linter)
-    walker.add_checker(checker)
     with assert_adds_messages(
         linter, _expect_redundant_domain(value_node, "MyBaseSensor")
     ):
-        walker.walk(root_node)
+        walk_checker(linter, checker, root_node)

--- a/tests/pylint/test_exception_translations.py
+++ b/tests/pylint/test_exception_translations.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import astroid
 from pylint.testutils import UnittestLinter
-from pylint.utils.ast_walker import ASTWalker
 from pylint_home_assistant.checkers.exception_translations import (
     ExceptionTranslationsChecker,
 )
@@ -14,7 +13,7 @@ from pylint_home_assistant.helpers.translations import clear_translations_cache
 import pytest
 import yaml
 
-from . import assert_no_messages
+from . import assert_no_messages, walk_checker
 
 # Pre-load so astroid can resolve exception classes in parsed snippets.
 astroid.MANAGER.ast_from_module_name("homeassistant.exceptions")
@@ -125,11 +124,8 @@ def test_no_warning(
     root_node = astroid.parse(code, "homeassistant.components.test_int.coordinator")
     root_node.file = str(integration_dir / "coordinator.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(translations_checker)
-
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, translations_checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -164,9 +160,7 @@ def test_hardcoded_string_flagged(
     root_node = astroid.parse(code, "homeassistant.components.test_int.coordinator")
     root_node.file = str(integration_dir / "coordinator.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(translations_checker)
-    walker.walk(root_node)
+    walk_checker(linter, translations_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -218,9 +212,7 @@ def test_translation_key_domain_mismatch_flagged(
     )
     root_node.file = str(integration_dir / "coordinator.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(translations_checker)
-    walker.walk(root_node)
+    walk_checker(linter, translations_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -249,9 +241,7 @@ raise HomeAssistantError(
     )
     root_node.file = str(integration_dir / "coordinator.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(translations_checker)
-    walker.walk(root_node)
+    walk_checker(linter, translations_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -280,9 +270,7 @@ raise HomeAssistantError(
     )
     root_node.file = str(integration_dir / "coordinator.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(translations_checker)
-    walker.walk(root_node)
+    walk_checker(linter, translations_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -312,11 +300,8 @@ raise HomeAssistantError(
     )
     root_node.file = str(integration_dir / "coordinator.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(translations_checker)
-
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, translations_checker, root_node)
 
 
 def test_extra_placeholders_flagged(
@@ -344,9 +329,7 @@ raise HomeAssistantError(
     )
     root_node.file = str(integration_dir / "coordinator.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(translations_checker)
-    walker.walk(root_node)
+    walk_checker(linter, translations_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -378,9 +361,7 @@ raise HomeAssistantError(
     )
     root_node.file = str(integration_dir / "coordinator.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(translations_checker)
-    walker.walk(root_node)
+    walk_checker(linter, translations_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -412,11 +393,8 @@ raise HomeAssistantError(
     )
     root_node.file = str(integration_dir / "coordinator.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(translations_checker)
-
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, translations_checker, root_node)
 
 
 def test_placeholder_variable_resolved(
@@ -445,11 +423,8 @@ raise HomeAssistantError(
     )
     root_node.file = str(integration_dir / "coordinator.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(translations_checker)
-
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, translations_checker, root_node)
 
 
 def test_placeholder_variable_mismatch_flagged(
@@ -478,9 +453,7 @@ raise HomeAssistantError(
     )
     root_node.file = str(integration_dir / "coordinator.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(translations_checker)
-    walker.walk(root_node)
+    walk_checker(linter, translations_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -513,11 +486,8 @@ raise HomeAssistantError(
     )
     root_node.file = str(integration_dir / "coordinator.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(translations_checker)
-
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, translations_checker, root_node)
 
 
 def test_constant_placeholder_keys_ok(
@@ -546,11 +516,8 @@ raise HomeAssistantError(
     )
     root_node.file = str(integration_dir / "coordinator.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(translations_checker)
-
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, translations_checker, root_node)
 
 
 def test_key_reference_resolution(
@@ -588,11 +555,8 @@ raise HomeAssistantError(
     )
     root_node.file = str(integration_dir / "coordinator.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(translations_checker)
-
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, translations_checker, root_node)
 
 
 def test_no_strings_json_flags_missing_key(
@@ -614,9 +578,7 @@ raise HomeAssistantError(
     )
     root_node.file = str(integration_dir / "coordinator.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(translations_checker)
-    walker.walk(root_node)
+    walk_checker(linter, translations_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -647,9 +609,7 @@ raise HomeAssistantError(
     )
     root_node.file = str(integration_dir / "coordinator.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(translations_checker)
-    walker.walk(root_node)
+    walk_checker(linter, translations_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -682,9 +642,7 @@ raise HomeAssistantError(
     )
     root_node.file = str(integration_dir / "coordinator.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(translations_checker)
-    walker.walk(root_node)
+    walk_checker(linter, translations_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -700,8 +658,6 @@ def test_not_integration_ignored(
         f'{_HA_IMPORTS}\nraise HomeAssistantError("hardcoded")',
         "tests.components.test_integration",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(translations_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, translations_checker, root_node)

--- a/tests/pylint/test_greek_micro_char.py
+++ b/tests/pylint/test_greek_micro_char.py
@@ -3,10 +3,9 @@
 import astroid
 from pylint.checkers import BaseChecker
 from pylint.testutils.unittest_linter import UnittestLinter
-from pylint.utils.ast_walker import ASTWalker
 import pytest
 
-from . import assert_no_messages
+from . import assert_no_messages, walk_checker
 
 
 @pytest.mark.parametrize(
@@ -77,11 +76,9 @@ def test_enforce_greek_micro_char(
 ) -> None:
     """Good test cases."""
     root_node = astroid.parse(code, "homeassistant.components.pylint_test")
-    walker = ASTWalker(linter)
-    walker.add_checker(enforce_greek_micro_char_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, enforce_greek_micro_char_checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -153,10 +150,8 @@ def test_enforce_greek_micro_char_assign_bad(
 ) -> None:
     """Bad assignment test cases."""
     root_node = astroid.parse(code, "homeassistant.components.pylint_test")
-    walker = ASTWalker(linter)
-    walker.add_checker(enforce_greek_micro_char_checker)
 
-    walker.walk(root_node)
+    walk_checker(linter, enforce_greek_micro_char_checker, root_node)
     messages = linter.release_messages()
     assert len(messages) == 1
     message = next(iter(messages))

--- a/tests/pylint/test_mdi_icons.py
+++ b/tests/pylint/test_mdi_icons.py
@@ -5,12 +5,11 @@ from pathlib import Path
 
 import astroid
 from pylint.testutils import UnittestLinter
-from pylint.utils.ast_walker import ASTWalker
 from pylint_home_assistant.checkers.mdi_icons import MdiIconsChecker
 from pylint_home_assistant.helpers.icons import clear_icons_cache
 import pytest
 
-from . import assert_no_messages
+from . import assert_no_messages, walk_checker
 
 
 @pytest.fixture(name="mdi_checker")
@@ -78,11 +77,9 @@ def test_python_no_warning(
 ) -> None:
     """Test that valid MDI icons in Python code pass."""
     root_node = astroid.parse(code, "homeassistant.components.test_integration.sensor")
-    walker = ASTWalker(linter)
-    walker.add_checker(mdi_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, mdi_checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -118,9 +115,7 @@ def test_python_invalid_icon_flagged(
 ) -> None:
     """Test that invalid MDI icons in Python code are flagged."""
     root_node = astroid.parse(code, "homeassistant.components.test_integration.sensor")
-    walker = ASTWalker(linter)
-    walker.add_checker(mdi_checker)
-    walker.walk(root_node)
+    walk_checker(linter, mdi_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -137,11 +132,9 @@ def test_python_not_integration_ignored(
         'ICON = "mdi:nonexistent-icon"',
         "tests.components.test_integration",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(mdi_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, mdi_checker, root_node)
 
 
 # --- icons.json tests ---
@@ -173,11 +166,8 @@ def test_icons_json_valid(
     )
     root_node.file = str(integration_dir / "__init__.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(mdi_checker)
-
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, mdi_checker, root_node)
 
 
 def test_icons_json_invalid_flagged(
@@ -203,9 +193,7 @@ def test_icons_json_invalid_flagged(
     )
     root_node.file = str(integration_dir / "__init__.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(mdi_checker)
-    walker.walk(root_node)
+    walk_checker(linter, mdi_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -227,11 +215,8 @@ def test_icons_json_no_file_no_warning(
     )
     root_node.file = str(integration_dir / "__init__.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(mdi_checker)
-
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, mdi_checker, root_node)
 
 
 def test_icons_json_nested_invalid_flagged(
@@ -265,9 +250,7 @@ def test_icons_json_nested_invalid_flagged(
     )
     root_node.file = str(integration_dir / "__init__.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(mdi_checker)
-    walker.walk(root_node)
+    walk_checker(linter, mdi_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1

--- a/tests/pylint/test_naive_now.py
+++ b/tests/pylint/test_naive_now.py
@@ -3,10 +3,9 @@
 import astroid
 from pylint.checkers import BaseChecker
 from pylint.testutils.unittest_linter import UnittestLinter
-from pylint.utils.ast_walker import ASTWalker
 import pytest
 
-from . import assert_no_messages
+from . import assert_no_messages, walk_checker
 
 
 @pytest.mark.parametrize(
@@ -71,11 +70,9 @@ def test_enforce_naive_now_good(
 ) -> None:
     """Good test cases -- no message expected."""
     root_node = astroid.parse(code, "homeassistant.components.pylint_test")
-    walker = ASTWalker(linter)
-    walker.add_checker(enforce_naive_now_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, enforce_naive_now_checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -158,10 +155,8 @@ def test_enforce_naive_now_bad(
 ) -> None:
     """Bad test cases -- one message expected per call."""
     root_node = astroid.parse(code, "homeassistant.components.pylint_test")
-    walker = ASTWalker(linter)
-    walker.add_checker(enforce_naive_now_checker)
 
-    walker.walk(root_node)
+    walk_checker(linter, enforce_naive_now_checker, root_node)
     messages = linter.release_messages()
     assert len(messages) == 1
     assert messages[0].msg_id == "home-assistant-enforce-naive-now"
@@ -197,8 +192,6 @@ def test_enforce_naive_now_skips_util_dt(
 ) -> None:
     """``homeassistant.util.dt`` defines ``naive_now`` itself, so it is skipped."""
     root_node = astroid.parse(code, "homeassistant.util.dt")
-    walker = ASTWalker(linter)
-    walker.add_checker(enforce_naive_now_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, enforce_naive_now_checker, root_node)

--- a/tests/pylint/test_now.py
+++ b/tests/pylint/test_now.py
@@ -3,10 +3,9 @@
 import astroid
 from pylint.checkers import BaseChecker
 from pylint.testutils.unittest_linter import UnittestLinter
-from pylint.utils.ast_walker import ASTWalker
 import pytest
 
-from . import assert_no_messages
+from . import assert_no_messages, walk_checker
 
 
 @pytest.mark.parametrize(
@@ -136,11 +135,9 @@ def test_enforce_now_good(
 ) -> None:
     """Good test cases -- no message expected."""
     root_node = astroid.parse(code, "homeassistant.components.pylint_test")
-    walker = ASTWalker(linter)
-    walker.add_checker(enforce_now_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, enforce_now_checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -230,10 +227,8 @@ def test_enforce_now_bad(
 ) -> None:
     """Bad test cases -- one message expected per call."""
     root_node = astroid.parse(code, "homeassistant.components.pylint_test")
-    walker = ASTWalker(linter)
-    walker.add_checker(enforce_now_checker)
 
-    walker.walk(root_node)
+    walk_checker(linter, enforce_now_checker, root_node)
     messages = linter.release_messages()
     assert len(messages) == 1
     assert messages[0].msg_id == "home-assistant-enforce-now"
@@ -270,8 +265,6 @@ def test_enforce_now_skips_util_dt(
 ) -> None:
     """``homeassistant.util.dt`` defines ``now`` itself, so it is skipped."""
     root_node = astroid.parse(code, "homeassistant.util.dt")
-    walker = ASTWalker(linter)
-    walker.add_checker(enforce_now_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, enforce_now_checker, root_node)

--- a/tests/pylint/test_runtime_data.py
+++ b/tests/pylint/test_runtime_data.py
@@ -5,10 +5,9 @@ from pathlib import Path
 import astroid
 from pylint.checkers import BaseChecker
 from pylint.testutils.unittest_linter import UnittestLinter
-from pylint.utils.ast_walker import ASTWalker
 import pytest
 
-from . import assert_no_messages
+from . import assert_no_messages, walk_checker
 
 
 @pytest.mark.parametrize(
@@ -104,11 +103,9 @@ def test_enforce_runtime_data(
 ) -> None:
     """Good test cases."""
     root_node = astroid.parse(code, module_name)
-    walker = ASTWalker(linter)
-    walker.add_checker(enforce_runtime_data_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, enforce_runtime_data_checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -160,10 +157,8 @@ def test_enforce_runtime_data_bad(
 ) -> None:
     """Bad test cases."""
     root_node = astroid.parse(code, module_name)
-    walker = ASTWalker(linter)
-    walker.add_checker(enforce_runtime_data_checker)
 
-    walker.walk(root_node)
+    walk_checker(linter, enforce_runtime_data_checker, root_node)
     messages = linter.release_messages()
     assert len(messages) == 1
     assert messages[0].msg_id == "home-assistant-use-runtime-data"
@@ -187,11 +182,8 @@ def test_enforce_runtime_data_no_config_flow(
     root_node = astroid.parse(code, "homeassistant.components.yaml_only")
     root_node.file = str(init_file)
 
-    walker = ASTWalker(linter)
-    walker.add_checker(enforce_runtime_data_checker)
-
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, enforce_runtime_data_checker, root_node)
 
 
 def test_enforce_runtime_data_with_config_flow(
@@ -213,10 +205,7 @@ def test_enforce_runtime_data_with_config_flow(
     root_node = astroid.parse(code, "homeassistant.components.modern")
     root_node.file = str(init_file)
 
-    walker = ASTWalker(linter)
-    walker.add_checker(enforce_runtime_data_checker)
-
-    walker.walk(root_node)
+    walk_checker(linter, enforce_runtime_data_checker, root_node)
     messages = linter.release_messages()
     assert len(messages) == 1
     assert messages[0].msg_id == "home-assistant-use-runtime-data"

--- a/tests/pylint/test_sequential_executor_jobs.py
+++ b/tests/pylint/test_sequential_executor_jobs.py
@@ -2,13 +2,12 @@
 
 import astroid
 from pylint.testutils import UnittestLinter
-from pylint.utils.ast_walker import ASTWalker
 from pylint_home_assistant.checkers.sequential_executor_jobs import (
     SequentialExecutorJobsChecker,
 )
 import pytest
 
-from . import assert_no_messages
+from . import assert_no_messages, walk_checker
 
 
 @pytest.fixture(name="executor_checker")
@@ -56,11 +55,9 @@ def test_no_warning(
 ) -> None:
     """Test cases that should not trigger a warning."""
     root_node = astroid.parse(code, "homeassistant.components.test_integration")
-    walker = ASTWalker(linter)
-    walker.add_checker(executor_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, executor_checker, root_node)
 
 
 def test_two_sequential_flagged(
@@ -76,9 +73,7 @@ async def async_setup(hass, config):
 """,
         "homeassistant.components.test_integration",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(executor_checker)
-    walker.walk(root_node)
+    walk_checker(linter, executor_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -99,9 +94,7 @@ async def async_setup(hass, config):
 """,
         "homeassistant.components.test_integration",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(executor_checker)
-    walker.walk(root_node)
+    walk_checker(linter, executor_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 2
@@ -120,9 +113,7 @@ async def async_setup(hass, config):
 """,
         "homeassistant.components.test_integration",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(executor_checker)
-    walker.walk(root_node)
+    walk_checker(linter, executor_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -144,9 +135,7 @@ async def async_setup(hass, config):
 """,
         "homeassistant.components.test_integration",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(executor_checker)
-    walker.walk(root_node)
+    walk_checker(linter, executor_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -168,9 +157,7 @@ async def async_setup(hass, config):
 """,
         "homeassistant.components.test_integration",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(executor_checker)
-    walker.walk(root_node)
+    walk_checker(linter, executor_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -193,9 +180,7 @@ async def async_setup(hass, config):
 """,
         "homeassistant.components.test_integration",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(executor_checker)
-    walker.walk(root_node)
+    walk_checker(linter, executor_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -218,9 +203,7 @@ async def async_setup(hass, config):
 """,
         "homeassistant.components.test_integration",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(executor_checker)
-    walker.walk(root_node)
+    walk_checker(linter, executor_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -240,9 +223,7 @@ async def async_setup(hass, config):
 """,
         "homeassistant.components.test_integration",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(executor_checker)
-    walker.walk(root_node)
+    walk_checker(linter, executor_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -262,8 +243,6 @@ async def async_setup(hass, config):
 """,
         "tests.components.test_integration",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(executor_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, executor_checker, root_node)

--- a/tests/pylint/test_sorted_platforms.py
+++ b/tests/pylint/test_sorted_platforms.py
@@ -5,10 +5,9 @@ from pylint.checkers import BaseChecker
 from pylint.interfaces import UNDEFINED
 from pylint.testutils import MessageTest
 from pylint.testutils.unittest_linter import UnittestLinter
-from pylint.utils.ast_walker import ASTWalker
 import pytest
 
-from . import assert_adds_messages, assert_no_messages
+from . import assert_adds_messages, assert_no_messages, walk_checker
 
 
 @pytest.mark.parametrize(
@@ -75,11 +74,9 @@ def test_enforce_sorted_platforms(
 ) -> None:
     """Good test cases."""
     root_node = astroid.parse(code, "homeassistant.components.pylint_test")
-    walker = ASTWalker(linter)
-    walker.add_checker(enforce_sorted_platforms_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, enforce_sorted_platforms_checker, root_node)
 
 
 def test_enforce_sorted_platforms_bad(

--- a/tests/pylint/test_super_call.py
+++ b/tests/pylint/test_super_call.py
@@ -7,10 +7,9 @@ from pylint.checkers import BaseChecker
 from pylint.interfaces import INFERENCE
 from pylint.testutils import MessageTest
 from pylint.testutils.unittest_linter import UnittestLinter
-from pylint.utils.ast_walker import ASTWalker
 import pytest
 
-from . import assert_adds_messages, assert_no_messages
+from . import assert_adds_messages, assert_no_messages, walk_checker
 
 
 @pytest.mark.parametrize(
@@ -117,8 +116,6 @@ def test_enforce_super_call(
 ) -> None:
     """Good test cases."""
     root_node = astroid.parse(code, "homeassistant.components.pylint_test")
-    walker = ASTWalker(linter)
-    walker.add_checker(super_call_checker)
 
     with (
         patch(
@@ -127,7 +124,7 @@ def test_enforce_super_call(
         ),
         assert_no_messages(linter),
     ):
-        walker.walk(root_node)
+        walk_checker(linter, super_call_checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -199,8 +196,6 @@ def test_enforce_super_call_bad(
 ) -> None:
     """Bad test cases."""
     root_node = astroid.parse(code, "homeassistant.components.pylint_test")
-    walker = ASTWalker(linter)
-    walker.add_checker(super_call_checker)
     node = root_node.body[node_idx].body[0]
 
     with (
@@ -222,4 +217,4 @@ def test_enforce_super_call_bad(
             ),
         ),
     ):
-        walker.walk(root_node)
+        walk_checker(linter, super_call_checker, root_node)

--- a/tests/pylint/test_unnecessary_format_mac.py
+++ b/tests/pylint/test_unnecessary_format_mac.py
@@ -2,13 +2,12 @@
 
 import astroid
 from pylint.testutils import UnittestLinter
-from pylint.utils.ast_walker import ASTWalker
 from pylint_home_assistant.checkers.unnecessary_format_mac import (
     UnnecessaryFormatMacChecker,
 )
 import pytest
 
-from . import assert_no_messages
+from . import assert_no_messages, walk_checker
 
 _IMPORTS = """\
 from homeassistant.helpers.device_registry import (
@@ -95,11 +94,8 @@ def test_no_warning(
     """Test cases that should not trigger a warning."""
     root_node = astroid.parse(code, "homeassistant.components.test_integration.sensor")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(format_mac_checker)
-
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, format_mac_checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -152,9 +148,7 @@ def test_format_mac_flagged(
     """Warning when format_mac is used in connections= keyword argument."""
     root_node = astroid.parse(code, "homeassistant.components.test_integration.sensor")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(format_mac_checker)
-    walker.walk(root_node)
+    walk_checker(linter, format_mac_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -174,8 +168,5 @@ device = DeviceInfo(
 """
     root_node = astroid.parse(code, "some_other.module")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(format_mac_checker)
-
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, format_mac_checker, root_node)

--- a/tests/pylint/test_unused_test_fixture_args.py
+++ b/tests/pylint/test_unused_test_fixture_args.py
@@ -2,13 +2,12 @@
 
 import astroid
 from pylint.testutils import UnittestLinter
-from pylint.utils.ast_walker import ASTWalker
 from pylint_home_assistant.checkers.unused_test_fixture_args import (
     UnusedTestFixtureArgsChecker,
 )
 import pytest
 
-from . import assert_no_messages
+from . import assert_no_messages, walk_checker
 
 
 @pytest.fixture(name="unused_args_checker")
@@ -68,11 +67,9 @@ def test_no_warning(
 ) -> None:
     """Test cases that should not trigger a warning."""
     root_node = astroid.parse(code, "tests.components.test_integration.test_init")
-    walker = ASTWalker(linter)
-    walker.add_checker(unused_args_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, unused_args_checker, root_node)
 
 
 def test_unused_single_arg(
@@ -87,9 +84,7 @@ def test_something(hass: HomeAssistant, enable_bluetooth: None) -> None:
 """,
         "tests.components.test_integration.test_init",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(unused_args_checker)
-    walker.walk(root_node)
+    walk_checker(linter, unused_args_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -115,9 +110,7 @@ def test_something(
 """,
         "tests.components.test_integration.test_init",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(unused_args_checker)
-    walker.walk(root_node)
+    walk_checker(linter, unused_args_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 2
@@ -137,11 +130,9 @@ def test_something(unused: str) -> None:
 """,
         "homeassistant.components.test_integration",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(unused_args_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, unused_args_checker, root_node)
 
 
 def test_async_test_function(
@@ -156,9 +147,7 @@ async def test_something(hass: HomeAssistant, enable_bluetooth: None) -> None:
 """,
         "tests.components.test_integration.test_init",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(unused_args_checker)
-    walker.walk(root_node)
+    walk_checker(linter, unused_args_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1

--- a/tests/pylint/test_utcnow.py
+++ b/tests/pylint/test_utcnow.py
@@ -3,10 +3,9 @@
 import astroid
 from pylint.checkers import BaseChecker
 from pylint.testutils.unittest_linter import UnittestLinter
-from pylint.utils.ast_walker import ASTWalker
 import pytest
 
-from . import assert_no_messages
+from . import assert_no_messages, walk_checker
 
 
 @pytest.mark.parametrize(
@@ -72,11 +71,9 @@ def test_enforce_utcnow_good(
 ) -> None:
     """Good test cases -- no message expected."""
     root_node = astroid.parse(code, "homeassistant.components.pylint_test")
-    walker = ASTWalker(linter)
-    walker.add_checker(enforce_utcnow_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, enforce_utcnow_checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -243,10 +240,8 @@ def test_enforce_utcnow_bad(
 ) -> None:
     """Bad test cases -- one message expected per call."""
     root_node = astroid.parse(code, "homeassistant.components.pylint_test")
-    walker = ASTWalker(linter)
-    walker.add_checker(enforce_utcnow_checker)
 
-    walker.walk(root_node)
+    walk_checker(linter, enforce_utcnow_checker, root_node)
     messages = linter.release_messages()
     assert len(messages) == 1
     assert messages[0].msg_id == "home-assistant-enforce-utcnow"
@@ -282,8 +277,6 @@ def test_enforce_utcnow_skips_util_dt(
 ) -> None:
     """``homeassistant.util.dt`` defines ``utcnow`` itself, so it is skipped."""
     root_node = astroid.parse(code, "homeassistant.util.dt")
-    walker = ASTWalker(linter)
-    walker.add_checker(enforce_utcnow_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, enforce_utcnow_checker, root_node)

--- a/tests/pylint/tests/test_direct_async_migrate_entry.py
+++ b/tests/pylint/tests/test_direct_async_migrate_entry.py
@@ -2,13 +2,12 @@
 
 import astroid
 from pylint.testutils import UnittestLinter
-from pylint.utils.ast_walker import ASTWalker
 from pylint_home_assistant.checkers.tests.direct_async_migrate_entry import (
     DirectAsyncMigrateEntry,
 )
 import pytest
 
-from tests.pylint import assert_no_messages
+from tests.pylint import assert_no_messages, walk_checker
 
 # Pre-load so astroid can resolve ``async_migrate_entry`` in parsed snippets.
 astroid.MANAGER.ast_from_module_name("homeassistant.components.ps4")
@@ -70,11 +69,9 @@ def test_no_warning(
 ) -> None:
     """Test cases that should not trigger a warning."""
     root_node = astroid.parse(code, module_name)
-    walker = ASTWalker(linter)
-    walker.add_checker(checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -110,9 +107,7 @@ def test_warning(
 ) -> None:
     """Test cases that should trigger a warning."""
     root_node = astroid.parse(code, module_name)
-    walker = ASTWalker(linter)
-    walker.add_checker(checker)
-    walker.walk(root_node)
+    walk_checker(linter, checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -136,9 +131,7 @@ async def test_b(hass, mock_config_entry):
 """,
         "tests.components.ps4.test_init",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(checker)
-    walker.walk(root_node)
+    walk_checker(linter, checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 2

--- a/tests/pylint/tests/test_direct_async_setup.py
+++ b/tests/pylint/tests/test_direct_async_setup.py
@@ -2,11 +2,10 @@
 
 import astroid
 from pylint.testutils import UnittestLinter
-from pylint.utils.ast_walker import ASTWalker
 from pylint_home_assistant.checkers.tests.direct_async_setup import DirectAsyncSetup
 import pytest
 
-from tests.pylint import assert_no_messages
+from tests.pylint import assert_no_messages, walk_checker
 
 # Pre-load so astroid can resolve ``async_setup`` in parsed snippets.
 astroid.MANAGER.ast_from_module_name("homeassistant.components.ps4")
@@ -78,11 +77,9 @@ def test_no_warning(
 ) -> None:
     """Test cases that should not trigger a warning."""
     root_node = astroid.parse(code, module_name)
-    walker = ASTWalker(linter)
-    walker.add_checker(checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -118,9 +115,7 @@ def test_warning(
 ) -> None:
     """Test cases that should trigger a warning."""
     root_node = astroid.parse(code, module_name)
-    walker = ASTWalker(linter)
-    walker.add_checker(checker)
-    walker.walk(root_node)
+    walk_checker(linter, checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -144,9 +139,7 @@ async def test_b(hass):
 """,
         "tests.components.ps4.test_init",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(checker)
-    walker.walk(root_node)
+    walk_checker(linter, checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 2

--- a/tests/pylint/tests/test_direct_async_setup_entry.py
+++ b/tests/pylint/tests/test_direct_async_setup_entry.py
@@ -2,13 +2,12 @@
 
 import astroid
 from pylint.testutils import UnittestLinter
-from pylint.utils.ast_walker import ASTWalker
 from pylint_home_assistant.checkers.tests.direct_async_setup_entry import (
     DirectAsyncSetupEntry,
 )
 import pytest
 
-from tests.pylint import assert_no_messages
+from tests.pylint import assert_no_messages, walk_checker
 
 # Pre-load so astroid can resolve ``async_setup_entry`` in parsed snippets.
 astroid.MANAGER.ast_from_module_name("homeassistant.components.sun")
@@ -71,11 +70,9 @@ def test_no_warning(
 ) -> None:
     """Test cases that should not trigger a warning."""
     root_node = astroid.parse(code, module_name)
-    walker = ASTWalker(linter)
-    walker.add_checker(checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -136,9 +133,7 @@ def test_warning(
 ) -> None:
     """Test cases that should trigger a warning."""
     root_node = astroid.parse(code, module_name)
-    walker = ASTWalker(linter)
-    walker.add_checker(checker)
-    walker.walk(root_node)
+    walk_checker(linter, checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -162,9 +157,7 @@ async def test_b(hass, mock_config_entry):
 """,
         "tests.components.sun.test_init",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(checker)
-    walker.walk(root_node)
+    walk_checker(linter, checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 2

--- a/tests/pylint/tests/test_direct_async_unload_entry.py
+++ b/tests/pylint/tests/test_direct_async_unload_entry.py
@@ -2,13 +2,12 @@
 
 import astroid
 from pylint.testutils import UnittestLinter
-from pylint.utils.ast_walker import ASTWalker
 from pylint_home_assistant.checkers.tests.direct_async_unload_entry import (
     DirectAsyncUnloadEntry,
 )
 import pytest
 
-from tests.pylint import assert_no_messages
+from tests.pylint import assert_no_messages, walk_checker
 
 # Pre-load so astroid can resolve ``async_unload_entry`` in parsed snippets.
 astroid.MANAGER.ast_from_module_name("homeassistant.components.ps4")
@@ -70,11 +69,9 @@ def test_no_warning(
 ) -> None:
     """Test cases that should not trigger a warning."""
     root_node = astroid.parse(code, module_name)
-    walker = ASTWalker(linter)
-    walker.add_checker(checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, checker, root_node)
 
 
 @pytest.mark.parametrize(
@@ -110,9 +107,7 @@ def test_warning(
 ) -> None:
     """Test cases that should trigger a warning."""
     root_node = astroid.parse(code, module_name)
-    walker = ASTWalker(linter)
-    walker.add_checker(checker)
-    walker.walk(root_node)
+    walk_checker(linter, checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -136,9 +131,7 @@ async def test_b(hass, mock_config_entry):
 """,
         "tests.components.ps4.test_init",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(checker)
-    walker.walk(root_node)
+    walk_checker(linter, checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 2

--- a/tests/pylint/tests/test_redundant_usefixtures.py
+++ b/tests/pylint/tests/test_redundant_usefixtures.py
@@ -4,13 +4,12 @@ from pathlib import Path
 
 import astroid
 from pylint.testutils import UnittestLinter
-from pylint.utils.ast_walker import ASTWalker
 from pylint_home_assistant.checkers.tests.redundant_usefixtures import (
     RedundantUsefixtures,
 )
 import pytest
 
-from tests.pylint import assert_no_messages
+from tests.pylint import assert_no_messages, walk_checker
 
 
 @pytest.mark.parametrize(
@@ -73,11 +72,9 @@ def test_no_warning(
 ) -> None:
     """Test cases that should not trigger a warning."""
     root_node = astroid.parse(code, "tests.components.test_integration.test_init")
-    walker = ASTWalker(linter)
-    walker.add_checker(usefixtures_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, usefixtures_checker, root_node)
 
 
 def test_single_fixture_redundant(
@@ -95,9 +92,7 @@ async def test_something(hass: HomeAssistant) -> None:
 """,
         "tests.components.test_integration.test_init",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(usefixtures_checker)
-    walker.walk(root_node)
+    walk_checker(linter, usefixtures_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -120,9 +115,7 @@ async def test_something(hass: HomeAssistant) -> None:
 """,
         "tests.components.test_integration.test_init",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(usefixtures_checker)
-    walker.walk(root_node)
+    walk_checker(linter, usefixtures_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -144,9 +137,7 @@ async def test_something(hass: HomeAssistant) -> None:
 """,
         "tests.components.test_integration.test_init",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(usefixtures_checker)
-    walker.walk(root_node)
+    walk_checker(linter, usefixtures_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -171,9 +162,7 @@ async def test_b(hass: HomeAssistant) -> None:
 """,
         "tests.components.test_integration.test_init",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(usefixtures_checker)
-    walker.walk(root_node)
+    walk_checker(linter, usefixtures_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 2
@@ -202,9 +191,7 @@ async def test_something(hass: HomeAssistant) -> None:
     )
     root_node.file = str(test_dir / "test_init.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(usefixtures_checker)
-    walker.walk(root_node)
+    walk_checker(linter, usefixtures_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -235,9 +222,7 @@ async def test_something(hass: HomeAssistant) -> None:
     )
     root_node.file = str(test_dir / "test_init.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(usefixtures_checker)
-    walker.walk(root_node)
+    walk_checker(linter, usefixtures_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -268,9 +253,7 @@ async def test_something(hass: HomeAssistant) -> None:
     )
     root_node.file = str(test_dir / "test_init.py")
 
-    walker = ASTWalker(linter)
-    walker.add_checker(usefixtures_checker)
-    walker.walk(root_node)
+    walk_checker(linter, usefixtures_checker, root_node)
 
     messages = linter.release_messages()
     assert len(messages) == 1
@@ -292,8 +275,6 @@ async def test_something(hass: HomeAssistant) -> None:
 """,
         "homeassistant.components.test_integration",
     )
-    walker = ASTWalker(linter)
-    walker.add_checker(usefixtures_checker)
 
     with assert_no_messages(linter):
-        walker.walk(root_node)
+        walk_checker(linter, usefixtures_checker, root_node)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The pylint rule tests in `tests/pylint/` repeated the same three-line walker setup at every call site (`walker = ASTWalker(linter)` / `walker.add_checker(...)` / `walker.walk(root_node)`). This pattern appeared 209 times across 35 test files.

This PR adds a small shared helper to `tests/pylint/__init__.py` that wraps those three lines, and converts every call site to a single `walk_checker(linter, some_checker, root_node)` call, dropping the now-unused `ASTWalker` import from each file.

The helper takes an already-parsed node rather than parsing the source itself, because some call sites reference the parsed tree (for example `node=root_node.body[...]` inside a `MessageTest`) before walking. Keeping `astroid.parse(...)` explicit in each test lets a single helper cover all 209 sites uniformly.

There is no behavior change: the only message-emitting operation is `walker.walk()`, which still runs inside the existing `assert_no_messages` / `assert_adds_messages` blocks exactly as before. The net change is roughly 470 fewer lines.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
