### PR TITLE
Do not mark switcher_kis entity unavailable on a failed command

### DIFF
--- a/homeassistant/components/switcher_kis/entity.py
+++ b/homeassistant/components/switcher_kis/entity.py
@@ -58,8 +58,8 @@ class SwitcherEntity(CoordinatorEntity[SwitcherDataUpdateCoordinator]):
             error = repr(err)
 
         if error or not response or not response.successful:
-            self.coordinator.last_update_success = False
-            self.async_write_ha_state()
+            # Availability is owned by the broadcast stream and coordinator poll,
+            # so surface the failure without marking the entity unavailable.
             raise HomeAssistantError(
                 f"Call api for {self.name} failed, api: '{api}', "
                 f"args: {args}, response/error: {response or error}"

--- a/homeassistant/components/switcher_kis/entity.py
+++ b/homeassistant/components/switcher_kis/entity.py
@@ -58,8 +58,8 @@ class SwitcherEntity(CoordinatorEntity[SwitcherDataUpdateCoordinator]):
             error = repr(err)
 
         if error or not response or not response.successful:
-            # Availability is owned by the broadcast stream and coordinator poll,
-            # so surface the failure without marking the entity unavailable.
+            # Availability is driven by the device broadcasts, so surface the
+            # failure without marking the entity unavailable.
             raise HomeAssistantError(
                 f"Call api for {self.name} failed, api: '{api}', "
                 f"args: {args}, response/error: {response or error}"

--- a/tests/components/switcher_kis/test_button.py
+++ b/tests/components/switcher_kis/test_button.py
@@ -120,14 +120,9 @@ async def test_control_device_fail(
             ANY, state=DeviceState.ON, update_state=True
         )
 
+        # A single failed command must not flap the entity unavailable.
         state = hass.states.get(ASSUME_ON_EID)
-        assert state.state == STATE_UNAVAILABLE
-
-    # Make device available again
-    mock_bridge.mock_callbacks([DEVICE])
-    await hass.async_block_till_done()
-
-    assert hass.states.get(ASSUME_ON_EID) is not None
+        assert state.state != STATE_UNAVAILABLE
 
     # Test error response during turn on
     with patch(
@@ -148,4 +143,4 @@ async def test_control_device_fail(
         )
 
         state = hass.states.get(ASSUME_ON_EID)
-        assert state.state == STATE_UNAVAILABLE
+        assert state.state != STATE_UNAVAILABLE

--- a/tests/components/switcher_kis/test_climate.py
+++ b/tests/components/switcher_kis/test_climate.py
@@ -24,7 +24,7 @@ from homeassistant.components.climate import (
     SERVICE_SET_TEMPERATURE,
     HVACMode,
 )
-from homeassistant.const import ATTR_ENTITY_ID, ATTR_TEMPERATURE, STATE_UNAVAILABLE
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_TEMPERATURE
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.util import slugify
@@ -264,17 +264,11 @@ async def test_control_device_fail(hass: HomeAssistant, mock_bridge, mock_api) -
         mock_control_device.assert_called_once_with(
             ANY, state=DeviceState.ON, mode=ThermostatMode.HEAT
         )
+        # A single failed command must not flap the entity unavailable.
         state = hass.states.get(ENTITY_ID)
-        assert state.state == STATE_UNAVAILABLE
+        assert state.state == HVACMode.COOL
 
-    # Make device available again
-    mock_bridge.mock_callbacks([DEVICE])
-    await hass.async_block_till_done()
-
-    state = hass.states.get(ENTITY_ID)
-    assert state.state == HVACMode.COOL
-
-    # Test error response during turn on
+    # Test error response during turn on - the entity stays available.
     with patch(
         "homeassistant.components.switcher_kis.entity.SwitcherApi.control_breeze_device",
         return_value=SwitcherBaseResponse(None),
@@ -292,7 +286,7 @@ async def test_control_device_fail(hass: HomeAssistant, mock_bridge, mock_api) -
             ANY, state=DeviceState.ON, mode=ThermostatMode.HEAT
         )
         state = hass.states.get(ENTITY_ID)
-        assert state.state == STATE_UNAVAILABLE
+        assert state.state == HVACMode.COOL
 
 
 @pytest.mark.parametrize("mock_bridge", [[DEVICE]], indirect=True)

--- a/tests/components/switcher_kis/test_cover.py
+++ b/tests/components/switcher_kis/test_cover.py
@@ -16,7 +16,7 @@ from homeassistant.components.cover import (
     SERVICE_STOP_COVER,
     CoverState,
 )
-from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE
+from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util import slugify
@@ -245,17 +245,11 @@ async def test_cover_control_fail(
 
         assert mock_api.call_count == 2
         mock_control_device.assert_called_once_with(44, cover_id)
+        # A single failed command must not flap the entity unavailable.
         state = hass.states.get(entity_id)
-        assert state.state == STATE_UNAVAILABLE
+        assert state.state == CoverState.OPEN
 
-    # Make device available again
-    mock_bridge.mock_callbacks([device])
-    await hass.async_block_till_done()
-
-    state = hass.states.get(entity_id)
-    assert state.state == CoverState.OPEN
-
-    # Test error response during set position
+    # Test error response during set position - the entity stays available.
     with patch(
         "homeassistant.components.switcher_kis.entity.SwitcherApi.set_position",
         return_value=SwitcherBaseResponse(None),
@@ -271,7 +265,7 @@ async def test_cover_control_fail(
         assert mock_api.call_count == 4
         mock_control_device.assert_called_once_with(27, cover_id)
         state = hass.states.get(entity_id)
-        assert state.state == STATE_UNAVAILABLE
+        assert state.state == CoverState.OPEN
 
 
 @pytest.mark.parametrize("mock_bridge", [[DEVICE2, DEVICE3]], indirect=True)

--- a/tests/components/switcher_kis/test_light.py
+++ b/tests/components/switcher_kis/test_light.py
@@ -13,7 +13,6 @@ from homeassistant.const import (
     SERVICE_TURN_ON,
     STATE_OFF,
     STATE_ON,
-    STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -203,17 +202,11 @@ async def test_light_control_fail(
 
         assert mock_api.call_count == 2
         mock_control_device.assert_called_once_with(DeviceState.ON, light_id)
+        # A single failed command must not flap the entity unavailable.
         state = hass.states.get(entity_id)
-        assert state.state == STATE_UNAVAILABLE
+        assert state.state == STATE_OFF
 
-    # Make device available again
-    mock_bridge.mock_callbacks([device])
-    await hass.async_block_till_done()
-
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_OFF
-
-    # Test error response during turn on
+    # Test error response during turn on - the entity stays available.
     with patch(
         "homeassistant.components.switcher_kis.entity.SwitcherApi.set_light",
         return_value=SwitcherBaseResponse(None),
@@ -229,4 +222,4 @@ async def test_light_control_fail(
         assert mock_api.call_count == 4
         mock_control_device.assert_called_once_with(DeviceState.ON, light_id)
         state = hass.states.get(entity_id)
-        assert state.state == STATE_UNAVAILABLE
+        assert state.state == STATE_OFF

--- a/tests/components/switcher_kis/test_services.py
+++ b/tests/components/switcher_kis/test_services.py
@@ -14,7 +14,7 @@ from homeassistant.components.switcher_kis.const import (
     SERVICE_SET_AUTO_OFF_NAME,
     SERVICE_TURN_ON_WITH_TIMER_NAME,
 )
-from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, STATE_UNAVAILABLE
+from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceNotSupported
 from homeassistant.helpers.config_validation import time_period_str
@@ -189,8 +189,9 @@ async def test_set_auto_off_service_fail(
         mock_set_auto_shutdown.assert_called_once_with(
             time_period_str(DUMMY_AUTO_OFF_SET)
         )
+        # A single failed service call must not flap the entity unavailable.
         state = hass.states.get(entity_id)
-        assert state.state == STATE_UNAVAILABLE
+        assert state.state == STATE_ON
 
 
 @pytest.mark.parametrize("mock_bridge", [[DUMMY_HEATER_DEVICE]], indirect=True)
@@ -220,8 +221,9 @@ async def test_set_auto_off_service_fail_token_needed(
 
     assert mock_api.call_count == 2
     mock_set_auto_shutdown.assert_called_once_with(time_period_str(DUMMY_AUTO_OFF_SET))
+    # A single failed service call must not flap the entity unavailable.
     state = hass.states.get(entity_id)
-    assert state.state == STATE_UNAVAILABLE
+    assert state.state == STATE_ON
 
 
 @pytest.mark.parametrize("mock_bridge", [[DUMMY_PLUG_DEVICE]], indirect=True)

--- a/tests/components/switcher_kis/test_switch.py
+++ b/tests/components/switcher_kis/test_switch.py
@@ -14,7 +14,6 @@ from homeassistant.const import (
     SERVICE_TURN_ON,
     STATE_OFF,
     STATE_ON,
-    STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -199,7 +198,8 @@ async def test_switch_control_fail(
     state = hass.states.get(entity_id)
     assert state.state == STATE_OFF
 
-    # Test exception during turn on
+    # Test exception during turn on - the call fails but a single failed
+    # command must not flap the entity unavailable.
     with patch(
         "homeassistant.components.switcher_kis.entity.SwitcherApi.control_device",
         side_effect=RuntimeError("fake error"),
@@ -215,16 +215,9 @@ async def test_switch_control_fail(
         assert mock_api.call_count == 2
         mock_control_device.assert_called_once_with(Command.ON)
         state = hass.states.get(entity_id)
-        assert state.state == STATE_UNAVAILABLE
+        assert state.state == STATE_OFF
 
-    # Make device available again
-    mock_bridge.mock_callbacks([DUMMY_PLUG_DEVICE])
-    await hass.async_block_till_done()
-
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_OFF
-
-    # Test error response during turn on
+    # Test error response during turn on - same, the entity stays available.
     with patch(
         "homeassistant.components.switcher_kis.entity.SwitcherApi.control_device",
         return_value=SwitcherBaseResponse(None),
@@ -240,7 +233,7 @@ async def test_switch_control_fail(
         assert mock_api.call_count == 4
         mock_control_device.assert_called_once_with(Command.ON)
         state = hass.states.get(entity_id)
-        assert state.state == STATE_UNAVAILABLE
+        assert state.state == STATE_OFF
 
 
 @pytest.mark.parametrize(
@@ -442,16 +435,9 @@ async def test_child_lock_control_fail(
         assert mock_api.call_count == 2
         mock_control_device.assert_called_once_with(ShutterChildLock.ON, cover_id)
         state = hass.states.get(entity_id)
-        assert state.state == STATE_UNAVAILABLE
+        assert state.state == STATE_OFF
 
-    # Make device available again
-    mock_bridge.mock_callbacks([device])
-    await hass.async_block_till_done()
-
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_OFF
-
-    # Test error response during turn on
+    # Test error response during turn on - the entity stays available.
     with patch(
         "homeassistant.components.switcher_kis.entity.SwitcherApi.set_shutter_child_lock",
         return_value=SwitcherBaseResponse(None),
@@ -467,4 +453,4 @@ async def test_child_lock_control_fail(
         assert mock_api.call_count == 4
         mock_control_device.assert_called_once_with(ShutterChildLock.ON, cover_id)
         state = hass.states.get(entity_id)
-        assert state.state == STATE_UNAVAILABLE
+        assert state.state == STATE_OFF


### PR DESCRIPTION
## Breaking change

## Proposed change

In `switcher_kis`, a single failed command forced the entity unavailable:
`_async_call_api` set `self.coordinator.last_update_success = False` and wrote
an unavailable state before raising. One dropped command therefore turned into
a device-offline state until the next broadcast arrived, even though the device
was still online and broadcasting.

Availability is owned by the broadcast stream and the coordinator, not by a
single control call. `_async_call_api` now still raises `HomeAssistantError` so
the caller sees the failure, but it no longer flips the entity unavailable on
its own. The command-failure tests across the platforms are updated to assert
the entity stays available after a failed command.

This is a small, independent follow-up split out of
home-assistant/core#175282 (poll switcher_kis devices before marking them
unavailable) at codeowner request. It stands alone against current `dev` and
needs no dependency change. #175282 is the primary change; this one is minor.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: home-assistant/core#175282
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to this PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
