### PR TITLE
Add application credentials setup hint to ViCare

### DIFF
--- a/homeassistant/components/vicare/application_credentials.py
+++ b/homeassistant/components/vicare/application_credentials.py
@@ -18,6 +18,13 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
 VICARE_SCOPES = [SCOPE_IOT, SCOPE_OFFLINE_ACCESS]
 
 
+async def async_get_description_placeholders(hass: HomeAssistant) -> dict[str, str]:
+    """Return description placeholders for the credentials dialog."""
+    return {
+        "more_info_url": "https://www.home-assistant.io/integrations/vicare/#prerequisites"
+    }
+
+
 async def async_get_auth_implementation(
     hass: HomeAssistant, auth_domain: str, credential: ClientCredential
 ) -> ViCareOAuth2Implementation:

--- a/homeassistant/components/vicare/strings.json
+++ b/homeassistant/components/vicare/strings.json
@@ -1,4 +1,7 @@
 {
+  "application_credentials": {
+    "description": "The **Client Secret** is ignored, enter any value. Follow the [setup instructions]({more_info_url}) to obtain the Client ID."
+  },
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",

--- a/homeassistant/components/vicare/strings.json
+++ b/homeassistant/components/vicare/strings.json
@@ -1,6 +1,6 @@
 {
   "application_credentials": {
-    "description": "The **Client Secret** is ignored, enter any value. Follow the [setup instructions]({more_info_url}) to obtain the Client ID."
+    "description": "The **client secret** is ignored, enter any value. Follow the [setup instructions]({more_info_url}) to obtain the Client ID."
   },
   "config": {
     "abort": {


### PR DESCRIPTION
## Proposed change

The ViCare credentials dialog currently shows only the generic application credentials text, which presents a required **Client Secret** field even though the ViCare API does not use one. This adds an integration-specific description that tells users the Client Secret is ignored and any value works, with a link to the setup instructions.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- Raised via user support; no tracking issue.
