### PR TITLE
Fix flaky anthropic test

### DIFF
--- a/tests/components/anthropic/test_ai_task.py
+++ b/tests/components/anthropic/test_ai_task.py
@@ -134,6 +134,7 @@ async def test_generate_structured_data_legacy(
                 CONF_THINKING_BUDGET: 0,
             },
         )
+    await hass.async_block_till_done()
 
     mock_create_stream.return_value = [
         create_tool_use_block(
@@ -194,6 +195,7 @@ async def test_generate_structured_data_legacy_tools(
                 "thinking_budget": 0,
             },
         )
+    await hass.async_block_till_done()
 
     result = await ai_task.async_generate_data(
         hass,
@@ -253,6 +255,7 @@ async def test_generate_structured_data_legacy_extended_thinking(
                 "thinking_budget": 1500,
             },
         )
+    await hass.async_block_till_done()
 
     result = await ai_task.async_generate_data(
         hass,
@@ -313,6 +316,7 @@ async def test_generate_structured_data_legacy_extra_text_block(
                 "thinking_budget": 1500,
             },
         )
+    await hass.async_block_till_done()
 
     result = await ai_task.async_generate_data(
         hass,
@@ -351,6 +355,7 @@ async def test_generate_invalid_structured_data_legacy(
                 CONF_CHAT_MODEL: "claude-sonnet-4-0",
             },
         )
+    await hass.async_block_till_done()
 
     mock_create_stream.return_value = [
         create_tool_use_block(

--- a/tests/components/anthropic/test_conversation.py
+++ b/tests/components/anthropic/test_conversation.py
@@ -1902,6 +1902,7 @@ async def test_web_fetch_error(
             CONF_WEB_FETCH_MAX_USES: 5,
         },
     )
+    await hass.async_block_till_done()
 
     web_fetch_result = WebFetchToolResultErrorBlock(
         type="web_fetch_tool_result_error",

--- a/tests/components/anthropic/test_conversation.py
+++ b/tests/components/anthropic/test_conversation.py
@@ -216,6 +216,7 @@ async def test_template_variables(
             ),
         },
     )
+    await hass.async_block_till_done()
 
     mock_create_stream.return_value = [
         create_content_block(0, ["Okay, let", " me take care of that for you", "."])
@@ -297,6 +298,7 @@ async def test_prompt_caching_automatic(
             CONF_PROMPT_CACHING: "automatic",
         },
     )
+    await hass.async_block_till_done()
 
     context = Context()
 
@@ -726,6 +728,7 @@ async def test_extended_thinking(
             CONF_THINKING_EFFORT: "medium",
         },
     )
+    await hass.async_block_till_done()
 
     mock_create_stream.return_value = [
         (
@@ -790,6 +793,7 @@ async def test_disabled_thinking(
         next(iter(mock_config_entry.subentries.values())),
         data=subentry_data,
     )
+    await hass.async_block_till_done()
 
     mock_create_stream.return_value = [
         create_content_block(1, ["Hello, how can I help you today?"])
@@ -862,6 +866,7 @@ async def test_extended_thinking_tool_call(
             CONF_THINKING_EFFORT: "medium",
         },
     )
+    await hass.async_block_till_done()
 
     agent_id = "conversation.claude_conversation"
     context = Context()
@@ -946,6 +951,7 @@ async def test_web_search(
             CONF_WEB_SEARCH_TIMEZONE: "America/Los_Angeles",
         },
     )
+    await hass.async_block_till_done()
 
     web_search_results = [
         WebSearchResultBlock(
@@ -1091,6 +1097,7 @@ async def test_web_search_error(
             CONF_WEB_SEARCH_TIMEZONE: "America/Los_Angeles",
         },
     )
+    await hass.async_block_till_done()
 
     web_search_results = WebSearchToolResultError(
         type="web_search_tool_result_error",
@@ -1169,6 +1176,7 @@ async def test_web_search_dynamic_filtering(
             CONF_WEB_SEARCH_TIMEZONE: "America/Los_Angeles",
         },
     )
+    await hass.async_block_till_done()
 
     web_search_results = [
         WebSearchResultBlock(
@@ -1305,6 +1313,7 @@ async def test_bash_code_execution(
             CONF_CODE_EXECUTION: True,
         },
     )
+    await hass.async_block_till_done()
 
     mock_create_stream.return_value = [
         (
@@ -1385,6 +1394,7 @@ async def test_bash_code_execution_error(
             CONF_CODE_EXECUTION: True,
         },
     )
+    await hass.async_block_till_done()
 
     mock_create_stream.return_value = [
         (
@@ -1558,6 +1568,7 @@ async def test_text_editor_code_execution(
             CONF_CODE_EXECUTION: True,
         },
     )
+    await hass.async_block_till_done()
 
     mock_create_stream.return_value = [
         (
@@ -1608,6 +1619,7 @@ async def test_tool_search(
             CONF_TOOL_SEARCH: True,
         },
     )
+    await hass.async_block_till_done()
 
     tool_search_result = ToolSearchToolSearchResultBlock(
         type="tool_search_tool_search_result",
@@ -1722,6 +1734,7 @@ async def test_tool_search_error(
             CONF_TOOL_SEARCH: True,
         },
     )
+    await hass.async_block_till_done()
 
     tool_search_result = ToolSearchToolResultError(
         type="tool_search_tool_result_error",
@@ -1795,6 +1808,7 @@ async def test_web_fetch(
             CONF_WEB_FETCH_MAX_USES: 5,
         },
     )
+    await hass.async_block_till_done()
 
     web_fetch_result = WebFetchBlock(
         type="web_fetch_result",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Spotted in https://github.com/home-assistant/core/actions/runs/28506510750/job/84500690646

> In [test_web_fetch_error](vscode-webview://0sn5qegf4n6b1e782hjkedpu709cftoj10hb5t8bd2bha7qcvd1o/tests/components/anthropic/test_conversation.py#L1886), the test calls hass.config_entries.async_update_subentry(...) and then immediately calls conversation.async_converse(...).
>
> Updating the subentry fires the entry's update listener ([anthropic/init.py:38](vscode-webview://0sn5qegf4n6b1e782hjkedpu709cftoj10hb5t8bd2bha7qcvd1o/homeassistant/components/anthropic/__init__.py#L38) → async_update_options → async_reload). Crucially, that listener is dispatched as a background task via async_create_task ([config_entries.py:2654-2659](vscode-webview://0sn5qegf4n6b1e782hjkedpu709cftoj10hb5t8bd2bha7qcvd1o/homeassistant/config_entries.py#L2654-L2659)) — it does not run synchronously. So when async_update_subentry returns, a reload of the config entry is still pending.
>
> During that reload the config entry unloads and re-adds its platforms, so the conversation.claude_conversation agent is briefly unregistered. If async_converse happens to run while the entity is in that unloaded window, the agent lookup at [agent_manager.py:97](vscode-webview://0sn5qegf4n6b1e782hjkedpu709cftoj10hb5t8bd2bha7qcvd1o/homeassistant/components/conversation/agent_manager.py#L97) fails. Whether it hits that window depends on event-loop scheduling — hence the flakiness.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
