### PR TITLE
Fix SolarEdge energy sensors losing unit of measurement

### DIFF
--- a/homeassistant/components/solaredge/sensor.py
+++ b/homeassistant/components/solaredge/sensor.py
@@ -543,7 +543,8 @@ class SolarEdgeEnergyDetailsSensor(SolarEdgeSensorEntity):
         """Initialize the power flow sensor."""
         super().__init__(sensor_type, data_service)
 
-        self._attr_native_unit_of_measurement = data_service.unit
+        if data_service.unit is not None:
+            self._attr_native_unit_of_measurement = data_service.unit
 
     @property
     @override
@@ -571,7 +572,8 @@ class SolarEdgePowerFlowSensor(SolarEdgeSensorEntity):
         """Initialize the power flow sensor."""
         super().__init__(description, data_service)
 
-        self._attr_native_unit_of_measurement = data_service.unit
+        if data_service.unit is not None:
+            self._attr_native_unit_of_measurement = data_service.unit
 
     @property
     @override

--- a/tests/components/solaredge/test_sensor.py
+++ b/tests/components/solaredge/test_sensor.py
@@ -214,6 +214,24 @@ async def test_energy_details_sensor_unknown_when_no_meters(
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_energy_details_sensor_keeps_unit_when_api_fails(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    solaredge_api: Mock,
+) -> None:
+    """Test energy detail sensors keep their unit when the initial API call fails."""
+    solaredge_api.get_energy_details.return_value = {}
+
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get("sensor.solaredge_produced_energy")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+    assert state.attributes["unit_of_measurement"] == "Wh"
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_energy_details_filters_meters(
     recorder_mock: Recorder,
     hass: HomeAssistant,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`SolarEdgeEnergyDetailsSensor` and `SolarEdgePowerFlowSensor` unconditionally copy `data_service.unit` into `self._attr_native_unit_of_measurement` during `__init__`. The data service initializes its `unit` to `None` and only populates it after a successful API response. When the initial API call fails (or returns data without the expected keys), `None` overwrites the entity description's default (`UnitOfEnergy.WATT_HOUR`), causing the sensor to report no unit of measurement.

This fix guards the override so it only applies when the data service has actually received a unit from the API. When `None`, the entity description's default is preserved.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/175332
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr