### PR TITLE
Add activity timestamp sensors to GitHub integration

### DIFF
--- a/homeassistant/components/github/coordinator.py
+++ b/homeassistant/components/github/coordinator.py
@@ -33,6 +33,7 @@ query ($owner: String!, $repository: String!) {
           message: messageHeadline
           url
           sha: oid
+          committed: committedDate
         }
       }
     }
@@ -52,6 +53,8 @@ query ($owner: String!, $repository: String!) {
         title
         url
         number
+        created: createdAt
+        updated: updatedAt
       }
     }
     issue: issues(
@@ -64,6 +67,8 @@ query ($owner: String!, $repository: String!) {
         title
         url
         number
+        created: createdAt
+        updated: updatedAt
       }
     }
     pull_request: pullRequests(
@@ -76,6 +81,8 @@ query ($owner: String!, $repository: String!) {
         title
         url
         number
+        created: createdAt
+        updated: updatedAt
       }
     }
     merged_pull_request: pullRequests(
@@ -88,6 +95,7 @@ query ($owner: String!, $repository: String!) {
       name
       url
       tag: tagName
+      published: publishedAt
     }
     refs(
       first: 1
@@ -98,6 +106,11 @@ query ($owner: String!, $repository: String!) {
         name
         target {
           url: commitUrl
+          # committedDate lives on Commit; an annotated tag's target is a
+          # Tag object, so this resolves to null for those.
+          ... on Commit {
+            committed: committedDate
+          }
         }
       }
     }

--- a/homeassistant/components/github/icons.json
+++ b/homeassistant/components/github/icons.json
@@ -19,7 +19,7 @@
       "latest_commit": {
         "default": "mdi:source-commit"
       },
-      "latest_commit_committed": {
+      "latest_commit_date": {
         "default": "mdi:calendar-clock"
       },
       "latest_discussion": {
@@ -52,13 +52,13 @@
       "latest_release": {
         "default": "mdi:github"
       },
-      "latest_release_published": {
+      "latest_release_date": {
         "default": "mdi:calendar-clock"
       },
       "latest_tag": {
         "default": "mdi:tag"
       },
-      "latest_tag_committed": {
+      "latest_tag_date": {
         "default": "mdi:calendar-clock"
       },
       "merged_pulls_count": {

--- a/homeassistant/components/github/icons.json
+++ b/homeassistant/components/github/icons.json
@@ -19,20 +19,47 @@
       "latest_commit": {
         "default": "mdi:source-commit"
       },
+      "latest_commit_committed": {
+        "default": "mdi:calendar-clock"
+      },
       "latest_discussion": {
         "default": "mdi:forum"
+      },
+      "latest_discussion_created": {
+        "default": "mdi:calendar-clock"
+      },
+      "latest_discussion_updated": {
+        "default": "mdi:calendar-clock"
       },
       "latest_issue": {
         "default": "mdi:github"
       },
+      "latest_issue_created": {
+        "default": "mdi:calendar-clock"
+      },
+      "latest_issue_updated": {
+        "default": "mdi:calendar-clock"
+      },
       "latest_pull_request": {
         "default": "mdi:source-pull"
+      },
+      "latest_pull_request_created": {
+        "default": "mdi:calendar-clock"
+      },
+      "latest_pull_request_updated": {
+        "default": "mdi:calendar-clock"
       },
       "latest_release": {
         "default": "mdi:github"
       },
+      "latest_release_published": {
+        "default": "mdi:calendar-clock"
+      },
       "latest_tag": {
         "default": "mdi:tag"
+      },
+      "latest_tag_committed": {
+        "default": "mdi:calendar-clock"
       },
       "merged_pulls_count": {
         "default": "mdi:source-merge"

--- a/homeassistant/components/github/sensor.py
+++ b/homeassistant/components/github/sensor.py
@@ -29,15 +29,6 @@ from .coordinator import (
 )
 
 
-def _as_datetime(value: str | None) -> datetime | None:
-    """Parse a GitHub ISO-8601 timestamp, tolerating missing values.
-
-    The latest_tag target only carries a date for lightweight tags; an
-    annotated tag's target is a Tag object, so the field is absent there.
-    """
-    return dt_util.parse_datetime(value) if value else None
-
-
 @dataclass(frozen=True, kw_only=True)
 class GitHubSensorEntityDescription(SensorEntityDescription):
     """Describes GitHub issue sensor entity."""
@@ -46,22 +37,6 @@ class GitHubSensorEntityDescription(SensorEntityDescription):
 
     attr_fn: Callable[[dict[str, Any]], Mapping[str, Any] | None] = lambda data: None
     avabl_fn: Callable[[dict[str, Any]], bool] = lambda data: True
-
-
-def _timestamp_description(
-    key: str,
-    value_fn: Callable[[dict[str, Any]], StateType | datetime],
-    avabl_fn: Callable[[dict[str, Any]], bool] = lambda data: True,
-) -> GitHubSensorEntityDescription:
-    """Build a default-disabled timestamp sensor for a latest_* item."""
-    return GitHubSensorEntityDescription(
-        key=key,
-        translation_key=key,
-        device_class=SensorDeviceClass.TIMESTAMP,
-        entity_registry_enabled_default=False,
-        avabl_fn=avabl_fn,
-        value_fn=value_fn,
-    )
 
 
 SENSOR_DESCRIPTIONS: tuple[GitHubSensorEntityDescription, ...] = (
@@ -172,50 +147,94 @@ SENSOR_DESCRIPTIONS: tuple[GitHubSensorEntityDescription, ...] = (
             "url": data["refs"]["tags"][0]["target"]["url"],
         },
     ),
-    _timestamp_description(
-        "latest_commit_committed",
-        lambda data: _as_datetime(data["default_branch_ref"]["commit"]["committed"]),
+    GitHubSensorEntityDescription(
+        key="latest_commit_date",
+        translation_key="latest_commit_date",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        entity_registry_enabled_default=False,
+        value_fn=lambda data: dt_util.parse_datetime(
+            data["default_branch_ref"]["commit"]["committed"]
+        ),
     ),
-    _timestamp_description(
-        "latest_discussion_created",
-        lambda data: _as_datetime(data["discussion"]["discussions"][0]["created"]),
+    GitHubSensorEntityDescription(
+        key="latest_discussion_created",
+        translation_key="latest_discussion_created",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        entity_registry_enabled_default=False,
         avabl_fn=lambda data: data["discussion"]["discussions"],
+        value_fn=lambda data: dt_util.parse_datetime(
+            data["discussion"]["discussions"][0]["created"]
+        ),
     ),
-    _timestamp_description(
-        "latest_discussion_updated",
-        lambda data: _as_datetime(data["discussion"]["discussions"][0]["updated"]),
+    GitHubSensorEntityDescription(
+        key="latest_discussion_updated",
+        translation_key="latest_discussion_updated",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        entity_registry_enabled_default=False,
         avabl_fn=lambda data: data["discussion"]["discussions"],
+        value_fn=lambda data: dt_util.parse_datetime(
+            data["discussion"]["discussions"][0]["updated"]
+        ),
     ),
-    _timestamp_description(
-        "latest_issue_created",
-        lambda data: _as_datetime(data["issue"]["issues"][0]["created"]),
+    GitHubSensorEntityDescription(
+        key="latest_issue_created",
+        translation_key="latest_issue_created",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        entity_registry_enabled_default=False,
         avabl_fn=lambda data: data["issue"]["issues"],
+        value_fn=lambda data: dt_util.parse_datetime(
+            data["issue"]["issues"][0]["created"]
+        ),
     ),
-    _timestamp_description(
-        "latest_issue_updated",
-        lambda data: _as_datetime(data["issue"]["issues"][0]["updated"]),
+    GitHubSensorEntityDescription(
+        key="latest_issue_updated",
+        translation_key="latest_issue_updated",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        entity_registry_enabled_default=False,
         avabl_fn=lambda data: data["issue"]["issues"],
+        value_fn=lambda data: dt_util.parse_datetime(
+            data["issue"]["issues"][0]["updated"]
+        ),
     ),
-    _timestamp_description(
-        "latest_pull_request_created",
-        lambda data: _as_datetime(data["pull_request"]["pull_requests"][0]["created"]),
+    GitHubSensorEntityDescription(
+        key="latest_pull_request_created",
+        translation_key="latest_pull_request_created",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        entity_registry_enabled_default=False,
         avabl_fn=lambda data: data["pull_request"]["pull_requests"],
+        value_fn=lambda data: dt_util.parse_datetime(
+            data["pull_request"]["pull_requests"][0]["created"]
+        ),
     ),
-    _timestamp_description(
-        "latest_pull_request_updated",
-        lambda data: _as_datetime(data["pull_request"]["pull_requests"][0]["updated"]),
+    GitHubSensorEntityDescription(
+        key="latest_pull_request_updated",
+        translation_key="latest_pull_request_updated",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        entity_registry_enabled_default=False,
         avabl_fn=lambda data: data["pull_request"]["pull_requests"],
+        value_fn=lambda data: dt_util.parse_datetime(
+            data["pull_request"]["pull_requests"][0]["updated"]
+        ),
     ),
-    _timestamp_description(
-        "latest_release_published",
-        lambda data: _as_datetime(data["release"]["published"]),
+    GitHubSensorEntityDescription(
+        key="latest_release_date",
+        translation_key="latest_release_date",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        entity_registry_enabled_default=False,
         avabl_fn=lambda data: data["release"] is not None,
+        value_fn=lambda data: dt_util.parse_datetime(data["release"]["published"]),
     ),
-    _timestamp_description(
-        "latest_tag_committed",
-        # Null for annotated tags (target is a Tag, not a Commit).
-        lambda data: _as_datetime(data["refs"]["tags"][0]["target"].get("committed")),
+    GitHubSensorEntityDescription(
+        key="latest_tag_date",
+        translation_key="latest_tag_date",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        entity_registry_enabled_default=False,
         avabl_fn=lambda data: data["refs"]["tags"],
+        # Annotated tags have a Tag target instead of a Commit, so `committed`
+        # is absent and the sensor reports as unknown.
+        value_fn=lambda data: dt_util.parse_datetime(
+            data["refs"]["tags"][0]["target"].get("committed") or ""
+        ),
     ),
 )
 

--- a/homeassistant/components/github/sensor.py
+++ b/homeassistant/components/github/sensor.py
@@ -2,11 +2,13 @@
 
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any, override
 
 from aiogithubapi import GitHubAuthenticatedUserModel
 
 from homeassistant.components.sensor import (
+    SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
     SensorStateClass,
@@ -17,6 +19,7 @@ from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
 from .coordinator import (
@@ -26,14 +29,44 @@ from .coordinator import (
 )
 
 
+def _as_datetime(value: str | None) -> datetime | None:
+    """Parse a GitHub ISO-8601 timestamp, tolerating missing values.
+
+    The latest_tag target only carries a date for lightweight tags; an
+    annotated tag's target is a Tag object, so the field is absent there.
+    """
+    return dt_util.parse_datetime(value) if value else None
+
+
 @dataclass(frozen=True, kw_only=True)
 class GitHubSensorEntityDescription(SensorEntityDescription):
     """Describes GitHub issue sensor entity."""
 
-    value_fn: Callable[[dict[str, Any]], StateType]
+    value_fn: Callable[[dict[str, Any]], StateType | datetime]
 
     attr_fn: Callable[[dict[str, Any]], Mapping[str, Any] | None] = lambda data: None
     avabl_fn: Callable[[dict[str, Any]], bool] = lambda data: True
+
+
+def _timestamp_description(
+    key: str,
+    value_fn: Callable[[dict[str, Any]], StateType | datetime],
+    avabl_fn: Callable[[dict[str, Any]], bool] = lambda data: True,
+) -> GitHubSensorEntityDescription:
+    """Build a default-disabled timestamp sensor for a latest_* item.
+
+    These are opt-in: most users won't graph them, and every enabled entity
+    adds recorder/state-machine load, so they follow the entity-disabled-by-
+    default guidance.
+    """
+    return GitHubSensorEntityDescription(
+        key=key,
+        translation_key=key,
+        device_class=SensorDeviceClass.TIMESTAMP,
+        entity_registry_enabled_default=False,
+        avabl_fn=avabl_fn,
+        value_fn=value_fn,
+    )
 
 
 SENSOR_DESCRIPTIONS: tuple[GitHubSensorEntityDescription, ...] = (
@@ -144,6 +177,51 @@ SENSOR_DESCRIPTIONS: tuple[GitHubSensorEntityDescription, ...] = (
             "url": data["refs"]["tags"][0]["target"]["url"],
         },
     ),
+    _timestamp_description(
+        "latest_commit_committed",
+        lambda data: _as_datetime(data["default_branch_ref"]["commit"]["committed"]),
+    ),
+    _timestamp_description(
+        "latest_discussion_created",
+        lambda data: _as_datetime(data["discussion"]["discussions"][0]["created"]),
+        avabl_fn=lambda data: data["discussion"]["discussions"],
+    ),
+    _timestamp_description(
+        "latest_discussion_updated",
+        lambda data: _as_datetime(data["discussion"]["discussions"][0]["updated"]),
+        avabl_fn=lambda data: data["discussion"]["discussions"],
+    ),
+    _timestamp_description(
+        "latest_issue_created",
+        lambda data: _as_datetime(data["issue"]["issues"][0]["created"]),
+        avabl_fn=lambda data: data["issue"]["issues"],
+    ),
+    _timestamp_description(
+        "latest_issue_updated",
+        lambda data: _as_datetime(data["issue"]["issues"][0]["updated"]),
+        avabl_fn=lambda data: data["issue"]["issues"],
+    ),
+    _timestamp_description(
+        "latest_pull_request_created",
+        lambda data: _as_datetime(data["pull_request"]["pull_requests"][0]["created"]),
+        avabl_fn=lambda data: data["pull_request"]["pull_requests"],
+    ),
+    _timestamp_description(
+        "latest_pull_request_updated",
+        lambda data: _as_datetime(data["pull_request"]["pull_requests"][0]["updated"]),
+        avabl_fn=lambda data: data["pull_request"]["pull_requests"],
+    ),
+    _timestamp_description(
+        "latest_release_published",
+        lambda data: _as_datetime(data["release"]["published"]),
+        avabl_fn=lambda data: data["release"] is not None,
+    ),
+    _timestamp_description(
+        "latest_tag_committed",
+        # Null for annotated tags (target is a Tag, not a Commit).
+        lambda data: _as_datetime(data["refs"]["tags"][0]["target"].get("committed")),
+        avabl_fn=lambda data: data["refs"]["tags"],
+    ),
 )
 
 
@@ -247,7 +325,7 @@ class GitHubSensorEntity(CoordinatorEntity[GitHubDataUpdateCoordinator], SensorE
 
     @property
     @override
-    def native_value(self) -> StateType:
+    def native_value(self) -> StateType | datetime:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.coordinator.data)
 

--- a/homeassistant/components/github/sensor.py
+++ b/homeassistant/components/github/sensor.py
@@ -221,7 +221,8 @@ SENSOR_DESCRIPTIONS: tuple[GitHubSensorEntityDescription, ...] = (
         translation_key="latest_release_date",
         device_class=SensorDeviceClass.TIMESTAMP,
         entity_registry_enabled_default=False,
-        avabl_fn=lambda data: data["release"] is not None,
+        avabl_fn=lambda data: data["release"] is not None
+        and data["release"]["published"] is not None,
         value_fn=lambda data: dt_util.parse_datetime(data["release"]["published"]),
     ),
     GitHubSensorEntityDescription(

--- a/homeassistant/components/github/sensor.py
+++ b/homeassistant/components/github/sensor.py
@@ -53,12 +53,7 @@ def _timestamp_description(
     value_fn: Callable[[dict[str, Any]], StateType | datetime],
     avabl_fn: Callable[[dict[str, Any]], bool] = lambda data: True,
 ) -> GitHubSensorEntityDescription:
-    """Build a default-disabled timestamp sensor for a latest_* item.
-
-    These are opt-in: most users won't graph them, and every enabled entity
-    adds recorder/state-machine load, so they follow the entity-disabled-by-
-    default guidance.
-    """
+    """Build a default-disabled timestamp sensor for a latest_* item."""
     return GitHubSensorEntityDescription(
         key=key,
         translation_key=key,

--- a/homeassistant/components/github/strings.json
+++ b/homeassistant/components/github/strings.json
@@ -55,20 +55,47 @@
       "latest_commit": {
         "name": "Latest commit"
       },
+      "latest_commit_committed": {
+        "name": "Latest commit committed"
+      },
       "latest_discussion": {
         "name": "Latest discussion"
+      },
+      "latest_discussion_created": {
+        "name": "Latest discussion created"
+      },
+      "latest_discussion_updated": {
+        "name": "Latest discussion updated"
       },
       "latest_issue": {
         "name": "Latest issue"
       },
+      "latest_issue_created": {
+        "name": "Latest issue created"
+      },
+      "latest_issue_updated": {
+        "name": "Latest issue updated"
+      },
       "latest_pull_request": {
         "name": "Latest pull request"
+      },
+      "latest_pull_request_created": {
+        "name": "Latest pull request created"
+      },
+      "latest_pull_request_updated": {
+        "name": "Latest pull request updated"
       },
       "latest_release": {
         "name": "Latest release"
       },
+      "latest_release_published": {
+        "name": "Latest release published"
+      },
       "latest_tag": {
         "name": "Latest tag"
+      },
+      "latest_tag_committed": {
+        "name": "Latest tag committed"
       },
       "merged_pulls_count": {
         "name": "Merged pull requests",

--- a/homeassistant/components/github/strings.json
+++ b/homeassistant/components/github/strings.json
@@ -55,8 +55,8 @@
       "latest_commit": {
         "name": "Latest commit"
       },
-      "latest_commit_committed": {
-        "name": "Latest commit committed"
+      "latest_commit_date": {
+        "name": "Latest commit date"
       },
       "latest_discussion": {
         "name": "Latest discussion"
@@ -88,14 +88,14 @@
       "latest_release": {
         "name": "Latest release"
       },
-      "latest_release_published": {
-        "name": "Latest release published"
+      "latest_release_date": {
+        "name": "Latest release date"
       },
       "latest_tag": {
         "name": "Latest tag"
       },
-      "latest_tag_committed": {
-        "name": "Latest tag committed"
+      "latest_tag_date": {
+        "name": "Latest tag date"
       },
       "merged_pulls_count": {
         "name": "Merged pull requests",

--- a/tests/components/github/fixtures/graphql.json
+++ b/tests/components/github/fixtures/graphql.json
@@ -9,7 +9,8 @@
         "commit": {
           "message": "Fix all the bugs",
           "url": "https://github.com/octocat/Hello-World/commit/6dcb09b5b57875f334f61aebed695e2e4193db5e",
-          "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e"
+          "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+          "committed": "2024-01-02T00:00:00Z"
         }
       },
       "stargazers_count": 9,
@@ -25,7 +26,9 @@
           {
             "title": "First discussion",
             "url": "https://github.com/octocat/Hello-World/discussions/1347",
-            "number": 1347
+            "number": 1347,
+            "created": "2024-01-01T00:00:00Z",
+            "updated": "2024-01-02T00:00:00Z"
           }
         ]
       },
@@ -35,7 +38,9 @@
           {
             "title": "Found a bug",
             "url": "https://github.com/octocat/Hello-World/issues/1347",
-            "number": 1347
+            "number": 1347,
+            "created": "2024-01-01T00:00:00Z",
+            "updated": "2024-01-02T00:00:00Z"
           }
         ]
       },
@@ -45,7 +50,9 @@
           {
             "title": "Amazing new feature",
             "url": "https://github.com/octocat/Hello-World/pull/1347",
-            "number": 1347
+            "number": 1347,
+            "created": "2024-01-01T00:00:00Z",
+            "updated": "2024-01-02T00:00:00Z"
           }
         ]
       },
@@ -55,14 +62,16 @@
       "release": {
         "name": "v1.0.0",
         "url": "https://github.com/octocat/Hello-World/releases/v1.0.0",
-        "tag": "v1.0.0"
+        "tag": "v1.0.0",
+        "published": "2024-01-02T00:00:00Z"
       },
       "refs": {
         "tags": [
           {
             "name": "v1.0.0",
             "target": {
-              "url": "https://github.com/octocat/Hello-World/commit/6dcb09b5b57875f334f61aebed695e2e4193db5e"
+              "url": "https://github.com/octocat/Hello-World/commit/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+              "committed": "2024-01-02T00:00:00Z"
             }
           }
         ]

--- a/tests/components/github/snapshots/test_diagnostics.ambr
+++ b/tests/components/github/snapshots/test_diagnostics.ambr
@@ -13,6 +13,7 @@
       'octocat/Hello-World': dict({
         'default_branch_ref': dict({
           'commit': dict({
+            'committed': '2024-01-02T00:00:00Z',
             'message': 'Fix all the bugs',
             'sha': '6dcb09b5b57875f334f61aebed695e2e4193db5e',
             'url': 'https://github.com/octocat/Hello-World/commit/6dcb09b5b57875f334f61aebed695e2e4193db5e',
@@ -21,8 +22,10 @@
         'discussion': dict({
           'discussions': list([
             dict({
+              'created': '2024-01-01T00:00:00Z',
               'number': 1347,
               'title': 'First discussion',
+              'updated': '2024-01-02T00:00:00Z',
               'url': 'https://github.com/octocat/Hello-World/discussions/1347',
             }),
           ]),
@@ -34,8 +37,10 @@
         'issue': dict({
           'issues': list([
             dict({
+              'created': '2024-01-01T00:00:00Z',
               'number': 1347,
               'title': 'Found a bug',
+              'updated': '2024-01-02T00:00:00Z',
               'url': 'https://github.com/octocat/Hello-World/issues/1347',
             }),
           ]),
@@ -47,8 +52,10 @@
         'pull_request': dict({
           'pull_requests': list([
             dict({
+              'created': '2024-01-01T00:00:00Z',
               'number': 1347,
               'title': 'Amazing new feature',
+              'updated': '2024-01-02T00:00:00Z',
               'url': 'https://github.com/octocat/Hello-World/pull/1347',
             }),
           ]),
@@ -59,6 +66,7 @@
             dict({
               'name': 'v1.0.0',
               'target': dict({
+                'committed': '2024-01-02T00:00:00Z',
                 'url': 'https://github.com/octocat/Hello-World/commit/6dcb09b5b57875f334f61aebed695e2e4193db5e',
               }),
             }),
@@ -66,6 +74,7 @@
         }),
         'release': dict({
           'name': 'v1.0.0',
+          'published': '2024-01-02T00:00:00Z',
           'tag': 'v1.0.0',
           'url': 'https://github.com/octocat/Hello-World/releases/v1.0.0',
         }),

--- a/tests/components/github/snapshots/test_sensor.ambr
+++ b/tests/components/github/snapshots/test_sensor.ambr
@@ -325,7 +325,7 @@
     'state': 'Fix all the bugs',
   })
 # ---
-# name: test_all_entities[sensor.octocat_hello_world_latest_commit_committed-entry]
+# name: test_all_entities[sensor.octocat_hello_world_latest_commit_date-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -339,7 +339,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.octocat_hello_world_latest_commit_committed',
+    'entity_id': 'sensor.octocat_hello_world_latest_commit_date',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -347,30 +347,30 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Latest commit committed',
+    'object_id_base': 'Latest commit date',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
     'original_icon': None,
-    'original_name': 'Latest commit committed',
+    'original_name': 'Latest commit date',
     'platform': 'github',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'latest_commit_committed',
-    'unique_id': '1296269_latest_commit_committed',
+    'translation_key': 'latest_commit_date',
+    'unique_id': '1296269_latest_commit_date',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[sensor.octocat_hello_world_latest_commit_committed-state]
+# name: test_all_entities[sensor.octocat_hello_world_latest_commit_date-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by the GitHub API',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'octocat/Hello-World Latest commit committed',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'octocat/Hello-World Latest commit date',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.octocat_hello_world_latest_commit_committed',
+    'entity_id': 'sensor.octocat_hello_world_latest_commit_date',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -901,7 +901,7 @@
     'state': 'v1.0.0',
   })
 # ---
-# name: test_all_entities[sensor.octocat_hello_world_latest_release_published-entry]
+# name: test_all_entities[sensor.octocat_hello_world_latest_release_date-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -915,7 +915,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.octocat_hello_world_latest_release_published',
+    'entity_id': 'sensor.octocat_hello_world_latest_release_date',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -923,30 +923,30 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Latest release published',
+    'object_id_base': 'Latest release date',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
     'original_icon': None,
-    'original_name': 'Latest release published',
+    'original_name': 'Latest release date',
     'platform': 'github',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'latest_release_published',
-    'unique_id': '1296269_latest_release_published',
+    'translation_key': 'latest_release_date',
+    'unique_id': '1296269_latest_release_date',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[sensor.octocat_hello_world_latest_release_published-state]
+# name: test_all_entities[sensor.octocat_hello_world_latest_release_date-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by the GitHub API',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'octocat/Hello-World Latest release published',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'octocat/Hello-World Latest release date',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.octocat_hello_world_latest_release_published',
+    'entity_id': 'sensor.octocat_hello_world_latest_release_date',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -1005,7 +1005,7 @@
     'state': 'v1.0.0',
   })
 # ---
-# name: test_all_entities[sensor.octocat_hello_world_latest_tag_committed-entry]
+# name: test_all_entities[sensor.octocat_hello_world_latest_tag_date-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1019,7 +1019,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.octocat_hello_world_latest_tag_committed',
+    'entity_id': 'sensor.octocat_hello_world_latest_tag_date',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1027,30 +1027,30 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Latest tag committed',
+    'object_id_base': 'Latest tag date',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
     'original_icon': None,
-    'original_name': 'Latest tag committed',
+    'original_name': 'Latest tag date',
     'platform': 'github',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'latest_tag_committed',
-    'unique_id': '1296269_latest_tag_committed',
+    'translation_key': 'latest_tag_date',
+    'unique_id': '1296269_latest_tag_date',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[sensor.octocat_hello_world_latest_tag_committed-state]
+# name: test_all_entities[sensor.octocat_hello_world_latest_tag_date-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by the GitHub API',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'octocat/Hello-World Latest tag committed',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'octocat/Hello-World Latest tag date',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.octocat_hello_world_latest_tag_committed',
+    'entity_id': 'sensor.octocat_hello_world_latest_tag_date',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/github/snapshots/test_sensor.ambr
+++ b/tests/components/github/snapshots/test_sensor.ambr
@@ -325,6 +325,58 @@
     'state': 'Fix all the bugs',
   })
 # ---
+# name: test_all_entities[sensor.octocat_hello_world_latest_commit_committed-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.octocat_hello_world_latest_commit_committed',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Latest commit committed',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Latest commit committed',
+    'platform': 'github',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'latest_commit_committed',
+    'unique_id': '1296269_latest_commit_committed',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.octocat_hello_world_latest_commit_committed-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by the GitHub API',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'octocat/Hello-World Latest commit committed',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.octocat_hello_world_latest_commit_committed',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2024-01-02T00:00:00+00:00',
+  })
+# ---
 # name: test_all_entities[sensor.octocat_hello_world_latest_discussion-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -376,6 +428,110 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'First discussion',
+  })
+# ---
+# name: test_all_entities[sensor.octocat_hello_world_latest_discussion_created-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.octocat_hello_world_latest_discussion_created',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Latest discussion created',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Latest discussion created',
+    'platform': 'github',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'latest_discussion_created',
+    'unique_id': '1296269_latest_discussion_created',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.octocat_hello_world_latest_discussion_created-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by the GitHub API',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'octocat/Hello-World Latest discussion created',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.octocat_hello_world_latest_discussion_created',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2024-01-01T00:00:00+00:00',
+  })
+# ---
+# name: test_all_entities[sensor.octocat_hello_world_latest_discussion_updated-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.octocat_hello_world_latest_discussion_updated',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Latest discussion updated',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Latest discussion updated',
+    'platform': 'github',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'latest_discussion_updated',
+    'unique_id': '1296269_latest_discussion_updated',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.octocat_hello_world_latest_discussion_updated-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by the GitHub API',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'octocat/Hello-World Latest discussion updated',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.octocat_hello_world_latest_discussion_updated',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2024-01-02T00:00:00+00:00',
   })
 # ---
 # name: test_all_entities[sensor.octocat_hello_world_latest_issue-entry]
@@ -431,6 +587,110 @@
     'state': 'Found a bug',
   })
 # ---
+# name: test_all_entities[sensor.octocat_hello_world_latest_issue_created-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.octocat_hello_world_latest_issue_created',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Latest issue created',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Latest issue created',
+    'platform': 'github',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'latest_issue_created',
+    'unique_id': '1296269_latest_issue_created',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.octocat_hello_world_latest_issue_created-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by the GitHub API',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'octocat/Hello-World Latest issue created',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.octocat_hello_world_latest_issue_created',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2024-01-01T00:00:00+00:00',
+  })
+# ---
+# name: test_all_entities[sensor.octocat_hello_world_latest_issue_updated-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.octocat_hello_world_latest_issue_updated',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Latest issue updated',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Latest issue updated',
+    'platform': 'github',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'latest_issue_updated',
+    'unique_id': '1296269_latest_issue_updated',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.octocat_hello_world_latest_issue_updated-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by the GitHub API',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'octocat/Hello-World Latest issue updated',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.octocat_hello_world_latest_issue_updated',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2024-01-02T00:00:00+00:00',
+  })
+# ---
 # name: test_all_entities[sensor.octocat_hello_world_latest_pull_request-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -482,6 +742,110 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'Amazing new feature',
+  })
+# ---
+# name: test_all_entities[sensor.octocat_hello_world_latest_pull_request_created-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.octocat_hello_world_latest_pull_request_created',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Latest pull request created',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Latest pull request created',
+    'platform': 'github',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'latest_pull_request_created',
+    'unique_id': '1296269_latest_pull_request_created',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.octocat_hello_world_latest_pull_request_created-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by the GitHub API',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'octocat/Hello-World Latest pull request created',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.octocat_hello_world_latest_pull_request_created',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2024-01-01T00:00:00+00:00',
+  })
+# ---
+# name: test_all_entities[sensor.octocat_hello_world_latest_pull_request_updated-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.octocat_hello_world_latest_pull_request_updated',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Latest pull request updated',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Latest pull request updated',
+    'platform': 'github',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'latest_pull_request_updated',
+    'unique_id': '1296269_latest_pull_request_updated',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.octocat_hello_world_latest_pull_request_updated-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by the GitHub API',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'octocat/Hello-World Latest pull request updated',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.octocat_hello_world_latest_pull_request_updated',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2024-01-02T00:00:00+00:00',
   })
 # ---
 # name: test_all_entities[sensor.octocat_hello_world_latest_release-entry]
