### PR TITLE
Poll switcher_kis devices before marking them unavailable

### DIFF
--- a/homeassistant/components/switcher_kis/const.py
+++ b/homeassistant/components/switcher_kis/const.py
@@ -17,6 +17,10 @@ SERVICE_TURN_ON_WITH_TIMER_NAME = "turn_on_with_timer"
 # Defines the maximum interval device must send an update before it marked unavailable
 MAX_UPDATE_INTERVAL_SEC = 30
 
+# When a device stops broadcasting, poll it over TCP before marking it
+# unavailable, so a lost broadcast alone does not take a reachable device down.
+POLL_TIMEOUT_SEC = 8
+
 PREREQUISITES_URL = (
     "https://www.home-assistant.io/integrations/switcher_kis/#prerequisites"
 )

--- a/homeassistant/components/switcher_kis/coordinator.py
+++ b/homeassistant/components/switcher_kis/coordinator.py
@@ -69,9 +69,8 @@ class SwitcherDataUpdateCoordinator(
             "Device %s missed broadcasts but answered a poll, keeping it available",
             self.name,
         )
-        # Return the coordinator's current data rather than the pre-probe
-        # snapshot: a broadcast that arrived during the probe already refreshed
-        # self.data, and returning it avoids reverting to a stale device.
+        # Return current data, not the pre-probe snapshot, to keep a broadcast
+        # that arrived during the probe.
         return self.data
 
     async def _async_probe(self, device: SwitcherBase) -> None:

--- a/homeassistant/components/switcher_kis/coordinator.py
+++ b/homeassistant/components/switcher_kis/coordinator.py
@@ -1,10 +1,12 @@
 """Coordinator for the Switcher integration."""
 
+import asyncio
 from datetime import timedelta
 import logging
 from typing import override
 
