### PR TITLE
Rewrite homeassistant started trigger

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -38,7 +38,7 @@ from homeassistant.core import (
     CALLBACK_TYPE,
     Context,
     CoreState,
-    Event,
+    HassJob,
     HomeAssistant,
     ServiceCall,
     callback,
@@ -830,13 +830,13 @@ class AutomationEntity(BaseAutomationEntity, RestoreEntity):
         if self._condition is not None:
             self._condition.async_unload()
 
-    async def _async_enable_automation(self, event: Event) -> None:
-        """Start automation on startup."""
+    async def _async_enable_automation(self) -> None:
+        """Arm the automation's triggers on startup."""
         # Don't do anything if no longer enabled or already attached
         if not self._is_enabled or self._async_detach_triggers is not None:
             return
 
-        self._async_detach_triggers = await self._async_attach_triggers(True)
+        self._async_detach_triggers = await self._async_attach_triggers()
         self.async_write_ha_state()
 
     async def _async_enable(self) -> None:
@@ -851,13 +851,14 @@ class AutomationEntity(BaseAutomationEntity, RestoreEntity):
         self._is_enabled = True
         # HomeAssistant is starting up
         if self.hass.state is not CoreState.not_running:
-            self._async_detach_triggers = await self._async_attach_triggers(False)
+            self._async_detach_triggers = await self._async_attach_triggers()
             return
 
-        self.hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_STARTED,
-            self._async_enable_automation,
-        )
+        # Arm the triggers in a startup job, which runs after all listeners to
+        # EVENT_HOMEASSISTANT_START have ran but before EVENT_HOMEASSISTANT_STARTED
+        # has fired. This ensures automations do not fire during startup, but
+        # triggers listening for the started event are armed in time to catch it.
+        self.hass.async_add_startup_job(HassJob(self._async_enable_automation))
 
     async def _async_disable(self, stop_actions: bool = DEFAULT_STOP_ACTIONS) -> None:
         """Disable the automation entity.
@@ -942,9 +943,7 @@ class AutomationEntity(BaseAutomationEntity, RestoreEntity):
 
             script_execution_set("not_triggered")
 
-    async def _async_attach_triggers(
-        self, home_assistant_start: bool
-    ) -> Callable[[], None] | None:
+    async def _async_attach_triggers(self) -> Callable[[], None] | None:
         """Set up the triggers."""
         this = None
         if state := self.hass.states.get(self.entity_id):
@@ -968,8 +967,7 @@ class AutomationEntity(BaseAutomationEntity, RestoreEntity):
             DOMAIN,
             str(self.name),
             self._log_callback,
-            home_assistant_start,
-            variables,
+            variables=variables,
             did_not_trigger=self._handle_not_triggered,
         )
 

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -855,7 +855,7 @@ class AutomationEntity(BaseAutomationEntity, RestoreEntity):
             return
 
         # Arm the triggers in a startup job, which runs after all listeners to
-        # EVENT_HOMEASSISTANT_START have ran but before EVENT_HOMEASSISTANT_STARTED
+        # EVENT_HOMEASSISTANT_START have run but before EVENT_HOMEASSISTANT_STARTED
         # has fired. This ensures automations do not fire during startup, but
         # triggers listening for the started event are armed in time to catch it.
         self.hass.async_add_startup_job(HassJob(self._async_enable_automation))

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -27,7 +27,6 @@ from homeassistant.const import (  # noqa: F401
     CONF_PATH,
     CONF_TRIGGERS,
     CONF_VARIABLES,
-    EVENT_HOMEASSISTANT_STARTED,
     SERVICE_RELOAD,
     SERVICE_TOGGLE,
     SERVICE_TURN_OFF,

--- a/homeassistant/components/homeassistant/triggers/homeassistant.py
+++ b/homeassistant/components/homeassistant/triggers/homeassistant.py
@@ -2,8 +2,8 @@
 
 import voluptuous as vol
 
-from homeassistant.const import CONF_EVENT, CONF_PLATFORM
-from homeassistant.core import CALLBACK_TYPE, HassJob, HomeAssistant
+from homeassistant.const import CONF_EVENT, CONF_PLATFORM, EVENT_HOMEASSISTANT_STARTED
+from homeassistant.core import CALLBACK_TYPE, Event, HassJob, HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
 from homeassistant.helpers.typing import ConfigType
@@ -45,9 +45,8 @@ async def async_attach_trigger(
             },
         )
 
-    # Automation are enabled while hass is starting up, fire right away
-    # Check state because a config reload shouldn't trigger it.
-    if trigger_info["home_assistant_start"]:
+    @callback
+    def hass_started(_: Event) -> None:
         hass.async_run_hass_job(
             job,
             {
@@ -60,4 +59,6 @@ async def async_attach_trigger(
             },
         )
 
-    return lambda: None
+    # Only fires if armed before EVENT_HOMEASSISTANT_STARTED; if hass is already
+    # started, the trigger doesn't fire.
+    return hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, hass_started)

--- a/homeassistant/components/homeassistant/triggers/homeassistant.py
+++ b/homeassistant/components/homeassistant/triggers/homeassistant.py
@@ -45,8 +45,12 @@ async def async_attach_trigger(
             },
         )
 
+    unsub: CALLBACK_TYPE | None = None
+
     @callback
     def hass_started(_: Event) -> None:
+        nonlocal unsub
+        unsub = None
         hass.async_run_hass_job(
             job,
             {
@@ -61,4 +65,11 @@ async def async_attach_trigger(
 
     # Only fires if armed before EVENT_HOMEASSISTANT_STARTED; if hass is already
     # started, the trigger doesn't fire.
-    return hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, hass_started)
+    unsub = hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, hass_started)
+
+    @callback
+    def remove() -> None:
+        if unsub is not None:
+            unsub()
+
+    return remove

--- a/homeassistant/components/template/coordinator.py
+++ b/homeassistant/components/template/coordinator.py
@@ -126,7 +126,6 @@ class TriggerUpdateCoordinator(DataUpdateCoordinator):
             DOMAIN,
             self.name,
             self.logger.log,
-            start_event is not None,
         )
 
     async def _handle_triggered_with_script(

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -156,6 +156,8 @@ class EventStateReportedData(EventStateEventData):
 
 # How long to wait until things that run on startup have to finish.
 TIMEOUT_EVENT_START = 15
+# How long to wait until startup jobs have to finish.
+TIMEOUT_STARTUP_JOBS = 15
 
 
 EVENTS_EXCLUDED_FROM_MATCH_ALL = {
@@ -416,6 +418,7 @@ class HomeAssistant:
         self.timeout: TimeoutManager = TimeoutManager()
         self._stop_future: concurrent.futures.Future[None] | None = None
         self._shutdown_jobs: list[HassJobWithArgs] = []
+        self._startup_jobs: list[HassJobWithArgs] = []
         self.import_executor = InterruptibleThreadPoolExecutor(
             max_workers=1, thread_name_prefix="ImportExecutor"
         )
@@ -503,6 +506,20 @@ class HomeAssistant:
         """
         _LOGGER.info("Starting Home Assistant %s", __version__)
 
