### PR TITLE
Use ThreadedResolver and disable DNS cache to prevent stale IPs

### DIFF
--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -51,6 +51,7 @@ from homeassistant.core import (
     callback as ha_callback,
     split_entity_id,
 )
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.util.decorator import Registry
@@ -645,12 +646,37 @@ class HomeAccessory(Accessory):  # type: ignore[misc]
         context = Context()
 
         self.hass.bus.async_fire(EVENT_HOMEKIT_CHANGED, event_data, context=context)
-        self.hass.async_create_task(
-            self.hass.services.async_call(
-                domain, service, service_data, context=context
-            ),
-            eager_start=True,
-        )
+
+        async def _call() -> None:
+            # blocking=True so the handler's exception reaches us (the
+            # non-blocking path swallows it); on failure we resync so pyhap's
+            # optimistic target characteristic doesn't strand the tile on the
+            # requested action.
+            try:
+                await self.hass.services.async_call(
+                    domain, service, service_data, blocking=True, context=context
+                )
+            except HomeAssistantError as err:
+                _LOGGER.warning(
+                    "%s: %s.%s failed (%s); re-syncing HomeKit state",
+                    self.entity_id,
+                    domain,
+                    service,
+                    err,
+                )
+            except Exception:
+                _LOGGER.exception(
+                    "%s: %s.%s raised unexpectedly; re-syncing HomeKit state",
+                    self.entity_id,
+                    domain,
+                    service,
+                )
+            else:
+                return
+            if (state := self.hass.states.get(self.entity_id)) is not None:
+                self.async_update_state(state)
+
+        self.hass.async_create_task(_call(), eager_start=True)
 
     @ha_callback
     def async_reload(self) -> None:

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -15,11 +15,10 @@ import aiohttp
 from aiohttp import ClientMiddlewareType, hdrs, web
 from aiohttp.hdrs import CONTENT_TYPE, USER_AGENT
 from aiohttp.web_exceptions import HTTPBadGateway, HTTPGatewayTimeout
-from aiohttp_asyncmdnsresolver.api import AsyncDualMDNSResolver
+from aiohttp.resolver import ThreadedResolver
 from yarl import URL
 
 from homeassistant import config_entries
-from homeassistant.components import zeroconf
 from homeassistant.const import APPLICATION_NAME, EVENT_HOMEASSISTANT_CLOSE, __version__
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.util import ssl as ssl_util
@@ -41,7 +40,7 @@ DATA_CONNECTOR: HassKey[dict[tuple[bool, int, str], aiohttp.BaseConnector]] = Ha
 DATA_CLIENTSESSION: HassKey[dict[tuple[bool, int, str], aiohttp.ClientSession]] = (
     HassKey("aiohttp_clientsession")
 )
