### PR TITLE
Fix HomeKit thermostat sending lowercased fan_mode to climate

### DIFF
--- a/homeassistant/components/homekit/type_thermostats.py
+++ b/homeassistant/components/homekit/type_thermostats.py
@@ -399,13 +399,15 @@ class Thermostat(HomeAccessory):
 
     def _set_fan_speed(self, speed: int) -> None:
         _LOGGER.debug("%s: Set fan speed to %s", self.entity_id, speed)
-        mode = percentage_to_ordered_list_item(self.ordered_fan_speeds, speed - 1)
+        speed_key = percentage_to_ordered_list_item(self.ordered_fan_speeds, speed - 1)
+        mode = self.fan_modes[speed_key]
         params = {ATTR_ENTITY_ID: self.entity_id, ATTR_FAN_MODE: mode}
         self.async_call_service(CLIMATE_DOMAIN, SERVICE_SET_FAN_MODE, params)
 
     def _get_on_mode(self) -> str:
         if self.ordered_fan_speeds:
-            return percentage_to_ordered_list_item(self.ordered_fan_speeds, 50)
+            speed_key = percentage_to_ordered_list_item(self.ordered_fan_speeds, 50)
+            return self.fan_modes[speed_key]
         return self.fan_modes[FAN_ON]
 
     def _set_fan_active(self, active: int) -> None:

--- a/tests/components/homekit/test_type_thermostats.py
+++ b/tests/components/homekit/test_type_thermostats.py
@@ -2896,3 +2896,74 @@ async def test_thermostat_reversed_min_max(hass: HomeAssistant, hk_driver) -> No
     assert acc.char_heating_thresh_temp.properties[PROP_MAX_VALUE] == DEFAULT_MAX_TEMP
     assert acc.char_heating_thresh_temp.properties[PROP_MIN_VALUE] == 7.0
     assert acc.char_heating_thresh_temp.properties[PROP_MIN_STEP] == 0.1
+
+async def test_thermostat_with_capitalized_fan_modes(
+    hass: HomeAssistant, hk_driver
+) -> None:
+    """Test that fan modes are sent back to the climate entity with their original casing."""
+    entity_id = "climate.test"
+    hass.states.async_set(
+        entity_id,
+        HVACMode.OFF,
+        {
+            ATTR_SUPPORTED_FEATURES: ClimateEntityFeature.TARGET_TEMPERATURE
+            | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+            | ClimateEntityFeature.FAN_MODE,
+            ATTR_FAN_MODES: ["Auto", "Low", "Medium", "High"],
+            ATTR_HVAC_ACTION: HVACAction.IDLE,
+            ATTR_FAN_MODE: "Auto",
+            ATTR_HVAC_MODES: [
+                HVACMode.HEAT,
+                HVACMode.COOL,
+                HVACMode.OFF,
+                HVACMode.AUTO,
+            ],
+        },
+    )
+    await hass.async_block_till_done()
+    acc = Thermostat(hass, hk_driver, "Climate", entity_id, 1, None)
+    hk_driver.add_accessory(acc)
+
+    acc.run()
+    await hass.async_block_till_done()
+
+    # ordered_fan_speeds tracks the lowercased keys, but the value sent back to
+    # the climate entity must use the entity's original casing.
+    assert acc.ordered_fan_speeds == [FAN_LOW, FAN_MEDIUM, FAN_HIGH]
+
+    call_set_fan_mode = async_mock_service(hass, CLIMATE_DOMAIN, SERVICE_SET_FAN_MODE)
+    char_rotation_speed_iid = acc.char_speed.to_HAP()[HAP_REPR_IID]
+
+    hk_driver.set_characteristics(
+        {
+            HAP_REPR_CHARS: [
+                {
+                    HAP_REPR_AID: acc.aid,
+                    HAP_REPR_IID: char_rotation_speed_iid,
+                    HAP_REPR_VALUE: 100,
+                }
+            ]
+        },
+        "mock_addr",
+    )
+    await hass.async_block_till_done()
+    assert len(call_set_fan_mode) == 1
+    assert call_set_fan_mode[-1].data[ATTR_ENTITY_ID] == entity_id
+    assert call_set_fan_mode[-1].data[ATTR_FAN_MODE] == "High"
+
+    hk_driver.set_characteristics(
+        {
+            HAP_REPR_CHARS: [
+                {
+                    HAP_REPR_AID: acc.aid,
+                    HAP_REPR_IID: char_rotation_speed_iid,
+                    HAP_REPR_VALUE: 100 / 3,
+                }
+            ]
+        },
+        "mock_addr",
+    )
+    await hass.async_block_till_done()
+    assert len(call_set_fan_mode) == 2
+    assert call_set_fan_mode[-1].data[ATTR_ENTITY_ID] == entity_id
+    assert call_set_fan_mode[-1].data[ATTR_FAN_MODE] == "Low"

--- a/tests/components/homekit/test_type_thermostats.py
+++ b/tests/components/homekit/test_type_thermostats.py
@@ -2901,7 +2901,7 @@ async def test_thermostat_reversed_min_max(hass: HomeAssistant, hk_driver) -> No
 async def test_thermostat_with_capitalized_fan_modes(
     hass: HomeAssistant, hk_driver
 ) -> None:
-    """Test that fan modes are sent back to the climate entity with their original casing."""
+    """Test fan modes are sent back with their original casing."""
     entity_id = "climate.test"
     hass.states.async_set(
         entity_id,

--- a/tests/components/homekit/test_type_thermostats.py
+++ b/tests/components/homekit/test_type_thermostats.py
@@ -2897,6 +2897,7 @@ async def test_thermostat_reversed_min_max(hass: HomeAssistant, hk_driver) -> No
     assert acc.char_heating_thresh_temp.properties[PROP_MIN_VALUE] == 7.0
     assert acc.char_heating_thresh_temp.properties[PROP_MIN_STEP] == 0.1
 
+
 async def test_thermostat_with_capitalized_fan_modes(
     hass: HomeAssistant, hk_driver
 ) -> None:


### PR DESCRIPTION
## Proposed change

The HomeKit thermostat accessory sends the wrong case for `fan_mode` to `climate.set_fan_mode`. `fan_modes` is built as a lowercase-key to original-value map, and `ordered_fan_speeds` holds the lowercase keys, so `_set_fan_speed` and `_get_on_mode` passed the lowercased key straight into the service call. For a climate entity whose fan modes are capitalized (for example `High`), `climate` then raises `ServiceValidationError: Fan mode high is not valid`.

The sibling setters `_set_fan_active` and `_set_fan_auto` already map back through `self.fan_modes[...]`. This does the same for the two spots that missed it, so the original casing is preserved.

Fixes #175167.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Testing

Added `test_thermostat_with_capitalized_fan_modes`, mirroring the existing `test_thermostat_with_fan_modes_with_auto`: a climate entity with capitalized fan modes (`["Auto", "Low", "Medium", "High"]`) now receives the original-cased value (`High`, `Low`) when the HomeKit rotation speed changes. It fails before the fix (sends `high`) and passes after.
