### PR TITLE
Bump anova-wifi to 1.0.1

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -134,8 +134,8 @@ CLAUDE.md @home-assistant/core
 /tests/components/androidtv_remote/ @tronikos @Drafteed
 /homeassistant/components/anglian_water/ @pantherale0
 /tests/components/anglian_water/ @pantherale0
-/homeassistant/components/anova/ @Lash-L
-/tests/components/anova/ @Lash-L
+/homeassistant/components/anova/ @Lash-L @rhys-saldanha
+/tests/components/anova/ @Lash-L @rhys-saldanha
 /homeassistant/components/anthemav/ @hyralex
 /tests/components/anthemav/ @hyralex
 /homeassistant/components/anthropic/ @Shulyaka

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -134,8 +134,8 @@ CLAUDE.md @home-assistant/core
 /tests/components/androidtv_remote/ @tronikos @Drafteed
 /homeassistant/components/anglian_water/ @pantherale0
 /tests/components/anglian_water/ @pantherale0
-/homeassistant/components/anova/ @Lash-L @rhys-saldanha
-/tests/components/anova/ @Lash-L @rhys-saldanha
+/homeassistant/components/anova/ @Lash-L
+/tests/components/anova/ @Lash-L
 /homeassistant/components/anthemav/ @hyralex
 /tests/components/anthemav/ @hyralex
 /homeassistant/components/anthropic/ @Shulyaka

--- a/homeassistant/components/anova/manifest.json
+++ b/homeassistant/components/anova/manifest.json
@@ -1,11 +1,11 @@
 {
   "domain": "anova",
   "name": "Anova",
-  "codeowners": ["@Lash-L"],
+  "codeowners": ["@Lash-L", "@rhys-saldanha"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/anova",
   "integration_type": "hub",
   "iot_class": "cloud_push",
   "loggers": ["anova_wifi"],
-  "requirements": ["anova-wifi==0.17.1"]
+  "requirements": ["anova-wifi==1.0.1"]
 }

--- a/homeassistant/components/anova/manifest.json
+++ b/homeassistant/components/anova/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "anova",
   "name": "Anova",
-  "codeowners": ["@Lash-L", "@rhys-saldanha"],
+  "codeowners": ["@Lash-L"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/anova",
   "integration_type": "hub",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -525,7 +525,7 @@ androidtvremote2==0.3.1
 anel-pwrctrl-homeassistant==0.0.1.dev2
 
 # homeassistant.components.anova
-anova-wifi==0.17.1
+anova-wifi==1.0.1
 
 # homeassistant.components.anthemav
 anthemav==1.4.2


### PR DESCRIPTION
## Proposed change

Bumps `anova-wifi` from `0.17.1` to `1.0.1`.

The key fix in `v1.0.1` adds a `heartbeat=30` parameter to the websocket connection, which keeps the underlying TCP connection alive through NAT/router idle timeouts. Without this, a silently-dropped connection caused the `async for msg in ws:` loop to hang indefinitely with no errors or updates — requiring a full integration reload to recover.

### Changelog (0.17.1 → 1.0.1)

Full diff: https://github.com/Lash-L/anova_wifi/compare/v0.17.1...v1.0.1

- **v1.0.1** — Bug fix: send websocket heartbeat to keep connection alive ([#74](https://github.com/Lash-L/anova_wifi/pull/74))
- **v1.0.0** — Chore: modernize semantic-release tooling (no functional/API changes)

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.
  - PyPI: https://pypi.org/project/anova-wifi/1.0.1/
  - Changelog: https://github.com/Lash-L/anova_wifi/releases/tag/v1.0.1
  - Comparison diff: https://github.com/Lash-L/anova_wifi/compare/v0.17.1...v1.0.1

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