+        def _log_startup_blocked(tasks: set[asyncio.Future[Any]]) -> None:
+            """Log when startup is blocked by tasks."""
+            _LOGGER.warning(
+                (
+                    "Something is blocking Home Assistant from wrapping up the start up"
+                    " phase. We're going to continue anyway. Please report the"
+                    " following info at"
+                    " https://github.com/home-assistant/core/issues: %s"
+                    " The system is waiting for tasks: %s"
+                ),
+                ", ".join(self.config.components),
+                tasks,
+            )
+
         self.set_state(CoreState.starting)
         self.bus.async_fire_internal(EVENT_CORE_CONFIG_UPDATE)
         self.bus.async_fire_internal(EVENT_HOMEASSISTANT_START)
@@ -515,17 +532,23 @@ class HomeAssistant:
             )
 
         if pending:
-            _LOGGER.warning(
-                (
-                    "Something is blocking Home Assistant from wrapping up the start up"
-                    " phase. We're going to continue anyway. Please report the"
-                    " following info at"
-                    " https://github.com/home-assistant/core/issues: %s"
-                    " The system is waiting for tasks: %s"
-                ),
-                ", ".join(self.config.components),
-                self._tasks,
-            )
+            _log_startup_blocked(self._tasks)
+
+        # Run startup jobs
+        tasks: list[asyncio.Future[Any]] = []
+        for job in self._startup_jobs:
+            task_or_none = self.async_run_hass_job(job.job, *job.args)
+            if not task_or_none:
+                continue
+            tasks.append(task_or_none)
+        self._startup_jobs.clear()
+        if not tasks:
+            pending = None
+        else:
+            _done, pending = await asyncio.wait(tasks, timeout=TIMEOUT_STARTUP_JOBS)
+
+        if pending:
+            _log_startup_blocked(pending)
 
         if self.state is not CoreState.starting:
             _LOGGER.warning(
@@ -1032,6 +1055,9 @@ class HomeAssistant:
     ) -> CALLBACK_TYPE:
         """Add a HassJob which will be executed on shutdown.
 
+        The job will be called (and awaited if it returns a coroutine) before firing
+        of event EVENT_HOMEASSISTANT_STOP when Home Assistant is shutting down.
+
         This method must be run in the event loop.
 
         hassjob: HassJob
@@ -1045,6 +1071,44 @@ class HomeAssistant:
         @callback
         def remove_job() -> None:
             self._shutdown_jobs.remove(job_with_args)
+
+        return remove_job
+
+    @overload
+    @callback
+    def async_add_startup_job(
+        self, hassjob: HassJob[..., Coroutine[Any, Any, Any]], *args: Any
+    ) -> CALLBACK_TYPE: ...
+
+    @overload
+    @callback
+    def async_add_startup_job(
+        self, hassjob: HassJob[..., Coroutine[Any, Any, Any] | Any], *args: Any
+    ) -> CALLBACK_TYPE: ...
+
+    @callback
+    def async_add_startup_job(
+        self, hassjob: HassJob[..., Coroutine[Any, Any, Any] | Any], *args: Any
+    ) -> CALLBACK_TYPE:
+        """Add a HassJob which will be executed on startup.
+
+        The job will be called (and awaited if it returns a coroutine) before firing
+        of event EVENT_HOMEASSISTANT_STARTED when Home Assistant is starting.
+
+        This method must be run in the event loop.
+
+        hassjob: HassJob
+        args: parameters for method to call.
+
+        Returns function to remove the job.
+        """
+        job_with_args = HassJobWithArgs(hassjob, args)
+        self._startup_jobs.append(job_with_args)
+
+        @callback
+        def remove_job() -> None:
+            if job_with_args in self._startup_jobs:
+                self._startup_jobs.remove(job_with_args)
 
         return remove_job
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -538,7 +538,7 @@ class HomeAssistant:
         tasks: list[asyncio.Future[Any]] = []
         for job in self._startup_jobs:
             task_or_none = self.async_run_hass_job(job.job, *job.args)
-            if not task_or_none:
+            if task_or_none is None:
                 continue
             tasks.append(task_or_none)
         self._startup_jobs.clear()

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -79,6 +79,7 @@ from .automation import (
     move_options_fields_to_top_level,
 )
 from .event import async_call_later
+from .frame import report_usage
 from .integration_platform import async_process_integration_platforms
 from .selector import (
     NumericThresholdMode,
@@ -1350,7 +1351,6 @@ class TriggerInfo(TypedDict):
 
     domain: str
     name: str
-    home_assistant_start: bool
     variables: TemplateVarsType
     trigger_data: TriggerData
 
@@ -1671,7 +1671,7 @@ async def async_initialize_triggers(
     domain: str,
     name: str,
     log_cb: Callable,
-    home_assistant_start: bool = False,
+    home_assistant_start: bool | UndefinedType = UNDEFINED,
     variables: TemplateVarsType = None,
     did_not_trigger: TriggerNotTriggeredAction | None = None,
 ) -> CALLBACK_TYPE | None:
@@ -1681,6 +1681,14 @@ async def async_initialize_triggers(
     invoked - for new-style triggers that support it - when a trigger evaluates
     a relevant change but reports it did not fire. Old-style triggers ignore it.
     """
