### PR TITLE
geniushub: add zone demand binary sensors

### DIFF
--- a/homeassistant/components/geniushub/binary_sensor.py
+++ b/homeassistant/components/geniushub/binary_sensor.py
@@ -2,15 +2,25 @@
 
 from typing import override
 
-from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import GeniusHubConfigEntry
-from .entity import GeniusDevice
+from .entity import GeniusDevice, GeniusZone
 
 GH_STATE_ATTR = "outputOnOff"
 GH_TYPE = "Receiver"
+
+GH_ZONES_WITH_DEMAND = [
+    "radiator",
+    "wet underfloor",
+    "on / off",
+    "hot water temperature",
+]
 
 
 async def async_setup_entry(
@@ -22,11 +32,18 @@ async def async_setup_entry(
 
     broker = entry.runtime_data
 
-    async_add_entities(
+    entities: list[GeniusBinarySensor | GeniusZoneDemand] = [
         GeniusBinarySensor(broker, d, GH_STATE_ATTR)
         for d in broker.client.device_objs
-        if GH_TYPE in d.data["type"]
+        if GH_TYPE in d.data.get("type", "")
+    ]
+    entities.extend(
+        GeniusZoneDemand(broker, z)
+        for z in broker.client.zone_objs
+        if z.data.get("type") in GH_ZONES_WITH_DEMAND
     )
+
+    async_add_entities(entities)
 
 
 class GeniusBinarySensor(GeniusDevice, BinarySensorEntity):
@@ -48,3 +65,21 @@ class GeniusBinarySensor(GeniusDevice, BinarySensorEntity):
     def is_on(self) -> bool:
         """Return the status of the sensor."""
         return self._device.data["state"][self._state_attr]
+
+
+class GeniusZoneDemand(GeniusZone, BinarySensorEntity):
+    """Representation of a Genius Hub zone demand binary sensor."""
+
+    _attr_device_class = BinarySensorDeviceClass.HEAT
+
+    def __init__(self, broker, zone) -> None:
+        """Initialize the zone demand binary sensor."""
+        super().__init__(broker, zone)
+
+        self._unique_id = f"{broker.hub_uid}_zone_{zone.id}_demand"
+        self._attr_name = f"{zone.name} Demand"
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if the zone is calling for heat."""
+        return self._zone.data.get("output") == 1

--- a/homeassistant/components/geniushub/binary_sensor.py
+++ b/homeassistant/components/geniushub/binary_sensor.py
@@ -80,6 +80,7 @@ class GeniusZoneDemand(GeniusZone, BinarySensorEntity):
         self._attr_name = f"{zone.name} Demand"
 
     @property
+    @override
     def is_on(self) -> bool:
         """Return true if the zone is calling for heat."""
         return self._zone.data.get("output") == 1

--- a/homeassistant/components/geniushub/binary_sensor.py
+++ b/homeassistant/components/geniushub/binary_sensor.py
@@ -77,7 +77,11 @@ class GeniusZoneDemand(GeniusZone, BinarySensorEntity):
         super().__init__(broker, zone)
 
         self._unique_id = f"{broker.hub_uid}_zone_{zone.id}_demand"
-        self._attr_name = f"{zone.name} Demand"
+    @property
+    @override
+    def name(self) -> str:
+        """Return the name of the binary sensor."""
+        return f"{self._zone.name} Demand"
 
     @property
     @override

--- a/tests/components/geniushub/snapshots/test_binary_sensor.ambr
+++ b/tests/components/geniushub/snapshots/test_binary_sensor.ambr
@@ -1,4 +1,546 @@
 # serializer version: 1
+# name: test_cloud_all_sensors[binary_sensor.bedroom-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.bedroom',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Bedroom',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.HEAT: 'heat'>,
+    'original_icon': None,
+    'original_name': 'Bedroom',
+    'platform': 'geniushub',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '01J71MQF0EC62D620DGYNG2R8H_zone_29_demand',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cloud_all_sensors[binary_sensor.bedroom-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'heat',
+      'friendly_name': 'Bedroom',
+      'status': dict({
+        'mode': 'off',
+        'override': dict({
+          'duration': 0,
+          'setpoint': 23.5,
+        }),
+        'temperature': 21.5,
+        'type': 'radiator',
+      }),
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.bedroom',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_cloud_all_sensors[binary_sensor.bedroom_socket-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.bedroom_socket',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Bedroom Socket',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.HEAT: 'heat'>,
+    'original_icon': None,
+    'original_name': 'Bedroom Socket',
+    'platform': 'geniushub',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '01J71MQF0EC62D620DGYNG2R8H_zone_27_demand',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cloud_all_sensors[binary_sensor.bedroom_socket-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'heat',
+      'friendly_name': 'Bedroom Socket',
+      'status': dict({
+        'mode': 'timer',
+        'override': dict({
+          'duration': 0,
+          'setpoint': 'True',
+        }),
+        'type': 'on / off',
+      }),
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.bedroom_socket',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_cloud_all_sensors[binary_sensor.ensuite-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.ensuite',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Ensuite',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.HEAT: 'heat'>,
+    'original_icon': None,
+    'original_name': 'Ensuite',
+    'platform': 'geniushub',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '01J71MQF0EC62D620DGYNG2R8H_zone_5_demand',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cloud_all_sensors[binary_sensor.ensuite-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'heat',
+      'friendly_name': 'Ensuite',
+      'status': dict({
+        'mode': 'off',
+        'occupied': 'False',
+        'override': dict({
+          'duration': 0,
+          'setpoint': 28,
+        }),
+        'temperature': 21,
+        'type': 'radiator',
+      }),
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.ensuite',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_cloud_all_sensors[binary_sensor.guest_room-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.guest_room',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Guest room',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.HEAT: 'heat'>,
+    'original_icon': None,
+    'original_name': 'Guest room',
+    'platform': 'geniushub',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '01J71MQF0EC62D620DGYNG2R8H_zone_7_demand',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cloud_all_sensors[binary_sensor.guest_room-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'heat',
+      'friendly_name': 'Guest room',
+      'status': dict({
+        'mode': 'off',
+        'occupied': 'True',
+        'override': dict({
+          'duration': 0,
+          'setpoint': 20,
+        }),
+        'temperature': 21,
+        'type': 'radiator',
+      }),
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.guest_room',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_cloud_all_sensors[binary_sensor.hall-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.hall',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Hall',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.HEAT: 'heat'>,
+    'original_icon': None,
+    'original_name': 'Hall',
+    'platform': 'geniushub',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '01J71MQF0EC62D620DGYNG2R8H_zone_2_demand',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cloud_all_sensors[binary_sensor.hall-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'heat',
+      'friendly_name': 'Hall',
+      'status': dict({
+        'mode': 'off',
+        'occupied': 'False',
+        'override': dict({
+          'duration': 0,
+          'setpoint': 20,
+        }),
+        'temperature': 21,
+        'type': 'radiator',
+      }),
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.hall',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_cloud_all_sensors[binary_sensor.hot_water-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.hot_water',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Hot Water',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.HEAT: 'heat'>,
+    'original_icon': None,
+    'original_name': 'Hot Water',
+    'platform': 'geniushub',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '01J71MQF0EC62D620DGYNG2R8H_zone_10_demand',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cloud_all_sensors[binary_sensor.hot_water-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'heat',
+      'friendly_name': 'Hot Water',
+      'status': dict({
+        'mode': 'override',
+        'override': dict({
+          'duration': 3600,
+          'setpoint': 80,
+        }),
+        'temperature': 45.5,
+        'type': 'hot water temperature',
+      }),
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.hot_water',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_cloud_all_sensors[binary_sensor.kitchen-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.kitchen',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Kitchen',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.HEAT: 'heat'>,
+    'original_icon': None,
+    'original_name': 'Kitchen',
+    'platform': 'geniushub',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '01J71MQF0EC62D620DGYNG2R8H_zone_3_demand',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cloud_all_sensors[binary_sensor.kitchen-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'heat',
+      'friendly_name': 'Kitchen',
+      'status': dict({
+        'mode': 'off',
+        'occupied': 'False',
+        'override': dict({
+          'duration': 0,
+          'setpoint': 20,
+        }),
+        'temperature': 21.5,
+        'type': 'radiator',
+      }),
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.kitchen',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_cloud_all_sensors[binary_sensor.kitchen_socket-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.kitchen_socket',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Kitchen Socket',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.HEAT: 'heat'>,
+    'original_icon': None,
+    'original_name': 'Kitchen Socket',
+    'platform': 'geniushub',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '01J71MQF0EC62D620DGYNG2R8H_zone_28_demand',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cloud_all_sensors[binary_sensor.kitchen_socket-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'heat',
+      'friendly_name': 'Kitchen Socket',
+      'status': dict({
+        'mode': 'timer',
+        'override': dict({
+          'duration': 0,
+          'setpoint': 'True',
+        }),
+        'type': 'on / off',
+      }),
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.kitchen_socket',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_cloud_all_sensors[binary_sensor.lounge-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.lounge',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Lounge',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.HEAT: 'heat'>,
+    'original_icon': None,
+    'original_name': 'Lounge',
+    'platform': 'geniushub',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '01J71MQF0EC62D620DGYNG2R8H_zone_1_demand',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cloud_all_sensors[binary_sensor.lounge-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'heat',
+      'friendly_name': 'Lounge',
+      'status': dict({
+        'mode': 'off',
+        'override': dict({
+          'duration': 0,
+          'setpoint': 20,
+        }),
+        'temperature': 20,
+        'type': 'radiator',
+      }),
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.lounge',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_cloud_all_sensors[binary_sensor.single_channel_receiver_22-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -50,5 +592,125 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
+  })
+# ---
+# name: test_cloud_all_sensors[binary_sensor.study-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.study',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Study',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.HEAT: 'heat'>,
+    'original_icon': None,
+    'original_name': 'Study',
+    'platform': 'geniushub',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '01J71MQF0EC62D620DGYNG2R8H_zone_30_demand',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cloud_all_sensors[binary_sensor.study-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'heat',
+      'friendly_name': 'Study',
+      'status': dict({
+        'mode': 'off',
+        'occupied': 'False',
+        'override': dict({
+          'duration': 0,
+          'setpoint': 28,
+        }),
+        'temperature': 22,
+        'type': 'radiator',
+      }),
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.study',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_cloud_all_sensors[binary_sensor.study_socket-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.study_socket',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Study Socket',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.HEAT: 'heat'>,
+    'original_icon': None,
+    'original_name': 'Study Socket',
+    'platform': 'geniushub',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '01J71MQF0EC62D620DGYNG2R8H_zone_32_demand',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cloud_all_sensors[binary_sensor.study_socket-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'heat',
+      'friendly_name': 'Study Socket',
+      'status': dict({
+        'mode': 'off',
+        'override': dict({
+          'duration': 0,
+          'setpoint': 'True',
+        }),
+        'type': 'on / off',
+      }),
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.study_socket',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
   })
 # ---

--- a/tests/components/geniushub/snapshots/test_binary_sensor.ambr
+++ b/tests/components/geniushub/snapshots/test_binary_sensor.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_cloud_all_sensors[binary_sensor.bedroom-entry]
+# name: test_cloud_all_sensors[binary_sensor.bedroom_demand-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -13,7 +13,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': None,
-    'entity_id': 'binary_sensor.bedroom',
+    'entity_id': 'binary_sensor.bedroom_demand',
     'has_entity_name': False,
     'hidden_by': None,
     'icon': None,
@@ -21,12 +21,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Bedroom',
+    'object_id_base': 'Bedroom Demand',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.HEAT: 'heat'>,
     'original_icon': None,
-    'original_name': 'Bedroom',
+    'original_name': 'Bedroom Demand',
     'platform': 'geniushub',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -36,11 +36,11 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_cloud_all_sensors[binary_sensor.bedroom-state]
+# name: test_cloud_all_sensors[binary_sensor.bedroom_demand-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'heat',
-      'friendly_name': 'Bedroom',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'heat',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bedroom Demand',
       'status': dict({
         'mode': 'off',
         'override': dict({
@@ -52,14 +52,14 @@
       }),
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.bedroom',
+    'entity_id': 'binary_sensor.bedroom_demand',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
   })
 # ---
-# name: test_cloud_all_sensors[binary_sensor.bedroom_socket-entry]
+# name: test_cloud_all_sensors[binary_sensor.bedroom_socket_demand-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -73,7 +73,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': None,
-    'entity_id': 'binary_sensor.bedroom_socket',
+    'entity_id': 'binary_sensor.bedroom_socket_demand',
     'has_entity_name': False,
     'hidden_by': None,
     'icon': None,
@@ -81,12 +81,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Bedroom Socket',
+    'object_id_base': 'Bedroom Socket Demand',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.HEAT: 'heat'>,
     'original_icon': None,
-    'original_name': 'Bedroom Socket',
+    'original_name': 'Bedroom Socket Demand',
     'platform': 'geniushub',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -96,11 +96,11 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_cloud_all_sensors[binary_sensor.bedroom_socket-state]
+# name: test_cloud_all_sensors[binary_sensor.bedroom_socket_demand-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'heat',
-      'friendly_name': 'Bedroom Socket',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'heat',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bedroom Socket Demand',
       'status': dict({
         'mode': 'timer',
         'override': dict({
@@ -111,14 +111,14 @@
       }),
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.bedroom_socket',
+    'entity_id': 'binary_sensor.bedroom_socket_demand',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
   })
 # ---
-# name: test_cloud_all_sensors[binary_sensor.ensuite-entry]
+# name: test_cloud_all_sensors[binary_sensor.ensuite_demand-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -132,7 +132,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': None,
-    'entity_id': 'binary_sensor.ensuite',
+    'entity_id': 'binary_sensor.ensuite_demand',
     'has_entity_name': False,
     'hidden_by': None,
     'icon': None,
@@ -140,12 +140,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Ensuite',
+    'object_id_base': 'Ensuite Demand',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.HEAT: 'heat'>,
     'original_icon': None,
-    'original_name': 'Ensuite',
+    'original_name': 'Ensuite Demand',
     'platform': 'geniushub',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -155,11 +155,11 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_cloud_all_sensors[binary_sensor.ensuite-state]
+# name: test_cloud_all_sensors[binary_sensor.ensuite_demand-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'heat',
-      'friendly_name': 'Ensuite',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'heat',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Ensuite Demand',
       'status': dict({
         'mode': 'off',
         'occupied': 'False',
@@ -172,14 +172,14 @@
       }),
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.ensuite',
+    'entity_id': 'binary_sensor.ensuite_demand',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
   })
 # ---
-# name: test_cloud_all_sensors[binary_sensor.guest_room-entry]
+# name: test_cloud_all_sensors[binary_sensor.guest_room_demand-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -193,7 +193,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': None,
-    'entity_id': 'binary_sensor.guest_room',
+    'entity_id': 'binary_sensor.guest_room_demand',
     'has_entity_name': False,
     'hidden_by': None,
     'icon': None,
@@ -201,12 +201,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Guest room',
+    'object_id_base': 'Guest room Demand',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.HEAT: 'heat'>,
     'original_icon': None,
-    'original_name': 'Guest room',
+    'original_name': 'Guest room Demand',
     'platform': 'geniushub',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -216,11 +216,11 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_cloud_all_sensors[binary_sensor.guest_room-state]
+# name: test_cloud_all_sensors[binary_sensor.guest_room_demand-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'heat',
-      'friendly_name': 'Guest room',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'heat',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Guest room Demand',
       'status': dict({
         'mode': 'off',
         'occupied': 'True',
@@ -233,14 +233,14 @@
       }),
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.guest_room',
+    'entity_id': 'binary_sensor.guest_room_demand',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
   })
 # ---
-# name: test_cloud_all_sensors[binary_sensor.hall-entry]
+# name: test_cloud_all_sensors[binary_sensor.hall_demand-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -254,7 +254,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': None,
-    'entity_id': 'binary_sensor.hall',
+    'entity_id': 'binary_sensor.hall_demand',
     'has_entity_name': False,
     'hidden_by': None,
     'icon': None,
@@ -262,12 +262,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Hall',
+    'object_id_base': 'Hall Demand',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.HEAT: 'heat'>,
     'original_icon': None,
-    'original_name': 'Hall',
+    'original_name': 'Hall Demand',
     'platform': 'geniushub',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -277,11 +277,11 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_cloud_all_sensors[binary_sensor.hall-state]
+# name: test_cloud_all_sensors[binary_sensor.hall_demand-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'heat',
-      'friendly_name': 'Hall',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'heat',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Hall Demand',
       'status': dict({
         'mode': 'off',
         'occupied': 'False',
@@ -294,14 +294,14 @@
       }),
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.hall',
+    'entity_id': 'binary_sensor.hall_demand',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
   })
 # ---
-# name: test_cloud_all_sensors[binary_sensor.hot_water-entry]
+# name: test_cloud_all_sensors[binary_sensor.hot_water_demand-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -315,7 +315,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': None,
-    'entity_id': 'binary_sensor.hot_water',
+    'entity_id': 'binary_sensor.hot_water_demand',
     'has_entity_name': False,
     'hidden_by': None,
     'icon': None,
@@ -323,12 +323,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Hot Water',
+    'object_id_base': 'Hot Water Demand',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.HEAT: 'heat'>,
     'original_icon': None,
-    'original_name': 'Hot Water',
+    'original_name': 'Hot Water Demand',
     'platform': 'geniushub',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -338,11 +338,11 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_cloud_all_sensors[binary_sensor.hot_water-state]
+# name: test_cloud_all_sensors[binary_sensor.hot_water_demand-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'heat',
-      'friendly_name': 'Hot Water',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'heat',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Hot Water Demand',
       'status': dict({
         'mode': 'override',
         'override': dict({
@@ -354,14 +354,14 @@
       }),
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.hot_water',
+    'entity_id': 'binary_sensor.hot_water_demand',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
   })
 # ---
-# name: test_cloud_all_sensors[binary_sensor.kitchen-entry]
+# name: test_cloud_all_sensors[binary_sensor.kitchen_demand-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -375,7 +375,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': None,
-    'entity_id': 'binary_sensor.kitchen',
+    'entity_id': 'binary_sensor.kitchen_demand',
     'has_entity_name': False,
     'hidden_by': None,
     'icon': None,
@@ -383,12 +383,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Kitchen',
+    'object_id_base': 'Kitchen Demand',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.HEAT: 'heat'>,
     'original_icon': None,
-    'original_name': 'Kitchen',
+    'original_name': 'Kitchen Demand',
     'platform': 'geniushub',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -398,11 +398,11 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_cloud_all_sensors[binary_sensor.kitchen-state]
+# name: test_cloud_all_sensors[binary_sensor.kitchen_demand-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'heat',
-      'friendly_name': 'Kitchen',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'heat',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Kitchen Demand',
       'status': dict({
         'mode': 'off',
         'occupied': 'False',
@@ -415,14 +415,14 @@
       }),
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.kitchen',
+    'entity_id': 'binary_sensor.kitchen_demand',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
   })
 # ---
-# name: test_cloud_all_sensors[binary_sensor.kitchen_socket-entry]
+# name: test_cloud_all_sensors[binary_sensor.kitchen_socket_demand-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -436,7 +436,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': None,
-    'entity_id': 'binary_sensor.kitchen_socket',
+    'entity_id': 'binary_sensor.kitchen_socket_demand',
     'has_entity_name': False,
     'hidden_by': None,
     'icon': None,
@@ -444,12 +444,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Kitchen Socket',
+    'object_id_base': 'Kitchen Socket Demand',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.HEAT: 'heat'>,
     'original_icon': None,
-    'original_name': 'Kitchen Socket',
+    'original_name': 'Kitchen Socket Demand',
     'platform': 'geniushub',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -459,11 +459,11 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_cloud_all_sensors[binary_sensor.kitchen_socket-state]
+# name: test_cloud_all_sensors[binary_sensor.kitchen_socket_demand-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'heat',
-      'friendly_name': 'Kitchen Socket',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'heat',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Kitchen Socket Demand',
       'status': dict({
         'mode': 'timer',
         'override': dict({
@@ -474,14 +474,14 @@
       }),
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.kitchen_socket',
+    'entity_id': 'binary_sensor.kitchen_socket_demand',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
   })
 # ---
-# name: test_cloud_all_sensors[binary_sensor.lounge-entry]
+# name: test_cloud_all_sensors[binary_sensor.lounge_demand-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -495,7 +495,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': None,
-    'entity_id': 'binary_sensor.lounge',
+    'entity_id': 'binary_sensor.lounge_demand',
     'has_entity_name': False,
     'hidden_by': None,
     'icon': None,
@@ -503,12 +503,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Lounge',
+    'object_id_base': 'Lounge Demand',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.HEAT: 'heat'>,
     'original_icon': None,
-    'original_name': 'Lounge',
+    'original_name': 'Lounge Demand',
     'platform': 'geniushub',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -518,11 +518,11 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_cloud_all_sensors[binary_sensor.lounge-state]
+# name: test_cloud_all_sensors[binary_sensor.lounge_demand-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'heat',
-      'friendly_name': 'Lounge',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'heat',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Lounge Demand',
       'status': dict({
         'mode': 'off',
         'override': dict({
@@ -534,7 +534,7 @@
       }),
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.lounge',
+    'entity_id': 'binary_sensor.lounge_demand',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -594,7 +594,7 @@
     'state': 'on',
   })
 # ---
-# name: test_cloud_all_sensors[binary_sensor.study-entry]
+# name: test_cloud_all_sensors[binary_sensor.study_demand-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -608,7 +608,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': None,
-    'entity_id': 'binary_sensor.study',
+    'entity_id': 'binary_sensor.study_demand',
     'has_entity_name': False,
     'hidden_by': None,
     'icon': None,
@@ -616,12 +616,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Study',
+    'object_id_base': 'Study Demand',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.HEAT: 'heat'>,
     'original_icon': None,
-    'original_name': 'Study',
+    'original_name': 'Study Demand',
     'platform': 'geniushub',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -631,11 +631,11 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_cloud_all_sensors[binary_sensor.study-state]
+# name: test_cloud_all_sensors[binary_sensor.study_demand-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'heat',
-      'friendly_name': 'Study',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'heat',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Study Demand',
       'status': dict({
         'mode': 'off',
         'occupied': 'False',
@@ -648,14 +648,14 @@
       }),
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.study',
+    'entity_id': 'binary_sensor.study_demand',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
   })
 # ---
-# name: test_cloud_all_sensors[binary_sensor.study_socket-entry]
+# name: test_cloud_all_sensors[binary_sensor.study_socket_demand-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -669,7 +669,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': None,
-    'entity_id': 'binary_sensor.study_socket',
+    'entity_id': 'binary_sensor.study_socket_demand',
     'has_entity_name': False,
     'hidden_by': None,
     'icon': None,
@@ -677,12 +677,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Study Socket',
+    'object_id_base': 'Study Socket Demand',
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.HEAT: 'heat'>,
     'original_icon': None,
-    'original_name': 'Study Socket',
+    'original_name': 'Study Socket Demand',
     'platform': 'geniushub',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -692,11 +692,11 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_cloud_all_sensors[binary_sensor.study_socket-state]
+# name: test_cloud_all_sensors[binary_sensor.study_socket_demand-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'heat',
-      'friendly_name': 'Study Socket',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'heat',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Study Socket Demand',
       'status': dict({
         'mode': 'off',
         'override': dict({
@@ -707,7 +707,7 @@
       }),
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.study_socket',
+    'entity_id': 'binary_sensor.study_socket_demand',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,


### PR DESCRIPTION
Repo:   home-assistant/core
Branch: geniushub-zone-demand-binary-sensors
URL:    https://github.com/wibbit/core/pull/new/geniushub-zone-demand-binary-sensors

## Proposed change

Add `GeniusZoneDemand`, a new `binary_sensor` entity with `device_class: heat`, for every
GeniusHub zone type that carries an `output` field: radiator, wet underfloor, on/off, and
hot water temperature.

- `on` — zone is actively calling for heat from the boiler (`output=1`)
- `off` — zone is satisfied, not demanding heat (`output=0`)

Hot water zones are represented as `water_heater` entities, which have no `hvac_action`
equivalent. Without this sensor there is no way to know programmatically when the hot water
cylinder is demanding heat — which is important for boiler control automations (e.g. switching
to a higher flow temperature for domestic hot water).

The sensor covers all zone types uniformly, including radiator and underfloor zones where it
complements the `hvac_action` on the corresponding climate entity.

Also adds a hot water temperature zone to the test fixture and a new `test_water_heater.py`
snapshot test for the water heater platform, which was previously untested.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/???
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
