### PR TITLE
Improve Tesla Fleet regional registration failure handling

### DIFF
--- a/homeassistant/components/tesla_fleet/config_flow.py
+++ b/homeassistant/components/tesla_fleet/config_flow.py
@@ -231,19 +231,11 @@ class OAuth2FlowHandler(
             )
 
         # Validate the home region's own returned public key against our shared
-        # key. The key file is shared across all region clients, so the point is
-        # identical per region.
-        registered_public_key = (
-            responses[self.region].get("response", {}).get("public_key")
-        )
+        # key. The loop above guarantees the home region produced a usable public
+        # key, and the key file is shared across all region clients, so the point
+        # is identical per region.
+        registered_public_key = responses[self.region]["response"]["public_key"]
 
-        if not registered_public_key:
-            errors["base"] = "public_key_not_found"
-            return self.async_show_form(
-                step_id="domain_registration",
-                description_placeholders=description_placeholders,
-                errors=errors,
-            )
         if (
             registered_public_key.lower()
             != self.apis[0][1].public_uncompressed_point.lower()

--- a/homeassistant/components/tesla_fleet/config_flow.py
+++ b/homeassistant/components/tesla_fleet/config_flow.py
@@ -339,31 +339,4 @@ class OAuth2FlowHandler(
         """Classify a Tesla registration failure into a translatable error key."""
         if isinstance(err, PreconditionFailed):
             return "origin_mismatch"
-
-        error_text = " ".join(
-            str(part).lower()
-            for part in (
-                getattr(err, "message", ""),
-                getattr(err, "data", ""),
-                err,
-            )
-            if part
-        )
-
-        if "origin" in error_text:
-            return "origin_mismatch"
-
-        if any(
-            marker in error_text
-            for marker in (
-                "public key",
-                "public_key",
-                "private key",
-                "private_key",
-                "prime256v1",
-                "secp256r1",
-            )
-        ):
-            return "reset_private_key"
-
         return "registration_failed"

--- a/homeassistant/components/tesla_fleet/config_flow.py
+++ b/homeassistant/components/tesla_fleet/config_flow.py
@@ -212,7 +212,7 @@ class OAuth2FlowHandler(
 
             # A non-raising but empty or malformed response (no usable public key)
             # must count as a failure, not a success.
-            if not (register_response or {}).get("response", {}).get("public_key"):
+            if not ((register_response or {}).get("response") or {}).get("public_key"):
                 LOGGER.warning(
                     "Partner registration for %s (%s) returned no usable response",
                     region,

--- a/homeassistant/components/tesla_fleet/config_flow.py
+++ b/homeassistant/components/tesla_fleet/config_flow.py
@@ -1,6 +1,7 @@
 """Config Flow for Tesla Fleet integration."""
 
 from collections.abc import Mapping
+from dataclasses import dataclass
 import logging
 import re
 from typing import Any, cast, override
@@ -31,6 +32,33 @@ from .const import DOMAIN, LOGGER
 from .oauth import TeslaUserImplementation
 
 
+@dataclass(slots=True)
+class RegionRegistrationFailure:
+    """Store a normalized regional registration failure."""
+
+    region: str
+    reason: str
+
+
+_REGION_LABELS = {
+    "na": "North America",
+    "eu": "Europe",
+}
+_REGION_REASONS = {
+    "origin_mismatch": (
+        "Verify the entered domain matches the Tesla developer app's allowed origin."
+    ),
+    "reset_private_key": (
+        "Remove `tesla_fleet.key` from your Home Assistant config directory so a "
+        "new key pair is generated, then retry registration."
+    ),
+    "generic": (
+        "Tesla rejected the registration in this region. Verify both the hosted "
+        "public key and the Tesla developer app configuration, then retry."
+    ),
+}
+
+
 class OAuth2FlowHandler(
     config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain=DOMAIN
 ):
@@ -44,7 +72,10 @@ class OAuth2FlowHandler(
         self.domain: str | None = None
         self.data: dict[str, Any] = {}
         self.uid: str | None = None
-        self.apis: list[TeslaFleetApi] = []
+        self.apis: list[tuple[str, TeslaFleetApi]] = []
+        self._region_failures: list[RegionRegistrationFailure] = []
+        self._successful_regions: list[str] = []
+        self._can_continue_after_region_failures = False
 
     @property
     @override
@@ -109,7 +140,7 @@ class OAuth2FlowHandler(
                 LOGGER.warning("Partner login failed for %s: %s", server_url, err)
                 failed_regions.append(server_url)
                 continue
-            self.apis.append(api)
+            self.apis.append((region, api))
 
         if not self.apis:
             LOGGER.warning(
@@ -144,16 +175,17 @@ class OAuth2FlowHandler(
                 self.domain = domain
                 return await self.async_step_domain_registration()
 
+        data_schema = self.add_suggested_values_to_schema(
+            vol.Schema({vol.Required(CONF_DOMAIN): str}),
+            {CONF_DOMAIN: self.domain} if self.domain else None,
+        )
+
         return self.async_show_form(
             step_id="domain_input",
             description_placeholders={
                 "dashboard": "https://developer.tesla.com/en_AU/dashboard/"
             },
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_DOMAIN): str,
-                }
-            ),
+            data_schema=data_schema,
             errors=errors,
         )
 
@@ -163,37 +195,50 @@ class OAuth2FlowHandler(
         """Handle domain registration for all regions."""
 
         assert self.apis
-        assert self.apis[0].private_key
+        assert self.apis[0][1].private_key
         assert self.domain
+
+        self._region_failures = []
+        self._successful_regions = []
+        self._can_continue_after_region_failures = False
 
         errors: dict[str, str] = {}
         description_placeholders = {
             "public_key_url": f"https://{self.domain}/.well-known/appspecific/com.tesla.3p.public-key.pem",
-            "pem": self.apis[0].public_pem,
+            "pem": self.apis[0][1].public_pem,
         }
 
         successful_response: dict[str, Any] | None = None
-        failed_regions: list[str] = []
 
-        for api in self.apis:
+        for region, api in self.apis:
             try:
                 register_response = await api.partner.register(self.domain)
-            except PreconditionFailed:
-                return await self.async_step_domain_input(
-                    errors={CONF_DOMAIN: "precondition_failed"}
-                )
-            except TeslaFleetError as e:
+            except TeslaFleetError as err:
                 LOGGER.warning(
-                    "Partner registration failed for %s: %s",
+                    "Partner registration failed for %s (%s) with payload %s",
+                    region,
                     api.server,
-                    e.message,
+                    getattr(err, "data", None),
+                    exc_info=err,
                 )
-                failed_regions.append(api.server or "unknown")
+                self._region_failures.append(
+                    RegionRegistrationFailure(
+                        region=region,
+                        reason=self._classify_region_registration_failure(err),
+                    )
+                )
             else:
+                self._successful_regions.append(region)
                 if successful_response is None:
                     successful_response = register_response
 
+        self._can_continue_after_region_failures = bool(
+            self._successful_regions and self._region_failures
+        )
+
         if successful_response is None:
+            if self._region_failures:
+                return await self.async_step_region_failures()
             errors["base"] = "invalid_response"
             return self.async_show_form(
                 step_id="domain_registration",
@@ -201,10 +246,10 @@ class OAuth2FlowHandler(
                 errors=errors,
             )
 
-        if failed_regions:
+        if self._region_failures:
             LOGGER.warning(
                 "Partner registration succeeded on some regions but failed on: %s",
-                ", ".join(failed_regions),
+                ", ".join(failure.region for failure in self._region_failures),
             )
 
         # Verify public key from the successful response
@@ -216,9 +261,11 @@ class OAuth2FlowHandler(
             errors["base"] = "public_key_not_found"
         elif (
             registered_public_key.lower()
-            != self.apis[0].public_uncompressed_point.lower()
+            != self.apis[0][1].public_uncompressed_point.lower()
         ):
             errors["base"] = "public_key_mismatch"
+        elif self._region_failures:
+            return await self.async_step_region_failures()
         else:
             return await self.async_step_registration_complete()
 
@@ -226,6 +273,21 @@ class OAuth2FlowHandler(
             step_id="domain_registration",
             description_placeholders=description_placeholders,
             errors=errors,
+        )
+
+    async def async_step_region_failures(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Warn about regional partner registration failures."""
+        if user_input is not None:
+            if self._can_continue_after_region_failures:
+                return await self.async_step_registration_complete()
+            return await self.async_step_domain_input()
+
+        return self.async_show_form(
+            step_id="region_failures",
+            data_schema=vol.Schema({}),
+            description_placeholders=self._region_failure_placeholders(),
         )
 
     async def async_step_registration_complete(
@@ -284,3 +346,77 @@ class OAuth2FlowHandler(
             r"^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$"
         )
         return bool(domain_pattern.match(domain))
+
+    def _classify_region_registration_failure(self, err: TeslaFleetError) -> str:
+        """Classify a Tesla registration failure for user guidance."""
+        if isinstance(err, PreconditionFailed):
+            return "origin_mismatch"
+
+        error_text = " ".join(
+            str(part).lower()
+            for part in (
+                getattr(err, "message", ""),
+                getattr(err, "data", ""),
+                err,
+            )
+            if part
+        )
+
+        if any(
+            marker in error_text
+            for marker in ("origin", "allowed origin", "allowed_origin", "domain")
+        ):
+            return "origin_mismatch"
+
+        if any(
+            marker in error_text
+            for marker in (
+                "public key",
+                "public_key",
+                "private key",
+                "private_key",
+                "prime256v1",
+                "secp256r1",
+            )
+        ):
+            return "reset_private_key"
+
+        return "generic"
+
+    def _region_failure_placeholders(self) -> dict[str, str]:
+        """Build the placeholders for the regional warning step."""
+        successful_regions = ""
+        if self._successful_regions:
+            regions = ", ".join(
+                _REGION_LABELS[region] for region in self._successful_regions
+            )
+            successful_regions = f"Successful regions: {regions}\n"
+
+        failed_regions = ", ".join(
+            _REGION_LABELS[region]
+            for region in dict.fromkeys(
+                failure.region for failure in self._region_failures
+            )
+        )
+        failure_details = "\n".join(
+            f"{_REGION_LABELS[failure.region]}: {_REGION_REASONS[failure.reason]}"
+            for failure in self._region_failures
+        )
+
+        if self._can_continue_after_region_failures:
+            next_step = (
+                "You can continue setup, but the integration will only be registered "
+                "in the successful regions."
+            )
+        else:
+            next_step = (
+                "Registration did not succeed in any region. After acknowledging this "
+                "warning, you will return to the domain step to retry."
+            )
+
+        return {
+            "successful_regions": successful_regions,
+            "failed_regions": f"Failed regions: {failed_regions}",
+            "failure_details": failure_details,
+            "next_step": next_step,
+        }

--- a/homeassistant/components/tesla_fleet/config_flow.py
+++ b/homeassistant/components/tesla_fleet/config_flow.py
@@ -1,7 +1,6 @@
 """Config Flow for Tesla Fleet integration."""
 
 from collections.abc import Mapping
-from dataclasses import dataclass
 import logging
 import re
 from typing import Any, cast, override
@@ -31,31 +30,10 @@ from homeassistant.helpers.selector import (
 from .const import DOMAIN, LOGGER
 from .oauth import TeslaUserImplementation
 
-
-@dataclass(slots=True)
-class RegionRegistrationFailure:
-    """Store a normalized regional registration failure."""
-
-    region: str
-    reason: str
-
-
+# Human-readable names for the regions we register partner accounts in.
 _REGION_LABELS = {
     "na": "North America",
     "eu": "Europe",
-}
-_REGION_REASONS = {
-    "origin_mismatch": (
-        "Verify the entered domain matches the Tesla developer app's allowed origin."
-    ),
-    "reset_private_key": (
-        "Remove `tesla_fleet.key` from your Home Assistant config directory so a "
-        "new key pair is generated, then retry registration."
-    ),
-    "generic": (
-        "Tesla rejected the registration in this region. Verify both the hosted "
-        "public key and the Tesla developer app configuration, then retry."
-    ),
 }
 
 
@@ -72,10 +50,9 @@ class OAuth2FlowHandler(
         self.domain: str | None = None
         self.data: dict[str, Any] = {}
         self.uid: str | None = None
+        self.region: str | None = None
         self.apis: list[tuple[str, TeslaFleetApi]] = []
-        self._region_failures: list[RegionRegistrationFailure] = []
-        self._successful_regions: list[str] = []
-        self._can_continue_after_region_failures = False
+        self._failed_regions: list[str] = []
 
     @property
     @override
@@ -95,6 +72,9 @@ class OAuth2FlowHandler(
 
         self.data = data
         self.uid = token["sub"]
+        # The integration signs commands using the account's home region, so the
+        # flow must ensure that region is registered before creating the entry.
+        self.region = token["ou_code"].lower()
 
         await self.async_set_unique_id(self.uid)
         if self.source == SOURCE_REAUTH:
@@ -148,6 +128,12 @@ class OAuth2FlowHandler(
             )
             return self.async_abort(reason="oauth_error")
 
+        if self.region not in {region for region, _ in self.apis}:
+            LOGGER.warning(
+                "Partner login failed for the account's home region (%s)", self.region
+            )
+            return self.async_abort(reason="oauth_error")
+
         if failed_regions:
             LOGGER.warning(
                 "Partner login succeeded on some regions but failed on: %s",
@@ -198,9 +184,7 @@ class OAuth2FlowHandler(
         assert self.apis[0][1].private_key
         assert self.domain
 
-        self._region_failures = []
-        self._successful_regions = []
-        self._can_continue_after_region_failures = False
+        self._failed_regions = []
 
         errors: dict[str, str] = {}
         description_placeholders = {
@@ -209,6 +193,7 @@ class OAuth2FlowHandler(
         }
 
         successful_response: dict[str, Any] | None = None
+        failures: dict[str, str] = {}
 
         for region, api in self.apis:
             try:
@@ -221,35 +206,25 @@ class OAuth2FlowHandler(
                     getattr(err, "data", None),
                     exc_info=err,
                 )
-                self._region_failures.append(
-                    RegionRegistrationFailure(
-                        region=region,
-                        reason=self._classify_region_registration_failure(err),
-                    )
-                )
+                failures[region] = self._classify_region_registration_failure(err)
             else:
-                self._successful_regions.append(region)
                 if successful_response is None:
                     successful_response = register_response
 
-        self._can_continue_after_region_failures = bool(
-            self._successful_regions and self._region_failures
-        )
+        # Commands are signed using the home region, so it must be registered
+        # before continuing. Send the user back to the domain step with guidance
+        # tailored to the home region's failure.
+        if self.region in failures:
+            return await self.async_step_domain_input(
+                errors={"base": failures[self.region]}
+            )
 
         if successful_response is None:
-            if self._region_failures:
-                return await self.async_step_region_failures()
             errors["base"] = "invalid_response"
             return self.async_show_form(
                 step_id="domain_registration",
                 description_placeholders=description_placeholders,
                 errors=errors,
-            )
-
-        if self._region_failures:
-            LOGGER.warning(
-                "Partner registration succeeded on some regions but failed on: %s",
-                ", ".join(failure.region for failure in self._region_failures),
             )
 
         # Verify public key from the successful response
@@ -259,35 +234,48 @@ class OAuth2FlowHandler(
 
         if not registered_public_key:
             errors["base"] = "public_key_not_found"
-        elif (
+            return self.async_show_form(
+                step_id="domain_registration",
+                description_placeholders=description_placeholders,
+                errors=errors,
+            )
+        if (
             registered_public_key.lower()
             != self.apis[0][1].public_uncompressed_point.lower()
         ):
             errors["base"] = "public_key_mismatch"
-        elif self._region_failures:
-            return await self.async_step_region_failures()
-        else:
-            return await self.async_step_registration_complete()
+            return self.async_show_form(
+                step_id="domain_registration",
+                description_placeholders=description_placeholders,
+                errors=errors,
+            )
 
-        return self.async_show_form(
-            step_id="domain_registration",
-            description_placeholders=description_placeholders,
-            errors=errors,
-        )
+        # The home region registered successfully. Acknowledge any secondary
+        # regions that failed, otherwise finish setup.
+        if failures:
+            self._failed_regions = list(failures)
+            LOGGER.warning(
+                "Partner registration succeeded on the home region but failed on: %s",
+                ", ".join(failures),
+            )
+            return await self.async_step_region_failures()
+
+        return await self.async_step_registration_complete()
 
     async def async_step_region_failures(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Warn about regional partner registration failures."""
+        """Acknowledge non-home regional registration failures before continuing."""
         if user_input is not None:
-            if self._can_continue_after_region_failures:
-                return await self.async_step_registration_complete()
-            return await self.async_step_domain_input()
+            return await self.async_step_registration_complete()
 
+        failed_regions = ", ".join(
+            _REGION_LABELS.get(region, region) for region in self._failed_regions
+        )
         return self.async_show_form(
             step_id="region_failures",
             data_schema=vol.Schema({}),
-            description_placeholders=self._region_failure_placeholders(),
+            description_placeholders={"failed_regions": failed_regions},
         )
 
     async def async_step_registration_complete(
@@ -348,7 +336,7 @@ class OAuth2FlowHandler(
         return bool(domain_pattern.match(domain))
 
     def _classify_region_registration_failure(self, err: TeslaFleetError) -> str:
-        """Classify a Tesla registration failure for user guidance."""
+        """Classify a Tesla registration failure into a translatable error key."""
         if isinstance(err, PreconditionFailed):
             return "origin_mismatch"
 
@@ -362,10 +350,7 @@ class OAuth2FlowHandler(
             if part
         )
 
-        if any(
-            marker in error_text
-            for marker in ("origin", "allowed origin", "allowed_origin", "domain")
-        ):
+        if "origin" in error_text:
             return "origin_mismatch"
 
         if any(
@@ -381,42 +366,4 @@ class OAuth2FlowHandler(
         ):
             return "reset_private_key"
 
-        return "generic"
-
-    def _region_failure_placeholders(self) -> dict[str, str]:
-        """Build the placeholders for the regional warning step."""
-        successful_regions = ""
-        if self._successful_regions:
-            regions = ", ".join(
-                _REGION_LABELS[region] for region in self._successful_regions
-            )
-            successful_regions = f"Successful regions: {regions}\n"
-
-        failed_regions = ", ".join(
-            _REGION_LABELS[region]
-            for region in dict.fromkeys(
-                failure.region for failure in self._region_failures
-            )
-        )
-        failure_details = "\n".join(
-            f"{_REGION_LABELS[failure.region]}: {_REGION_REASONS[failure.reason]}"
-            for failure in self._region_failures
-        )
-
-        if self._can_continue_after_region_failures:
-            next_step = (
-                "You can continue setup, but the integration will only be registered "
-                "in the successful regions."
-            )
-        else:
-            next_step = (
-                "Registration did not succeed in any region. After acknowledging this "
-                "warning, you will return to the domain step to retry."
-            )
-
-        return {
-            "successful_regions": successful_regions,
-            "failed_regions": f"Failed regions: {failed_regions}",
-            "failure_details": failure_details,
-            "next_step": next_step,
-        }
+        return "registration_failed"

--- a/homeassistant/components/tesla_fleet/config_flow.py
+++ b/homeassistant/components/tesla_fleet/config_flow.py
@@ -183,6 +183,7 @@ class OAuth2FlowHandler(
         assert self.apis
         assert self.apis[0][1].private_key
         assert self.domain
+        assert self.region
 
         self._failed_regions = []
 
@@ -192,7 +193,7 @@ class OAuth2FlowHandler(
             "pem": self.apis[0][1].public_pem,
         }
 
-        successful_response: dict[str, Any] | None = None
+        responses: dict[str, dict[str, Any]] = {}
         failures: dict[str, str] = {}
 
         for region, api in self.apis:
@@ -207,9 +208,19 @@ class OAuth2FlowHandler(
                     exc_info=err,
                 )
                 failures[region] = self._classify_region_registration_failure(err)
+                continue
+
+            # A non-raising but empty or malformed response (no usable public key)
+            # must count as a failure, not a success.
+            if not (register_response or {}).get("response", {}).get("public_key"):
+                LOGGER.warning(
+                    "Partner registration for %s (%s) returned no usable response",
+                    region,
+                    api.server,
+                )
+                failures[region] = "invalid_response"
             else:
-                if successful_response is None:
-                    successful_response = register_response
+                responses[region] = register_response
 
         # Commands are signed using the home region, so it must be registered
         # before continuing. Send the user back to the domain step with guidance
@@ -219,17 +230,11 @@ class OAuth2FlowHandler(
                 errors={"base": failures[self.region]}
             )
 
-        if successful_response is None:
-            errors["base"] = "invalid_response"
-            return self.async_show_form(
-                step_id="domain_registration",
-                description_placeholders=description_placeholders,
-                errors=errors,
-            )
-
-        # Verify public key from the successful response
-        registered_public_key = successful_response.get("response", {}).get(
-            "public_key"
+        # Validate the home region's own returned public key against our shared
+        # key. The key file is shared across all region clients, so the point is
+        # identical per region.
+        registered_public_key = (
+            responses[self.region].get("response", {}).get("public_key")
         )
 
         if not registered_public_key:

--- a/homeassistant/components/tesla_fleet/strings.json
+++ b/homeassistant/components/tesla_fleet/strings.json
@@ -22,7 +22,6 @@
       "invalid_response": "The registration was rejected by Tesla",
       "origin_mismatch": "Tesla rejected the registration because the domain does not match your Tesla developer app's allowed origin. Check that the entered domain matches the allowed origin, then try again.",
       "public_key_mismatch": "The public key hosted at your domain does not match the expected key. Please ensure the correct public key is hosted at the specified location.",
-      "public_key_not_found": "Public key not found.",
       "registration_failed": "Tesla rejected the registration in your account's home region. Check that the hosted public key and your Tesla developer app configuration are correct, then try again.",
       "unknown_error": "An unknown error occurred: {error}"
     },

--- a/homeassistant/components/tesla_fleet/strings.json
+++ b/homeassistant/components/tesla_fleet/strings.json
@@ -24,7 +24,6 @@
       "public_key_mismatch": "The public key hosted at your domain does not match the expected key. Please ensure the correct public key is hosted at the specified location.",
       "public_key_not_found": "Public key not found.",
       "registration_failed": "Tesla rejected the registration in your account's home region. Check that the hosted public key and your Tesla developer app configuration are correct, then try again.",
-      "reset_private_key": "Tesla rejected the public key. Remove `tesla_fleet.key` from your Home Assistant configuration directory so a new key pair is generated, then try again.",
       "unknown_error": "An unknown error occurred: {error}"
     },
     "step": {

--- a/homeassistant/components/tesla_fleet/strings.json
+++ b/homeassistant/components/tesla_fleet/strings.json
@@ -19,7 +19,7 @@
     },
     "error": {
       "invalid_domain": "Invalid domain format. Please enter a valid domain name.",
-      "invalid_response": "The registration was rejected by Tesla",
+      "invalid_response": "Tesla returned an empty or malformed response for your account's home region. Check that the hosted public key is reachable, then try again.",
       "origin_mismatch": "Tesla rejected the registration because the domain does not match your Tesla developer app's allowed origin. Check that the entered domain matches the allowed origin, then try again.",
       "public_key_mismatch": "The public key hosted at your domain does not match the expected key. Please ensure the correct public key is hosted at the specified location.",
       "registration_failed": "Tesla rejected the registration in your account's home region. Check that the hosted public key and your Tesla developer app configuration are correct, then try again.",

--- a/homeassistant/components/tesla_fleet/strings.json
+++ b/homeassistant/components/tesla_fleet/strings.json
@@ -20,7 +20,6 @@
     "error": {
       "invalid_domain": "Invalid domain format. Please enter a valid domain name.",
       "invalid_response": "The registration was rejected by Tesla",
-      "precondition_failed": "The domain does not match the application's allowed origins.",
       "public_key_mismatch": "The public key hosted at your domain does not match the expected key. Please ensure the correct public key is hosted at the specified location.",
       "public_key_not_found": "Public key not found.",
       "unknown_error": "An unknown error occurred: {error}"
@@ -52,6 +51,10 @@
       "reauth_confirm": {
         "description": "The {name} integration needs to re-authenticate your account. Reauthentication refreshes the Tesla API permissions granted to Home Assistant, including any newly enabled scopes.",
         "title": "[%key:common::config_flow::title::reauth%]"
+      },
+      "region_failures": {
+        "description": "{successful_regions}{failed_regions}\n\n{failure_details}\n\n{next_step}",
+        "title": "Regional registration issues"
       },
       "registration_complete": {
         "data": {

--- a/homeassistant/components/tesla_fleet/strings.json
+++ b/homeassistant/components/tesla_fleet/strings.json
@@ -20,8 +20,11 @@
     "error": {
       "invalid_domain": "Invalid domain format. Please enter a valid domain name.",
       "invalid_response": "The registration was rejected by Tesla",
+      "origin_mismatch": "Tesla rejected the registration because the domain does not match your Tesla developer app's allowed origin. Check that the entered domain matches the allowed origin, then try again.",
       "public_key_mismatch": "The public key hosted at your domain does not match the expected key. Please ensure the correct public key is hosted at the specified location.",
       "public_key_not_found": "Public key not found.",
+      "registration_failed": "Tesla rejected the registration in your account's home region. Check that the hosted public key and your Tesla developer app configuration are correct, then try again.",
+      "reset_private_key": "Tesla rejected the public key. Remove `tesla_fleet.key` from your Home Assistant configuration directory so a new key pair is generated, then try again.",
       "unknown_error": "An unknown error occurred: {error}"
     },
     "step": {
@@ -53,7 +56,7 @@
         "title": "[%key:common::config_flow::title::reauth%]"
       },
       "region_failures": {
-        "description": "{successful_regions}{failed_regions}\n\n{failure_details}\n\n{next_step}",
+        "description": "Registration succeeded in your account's home region but failed in the following regions: {failed_regions}.\n\nThese regions are not required to use the integration, so you can continue. Command signing will use your home region.",
         "title": "Regional registration issues"
       },
       "registration_complete": {

--- a/tests/components/tesla_fleet/test_config_flow.py
+++ b/tests/components/tesla_fleet/test_config_flow.py
@@ -5,7 +5,6 @@ from urllib.parse import parse_qs, urlparse
 
 import pytest
 from tesla_fleet_api.exceptions import (
-    InvalidResponse,
     LoginRequired,
     PreconditionFailed,
     TeslaFleetError,
@@ -30,12 +29,51 @@ from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.setup import async_setup_component
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, get_schema_suggested_value
 from tests.test_util.aiohttp import AiohttpClientMocker
 from tests.typing import ClientSessionGenerator
 
 REDIRECT = "https://example.com/auth/external/callback"
 UNIQUE_ID = "uid"
+PUBLIC_KEY = (
+    "0404112233445566778899aabbccddeeff112233445566778899aabbccddeeff"
+    "112233445566778899aabbccddeeff112233445566778899aabbccddeeff1122"
+)
+DEFAULT_REGISTER_RESPONSE = object()
+
+
+def _mock_api(
+    mock_private_key: Mock,
+    *,
+    public_key: str = PUBLIC_KEY,
+    server: str | None = None,
+    register_response: dict[str, dict[str, str]] | None | object = (
+        DEFAULT_REGISTER_RESPONSE
+    ),
+    register_side_effect: BaseException | type[BaseException] | None = None,
+) -> AsyncMock:
+    """Create a mocked Tesla Fleet API client."""
+    mock_api = AsyncMock()
+    mock_api.private_key = mock_private_key
+    mock_api.get_private_key = AsyncMock()
+    mock_api.partner_login = AsyncMock()
+    mock_api.public_pem = "test_pem"
+    mock_api.public_uncompressed_point = public_key
+    mock_api.server = server
+    if register_side_effect is not None:
+        mock_api.partner.register.side_effect = register_side_effect
+    elif register_response is DEFAULT_REGISTER_RESPONSE:
+        mock_api.partner.register.return_value = {
+            "response": {"public_key": public_key}
+        }
+    else:
+        mock_api.partner.register.return_value = register_response
+    return mock_api
+
+
+def _tesla_error(data: str | dict[str, str]) -> TeslaFleetError:
+    """Create a TeslaFleetError with a test payload."""
+    return TeslaFleetError(data)
 
 
 @pytest.fixture
@@ -74,7 +112,7 @@ async def create_credential(hass: HomeAssistant) -> None:
 
 
 @pytest.fixture
-def mock_private_key():
+def mock_private_key() -> Mock:
     """Mock private key for testing."""
     private_key = Mock()
     public_key = Mock()
@@ -219,7 +257,7 @@ async def test_full_flow_with_domain_registration(
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
     access_token: str,
-    mock_private_key,
+    mock_private_key: Mock,
 ) -> None:
     """Test full flow with domain registration."""
     result = await hass.config_entries.flow.async_init(
@@ -271,26 +309,7 @@ async def test_full_flow_with_domain_registration(
             "homeassistant.components.tesla_fleet.async_setup_entry", return_value=True
         ),
     ):
-        mock_api = AsyncMock()
-        mock_api.private_key = mock_private_key
-        mock_api.get_private_key = AsyncMock()
-        mock_api.partner_login = AsyncMock()
-        mock_api.public_uncompressed_point = (
-            "0404112233445566778899aabbccddeeff"
-            "112233445566778899aabbccddeeff"
-            "112233445566778899aabbccddeeff"
-            "112233445566778899aabbccddeeff1122"
-        )
-        mock_api.partner.register.return_value = {
-            "response": {
-                "public_key": (
-                    "0404112233445566778899aabbccddeeff"
-                    "112233445566778899aabbccddeeff"
-                    "112233445566778899aabbccddeeff"
-                    "112233445566778899aabbccddeeff1122"
-                )
-            }
-        }
+        mock_api = _mock_api(mock_private_key)
         mock_api_class.return_value = mock_api
 
         # Complete OAuth
@@ -320,7 +339,7 @@ async def test_domain_input_invalid_domain(
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
     access_token: str,
-    mock_private_key,
+    mock_private_key: Mock,
 ) -> None:
     """Test domain input with invalid domain."""
     result = await hass.config_entries.flow.async_init(
@@ -353,10 +372,10 @@ async def test_domain_input_invalid_domain(
             "homeassistant.components.tesla_fleet.config_flow.TeslaFleetApi"
         ) as mock_api_class,
     ):
-        mock_api = AsyncMock()
-        mock_api.private_key = mock_private_key
-        mock_api.get_private_key = AsyncMock()
-        mock_api.partner_login = AsyncMock()
+        mock_api = _mock_api(
+            mock_private_key,
+            register_response={"response": {"public_key": PUBLIC_KEY}},
+        )
         mock_api_class.return_value = mock_api
 
         # Complete OAuth
@@ -372,24 +391,7 @@ async def test_domain_input_invalid_domain(
         assert result["step_id"] == "domain_input"
         assert result["errors"] == {CONF_DOMAIN: "invalid_domain"}
 
-        # Enter valid domain - this should automatically register
-        # and go to registration_complete
-        mock_api.public_uncompressed_point = (
-            "0404112233445566778899aabbccddeeff"
-            "112233445566778899aabbccddeeff"
-            "112233445566778899aabbccddeeff"
-            "112233445566778899aabbccddeeff1122"
-        )
-        mock_api.partner.register.return_value = {
-            "response": {
-                "public_key": (
-                    "0404112233445566778899aabbccddeeff"
-                    "112233445566778899aabbccddeeff"
-                    "112233445566778899aabbccddeeff"
-                    "112233445566778899aabbccddeeff1122"
-                )
-            }
-        }
+        # Enter valid domain - this should automatically register and go to registration_complete
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {CONF_DOMAIN: "example.com"}
         )
@@ -397,24 +399,15 @@ async def test_domain_input_invalid_domain(
         assert result["step_id"] == "registration_complete"
 
 
-@pytest.mark.parametrize(
-    ("side_effect", "expected_error"),
-    [
-        (InvalidResponse, "invalid_response"),
-        (TeslaFleetError("Custom error"), "invalid_response"),
-    ],
-)
 @pytest.mark.usefixtures("current_request_with_host")
-async def test_domain_registration_errors(
+async def test_domain_registration_invalid_response(
     hass: HomeAssistant,
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
     access_token: str,
-    mock_private_key,
-    side_effect,
-    expected_error,
+    mock_private_key: Mock,
 ) -> None:
-    """Test domain registration with errors that stay on domain_registration step."""
+    """Test domain registration with an invalid response payload."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
@@ -445,12 +438,10 @@ async def test_domain_registration_errors(
             "homeassistant.components.tesla_fleet.config_flow.TeslaFleetApi"
         ) as mock_api_class,
     ):
-        mock_api = AsyncMock()
-        mock_api.private_key = mock_private_key
-        mock_api.get_private_key = AsyncMock()
-        mock_api.partner_login = AsyncMock()
-        mock_api.public_uncompressed_point = "test_point"
-        mock_api.partner.register.side_effect = side_effect
+        mock_api = _mock_api(
+            mock_private_key,
+            register_response=None,
+        )
         mock_api_class.return_value = mock_api
 
         # Complete OAuth
@@ -462,7 +453,7 @@ async def test_domain_registration_errors(
         )
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "domain_registration"
-        assert result["errors"] == {"base": expected_error}
+        assert result["errors"] == {"base": "invalid_response"}
 
 
 @pytest.mark.usefixtures("current_request_with_host")
@@ -471,9 +462,9 @@ async def test_domain_registration_precondition_failed(
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
     access_token: str,
-    mock_private_key,
+    mock_private_key: Mock,
 ) -> None:
-    """Test domain registration with PreconditionFailed redirects to domain_input."""
+    """Test PreconditionFailed maps to the origin mismatch guidance."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
@@ -501,28 +492,31 @@ async def test_domain_registration_precondition_failed(
 
     with (
         patch(
-            "homeassistant.components.tesla_fleet.config_flow.TeslaFleetApi"
-        ) as mock_api_class,
+            "homeassistant.components.tesla_fleet.config_flow.TeslaFleetApi",
+            side_effect=[
+                _mock_api(
+                    mock_private_key,
+                    server="https://fleet-api.prd.na.vn.cloud.tesla.com",
+                    register_side_effect=PreconditionFailed,
+                ),
+                _mock_api(
+                    mock_private_key,
+                    server="https://fleet-api.prd.eu.vn.cloud.tesla.com",
+                    register_side_effect=PreconditionFailed,
+                ),
+            ],
+        ),
     ):
-        mock_api = AsyncMock()
-        mock_api.private_key = mock_private_key
-        mock_api.get_private_key = AsyncMock()
-        mock_api.partner_login = AsyncMock()
-        mock_api.public_uncompressed_point = "test_point"
-        mock_api.partner.register.side_effect = PreconditionFailed
-        mock_api_class.return_value = mock_api
-
         # Complete OAuth
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-        # Enter domain - this should go to domain_registration
-        # and then fail back to domain_input
+        # Enter domain - both regions fail and should show the warning step
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {CONF_DOMAIN: "example.com"}
         )
         assert result["type"] is FlowResultType.FORM
-        assert result["step_id"] == "domain_input"
-        assert result["errors"] == {CONF_DOMAIN: "precondition_failed"}
+        assert result["step_id"] == "region_failures"
+        assert "allowed origin" in result["description_placeholders"]["failure_details"]
 
 
 @pytest.mark.usefixtures("current_request_with_host")
@@ -531,7 +525,7 @@ async def test_domain_registration_public_key_not_found(
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
     access_token: str,
-    mock_private_key,
+    mock_private_key: Mock,
 ) -> None:
     """Test domain registration with missing public key."""
     result = await hass.config_entries.flow.async_init(
@@ -564,12 +558,11 @@ async def test_domain_registration_public_key_not_found(
             "homeassistant.components.tesla_fleet.config_flow.TeslaFleetApi"
         ) as mock_api_class,
     ):
-        mock_api = AsyncMock()
-        mock_api.private_key = mock_private_key
-        mock_api.get_private_key = AsyncMock()
-        mock_api.partner_login = AsyncMock()
-        mock_api.public_uncompressed_point = "test_point"
-        mock_api.partner.register.return_value = {"response": {}}
+        mock_api = _mock_api(
+            mock_private_key,
+            public_key="test_point",
+            register_response={"response": {}},
+        )
         mock_api_class.return_value = mock_api
 
         # Complete OAuth
@@ -590,7 +583,7 @@ async def test_domain_registration_public_key_mismatch(
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
     access_token: str,
-    mock_private_key,
+    mock_private_key: Mock,
 ) -> None:
     """Test domain registration with public key mismatch."""
     result = await hass.config_entries.flow.async_init(
@@ -623,14 +616,11 @@ async def test_domain_registration_public_key_mismatch(
             "homeassistant.components.tesla_fleet.config_flow.TeslaFleetApi"
         ) as mock_api_class,
     ):
-        mock_api = AsyncMock()
-        mock_api.private_key = mock_private_key
-        mock_api.get_private_key = AsyncMock()
-        mock_api.partner_login = AsyncMock()
-        mock_api.public_uncompressed_point = "expected_key"
-        mock_api.partner.register.return_value = {
-            "response": {"public_key": "different_key"}
-        }
+        mock_api = _mock_api(
+            mock_private_key,
+            public_key="expected_key",
+            register_response={"response": {"public_key": "different_key"}},
+        )
         mock_api_class.return_value = mock_api
 
         # Complete OAuth
@@ -651,7 +641,7 @@ async def test_domain_registration_partial_failure(
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
     access_token: str,
-    mock_private_key,
+    mock_private_key: Mock,
 ) -> None:
     """Test domain registration succeeds when one region fails."""
     result = await hass.config_entries.flow.async_init(
@@ -679,35 +669,20 @@ async def test_domain_registration_partial_failure(
         },
     )
 
-    public_key = (
-        "0404112233445566778899aabbccddeeff"
-        "112233445566778899aabbccddeeff"
-        "112233445566778899aabbccddeeff"
-        "112233445566778899aabbccddeeff1122"
-    )
-
-    # Create two separate mocks for NA and EU
-    mock_api_na = AsyncMock()
-    mock_api_na.private_key = mock_private_key
-    mock_api_na.get_private_key = AsyncMock()
-    mock_api_na.partner_login = AsyncMock()
-    mock_api_na.public_pem = "test_pem"
-    mock_api_na.public_uncompressed_point = public_key
-    mock_api_na.partner.register.return_value = {"response": {"public_key": public_key}}
-
-    mock_api_eu = AsyncMock()
-    mock_api_eu.private_key = mock_private_key
-    mock_api_eu.get_private_key = AsyncMock()
-    mock_api_eu.partner_login = AsyncMock()
-    mock_api_eu.public_pem = "test_pem"
-    mock_api_eu.public_uncompressed_point = public_key
-    mock_api_eu.server = "https://fleet-api.prd.eu.vn.cloud.tesla.com"
-    mock_api_eu.partner.register.side_effect = TeslaFleetError("EU registration failed")
-
     with (
         patch(
             "homeassistant.components.tesla_fleet.config_flow.TeslaFleetApi",
-            side_effect=[mock_api_na, mock_api_eu],
+            side_effect=[
+                _mock_api(
+                    mock_private_key,
+                    server="https://fleet-api.prd.na.vn.cloud.tesla.com",
+                ),
+                _mock_api(
+                    mock_private_key,
+                    server="https://fleet-api.prd.eu.vn.cloud.tesla.com",
+                    register_side_effect=TeslaFleetError("EU registration failed"),
+                ),
+            ],
         ),
         patch(
             "homeassistant.components.tesla_fleet.async_setup_entry", return_value=True
@@ -718,10 +693,22 @@ async def test_domain_registration_partial_failure(
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "domain_input"
 
-        # Enter domain - NA succeeds, EU fails, should still proceed
+        # Enter domain - NA succeeds, EU fails, so show the warning first
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {CONF_DOMAIN: "example.com"}
         )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "region_failures"
+        assert (
+            result["description_placeholders"]["successful_regions"]
+            == "Successful regions: North America\n"
+        )
+        assert (
+            result["description_placeholders"]["failed_regions"]
+            == "Failed regions: Europe"
+        )
+
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "registration_complete"
 
@@ -738,7 +725,7 @@ async def test_domain_registration_all_regions_fail(
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
     access_token: str,
-    mock_private_key,
+    mock_private_key: Mock,
 ) -> None:
     """Test domain registration fails when all regions fail."""
     result = await hass.config_entries.flow.async_init(
@@ -766,41 +753,177 @@ async def test_domain_registration_all_regions_fail(
         },
     )
 
-    mock_api_na = AsyncMock()
-    mock_api_na.private_key = mock_private_key
-    mock_api_na.get_private_key = AsyncMock()
-    mock_api_na.partner_login = AsyncMock()
-    mock_api_na.public_pem = "test_pem"
-    mock_api_na.public_uncompressed_point = "test_point"
-    mock_api_na.server = "https://fleet-api.prd.na.vn.cloud.tesla.com"
-    mock_api_na.partner.register.side_effect = TeslaFleetError("NA registration failed")
-
-    mock_api_eu = AsyncMock()
-    mock_api_eu.private_key = mock_private_key
-    mock_api_eu.get_private_key = AsyncMock()
-    mock_api_eu.partner_login = AsyncMock()
-    mock_api_eu.public_pem = "test_pem"
-    mock_api_eu.public_uncompressed_point = "test_point"
-    mock_api_eu.server = "https://fleet-api.prd.eu.vn.cloud.tesla.com"
-    mock_api_eu.partner.register.side_effect = TeslaFleetError("EU registration failed")
-
     with patch(
         "homeassistant.components.tesla_fleet.config_flow.TeslaFleetApi",
-        side_effect=[mock_api_na, mock_api_eu],
+        side_effect=[
+            _mock_api(
+                mock_private_key,
+                public_key="test_point",
+                server="https://fleet-api.prd.na.vn.cloud.tesla.com",
+                register_side_effect=TeslaFleetError("NA registration failed"),
+            ),
+            _mock_api(
+                mock_private_key,
+                public_key="test_point",
+                server="https://fleet-api.prd.eu.vn.cloud.tesla.com",
+                register_side_effect=TeslaFleetError("EU registration failed"),
+            ),
+        ],
     ):
         # Complete OAuth
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
         # Enter domain - both regions fail
-        with patch(
-            "homeassistant.helpers.translation.async_get_translations", return_value={}
-        ):
-            result = await hass.config_entries.flow.async_configure(
-                result["flow_id"], {CONF_DOMAIN: "example.com"}
-            )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_DOMAIN: "example.com"}
+        )
         assert result["type"] is FlowResultType.FORM
-        assert result["step_id"] == "domain_registration"
-        assert result["errors"] == {"base": "invalid_response"}
+        assert result["step_id"] == "region_failures"
+        assert (
+            result["description_placeholders"]["failed_regions"]
+            == "Failed regions: North America, Europe"
+        )
+        assert (
+            "Tesla rejected the registration in this region"
+            in result["description_placeholders"]["failure_details"]
+        )
+
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "domain_input"
+        assert (
+            get_schema_suggested_value(result["data_schema"].schema, CONF_DOMAIN)
+            == "example.com"
+        )
+
+
+@pytest.mark.usefixtures("current_request_with_host")
+async def test_domain_registration_failure_with_key_guidance(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    access_token: str,
+    mock_private_key: Mock,
+) -> None:
+    """Test Tesla key errors map to the reset-private-key guidance."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    state = config_entry_oauth2_flow._encode_jwt(
+        hass,
+        {
+            "flow_id": result["flow_id"],
+            "redirect_uri": REDIRECT,
+        },
+    )
+
+    client = await hass_client_no_auth()
+    await client.get(f"/auth/external/callback?code=abcd&state={state}")
+
+    aioclient_mock.post(
+        TOKEN_URL,
+        json={
+            "refresh_token": "mock-refresh-token",
+            "access_token": access_token,
+            "type": "Bearer",
+            "expires_in": 60,
+        },
+    )
+
+    with patch(
+        "homeassistant.components.tesla_fleet.config_flow.TeslaFleetApi",
+        side_effect=[
+            _mock_api(
+                mock_private_key,
+                public_key="test_point",
+                server="https://fleet-api.prd.na.vn.cloud.tesla.com",
+                register_side_effect=_tesla_error(
+                    {"error": "public key must use secp256r1"}
+                ),
+            ),
+            _mock_api(
+                mock_private_key,
+                public_key="test_point",
+                server="https://fleet-api.prd.eu.vn.cloud.tesla.com",
+                register_side_effect=_tesla_error(
+                    {"error": "private_key does not match"}
+                ),
+            ),
+        ],
+    ):
+        result = await hass.config_entries.flow.async_configure(result["flow_id"])
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_DOMAIN: "example.com"}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "region_failures"
+    assert "tesla_fleet.key" in result["description_placeholders"]["failure_details"]
+
+
+@pytest.mark.usefixtures("current_request_with_host")
+async def test_domain_registration_failure_with_generic_guidance(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    access_token: str,
+    mock_private_key: Mock,
+) -> None:
+    """Test unknown Tesla payloads map to the generic guidance."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    state = config_entry_oauth2_flow._encode_jwt(
+        hass,
+        {
+            "flow_id": result["flow_id"],
+            "redirect_uri": REDIRECT,
+        },
+    )
+
+    client = await hass_client_no_auth()
+    await client.get(f"/auth/external/callback?code=abcd&state={state}")
+
+    aioclient_mock.post(
+        TOKEN_URL,
+        json={
+            "refresh_token": "mock-refresh-token",
+            "access_token": access_token,
+            "type": "Bearer",
+            "expires_in": 60,
+        },
+    )
+
+    with patch(
+        "homeassistant.components.tesla_fleet.config_flow.TeslaFleetApi",
+        side_effect=[
+            _mock_api(
+                mock_private_key,
+                public_key="test_point",
+                server="https://fleet-api.prd.na.vn.cloud.tesla.com",
+                register_side_effect=_tesla_error({"error": "registration rejected"}),
+            ),
+            _mock_api(
+                mock_private_key,
+                public_key="test_point",
+                server="https://fleet-api.prd.eu.vn.cloud.tesla.com",
+                register_side_effect=_tesla_error({"error": "something else"}),
+            ),
+        ],
+    ):
+        result = await hass.config_entries.flow.async_configure(result["flow_id"])
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_DOMAIN: "example.com"}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "region_failures"
+    assert (
+        "Tesla rejected the registration in this region"
+        in result["description_placeholders"]["failure_details"]
+    )
 
 
 @pytest.mark.usefixtures("current_request_with_host")

--- a/tests/components/tesla_fleet/test_config_flow.py
+++ b/tests/components/tesla_fleet/test_config_flow.py
@@ -1027,6 +1027,63 @@ async def test_partner_login_home_region_failure(
 
 
 @pytest.mark.usefixtures("current_request_with_host")
+async def test_partner_login_all_regions_fail(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    access_token: str,
+    mock_private_key: Mock,
+) -> None:
+    """Test the flow aborts when partner login fails for every region."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    state = config_entry_oauth2_flow._encode_jwt(
+        hass,
+        {
+            "flow_id": result["flow_id"],
+            "redirect_uri": REDIRECT,
+        },
+    )
+
+    client = await hass_client_no_auth()
+    await client.get(f"/auth/external/callback?code=abcd&state={state}")
+
+    aioclient_mock.post(
+        TOKEN_URL,
+        json={
+            "refresh_token": "mock-refresh-token",
+            "access_token": access_token,
+            "type": "Bearer",
+            "expires_in": 60,
+        },
+    )
+
+    mock_api_na = _mock_api(
+        mock_private_key, server="https://fleet-api.prd.na.vn.cloud.tesla.com"
+    )
+    mock_api_na.partner_login = AsyncMock(
+        side_effect=TeslaFleetError("NA partner login failed")
+    )
+    mock_api_eu = _mock_api(
+        mock_private_key, server="https://fleet-api.prd.eu.vn.cloud.tesla.com"
+    )
+    mock_api_eu.partner_login = AsyncMock(
+        side_effect=TeslaFleetError("EU partner login failed")
+    )
+
+    with patch(
+        "homeassistant.components.tesla_fleet.config_flow.TeslaFleetApi",
+        side_effect=[mock_api_na, mock_api_eu],
+    ):
+        result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "oauth_error"
+
+
+@pytest.mark.usefixtures("current_request_with_host")
 async def test_registration_complete_no_domain(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/components/tesla_fleet/test_config_flow.py
+++ b/tests/components/tesla_fleet/test_config_flow.py
@@ -464,7 +464,7 @@ async def test_domain_registration_precondition_failed(
     access_token: str,
     mock_private_key: Mock,
 ) -> None:
-    """Test PreconditionFailed maps to the origin mismatch guidance."""
+    """Test PreconditionFailed on the home region maps to origin mismatch guidance."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
@@ -510,13 +510,13 @@ async def test_domain_registration_precondition_failed(
         # Complete OAuth
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-        # Enter domain - both regions fail and should show the warning step
+        # Enter domain - the home region fails, returning to the domain step
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {CONF_DOMAIN: "example.com"}
         )
         assert result["type"] is FlowResultType.FORM
-        assert result["step_id"] == "region_failures"
-        assert "allowed origin" in result["description_placeholders"]["failure_details"]
+        assert result["step_id"] == "domain_input"
+        assert result["errors"] == {"base": "origin_mismatch"}
 
 
 @pytest.mark.usefixtures("current_request_with_host")
@@ -693,20 +693,14 @@ async def test_domain_registration_partial_failure(
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "domain_input"
 
-        # Enter domain - NA succeeds, EU fails, so show the warning first
+        # Enter domain - the home region (NA) succeeds, EU fails, so acknowledge
+        # the non-home region failure first
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {CONF_DOMAIN: "example.com"}
         )
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "region_failures"
-        assert (
-            result["description_placeholders"]["successful_regions"]
-            == "Successful regions: North America\n"
-        )
-        assert (
-            result["description_placeholders"]["failed_regions"]
-            == "Failed regions: Europe"
-        )
+        assert result["description_placeholders"]["failed_regions"] == "Europe"
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
         assert result["type"] is FlowResultType.FORM
@@ -773,24 +767,14 @@ async def test_domain_registration_all_regions_fail(
         # Complete OAuth
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-        # Enter domain - both regions fail
+        # Enter domain - both regions fail, so return to the domain step with
+        # the previously entered domain pre-filled
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {CONF_DOMAIN: "example.com"}
         )
         assert result["type"] is FlowResultType.FORM
-        assert result["step_id"] == "region_failures"
-        assert (
-            result["description_placeholders"]["failed_regions"]
-            == "Failed regions: North America, Europe"
-        )
-        assert (
-            "Tesla rejected the registration in this region"
-            in result["description_placeholders"]["failure_details"]
-        )
-
-        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-        assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "domain_input"
+        assert result["errors"] == {"base": "registration_failed"}
         assert (
             get_schema_suggested_value(result["data_schema"].schema, CONF_DOMAIN)
             == "example.com"
@@ -858,8 +842,8 @@ async def test_domain_registration_failure_with_key_guidance(
         )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "region_failures"
-    assert "tesla_fleet.key" in result["description_placeholders"]["failure_details"]
+    assert result["step_id"] == "domain_input"
+    assert result["errors"] == {"base": "reset_private_key"}
 
 
 @pytest.mark.usefixtures("current_request_with_host")
@@ -919,11 +903,127 @@ async def test_domain_registration_failure_with_generic_guidance(
         )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "region_failures"
-    assert (
-        "Tesla rejected the registration in this region"
-        in result["description_placeholders"]["failure_details"]
+    assert result["step_id"] == "domain_input"
+    assert result["errors"] == {"base": "registration_failed"}
+
+
+@pytest.mark.usefixtures("current_request_with_host")
+async def test_domain_registration_home_region_must_register(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    access_token: str,
+    mock_private_key: Mock,
+) -> None:
+    """Test the flow cannot continue when only a non-home region registers.
+
+    Commands are signed using the account's home region (NA), so a successful
+    secondary region (EU) must not allow the flow to complete.
+    """
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
     )
+
+    state = config_entry_oauth2_flow._encode_jwt(
+        hass,
+        {
+            "flow_id": result["flow_id"],
+            "redirect_uri": REDIRECT,
+        },
+    )
+
+    client = await hass_client_no_auth()
+    await client.get(f"/auth/external/callback?code=abcd&state={state}")
+
+    aioclient_mock.post(
+        TOKEN_URL,
+        json={
+            "refresh_token": "mock-refresh-token",
+            "access_token": access_token,
+            "type": "Bearer",
+            "expires_in": 60,
+        },
+    )
+
+    with patch(
+        "homeassistant.components.tesla_fleet.config_flow.TeslaFleetApi",
+        side_effect=[
+            _mock_api(
+                mock_private_key,
+                server="https://fleet-api.prd.na.vn.cloud.tesla.com",
+                register_side_effect=PreconditionFailed,
+            ),
+            _mock_api(
+                mock_private_key,
+                server="https://fleet-api.prd.eu.vn.cloud.tesla.com",
+            ),
+        ],
+    ):
+        # Complete OAuth
+        result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+        # Enter domain - the home region (NA) fails while EU succeeds
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_DOMAIN: "example.com"}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "domain_input"
+    assert result["errors"] == {"base": "origin_mismatch"}
+
+
+@pytest.mark.usefixtures("current_request_with_host")
+async def test_partner_login_home_region_failure(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    access_token: str,
+    mock_private_key: Mock,
+) -> None:
+    """Test the flow aborts when the home region's partner login fails."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    state = config_entry_oauth2_flow._encode_jwt(
+        hass,
+        {
+            "flow_id": result["flow_id"],
+            "redirect_uri": REDIRECT,
+        },
+    )
+
+    client = await hass_client_no_auth()
+    await client.get(f"/auth/external/callback?code=abcd&state={state}")
+
+    aioclient_mock.post(
+        TOKEN_URL,
+        json={
+            "refresh_token": "mock-refresh-token",
+            "access_token": access_token,
+            "type": "Bearer",
+            "expires_in": 60,
+        },
+    )
+
+    mock_api_na = _mock_api(
+        mock_private_key, server="https://fleet-api.prd.na.vn.cloud.tesla.com"
+    )
+    mock_api_na.partner_login = AsyncMock(
+        side_effect=TeslaFleetError("NA partner login failed")
+    )
+    mock_api_eu = _mock_api(
+        mock_private_key, server="https://fleet-api.prd.eu.vn.cloud.tesla.com"
+    )
+
+    with patch(
+        "homeassistant.components.tesla_fleet.config_flow.TeslaFleetApi",
+        side_effect=[mock_api_na, mock_api_eu],
+    ):
+        result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "oauth_error"
 
 
 @pytest.mark.usefixtures("current_request_with_host")
@@ -1162,3 +1262,22 @@ def test_is_valid_domain(domain: str, expected_valid: bool) -> None:
     """Test domain validation."""
 
     assert OAuth2FlowHandler()._is_valid_domain(domain) == expected_valid
+
+
+@pytest.mark.parametrize(
+    ("err", "expected"),
+    [
+        (PreconditionFailed(), "origin_mismatch"),
+        (_tesla_error({"error": "allowed origin mismatch"}), "origin_mismatch"),
+        (_tesla_error({"error": "public key must use secp256r1"}), "reset_private_key"),
+        (_tesla_error({"error": "private_key does not match"}), "reset_private_key"),
+        (_tesla_error({"error": "registration rejected"}), "registration_failed"),
+    ],
+    ids=["precondition", "origin_text", "public_key", "private_key", "generic"],
+)
+def test_classify_region_registration_failure(
+    err: TeslaFleetError, expected: str
+) -> None:
+    """Test registration failures are classified into translatable error keys."""
+
+    assert OAuth2FlowHandler()._classify_region_registration_failure(err) == expected

--- a/tests/components/tesla_fleet/test_config_flow.py
+++ b/tests/components/tesla_fleet/test_config_flow.py
@@ -407,7 +407,7 @@ async def test_domain_registration_invalid_response(
     access_token: str,
     mock_private_key: Mock,
 ) -> None:
-    """Test domain registration with an invalid response payload."""
+    """Test an empty home region response returns to the domain step."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
@@ -447,12 +447,13 @@ async def test_domain_registration_invalid_response(
         # Complete OAuth
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-        # Enter domain - this should fail and stay on domain_registration
+        # Enter domain - the home region returns nothing usable, so the flow
+        # returns to the domain step instead of creating an entry
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {CONF_DOMAIN: "example.com"}
         )
         assert result["type"] is FlowResultType.FORM
-        assert result["step_id"] == "domain_registration"
+        assert result["step_id"] == "domain_input"
         assert result["errors"] == {"base": "invalid_response"}
 
 
@@ -520,14 +521,14 @@ async def test_domain_registration_precondition_failed(
 
 
 @pytest.mark.usefixtures("current_request_with_host")
-async def test_domain_registration_public_key_not_found(
+async def test_domain_registration_missing_public_key(
     hass: HomeAssistant,
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
     access_token: str,
     mock_private_key: Mock,
 ) -> None:
-    """Test domain registration with missing public key."""
+    """Test a home region response without a public key returns to the domain step."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
@@ -568,13 +569,14 @@ async def test_domain_registration_public_key_not_found(
         # Complete OAuth
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-        # Enter domain - this should fail and stay on domain_registration
+        # Enter domain - the home region returns no public key, so the flow
+        # returns to the domain step instead of creating an entry
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {CONF_DOMAIN: "example.com"}
         )
         assert result["type"] is FlowResultType.FORM
-        assert result["step_id"] == "domain_registration"
-        assert result["errors"] == {"base": "public_key_not_found"}
+        assert result["step_id"] == "domain_input"
+        assert result["errors"] == {"base": "invalid_response"}
 
 
 @pytest.mark.usefixtures("current_request_with_host")
@@ -970,6 +972,73 @@ async def test_domain_registration_home_region_must_register(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "domain_input"
     assert result["errors"] == {"base": "origin_mismatch"}
+
+
+@pytest.mark.usefixtures("current_request_with_host")
+async def test_domain_registration_home_region_invalid_response(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    access_token: str,
+    mock_private_key: Mock,
+) -> None:
+    """Test a malformed home region response does not create an entry.
+
+    The home region (NA) returns a 200 with no usable payload while a secondary
+    region (EU) succeeds. Commands are signed using the home region, so the flow
+    must not validate the secondary region's key and complete setup.
+    """
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    state = config_entry_oauth2_flow._encode_jwt(
+        hass,
+        {
+            "flow_id": result["flow_id"],
+            "redirect_uri": REDIRECT,
+        },
+    )
+
+    client = await hass_client_no_auth()
+    await client.get(f"/auth/external/callback?code=abcd&state={state}")
+
+    aioclient_mock.post(
+        TOKEN_URL,
+        json={
+            "refresh_token": "mock-refresh-token",
+            "access_token": access_token,
+            "type": "Bearer",
+            "expires_in": 60,
+        },
+    )
+
+    with patch(
+        "homeassistant.components.tesla_fleet.config_flow.TeslaFleetApi",
+        side_effect=[
+            _mock_api(
+                mock_private_key,
+                server="https://fleet-api.prd.na.vn.cloud.tesla.com",
+                register_response=None,
+            ),
+            _mock_api(
+                mock_private_key,
+                server="https://fleet-api.prd.eu.vn.cloud.tesla.com",
+            ),
+        ],
+    ):
+        # Complete OAuth
+        result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+        # Enter domain - the home region (NA) returns nothing usable while EU
+        # succeeds, so the flow returns to the domain step
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_DOMAIN: "example.com"}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "domain_input"
+    assert result["errors"] == {"base": "invalid_response"}
 
 
 @pytest.mark.usefixtures("current_request_with_host")

--- a/tests/components/tesla_fleet/test_config_flow.py
+++ b/tests/components/tesla_fleet/test_config_flow.py
@@ -400,14 +400,22 @@ async def test_domain_input_invalid_domain(
 
 
 @pytest.mark.usefixtures("current_request_with_host")
+@pytest.mark.parametrize(
+    "register_response",
+    [
+        pytest.param(None, id="none"),
+        pytest.param({"response": None}, id="null_response"),
+    ],
+)
 async def test_domain_registration_invalid_response(
     hass: HomeAssistant,
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
     access_token: str,
     mock_private_key: Mock,
+    register_response: dict[str, dict[str, str] | None] | None,
 ) -> None:
-    """Test an empty home region response returns to the domain step."""
+    """Test an empty or malformed home region response returns to the domain step."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
@@ -440,7 +448,7 @@ async def test_domain_registration_invalid_response(
     ):
         mock_api = _mock_api(
             mock_private_key,
-            register_response=None,
+            register_response=register_response,
         )
         mock_api_class.return_value = mock_api
 

--- a/tests/components/tesla_fleet/test_config_flow.py
+++ b/tests/components/tesla_fleet/test_config_flow.py
@@ -47,7 +47,7 @@ def _mock_api(
     *,
     public_key: str = PUBLIC_KEY,
     server: str | None = None,
-    register_response: dict[str, dict[str, str]] | None | object = (
+    register_response: dict[str, dict[str, str] | None] | None | object = (
         DEFAULT_REGISTER_RESPONSE
     ),
     register_side_effect: BaseException | type[BaseException] | None = None,
@@ -441,17 +441,26 @@ async def test_domain_registration_invalid_response(
         },
     )
 
+    mock_api_na = _mock_api(
+        mock_private_key, server="https://fleet-api.prd.na.vn.cloud.tesla.com"
+    )
+    mock_api_na.partner.register.side_effect = [
+        register_response,
+        {"response": {"public_key": PUBLIC_KEY}},
+    ]
+    mock_api_eu = _mock_api(
+        mock_private_key, server="https://fleet-api.prd.eu.vn.cloud.tesla.com"
+    )
+
     with (
         patch(
-            "homeassistant.components.tesla_fleet.config_flow.TeslaFleetApi"
-        ) as mock_api_class,
+            "homeassistant.components.tesla_fleet.config_flow.TeslaFleetApi",
+            side_effect=[mock_api_na, mock_api_eu],
+        ),
+        patch(
+            "homeassistant.components.tesla_fleet.async_setup_entry", return_value=True
+        ),
     ):
-        mock_api = _mock_api(
-            mock_private_key,
-            register_response=register_response,
-        )
-        mock_api_class.return_value = mock_api
-
         # Complete OAuth
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
@@ -463,6 +472,19 @@ async def test_domain_registration_invalid_response(
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "domain_input"
         assert result["errors"] == {"base": "invalid_response"}
+
+        # Retry - the home region now returns a usable response, so the flow
+        # recovers and completes
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_DOMAIN: "example.com"}
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "registration_complete"
+
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == UNIQUE_ID
 
 
 @pytest.mark.usefixtures("current_request_with_host")
@@ -499,21 +521,28 @@ async def test_domain_registration_precondition_failed(
         },
     )
 
+    mock_api_na = _mock_api(
+        mock_private_key, server="https://fleet-api.prd.na.vn.cloud.tesla.com"
+    )
+    mock_api_na.partner.register.side_effect = [
+        PreconditionFailed(),
+        {"response": {"public_key": PUBLIC_KEY}},
+    ]
+    mock_api_eu = _mock_api(
+        mock_private_key, server="https://fleet-api.prd.eu.vn.cloud.tesla.com"
+    )
+    mock_api_eu.partner.register.side_effect = [
+        PreconditionFailed(),
+        {"response": {"public_key": PUBLIC_KEY}},
+    ]
+
     with (
         patch(
             "homeassistant.components.tesla_fleet.config_flow.TeslaFleetApi",
-            side_effect=[
-                _mock_api(
-                    mock_private_key,
-                    server="https://fleet-api.prd.na.vn.cloud.tesla.com",
-                    register_side_effect=PreconditionFailed,
-                ),
-                _mock_api(
-                    mock_private_key,
-                    server="https://fleet-api.prd.eu.vn.cloud.tesla.com",
-                    register_side_effect=PreconditionFailed,
-                ),
-            ],
+            side_effect=[mock_api_na, mock_api_eu],
+        ),
+        patch(
+            "homeassistant.components.tesla_fleet.async_setup_entry", return_value=True
         ),
     ):
         # Complete OAuth
@@ -526,6 +555,18 @@ async def test_domain_registration_precondition_failed(
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "domain_input"
         assert result["errors"] == {"base": "origin_mismatch"}
+
+        # Retry - both regions now register successfully, so the flow recovers
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_DOMAIN: "example.com"}
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "registration_complete"
+
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == UNIQUE_ID
 
 
 @pytest.mark.usefixtures("current_request_with_host")
@@ -562,18 +603,30 @@ async def test_domain_registration_missing_public_key(
         },
     )
 
+    mock_api_na = _mock_api(
+        mock_private_key,
+        public_key="test_point",
+        server="https://fleet-api.prd.na.vn.cloud.tesla.com",
+    )
+    mock_api_na.partner.register.side_effect = [
+        {"response": {}},
+        {"response": {"public_key": "test_point"}},
+    ]
+    mock_api_eu = _mock_api(
+        mock_private_key,
+        public_key="test_point",
+        server="https://fleet-api.prd.eu.vn.cloud.tesla.com",
+    )
+
     with (
         patch(
-            "homeassistant.components.tesla_fleet.config_flow.TeslaFleetApi"
-        ) as mock_api_class,
+            "homeassistant.components.tesla_fleet.config_flow.TeslaFleetApi",
+            side_effect=[mock_api_na, mock_api_eu],
+        ),
+        patch(
+            "homeassistant.components.tesla_fleet.async_setup_entry", return_value=True
+        ),
     ):
-        mock_api = _mock_api(
-            mock_private_key,
-            public_key="test_point",
-            register_response={"response": {}},
-        )
-        mock_api_class.return_value = mock_api
-
         # Complete OAuth
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
@@ -585,6 +638,18 @@ async def test_domain_registration_missing_public_key(
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "domain_input"
         assert result["errors"] == {"base": "invalid_response"}
+
+        # Retry - the home region now returns a usable public key
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_DOMAIN: "example.com"}
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "registration_complete"
+
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == UNIQUE_ID
 
 
 @pytest.mark.usefixtures("current_request_with_host")
@@ -621,18 +686,30 @@ async def test_domain_registration_public_key_mismatch(
         },
     )
 
+    mock_api_na = _mock_api(
+        mock_private_key,
+        public_key="expected_key",
+        server="https://fleet-api.prd.na.vn.cloud.tesla.com",
+    )
+    mock_api_na.partner.register.side_effect = [
+        {"response": {"public_key": "different_key"}},
+        {"response": {"public_key": "expected_key"}},
+    ]
+    mock_api_eu = _mock_api(
+        mock_private_key,
+        public_key="expected_key",
+        server="https://fleet-api.prd.eu.vn.cloud.tesla.com",
+    )
+
     with (
         patch(
-            "homeassistant.components.tesla_fleet.config_flow.TeslaFleetApi"
-        ) as mock_api_class,
+            "homeassistant.components.tesla_fleet.config_flow.TeslaFleetApi",
+            side_effect=[mock_api_na, mock_api_eu],
+        ),
+        patch(
+            "homeassistant.components.tesla_fleet.async_setup_entry", return_value=True
+        ),
     ):
-        mock_api = _mock_api(
-            mock_private_key,
-            public_key="expected_key",
-            register_response={"response": {"public_key": "different_key"}},
-        )
-        mock_api_class.return_value = mock_api
-
         # Complete OAuth
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
@@ -643,6 +720,16 @@ async def test_domain_registration_public_key_mismatch(
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "domain_registration"
         assert result["errors"] == {"base": "public_key_mismatch"}
+
+        # Retry - the hosted public key now matches, so the flow recovers
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "registration_complete"
+
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == UNIQUE_ID
 
 
 @pytest.mark.usefixtures("current_request_with_host")
@@ -757,22 +844,33 @@ async def test_domain_registration_all_regions_fail(
         },
     )
 
-    with patch(
-        "homeassistant.components.tesla_fleet.config_flow.TeslaFleetApi",
-        side_effect=[
-            _mock_api(
-                mock_private_key,
-                public_key="test_point",
-                server="https://fleet-api.prd.na.vn.cloud.tesla.com",
-                register_side_effect=TeslaFleetError("NA registration failed"),
-            ),
-            _mock_api(
-                mock_private_key,
-                public_key="test_point",
-                server="https://fleet-api.prd.eu.vn.cloud.tesla.com",
-                register_side_effect=TeslaFleetError("EU registration failed"),
-            ),
-        ],
+    mock_api_na = _mock_api(
+        mock_private_key,
+        public_key="test_point",
+        server="https://fleet-api.prd.na.vn.cloud.tesla.com",
+    )
+    mock_api_na.partner.register.side_effect = [
+        TeslaFleetError("NA registration failed"),
+        {"response": {"public_key": "test_point"}},
+    ]
+    mock_api_eu = _mock_api(
+        mock_private_key,
+        public_key="test_point",
+        server="https://fleet-api.prd.eu.vn.cloud.tesla.com",
+    )
+    mock_api_eu.partner.register.side_effect = [
+        TeslaFleetError("EU registration failed"),
+        {"response": {"public_key": "test_point"}},
+    ]
+
+    with (
+        patch(
+            "homeassistant.components.tesla_fleet.config_flow.TeslaFleetApi",
+            side_effect=[mock_api_na, mock_api_eu],
+        ),
+        patch(
+            "homeassistant.components.tesla_fleet.async_setup_entry", return_value=True
+        ),
     ):
         # Complete OAuth
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
@@ -790,16 +888,49 @@ async def test_domain_registration_all_regions_fail(
             == "example.com"
         )
 
+        # Retry - both regions now register successfully, so the flow recovers
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_DOMAIN: "example.com"}
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "registration_complete"
+
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == UNIQUE_ID
+
 
 @pytest.mark.usefixtures("current_request_with_host")
-async def test_domain_registration_failure_with_key_guidance(
+@pytest.mark.parametrize(
+    ("na_error", "eu_error"),
+    [
+        pytest.param(
+            {"error": "public key must use secp256r1"},
+            {"error": "private_key does not match"},
+            id="key_related_text",
+        ),
+        pytest.param(
+            {"error": "registration rejected"},
+            {"error": "something else"},
+            id="generic_text",
+        ),
+    ],
+)
+async def test_domain_registration_failure_unclassified_error(
     hass: HomeAssistant,
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
     access_token: str,
     mock_private_key: Mock,
+    na_error: dict[str, str],
+    eu_error: dict[str, str],
 ) -> None:
-    """Test unclassified Tesla errors map to the generic registration guidance."""
+    """Test Tesla errors that aren't PreconditionFailed map to the generic guidance.
+
+    The classifier only distinguishes PreconditionFailed (origin_mismatch) from
+    everything else (registration_failed), regardless of the error payload text.
+    """
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
@@ -825,96 +956,54 @@ async def test_domain_registration_failure_with_key_guidance(
         },
     )
 
-    with patch(
-        "homeassistant.components.tesla_fleet.config_flow.TeslaFleetApi",
-        side_effect=[
-            _mock_api(
-                mock_private_key,
-                public_key="test_point",
-                server="https://fleet-api.prd.na.vn.cloud.tesla.com",
-                register_side_effect=_tesla_error(
-                    {"error": "public key must use secp256r1"}
-                ),
-            ),
-            _mock_api(
-                mock_private_key,
-                public_key="test_point",
-                server="https://fleet-api.prd.eu.vn.cloud.tesla.com",
-                register_side_effect=_tesla_error(
-                    {"error": "private_key does not match"}
-                ),
-            ),
-        ],
+    mock_api_na = _mock_api(
+        mock_private_key,
+        public_key="test_point",
+        server="https://fleet-api.prd.na.vn.cloud.tesla.com",
+    )
+    mock_api_na.partner.register.side_effect = [
+        _tesla_error(na_error),
+        {"response": {"public_key": "test_point"}},
+    ]
+    mock_api_eu = _mock_api(
+        mock_private_key,
+        public_key="test_point",
+        server="https://fleet-api.prd.eu.vn.cloud.tesla.com",
+    )
+    mock_api_eu.partner.register.side_effect = [
+        _tesla_error(eu_error),
+        {"response": {"public_key": "test_point"}},
+    ]
+
+    with (
+        patch(
+            "homeassistant.components.tesla_fleet.config_flow.TeslaFleetApi",
+            side_effect=[mock_api_na, mock_api_eu],
+        ),
+        patch(
+            "homeassistant.components.tesla_fleet.async_setup_entry", return_value=True
+        ),
     ):
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {CONF_DOMAIN: "example.com"}
         )
 
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "domain_input"
-    assert result["errors"] == {"base": "registration_failed"}
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "domain_input"
+        assert result["errors"] == {"base": "registration_failed"}
 
-
-@pytest.mark.usefixtures("current_request_with_host")
-async def test_domain_registration_failure_with_generic_guidance(
-    hass: HomeAssistant,
-    hass_client_no_auth: ClientSessionGenerator,
-    aioclient_mock: AiohttpClientMocker,
-    access_token: str,
-    mock_private_key: Mock,
-) -> None:
-    """Test unknown Tesla payloads map to the generic guidance."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
-
-    state = config_entry_oauth2_flow._encode_jwt(
-        hass,
-        {
-            "flow_id": result["flow_id"],
-            "redirect_uri": REDIRECT,
-        },
-    )
-
-    client = await hass_client_no_auth()
-    await client.get(f"/auth/external/callback?code=abcd&state={state}")
-
-    aioclient_mock.post(
-        TOKEN_URL,
-        json={
-            "refresh_token": "mock-refresh-token",
-            "access_token": access_token,
-            "type": "Bearer",
-            "expires_in": 60,
-        },
-    )
-
-    with patch(
-        "homeassistant.components.tesla_fleet.config_flow.TeslaFleetApi",
-        side_effect=[
-            _mock_api(
-                mock_private_key,
-                public_key="test_point",
-                server="https://fleet-api.prd.na.vn.cloud.tesla.com",
-                register_side_effect=_tesla_error({"error": "registration rejected"}),
-            ),
-            _mock_api(
-                mock_private_key,
-                public_key="test_point",
-                server="https://fleet-api.prd.eu.vn.cloud.tesla.com",
-                register_side_effect=_tesla_error({"error": "something else"}),
-            ),
-        ],
-    ):
-        result = await hass.config_entries.flow.async_configure(result["flow_id"])
+        # Retry - both regions now register successfully, so the flow recovers
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {CONF_DOMAIN: "example.com"}
         )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "registration_complete"
 
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "domain_input"
-    assert result["errors"] == {"base": "registration_failed"}
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == UNIQUE_ID
 
 
 @pytest.mark.usefixtures("current_request_with_host")
@@ -955,19 +1044,25 @@ async def test_domain_registration_home_region_must_register(
         },
     )
 
-    with patch(
-        "homeassistant.components.tesla_fleet.config_flow.TeslaFleetApi",
-        side_effect=[
-            _mock_api(
-                mock_private_key,
-                server="https://fleet-api.prd.na.vn.cloud.tesla.com",
-                register_side_effect=PreconditionFailed,
-            ),
-            _mock_api(
-                mock_private_key,
-                server="https://fleet-api.prd.eu.vn.cloud.tesla.com",
-            ),
-        ],
+    mock_api_na = _mock_api(
+        mock_private_key, server="https://fleet-api.prd.na.vn.cloud.tesla.com"
+    )
+    mock_api_na.partner.register.side_effect = [
+        PreconditionFailed(),
+        {"response": {"public_key": PUBLIC_KEY}},
+    ]
+    mock_api_eu = _mock_api(
+        mock_private_key, server="https://fleet-api.prd.eu.vn.cloud.tesla.com"
+    )
+
+    with (
+        patch(
+            "homeassistant.components.tesla_fleet.config_flow.TeslaFleetApi",
+            side_effect=[mock_api_na, mock_api_eu],
+        ),
+        patch(
+            "homeassistant.components.tesla_fleet.async_setup_entry", return_value=True
+        ),
     ):
         # Complete OAuth
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
@@ -976,10 +1071,22 @@ async def test_domain_registration_home_region_must_register(
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {CONF_DOMAIN: "example.com"}
         )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "domain_input"
+        assert result["errors"] == {"base": "origin_mismatch"}
 
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "domain_input"
-    assert result["errors"] == {"base": "origin_mismatch"}
+        # Retry - the home region (NA) now registers successfully, so the
+        # flow recovers instead of completing on the EU registration alone
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_DOMAIN: "example.com"}
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "registration_complete"
+
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == UNIQUE_ID
 
 
 @pytest.mark.usefixtures("current_request_with_host")
@@ -1021,19 +1128,25 @@ async def test_domain_registration_home_region_invalid_response(
         },
     )
 
-    with patch(
-        "homeassistant.components.tesla_fleet.config_flow.TeslaFleetApi",
-        side_effect=[
-            _mock_api(
-                mock_private_key,
-                server="https://fleet-api.prd.na.vn.cloud.tesla.com",
-                register_response=None,
-            ),
-            _mock_api(
-                mock_private_key,
-                server="https://fleet-api.prd.eu.vn.cloud.tesla.com",
-            ),
-        ],
+    mock_api_na = _mock_api(
+        mock_private_key, server="https://fleet-api.prd.na.vn.cloud.tesla.com"
+    )
+    mock_api_na.partner.register.side_effect = [
+        None,
+        {"response": {"public_key": PUBLIC_KEY}},
+    ]
+    mock_api_eu = _mock_api(
+        mock_private_key, server="https://fleet-api.prd.eu.vn.cloud.tesla.com"
+    )
+
+    with (
+        patch(
+            "homeassistant.components.tesla_fleet.config_flow.TeslaFleetApi",
+            side_effect=[mock_api_na, mock_api_eu],
+        ),
+        patch(
+            "homeassistant.components.tesla_fleet.async_setup_entry", return_value=True
+        ),
     ):
         # Complete OAuth
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
@@ -1043,10 +1156,21 @@ async def test_domain_registration_home_region_invalid_response(
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {CONF_DOMAIN: "example.com"}
         )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "domain_input"
+        assert result["errors"] == {"base": "invalid_response"}
 
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "domain_input"
-    assert result["errors"] == {"base": "invalid_response"}
+        # Retry - the home region (NA) now returns a usable response
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_DOMAIN: "example.com"}
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "registration_complete"
+
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == UNIQUE_ID
 
 
 @pytest.mark.usefixtures("current_request_with_host")

--- a/tests/components/tesla_fleet/test_config_flow.py
+++ b/tests/components/tesla_fleet/test_config_flow.py
@@ -789,7 +789,7 @@ async def test_domain_registration_failure_with_key_guidance(
     access_token: str,
     mock_private_key: Mock,
 ) -> None:
-    """Test Tesla key errors map to the reset-private-key guidance."""
+    """Test unclassified Tesla errors map to the generic registration guidance."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
@@ -843,7 +843,7 @@ async def test_domain_registration_failure_with_key_guidance(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "domain_input"
-    assert result["errors"] == {"base": "reset_private_key"}
+    assert result["errors"] == {"base": "registration_failed"}
 
 
 @pytest.mark.usefixtures("current_request_with_host")
@@ -1325,12 +1325,14 @@ def test_is_valid_domain(domain: str, expected_valid: bool) -> None:
     ("err", "expected"),
     [
         (PreconditionFailed(), "origin_mismatch"),
-        (_tesla_error({"error": "allowed origin mismatch"}), "origin_mismatch"),
-        (_tesla_error({"error": "public key must use secp256r1"}), "reset_private_key"),
-        (_tesla_error({"error": "private_key does not match"}), "reset_private_key"),
+        (_tesla_error({"error": "allowed origin mismatch"}), "registration_failed"),
+        (
+            _tesla_error({"error": "public key must use secp256r1"}),
+            "registration_failed",
+        ),
         (_tesla_error({"error": "registration rejected"}), "registration_failed"),
     ],
-    ids=["precondition", "origin_text", "public_key", "private_key", "generic"],
+    ids=["precondition", "origin_text", "public_key", "generic"],
 )
 def test_classify_region_registration_failure(
     err: TeslaFleetError, expected: str

--- a/tests/components/tesla_fleet/test_config_flow.py
+++ b/tests/components/tesla_fleet/test_config_flow.py
@@ -47,7 +47,7 @@ def _mock_api(
     *,
     public_key: str = PUBLIC_KEY,
     server: str | None = None,
-    register_response: dict[str, dict[str, str] | None] | None | object = (
+    register_response: dict[str, dict[str, str] | None] | object | None = (
         DEFAULT_REGISTER_RESPONSE
     ),
     register_side_effect: BaseException | type[BaseException] | None = None,


### PR DESCRIPTION
## Proposed change

When partner registration failed for some of the selected regions, the Tesla Fleet config flow dropped the user back to a generic error, with no way to tell which region failed or what to do about it. A new step now reports per-region success and failure, turns each failure into actionable guidance, and lets the user continue if at least one region registered, or retry with their domain pre-filled.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

