### PR TITLE
Add restore to cover template entities

### DIFF
--- a/homeassistant/components/template/cover.py
+++ b/homeassistant/components/template/cover.py
@@ -171,12 +171,12 @@ class CoverExtraStoredData(ExtraStoredData):
 
     @override
     def as_dict(self) -> dict[str, Any]:
-        """Return a dict representation of the event data."""
+        """Return a dict representation of the cover data."""
         return asdict(self)
 
     @classmethod
-    def from_dict(cls, restored: dict[str, Any]) -> Self | None:
-        """Initialize a stored event state from a dict."""
+    def from_dict(cls, restored: dict[str, Any]) -> Self:
+        """Initialize a stored cover state from a dict."""
         return cls(
             current_cover_position=restored["current_cover_position"],
             current_cover_tilt_position=restored["current_cover_tilt_position"],
@@ -356,7 +356,7 @@ class AbstractTemplateCover(AbstractTemplateEntity, CoverEntity, RestoreEntity):
     @property
     @override
     def extra_restore_state_data(self) -> CoverExtraStoredData:
-        """Return weather specific state data to be restored."""
+        """Return cover specific state data to be restored."""
         return CoverExtraStoredData(
             current_cover_position=self._attr_current_cover_position,
             current_cover_tilt_position=self._attr_current_cover_tilt_position,

--- a/homeassistant/components/template/cover.py
+++ b/homeassistant/components/template/cover.py
@@ -1,6 +1,7 @@
 """Support for covers which integrate with other components."""
 
-from typing import TYPE_CHECKING, Any, override
+from dataclasses import asdict, dataclass
+from typing import TYPE_CHECKING, Any, Self, override
 
 import voluptuous as vol
 
@@ -22,6 +23,7 @@ from homeassistant.helpers.entity_platform import (
     AddConfigEntryEntitiesCallback,
     AddEntitiesCallback,
 )
+from homeassistant.helpers.restore_state import ExtraStoredData, RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import TriggerUpdateCoordinator, validators as template_validators
@@ -158,13 +160,40 @@ def async_create_preview_cover(
     )
 
 
-class AbstractTemplateCover(AbstractTemplateEntity, CoverEntity):
+@dataclass(kw_only=True)
+class CoverExtraStoredData(ExtraStoredData):
+    """Holds extra stored data for template cover entities."""
+
+    current_cover_position: int | None
+    current_cover_tilt_position: int | None
+    is_opening: bool | None
+    is_closing: bool | None
+
+    @override
+    def as_dict(self) -> dict[str, Any]:
+        """Return a dict representation of the event data."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, restored: dict[str, Any]) -> Self | None:
+        """Initialize a stored event state from a dict."""
+        return cls(
+            current_cover_position=restored["current_cover_position"],
+            current_cover_tilt_position=restored["current_cover_tilt_position"],
+            is_opening=restored["is_opening"],
+            is_closing=restored["is_closing"],
+        )
+
+
+class AbstractTemplateCover(AbstractTemplateEntity, CoverEntity, RestoreEntity):
     """Representation of a template cover features."""
 
     _entity_id_format = ENTITY_ID_FORMAT
     _optimistic_entity = True
     _extra_optimistic_options = (CONF_POSITION,)
     _state_option = CONF_STATE
+    _restore_state_extra_data = CoverExtraStoredData
+    _restore_state_properties = ("_attr_current_cover_position",)
 
     # The super init is not called because TemplateEntity
     # and TriggerEntity will call
@@ -323,6 +352,25 @@ class AbstractTemplateCover(AbstractTemplateEntity, CoverEntity):
         )
         if self._tilt_optimistic:
             self.async_write_ha_state()
+
+    @property
+    @override
+    def extra_restore_state_data(self) -> CoverExtraStoredData:
+        """Return weather specific state data to be restored."""
+        return CoverExtraStoredData(
+            current_cover_position=self._attr_current_cover_position,
+            current_cover_tilt_position=self._attr_current_cover_tilt_position,
+            is_opening=self._attr_is_opening,
+            is_closing=self._attr_is_closing,
+        )
+
+    @override
+    def restore_extra_data(self, extra_data: CoverExtraStoredData) -> None:
+        """Restore the extra data."""
+        self._attr_current_cover_position = extra_data.current_cover_position
+        self._attr_current_cover_tilt_position = extra_data.current_cover_tilt_position
+        self._attr_is_opening = extra_data.is_opening
+        self._attr_is_closing = extra_data.is_closing
 
 
 class StateCoverEntity(TemplateEntity, AbstractTemplateCover):

--- a/tests/components/template/test_cover.py
+++ b/tests/components/template/test_cover.py
@@ -35,6 +35,7 @@ from .conftest import (
     ConfigurationStyle,
     TemplatePlatformSetup,
     assert_action,
+    assert_state_and_attributes,
     async_get_flow_preview_state,
     async_trigger,
     make_test_action,
@@ -42,6 +43,8 @@ from .conftest import (
     setup_and_test_nested_unique_id,
     setup_and_test_unique_id,
     setup_entity,
+    setup_mock_template_entity_restore_state,
+    setup_restore_template_entity,
 )
 
 from tests.common import MockConfigEntry
@@ -49,6 +52,7 @@ from tests.typing import WebSocketGenerator
 
 TEST_STATE_ENTITY_ID = "sensor.test_state"
 TEST_POSITION_ENTITY_ID = "sensor.test_position"
+TEST_TILT_POSITION_ENTITY_ID = "sensor.test_tilt_position"
 TEST_AVAILABILITY_ENTITY = "binary_sensor.availability"
 
 TEST_COVER = TemplatePlatformSetup(
@@ -57,6 +61,7 @@ TEST_COVER = TemplatePlatformSetup(
     make_test_trigger(
         TEST_STATE_ENTITY_ID,
         TEST_POSITION_ENTITY_ID,
+        TEST_TILT_POSITION_ENTITY_ID,
         TEST_AVAILABILITY_ENTITY,
     ),
 )
@@ -1102,3 +1107,167 @@ async def test_flow_preview(
     )
 
     assert state["state"] == CoverState.OPEN
+
+
+@pytest.mark.parametrize(
+    "style", [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER]
+)
+@pytest.mark.parametrize(
+    "config",
+    [
+        {
+            "position": "{{ states('sensor.test_position') | float(None) }}",
+            "set_cover_position": [],
+            "tilt": "{{ states('sensor.test_tilt_position') | float(None) }}",
+            "set_cover_tilt_position": [],
+        },
+    ],
+)
+@pytest.mark.parametrize(
+    (
+        "saved_state",
+        "saved_extra_data",
+        "initial_state",
+        "initial_attributes",
+        "final_state",
+    ),
+    [
+        (
+            CoverState.OPEN,
+            {
+                "current_cover_position": 10,
+                "current_cover_tilt_position": 10,
+                "is_opening": False,
+                "is_closing": False,
+            },
+            CoverState.OPEN,
+            {
+                "current_position": 10,
+                "current_tilt_position": 10,
+            },
+            CoverState.OPEN,
+        ),
+        (
+            CoverState.OPEN,
+            {
+                "current_cover_position": 10,
+                "current_cover_tilt_position": 10,
+                "is_opening": True,
+                "is_closing": False,
+            },
+            CoverState.OPENING,
+            {
+                "current_position": 10,
+                "current_tilt_position": 10,
+            },
+            CoverState.OPENING,
+        ),
+        (
+            CoverState.OPEN,
+            {
+                "current_cover_position": 10,
+                "current_cover_tilt_position": 10,
+                "is_opening": False,
+                "is_closing": True,
+            },
+            CoverState.CLOSING,
+            {
+                "current_position": 10,
+                "current_tilt_position": 10,
+            },
+            CoverState.CLOSING,
+        ),
+        (
+            CoverState.OPEN,
+            {
+                "current_cover_position": 0,
+                "current_cover_tilt_position": 10,
+                "is_opening": False,
+                "is_closing": False,
+            },
+            CoverState.CLOSED,
+            {
+                "current_position": 0,
+                "current_tilt_position": 10,
+            },
+            CoverState.OPEN,
+        ),
+        (
+            STATE_UNAVAILABLE,
+            {
+                "current_cover_position": 0,
+                "current_cover_tilt_position": 10,
+                "is_opening": False,
+                "is_closing": False,
+            },
+            STATE_UNKNOWN,
+            {
+                "current_position": None,
+                "current_tilt_position": None,
+            },
+            CoverState.OPEN,
+        ),
+        (
+            STATE_UNKNOWN,
+            {
+                "current_cover_position": 0,
+                "current_cover_tilt_position": 10,
+                "is_opening": False,
+                "is_closing": False,
+            },
+            STATE_UNKNOWN,
+            {
+                "current_position": None,
+                "current_tilt_position": None,
+            },
+            CoverState.OPEN,
+        ),
+    ],
+)
+async def test_restore_state(
+    hass: HomeAssistant,
+    config: ConfigType,
+    style: ConfigurationStyle,
+    saved_state: CoverState | str,
+    saved_extra_data: dict | None,
+    initial_state: CoverState | str,
+    initial_attributes: ConfigType,
+    final_state: CoverState | str,
+) -> None:
+    """Test restoring trigger template weather."""
+
+    restored_attributes = {  # These should be ignored
+        "current_position": 5,
+        "current_tilt_position": 5,
+    }
+
+    setup_mock_template_entity_restore_state(
+        hass,
+        TEST_COVER,
+        saved_state,
+        saved_extra_data=saved_extra_data,
+        saved_attributes=restored_attributes,
+    )
+
+    await setup_restore_template_entity(
+        hass,
+        TEST_COVER,
+        style,
+        config,
+        "states('sensor.test_position') | float(0) > 50",
+    )
+
+    state = assert_state_and_attributes(
+        hass,
+        TEST_COVER,
+        initial_state,
+        initial_attributes,
+    )
+
+    await async_trigger(hass, "sensor.test_position", "75")
+    await async_trigger(hass, "sensor.test_tilt_position", "75")
+
+    state = hass.states.get(TEST_COVER.entity_id)
+    assert state.state == final_state
+    assert state.attributes["current_position"] == 75
+    assert state.attributes["current_tilt_position"] == 75


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add restore state to cover template entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
