### PR TITLE
Cleanup auth error handling which is now handled by library

### DIFF
--- a/homeassistant/components/teltonika/coordinator.py
+++ b/homeassistant/components/teltonika/coordinator.py
@@ -4,9 +4,7 @@ from datetime import timedelta
 import logging
 from typing import TYPE_CHECKING, override
 
-from aiohttp import ClientResponseError, ContentTypeError
 from teltasync import Teltasync, TeltonikaAuthenticationError, TeltonikaConnectionError
-from teltasync.error_codes import TeltonikaErrorCode
 from teltasync.modems import Modems, ModemStatusFull
 
 from homeassistant.core import HomeAssistant
@@ -22,13 +20,6 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = timedelta(seconds=30)
-AUTH_ERROR_CODES = frozenset(
-    {
-        TeltonikaErrorCode.UNAUTHORIZED_ACCESS,
-        TeltonikaErrorCode.LOGIN_FAILED,
-        TeltonikaErrorCode.INVALID_JWT_TOKEN,
-    }
-)
 
 
 class TeltonikaDataUpdateCoordinator(DataUpdateCoordinator[dict[str, ModemStatusFull]]):
@@ -62,12 +53,6 @@ class TeltonikaDataUpdateCoordinator(DataUpdateCoordinator[dict[str, ModemStatus
             system_info_response = await self.client.get_system_info()
         except TeltonikaAuthenticationError as err:
             raise ConfigEntryAuthFailed(f"Authentication failed: {err}") from err
-        except (ClientResponseError, ContentTypeError) as err:
-            if (isinstance(err, ClientResponseError) and err.status in (401, 403)) or (
-                isinstance(err, ContentTypeError) and err.status == 403
-            ):
-                raise ConfigEntryAuthFailed(f"Authentication failed: {err}") from err
-            raise ConfigEntryNotReady(f"Failed to connect to device: {err}") from err
         except TeltonikaConnectionError as err:
             raise ConfigEntryNotReady(f"Failed to connect to device: {err}") from err
 
@@ -99,23 +84,10 @@ class TeltonikaDataUpdateCoordinator(DataUpdateCoordinator[dict[str, ModemStatus
             modems_response = await modems.get_status()
         except TeltonikaAuthenticationError as err:
             raise ConfigEntryAuthFailed(f"Authentication failed: {err}") from err
-        except (ClientResponseError, ContentTypeError) as err:
-            if (isinstance(err, ClientResponseError) and err.status in (401, 403)) or (
-                isinstance(err, ContentTypeError) and err.status == 403
-            ):
-                raise ConfigEntryAuthFailed(f"Authentication failed: {err}") from err
-            raise UpdateFailed(f"Error communicating with device: {err}") from err
         except TeltonikaConnectionError as err:
             raise UpdateFailed(f"Error communicating with device: {err}") from err
 
         if not modems_response.success:
-            if modems_response.errors and any(
-                error.code in AUTH_ERROR_CODES for error in modems_response.errors
-            ):
-                raise ConfigEntryAuthFailed(
-                    "Authentication failed: unauthorized access"
-                )
-
             error_message = (
                 modems_response.errors[0].error
                 if modems_response.errors

--- a/tests/components/teltonika/test_init.py
+++ b/tests/components/teltonika/test_init.py
@@ -2,7 +2,6 @@
 
 from unittest.mock import MagicMock
 
-from aiohttp import ClientResponseError, ContentTypeError
 import pytest
 from syrupy.assertion import SnapshotAssertion
 from teltasync import TeltonikaAuthenticationError, TeltonikaConnectionError
@@ -36,45 +35,12 @@ async def test_load_unload_config_entry(
             ConfigEntryState.SETUP_RETRY,
         ),
         (
-            ContentTypeError(
-                request_info=MagicMock(),
-                history=(),
-                status=403,
-                message="Attempt to decode JSON with unexpected mimetype: text/html",
-                headers={},
-            ),
-            ConfigEntryState.SETUP_ERROR,
-        ),
-        (
-            ClientResponseError(
-                request_info=MagicMock(),
-                history=(),
-                status=401,
-                message="Unauthorized",
-                headers={},
-            ),
-            ConfigEntryState.SETUP_ERROR,
-        ),
-        (
-            ClientResponseError(
-                request_info=MagicMock(),
-                history=(),
-                status=403,
-                message="Forbidden",
-                headers={},
-            ),
-            ConfigEntryState.SETUP_ERROR,
-        ),
-        (
             TeltonikaAuthenticationError("Invalid credentials"),
             ConfigEntryState.SETUP_ERROR,
         ),
     ],
     ids=[
         "connection_error",
-        "content_type_403",
-        "response_401",
-        "response_403",
         "auth_error",
     ],
 )
@@ -95,9 +61,9 @@ async def test_setup_errors(
     assert mock_config_entry.state is expected_state
 
 
+@pytest.mark.usefixtures("hass")
+@pytest.mark.usefixtures("init_integration")
 async def test_device_registry_creation(
-    hass: HomeAssistant,
-    init_integration: MockConfigEntry,
     device_registry: dr.DeviceRegistry,
     snapshot: SnapshotAssertion,
 ) -> None:

--- a/tests/components/teltonika/test_sensor.py
+++ b/tests/components/teltonika/test_sensor.py
@@ -3,12 +3,10 @@
 from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock
 
-from aiohttp import ClientResponseError
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 from teltasync import TeltonikaAuthenticationError, TeltonikaConnectionError
-from teltasync.error_codes import TeltonikaErrorCode
 
 from homeassistant.components.teltonika.const import DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH
@@ -28,10 +26,10 @@ async def test_sensors(
     await snapshot_platform(hass, entity_registry, snapshot, init_integration.entry_id)
 
 
+@pytest.mark.usefixtures("init_integration")
 async def test_sensor_modem_removed(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    init_integration: MockConfigEntry,
     mock_modems: MagicMock,
     freezer: FrozenDateTimeFactory,
 ) -> None:
@@ -62,10 +60,10 @@ async def test_sensor_modem_removed(
     assert state.state == "unavailable"
 
 
+@pytest.mark.usefixtures("init_integration")
 async def test_sensor_update_failure_and_recovery(
     hass: HomeAssistant,
     mock_modems: AsyncMock,
-    init_integration: MockConfigEntry,
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test sensor becomes unavailable on update failure and recovers."""
@@ -102,38 +100,19 @@ async def test_sensor_update_failure_and_recovery(
     ("side_effect", "expect_reauth"),
     [
         (TeltonikaAuthenticationError("Invalid credentials"), True),
-        (
-            ClientResponseError(
-                request_info=MagicMock(),
-                history=(),
-                status=401,
-                message="Unauthorized",
-                headers={},
-            ),
-            True,
-        ),
-        (
-            ClientResponseError(
-                request_info=MagicMock(),
-                history=(),
-                status=500,
-                message="Server error",
-                headers={},
-            ),
-            False,
-        ),
+        (TeltonikaConnectionError("Connection lost"), False),
     ],
-    ids=["auth_exception", "http_auth_error", "http_non_auth_error"],
+    ids=["auth_error", "connection_error"],
 )
+@pytest.mark.usefixtures("init_integration")
 async def test_sensor_update_exception_paths(
     hass: HomeAssistant,
     mock_modems: AsyncMock,
-    init_integration: MockConfigEntry,
     freezer: FrozenDateTimeFactory,
     side_effect: Exception,
     expect_reauth: bool,
 ) -> None:
-    """Test auth and non-auth exceptions during updates."""
+    """Test an auth error triggers reauth while a connection error stays working."""
     mock_modems.get_status.side_effect = side_effect
 
     freezer.tick(timedelta(seconds=31))
@@ -151,28 +130,18 @@ async def test_sensor_update_exception_paths(
     assert has_reauth is expect_reauth
 
 
-@pytest.mark.parametrize(
-    ("error_code", "expect_reauth"),
-    [
-        (TeltonikaErrorCode.UNAUTHORIZED_ACCESS, True),
-        (999, False),
-    ],
-    ids=["api_auth_error", "api_non_auth_error"],
-)
-async def test_sensor_update_unsuccessful_response_paths(
+@pytest.mark.usefixtures("init_integration")
+async def test_sensor_update_unsuccessful_response(
     hass: HomeAssistant,
     mock_modems: AsyncMock,
-    init_integration: MockConfigEntry,
     freezer: FrozenDateTimeFactory,
-    error_code: int,
-    expect_reauth: bool,
 ) -> None:
-    """Test unsuccessful API response handling."""
+    """Test an unsuccessful API response marks entities unavailable without reauth."""
     mock_modems.get_status.side_effect = None
     mock_modems.get_status.return_value = MagicMock(
         success=False,
         data=None,
-        errors=[MagicMock(code=error_code, error="API error")],
+        errors=[MagicMock(code=999, error="API error")],
     )
 
     freezer.tick(timedelta(seconds=31))
@@ -187,4 +156,4 @@ async def test_sensor_update_unsuccessful_response_paths(
         flow["handler"] == DOMAIN and flow["context"]["source"] == SOURCE_REAUTH
         for flow in hass.config_entries.flow.async_progress()
     )
-    assert has_reauth is expect_reauth
+    assert has_reauth is False


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a follow up on #175084, which upgraded the teltasync dependency. A new feature is that the library now handles re-authentication/token renewal errors transparent internally, and only raises when the login credentials (not the token) were rejected. For this reason, we don't need the related error handling anymore in the HA integration side, and the corresponding tests can also be removed.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