-DATA_RESOLVER: HassKey[HassAsyncDNSResolver] = HassKey("aiohttp_resolver")
+DATA_RESOLVER: HassKey[ThreadedResolver] = HassKey("aiohttp_resolver")
 
 SERVER_SOFTWARE = (
     f"{APPLICATION_NAME}/{__version__} "
@@ -155,22 +154,6 @@ async def _async_is_blocked_host(
 #
 MAXIMUM_CONNECTIONS = 4096
 MAXIMUM_CONNECTIONS_PER_HOST = 100
-
-
-class HassAsyncDNSResolver(AsyncDualMDNSResolver):
-    """Home Assistant AsyncDNSResolver.
-
-    This is a wrapper around the AsyncDualMDNSResolver to only
-    close the resolver when the Home Assistant instance is closed.
-    """
-
-    async def real_close(self) -> None:
-        """Close the resolver."""
-        await super().close()
-
-    @override
-    async def close(self) -> None:
-        """Close the resolver."""
 
 
 class HassClientResponse(aiohttp.ClientResponse):
@@ -476,6 +459,7 @@ def _async_get_connector(
         ssl=ssl_context,
         limit=MAXIMUM_CONNECTIONS,
         limit_per_host=MAXIMUM_CONNECTIONS_PER_HOST,
+        ttl_dns_cache=0,
         resolver=_async_get_or_create_resolver(hass),
     )
     connectors[connector_key] = connector
@@ -491,17 +475,12 @@ def _async_get_connector(
 
 @singleton(DATA_RESOLVER)
 @callback
-def _async_get_or_create_resolver(hass: HomeAssistant) -> HassAsyncDNSResolver:
-    """Return the HassAsyncDNSResolver."""
-    resolver = _async_make_resolver(hass)
+def _async_get_or_create_resolver(hass: HomeAssistant) -> ThreadedResolver:
+    """Return the ThreadedResolver."""
+    resolver = ThreadedResolver()
 
     async def _async_close_resolver(event: Event) -> None:
-        await resolver.real_close()
+        await resolver.close()
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_CLOSE, _async_close_resolver)
     return resolver
-
-
-@callback
-def _async_make_resolver(hass: HomeAssistant) -> HassAsyncDNSResolver:
-    return HassAsyncDNSResolver(async_zeroconf=zeroconf.async_get_async_zeroconf(hass))

--- a/tests/components/homekit/test_accessories.py
+++ b/tests/components/homekit/test_accessories.py
@@ -48,6 +48,7 @@ from homeassistant.const import (
     __version__ as hass_version,
 )
 from homeassistant.core import Event, HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 
 from tests.common import async_mock_service
 
@@ -729,6 +730,42 @@ async def test_call_service(
     assert call_service[0].domain == test_domain
     assert call_service[0].service == test_service
     assert call_service[0].data == {ATTR_ENTITY_ID: entity_id}
+
+
+@pytest.mark.parametrize(
+    "raise_exception",
+    [
+        pytest.param(HomeAssistantError("nope"), id="home_assistant_error"),
+        pytest.param(RuntimeError("third-party blew up"), id="unexpected_exception"),
+    ],
+)
+async def test_call_service_resyncs_on_failure(
+    hass: HomeAssistant, hk_driver, raise_exception: Exception
+) -> None:
+    """When the dispatched service raises, re-push the entity's current state.
+
+    pyhap optimistically advances the target characteristic before the setter runs.
+    If the service refuses, the optimistic target strands the accessory out of sync.
+    blocking=True surfaces every exception (HomeAssistantError and unexpected alike);
+    both paths must resync via async_update_state with the current state.
+    """
+    entity_id = "homekit.accessory"
+    hass.states.async_set(entity_id, STATE_OFF)
+    await hass.async_block_till_done()
+
+    acc = HomeAccessory(hass, hk_driver, "Home Accessory", entity_id, 2, {})
+    async_mock_service(hass, "cover", "open_cover", raise_exception=raise_exception)
+
+    with patch.object(acc, "async_update_state") as mock_update_state:
+        acc.async_call_service(
+            "cover", "open_cover", {ATTR_ENTITY_ID: entity_id}, "value"
+        )
+        await hass.async_block_till_done()
+
+    mock_update_state.assert_called_once()
+    pushed_state = mock_update_state.call_args.args[0]
+    assert pushed_state.entity_id == entity_id
+    assert pushed_state.state == STATE_OFF
 
 
 def test_home_bridge(hk_driver) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1431,9 +1431,8 @@ def disable_translations_once(
 async def mock_zeroconf_resolver() -> AsyncGenerator[_patch]:
     """Mock out the zeroconf resolver."""
     resolver = AsyncResolver()
-    resolver.real_close = resolver.close
     patcher = patch(
-        "homeassistant.helpers.aiohttp_client._async_make_resolver",
+        "homeassistant.helpers.aiohttp_client._async_get_or_create_resolver",
         return_value=resolver,
     )
     patcher.start()

--- a/tests/helpers/test_aiohttp_client.py
+++ b/tests/helpers/test_aiohttp_client.py
@@ -393,19 +393,6 @@ async def test_client_session_immutable_headers(hass: HomeAssistant) -> None:
         session.headers.update({"user-agent": "bla"})
 
 
-@pytest.mark.usefixtures("disable_mock_zeroconf_resolver")
-@pytest.mark.usefixtures("mock_async_zeroconf")
-async def test_async_mdnsresolver(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
-) -> None:
-    """Test async_mdnsresolver."""
-    resp = aioclient_mock.post("http://localhost/xyz", json={"x": 1})
-    session = client.async_create_clientsession(hass)
-    resp = await session.post("http://localhost/xyz", json={"x": 1})
-    assert resp.status == 200
-    assert await resp.json() == {"x": 1}
-
-
 async def test_resolver_is_singleton(hass: HomeAssistant) -> None:
     """Test that the resolver is a singleton."""
     session = client.async_get_clientsession(hass)
@@ -442,6 +429,15 @@ async def test_connector_no_verify_uses_http11_alpn(hass: HomeAssistant) -> None
         mock_client_context_no_verify.assert_called_once_with(
             SSLCipherList.PYTHON_DEFAULT, ssl_util.SSL_ALPN_HTTP11
         )
+
+
+async def test_connector_ttl_dns_cache_zero(hass: HomeAssistant) -> None:
+    """Test that the connector has DNS cache TTL set to 0."""
+    session = client.async_get_clientsession(hass)
+
+    connector = session.connector
+    assert isinstance(connector, aiohttp.TCPConnector)
+    assert connector._ttl_dns_cache == 0
 
 
 @pytest.fixture


### PR DESCRIPTION
When a service behind a hostname changes IP (Docker container restart, DNS failover, etc.), the aiohttp connector's default DNS cache TTL of 10 seconds causes integrations to send requests to stale IPs. Repeated failures within the cache window can leave integrations stuck in error states until HA is restarted.

Two changes fix this:

1. ttl_dns_cache=0 on HomeAssistantTCPConnector - disables aiohttp's _cached_hosts DNS cache entirely. DNS lookups are cheap and the 10s TTL provides no benefit for HA's typical polling intervals.

2. Switch from AsyncResolver (c-ares via pycares) to ThreadedResolver (glibc getaddrinfo in a thread pool). c-ares has its own internal DNS cache that survives aiohttp's _cached_hosts eviction, causing stale IPs to persist beyond the 10s TTL. ThreadedResolver uses the same resolver as curl/getent, which resolves fresh on every call.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #175239, potentially #157017
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
