### PR TITLE
Raise ServiceValidationError for CCM15 writes to an unavailable slot

### DIFF
--- a/homeassistant/components/ccm15/climate.py
+++ b/homeassistant/components/ccm15/climate.py
@@ -161,25 +161,23 @@ class CCM15Climate(CoordinatorEntity[CCM15Coordinator], ClimateEntity):
         """Set the target temperature."""
         if (temperature := kwargs.get(ATTR_TEMPERATURE)) is not None:
             await self.coordinator.async_set_temperature(
-                self._ac_index, self.data, temperature, kwargs.get(ATTR_HVAC_MODE)
+                self._ac_index, temperature, kwargs.get(ATTR_HVAC_MODE)
             )
 
     @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set the hvac mode."""
-        await self.coordinator.async_set_hvac_mode(self._ac_index, self.data, hvac_mode)
+        await self.coordinator.async_set_hvac_mode(self._ac_index, hvac_mode)
 
     @override
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set the fan mode."""
-        await self.coordinator.async_set_fan_mode(self._ac_index, self.data, fan_mode)
+        await self.coordinator.async_set_fan_mode(self._ac_index, fan_mode)
 
     @override
     async def async_set_swing_mode(self, swing_mode: str) -> None:
         """Set the swing mode."""
-        await self.coordinator.async_set_swing_mode(
-            self._ac_index, self.data, swing_mode
-        )
+        await self.coordinator.async_set_swing_mode(self._ac_index, swing_mode)
 
     @override
     async def async_turn_off(self) -> None:

--- a/homeassistant/components/ccm15/coordinator.py
+++ b/homeassistant/components/ccm15/coordinator.py
@@ -10,6 +10,7 @@ import httpx
 from homeassistant.components.climate import SWING_ON, HVACMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -18,6 +19,7 @@ from .const import (
     CONST_STATE_CMD_MAP,
     DEFAULT_INTERVAL,
     DEFAULT_TIMEOUT,
+    DOMAIN,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -70,38 +72,41 @@ class CCM15Coordinator(DataUpdateCoordinator[CCM15DeviceState]):
         # Slot indices can be sparse and reach >= 32, so look up by key.
         return self.data.devices.get(ac_index)
 
-    async def async_set_hvac_mode(
-        self, ac_index: int, data: CCM15SlaveDevice, hvac_mode: HVACMode
-    ) -> None:
+    def _require_ac_data(self, ac_index: int) -> CCM15SlaveDevice:
+        """Return the cached state for a slot, or raise if it is unavailable."""
+        if (data := self.get_ac_data(ac_index)) is None:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="device_unavailable",
+            )
+        return data
+
+    async def async_set_hvac_mode(self, ac_index: int, hvac_mode: HVACMode) -> None:
         """Set the HVAC mode."""
+        data = self._require_ac_data(ac_index)
         _LOGGER.debug("Set Hvac[%s]='%s'", ac_index, str(hvac_mode))
         data.ac_mode = CONST_STATE_CMD_MAP[hvac_mode]
         await self.async_set_state(ac_index, data)
 
-    async def async_set_fan_mode(
-        self, ac_index: int, data: CCM15SlaveDevice, fan_mode: str
-    ) -> None:
+    async def async_set_fan_mode(self, ac_index: int, fan_mode: str) -> None:
         """Set the fan mode."""
+        data = self._require_ac_data(ac_index)
         _LOGGER.debug("Set Fan[%s]='%s'", ac_index, fan_mode)
         data.fan_mode = CONST_FAN_CMD_MAP[fan_mode]
         await self.async_set_state(ac_index, data)
 
-    async def async_set_swing_mode(
-        self, ac_index: int, data: CCM15SlaveDevice, swing_mode: str
-    ) -> None:
+    async def async_set_swing_mode(self, ac_index: int, swing_mode: str) -> None:
         """Set the swing mode."""