@@ -537,6 +901,58 @@
     'state': 'v1.0.0',
   })
 # ---
+# name: test_all_entities[sensor.octocat_hello_world_latest_release_published-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.octocat_hello_world_latest_release_published',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Latest release published',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Latest release published',
+    'platform': 'github',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'latest_release_published',
+    'unique_id': '1296269_latest_release_published',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.octocat_hello_world_latest_release_published-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by the GitHub API',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'octocat/Hello-World Latest release published',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.octocat_hello_world_latest_release_published',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2024-01-02T00:00:00+00:00',
+  })
+# ---
 # name: test_all_entities[sensor.octocat_hello_world_latest_tag-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -587,6 +1003,58 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'v1.0.0',
+  })
+# ---
+# name: test_all_entities[sensor.octocat_hello_world_latest_tag_committed-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.octocat_hello_world_latest_tag_committed',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Latest tag committed',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Latest tag committed',
+    'platform': 'github',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'latest_tag_committed',
+    'unique_id': '1296269_latest_tag_committed',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.octocat_hello_world_latest_tag_committed-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by the GitHub API',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'octocat/Hello-World Latest tag committed',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.octocat_hello_world_latest_tag_committed',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2024-01-02T00:00:00+00:00',
   })
 # ---
 # name: test_all_entities[sensor.octocat_hello_world_merged_pull_requests-entry]

