### PR TITLE
Use a major version bump for the History Stats "additional_settings" rename

### DIFF
--- a/homeassistant/components/history_stats/__init__.py
+++ b/homeassistant/components/history_stats/__init__.py
@@ -121,12 +121,11 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         hass.config_entries.async_update_entry(
             config_entry, options=options, minor_version=3
         )
-        if config_entry.minor_version < 4:
-            # The "advanced_settings" section was renamed to "additional_settings"
-            if (additional := options.pop("advanced_settings", None)) is not None:
-                options[SECTION_ADDITIONAL_SETTINGS] = additional
+        # The "advanced_settings" section was renamed to "additional_settings"
+        if (additional := options.pop("advanced_settings", None)) is not None:
+            options[SECTION_ADDITIONAL_SETTINGS] = additional
         hass.config_entries.async_update_entry(
-            config_entry, options=options, minor_version=4
+            config_entry, options=options, version=2, minor_version=1
         )
 
     _LOGGER.debug(

--- a/homeassistant/components/history_stats/config_flow.py
+++ b/homeassistant/components/history_stats/config_flow.py
@@ -189,7 +189,7 @@ OPTIONS_FLOW = {
 class HistoryStatsConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
     """Handle a config flow for History stats."""
 
-    MINOR_VERSION = 4
+    VERSION = 2
 
     config_flow = CONFIG_FLOW
     options_flow = OPTIONS_FLOW

--- a/tests/components/history_stats/test_config_flow.py
+++ b/tests/components/history_stats/test_config_flow.py
@@ -62,7 +62,7 @@ async def test_form(
     await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["version"] == 1
+    assert result["version"] == 2
     assert result["options"] == {
         CONF_NAME: DEFAULT_NAME,
         CONF_ENTITY_ID: "binary_sensor.test_monitored",
@@ -174,7 +174,7 @@ async def test_validation_options(
     await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["version"] == 1
+    assert result["version"] == 2
     assert result["options"] == {
         CONF_NAME: DEFAULT_NAME,
         CONF_ENTITY_ID: "binary_sensor.test_monitored",

--- a/tests/components/history_stats/test_init.py
+++ b/tests/components/history_stats/test_init.py
@@ -423,7 +423,7 @@ async def test_migration_1_1(
     history_stats_entity_entry = entity_registry.async_get("sensor.my_history_stats")
     assert history_stats_entity_entry.device_id == sensor_entity_entry.device_id
 
-    assert history_stats_config_entry.version == 1
+    assert history_stats_config_entry.version == 2
     assert (
         history_stats_config_entry.minor_version
         == HistoryStatsConfigFlowHandler.MINOR_VERSION
@@ -465,7 +465,7 @@ async def test_migration_1_2(
         history_stats_config_entry.options.get(CONF_STATE_CLASS)
         == SensorStateClass.MEASUREMENT
     )
-    assert history_stats_config_entry.version == 1
+    assert history_stats_config_entry.version == 2
     assert (
         history_stats_config_entry.minor_version
         == HistoryStatsConfigFlowHandler.MINOR_VERSION
@@ -511,7 +511,7 @@ async def test_migration_1_3(
     assert history_stats_config_entry.options[SECTION_ADDITIONAL_SETTINGS] == {
         CONF_MIN_STATE_DURATION: {"seconds": 30}
     }
-    assert history_stats_config_entry.version == 1
+    assert history_stats_config_entry.version == 2
     assert (
         history_stats_config_entry.minor_version
         == HistoryStatsConfigFlowHandler.MINOR_VERSION
@@ -535,7 +535,7 @@ async def test_migration_from_future_version(
             CONF_END: "{{ utcnow() }}",
         },
         title="My history stats",
-        version=2,
+        version=3,
         minor_version=1,
     )
     config_entry.add_to_hass(hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #175109, which renamed the History Stats config-flow section `advanced_settings` to `additional_settings` using a minor version bump. That PR got merged, but I made the migration a minor version bump. This is incorrect as renaming a persisted config-entry option key is not backwards compatible. This bumps the config entry to version 2, folds the rename into the 1→2 migration (the intermediate 1.4 minor version was never released, so there should be no need to keep it as a separate step), and updates the migration tests accordingly.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes 
- This PR is related to issue: #174042, #173016
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
