### PR TITLE
Remove unused Silicon Labs Flasher add-on manager

### DIFF
--- a/homeassistant/components/homeassistant_hardware/const.py
+++ b/homeassistant/components/homeassistant_hardware/const.py
@@ -28,12 +28,7 @@ OTBR_ADDON_NAME = "OpenThread Border Router"
 OTBR_ADDON_MANAGER_DATA = "openthread_border_router"
 OTBR_ADDON_SLUG = "core_openthread_border_router"
 
-ZIGBEE_FLASHER_ADDON_NAME = "Silicon Labs Flasher"
-ZIGBEE_FLASHER_ADDON_MANAGER_DATA = "silabs_flasher"
-ZIGBEE_FLASHER_ADDON_SLUG = "core_silabs_flasher"
-
 SILABS_MULTIPROTOCOL_ADDON_SLUG = "core_silabs_multiprotocol"
-SILABS_FLASHER_ADDON_SLUG = "core_silabs_flasher"
 
 Z2M_EMBER_DOCS_URL = "https://www.zigbee2mqtt.io/guide/adapters/emberznet.html"
 

--- a/homeassistant/components/homeassistant_hardware/util.py
+++ b/homeassistant/components/homeassistant_hardware/util.py
@@ -36,9 +36,6 @@ from .const import (
     OTBR_ADDON_SLUG,
     Z2M_ADDON_NAME,
     Z2M_ADDON_SLUG_REGEX,
-    ZIGBEE_FLASHER_ADDON_MANAGER_DATA,
-    ZIGBEE_FLASHER_ADDON_NAME,
-    ZIGBEE_FLASHER_ADDON_SLUG,
 )
 from .helpers import async_firmware_update_context
 
@@ -125,18 +122,6 @@ def get_otbr_addon_manager(hass: HomeAssistant) -> WaitingAddonManager:
         _LOGGER,
         OTBR_ADDON_NAME,
         OTBR_ADDON_SLUG,
-    )
-
-
-@singleton(ZIGBEE_FLASHER_ADDON_MANAGER_DATA)
-@callback
-def get_zigbee_flasher_addon_manager(hass: HomeAssistant) -> WaitingAddonManager:
-    """Get the flasher add-on manager."""
-    return WaitingAddonManager(
-        hass,
-        _LOGGER,
-        ZIGBEE_FLASHER_ADDON_NAME,
-        ZIGBEE_FLASHER_ADDON_SLUG,
     )
 
 


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The core_silabs_flasher add-on is no longer used since firmware flashing moved into Core (using the universal_silabs_flasher library directly). Two separate flows retired it and left constants behind:

- The ZBT-1/Yellow firmware config flow stopped using get_zigbee_flasher_addon_manager() and the ZIGBEE_FLASHER_ADDON_* constants in #145019.
- The multiprotocol disable / multi-PAN-to-Zigbee migration flow stopped using SILABS_FLASHER_ADDON_SLUG in #168431.

Remove the now-unused get_zigbee_flasher_addon_manager() helper and the orphaned ZIGBEE_FLASHER_ADDON_* and SILABS_FLASHER_ADDON_SLUG constants.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
