### PR TITLE
Avoid cutting command off during thinking pause

### DIFF
--- a/homeassistant/components/assist_pipeline/pipeline.py
+++ b/homeassistant/components/assist_pipeline/pipeline.py
@@ -522,6 +522,9 @@ class AudioSettings:
     silence_seconds: float = 0.7
     """Seconds of silence after voice command has ended."""
 
+    in_command_silence_threshold: float = 0.2
+    """Probability below which in-command audio counts toward ending the command."""
+
     def __post_init__(self) -> None:
         """Verify settings post-initialization."""
         if (self.noise_suppression_level < 0) or (self.noise_suppression_level > 4):
@@ -953,7 +956,10 @@ class PipelineRun:
                 and self.stt_provider.audio_processing.requires_external_vad
             ):
                 stt_vad = VoiceCommandSegmenter(
-                    silence_seconds=self.audio_settings.silence_seconds
+                    silence_seconds=self.audio_settings.silence_seconds,
+                    in_command_silence_threshold=(
+                        self.audio_settings.in_command_silence_threshold
+                    ),
                 )
 
             result = await self.stt_provider.async_process_audio_stream(

--- a/homeassistant/components/assist_pipeline/vad.py
+++ b/homeassistant/components/assist_pipeline/vad.py
@@ -29,6 +29,23 @@ class VadSensitivity(StrEnum):
 
         return 0.7
 
+    @staticmethod
+    def to_in_command_silence_threshold(sensitivity: VadSensitivity | str) -> float:
+        """Return in-command silence probability threshold for sensitivity level.
+
+        Lower values keep the command open through thinking pauses (more pause
+        tolerance, more hang-on in noise); a value equal to the in-command speech
+        threshold disables the dead band entirely.
+        """
+        sensitivity = VadSensitivity(sensitivity)
+        if sensitivity == VadSensitivity.RELAXED:
+            return 0.1
+
+        if sensitivity == VadSensitivity.AGGRESSIVE:
+            return 0.5
+
+        return 0.2
+
 
 class AudioBuffer:
     """Fixed-sized audio buffer with variable internal length."""
@@ -100,6 +117,9 @@ class VoiceCommandSegmenter:
     in_command_speech_threshold: float = 0.5
     """Probability threshold for speech during voice command."""
 
+    in_command_silence_threshold: float = 0.2
+    """Probability below which an in-command chunk counts toward ending the command."""
+
     _speech_seconds_left: float = 0.0
     """Seconds left before considering voice command as started."""
 
@@ -148,6 +168,9 @@ class VoiceCommandSegmenter:
 
         if speech_probability is None:
             speech_probability = 0.0
+        else:
+            # MicroVad returns -1.0 as a "no result yet" sentinel; clamp to [0, 1]
+            speech_probability = min(1.0, max(0.0, speech_probability))
 
         if not self.in_command:
             # Before command
@@ -171,12 +194,18 @@ class VoiceCommandSegmenter:
                     self._reset_seconds_left = self.reset_seconds
         else:
             # In command
-            is_speech = speech_probability > self.in_command_speech_threshold
-            if not is_speech:
+            self._command_seconds_left -= chunk_seconds
+            if speech_probability > self.in_command_speech_threshold:
+                # Speech in command.
+                # Reset silence counter if enough speech.
+                self._reset_seconds_left -= chunk_seconds
+                if self._reset_seconds_left <= 0:
+                    self._silence_seconds_left = self.silence_seconds
+                    self._reset_seconds_left = self.reset_seconds
+            elif speech_probability < self.in_command_silence_threshold:
                 # Silence in command
                 self._reset_seconds_left = self.reset_seconds
                 self._silence_seconds_left -= chunk_seconds
-                self._command_seconds_left -= chunk_seconds
                 if (self._silence_seconds_left <= 0) and (
                     self._command_seconds_left <= 0
                 ):
@@ -184,14 +213,7 @@ class VoiceCommandSegmenter:
                     self.reset()
                     _LOGGER.debug("Voice command finished")
                     return False
-            else:
-                # Speech in command.
-                # Reset silence counter if enough speech.
-                self._reset_seconds_left -= chunk_seconds
-                self._command_seconds_left -= chunk_seconds
-                if self._reset_seconds_left <= 0:
-                    self._silence_seconds_left = self.silence_seconds
-                    self._reset_seconds_left = self.reset_seconds
+            # else: dead-band activity holds the command open without refreshing
 
         return True
 

--- a/homeassistant/components/assist_pipeline/vad.py
+++ b/homeassistant/components/assist_pipeline/vad.py
@@ -120,8 +120,17 @@ class VoiceCommandSegmenter:
     in_command_silence_threshold: float = 0.2
     """Probability below which an in-command chunk counts toward ending the command."""
 
+    min_command_speech_seconds: float = 0.05
+    """Confident speech required before a command may finish on silence."""
+
+    false_start_timeout_seconds: float = 5.0
+    """Seconds to wait for confident speech before giving up (a false activation)."""
+
     _speech_seconds_left: float = 0.0
     """Seconds left before considering voice command as started."""
+
+    _command_speech_seconds_left: float = 0.0
+    """Confident speech still required before the command may finish."""
 
     _command_seconds_left: float = 0.0
     """Seconds left before voice command could stop."""
@@ -143,6 +152,7 @@ class VoiceCommandSegmenter:
         """Reset all counters and state."""
         self._speech_seconds_left = self.speech_seconds
         self._command_seconds_left = self.command_seconds - self.speech_seconds
+        self._command_speech_seconds_left = self.min_command_speech_seconds
         self._silence_seconds_left = self.silence_seconds
         self._timeout_seconds_left = self.timeout_seconds
         self._reset_seconds_left = self.reset_seconds
@@ -157,10 +167,15 @@ class VoiceCommandSegmenter:
             self.timed_out = False
 
         self._timeout_seconds_left -= chunk_seconds
-        if self._timeout_seconds_left <= 0:
+        no_speech_yet = self._command_speech_seconds_left > 0
+        elapsed = self.timeout_seconds - self._timeout_seconds_left
+        if (self._timeout_seconds_left <= 0) or (
+            no_speech_yet and (elapsed >= self.false_start_timeout_seconds)
+        ):
             _LOGGER.debug(
-                "VAD end of speech detection timed out after %s seconds",
-                self.timeout_seconds,
+                "VAD timed out after %.2f seconds (no_speech_yet=%s)",
+                elapsed,
+                no_speech_yet,
             )
             self.reset()
             self.timed_out = True
@@ -178,6 +193,9 @@ class VoiceCommandSegmenter:
             if is_speech:
                 self._reset_seconds_left = self.reset_seconds
                 self._speech_seconds_left -= chunk_seconds
+                if speech_probability > self.in_command_speech_threshold:
+                    # Confident speech during onset also counts toward confirmation
+                    self._command_speech_seconds_left -= chunk_seconds
                 if self._speech_seconds_left <= 0:
                     # Inside voice command
                     self.in_command = True
@@ -191,12 +209,14 @@ class VoiceCommandSegmenter:
                 self._reset_seconds_left -= chunk_seconds
                 if self._reset_seconds_left <= 0:
                     self._speech_seconds_left = self.speech_seconds
+                    self._command_speech_seconds_left = self.min_command_speech_seconds
                     self._reset_seconds_left = self.reset_seconds
         else:
             # In command
             self._command_seconds_left -= chunk_seconds
             if speech_probability > self.in_command_speech_threshold:
                 # Speech in command.
+                self._command_speech_seconds_left -= chunk_seconds
                 # Reset silence counter if enough speech.
                 self._reset_seconds_left -= chunk_seconds
                 if self._reset_seconds_left <= 0:
@@ -209,10 +229,16 @@ class VoiceCommandSegmenter:
                 if (self._silence_seconds_left <= 0) and (
                     self._command_seconds_left <= 0
                 ):
-                    # Command finished successfully
+                    if self._command_speech_seconds_left <= 0:
+                        # Command finished successfully
+                        self.reset()
+                        _LOGGER.debug("Voice command finished")
+                        return False
+                    # Triggered without real speech: false start, resume listening
+                    _LOGGER.debug("Discarding false start (no speech detected)")
+                    timeout_seconds_left = self._timeout_seconds_left
                     self.reset()
-                    _LOGGER.debug("Voice command finished")
-                    return False
+                    self._timeout_seconds_left = timeout_seconds_left
             # else: dead-band activity holds the command open without refreshing
 
         return True

--- a/homeassistant/components/assist_satellite/entity.py
+++ b/homeassistant/components/assist_satellite/entity.py
@@ -506,6 +506,7 @@ class AssistSatelliteEntity(entity.Entity):
             # Store the conversation ID. If it is no longer valid,
             # get_chat_session will reset it
             self._conversation_id = session.conversation_id
+            vad_sensitivity = self._resolve_vad_sensitivity()
             self._pipeline_task = (
                 self.platform.config_entry.async_create_background_task(
                     self.hass,
@@ -529,7 +530,14 @@ class AssistSatelliteEntity(entity.Entity):
                         tts_audio_output=self.tts_options,
                         wake_word_phrase=wake_word_phrase,
                         audio_settings=AudioSettings(
-                            silence_seconds=self._resolve_vad_sensitivity()
+                            silence_seconds=vad.VadSensitivity.to_seconds(
+                                vad_sensitivity
+                            ),
+                            in_command_silence_threshold=(
+                                vad.VadSensitivity.to_in_command_silence_threshold(
+                                    vad_sensitivity
+                                )
+                            ),
                         ),
                         start_stage=start_stage,
                         end_stage=end_stage,
@@ -627,7 +635,7 @@ class AssistSatelliteEntity(entity.Entity):
         return None
 
     @callback
-    def _resolve_vad_sensitivity(self) -> float:
+    def _resolve_vad_sensitivity(self) -> vad.VadSensitivity:
         """Resolve VAD sensitivity from select entity to enum."""
         vad_sensitivity = vad.VadSensitivity.DEFAULT
 
@@ -639,7 +647,7 @@ class AssistSatelliteEntity(entity.Entity):
 
             vad_sensitivity = vad.VadSensitivity(vad_sensitivity_state.state)
 
-        return vad.VadSensitivity.to_seconds(vad_sensitivity)
+        return vad_sensitivity
 
     async def _resolve_announcement_media_id(
         self,

--- a/tests/components/assist_pipeline/test_vad.py
+++ b/tests/components/assist_pipeline/test_vad.py
@@ -2,8 +2,11 @@
 
 import itertools as it
 
+import pytest
+
 from homeassistant.components.assist_pipeline.vad import (
     AudioBuffer,
+    VadSensitivity,
     VoiceCommandSegmenter,
     chunk_samples,
 )
@@ -234,6 +237,7 @@ def test_speech_thresholds() -> None:
     segmenter = VoiceCommandSegmenter(
         before_command_speech_threshold=0.2,
         in_command_speech_threshold=0.5,
+        in_command_silence_threshold=0.2,
         command_seconds=2,
         speech_seconds=1,
         silence_seconds=1,
@@ -247,6 +251,79 @@ def test_speech_thresholds() -> None:
     assert segmenter.process(_ONE_SECOND, 0.3)
     assert segmenter.in_command
 
-    # Now that same probability is considered silence.
-    # Finishes command.
+    # Dead-band probability is neither speech nor silence: command stays open
+    assert segmenter.process(_ONE_SECOND, 0.3)
+    assert segmenter.in_command
+
+    # Clear silence finishes the command
+    assert not segmenter.process(_ONE_SECOND, 0.05)
+
+
+def test_dead_band_preserves_pause() -> None:
+    """Test dead-band activity during a pause does not end the command early."""
+
+    segmenter = VoiceCommandSegmenter(
+        in_command_speech_threshold=0.5,
+        in_command_silence_threshold=0.2,
+        speech_seconds=0.5,
+        command_seconds=1.0,
+        silence_seconds=1.0,
+        reset_seconds=0.5,
+    )
+
+    # Start the command
+    assert segmenter.process(_ONE_SECOND * 0.5, 1.0)
+    assert segmenter.in_command
+
+    # 1.5s of dead-band activity (> silence_seconds) keeps the command open.
+    # The original single-threshold logic would have ended it during this pause.
+    for _ in range(3):
+        assert segmenter.process(_ONE_SECOND * 0.5, 0.3)
+        assert segmenter.in_command
+
+    # Speech resumes, then genuine silence ends the command
+    assert segmenter.process(_ONE_SECOND * 0.5, 1.0)
+    assert segmenter.process(_ONE_SECOND * 0.5, 0.0)
+    assert not segmenter.process(_ONE_SECOND * 0.5, 0.0)
+    assert not segmenter.in_command
+
+
+def test_dead_band_times_out() -> None:
+    """Test sustained dead-band audio ends via timeout, never a premature finish."""
+
+    segmenter = VoiceCommandSegmenter(
+        in_command_speech_threshold=0.5,
+        in_command_silence_threshold=0.2,
+        speech_seconds=0.5,
+        timeout_seconds=2.0,
+    )
+
+    # Start the command
+    assert segmenter.process(_ONE_SECOND * 0.5, 1.0)
+    assert segmenter.in_command
+
+    # Dead-band audio holds the command open (never finishes) until the timeout
+    assert segmenter.process(_ONE_SECOND, 0.3)
+    assert not segmenter.timed_out
+
     assert not segmenter.process(_ONE_SECOND, 0.3)
+    assert segmenter.timed_out
+
+
+@pytest.mark.parametrize(
+    ("sensitivity", "expected_threshold"),
+    [
+        pytest.param(VadSensitivity.AGGRESSIVE, 0.5, id="aggressive"),
+        pytest.param(VadSensitivity.DEFAULT, 0.2, id="default"),
+        pytest.param(VadSensitivity.RELAXED, 0.1, id="relaxed"),
+    ],
+)
+def test_vad_sensitivity_in_command_silence_threshold(
+    sensitivity: VadSensitivity, expected_threshold: float
+) -> None:
+    """Test sensitivity maps to an in-command silence threshold."""
+
+    assert (
+        VadSensitivity.to_in_command_silence_threshold(sensitivity)
+        == expected_threshold
+    )

--- a/tests/components/assist_pipeline/test_vad.py
+++ b/tests/components/assist_pipeline/test_vad.py
@@ -241,6 +241,7 @@ def test_speech_thresholds() -> None:
         command_seconds=2,
         speech_seconds=1,
         silence_seconds=1,
+        min_command_speech_seconds=0.0,
     )
 
     # Not high enough probability to trigger command
@@ -308,6 +309,98 @@ def test_dead_band_times_out() -> None:
 
     assert not segmenter.process(_ONE_SECOND, 0.3)
     assert segmenter.timed_out
+
+
+def test_false_start_aborts_and_resumes() -> None:
+    """Test a trigger without confident speech aborts instead of finishing."""
+
+    segmenter = VoiceCommandSegmenter(
+        before_command_speech_threshold=0.2,
+        in_command_speech_threshold=0.5,
+        in_command_silence_threshold=0.2,
+        min_command_speech_seconds=0.1,
+        speech_seconds=0.3,
+        command_seconds=1.0,
+        silence_seconds=0.5,
+    )
+
+    # A sub-0.5 transient (above entry, below speech) triggers a command...
+    assert segmenter.process(_ONE_SECOND * 0.3, 0.35)
+    assert segmenter.in_command
+
+    # ...but with no confident speech, the silence end aborts back to listening
+    # instead of finishing into near-empty audio.
+    assert segmenter.process(_ONE_SECOND, 0.0)
+    assert not segmenter.in_command
+
+    # The real command then arrives and finishes normally
+    assert segmenter.process(_ONE_SECOND, 1.0)
+    assert segmenter.in_command
+    assert not segmenter.process(_ONE_SECOND, 0.0)
+    assert not segmenter.in_command
+
+
+def test_false_start_timeout() -> None:
+    """Test a false activation gives up at false_start_timeout, not timeout_seconds."""
+
+    segmenter = VoiceCommandSegmenter(
+        before_command_speech_threshold=0.2,
+        in_command_speech_threshold=0.5,
+        in_command_silence_threshold=0.2,
+        min_command_speech_seconds=0.05,
+        false_start_timeout_seconds=3.0,
+        timeout_seconds=15.0,
+    )
+
+    # A trigger with no confident speech, followed by silence: gives up at 3s,
+    # well before the 15s command timeout.
+    assert segmenter.process(_ONE_SECOND, 0.35)
+    assert segmenter.process(_ONE_SECOND, 0.0)
+    assert not segmenter.timed_out
+
+    # Crosses false_start_timeout (3s elapsed) without confident speech
+    assert not segmenter.process(_ONE_SECOND, 0.0)
+    assert segmenter.timed_out
+
+
+def test_false_start_timeout_not_applied_after_speech() -> None:
+    """Test confident speech lifts the false-start timeout to the full command timeout."""
+
+    segmenter = VoiceCommandSegmenter(
+        in_command_speech_threshold=0.5,
+        min_command_speech_seconds=0.05,
+        false_start_timeout_seconds=3.0,
+        timeout_seconds=15.0,
+        speech_seconds=0.3,
+    )
+
+    # Confident speech early confirms the command...
+    assert segmenter.process(_ONE_SECOND * 0.5, 1.0)
+    assert segmenter.in_command
+
+    # ...so a long pause past false_start_timeout does NOT give up early
+    assert segmenter.process(_ONE_SECOND * 4, 0.3)
+    assert not segmenter.timed_out
+    assert segmenter.in_command
+
+
+def test_min_command_speech_disabled() -> None:
+    """Test min_command_speech_seconds=0 keeps the original finish behavior."""
+
+    segmenter = VoiceCommandSegmenter(
+        in_command_speech_threshold=0.5,
+        in_command_silence_threshold=0.2,
+        min_command_speech_seconds=0.0,
+        speech_seconds=0.3,
+        command_seconds=1.0,
+        silence_seconds=0.5,
+    )
+
+    # Trigger on a sub-0.5 transient and finish on silence (no abort)
+    assert segmenter.process(_ONE_SECOND * 0.3, 0.35)
+    assert segmenter.in_command
+    assert not segmenter.process(_ONE_SECOND, 0.0)
+    assert not segmenter.in_command
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adjust voice command segmenter to fix some common issues:

1. Hold the command open through natural pauses ("dead band") - new "in command silence" threshold
2. Reject false starts - require a minimum amount of "confident speech" for a command to start (avoid coughs, etc.)
3. Bound false activations  - requires "confident speech" within 5 seconds or else the command times out early

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
