### PR TITLE
Bump py_ccm15 to 1.1.1

### DIFF
--- a/homeassistant/components/ccm15/climate.py
+++ b/homeassistant/components/ccm15/climate.py
@@ -160,26 +160,32 @@ class CCM15Climate(CoordinatorEntity[CCM15Coordinator], ClimateEntity):
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set the target temperature."""
         if (temperature := kwargs.get(ATTR_TEMPERATURE)) is not None:
+            data = self.data
+            assert data is not None
             await self.coordinator.async_set_temperature(
-                self._ac_index, self.data, temperature, kwargs.get(ATTR_HVAC_MODE)
+                self._ac_index, data, temperature, kwargs.get(ATTR_HVAC_MODE)
             )
 
     @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set the hvac mode."""
-        await self.coordinator.async_set_hvac_mode(self._ac_index, self.data, hvac_mode)
+        data = self.data
+        assert data is not None
+        await self.coordinator.async_set_hvac_mode(self._ac_index, data, hvac_mode)
 
     @override
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set the fan mode."""
-        await self.coordinator.async_set_fan_mode(self._ac_index, self.data, fan_mode)
+        data = self.data
+        assert data is not None
+        await self.coordinator.async_set_fan_mode(self._ac_index, data, fan_mode)
 
     @override
     async def async_set_swing_mode(self, swing_mode: str) -> None:
         """Set the swing mode."""
-        await self.coordinator.async_set_swing_mode(
-            self._ac_index, self.data, swing_mode
-        )
+        data = self.data
+        assert data is not None
+        await self.coordinator.async_set_swing_mode(self._ac_index, data, swing_mode)
 
     @override
     async def async_turn_off(self) -> None:

--- a/homeassistant/components/ccm15/manifest.json
+++ b/homeassistant/components/ccm15/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "quality_scale": "bronze",
-  "requirements": ["py_ccm15==1.0.0"]
+  "requirements": ["py_ccm15==1.1.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1988,7 +1988,7 @@ pyW215==0.8.0
 pyW800rf32==0.4
 
 # homeassistant.components.ccm15
-py_ccm15==1.0.0
+py_ccm15==1.1.1
 
 # homeassistant.components.html5
 py_vapid==1.9.4


### PR DESCRIPTION
> [!IMPORTANT]
> **Merge #175626 first.** This PR is stacked on it, so the `climate.py` changes
> in this diff (the four `assert`s) belong to #175626 — they disappear once it
> merges, leaving only the two-line version pin. #175626 adds the `| None`
> narrowing that 1.1.x's `py.typed` makes `mypy --strict` require, so this bump
> cannot pass CI without it.

## Breaking change


## Proposed change

Bump `py_ccm15` from `1.0.0` to `1.1.1`.

The 1.1.x per-slot back-fill cache stops climate entities flapping to
*unavailable* on partial `status.xml` dropouts, where the controller reports most
slots as `-` (or an empty body) for a single poll (HomeOps/py-ccm15#62). Verified
on real hardware: a 60-minute soak saw **8 partial dropouts — 4 of them fully
empty polls — and 0 entity flaps**.

**Stacked on #175626** (merge that first — see the note above).

## Type of change

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: #173804
- This PR depends on: #175626
- This PR supersedes: #175177

py_ccm15 1.1.1 release: https://github.com/HomeOps/py-ccm15/releases/tag/v1.1.1
Full delta 0.6.0...1.1.1: https://github.com/HomeOps/py-ccm15/compare/v0.6.0...v1.1.1
(runtime-affecting: the per-slot dropout cache above, the 1.0.0 `CCM15ReturnCode`
return type — already in `dev` — and the 1.1.0 fan-off fix; the rest are
docs/chore/ci/test.)

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and a link to
      the changelog/release notes is added to the PR description.

[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
