### PR TITLE
Validate auth provider configs against provider-specific schemas during config check

### DIFF
--- a/homeassistant/helpers/check_config.py
+++ b/homeassistant/helpers/check_config.py
@@ -10,6 +10,7 @@ from annotatedyaml import loader as yaml_loader
 import voluptuous as vol
 
 from homeassistant import loader
+from homeassistant.auth.providers import load_auth_provider_module
 from homeassistant.config import (  # type: ignore[attr-defined]
     CONF_PACKAGES,
     YAML_CONFIG_FILE,
@@ -20,6 +21,7 @@ from homeassistant.config import (  # type: ignore[attr-defined]
     load_yaml_config_file,
     merge_packages_config,
 )
+from homeassistant.const import CONF_AUTH_PROVIDERS, CONF_TYPE
 from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
 from homeassistant.core_config import CORE_CONFIG_SCHEMA
 from homeassistant.exceptions import HomeAssistantError
@@ -167,6 +169,24 @@ async def async_check_ha_config_file(  # noqa: C901
     core_config = config.pop(HOMEASSISTANT_DOMAIN, {})
     try:
         core_config = CORE_CONFIG_SCHEMA(core_config)
+
+        # Validate auth provider configs against provider-specific schemas.
+        # CORE_CONFIG_SCHEMA only validates against the base AUTH_PROVIDER_SCHEMA
+        # which uses extra=vol.ALLOW_EXTRA, so provider-specific required keys
+        # (e.g. trusted_networks, command) are not enforced there.  Load each
+        # provider module and validate against its CONFIG_SCHEMA to surface
+        # missing required keys at config-check time rather than startup.
+        if auth_providers_conf := core_config.get(CONF_AUTH_PROVIDERS):
+            for provider_conf in auth_providers_conf:
+                provider_type = provider_conf[CONF_TYPE]
+                try:
+                    module = await load_auth_provider_module(hass, provider_type)
+                except HomeAssistantError:
+                    # Unknown provider type — deferred to startup.
+                    continue
+                if hasattr(module, "CONFIG_SCHEMA"):
+                    module.CONFIG_SCHEMA(provider_conf)
+
         result[HOMEASSISTANT_DOMAIN] = core_config
 
         # Merge packages

--- a/tests/helpers/test_check_config.py
+++ b/tests/helpers/test_check_config.py
@@ -608,3 +608,44 @@ async def test_removed_yaml_support(hass: HomeAssistant) -> None:
 
         assert res.keys() == {"homeassistant"}
         _assert_warnings_errors(res, [], [])
+
+
+@pytest.mark.parametrize(
+    ("provider_type", "missing_key"),
+    [
+        ("trusted_networks", "trusted_networks"),
+        ("command_line", "command"),
+    ],
+)
+async def test_auth_provider_missing_required_key(
+    hass: HomeAssistant, provider_type: str, missing_key: str
+) -> None:
+    """Test config check flags missing required key in auth provider config."""
+    files = {
+        YAML_CONFIG_FILE: BASE_CONFIG
+        + f"  auth_providers:\n    - type: {provider_type}\n"
+    }
+    with patch("os.path.isfile", return_value=True), patch_yaml_files(files):
+        res = await async_check_ha_config_file(hass)
+        log_ha_config(res)
+
+        assert len(res.errors) == 1
+        assert missing_key in res.errors[0].message
+
+
+async def test_auth_provider_valid_trusted_networks(
+    hass: HomeAssistant,
+) -> None:
+    """Test config check accepts a valid trusted_networks provider config."""
+    files = {
+        YAML_CONFIG_FILE: BASE_CONFIG
+        + "  auth_providers:\n"
+        + "    - type: trusted_networks\n"
+        + "      trusted_networks:\n"
+        + "        - 192.168.0.0/24\n"
+    }
+    with patch("os.path.isfile", return_value=True), patch_yaml_files(files):
+        res = await async_check_ha_config_file(hass)
+        log_ha_config(res)
+
+        _assert_warnings_errors(res, [], [])


### PR DESCRIPTION
## What does it do?

Fixes #175121.

`CORE_CONFIG_SCHEMA` validates auth provider entries only against the base `AUTH_PROVIDER_SCHEMA` which uses `extra=vol.ALLOW_EXTRA`, so provider-specific required keys (e.g. `trusted_networks` for the trusted_networks provider, `command` for the command_line provider) are not enforced during config check. Missing keys are only caught at startup in `auth_provider_from_config()`.

This PR adds provider-specific schema validation to `async_check_ha_config_file()` using the existing `load_auth_provider_module`, catching missing required keys at configuration-check time.

## How does it work?

After `CORE_CONFIG_SCHEMA` succeeds in `async_check_ha_config_file()`, the new code iterates over auth provider configs and for each one:

1. Loads the provider module via `load_auth_provider_module` (async, reuses the existing import path)
2. Validates against the provider's `CONFIG_SCHEMA` if present — this enforces provider-required keys
3. Gracefully handles unknown provider types (deferred to startup)

This runs in an async context, avoids synchronous imports on the event loop, and reuses the existing `load_auth_provider_module` / `async_import_module` infrastructure rather than duplicating import logic.

## Type of change

Bug fix (non-breaking change which fixes an issue)

## Additional information

- `core_config.py` is not modified — validation lives in `check_config.py` where it runs in an async context
- Tests use `pytest.mark.parametrize` to cover both `trusted_networks` and `command_line` providers
- All existing tests pass with no modifications needed

## Checklist

- [x] The code change is tested and works locally
- [x] Local tests pass with `pytest tests/helpers/test_check_config.py`
- [x] Code follows the project's style guidelines
- [x] Code formatted with Ruff