### PR TITLE
Add StiebelEltronEntity base class for stiebel_eltron

### DIFF
--- a/homeassistant/components/stiebel_eltron/climate.py
+++ b/homeassistant/components/stiebel_eltron/climate.py
@@ -24,8 +24,7 @@ from .entity import StiebelEltronEntity
 
 _LOGGER = logging.getLogger(__name__)
 
-# Serialize write calls: concurrent Modbus writes to the device can cause errors.
-PARALLEL_UPDATES = 1
+PARALLEL_UPDATES = 0
 
 CLIMATE_HK_1 = "climate_hk_1"
 
@@ -82,7 +81,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up STIEBEL ELTRON climate platform."""
 
-    async_add_entities([StiebelEltron(entry.entry_id, entry.runtime_data)])
+    async_add_entities([StiebelEltron(entry.runtime_data)])
 
 
 class StiebelEltron(StiebelEltronEntity, ClimateEntity):
@@ -102,11 +101,11 @@ class StiebelEltron(StiebelEltronEntity, ClimateEntity):
     _attr_min_temp = 10.0
     _attr_max_temp = 30.0
 
-    def __init__(
-        self, unique_id: str, coordinator: StiebelEltronDataCoordinator
-    ) -> None:
+    def __init__(self, coordinator: StiebelEltronDataCoordinator) -> None:
         """Initialize the unit."""
-        super().__init__(coordinator, f"{unique_id}-{CLIMATE_HK_1}")
+        super().__init__(
+            coordinator, f"{coordinator.config_entry.entry_id}-{CLIMATE_HK_1}"
+        )
         self._set_attr()
 
     @override

--- a/homeassistant/components/stiebel_eltron/climate.py
+++ b/homeassistant/components/stiebel_eltron/climate.py
@@ -17,12 +17,15 @@ from homeassistant.const import ATTR_TEMPERATURE, PRECISION_TENTHS, UnitOfTemper
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import StiebelEltronConfigEntry
 from .coordinator import StiebelEltronDataCoordinator
+from .entity import StiebelEltronEntity
 
 _LOGGER = logging.getLogger(__name__)
+
+# Serialize write calls: concurrent Modbus writes to the device can cause errors.
+PARALLEL_UPDATES = 1
 
 CLIMATE_HK_1 = "climate_hk_1"
 
@@ -82,10 +85,9 @@ async def async_setup_entry(
     async_add_entities([StiebelEltron(entry.entry_id, entry.runtime_data)])
 
 
-class StiebelEltron(CoordinatorEntity[StiebelEltronDataCoordinator], ClimateEntity):
+class StiebelEltron(StiebelEltronEntity, ClimateEntity):
     """Representation of a STIEBEL ELTRON heat pump."""
 
-    _attr_has_entity_name = True
     _attr_name = None
     _attr_hvac_modes = list(HA_TO_LWZ_HVAC)
     _attr_preset_modes = list(HA_TO_LWZ_PRESET)
@@ -104,10 +106,7 @@ class StiebelEltron(CoordinatorEntity[StiebelEltronDataCoordinator], ClimateEnti
         self, unique_id: str, coordinator: StiebelEltronDataCoordinator
     ) -> None:
         """Initialize the unit."""
-        super().__init__(coordinator)
-        self._attr_device_info = coordinator.device_info
-        self._attr_unique_id = f"{unique_id}-{CLIMATE_HK_1}"
-        # Initialize runtime attributes to avoid attribute errors
+        super().__init__(coordinator, f"{unique_id}-{CLIMATE_HK_1}")
         self._set_attr()
 
     @override

--- a/homeassistant/components/stiebel_eltron/climate.py
+++ b/homeassistant/components/stiebel_eltron/climate.py
@@ -103,6 +103,7 @@ class StiebelEltron(StiebelEltronEntity, ClimateEntity):
 
     def __init__(self, coordinator: StiebelEltronDataCoordinator) -> None:
         """Initialize the unit."""
+        assert coordinator.config_entry is not None
         super().__init__(
             coordinator, f"{coordinator.config_entry.entry_id}-{CLIMATE_HK_1}"
         )

--- a/homeassistant/components/stiebel_eltron/coordinator.py
+++ b/homeassistant/components/stiebel_eltron/coordinator.py
@@ -58,11 +58,6 @@ class StiebelEltronDataCoordinator(DataUpdateCoordinator[None]):
         _LOGGER.debug("Closing connection to %s", self.host)
         await self.api_client.close()
 
-    async def connect(self) -> None:
-        """Connect client."""
-        _LOGGER.debug("Connecting to %s", self.host)
-        await self.api_client.connect()
-
     @property
     def is_connected(self) -> bool:
         """Check modbus client connection status."""

--- a/homeassistant/components/stiebel_eltron/coordinator.py
+++ b/homeassistant/components/stiebel_eltron/coordinator.py
@@ -66,8 +66,6 @@ class StiebelEltronDataCoordinator(DataUpdateCoordinator[None]):
     @property
     def is_connected(self) -> bool:
         """Check modbus client connection status."""
-        if self.api_client is None:
-            return False
         return self.api_client.is_connected
 
     @property

--- a/homeassistant/components/stiebel_eltron/entity.py
+++ b/homeassistant/components/stiebel_eltron/entity.py
@@ -1,0 +1,19 @@
+"""Base entity for the STIEBEL ELTRON integration."""
+
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .coordinator import StiebelEltronDataCoordinator
+
+
+class StiebelEltronEntity(CoordinatorEntity[StiebelEltronDataCoordinator]):
+    """Base class for STIEBEL ELTRON entities."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self, coordinator: StiebelEltronDataCoordinator, unique_id: str
+    ) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+        self._attr_device_info = coordinator.device_info
+        self._attr_unique_id = unique_id

--- a/tests/components/stiebel_eltron/test_climate.py
+++ b/tests/components/stiebel_eltron/test_climate.py
@@ -169,6 +169,33 @@ async def test_climate_entity_set_temperature(
     mock_lwz_api.set_target_temp.assert_awaited_with(23.5)
 
 
+async def test_climate_entity_set_hvac_mode_handles_api_exception(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_lwz_api: MagicMock,
+) -> None:
+    """Test setting HVAC mode handles API exception."""
+    mock_lwz_api.get_operation.return_value = None
+    await _setup_integration(hass, mock_config_entry)
+
+    mock_lwz_api.set_operation.side_effect = ModbusException("write failed")
+    with pytest.raises(HomeAssistantError):
+        await async_set_hvac_mode(hass, HVACMode.AUTO, CLIMATE_ENTITY_ID)
+
+
+async def test_climate_entity_set_preset_mode_handles_api_exception(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_lwz_api: MagicMock,
+) -> None:
+    """Test setting preset mode handles API exception."""
+    await _setup_integration(hass, mock_config_entry)
+
+    mock_lwz_api.set_operation.side_effect = ModbusException("write failed")
+    with pytest.raises(HomeAssistantError):
+        await async_set_preset_mode(hass, PRESET_COMFORT, CLIMATE_ENTITY_ID)
+
+
 async def test_climate_entity_set_temperature_handles_api_exception(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,

--- a/tests/components/stiebel_eltron/test_init.py
+++ b/tests/components/stiebel_eltron/test_init.py
@@ -89,19 +89,3 @@ async def test_async_setup_entry_coordinator_update_fails(
 
     assert result is False
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
-
-
-async def test_coordinator_connect(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_lwz_api: MagicMock,
-) -> None:
-    """Test coordinator connect method."""
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    coordinator = mock_config_entry.runtime_data
-    mock_lwz_api.connect.reset_mock()
-    await coordinator.connect()
-    mock_lwz_api.connect.assert_awaited_once()

--- a/tests/components/stiebel_eltron/test_init.py
+++ b/tests/components/stiebel_eltron/test_init.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock
 
+from pymodbus.exceptions import ModbusException
 from pystiebeleltron import StiebelEltronModbusError
 
 from homeassistant.components.stiebel_eltron.const import DOMAIN
@@ -73,3 +74,34 @@ async def test_async_setup_entry_modbus_error(
 
     assert result is False
     assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+
+
+async def test_async_setup_entry_coordinator_update_fails(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_lwz_api: MagicMock,
+) -> None:
+    """Test setup retries when coordinator data update raises ModbusException."""
+    mock_lwz_api.async_update.side_effect = ModbusException("update failed")
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.async_setup(mock_config_entry.entry_id)
+
+    assert result is False
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_coordinator_connect(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_lwz_api: MagicMock,
+) -> None:
+    """Test coordinator connect method."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data
+    mock_lwz_api.connect.reset_mock()
+    await coordinator.connect()
+    mock_lwz_api.connect.assert_awaited_once()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Introduces entity.py with StiebelEltronEntity (CoordinatorEntity subclass) carrying _attr_has_entity_name, device_info, and unique_id, then switches StiebelEltron in climate.py to inherit from it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

Merge https://github.com/home-assistant/core/pull/174953 before this one.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
