### PR TITLE
Add restore to fan template entities

### DIFF
--- a/homeassistant/components/template/fan.py
+++ b/homeassistant/components/template/fan.py
@@ -1,8 +1,9 @@
 """Support for Template fans."""
 
+from dataclasses import asdict, dataclass
 from enum import StrEnum
 import logging
-from typing import TYPE_CHECKING, Any, override
+from typing import TYPE_CHECKING, Any, Self, override
 
 import voluptuous as vol
 
@@ -22,6 +23,7 @@ from homeassistant.helpers.entity_platform import (
     AddConfigEntryEntitiesCallback,
     AddEntitiesCallback,
 )
+from homeassistant.helpers.restore_state import ExtraStoredData, RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import validators as template_validators
@@ -155,12 +157,56 @@ def async_create_preview_fan(
     )
 
 
-class AbstractTemplateFan(AbstractTemplateEntity, FanEntity):
+@dataclass(kw_only=True)
+class FanExtraStoredData(ExtraStoredData):
+    """Fan extra stored data."""
+
+    is_on: bool | None
+    percentage: int | None
+    preset_mode: str | None
+    oscillating: bool | None
+    direction: str | None
+
+    @override
+    def as_dict(self) -> dict[str, Any]:
+        """Return a dict representation of the fan data."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, restored: dict[str, Any]) -> Self | None:
+        """Initialize a stored fan data from a dict."""
+        is_on = restored.get("is_on")
+        percentage = restored.get("percentage")
+        preset_mode = restored.get("preset_mode")
+        oscillating = restored.get("oscillating")
+        direction = restored.get("direction")
+        if is_on is not None and not isinstance(is_on, bool):
+            return None
+        if percentage is not None and not isinstance(percentage, int):
+            return None
+        if preset_mode is not None and not isinstance(preset_mode, str):
+            return None
+        if oscillating is not None and not isinstance(oscillating, bool):
+            return None
+        if direction is not None and not isinstance(direction, str):
+            return None
+        return cls(
+            is_on=is_on,
+            percentage=percentage,
+            preset_mode=preset_mode,
+            oscillating=oscillating,
+            direction=direction,
+        )
+
+
+class AbstractTemplateFan(AbstractTemplateEntity, FanEntity, RestoreEntity):
     """Representation of a template fan features."""
 
     _entity_id_format = ENTITY_ID_FORMAT
     _optimistic_entity = True
     _state_option = CONF_STATE
+    _restore_state_extra_data = FanExtraStoredData
+    _restore_state_properties = ("_attr_is_on",)
 
     # The super init is not called because TemplateEntity
     # and TriggerEntity will call
@@ -343,6 +389,27 @@ class AbstractTemplateFan(AbstractTemplateEntity, FanEntity):
                 self.entity_id,
                 ", ".join(_VALID_DIRECTIONS),
             )
+
+    @property
+    @override
+    def extra_restore_state_data(self) -> FanExtraStoredData:
+        """Return extra state data to be restored."""
+        return FanExtraStoredData(
+            is_on=self._attr_is_on,
+            percentage=self._attr_percentage,
+            preset_mode=self._attr_preset_mode,
+            oscillating=self._attr_oscillating,
+            direction=self._attr_current_direction,
+        )
+
+    @override
+    def restore_extra_data(self, extra_data: FanExtraStoredData) -> None:
+        """Restore extra state data."""
+        self._attr_is_on = extra_data.is_on
+        self._attr_percentage = extra_data.percentage
+        self._attr_preset_mode = extra_data.preset_mode
+        self._attr_oscillating = extra_data.oscillating
+        self._attr_current_direction = extra_data.direction
 
 
 class StateFanEntity(TemplateEntity, AbstractTemplateFan):

--- a/tests/components/template/test_fan.py
+++ b/tests/components/template/test_fan.py
@@ -1469,6 +1469,71 @@ async def test_flow_preview(
                 "direction": None,
             },
         ),
+        (
+            STATE_ON,
+            {
+                "is_on": "True",
+            },
+            STATE_UNKNOWN,
+            {
+                "percentage": None,
+                "preset_mode": None,
+                "oscillating": None,
+                "direction": None,
+            },
+        ),
+        (
+            STATE_ON,
+            {
+                "percentage": "0",
+            },
+            STATE_UNKNOWN,
+            {
+                "percentage": None,
+                "preset_mode": None,
+                "oscillating": None,
+                "direction": None,
+            },
+        ),
+        (
+            STATE_ON,
+            {
+                "oscillating": "True",
+            },
+            STATE_UNKNOWN,
+            {
+                "percentage": None,
+                "preset_mode": None,
+                "oscillating": None,
+                "direction": None,
+            },
+        ),
+        (
+            STATE_ON,
+            {
+                "preset_mode": 75,
+            },
+            STATE_UNKNOWN,
+            {
+                "percentage": None,
+                "preset_mode": None,
+                "oscillating": None,
+                "direction": None,
+            },
+        ),
+        (
+            STATE_ON,
+            {
+                "direction": 75,
+            },
+            STATE_UNKNOWN,
+            {
+                "percentage": None,
+                "preset_mode": None,
+                "oscillating": None,
+                "direction": None,
+            },
+        ),
     ],
 )
 async def test_restore_state(

--- a/tests/components/template/test_fan.py
+++ b/tests/components/template/test_fan.py
@@ -26,6 +26,7 @@ from .conftest import (
     ConfigurationStyle,
     TemplatePlatformSetup,
     assert_action,
+    assert_state_and_attributes,
     async_get_flow_preview_state,
     async_trigger,
     make_test_action,
@@ -33,6 +34,8 @@ from .conftest import (
     setup_and_test_nested_unique_id,
     setup_and_test_unique_id,
     setup_entity,
+    setup_mock_template_entity_restore_state,
+    setup_restore_template_entity,
 )
 
 from tests.common import MockConfigEntry
@@ -47,7 +50,7 @@ TEST_FAN = TemplatePlatformSetup(
     fan.DOMAIN,
     "test_fan",
     make_test_trigger(
-        TEST_INPUT_BOOLEAN, TEST_STATE_ENTITY_ID, TEST_AVAILABILITY_ENTITY
+        TEST_AVAILABILITY_ENTITY, TEST_INPUT_BOOLEAN, TEST_STATE_ENTITY_ID
     ),
 )
 
@@ -1366,3 +1369,165 @@ async def test_flow_preview(
     )
 
     assert state["state"] == STATE_ON
+
+
+@pytest.mark.parametrize(
+    "style", [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER]
+)
+@pytest.mark.parametrize(
+    "config",
+    [
+        {
+            "state": "{{ state_attr('sensor.test_sensor', 'is_on') }}",
+            "turn_on": [],
+            "turn_off": [],
+            "percentage": "{{ state_attr('sensor.test_sensor', 'percentage') }}",
+            "set_percentage": [],
+            "preset_mode": "{{ state_attr('sensor.test_sensor', 'preset_mode') }}",
+            "set_preset_mode": [],
+            "preset_modes": ["off", "auto", "low", "medium", "high"],
+            "oscillating": "{{ state_attr('sensor.test_sensor', 'oscillating') }}",
+            "set_oscillating": [],
+            "direction": "{{ state_attr('sensor.test_sensor', 'direction') }}",
+            "set_direction": [],
+        },
+    ],
+)
+@pytest.mark.parametrize(
+    (
+        "saved_state",
+        "saved_extra_data",
+        "initial_state",
+        "initial_attributes",
+    ),
+    [
+        (
+            STATE_ON,
+            {
+                "is_on": True,
+                "percentage": 10,
+                "preset_mode": "auto",
+                "oscillating": True,
+                "direction": DIRECTION_FORWARD,
+            },
+            STATE_ON,
+            {
+                "percentage": 10,
+                "preset_mode": "auto",
+                "oscillating": True,
+                "direction": DIRECTION_FORWARD,
+            },
+        ),
+        (
+            STATE_OFF,
+            {
+                "is_on": False,
+                "percentage": 0,
+                "preset_mode": "off",
+                "oscillating": False,
+                "direction": DIRECTION_FORWARD,
+            },
+            STATE_OFF,
+            {
+                "percentage": 0,
+                "preset_mode": "off",
+                "oscillating": False,
+                "direction": DIRECTION_FORWARD,
+            },
+        ),
+        (
+            STATE_UNAVAILABLE,
+            {
+                "is_on": True,
+                "percentage": 0,
+                "preset_mode": "auto",
+                "oscillating": True,
+                "direction": DIRECTION_FORWARD,
+            },
+            STATE_UNKNOWN,
+            {
+                "percentage": None,
+                "preset_mode": None,
+                "oscillating": None,
+                "direction": None,
+            },
+        ),
+        (
+            STATE_UNKNOWN,
+            {
+                "is_on": False,
+                "percentage": 0,
+                "preset_mode": "off",
+                "oscillating": False,
+                "direction": DIRECTION_FORWARD,
+            },
+            STATE_UNKNOWN,
+            {
+                "percentage": None,
+                "preset_mode": None,
+                "oscillating": None,
+                "direction": None,
+            },
+        ),
+    ],
+)
+async def test_restore_state(
+    hass: HomeAssistant,
+    config: ConfigType,
+    style: ConfigurationStyle,
+    saved_state: str,
+    saved_extra_data: dict | None,
+    initial_state: str,
+    initial_attributes: ConfigType,
+) -> None:
+    """Test restoring template fan."""
+
+    restored_attributes = {  # These should be ignored
+        "percentage": 45,
+        "preset_mode": "high",
+        "oscillating": True,
+        "direction": DIRECTION_REVERSE,
+    }
+
+    setup_mock_template_entity_restore_state(
+        hass,
+        TEST_FAN,
+        saved_state,
+        saved_extra_data=saved_extra_data,
+        saved_attributes=restored_attributes,
+    )
+
+    await setup_restore_template_entity(
+        hass,
+        TEST_FAN,
+        style,
+        config,
+        f"states('{TEST_STATE_ENTITY_ID}') | float(0) > 10",
+    )
+
+    state = assert_state_and_attributes(
+        hass,
+        TEST_FAN,
+        initial_state,
+        initial_attributes,
+    )
+
+    await async_trigger(
+        hass,
+        TEST_STATE_ENTITY_ID,
+        "11",
+        {
+            "is_on": True,
+            "percentage": 55,
+            "preset_mode": "low",
+            "oscillating": True,
+            "direction": DIRECTION_REVERSE,
+        },
+    )
+
+    state = hass.states.get(TEST_FAN.entity_id)
+    assert state.state == STATE_ON
+    assert state.attributes["percentage"] == 55
+    assert state.attributes["preset_mode"] == "low"
+    assert state.attributes["oscillating"] is True
+    assert state.attributes["direction"] == DIRECTION_REVERSE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add restore state to fan template entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