+        data = self._require_ac_data(ac_index)
         _LOGGER.debug("Set Swing[%s]='%s'", ac_index, swing_mode)
         data.desired_swing = TriState.ON if swing_mode == SWING_ON else TriState.OFF
         await self.async_set_state(ac_index, data)
 
     async def async_set_temperature(
-        self,
-        ac_index: int,
-        data: CCM15SlaveDevice,
-        temp: int,
-        hvac_mode: HVACMode | None,
+        self, ac_index: int, temp: int, hvac_mode: HVACMode | None
     ) -> None:
         """Set the target temperature mode."""
+        data = self._require_ac_data(ac_index)
         _LOGGER.debug("Set Temp[%s]='%s'", ac_index, temp)
         data.temperature_setpoint = temp
         if hvac_mode is not None:

--- a/homeassistant/components/ccm15/strings.json
+++ b/homeassistant/components/ccm15/strings.json
@@ -19,5 +19,10 @@
         }
       }
     }
+  },
+  "exceptions": {
+    "device_unavailable": {
+      "message": "Cannot send the command because the AC unit is unavailable."
+    }
   }
 }

--- a/tests/components/ccm15/test_climate.py
+++ b/tests/components/ccm15/test_climate.py
@@ -34,6 +34,7 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
@@ -177,6 +178,24 @@ async def test_climate_fahrenheit_unit(hass: HomeAssistant) -> None:
     assert state is not None
     assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 75
     assert state.attributes[ATTR_TEMPERATURE] == 86
+
+
+@pytest.mark.usefixtures("ccm15_device")
+async def test_set_state_unavailable_slot_raises(hass: HomeAssistant) -> None:
+    """Writing to a slot with no current data raises instead of silently no-op."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="1.1.1.1",
+        data={CONF_HOST: "1.1.1.1", CONF_PORT: 80},
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Slot 99 is not reported by the controller, so it has no cached state.
+    with pytest.raises(ServiceValidationError):
+        await entry.runtime_data.async_set_hvac_mode(99, HVACMode.COOL)
 
 
 @pytest.mark.usefixtures("ccm15_device")


### PR DESCRIPTION
## Breaking change


## Proposed change

Harden the CCM15 climate write path against missing device data.

The four climate write helpers (`async_set_temperature` / `async_set_hvac_mode`
/ `async_set_fan_mode` / `async_set_swing_mode`) need the current device state
for the targeted slot. The coordinator exposes that state as
`CCM15SlaveDevice | None` — it becomes `None` once a slot drops out of a poll
(and the entity is unavailable). The entity passed `self.data` straight through
to the coordinator, so a write to an unavailable slot dereferenced `None`.

This resolves the target in the coordinator instead: a single
`_require_ac_data` helper looks the slot up and raises a translated
`ServiceValidationError` when it is missing, so the failure is surfaced to the
caller rather than crashing or being silently swallowed. The entity setters
become thin delegations and no longer hand the coordinator data it already owns.

**Why this lands first in a small CCM15 series.** This is a standalone
correctness fix, and it is deliberately the only non-draft PR of a short chain
that depends on it. It unblocks bumping `py_ccm15` to 1.1.1 (#175203, draft):
the 1.1.x line ships `py.typed` (PEP 561), which turns on `mypy --strict`
against the library and makes this non-`None` requirement enforced — so the
bump cannot pass CI until this fix lands.

That bump is the gate for several user-facing CCM15 improvements that can only
reach users once the pin moves:

- **Entities flapping to unavailable** — a partial `status.xml` dropout (the
  controller reporting most slots as `-` for a single poll) currently flaps
  every CCM15 entity to *unavailable* every few minutes. Fixed in the library
  and verified against real hardware.
- **Fan-setting bug** — the "active HVAC command with fan off" fix now lives in
  the library write path (the integration-side workaround #175177 was closed in
  favour of it).
- **Optional device password** — the config-flow password / reauth work
  (#173804, draft) relies on the library's password support from the same line.
- A separate silver quality-scale change (#174945, draft) also stacks behind it.

A test covers the new raise path.

`python3 -m script.hassfest` and the ccm15 test suite pass locally.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #175203, #174945, #173804
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
