### PR TITLE
Sanitize add-on name in Supervisor backup filenames

### DIFF
--- a/homeassistant/components/hassio/backup.py
+++ b/homeassistant/components/hassio/backup.py
@@ -48,14 +48,13 @@ from homeassistant.components.backup import (
     RestoreBackupState,
     WrittenBackup,
     async_get_manager as async_get_backup_manager,
-    suggested_filename as suggested_backup_filename,
     suggested_filename_from_name_date,
 )
 from homeassistant.const import __version__ as HAVERSION
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.util import dt as dt_util
+from homeassistant.util import dt as dt_util, slugify
 from homeassistant.util.enum import try_parse_enum
 
 from .const import DATA_CONFIG_STORE, DOMAIN, EVENT_SUPERVISOR_EVENT
@@ -66,6 +65,16 @@ RESTORE_JOB_ID_ENV = "SUPERVISOR_RESTORE_JOB_ID"
 # Set on backups automatically created when updating an addon
 TAG_ADDON_UPDATE = "supervisor.addon_update"
 _LOGGER = logging.getLogger(__name__)
+
+
+def _suggested_backup_filename(name: str, date: str) -> str:
+    """Suggest a filename for a Supervisor backup.
+
+    Slugify the name so a display name with path separators (e.g. an add-on
+    named "Nabu Casa / Webhook Proxy") can't produce a filename Supervisor
+    rejects. The unsanitized name is still stored as the backup's display name.
+    """
+    return suggested_filename_from_name_date(slugify(name), date)
 
 
 async def async_get_backup_agents(
@@ -202,7 +211,7 @@ class SupervisorBackupAgent(BackupAgent):
         stream = await open_stream()
         upload_options = supervisor_backups.UploadBackupOptions(
             location={self.location},
-            filename=PurePath(suggested_backup_filename(backup)),
+            filename=PurePath(_suggested_backup_filename(backup.name, backup.date)),
         )
 
         async def stream_with_progress() -> AsyncIterator[bytes]:
@@ -361,7 +370,7 @@ class SupervisorBackupReaderWriter(BackupReaderWriter):
 
         date = dt_util.now().isoformat()
         extra_metadata = extra_metadata | {"supervisor.backup_request_date": date}
-        filename = suggested_filename_from_name_date(backup_name, date)
+        filename = _suggested_backup_filename(backup_name, date)
         try:
             backup = await self._client.backups.partial_backup(
                 supervisor_backups.PartialBackupOptions(

--- a/tests/components/hassio/test_backup.py
+++ b/tests/components/hassio/test_backup.py
@@ -961,7 +961,7 @@ DEFAULT_BACKUP_OPTIONS = supervisor_backups.PartialBackupOptions(
         "supervisor.backup_request_date": "2025-01-30T05:42:12.345678-08:00",
         "with_automatic_settings": False,
     },
-    filename=PurePath("Test_2025-01-30_05.42_12345678.tar"),
+    filename=PurePath("test_2025-01-30_05.42_12345678.tar"),
     folders={supervisor_backups.Folder("ssl")},
     homeassistant_exclude_database=False,
     homeassistant=True,
@@ -1013,6 +1013,16 @@ DEFAULT_BACKUP_OPTIONS = supervisor_backups.PartialBackupOptions(
                 folders={supervisor_backups.Folder("media")},
                 homeassistant=False,
                 homeassistant_exclude_database=True,
+            ),
+        ),
+        (
+            {"name": "Nabu Casa / Webhook Proxy for HA MCP"},
+            replace(
+                DEFAULT_BACKUP_OPTIONS,
+                name="Nabu Casa / Webhook Proxy for HA MCP",
+                filename=PurePath(
+                    "nabu_casa_webhook_proxy_for_ha_mcp_2025-01-30_05.42_12345678.tar"
+                ),
             ),
         ),
     ],
@@ -1701,7 +1711,7 @@ async def test_reader_writer_create_per_agent_encryption(
         upload_locations
     )
     for call in supervisor_client.backups.upload_backup.mock_calls:
-        assert call.args[1].filename == PurePath("Test_2025-01-30_05.42_12345678.tar")
+        assert call.args[1].filename == PurePath("test_2025-01-30_05.42_12345678.tar")
         upload_call_locations: set = call.args[1].location
         assert len(upload_call_locations) == 1
         assert upload_call_locations.pop() in upload_locations


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

## Proposed change

An add-on display name can legitimately contain a slash, e.g. "Nabu Casa / Webhook Proxy for HA MCP". When such a name flowed into the backup filename sent to Supervisor, the slash was kept verbatim and Supervisor rejected the filename (it validates against `^[^\\/]+\.tar$`). This failed the automatic backup that runs before an add-on update, and thus failed the update itself.

This slugifies the name when deriving the filename for both Supervisor-bound paths — partial backup creation and upload-to-agent — via a small shared helper. The unsanitized name is still stored as the backup's display name; only the on-disk filename is sanitized (which is consistent with the download filename, which already uses `slugify(backup.name)`).

Note on why this is sanitized here rather than in the shared `backup` helpers: the inner name of an *uploaded* backup is attacker-controlled and is deliberately *rejected* rather than sanitized (see #167211 and #172368). The add-on name, by contrast, is a trusted, HA-generated source that legitimately contains a slash, so sanitizing it at the hassio layer is the correct behavior and leaves the reject-based guards for untrusted input fully intact.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #175147
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
