### PR TITLE
Use event time for sun is_up and is_set conditions

### DIFF
--- a/homeassistant/components/sun/condition.py
+++ b/homeassistant/components/sun/condition.py
@@ -36,7 +36,7 @@ from homeassistant.helpers.selector import (
     NumericThresholdSelector,
     NumericThresholdSelectorConfig,
 )
-from homeassistant.helpers.sun import get_astral_event_date, get_astral_observer
+from homeassistant.helpers.sun import get_astral_event_date, get_astral_observer, is_up
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import dt as dt_util
 
@@ -226,8 +226,7 @@ class _UpCondition(_SunStateCondition):
     @override
     def _async_check(self, **kwargs: Unpack[ConditionCheckParams]) -> bool:
         """Check the condition."""
-        elevation, _ = _solar_position(self._hass)
-        return elevation >= ELEVATION_HORIZON
+        return is_up(self._hass)
 
 
 class _SetCondition(_SunStateCondition):
@@ -236,8 +235,7 @@ class _SetCondition(_SunStateCondition):
     @override
     def _async_check(self, **kwargs: Unpack[ConditionCheckParams]) -> bool:
         """Check the condition."""
-        elevation, _ = _solar_position(self._hass)
-        return elevation < ELEVATION_HORIZON
+        return not is_up(self._hass)
 
 
 class _AscendingCondition(_SunStateCondition):

--- a/homeassistant/components/sun/entity.py
+++ b/homeassistant/components/sun/entity.py
@@ -20,13 +20,13 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.sun import (
     get_astral_observer,
     get_observer_astral_event_next,
-    is_up,
 )
 from homeassistant.util import dt as dt_util
 
 from .const import (
     ELEVATION_ASTRONOMICAL,
     ELEVATION_CIVIL,
+    ELEVATION_HORIZON,
     ELEVATION_NAUTICAL,
     SIGNAL_EVENTS_CHANGED,
     SIGNAL_POSITION_CHANGED,
@@ -162,7 +162,7 @@ class Sun(Entity):
     @override
     def state(self) -> str:
         """Return the state of the sun."""
-        if is_up(self.hass):
+        if self.solar_elevation > ELEVATION_HORIZON:
             return STATE_ABOVE_HORIZON
 
         return STATE_BELOW_HORIZON

--- a/homeassistant/components/sun/entity.py
+++ b/homeassistant/components/sun/entity.py
@@ -20,13 +20,13 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.sun import (
     get_astral_observer,
     get_observer_astral_event_next,
+    is_up,
 )
 from homeassistant.util import dt as dt_util
 
 from .const import (
     ELEVATION_ASTRONOMICAL,
     ELEVATION_CIVIL,
-    ELEVATION_HORIZON,
     ELEVATION_NAUTICAL,
     SIGNAL_EVENTS_CHANGED,
     SIGNAL_POSITION_CHANGED,
@@ -162,7 +162,7 @@ class Sun(Entity):
     @override
     def state(self) -> str:
         """Return the state of the sun."""
-        if self.solar_elevation > ELEVATION_HORIZON:
+        if is_up(self.hass):
             return STATE_ABOVE_HORIZON
 
         return STATE_BELOW_HORIZON

--- a/tests/components/sun/test_condition.py
+++ b/tests/components/sun/test_condition.py
@@ -1,6 +1,6 @@
 """The tests for sun conditions."""
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from freezegun import freeze_time
 import pytest
@@ -11,6 +11,7 @@ from homeassistant.const import SUN_EVENT_SUNRISE, SUN_EVENT_SUNSET
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import trace
 from homeassistant.helpers.condition import async_validate_condition_config
+from homeassistant.helpers.sun import get_astral_event_next
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -1457,6 +1458,45 @@ async def test_sun_state_condition_takes_no_options(
         await async_validate_condition_config(
             hass, {"condition": condition_key, "options": {"unknown": True}}
         )
+
+
+async def test_is_set_agrees_with_sunset_trigger_time(
+    hass: HomeAssistant,
+    service_calls: list[ServiceCall],
+) -> None:
+    """Test is_set flips at the exact calculated sunset time."""
+    latitude, longitude, time_zone = _SAN_DIEGO
+    await hass.config.async_set_time_zone(time_zone)
+    hass.config.latitude = latitude
+    hass.config.longitude = longitude
+
+    ref = datetime(2015, 9, 15, 12, tzinfo=dt_util.UTC)
+    with freeze_time(ref):
+        sunset = get_astral_event_next(hass, SUN_EVENT_SUNSET, ref)
+
+    await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {"platform": "event", "event_type": "test_event"},
+                "condition": {"condition": "sun.is_set"},
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
+
+    # One second before sunset: is_set should be false
+    with freeze_time(sunset - timedelta(seconds=1)):
+        hass.bus.async_fire("test_event")
+        await hass.async_block_till_done()
+    assert len(service_calls) == 0
+
+    # One second after sunset: is_set should be true
+    with freeze_time(sunset + timedelta(seconds=1)):
+        hass.bus.async_fire("test_event")
+        await hass.async_block_till_done()
+    assert len(service_calls) == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Breaking change

## Proposed change

The `sun.is_set` condition flips about 2 minutes after the `sun.sunset` trigger fires. The root cause is that the conditions used `astral.sun.elevation()` to check the sun's real-time position, while the triggers use `astral.sun.sunset()`/`sunrise()` to compute exact event times. These are different algorithms in the astral library that disagree by roughly 2 minutes near the horizon.

This PR switches `_UpCondition` and `_SetCondition` to use the existing `helpers.sun.is_up()` helper, which compares the next sunrise and sunset event times. This is the same approach the triggers use, so the conditions now agree with the triggers on the exact moment the sun sets or rises.

The other sun conditions (`is_ascending`, `is_descending`, `is_night`, twilight) still use real-time elevation, which is correct for those use cases.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/175157
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr