### PR TITLE
Fix ccm15 active HVAC commands with fan off

### DIFF
--- a/homeassistant/components/ccm15/coordinator.py
+++ b/homeassistant/components/ccm15/coordinator.py
@@ -7,7 +7,7 @@ from typing import override
 from ccm15 import CCM15Device, CCM15DeviceState, CCM15SlaveDevice, TriState
 import httpx
 
-from homeassistant.components.climate import SWING_ON, HVACMode
+from homeassistant.components.climate import FAN_AUTO, FAN_OFF, SWING_ON, HVACMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.httpx_client import get_async_client
@@ -62,8 +62,25 @@ class CCM15Coordinator(DataUpdateCoordinator[CCM15DeviceState]):
 
     async def async_set_state(self, ac_index: int, data) -> None:
         """Set new target states."""
+        self._ensure_active_state_has_fan_mode(ac_index, data)
         if await self._ccm15.async_set_state(ac_index, data):
             await self.async_request_refresh()
+
+    def _ensure_active_state_has_fan_mode(
+        self, ac_index: int, data: CCM15SlaveDevice
+    ) -> None:
+        """Avoid sending active HVAC commands with the fan left off."""
+        fan_off = CONST_FAN_CMD_MAP[FAN_OFF]
+        if (
+            data.fan_mode != fan_off
+            or data.ac_mode == CONST_STATE_CMD_MAP[HVACMode.OFF]
+        ):
+            return
+
+        data.fan_mode = CONST_FAN_CMD_MAP[FAN_AUTO]
+        _LOGGER.debug(
+            "Set Fan[%s]='%s' for active HVAC command", ac_index, data.fan_mode
+        )
 
     def get_ac_data(self, ac_index: int) -> CCM15SlaveDevice | None:
         """Get ac data from the ac_index."""

--- a/homeassistant/components/ccm15/coordinator.py
+++ b/homeassistant/components/ccm15/coordinator.py
@@ -78,9 +78,7 @@ class CCM15Coordinator(DataUpdateCoordinator[CCM15DeviceState]):
             return
 
         data.fan_mode = CONST_FAN_CMD_MAP[FAN_AUTO]
-        _LOGGER.debug(
-            "Set Fan[%s]='%s' for active HVAC command", ac_index, data.fan_mode
-        )
+        _LOGGER.debug("Set Fan[%s]='%s' for active HVAC command", ac_index, FAN_AUTO)
 
     def get_ac_data(self, ac_index: int) -> CCM15SlaveDevice | None:
         """Get ac data from the ac_index."""

--- a/tests/components/ccm15/test_climate.py
+++ b/tests/components/ccm15/test_climate.py
@@ -8,7 +8,7 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.ccm15.const import DOMAIN
+from homeassistant.components.ccm15.const import CONST_FAN_CMD_MAP, DOMAIN
 from homeassistant.components.climate import (
     ATTR_CURRENT_TEMPERATURE,
     ATTR_FAN_MODE,
@@ -16,6 +16,7 @@ from homeassistant.components.climate import (
     ATTR_SWING_MODE,
     ATTR_TEMPERATURE,
     DOMAIN as CLIMATE_DOMAIN,
+    FAN_AUTO,
     FAN_HIGH,
     SERVICE_SET_FAN_MODE,
     SERVICE_SET_HVAC_MODE,
@@ -177,6 +178,49 @@ async def test_climate_fahrenheit_unit(hass: HomeAssistant) -> None:
     assert state is not None
     assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 75
     assert state.attributes[ATTR_TEMPERATURE] == 86
+
+
+@pytest.mark.usefixtures("ccm15_device")
+@pytest.mark.parametrize(
+    ("service", "service_data"),
+    [
+        (SERVICE_SET_HVAC_MODE, {ATTR_HVAC_MODE: HVACMode.COOL}),
+        (
+            SERVICE_SET_TEMPERATURE,
+            {ATTR_HVAC_MODE: HVACMode.COOL, ATTR_TEMPERATURE: 25},
+        ),
+        (SERVICE_TURN_ON, {}),
+    ],
+)
+async def test_climate_active_state_sets_auto_fan_from_off(
+    hass: HomeAssistant, service: str, service_data: dict[str, object]
+) -> None:
+    """Active HVAC commands do not keep the off-state fan setting."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="1.1.1.1",
+        data={CONF_HOST: "1.1.1.1", CONF_PORT: 80},
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    with patch(
+        "homeassistant.components.ccm15.coordinator.CCM15Device.async_set_state",
+        return_value=True,
+    ) as mock_set_state:
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            service,
+            {ATTR_ENTITY_ID: ["climate.midea_0"], **service_data},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    mock_set_state.assert_called_once()
+    data = mock_set_state.call_args.args[1]
+    assert data.fan_mode == CONST_FAN_CMD_MAP[FAN_AUTO]
 
 
 @pytest.mark.usefixtures("ccm15_device")


### PR DESCRIPTION
## Proposed change

The CCM15 controller treats each `ctrl.xml` write as the complete target state for an AC unit. When an AC is off, the reported fan mode can also be off. If Home Assistant then turns the AC on or sets an active HVAC mode without an explicit fan mode, the integration can send an active mode together with `fan=off`.

For some CCM15 controllers, that command does not start the AC reliably because the request effectively asks for an active HVAC mode with the fan disabled.

This PR avoids sending active CCM15 HVAC commands with the fan mode left at off. When an active HVAC command would otherwise be sent with `fan=off`, the coordinator changes the fan mode to auto so the controller receives a complete runnable target state.

This applies to:

- `climate.set_hvac_mode`
- `climate.set_temperature` with `hvac_mode`
- `climate.turn_on`

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: N/A
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

Verified on a CCM15 controller that turning on from an off/fan-off state starts the unit without requiring a separate fan mode service call.


## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.