### PR TITLE
Make ZHA OTA update messages translatable

### DIFF
--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -1,4 +1,8 @@
 {
+  "common": {
+    "ota_reliability_message": "If you are having issues updating a specific device, make sure that you've eliminated [common environmental issues]({docs_url}) that could be affecting network reliability. OTA updates require a reliable network.",
+    "ota_battery_message": "Battery powered devices can sometimes take multiple hours to update and you may need to wake the device for the update to begin."
+  },
   "config": {
     "abort": {
       "cannot_form_network": "Could not form a new Zigbee network.\n\nError: {error}",

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -1,7 +1,7 @@
 {
   "common": {
-    "ota_reliability_message": "If you are having issues updating a specific device, make sure that you've eliminated [common environmental issues]({docs_url}) that could be affecting network reliability. OTA updates require a reliable network.",
-    "ota_battery_message": "Battery powered devices can sometimes take multiple hours to update and you may need to wake the device for the update to begin."
+    "ota_battery_message": "Battery powered devices can sometimes take multiple hours to update and you may need to wake the device for the update to begin.",
+    "ota_reliability_message": "If you are having issues updating a specific device, make sure that you've eliminated [common environmental issues]({docs_url}) that could be affecting network reliability. OTA updates require a reliable network."
   },
   "config": {
     "abort": {

--- a/homeassistant/components/zha/update.py
+++ b/homeassistant/components/zha/update.py
@@ -16,6 +16,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import translation
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import (
@@ -23,6 +24,7 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 
+from .const import DOMAIN
 from .entity import ZHAEntity
 from .helpers import (
     SIGNAL_ADD_ENTITIES,
@@ -34,16 +36,18 @@ from .helpers import (
 
 _LOGGER = logging.getLogger(__name__)
 
+ZHA_DOCS_NETWORK_RELIABILITY = "https://www.home-assistant.io/integrations/zha/#zigbee-interference-avoidance-and-network-rangecoverage-optimization"
+
+# English fallbacks. The translated source of truth lives in `strings.json` under the
+# `common` section, so these messages can be localized (see `async_release_notes`).
 OTA_MESSAGE_BATTERY_POWERED = (
     "Battery powered devices can sometimes take multiple hours to update and you may"
     " need to wake the device for the update to begin."
 )
-
-ZHA_DOCS_NETWORK_RELIABILITY = "https://www.home-assistant.io/integrations/zha/#zigbee-interference-avoidance-and-network-rangecoverage-optimization"
 OTA_MESSAGE_RELIABILITY = (
     "If you are having issues updating a specific device, make sure that you've"
-    f" eliminated [common environmental issues]({ZHA_DOCS_NETWORK_RELIABILITY}) that"
-    " could be affecting network reliability. OTA updates require a reliable network."
+    " eliminated [common environmental issues]({docs_url}) that could be affecting"
+    " network reliability. OTA updates require a reliable network."
 )
 
 
@@ -170,15 +174,24 @@ class ZHAFirmwareUpdateEntity(
         property. The returned string can contain markdown.
         """
 
-        if self.entity_data.device_proxy.device.is_mains_powered:
-            header = f"<ha-alert alert-type='info'>{OTA_MESSAGE_RELIABILITY}</ha-alert>"
-        else:
-            header = (
-                "<ha-alert alert-type='info'>"
-                f"{OTA_MESSAGE_BATTERY_POWERED} {OTA_MESSAGE_RELIABILITY}"
-                "</ha-alert>"
-            )
+        translations = await translation.async_get_translations(
+            self.hass, self.hass.config.language, "common", {DOMAIN}
+        )
+        reliability = translations.get(
+            f"component.{DOMAIN}.common.ota_reliability_message",
+            OTA_MESSAGE_RELIABILITY,
+        ).format(docs_url=ZHA_DOCS_NETWORK_RELIABILITY)
 
+        if self.entity_data.device_proxy.device.is_mains_powered:
+            message = reliability
+        else:
+            battery = translations.get(
+                f"component.{DOMAIN}.common.ota_battery_message",
+                OTA_MESSAGE_BATTERY_POWERED,
+            )
+            message = f"{battery} {reliability}"
+
+        header = f"<ha-alert alert-type='info'>{message}</ha-alert>"
         return f"{header}\n\n{self.entity_data.entity.release_notes or ''}"
 
     @property

--- a/tests/components/zha/test_update.py
+++ b/tests/components/zha/test_update.py
@@ -40,6 +40,7 @@ from homeassistant.components.zha.helpers import (
 from homeassistant.components.zha.update import (
     OTA_MESSAGE_BATTERY_POWERED,
     OTA_MESSAGE_RELIABILITY,
+    ZHA_DOCS_NETWORK_RELIABILITY,
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -682,7 +683,10 @@ async def test_update_release_notes(
         result = await ws_client.receive_json()
         assert result["success"] is True
         assert "Some lengthy release notes" in result["result"]
-        assert OTA_MESSAGE_RELIABILITY in result["result"]
+        assert (
+            OTA_MESSAGE_RELIABILITY.format(docs_url=ZHA_DOCS_NETWORK_RELIABILITY)
+            in result["result"]
+        )
         assert OTA_MESSAGE_BATTERY_POWERED not in result["result"]
 
     # Battery-powered devices
@@ -700,7 +704,10 @@ async def test_update_release_notes(
         result = await ws_client.receive_json()
         assert result["success"] is True
         assert "Some lengthy release notes" in result["result"]
-        assert OTA_MESSAGE_RELIABILITY in result["result"]
+        assert (
+            OTA_MESSAGE_RELIABILITY.format(docs_url=ZHA_DOCS_NETWORK_RELIABILITY)
+            in result["result"]
+        )
         assert OTA_MESSAGE_BATTERY_POWERED in result["result"]
 
 


### PR DESCRIPTION
## Proposed change

The OTA advisory messages shown in the ZHA update entity's release notes were
hardcoded English strings in `update.py`:

- the network-reliability hint ("If you are having issues updating a specific
  device, make sure that you've eliminated common environmental issues… OTA
  updates require a reliable network."), and
- the battery-powered device hint.

Because they were built inline in `async_release_notes`, they were never
translatable and always appeared in English regardless of the user's language.

This moves both messages into `strings.json` under the `common` section and
resolves them at runtime via `translation.async_get_translations`, so they are
now localizable (and will be picked up by the normal translation pipeline). The
docs URL is passed as a `{docs_url}` placeholder, and the original English
strings are kept as fallbacks. The rendered output is unchanged for English
users.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
