### PR TITLE
Allow roomba to update ip address for registered devices via dhcp

### DIFF
--- a/homeassistant/components/roomba/config_flow.py
+++ b/homeassistant/components/roomba/config_flow.py
@@ -114,11 +114,21 @@ class RoombaConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle any discovery."""
         self._async_abort_entries_match({CONF_HOST: ip_address})
 
-        if not hostname.startswith(("irobot-", "roomba-")):
+        self.host = ip_address
+
+        # Actively probe the device at this IP for its real blid. This is
+        # authoritative and handles two cases where the hostname can't be
+        # trusted: some routers substitute a user-assigned friendly name
+        # for the DHCP/mDNS hostname instead of irobot-<blid>/roomba-<blid>,
+        # and even a well-formed hostname's blid may be truncated if the
+        # hostname exceeds length limits somewhere in the chain.
+        if devices := await _async_discover_roombas(self.hass, self.host):
+            self.blid = devices[0].blid
+        elif hostname.startswith(("irobot-", "roomba-")):
+            self.blid = _async_blid_from_hostname(hostname)
+        else:
             return self.async_abort(reason="not_irobot_device")
 
-        self.host = ip_address
-        self.blid = _async_blid_from_hostname(hostname)
         await self.async_set_unique_id(self.blid)
         self._abort_if_unique_id_configured(updates={CONF_HOST: ip_address})
 

--- a/homeassistant/components/roomba/manifest.json
+++ b/homeassistant/components/roomba/manifest.json
@@ -19,6 +19,9 @@
     {
       "hostname": "roomba-*",
       "macaddress": "204EF6*"
+    },
+    {
+      "registered_devices": true
     }
   ],
   "documentation": "https://www.home-assistant.io/integrations/roomba",

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -911,6 +911,10 @@ DHCP: Final[list[dict[str, str | bool]]] = [
         "macaddress": "204EF6*",
     },
     {
+        "domain": "roomba",
+        "registered_devices": True,
+    },
+    {
         "domain": "ruuvi_gateway",
         "hostname": "ruuvigateway*",
     },

--- a/tests/components/roomba/test_config_flow.py
+++ b/tests/components/roomba/test_config_flow.py
@@ -1,5 +1,6 @@
 """Test the iRobot Roomba config flow."""
 
+from functools import partial
 from ipaddress import ip_address
 from unittest.mock import MagicMock, PropertyMock, patch
 
@@ -106,11 +107,11 @@ def _create_mocked_roomba(
     return mocked_roomba
 
 
-def _mocked_discovery(*_):
+def _mocked_discovery(*_, blid="BLID"):
     roomba_discovery = MagicMock()
 
     roomba = RoombaInfo(
-        hostname="irobot-BLID",
+        hostname=f"irobot-{blid}",
         robot_name="robot_name",
         ip=MOCK_IP,
         mac="mac",
@@ -981,7 +982,8 @@ async def test_dhcp_discovery_not_irobot(hass: HomeAssistant) -> None:
     config_entry.add_to_hass(hass)
 
     with patch(
-        "homeassistant.components.roomba.config_flow.RoombaDiscovery", _mocked_discovery
+        "homeassistant.components.roomba.config_flow.RoombaDiscovery",
+        _mocked_no_devices_found_discovery,
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -1018,8 +1020,10 @@ async def test_dhcp_discovery_partial_hostname(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "link"
 
+    blid = "blidthatislonger"
     with patch(
-        "homeassistant.components.roomba.config_flow.RoombaDiscovery", _mocked_discovery
+        "homeassistant.components.roomba.config_flow.RoombaDiscovery",
+        partial(_mocked_discovery, blid=blid),
     ):
         result2 = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -1027,7 +1031,7 @@ async def test_dhcp_discovery_partial_hostname(hass: HomeAssistant) -> None:
             data=DhcpServiceInfo(
                 ip=MOCK_IP,
                 macaddress="aabbccddeeff",
-                hostname="irobot-blidthatislonger",
+                hostname=f"irobot-{blid}",
             ),
         )
         await hass.async_block_till_done()
@@ -1039,8 +1043,10 @@ async def test_dhcp_discovery_partial_hostname(hass: HomeAssistant) -> None:
     assert len(current_flows) == 1
     assert current_flows[0]["flow_id"] == result2["flow_id"]
 
+    blid = "bl"
     with patch(
-        "homeassistant.components.roomba.config_flow.RoombaDiscovery", _mocked_discovery
+        "homeassistant.components.roomba.config_flow.RoombaDiscovery",
+        partial(_mocked_discovery, blid=blid),
     ):
         result3 = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -1048,7 +1054,7 @@ async def test_dhcp_discovery_partial_hostname(hass: HomeAssistant) -> None:
             data=DhcpServiceInfo(
                 ip=MOCK_IP,
                 macaddress="aabbccddeeff",
-                hostname="irobot-bl",
+                hostname=f"irobot-{blid}",
             ),
         )
         await hass.async_block_till_done()

--- a/tests/components/roomba/test_config_flow.py
+++ b/tests/components/roomba/test_config_flow.py
@@ -1003,8 +1003,10 @@ async def test_dhcp_discovery_not_irobot(hass: HomeAssistant) -> None:
 async def test_dhcp_discovery_partial_hostname(hass: HomeAssistant) -> None:
     """Test we abort flows when we have a partial hostname."""
 
+    blid = "blid"
     with patch(
-        "homeassistant.components.roomba.config_flow.RoombaDiscovery", _mocked_discovery
+        "homeassistant.components.roomba.config_flow.RoombaDiscovery",
+        partial(_mocked_discovery, blid=blid),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -1012,7 +1014,7 @@ async def test_dhcp_discovery_partial_hostname(hass: HomeAssistant) -> None:
             data=DhcpServiceInfo(
                 ip=MOCK_IP,
                 macaddress="aabbccddeeff",
-                hostname="irobot-blid",
+                hostname=f"irobot-{blid}",
             ),
         )
         await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #129321
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