-from aioswitcher.device import SwitcherBase
+from aioswitcher.api import SwitcherApi
+from aioswitcher.device import DeviceCategory, SwitcherBase
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_TOKEN
@@ -12,7 +14,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, update_coordinator
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from .const import DOMAIN, MAX_UPDATE_INTERVAL_SEC, SIGNAL_DEVICE_ADD
+from .const import DOMAIN, MAX_UPDATE_INTERVAL_SEC, POLL_TIMEOUT_SEC, SIGNAL_DEVICE_ADD
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,11 +45,59 @@ class SwitcherDataUpdateCoordinator(
 
     @override
     async def _async_update_data(self) -> SwitcherBase:
-        """Mark device offline if no data."""
-        raise update_coordinator.UpdateFailed(
-            f"Device {self.name} did not send update for"
-            f" {MAX_UPDATE_INTERVAL_SEC} seconds"
+        """Poll the device when broadcasts stop before marking it unavailable.
+
+        This is only reached when no broadcast has arrived for
+        ``MAX_UPDATE_INTERVAL_SEC``. Rather than declaring the device dead on a
+        lost broadcast alone, probe it over TCP. If it answers it stays
+        available (the next broadcast refreshes the live state); if it does not,
+        it is marked unavailable while the listener keeps waiting for it to come
+        back on its own.
+        """
+        device = self.data
+        try:
+            async with asyncio.timeout(POLL_TIMEOUT_SEC):
+                await self._async_probe(device)
+        except (TimeoutError, OSError, RuntimeError) as err:
+            raise update_coordinator.UpdateFailed(
+                f"Device {self.name} did not send an update for"
+                f" {MAX_UPDATE_INTERVAL_SEC} seconds and did not answer a poll:"
+                f" {err}"
+            ) from err
+
+        _LOGGER.debug(
+            "Device %s missed broadcasts but answered a poll, keeping it available",
+            self.name,
         )
+        # Return the coordinator's current data rather than the pre-probe
+        # snapshot: a broadcast that arrived during the probe already refreshed
+        # self.data, and returning it avoids reverting to a stale device.
+        return self.data
+
+    async def _async_probe(self, device: SwitcherBase) -> None:
+        """Open a TCP session to the device and read its state as a liveness check."""
+        category = device.device_type.category
+        async with SwitcherApi(
+            device.device_type,
+            device.ip_address,
+            device.device_id,
+            device.device_key,
+            self.token,
+        ) as api:
+            if category is DeviceCategory.THERMOSTAT:
+                await api.get_breeze_state()
+            elif category in (
+                DeviceCategory.SHUTTER,
+                DeviceCategory.SINGLE_SHUTTER_DUAL_LIGHT,
+                DeviceCategory.DUAL_SHUTTER_SINGLE_LIGHT,
+            ):
+                await api.get_shutter_state()
+            elif category is DeviceCategory.LIGHT:
+                await api.get_light_state()
+            elif category is DeviceCategory.HEATER:
+                await api.get_heater_state()
+            else:
+                await api.get_state()
 
     @property
     def model(self) -> str:

--- a/tests/components/switcher_kis/test_init.py
+++ b/tests/components/switcher_kis/test_init.py
@@ -43,7 +43,7 @@ def _mock_probe_fail():
     )
 
 
-def _mock_probe_success() -> AsyncMock:
+def _mock_probe_success():
     """Patch the coordinator poll so it answers, as if the device is reachable.
 
     Returns the patcher; its ``return_value`` is the mocked api used as an async

--- a/tests/components/switcher_kis/test_init.py
+++ b/tests/components/switcher_kis/test_init.py
@@ -22,8 +22,11 @@ from .consts import (
     DUMMY_DEVICE_ID10,
     DUMMY_HEATER_DEVICE,
     DUMMY_IP_ADDRESS1,
+    DUMMY_LIGHT_DEVICE,
     DUMMY_PLUG_DEVICE,
+    DUMMY_SHUTTER_DEVICE,
     DUMMY_SWITCHER_DEVICES,
+    DUMMY_THERMOSTAT_DEVICE,
     DUMMY_TOKEN as TOKEN,
     DUMMY_USERNAME as USERNAME,
 )
@@ -40,8 +43,12 @@ def _mock_probe_fail():
     )
 
 
-def _mock_probe_success():
-    """Patch the coordinator poll so it answers, as if the device is reachable."""
+def _mock_probe_success() -> AsyncMock:
+    """Patch the coordinator poll so it answers, as if the device is reachable.
+
+    Returns the patcher; its ``return_value`` is the mocked api used as an async
+    context manager, so tests can assert which ``get_*_state`` call was made.
+    """
     api = AsyncMock()
     api.__aenter__.return_value = api
     api.__aexit__.return_value = False
@@ -188,6 +195,41 @@ async def test_poll_on_silence_keeps_available(
         entity_id = f"switch.{slugify(device.name)}"
         state = hass.states.get(entity_id)
         assert state.state != STATE_UNAVAILABLE
+
+
+@pytest.mark.parametrize(
+    ("device", "probe_method"),
+    [
+        (DUMMY_THERMOSTAT_DEVICE, "get_breeze_state"),
+        (DUMMY_SHUTTER_DEVICE, "get_shutter_state"),
+        (DUMMY_LIGHT_DEVICE, "get_light_state"),
+        (DUMMY_HEATER_DEVICE, "get_heater_state"),
+        (DUMMY_PLUG_DEVICE, "get_state"),
+    ],
+)
+async def test_poll_uses_category_probe(
+    hass: HomeAssistant,
+    mock_bridge,
+    freezer: FrozenDateTimeFactory,
+    device,
+    probe_method: str,
+) -> None:
+    """Test the poll reads state with the api call for the device category."""
+    entry = await init_integration(hass, USERNAME, TOKEN)
+    assert mock_bridge
+
+    mock_bridge.mock_callbacks([device])
+    await hass.async_block_till_done()
+    assert len(entry.runtime_data) == 1
+
+    with _mock_probe_success() as mock_api:
+        freezer.tick(timedelta(seconds=MAX_UPDATE_INTERVAL_SEC + 1))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+    api = mock_api.return_value.__aenter__.return_value
+    getattr(api, probe_method).assert_awaited_once_with()
+    assert entry.runtime_data[device.device_id].last_update_success is True
 
 
 async def test_poll_does_not_clobber_broadcast(

--- a/tests/components/switcher_kis/test_init.py
+++ b/tests/components/switcher_kis/test_init.py
@@ -1,6 +1,8 @@
 """Test cases for the switcher_kis component."""
 
+from dataclasses import replace
 from datetime import timedelta
+from unittest.mock import AsyncMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
@@ -19,6 +21,8 @@ from .consts import (
     DUMMY_DEVICE_ID4,
     DUMMY_DEVICE_ID10,
     DUMMY_HEATER_DEVICE,
+    DUMMY_IP_ADDRESS1,
+    DUMMY_PLUG_DEVICE,
     DUMMY_SWITCHER_DEVICES,
     DUMMY_TOKEN as TOKEN,
     DUMMY_USERNAME as USERNAME,
@@ -28,13 +32,32 @@ from tests.common import async_fire_time_changed
 from tests.typing import WebSocketGenerator
 
 
+def _mock_probe_fail():
+    """Patch the coordinator poll so it fails, as if the device is unreachable."""
+    return patch(
+        "homeassistant.components.switcher_kis.coordinator.SwitcherApi",
+        side_effect=RuntimeError("fake poll error"),
+    )
+
+
+def _mock_probe_success():
+    """Patch the coordinator poll so it answers, as if the device is reachable."""
+    api = AsyncMock()
+    api.__aenter__.return_value = api
+    api.__aexit__.return_value = False
+    return patch(
+        "homeassistant.components.switcher_kis.coordinator.SwitcherApi",
+        return_value=api,
+    )
+
+
 async def test_update_fail(
     hass: HomeAssistant,
     mock_bridge,
     caplog: pytest.LogCaptureFixture,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test entities state unavailable when updates fail.."""
+    """Test entities become unavailable when a broadcast stops and a poll fails."""
     entry = await init_integration(hass)
     assert mock_bridge
 
@@ -44,14 +67,16 @@ async def test_update_fail(
     assert mock_bridge.is_running is True
     assert len(entry.runtime_data) == 2
 
-    freezer.tick(timedelta(seconds=MAX_UPDATE_INTERVAL_SEC + 1))
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
+    with _mock_probe_fail():
+        freezer.tick(timedelta(seconds=MAX_UPDATE_INTERVAL_SEC + 1))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
 
     for device in DUMMY_SWITCHER_DEVICES:
         assert (
-            f"Device {device.name} did not send update for"
-            f" {MAX_UPDATE_INTERVAL_SEC} seconds" in caplog.text
+            f"Device {device.name} did not send an update for"
+            f" {MAX_UPDATE_INTERVAL_SEC} seconds and did not answer a poll"
+            in caplog.text
         )
 
         entity_id = f"switch.{slugify(device.name)}"
@@ -85,7 +110,7 @@ async def test_update_fail_token_needed(
     caplog: pytest.LogCaptureFixture,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test entities state unavailable when updates fail.."""
+    """Test a token device becomes unavailable when broadcasts stop and a poll fails."""
     entry = await init_integration(hass, USERNAME, TOKEN)
     assert mock_bridge
 
@@ -97,13 +122,14 @@ async def test_update_fail_token_needed(
     assert mock_bridge.is_running is True
     assert len(entry.runtime_data) == 1
 
-    freezer.tick(timedelta(seconds=MAX_UPDATE_INTERVAL_SEC + 1))
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
+    with _mock_probe_fail():
+        freezer.tick(timedelta(seconds=MAX_UPDATE_INTERVAL_SEC + 1))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
 
     assert (
-        f"Device {device.name} did not send update for"
-        f" {MAX_UPDATE_INTERVAL_SEC} seconds" in caplog.text
+        f"Device {device.name} did not send an update for"
+        f" {MAX_UPDATE_INTERVAL_SEC} seconds and did not answer a poll" in caplog.text
     )
 
     entity_id = f"switch.{slugify(device.name)}"
@@ -128,6 +154,73 @@ async def test_update_fail_token_needed(
     entity_id = f"sensor.{slugify(device.name)}_power"
     state = hass.states.get(entity_id)
     assert state.state != STATE_UNAVAILABLE
+
+
+async def test_poll_on_silence_keeps_available(
+    hass: HomeAssistant,
+    mock_bridge,
+    caplog: pytest.LogCaptureFixture,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a device that misses broadcasts but answers a poll stays available."""
+    entry = await init_integration(hass)
+    assert mock_bridge
+
+    mock_bridge.mock_callbacks(DUMMY_SWITCHER_DEVICES)
+    await hass.async_block_till_done()
+
+    assert mock_bridge.is_running is True
+    assert len(entry.runtime_data) == 2
+
+    # No broadcast for the whole interval, but the TCP poll answers, so the
+    # devices must stay available instead of flapping to unavailable.
+    with _mock_probe_success():
+        freezer.tick(timedelta(seconds=MAX_UPDATE_INTERVAL_SEC + 1))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+    for device in DUMMY_SWITCHER_DEVICES:
+        assert (
+            f"Device {device.name} missed broadcasts but answered a poll" in caplog.text
+        )
+        assert entry.runtime_data[device.device_id].last_update_success is True
+
+        entity_id = f"switch.{slugify(device.name)}"
+        state = hass.states.get(entity_id)
+        assert state.state != STATE_UNAVAILABLE
+
+
+async def test_poll_does_not_clobber_broadcast(
+    hass: HomeAssistant,
+    mock_bridge,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a broadcast arriving during the probe is preserved, not reverted."""
+    entry = await init_integration(hass)
+    assert mock_bridge
+
+    mock_bridge.mock_callbacks([DUMMY_PLUG_DEVICE])
+    await hass.async_block_till_done()
+
+    coordinator = entry.runtime_data[DUMMY_PLUG_DEVICE.device_id]
+    assert coordinator.data.ip_address == DUMMY_IP_ADDRESS1
+
+    # A fresh broadcast lands mid-probe: the probe answers, but while it runs a
+    # new device snapshot arrives and refreshes the coordinator data. The update
+    # must return that fresh data, never the pre-probe snapshot.
+    new_ip = "192.168.100.200"
+    fresh_device = replace(DUMMY_PLUG_DEVICE, ip_address=new_ip)
+
+    async def probe_then_broadcast(_device):
+        coordinator.async_set_updated_data(fresh_device)
+
+    with patch.object(coordinator, "_async_probe", side_effect=probe_then_broadcast):
+        freezer.tick(timedelta(seconds=MAX_UPDATE_INTERVAL_SEC + 1))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+    assert coordinator.last_update_success is True
+    assert coordinator.data.ip_address == new_ip
 
 
 async def test_entry_unload(hass: HomeAssistant, mock_bridge) -> None:

--- a/tests/components/switcher_kis/test_init.py
+++ b/tests/components/switcher_kis/test_init.py
@@ -247,16 +247,19 @@ async def test_poll_does_not_clobber_broadcast(
     coordinator = entry.runtime_data[DUMMY_PLUG_DEVICE.device_id]
     assert coordinator.data.ip_address == DUMMY_IP_ADDRESS1
 
-    # A fresh broadcast lands mid-probe: the probe answers, but while it runs a
-    # new device snapshot arrives and refreshes the coordinator data. The update
-    # must return that fresh data, never the pre-probe snapshot.
+    # A fresh broadcast lands mid-probe: the state read answers, but while it
+    # runs a new device snapshot arrives and refreshes the coordinator data. The
+    # update must return that fresh data, never the pre-probe snapshot.
     new_ip = "192.168.100.200"
     fresh_device = replace(DUMMY_PLUG_DEVICE, ip_address=new_ip)
 
-    async def probe_then_broadcast(_device):
+    async def read_state_then_broadcast():
         coordinator.async_set_updated_data(fresh_device)
 
-    with patch.object(coordinator, "_async_probe", side_effect=probe_then_broadcast):
+    with _mock_probe_success() as mock_api:
+        mock_api.return_value.__aenter__.return_value.get_state.side_effect = (
+            read_state_then_broadcast
+        )
         freezer.tick(timedelta(seconds=MAX_UPDATE_INTERVAL_SEC + 1))
         async_fire_time_changed(hass)
         await hass.async_block_till_done()


### PR DESCRIPTION
## Breaking change

## Proposed change

The `switcher_kis` integration is push only. The coordinator marks a device
unavailable after `MAX_UPDATE_INTERVAL_SEC` (30s) with no UDP broadcast, and it
has no fallback poll. In practice a transient broadcast loss (a VLAN or
AP-isolation boundary, a docker bridge, a momentarily busy network) flaps a
device that is actually reachable, even though the exact same device answers a
direct TCP request the whole time.

Push stays the primary update path and nothing changes on the happy path. This
PR only adds a fallback: when no broadcast has arrived for the whole interval,
`_async_update_data` opens a single short TCP session and reads the device
state (dispatched by `DeviceCategory`: `get_state` / `get_breeze_state` /
`get_shutter_state` / `get_light_state` / `get_heater_state`) under an 8s
timeout (`POLL_TIMEOUT_SEC`) before marking the device unavailable. If the
device answers, it stays available and the next broadcast refreshes the live
state. Only a device that also fails the poll is marked unavailable. This is a
poll-on-silence fallback, not a switch from push to polling.

It returns the coordinator's current data rather than the pre-probe snapshot,
so a broadcast that arrives during the probe (via `async_set_updated_data`) is
preserved and not reverted until the next broadcast.

This change is deliberately **library independent**: it works against the
currently pinned `aioswitcher==6.1.1` and needs no dependency bump. The read
methods and `DeviceCategory` members used here already exist in 6.1.1.

This behavior has been running in production on 15 Home Assistant instances
(HA 2026.5.0) and reliably stopped the false-unavailable flapping on push-only
Switcher devices.

This PR was split out of a larger change at codeowner request and now contains
only the poll-on-silence fallback. The other two pieces are opened as separate,
independent follow-ups:

- #175288 - do not mark the entity unavailable on a single failed command.
- #175289 - log a device ip change on a broadcast from a new address.

This poll-on-silence change is the primary one; the other two are minor.

A further follow-up will add a UDP listener watchdog that rebuilds the broadcast
socket in place when it wedges. That is intentionally left out because it
depends on an unreleased `aioswitcher` socket fix.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to this PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
