### PR TITLE
Add did not trigger trace when behavior first and all are not met

### DIFF
--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -641,6 +641,9 @@ class EntityTriggerBase(Trigger):
                     target_state_change_data.targeted_entity_states,
                 )
                 if matches != included:
+                    report_not_triggered(
+                        "not_all_targets_matched", matches=matches, included=included
+                    )
                     return
             elif behavior == BEHAVIOR_FIRST:
                 # Note: It's enough to test for exactly 1 match here because if there
@@ -651,6 +654,9 @@ class EntityTriggerBase(Trigger):
                     target_state_change_data.targeted_entity_states,
                 )
                 if matches != 1:
+                    report_not_triggered(
+                        "behavior_first_not_satisfied", matches=matches
+                    )
                     return
 
             @callback

--- a/tests/helpers/test_trigger.py
+++ b/tests/helpers/test_trigger.py
@@ -4277,6 +4277,122 @@ async def _arm_off_to_on_trigger(
     )
 
 
+async def _arm_off_to_on_trigger_with_diagnostics(
+    hass: HomeAssistant,
+    entity_ids: list[str],
+    behavior: str,
+    calls: list[dict[str, Any]],
+    did_not_trigger_reports: list[NotTriggeredInfo],
+) -> CALLBACK_TYPE:
+    """Set up _OffToOnTrigger with both an action and a did_not_trigger reporter."""
+
+    async def async_get_triggers(
+        hass: HomeAssistant,
+    ) -> dict[str, type[Trigger]]:
+        return {"off_to_on": _OffToOnTrigger}
+
+    mock_integration(hass, MockModule("test"))
+    mock_platform(hass, "test.trigger", Mock(async_get_triggers=async_get_triggers))
+
+    trigger_config = {
+        CONF_PLATFORM: "test.off_to_on",
+        CONF_TARGET: {CONF_ENTITY_ID: entity_ids},
+        CONF_OPTIONS: {ATTR_BEHAVIOR: behavior},
+    }
+    log = logging.getLogger(__name__)
+
+    @callback
+    def action(run_variables: dict[str, Any], context: Context | None = None) -> None:
+        calls.append(run_variables["trigger"])
+
+    @callback
+    def did_not_trigger(
+        run_variables: dict[str, Any],
+        info: NotTriggeredInfo,
+        context: Context | None = None,
+    ) -> None:
+        did_not_trigger_reports.append(info)
+
+    validated_config = await async_validate_trigger_config(hass, [trigger_config])
+    return await async_initialize_triggers(
+        hass,
+        validated_config,
+        action,
+        domain="test",
+        name="test_off_to_on",
+        log_cb=log.log,
+        did_not_trigger=did_not_trigger,
+    )
+
+
+async def test_entity_trigger_reports_did_not_trigger_behavior_all(
+    hass: HomeAssistant,
+) -> None:
+    """Behavior 'all' reports when not every targeted entity matches."""
+    entity_1 = "test.entity_1"
+    entity_2 = "test.entity_2"
+    hass.states.async_set(entity_1, STATE_OFF)
+    hass.states.async_set(entity_2, STATE_OFF)
+    await hass.async_block_till_done()
+
+    calls: list[dict[str, Any]] = []
+    did_not_trigger_reports: list[NotTriggeredInfo] = []
+    unsub = await _arm_off_to_on_trigger_with_diagnostics(
+        hass, [entity_1, entity_2], BEHAVIOR_ALL, calls, did_not_trigger_reports
+    )
+
+    # Only one of the two targets is on, so the trigger does not fire.
+    hass.states.async_set(entity_1, STATE_ON)
+    await hass.async_block_till_done()
+    assert calls == []
+    assert _reported_reasons(did_not_trigger_reports) == [
+        ("not_all_targets_matched", {"matches": 1, "included": 2})
+    ]
+    did_not_trigger_reports.clear()
+
+    # Now both targets are on, so the trigger fires and reports nothing further.
+    hass.states.async_set(entity_2, STATE_ON)
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert did_not_trigger_reports == []
+
+    unsub()
+
+
+async def test_entity_trigger_reports_did_not_trigger_behavior_first(
+    hass: HomeAssistant,
+) -> None:
+    """Behavior 'first' reports when the number of matches isn't exactly one."""
+    entity_1 = "test.entity_1"
+    entity_2 = "test.entity_2"
+    hass.states.async_set(entity_1, STATE_OFF)
+    hass.states.async_set(entity_2, STATE_OFF)
+    await hass.async_block_till_done()
+
+    calls: list[dict[str, Any]] = []
+    did_not_trigger_reports: list[NotTriggeredInfo] = []
+    unsub = await _arm_off_to_on_trigger_with_diagnostics(
+        hass, [entity_1, entity_2], BEHAVIOR_FIRST, calls, did_not_trigger_reports
+    )
+
+    # The first target turns on: exactly one match, so the trigger fires.
+    hass.states.async_set(entity_1, STATE_ON)
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert did_not_trigger_reports == []
+    calls.clear()
+
+    # The second target turns on while the first is still on: two matches, no fire.
+    hass.states.async_set(entity_2, STATE_ON)
+    await hass.async_block_till_done()
+    assert calls == []
+    assert _reported_reasons(did_not_trigger_reports) == [
+        ("behavior_first_not_satisfied", {"matches": 2})
+    ]
+
+    unsub()
+
+
 @pytest.mark.usefixtures("mock_integration_frame")
 async def test_async_initialize_triggers_home_assistant_start_deprecated(
     hass: HomeAssistant,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Report when first and all behavior of triggers are not met

This implements parts of https://github.com/home-assistant/core/issues/166928:

From the linked document:
https://docs.google.com/document/d/1kULQfi-lV9iD42837rwzZn4Ehha1fkQnq_HNk_Neu9g/edit?tab=t.0#heading=h.oikhylpvr5no
- Item 5 With "all" behavior, some of the targeted entities matched but not every one did
- Item 6 With "first" behavior, the number of matching entities wasn't exactly one (none matched, or several already matched).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
