### PR TITLE
Add Velbus button event entities

### DIFF
--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -27,6 +27,7 @@ PLATFORMS = [
     Platform.BUTTON,
     Platform.CLIMATE,
     Platform.COVER,
+    Platform.EVENT,
     Platform.LIGHT,
     Platform.SELECT,
     Platform.SENSOR,

--- a/homeassistant/components/velbus/event.py
+++ b/homeassistant/components/velbus/event.py
@@ -49,6 +49,9 @@ class VelbusButtonEvent(VelbusEntity, EventEntity):
 
     def _is_long_pressed(self) -> bool:
         """Return if Velbus has reported a long press."""
+        if callable(is_long_pressed := getattr(self._channel, "is_long_pressed", None)):
+            return bool(is_long_pressed())
+
         return bool(self._channel.get_channel_info().get("long", False))
 
     @override

--- a/homeassistant/components/velbus/event.py
+++ b/homeassistant/components/velbus/event.py
@@ -44,7 +44,6 @@ class VelbusButtonEvent(VelbusEntity, EventEntity):
     def __init__(self, channel: VelbusaioButton | VelbusaioButtonCounter) -> None:
         """Initialize a Velbus button event entity."""
         super().__init__(channel)
-        self._attr_unique_id = f"{self._attr_unique_id}-event"
         self._was_closed = self._channel.is_closed()
         self._long_seen = self._was_closed and self._is_long_pressed()
 

--- a/homeassistant/components/velbus/event.py
+++ b/homeassistant/components/velbus/event.py
@@ -1,0 +1,74 @@
+"""Support for Velbus Event entities."""
+
+from typing import override
+
+from velbusaio.channels import (
+    Button as VelbusaioButton,
+    ButtonCounter as VelbusaioButtonCounter,
+)
+
+from homeassistant.components.event import EventDeviceClass, EventEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import VelbusConfigEntry
+from .entity import VelbusEntity
+
+EVENT_SHORT_PRESS = "short_press"
+EVENT_LONG_PRESS = "long_press"
+EVENT_TYPES = [EVENT_SHORT_PRESS, EVENT_LONG_PRESS]
+
+PARALLEL_UPDATES = 0
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: VelbusConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Velbus event entities based on config entry."""
+    await entry.runtime_data.scan_task
+    async_add_entities(
+        VelbusButtonEvent(channel)
+        for channel in entry.runtime_data.controller.get_all_button()
+    )
+
+
+class VelbusButtonEvent(VelbusEntity, EventEntity):
+    """Representation of a Velbus button event entity."""
+
+    _channel: VelbusaioButton | VelbusaioButtonCounter
+    _attr_device_class = EventDeviceClass.BUTTON
+    _attr_event_types = EVENT_TYPES
+
+    def __init__(self, channel: VelbusaioButton | VelbusaioButtonCounter) -> None:
+        """Initialize a Velbus button event entity."""
+        super().__init__(channel)
+        self._attr_unique_id = f"{self._attr_unique_id}-event"
+        self._was_closed = self._channel.is_closed()
+        self._long_seen = self._was_closed and self._is_long_pressed()
+
+    def _is_long_pressed(self) -> bool:
+        """Return if Velbus has reported a long press."""
+        return bool(self._channel.get_channel_info().get("long", False))
+
+    @override
+    async def _on_update(self) -> None:
+        """Handle status updates from the channel."""
+        closed = self._channel.is_closed()
+        long_pressed = self._is_long_pressed()
+
+        if not self._was_closed and closed:
+            self._long_seen = long_pressed
+        elif closed and long_pressed:
+            self._long_seen = True
+        elif self._was_closed and not closed:
+            self._trigger_event(
+                EVENT_LONG_PRESS if self._long_seen else EVENT_SHORT_PRESS
+            )
+            self._long_seen = False
+        elif not closed:
+            self._long_seen = False
+
+        self._was_closed = closed
+        await super()._on_update()

--- a/tests/components/velbus/conftest.py
+++ b/tests/components/velbus/conftest.py
@@ -121,6 +121,7 @@ def mock_button() -> AsyncMock:
     channel.get_module_serial.return_value = "a1b2c3d4e5f6"
     channel.is_sub_device.return_value = False
     channel.is_closed.return_value = True
+    channel.get_channel_info.return_value = {"long": False}
     channel.is_on.return_value = False
     return channel
 

--- a/tests/components/velbus/test_event.py
+++ b/tests/components/velbus/test_event.py
@@ -17,7 +17,6 @@ from homeassistant.components.velbus.event import (
     EVENT_LONG_PRESS,
     EVENT_SHORT_PRESS,
     EVENT_TYPES,
-    VelbusButtonEvent,
 )
 from homeassistant.const import ATTR_DEVICE_CLASS, STATE_ON, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant, State
@@ -44,12 +43,8 @@ def _event_state(hass: HomeAssistant) -> State:
 
 def _get_event_callback(mock_button: AsyncMock) -> StatusUpdateCallback:
     """Return the status update callback registered by the event entity."""
-    for call in mock_button.on_status_update.call_args_list:
-        callback = call.args[0]
-        owner = getattr(callback, "__self__", None)
-        if isinstance(owner, VelbusButtonEvent):
-            return cast(StatusUpdateCallback, callback)
-    raise AssertionError("Velbus event entity callback was not registered")
+    mock_button.on_status_update.assert_called_once()
+    return cast(StatusUpdateCallback, mock_button.on_status_update.call_args.args[0])
 
 
 async def _setup_event_entity(

--- a/tests/components/velbus/test_event.py
+++ b/tests/components/velbus/test_event.py
@@ -1,0 +1,280 @@
+"""Velbus event platform tests."""
+
+from collections.abc import Awaitable, Callable
+from datetime import timedelta
+from typing import cast
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from freezegun.api import FrozenDateTimeFactory
+
+from homeassistant.components.event import (
+    ATTR_EVENT_TYPE,
+    ATTR_EVENT_TYPES,
+    EventDeviceClass,
+)
+from homeassistant.components.velbus.event import (
+    EVENT_LONG_PRESS,
+    EVENT_SHORT_PRESS,
+    EVENT_TYPES,
+    VelbusButtonEvent,
+)
+from homeassistant.const import ATTR_DEVICE_CLASS, STATE_ON, STATE_UNKNOWN, Platform
+from homeassistant.core import HomeAssistant, State
+from homeassistant.helpers import entity_registry as er
+
+from . import init_integration
+
+from tests.common import MockConfigEntry
+
+BINARY_SENSOR_ENTITY_ID = "binary_sensor.bedroom_kid_1_buttonon"
+BUTTON_ENTITY_ID = "button.bedroom_kid_1_buttonon"
+EVENT_ENTITY_ID = "event.bedroom_kid_1_buttonon"
+LED_ENTITY_ID = "light.bedroom_kid_1_led_buttonon"
+
+type StatusUpdateCallback = Callable[[], Awaitable[None]]
+
+
+def _event_state(hass: HomeAssistant) -> State:
+    """Return the Velbus event entity state."""
+    state = hass.states.get(EVENT_ENTITY_ID)
+    assert state is not None
+    return state
+
+
+def _get_event_callback(mock_button: AsyncMock) -> StatusUpdateCallback:
+    """Return the status update callback registered by the event entity."""
+    for call in mock_button.on_status_update.call_args_list:
+        callback = call.args[0]
+        owner = getattr(callback, "__self__", None)
+        if isinstance(owner, VelbusButtonEvent):
+            return cast(StatusUpdateCallback, callback)
+    raise AssertionError("Velbus event entity callback was not registered")
+
+
+async def _setup_event_entity(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_button: AsyncMock,
+) -> StatusUpdateCallback:
+    """Set up only the Velbus event platform."""
+    mock_button.is_closed.return_value = False
+    mock_button.get_channel_info.return_value = {"long": False}
+    with patch("homeassistant.components.velbus.PLATFORMS", [Platform.EVENT]):
+        await init_integration(hass, config_entry)
+    return _get_event_callback(mock_button)
+
+
+async def _update_button(
+    hass: HomeAssistant,
+    mock_button: AsyncMock,
+    callback: StatusUpdateCallback,
+    *,
+    closed: bool,
+    long_pressed: bool,
+) -> None:
+    """Update the mocked button state and invoke its callback."""
+    mock_button.is_closed.return_value = closed
+    mock_button.get_channel_info.return_value = {"long": long_pressed}
+    await callback()
+    await hass.async_block_till_done()
+
+
+def _assert_no_completed_event(hass: HomeAssistant) -> None:
+    """Assert no completed press event has been emitted."""
+    state = _event_state(hass)
+    assert state.state == STATE_UNKNOWN
+    assert state.attributes[ATTR_EVENT_TYPE] is None
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_entities(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test event entity creation."""
+    with patch(
+        "homeassistant.components.velbus.PLATFORMS",
+        [Platform.BINARY_SENSOR, Platform.BUTTON, Platform.EVENT, Platform.LIGHT],
+    ):
+        await init_integration(hass, config_entry)
+
+    state = _event_state(hass)
+    assert state.state == STATE_UNKNOWN
+    assert state.attributes[ATTR_DEVICE_CLASS] == EventDeviceClass.BUTTON
+    assert state.attributes[ATTR_EVENT_TYPES] == EVENT_TYPES
+
+    binary_sensor_state = hass.states.get(BINARY_SENSOR_ENTITY_ID)
+    assert binary_sensor_state is not None
+    assert binary_sensor_state.state == STATE_ON
+
+    event_entry = entity_registry.async_get(EVENT_ENTITY_ID)
+    binary_sensor_entry = entity_registry.async_get(BINARY_SENSOR_ENTITY_ID)
+    button_entry = entity_registry.async_get(BUTTON_ENTITY_ID)
+    led_entry = entity_registry.async_get(LED_ENTITY_ID)
+    assert event_entry is not None
+    assert binary_sensor_entry is not None
+    assert button_entry is not None
+    assert led_entry is not None
+    assert event_entry.unique_id == "a1b2c3d4e5f6-1-event"
+    assert event_entry.unique_id not in {
+        binary_sensor_entry.unique_id,
+        button_entry.unique_id,
+        led_entry.unique_id,
+    }
+
+
+async def test_normal_press(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_button: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a normal press emits a short press event on release."""
+    callback = await _setup_event_entity(hass, config_entry, mock_button)
+
+    await _update_button(hass, mock_button, callback, closed=True, long_pressed=False)
+    _assert_no_completed_event(hass)
+
+    freezer.tick(timedelta(milliseconds=1))
+    await _update_button(hass, mock_button, callback, closed=False, long_pressed=False)
+    state = _event_state(hass)
+    assert state.attributes[ATTR_EVENT_TYPE] == EVENT_SHORT_PRESS
+    event_state = state.state
+
+    freezer.tick(timedelta(milliseconds=1))
+    await _update_button(hass, mock_button, callback, closed=False, long_pressed=False)
+    state = _event_state(hass)
+    assert state.attributes[ATTR_EVENT_TYPE] == EVENT_SHORT_PRESS
+    assert state.state == event_state
+
+
+async def test_long_press(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_button: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a long press emits a long press event on release."""
+    callback = await _setup_event_entity(hass, config_entry, mock_button)
+
+    await _update_button(hass, mock_button, callback, closed=True, long_pressed=False)
+    _assert_no_completed_event(hass)
+
+    freezer.tick(timedelta(milliseconds=1))
+    await _update_button(hass, mock_button, callback, closed=True, long_pressed=True)
+    _assert_no_completed_event(hass)
+
+    freezer.tick(timedelta(milliseconds=1))
+    await _update_button(hass, mock_button, callback, closed=False, long_pressed=False)
+    state = _event_state(hass)
+    assert state.attributes[ATTR_EVENT_TYPE] == EVENT_LONG_PRESS
+
+
+async def test_repeated_long_status(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_button: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test repeated long status callbacks emit only on release."""
+    callback = await _setup_event_entity(hass, config_entry, mock_button)
+
+    await _update_button(hass, mock_button, callback, closed=True, long_pressed=False)
+
+    freezer.tick(timedelta(milliseconds=1))
+    await _update_button(hass, mock_button, callback, closed=True, long_pressed=True)
+    _assert_no_completed_event(hass)
+
+    freezer.tick(timedelta(milliseconds=1))
+    await _update_button(hass, mock_button, callback, closed=True, long_pressed=True)
+    _assert_no_completed_event(hass)
+
+    freezer.tick(timedelta(milliseconds=1))
+    await _update_button(hass, mock_button, callback, closed=True, long_pressed=True)
+    _assert_no_completed_event(hass)
+
+    freezer.tick(timedelta(milliseconds=1))
+    await _update_button(hass, mock_button, callback, closed=False, long_pressed=False)
+    state = _event_state(hass)
+    assert state.attributes[ATTR_EVENT_TYPE] == EVENT_LONG_PRESS
+
+
+async def test_repeated_release_idle_updates(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_button: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test repeated idle release updates do not emit events."""
+    callback = await _setup_event_entity(hass, config_entry, mock_button)
+
+    await _update_button(hass, mock_button, callback, closed=False, long_pressed=False)
+    _assert_no_completed_event(hass)
+
+    freezer.tick(timedelta(milliseconds=1))
+    await _update_button(hass, mock_button, callback, closed=False, long_pressed=False)
+    _assert_no_completed_event(hass)
+
+    freezer.tick(timedelta(milliseconds=1))
+    await _update_button(hass, mock_button, callback, closed=False, long_pressed=False)
+    _assert_no_completed_event(hass)
+
+
+async def test_state_reset_after_long_press(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_button: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test long state is reset before the next interaction."""
+    callback = await _setup_event_entity(hass, config_entry, mock_button)
+
+    await _update_button(hass, mock_button, callback, closed=True, long_pressed=False)
+    freezer.tick(timedelta(milliseconds=1))
+    await _update_button(hass, mock_button, callback, closed=True, long_pressed=True)
+    freezer.tick(timedelta(milliseconds=1))
+    await _update_button(hass, mock_button, callback, closed=False, long_pressed=False)
+    state = _event_state(hass)
+    assert state.attributes[ATTR_EVENT_TYPE] == EVENT_LONG_PRESS
+    long_event_state = state.state
+
+    freezer.tick(timedelta(milliseconds=1))
+    await _update_button(hass, mock_button, callback, closed=True, long_pressed=False)
+    state = _event_state(hass)
+    assert state.state == long_event_state
+    assert state.attributes[ATTR_EVENT_TYPE] == EVENT_LONG_PRESS
+
+    freezer.tick(timedelta(milliseconds=1))
+    await _update_button(hass, mock_button, callback, closed=False, long_pressed=False)
+    state = _event_state(hass)
+    assert state.state != long_event_state
+    assert state.attributes[ATTR_EVENT_TYPE] == EVENT_SHORT_PRESS
+
+
+async def test_unload_removes_callback(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_button: AsyncMock,
+) -> None:
+    """Test unloading the config entry removes the event callback."""
+    callbacks: list[StatusUpdateCallback] = []
+
+    def register_callback(callback: StatusUpdateCallback) -> None:
+        callbacks.append(callback)
+
+    def remove_callback(callback: StatusUpdateCallback) -> None:
+        callbacks.remove(callback)
+
+    mock_button.on_status_update.side_effect = register_callback
+    mock_button.remove_on_status_update.side_effect = remove_callback
+
+    callback = await _setup_event_entity(hass, config_entry, mock_button)
+    assert callback in callbacks
+
+    assert await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert callback not in callbacks
+    mock_button.remove_on_status_update.assert_called_once_with(callback)

--- a/tests/components/velbus/test_event.py
+++ b/tests/components/velbus/test_event.py
@@ -5,8 +5,8 @@ from datetime import timedelta
 from typing import cast
 from unittest.mock import AsyncMock, patch
 
-import pytest
 from freezegun.api import FrozenDateTimeFactory
+import pytest
 
 from homeassistant.components.event import (
     ATTR_EVENT_TYPE,
@@ -117,12 +117,7 @@ async def test_entities(
     assert binary_sensor_entry is not None
     assert button_entry is not None
     assert led_entry is not None
-    assert event_entry.unique_id == "a1b2c3d4e5f6-1-event"
-    assert event_entry.unique_id not in {
-        binary_sensor_entry.unique_id,
-        button_entry.unique_id,
-        led_entry.unique_id,
-    }
+    assert event_entry.unique_id == "a1b2c3d4e5f6-1"
 
 
 async def test_normal_press(


### PR DESCRIPTION
## Breaking change

No.

## Proposed change

Add event entities for physical Velbus buttons.

The existing Velbus binary sensor continues to represent the current pressed or released state and remains unchanged.

The new event entity emits a completed button action on release:

* `short_press` after `PRESSED → RELEASED`
* `long_press` after `PRESSED → LONG_PRESSED → RELEASED`

Home Assistant does not calculate the press duration. The Velbus module already detects the long press, and `velbus-aio` exposes that information through the channel state.

The implementation remembers whether the Velbus long-press state was received during the current press and emits the corresponding event when the button is released.

## Type of change

* [ ] Dependency upgrade
* [ ] Bugfix (non-breaking change which fixes an issue)
* [ ] New integration (thank you!)
* [x] New feature (which adds functionality to an existing integration)
* [ ] Deprecation (breaking change to happen in the future)
* [ ] Breaking change (fix/feature causing existing functionality to break)
* [ ] Code quality improvements to existing code or addition of tests

## Additional information

* This PR fixes or closes issue: fixes #175149
* This PR is related to issue:
* Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/46549
* Link to developer documentation pull request:
* Link to frontend pull request:

## Checklist

* [x] I understand the code I am submitting and can explain how it works.
* [x] The code change is tested and works locally.
* [x] Local tests pass.
* [x] There is no commented out code in this PR.
* [x] I have followed the development checklist.
* [x] I have followed the perfect PR recommendations.
* [x] The code has been formatted using Ruff.
* [x] Tests have been added to verify that the new code works.
* [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.