--- a/tests/components/github/test_sensor.py
+++ b/tests/components/github/test_sensor.py
@@ -84,6 +84,22 @@ async def test_latest_tag_date_annotated_tag(
     assert state.state == STATE_UNKNOWN
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_latest_release_date_unpublished_release(
+    hass: HomeAssistant,
+    github_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """A release with a null publishedAt (for example a draft) -> unavailable."""
+    github_client.graphql.return_value.data["data"]["repository"]["release"][
+        "published"
+    ] = None
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get("sensor.octocat_hello_world_latest_release_date")
+    assert state.state == STATE_UNAVAILABLE
+
+
 async def test_sensor_updates_with_empty_release_array(
     hass: HomeAssistant,
     github_client: AsyncMock,

--- a/tests/components/github/test_sensor.py
+++ b/tests/components/github/test_sensor.py
@@ -7,7 +7,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.github.const import FALLBACK_UPDATE_INTERVAL
-from homeassistant.const import STATE_UNAVAILABLE, Platform
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -30,6 +30,60 @@ async def test_all_entities(
     with patch("homeassistant.components.github.PLATFORMS", [Platform.SENSOR]):
         await setup_integration(hass, mock_config_entry)
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "expected"),
+    [
+        (
+            "sensor.octocat_hello_world_latest_commit_committed",
+            "2024-01-02T00:00:00+00:00",
+        ),
+        (
+            "sensor.octocat_hello_world_latest_issue_created",
+            "2024-01-01T00:00:00+00:00",
+        ),
+        (
+            "sensor.octocat_hello_world_latest_release_published",
+            "2024-01-02T00:00:00+00:00",
+        ),
+        (
+            "sensor.octocat_hello_world_latest_tag_committed",
+            "2024-01-02T00:00:00+00:00",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_latest_timestamp_sensors(
+    hass: HomeAssistant,
+    github_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    entity_id: str,
+    expected: str,
+) -> None:
+    """Test the default-disabled latest_* timestamp sensors."""
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get(entity_id)
+    assert state.state == expected
+    assert state.attributes["device_class"] == "timestamp"
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_latest_tag_committed_annotated_tag(
+    hass: HomeAssistant,
+    github_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Annotated tags have a Tag target, so committedDate is absent -> unknown."""
+    # Drop the Commit-only field the inline GraphQL fragment would omit.
+    del github_client.graphql.return_value.data["data"]["repository"]["refs"]["tags"][
+        0
+    ]["target"]["committed"]
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get("sensor.octocat_hello_world_latest_tag_committed")
+    assert state.state == STATE_UNKNOWN
 
 
 async def test_sensor_updates_with_empty_release_array(

--- a/tests/components/github/test_sensor.py
+++ b/tests/components/github/test_sensor.py
@@ -36,7 +36,7 @@ async def test_all_entities(
     ("entity_id", "expected"),
     [
         (
-            "sensor.octocat_hello_world_latest_commit_committed",
+            "sensor.octocat_hello_world_latest_commit_date",
             "2024-01-02T00:00:00+00:00",
         ),
         (
@@ -44,19 +44,18 @@ async def test_all_entities(
             "2024-01-01T00:00:00+00:00",
         ),
         (
-            "sensor.octocat_hello_world_latest_release_published",
+            "sensor.octocat_hello_world_latest_release_date",
             "2024-01-02T00:00:00+00:00",
         ),
         (
-            "sensor.octocat_hello_world_latest_tag_committed",
+            "sensor.octocat_hello_world_latest_tag_date",
             "2024-01-02T00:00:00+00:00",
         ),
     ],
 )
-@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "github_client")
 async def test_latest_timestamp_sensors(
     hass: HomeAssistant,
-    github_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
     entity_id: str,
     expected: str,
@@ -70,19 +69,18 @@ async def test_latest_timestamp_sensors(
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
-async def test_latest_tag_committed_annotated_tag(
+async def test_latest_tag_date_annotated_tag(
     hass: HomeAssistant,
     github_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Annotated tags have a Tag target, so committedDate is absent -> unknown."""
-    # Drop the Commit-only field the inline GraphQL fragment would omit.
     del github_client.graphql.return_value.data["data"]["repository"]["refs"]["tags"][
         0
     ]["target"]["committed"]
     await setup_integration(hass, mock_config_entry)
 
-    state = hass.states.get("sensor.octocat_hello_world_latest_tag_committed")
+    state = hass.states.get("sensor.octocat_hello_world_latest_tag_date")
     assert state.state == STATE_UNKNOWN
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This adds per-repository timestamp sensors so the "latest" items the integration
already tracks can be filtered and sorted by recency. The motivating use case:
surfacing only *recent* activity — for example, a card (such as the custom
Auto-entities card) that shows only repositories with a release or issue in the
last week. That requires the date to be a first-class entity *state* (cards filter
and sort on state), which a buried attribute can't provide — hence dedicated
`timestamp` sensors rather than extra attributes on the existing sensors.

Nine sensors are added to each tracked repository, exposing the relevant dates of
the latest items:

- Latest commit committed
- Latest discussion created / updated
- Latest issue created / updated
- Latest pull request created / updated
- Latest release published
- Latest tag committed (not provided for annotated tags)

The dates are pulled from the existing repository GraphQL query — no additional
API requests or rate-limit cost. Each sensor uses the `timestamp` device class and
is **disabled by default**, following the entity-disabled-by-default guidance (the
integration already does this for its user sensors).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#46557
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
