### PR TITLE
Handle cname records in dnsip

### DIFF
--- a/homeassistant/components/dnsip/sensor.py
+++ b/homeassistant/components/dnsip/sensor.py
@@ -142,35 +142,41 @@ class WanIpSensor(SensorEntity):
         else:
             self.entry.runtime_data.resolver_ipv4 = new_resolver
 
+    async def async_resolve(self, hostname: str) -> list[str]:
+        """Resolve a hostname to an IP address."""
+        ips: list[str] = []
+        try:
+            async with asyncio.timeout(10):
+                response = await self._resolver.query_dns(hostname, self.querytype)
+        except TimeoutError as err:
+            _LOGGER.debug("Timeout while resolving host: %s", err)
+            await self._resolver.close()
+            return ips
+        except DNSError as err:
+            _LOGGER.warning("Exception while resolving host: %s", err)
+            await self._resolver.close()
+            return ips
+
+        for res in response.answer:
+            if type(res.data) is pycares.CNAMERecordData:
+                addr = await self.async_resolve(res.data.cname)
+                ips.extend(addr)
+            else:
+                if TYPE_CHECKING:
+                    assert isinstance(
+                        res.data, (pycares.AAAARecordData, pycares.ARecordData)
+                    )
+                ips.append(res.data.addr)
+        return ips
+
     async def async_update(self) -> None:
         """Get the current DNS IP address for hostname."""
         if self._resolver._closed:  # noqa: SLF001
             self.create_dns_resolver()
-        response = None
-        try:
-            async with asyncio.timeout(10):
-                response = await self._resolver.query_dns(self.hostname, self.querytype)
-        except TimeoutError as err:
-            _LOGGER.debug("Timeout while resolving host: %s", err)
-            await self._resolver.close()
-        except DNSError as err:
-            _LOGGER.warning("Exception while resolving host: %s", err)
-            await self._resolver.close()
+        response = await self.async_resolve(self.hostname)
 
         if response:
-            if TYPE_CHECKING:
-                assert all(
-                    isinstance(res.data, (pycares.ARecordData, pycares.AAAARecordData))
-                    for res in response.answer
-                )
-            _ips = []
-            for res in response.answer:
-                if TYPE_CHECKING:
-                    assert isinstance(
-                        res.data, (pycares.ARecordData, pycares.AAAARecordData)
-                    )
-                _ips.append(res.data.addr)
-            sorted_ips = sort_ips(_ips, querytype=self.querytype)
+            sorted_ips = sort_ips(response, querytype=self.querytype)
             self._attr_native_value = sorted_ips[0]
             self._attr_extra_state_attributes["ip_addresses"] = sorted_ips
             self._attr_available = True

--- a/homeassistant/components/dnsip/sensor.py
+++ b/homeassistant/components/dnsip/sensor.py
@@ -158,15 +158,9 @@ class WanIpSensor(SensorEntity):
             return ips
 
         for res in response.answer:
-            if type(res.data) is pycares.CNAMERecordData:
-                addr = await self.async_resolve(res.data.cname)
-                ips.extend(addr)
-            else:
-                if TYPE_CHECKING:
-                    assert isinstance(
-                        res.data, (pycares.AAAARecordData, pycares.ARecordData)
-                    )
-                ips.append(res.data.addr)
+            if isinstance(res.data, (pycares.AAAARecordData, pycares.ARecordData)):
+                addr = res.data.addr
+                ips.append(addr)
         return ips
 
     async def async_update(self) -> None:

--- a/homeassistant/components/dnsip/sensor.py
+++ b/homeassistant/components/dnsip/sensor.py
@@ -35,14 +35,14 @@ _LOGGER = logging.getLogger(__name__)
 SCAN_INTERVAL = timedelta(seconds=120)
 
 
-def sort_ips(ips: list, querytype: Literal["A", "AAAA"]) -> list:
+def sort_ips(ips: list[str], querytype: Literal["A", "AAAA"]) -> list[str]:
     """Join IPs into a single string."""
