### PR TITLE
Add restore to device_tracker template entities

### DIFF
--- a/homeassistant/components/template/device_tracker.py
+++ b/homeassistant/components/template/device_tracker.py
@@ -1,7 +1,8 @@
 """Support for device trackers which integrates with other components."""
 
 from collections.abc import Callable
-from typing import Any
+from dataclasses import asdict, dataclass
+from typing import Any, Self, override
 
 import voluptuous as vol
 
@@ -19,6 +20,7 @@ from homeassistant.helpers.entity_platform import (
     AddConfigEntryEntitiesCallback,
     AddEntitiesCallback,
 )
+from homeassistant.helpers.restore_state import ExtraStoredData, RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import TriggerUpdateCoordinator, validators as template_validators
@@ -174,10 +176,37 @@ def async_create_preview_tracker(
     )
 
 
-class AbstractTemplateTracker(AbstractTemplateEntity, TrackerEntity):
+@dataclass(kw_only=True)
+class TrackerExtraStoredData(ExtraStoredData):
+    """Holds extra stored data for template tracker entities."""
+
+    in_zones: list[str] | None
+    latitude: float | None
+    longitude: float | None
+    location_accuracy: float
+
+    @override
+    def as_dict(self) -> dict[str, Any]:
+        """Return a dict representation of the tracker data."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, restored: dict[str, Any]) -> Self:
+        """Initialize a stored tracker state from a dict."""
+        return cls(
+            in_zones=restored["in_zones"],
+            latitude=restored["latitude"],
+            longitude=restored["longitude"],
+            location_accuracy=restored["location_accuracy"],
+        )
+
+
+class AbstractTemplateTracker(AbstractTemplateEntity, TrackerEntity, RestoreEntity):
     """Representation of a template device tracker features."""
 
     _entity_id_format = ENTITY_ID_FORMAT
+    _restore_state_extra_data = TrackerExtraStoredData
+    _restore_state_properties = ("_attr_in_zones",)
 
     # The super init is not called because TemplateEntity
     # and TriggerEntity will call
@@ -216,6 +245,25 @@ class AbstractTemplateTracker(AbstractTemplateEntity, TrackerEntity):
     def _update_location_accuracy(self, value: float | None) -> None:
         """Update the location accuracy."""
         self._attr_location_accuracy = self._location_accuracy_validator(value) or 0.0
+
+    @property
+    @override
+    def extra_restore_state_data(self) -> TrackerExtraStoredData:
+        """Return tracker specific state data to be restored."""
+        return TrackerExtraStoredData(
+            in_zones=self._attr_in_zones,
+            latitude=self._attr_latitude,
+            longitude=self._attr_longitude,
+            location_accuracy=self._attr_location_accuracy,
+        )
+
+    @override
+    def restore_extra_data(self, extra_data: TrackerExtraStoredData) -> None:
+        """Restore the extra data."""
+        self._attr_in_zones = extra_data.in_zones
+        self._attr_latitude = extra_data.latitude
+        self._attr_longitude = extra_data.longitude
+        self._attr_location_accuracy = extra_data.location_accuracy
 
 
 class StateTrackerEntity(TemplateEntity, AbstractTemplateTracker):

--- a/tests/components/template/test_device_tracker.py
+++ b/tests/components/template/test_device_tracker.py
@@ -21,12 +21,15 @@ from homeassistant.helpers.typing import ConfigType
 from .conftest import (
     ConfigurationStyle,
     TemplatePlatformSetup,
+    assert_state_and_attributes,
     async_get_flow_preview_state,
     async_trigger,
     make_test_trigger,
     setup_and_test_nested_unique_id,
     setup_and_test_unique_id,
     setup_entity,
+    setup_mock_template_entity_restore_state,
+    setup_restore_template_entity,
 )
 
 from tests.common import MockConfigEntry, async_setup_component
@@ -35,6 +38,7 @@ from tests.conftest import WebSocketGenerator
 TEST_STATE_ENTITY_ID = "sensor.test_state"
 TEST_LATITUDE_ENTITY_ID = "sensor.test_latitude"
 TEST_LONGITUDE_ENTITY_ID = "sensor.test_longitude"
+TEST_LOCATION_ACCURACY_ENTITY_ID = "sensor.test_location_accuracy"
 TEST_AVAILABILITY_ENTITY_ID = "binary_sensor.availability"
 TEST_TRACKER = TemplatePlatformSetup(
     device_tracker.DOMAIN,
@@ -43,6 +47,7 @@ TEST_TRACKER = TemplatePlatformSetup(
         TEST_AVAILABILITY_ENTITY_ID,
         TEST_LATITUDE_ENTITY_ID,
         TEST_LONGITUDE_ENTITY_ID,
+        TEST_LOCATION_ACCURACY_ENTITY_ID,
         TEST_STATE_ENTITY_ID,
     ),
 )
@@ -623,3 +628,146 @@ async def test_flow_preview(
     assert state["state"] == STATE_NOT_HOME
     assert state["attributes"]["latitude"] == 10.0
     assert state["attributes"]["longitude"] == 40.0
+
+
+@pytest.mark.parametrize(
+    "style", [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER]
+)
+@pytest.mark.parametrize(
+    "config",
+    [
+        {
+            "in_zones": "{{ state_attr('sensor.test_state', 'in_zones') }}",
+            "latitude": "{{ states('sensor.test_latitude') | float(None) }}",
+            "longitude": "{{ states('sensor.test_longitude') | float(None) }}",
+            "location_accuracy": "{{ states('sensor.test_location_accuracy') | float(None) }}",
+        },
+    ],
+)
+@pytest.mark.parametrize(
+    (
+        "saved_state",
+        "saved_extra_data",
+        "initial_state",
+        "initial_attributes",
+    ),
+    [
+        (
+            STATE_HOME,
+            {
+                "in_zones": ["zone.home"],
+                "latitude": 32.87336,
+                "longitude": 117.228743,
+                "location_accuracy": 5.0,
+            },
+            STATE_HOME,
+            {
+                "in_zones": ["zone.home"],
+                "latitude": 32.87336,
+                "longitude": 117.228743,
+                "gps_accuracy": 5.0,
+            },
+        ),
+        (
+            STATE_NOT_HOME,
+            {
+                "in_zones": [],
+                "latitude": 15.0,
+                "longitude": 15.0,
+                "location_accuracy": 10.0,
+            },
+            STATE_NOT_HOME,
+            {
+                "in_zones": [],
+                "latitude": 15.0,
+                "longitude": 15.0,
+                "gps_accuracy": 10.0,
+            },
+        ),
+        (
+            STATE_UNAVAILABLE,
+            {
+                "in_zones": [],
+                "latitude": 15.0,
+                "longitude": 15.0,
+                "location_accuracy": 10.0,
+            },
+            STATE_UNKNOWN,
+            {
+                "in_zones": [],
+                "latitude": None,
+                "longitude": None,
+                "gps_accuracy": None,
+            },
+        ),
+        (
+            STATE_UNKNOWN,
+            {
+                "in_zones": [],
+                "latitude": 15.0,
+                "longitude": 15.0,
+                "location_accuracy": 10.0,
+            },
+            STATE_UNKNOWN,
+            {
+                "in_zones": [],
+                "latitude": None,
+                "longitude": None,
+                "gps_accuracy": None,
+            },
+        ),
+    ],
+)
+async def test_restore_state(
+    hass: HomeAssistant,
+    config: ConfigType,
+    style: ConfigurationStyle,
+    saved_state: str,
+    saved_extra_data: dict | None,
+    initial_state: str,
+    initial_attributes: ConfigType,
+) -> None:
+    """Test restoring trigger template device tracker."""
+
+    restored_attributes = {  # These should be ignored
+        "latitude": 5,
+        "longitude": 5,
+        "location_accuracy": 2.0,
+    }
+
+    setup_mock_template_entity_restore_state(
+        hass,
+        TEST_TRACKER,
+        saved_state,
+        saved_extra_data=saved_extra_data,
+        saved_attributes=restored_attributes,
+    )
+
+    await setup_restore_template_entity(
+        hass,
+        TEST_TRACKER,
+        style,
+        config,
+        "states('sensor.test_latitude') | float(0) > 19.9",
+    )
+
+    state = assert_state_and_attributes(
+        hass,
+        TEST_TRACKER,
+        initial_state,
+        initial_attributes,
+    )
+
+    await async_trigger(
+        hass, "sensor.test_state", "anything", {"in_zones": ["zone.home"]}
+    )
+    await async_trigger(hass, "sensor.test_latitude", "32.88")
+    await async_trigger(hass, "sensor.test_longitude", "117.24")
+    await async_trigger(hass, "sensor.test_location_accuracy", "20")
+
+    state = hass.states.get(TEST_TRACKER.entity_id)
+    assert state.state == STATE_HOME
+    assert state.attributes["in_zones"] == ["zone.home"]
+    assert state.attributes["latitude"] == 32.88
+    assert state.attributes["longitude"] == 117.24
+    assert state.attributes["gps_accuracy"] == 20.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add restore state to device tracker template entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
