### PR TITLE
Fix invalid marker usage in LIFX service schemas

### DIFF
--- a/homeassistant/components/lifx/light.py
+++ b/homeassistant/components/lifx/light.py
@@ -66,7 +66,7 @@ LIFX_SET_STATE_SCHEMA: VolDictType = {
 SERVICE_LIFX_SET_HEV_CYCLE_STATE = "set_hev_cycle_state"
 
 LIFX_SET_HEV_CYCLE_STATE_SCHEMA: VolDictType = {
-    ATTR_POWER: vol.Required(cv.boolean),
+    vol.Required(ATTR_POWER): cv.boolean,
     ATTR_DURATION: vol.All(vol.Coerce(float), vol.Clamp(min=0, max=86400)),
 }
 

--- a/homeassistant/components/lifx/manager.py
+++ b/homeassistant/components/lifx/manager.py
@@ -178,9 +178,7 @@ LIFX_EFFECT_MORPH_SCHEMA = cv.make_entity_service_schema(
     {
         **LIFX_EFFECT_SCHEMA,
         ATTR_SPEED: vol.All(vol.Coerce(int), vol.Clamp(min=1, max=25)),
-        vol.Exclusive(ATTR_THEME, COLOR_GROUP): vol.Optional(
-            vol.In(ThemeLibrary().themes)
-        ),
+        vol.Exclusive(ATTR_THEME, COLOR_GROUP): vol.In(ThemeLibrary().themes),
         vol.Exclusive(ATTR_PALETTE, COLOR_GROUP): vol.All(
             cv.ensure_list, [HSBK_SCHEMA]
         ),
@@ -192,7 +190,7 @@ LIFX_EFFECT_MOVE_SCHEMA = cv.make_entity_service_schema(
         **LIFX_EFFECT_SCHEMA,
         ATTR_SPEED: vol.All(vol.Coerce(float), vol.Clamp(min=0.1, max=60)),
         ATTR_DIRECTION: vol.In(EFFECT_MOVE_DIRECTIONS),
-        ATTR_THEME: vol.Optional(vol.In(ThemeLibrary().themes)),
+        vol.Optional(ATTR_THEME): vol.In(ThemeLibrary().themes),
     }
 )
 
@@ -211,9 +209,7 @@ LIFX_PAINT_THEME_SCHEMA = cv.make_entity_service_schema(
     {
         **LIFX_EFFECT_SCHEMA,
         ATTR_TRANSITION: vol.All(vol.Coerce(int), vol.Clamp(min=1, max=3600)),
-        vol.Exclusive(ATTR_THEME, COLOR_GROUP): vol.Optional(
-            vol.In(ThemeLibrary().themes)
-        ),
+        vol.Exclusive(ATTR_THEME, COLOR_GROUP): vol.In(ThemeLibrary().themes),
         vol.Exclusive(ATTR_PALETTE, COLOR_GROUP): vol.All(
             cv.ensure_list, [HSBK_SCHEMA]
         ),


### PR DESCRIPTION
## Proposed change

Several LIFX service schemas placed `vol.Required` / `vol.Optional` markers in the *value* position instead of on the key. Markers are key constructs; in value position voluptuous silently delegates to the inner validator, so they were no-ops that masked the real intent.

- `set_hev_cycle_state`: `{ATTR_POWER: vol.Required(cv.boolean)}` made `power` an *optional* key whose value happened to be validated as a boolean. `services.yaml` already declares `power` as `required: true`, so the schema did not match the documented contract. Changed to `{vol.Required(ATTR_POWER): cv.boolean}` so the schema enforces what the service already documents.
- The morph, move, and paint-theme effect schemas wrapped the theme validator in a value-position `vol.Optional(...)`. The value is now validated directly with `vol.In(ThemeLibrary().themes)`, leaving the existing key markers (`Optional` / `Exclusive`) untouched.

No user-facing behavior change beyond `power` now being enforced as required for `set_hev_cycle_state`, which matches its existing `services.yaml` definition.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