+    if home_assistant_start is not UNDEFINED:
+        report_usage(
+            "passes `home_assistant_start` to `async_initialize_triggers`, which is "
+            "deprecated and will be removed in Home Assistant 2027.8; the parameter "
+            "no longer has any effect",
+            breaks_in_ha_version="2027.8.0",
+        )
+
     triggers: list[asyncio.Task[CALLBACK_TYPE]] = []
     for idx, conf in enumerate(trigger_config):
         # Skip triggers that are not enabled
@@ -1704,7 +1712,6 @@ async def async_initialize_triggers(
         info = TriggerInfo(
             domain=domain,
             name=name,
-            home_assistant_start=home_assistant_start,
             variables=variables,
             trigger_data=trigger_data,
         )

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -23,7 +23,6 @@ from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_NAME,
     CONF_ID,
-    EVENT_HOMEASSISTANT_STARTED,
     SERVICE_RELOAD,
     SERVICE_TOGGLE,
     SERVICE_TURN_OFF,
@@ -1683,7 +1682,9 @@ async def test_automation_not_trigger_on_bootstrap(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     assert len(calls) == 0
 
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    # Triggers are armed by a startup job which runs during async_start, before
+    # EVENT_HOMEASSISTANT_STARTED is fired.
+    await hass.async_start()
     await hass.async_block_till_done()
     assert automation.is_on(hass, "automation.hello")
 

--- a/tests/components/homeassistant/triggers/test_homeassistant.py
+++ b/tests/components/homeassistant/triggers/test_homeassistant.py
@@ -29,7 +29,9 @@ from tests.common import async_mock_service
 )
 @pytest.mark.usefixtures("mock_hass_config")
 async def test_if_fires_on_hass_start(
-    hass: HomeAssistant, hass_config: ConfigType
+    hass: HomeAssistant,
+    hass_config: ConfigType,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test the firing when Home Assistant starts."""
     calls = async_mock_service(hass, "test", "automation")
@@ -51,6 +53,10 @@ async def test_if_fires_on_hass_start(
     assert automation.is_on(hass, "automation.hello")
     assert len(calls) == 1
     assert calls[0].data["id"] == 0
+
+    # Detaching the trigger after it fired must not re-invoke the stale once
+    # listener's remove callback.
+    assert "Unable to remove unknown job listener" not in caplog.text
 
 
 async def test_if_not_fires_when_set_up_after_start(hass: HomeAssistant) -> None:

--- a/tests/components/homeassistant/triggers/test_homeassistant.py
+++ b/tests/components/homeassistant/triggers/test_homeassistant.py
@@ -53,6 +53,29 @@ async def test_if_fires_on_hass_start(
     assert calls[0].data["id"] == 0
 
 
+async def test_if_not_fires_when_set_up_after_start(hass: HomeAssistant) -> None:
+    """Test the start trigger stays silent when armed after Home Assistant started."""
+    calls = async_mock_service(hass, "test", "automation")
+    assert hass.state is CoreState.running
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "alias": "hello",
+                "trigger": {"platform": "homeassistant", "event": "start"},
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
+    assert automation.is_on(hass, "automation.hello")
+    await hass.async_block_till_done()
+
+    # EVENT_HOMEASSISTANT_STARTED has already fired, so the trigger must not fire.
+    assert len(calls) == 0
+
+
 async def test_if_fires_on_hass_shutdown(hass: HomeAssistant) -> None:
     """Test the firing when Home Assistant shuts down."""
     calls = async_mock_service(hass, "test", "automation")

--- a/tests/helpers/test_trigger.py
+++ b/tests/helpers/test_trigger.py
@@ -3856,6 +3856,36 @@ async def _arm_off_to_on_trigger(
     )
 
 
+async def test_async_initialize_triggers_home_assistant_start_deprecated(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test passing the deprecated home_assistant_start parameter is reported."""
+    log = logging.getLogger(__name__)
+
+    @callback
+    def action(run_variables: dict[str, Any], context: Context | None = None) -> None:
+        pass
+
+    # The parameter no longer has any effect but must not raise for compatibility.
+    assert (
+        await async_initialize_triggers(
+            hass,
+            [],
+            action,
+            "test",
+            "test",
+            log.log,
+            home_assistant_start=True,
+        )
+        is None
+    )
+    assert (
+        "passes `home_assistant_start` to `async_initialize_triggers`, which is "
+        "deprecated and will be removed in Home Assistant 2027.2" in caplog.text
+    )
+
+
 def _set_or_remove_state(
     hass: HomeAssistant, entity_id: str, state: str | None
 ) -> None:

--- a/tests/helpers/test_trigger.py
+++ b/tests/helpers/test_trigger.py
@@ -3856,6 +3856,7 @@ async def _arm_off_to_on_trigger(
     )
 
 
+@pytest.mark.usefixtures("mock_integration_frame")
 async def test_async_initialize_triggers_home_assistant_start_deprecated(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
@@ -3867,7 +3868,7 @@ async def test_async_initialize_triggers_home_assistant_start_deprecated(
     def action(run_variables: dict[str, Any], context: Context | None = None) -> None:
         pass
 
-    # The parameter no longer has any effect but must not raise for compatibility.
+    # The parameter no longer has any effect; passing it is logged, not raised.
     assert (
         await async_initialize_triggers(
             hass,
@@ -3882,7 +3883,7 @@ async def test_async_initialize_triggers_home_assistant_start_deprecated(
     )
     assert (
         "passes `home_assistant_start` to `async_initialize_triggers`, which is "
-        "deprecated and will be removed in Home Assistant 2027.2" in caplog.text
+        "deprecated and will be removed in Home Assistant 2027.8" in caplog.text
     )
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3211,6 +3211,26 @@ async def test_cancel_shutdown_job(hass: HomeAssistant) -> None:
     assert not evt.is_set()
 
 
+async def test_shutdown_job_runs_before_stop(hass: HomeAssistant) -> None:
+    """Test shutdown jobs run before EVENT_HOMEASSISTANT_STOP is fired."""
+    order: list[str] = []
+
+    @callback
+    def stop_listener(event: ha.Event) -> None:
+        order.append("stop_listener")
+
+    async def shutdown_func() -> None:
+        order.append("shutdown_job")
+        assert hass.state is CoreState.running
+        assert "stop_listener" not in order
+
+    hass.bus.async_listen(EVENT_HOMEASSISTANT_STOP, stop_listener)
+    hass.async_add_shutdown_job(HassJob(shutdown_func, "shutdown_job"))
+
+    await hass.async_stop()
+    assert order == ["shutdown_job", "stop_listener"]
+
+
 async def test_startup_job(hass: HomeAssistant) -> None:
     """Test async_add_startup_job."""
     evt = asyncio.Event()
@@ -3238,6 +3258,35 @@ async def test_cancel_startup_job(hass: HomeAssistant) -> None:
     cancel()
     await hass.async_start()
     assert not evt.is_set()
+
+
+async def test_startup_job_runs_after_start_before_started(hass: HomeAssistant) -> None:
+    """Test startup jobs run after START listeners finish and before STARTED is fired."""
+    order: list[str] = []
+
+    async def start_listener(event: ha.Event) -> None:
+        # Yield control to prove startup jobs wait for in-flight START listeners.
+        await asyncio.sleep(0.01)
+        order.append("start_listener")
+
+    @callback
+    def started_listener(event: ha.Event) -> None:
+        order.append("started_listener")
+
+    async def startup_func() -> None:
+        order.append("startup_job")
+        assert hass.state is CoreState.starting
+        assert "started_listener" not in order
+
+    hass.bus.async_listen(EVENT_HOMEASSISTANT_START, start_listener)
+    hass.bus.async_listen(EVENT_HOMEASSISTANT_STARTED, started_listener)
+    hass.async_add_startup_job(HassJob(startup_func, "startup_job"))
+
+    hass.set_state(CoreState.not_running)
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    assert order == ["start_listener", "startup_job", "started_listener"]
 
 
 def test_one_time_listener_repr(hass: HomeAssistant) -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3211,6 +3211,35 @@ async def test_cancel_shutdown_job(hass: HomeAssistant) -> None:
     assert not evt.is_set()
 
 
+async def test_startup_job(hass: HomeAssistant) -> None:
+    """Test async_add_startup_job."""
+    evt = asyncio.Event()
+
+    async def startup_func() -> None:
+        # Sleep to ensure core is waiting for the task to finish
+        await asyncio.sleep(0.01)
+        evt.set()
+
+    job = HassJob(startup_func, "startup_job")
+    hass.async_add_startup_job(job)
+    await hass.async_start()
+    assert evt.is_set()
+
+
+async def test_cancel_startup_job(hass: HomeAssistant) -> None:
+    """Test cancelling a job added to async_add_startup_job."""
+    evt = asyncio.Event()
+
+    async def startup_func() -> None:
+        evt.set()
+
+    job = HassJob(startup_func, "startup_job")
+    cancel = hass.async_add_startup_job(job)
+    cancel()
+    await hass.async_start()
+    assert not evt.is_set()
+
+
 def test_one_time_listener_repr(hass: HomeAssistant) -> None:
     """Test one time listener repr."""
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Rewrite homeassistant started trigger to work as a real trigger instead of a pseudo trigger where the user of the trigger API needs to pass down a dedicated flag.

The dedicated flag `home_assistant_start` of `async_initialize_trigger` is deprecated and will be removed in Home Assistant Core 2027.8

To make the new implementation possible, add `HomeAssistant.async_add_startup_job` which allows registering a job which will be called after all listeners to `EVENT_HOMEASSISTANT_START` have executed but before `EVENT_HOMEASSISTANT_STARTED` is fired.

An alternative would have been to add another core state and another event, but the connection between core states and events is already complex, and further complicating it invites to introducing more bugs and races.

The new solution is inspired by https://github.com/home-assistant/core/pull/91165 which improved the homeassistant shutdown trigger and added shutdown jobs, instead of adding another event and another core state.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/3215
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
