### PR TITLE
Bump WattWächter Plus to silver quality scale

### DIFF
--- a/homeassistant/components/wattwaechter/manifest.json
+++ b/homeassistant/components/wattwaechter/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/wattwaechter",
   "integration_type": "device",
   "iot_class": "local_polling",
-  "quality_scale": "bronze",
+  "quality_scale": "silver",
   "requirements": ["aio-wattwaechter==1.0.0"],
   "zeroconf": [
     {

--- a/homeassistant/components/wattwaechter/quality_scale.yaml
+++ b/homeassistant/components/wattwaechter/quality_scale.yaml
@@ -36,8 +36,10 @@ rules:
     status: exempt
     comment: Integration does not provide service actions.
   config-entry-unloading: done
-  docs-configuration-parameters: todo
-  docs-installation-parameters: todo
+  docs-configuration-parameters:
+    status: exempt
+    comment: Integration does not provide configuration options.
+  docs-installation-parameters: done
   entity-unavailable: done
   integration-owner: done
   log-when-unavailable: done


### PR DESCRIPTION
## Proposed change

Raises the WattWächter Plus integration from **bronze** to **silver** on the [Integration Quality Scale][quality-scale].

All silver rules are now satisfied:

- `reauthentication-flow` — implemented and merged in #174281.
- `docs-installation-parameters` — the setup parameters (host, API token) are documented in the integration docs ([home-assistant.io#44004], merged).
- `docs-configuration-parameters` — marked `exempt`: the integration exposes no configuration options (no options flow).
- All remaining silver rules (`config-entry-unloading`, `entity-unavailable`, `integration-owner`, `log-when-unavailable`, `parallel-updates`, `test-coverage`, `action-exceptions` [exempt]) were already `done`/`exempt`.

This PR only updates `quality_scale.yaml` (the two docs rules) and bumps `quality_scale` in `manifest.json` to `silver`.

[home-assistant.io#44004]: https://github.com/home-assistant/home-assistant.io/pull/44004

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
