### PR TITLE
Consider current connection type in reconnect action in FRITZ!Box Tools

### DIFF
--- a/homeassistant/components/fritz/coordinator.py
+++ b/homeassistant/components/fritz/coordinator.py
@@ -11,7 +11,7 @@ from typing import Any, TypedDict, cast, override
 from xml.etree.ElementTree import ParseError
 
 from fritzconnection import FritzConnection
-from fritzconnection.core.exceptions import FritzActionError
+from fritzconnection.core.exceptions import FritzActionError, FritzConnectionException
 from fritzconnection.lib.fritzcall import FritzCall
 from fritzconnection.lib.fritzhosts import FritzHosts
 from fritzconnection.lib.fritzstatus import FritzStatus
@@ -267,9 +267,7 @@ class FritzBoxTools(DataUpdateCoordinator[UpdateCoordinatorDataType]):
         ) = self._update_device_info()
 
         if self.fritz_status.has_wan_support:
-            self.device_conn_type = (
-                self.fritz_status.get_default_connection_service().connection_service
-            )
+            self.device_conn_type = self.fritz_status.connection_service
             self.device_is_router = self.fritz_status.has_wan_enabled
 
         self.has_call_deflections = "X_AVM-DE_OnTel1" in self.connection.services
@@ -682,7 +680,18 @@ class FritzBoxTools(DataUpdateCoordinator[UpdateCoordinatorDataType]):
 
     async def async_trigger_reconnect(self) -> None:
         """Trigger device reconnect."""
-        await self.hass.async_add_executor_job(self.connection.reconnect)
+        try:
+            await self.hass.async_add_executor_job(
+                self.connection.call_action,
+                f"{self.device_conn_type}1",
+                "ForceTermination",
+            )
+        except FritzConnectionException as ex:
+            # ignore UPnPError:
+            # errorCode: 707
+            # errorDescription: DisconnectInProgress
+            if "disconnectinprogress" not in str(ex).lower():
+                raise
 
     async def async_trigger_set_guest_password(
         self, password: str | None, length: int

--- a/tests/components/fritz/test_coordinator.py
+++ b/tests/components/fritz/test_coordinator.py
@@ -483,31 +483,44 @@ async def test_trigger_methods(
 ) -> None:
     """Test trigger methods delegate to correct underlying calls."""
 
+    # test async_trigger_firmware_update
     fritz_tools.connection.call_action = MagicMock(
         return_value={"NewX_AVM-DE_UpdateState": True}
     )
+    assert await fritz_tools.async_trigger_firmware_update() is True
+
+    # test async_trigger_reboot
     fritz_tools.connection.reboot = MagicMock()
-    fritz_tools.connection.reconnect = MagicMock()
+    await fritz_tools.async_trigger_reboot()
+    fritz_tools.connection.reboot.assert_called_once()
+
+    # test async_trigger_set_guest_password
     fritz_tools.fritz_guest_wifi.set_password = MagicMock()
+    await fritz_tools.async_trigger_set_guest_password("new-password", 20)
+    fritz_tools.fritz_guest_wifi.set_password.assert_called_once_with(
+        "new-password", 20
+    )
+
+    # test async_trigger_reconnect
+    fritz_tools.connection.call_action = MagicMock(
+        side_effect=FritzConnectionException(
+            "UPnPError:\nerrorCode: 707\nerrorDescription: DisconnectInProgress"
+        )
+    )
+    await fritz_tools.async_trigger_reconnect()
+    fritz_tools.connection.call_action.assert_called_with(
+        "WANPPPConnection1", "ForceTermination"
+    )
+
+    # test async_trigger_dial
     fritz_tools.fritz_call.dial = MagicMock()
     fritz_tools.fritz_call.hangup = MagicMock()
-
-    assert await fritz_tools.async_trigger_firmware_update() is True
-    await fritz_tools.async_trigger_reboot()
-    await fritz_tools.async_trigger_reconnect()
-    await fritz_tools.async_trigger_set_guest_password("new-password", 20)
-
     with patch(
         "homeassistant.components.fritz.coordinator.asyncio.sleep",
         new=AsyncMock(),
     ) as sleep_mock:
         await fritz_tools.async_trigger_dial("012345", 1)
 
-    fritz_tools.connection.reboot.assert_called_once()
-    fritz_tools.connection.reconnect.assert_called_once()
-    fritz_tools.fritz_guest_wifi.set_password.assert_called_once_with(
-        "new-password", 20
-    )
     fritz_tools.fritz_call.dial.assert_called_once_with("012345")
     sleep_mock.assert_awaited_once_with(1)
     fritz_tools.fritz_call.hangup.assert_called_once()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This takes the current connection type into account to perform the reconnect action. Performing this action returns an UPnPError (_at least on my PPP connected device_) instead of just some OK return code, so we need to ignore this

```
[...]
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/fritzconnection/core/fritzconnection.py", line 502, in reconnect
    self.call_action("WANPPPConnection1", "ForceTermination")
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/homeassistant-core/homeassistant/components/fritz/coordinator.py", line 111, in call_action
    return super().call_action(  # type: ignore[no-any-return]
           ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        service_name, action_name, arguments=arguments, **kwargs
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/fritzconnection/core/fritzconnection.py", line 461, in call_action
    return self.soaper.execute(service, action_name, arguments)
           ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/fritzconnection/core/soaper.py", line 304, in execute
    return handle_response(response)
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/fritzconnection/core/soaper.py", line 286, in handle_response
    raise_fritzconnection_error(response)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/fritzconnection/core/soaper.py", line 192, in raise_fritzconnection_error
    raise exception(message)
fritzconnection.core.exceptions.FritzConnectionException: UPnPError: 
errorCode: 707
errorDescription: DisconnectInProgress
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #172413
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