-
+    _ips: list[IPv4Address | IPv6Address]
     if querytype == "AAAA":
-        ips = [IPv6Address(ip) for ip in ips]
+        _ips = [IPv6Address(ip) for ip in ips]
     else:
-        ips = [IPv4Address(ip) for ip in ips]
-    return [str(ip) for ip in sorted(ips)][:MAX_RESULTS]
+        _ips = [IPv4Address(ip) for ip in ips]
+    return [str(ip) for ip in sorted(_ips)][:MAX_RESULTS]
 
 
 async def async_setup_entry(
@@ -143,7 +143,7 @@ class WanIpSensor(SensorEntity):
             self.entry.runtime_data.resolver_ipv4 = new_resolver
 
     async def async_resolve(self, hostname: str) -> list[str]:
-        """Resolve a hostname to an IP address."""
+        """Resolve a hostname to its IP addresses."""
         ips: list[str] = []
         try:
             async with asyncio.timeout(10):
@@ -168,8 +168,8 @@ class WanIpSensor(SensorEntity):
         if self._resolver._closed:  # noqa: SLF001
             self.create_dns_resolver()
 
-        if response := await self.async_resolve(self.hostname):
-            sorted_ips = sort_ips(response, querytype=self.querytype)
+        if ips := await self.async_resolve(self.hostname):
+            sorted_ips = sort_ips(ips, querytype=self.querytype)
             self._attr_native_value = sorted_ips[0]
             self._attr_extra_state_attributes["ip_addresses"] = sorted_ips
             self._attr_available = True

--- a/homeassistant/components/dnsip/sensor.py
+++ b/homeassistant/components/dnsip/sensor.py
@@ -167,9 +167,8 @@ class WanIpSensor(SensorEntity):
         """Get the current DNS IP address for hostname."""
         if self._resolver._closed:  # noqa: SLF001
             self.create_dns_resolver()
-        response = await self.async_resolve(self.hostname)
 
-        if response:
+        if response := await self.async_resolve(self.hostname):
             sorted_ips = sort_ips(response, querytype=self.querytype)
             self._attr_native_value = sorted_ips[0]
             self._attr_extra_state_attributes["ip_addresses"] = sorted_ips

--- a/tests/components/dnsip/__init__.py
+++ b/tests/components/dnsip/__init__.py
@@ -16,7 +16,10 @@ class RetrieveDNS:
     """Return list of test information."""
 
     def __init__(
-        self, nameservers: list[str] | None = None, error: Exception | None = None
+        self,
+        nameservers: list[str] | None = None,
+        error: Exception | None = None,
+        cname_runs: int = 0,
     ) -> None:
         """Initialize DNS class."""
         if nameservers:
@@ -24,6 +27,7 @@ class RetrieveDNS:
         self._nameservers = ["1.2.3.4"]
         self.error = error
         self._closed = False
+        self.cname_runs = cname_runs
 
     async def query_dns(
         self, host: str, qtype: str, qclass: str | None = None
@@ -31,6 +35,21 @@ class RetrieveDNS:
         """Return dns information."""
         if self.error:
             raise self.error
+        if self.cname_runs > 0:
+            self.cname_runs -= 1
+            return pycares.DNSResult(
+                answer=[
+                    pycares.DNSRecord(
+                        name="test",
+                        type=pycares.QUERY_TYPE_A,
+                        record_class=pycares.QUERY_CLASS_IN,
+                        data=pycares.CNAMERecordData(cname="test.testing.com"),
+                        ttl=60,
+                    ),
+                ],
+                authority=[],
+                additional=[],
+            )
         if qtype == "AAAA":
             results = pycares.DNSResult(
                 answer=[

--- a/tests/components/dnsip/__init__.py
+++ b/tests/components/dnsip/__init__.py
@@ -16,10 +16,7 @@ class RetrieveDNS:
     """Return list of test information."""
 
     def __init__(
-        self,
-        nameservers: list[str] | None = None,
-        error: Exception | None = None,
-        cname_runs: int = 0,
+        self, nameservers: list[str] | None = None, error: Exception | None = None
     ) -> None:
         """Initialize DNS class."""
         if nameservers:
@@ -27,7 +24,6 @@ class RetrieveDNS:
         self._nameservers = ["1.2.3.4"]
         self.error = error
         self._closed = False
-        self.cname_runs = cname_runs
 
     async def query_dns(
         self, host: str, qtype: str, qclass: str | None = None
@@ -35,21 +31,6 @@ class RetrieveDNS:
         """Return dns information."""
         if self.error:
             raise self.error
-        if self.cname_runs > 0:
-            self.cname_runs -= 1
-            return pycares.DNSResult(
-                answer=[
-                    pycares.DNSRecord(
-                        name="test",
-                        type=pycares.QUERY_TYPE_A,
-                        record_class=pycares.QUERY_CLASS_IN,
-                        data=pycares.CNAMERecordData(cname="test.testing.com"),
-                        ttl=60,
-                    ),
-                ],
-                authority=[],
-                additional=[],
-            )
         if qtype == "AAAA":
             results = pycares.DNSResult(
                 answer=[
@@ -88,6 +69,13 @@ class RetrieveDNS:
         else:
             results = pycares.DNSResult(
                 answer=[
+                    pycares.DNSRecord(
+                        name="test",
+                        type=pycares.QUERY_TYPE_CNAME,
+                        record_class=pycares.QUERY_CLASS_IN,
+                        data=pycares.CNAMERecordData(cname="test.testing.com"),
+                        ttl=60,
+                    ),
                     pycares.DNSRecord(
                         name="test",
                         type=pycares.QUERY_TYPE_A,

--- a/tests/components/dnsip/test_sensor.py
+++ b/tests/components/dnsip/test_sensor.py
@@ -237,7 +237,7 @@ async def test_sensor_timeout(
 
 
 async def test_handle_cname(hass: HomeAssistant) -> None:
-    """Test handling of CNAME records."""
+    """Test CNAME records are dropped."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         source=SOURCE_USER,
@@ -260,7 +260,7 @@ async def test_handle_cname(hass: HomeAssistant) -> None:
 
     with patch(
         "homeassistant.components.dnsip.aiodns.DNSResolver",
-        side_effect=[RetrieveDNS(cname_runs=2)],
+        return_value=RetrieveDNS(),
     ):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/components/dnsip/test_sensor.py
+++ b/tests/components/dnsip/test_sensor.py
@@ -234,3 +234,38 @@ async def test_sensor_timeout(
 
     state = hass.states.get("sensor.home_assistant_io")
     assert state.state == STATE_UNAVAILABLE
+
+
+async def test_handle_cname(hass: HomeAssistant) -> None:
+    """Test handling of CNAME records."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        source=SOURCE_USER,
+        data={
+            CONF_HOSTNAME: "home-assistant.io",
+            CONF_NAME: "home-assistant.io",
+            CONF_IPV4: True,
+            CONF_IPV6: False,
+        },
+        options={
+            CONF_RESOLVER: "208.67.222.222",
+            CONF_RESOLVER_IPV6: "2620:119:53::53",
+            CONF_PORT: 53,
+            CONF_PORT_IPV6: 53,
+        },
+        entry_id="1",
+        unique_id="home-assistant.io",
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.dnsip.aiodns.DNSResolver",
+        side_effect=[RetrieveDNS(cname_runs=2)],
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    state1 = hass.states.get("sensor.home_assistant_io")
+
+    assert state1.state == "1.1.1.1"
+    assert state1.attributes["ip_addresses"] == ["1.1.1.1", "1.2.3.4"]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change


## Proposed change
Drop other types than A or AAAA records. As example querying a record which is a `CNAME` record returns both the `CNAME` record and the corresponding final `A` record.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #175303
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository. 