### PR TITLE
Fix Duco state end time being rounded by the integration

### DIFF
--- a/homeassistant/components/duco/sensor.py
+++ b/homeassistant/components/duco/sensor.py
@@ -83,7 +83,9 @@ SENSOR_DESCRIPTIONS: tuple[DucoSensorEntityDescription, ...] = (
         translation_key="time_state_end",
         device_class=SensorDeviceClass.TIMESTAMP,
         value_fn=lambda node: (
-            dt_util.utc_from_timestamp(node.ventilation.time_state_end)
+            dt_util.utc_from_timestamp(node.ventilation.time_state_end + 59).replace(
+                second=0, microsecond=0
+            )
             if node.ventilation and node.ventilation.time_state_end != 0
             else None
         ),

--- a/homeassistant/components/duco/sensor.py
+++ b/homeassistant/components/duco/sensor.py
@@ -83,9 +83,7 @@ SENSOR_DESCRIPTIONS: tuple[DucoSensorEntityDescription, ...] = (
         translation_key="time_state_end",
         device_class=SensorDeviceClass.TIMESTAMP,
         value_fn=lambda node: (
-            dt_util.utc_from_timestamp(node.ventilation.time_state_end + 59).replace(
-                second=0, microsecond=0
-            )
+            dt_util.utc_from_timestamp(node.ventilation.time_state_end)
             if node.ventilation and node.ventilation.time_state_end != 0
             else None
         ),

--- a/homeassistant/components/duco/sensor.py
+++ b/homeassistant/components/duco/sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 import logging
 from typing import override
 
@@ -32,6 +32,14 @@ from .entity import DucoEntity
 _LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
+
+
+def _round_up_timestamp_to_minute(timestamp: int) -> datetime:
+    """Round a UTC timestamp up to the next whole minute."""
+    rounded = dt_util.utc_from_timestamp(timestamp)
+    if rounded.second or rounded.microsecond:
+        rounded += timedelta(minutes=1)
+    return rounded.replace(second=0, microsecond=0)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -83,9 +91,7 @@ SENSOR_DESCRIPTIONS: tuple[DucoSensorEntityDescription, ...] = (
         translation_key="time_state_end",
         device_class=SensorDeviceClass.TIMESTAMP,
         value_fn=lambda node: (
-            dt_util.utc_from_timestamp(node.ventilation.time_state_end).replace(
-                second=0, microsecond=0
-            )
+            _round_up_timestamp_to_minute(node.ventilation.time_state_end)
             if node.ventilation and node.ventilation.time_state_end != 0
             else None
         ),

--- a/homeassistant/components/duco/sensor.py
+++ b/homeassistant/components/duco/sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime
 import logging
 from typing import override
 
@@ -32,14 +32,6 @@ from .entity import DucoEntity
 _LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
-
-
-def _round_up_timestamp_to_minute(timestamp: int) -> datetime:
-    """Round a UTC timestamp up to the next whole minute."""
-    rounded = dt_util.utc_from_timestamp(timestamp)
-    if rounded.second or rounded.microsecond:
-        rounded += timedelta(minutes=1)
-    return rounded.replace(second=0, microsecond=0)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -91,7 +83,7 @@ SENSOR_DESCRIPTIONS: tuple[DucoSensorEntityDescription, ...] = (
         translation_key="time_state_end",
         device_class=SensorDeviceClass.TIMESTAMP,
         value_fn=lambda node: (
-            _round_up_timestamp_to_minute(node.ventilation.time_state_end)
+            dt_util.utc_from_timestamp(node.ventilation.time_state_end)
             if node.ventilation and node.ventilation.time_state_end != 0
             else None
         ),

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -86,32 +86,6 @@ async def test_ventilation_related_sensors_created_for_supported_node_types(
     assert hass.states.get("sensor.office_co2_state_end_time") is None
 
 
-async def test_time_state_end_rounds_up_partial_minute(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_duco_client: AsyncMock,
-    mock_sensor_nodes: list[Node],
-) -> None:
-    """Test state end time stays in the future during the final partial minute."""
-    partial_minute_node = replace(
-        mock_sensor_nodes[0],
-        ventilation=replace(
-            mock_sensor_nodes[0].ventilation,
-            time_state_end=1700000459,
-        ),
-    )
-    mock_duco_client.async_get_nodes.return_value = [
-        partial_minute_node,
-        *mock_sensor_nodes[1:],
-    ]
-
-    await setup_platform_integration(hass, mock_config_entry, [Platform.SENSOR])
-
-    state = hass.states.get("sensor.living_state_end_time")
-    assert state is not None
-    assert state.state == "2023-11-14T22:21:00+00:00"
-
-
 @pytest.fixture
 async def init_integration(
     hass: HomeAssistant,

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -86,6 +86,32 @@ async def test_ventilation_related_sensors_created_for_supported_node_types(
     assert hass.states.get("sensor.office_co2_state_end_time") is None
 
 
+async def test_time_state_end_rounds_up_partial_minute(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_duco_client: AsyncMock,
+    mock_sensor_nodes: list[Node],
+) -> None:
+    """Test state end time stays in the future during the final partial minute."""
+    partial_minute_node = replace(
+        mock_sensor_nodes[0],
+        ventilation=replace(
+            mock_sensor_nodes[0].ventilation,
+            time_state_end=1700000459,
+        ),
+    )
+    mock_duco_client.async_get_nodes.return_value = [
+        partial_minute_node,
+        *mock_sensor_nodes[1:],
+    ]
+
+    await setup_platform_integration(hass, mock_config_entry, [Platform.SENSOR])
+
+    state = hass.states.get("sensor.living_state_end_time")
+    assert state is not None
+    assert state.state == "2023-11-14T22:21:00+00:00"
+
+
 @pytest.fixture
 async def init_integration(
     hass: HomeAssistant,

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -59,7 +59,7 @@ async def test_ventilation_related_sensors_created_for_supported_node_types(
         ventilation=replace(
             mock_sensor_nodes[0].ventilation,
             flow_lvl_tgt=42,
-            time_state_end=1700000400,
+            time_state_end=1700000459,
         ),
     )
     mock_duco_client.async_get_nodes.return_value = [
@@ -79,7 +79,7 @@ async def test_ventilation_related_sensors_created_for_supported_node_types(
 
     state = hass.states.get("sensor.living_state_end_time")
     assert state is not None
-    assert state.state == "2023-11-14T22:20:00+00:00"
+    assert state.state == "2023-11-14T22:20:59+00:00"
 
     assert hass.states.get("sensor.office_co2_ventilation_state") is None
     assert hass.states.get("sensor.office_co2_target_flow_level") is None


### PR DESCRIPTION
> [!IMPORTANT]
> This PR fixes a user-visible Duco timestamp issue in already shipped functionality. The integration currently rounds the reported `time_state_end` value instead of exposing the raw end timestamp from the device. Because this is a bugfix for existing functionality rather than a new capability, could this PR be considered for the next release milestone?

## Proposed change
This PR changes the Duco `time_state_end` sensor to expose the raw timestamp reported by the device instead of rounding it inside the integration.

The previous implementation normalized the timestamp to minute precision. That reduced state churn, but it also meant the integration was no longer exposing the actual device-reported end moment. Depending on the rounding direction, that could make the visible end moment look too early or too late.

This change keeps the integration closer to the source data and leaves presentation concerns to Home Assistant and the user. It does mean the timestamp can change more often as new polls come in, but the exposed value now corresponds directly to what the device reports.

Because this corrects a user-visible bug in already released functionality, I think this fits best as a bugfix rather than a new feature. If merged in time, it looks like a good fit for the next release milestone.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr