### PR TITLE
Log switcher_kis device ip change

### DIFF
--- a/homeassistant/components/switcher_kis/__init__.py
+++ b/homeassistant/components/switcher_kis/__init__.py
@@ -41,6 +41,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: SwitcherConfigEntry) -> 
 
         # Existing device update device data
         if coordinator := coordinators.get(device.device_id):
+            if coordinator.data.ip_address != device.ip_address:
+                _LOGGER.info(
+                    "Switcher device %s changed ip from %s to %s",
+                    device.device_id,
+                    coordinator.data.ip_address,
+                    device.ip_address,
+                )
             coordinator.async_set_updated_data(device)
             return
 

--- a/tests/components/switcher_kis/test_init.py
+++ b/tests/components/switcher_kis/test_init.py
@@ -1,5 +1,6 @@
 """Test cases for the switcher_kis component."""
 
+from dataclasses import replace
 from datetime import timedelta
 
 from freezegun.api import FrozenDateTimeFactory
@@ -19,6 +20,8 @@ from .consts import (
     DUMMY_DEVICE_ID4,
     DUMMY_DEVICE_ID10,
     DUMMY_HEATER_DEVICE,
+    DUMMY_IP_ADDRESS1,
+    DUMMY_PLUG_DEVICE,
     DUMMY_SWITCHER_DEVICES,
     DUMMY_TOKEN as TOKEN,
     DUMMY_USERNAME as USERNAME,
@@ -128,6 +131,34 @@ async def test_update_fail_token_needed(
     entity_id = f"sensor.{slugify(device.name)}_power"
     state = hass.states.get(entity_id)
     assert state.state != STATE_UNAVAILABLE
+
+
+async def test_ip_change_logged(
+    hass: HomeAssistant,
+    mock_bridge,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a broadcast from a new ip address is logged for an existing device."""
+    entry = await init_integration(hass)
+    assert mock_bridge
+
+    mock_bridge.mock_callbacks([DUMMY_PLUG_DEVICE])
+    await hass.async_block_till_done()
+
+    assert len(entry.runtime_data) == 1
+    coordinator = entry.runtime_data[DUMMY_PLUG_DEVICE.device_id]
+    assert coordinator.data.ip_address == DUMMY_IP_ADDRESS1
+
+    new_ip = "192.168.100.200"
+    moved_device = replace(DUMMY_PLUG_DEVICE, ip_address=new_ip)
+    mock_bridge.mock_callbacks([moved_device])
+    await hass.async_block_till_done()
+
+    assert (
+        f"Switcher device {DUMMY_PLUG_DEVICE.device_id} changed ip from"
+        f" {DUMMY_IP_ADDRESS1} to {new_ip}" in caplog.text
+    )
+    assert coordinator.data.ip_address == new_ip
 
 
 async def test_entry_unload(hass: HomeAssistant, mock_bridge) -> None:


### PR DESCRIPTION
## Breaking change

## Proposed change

When a broadcast arrives for a known `switcher_kis` device from a different ip
address, log the old and new ip at info level. This makes DHCP moves visible in
the logs, which helps when diagnosing connectivity to a device that changed
address. Behavior is otherwise unchanged: the coordinator still updates on
every broadcast.

This is a small, independent follow-up split out of
home-assistant/core#175282 (poll switcher_kis devices before marking them
unavailable) at codeowner request. It stands alone against current `dev` and
needs no dependency change. #175282 is the primary change; this one is minor.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: home-assistant/core#175282
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to this PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
