### PR TITLE
Fix deleted UniFi Protect public devices leaving entities available

### DIFF
--- a/homeassistant/components/unifiprotect/data.py
+++ b/homeassistant/components/unifiprotect/data.py
@@ -19,8 +19,6 @@ from uiprotect.data import (
     ProtectAdoptableDeviceModel,
     PTZPatrol,
     PublicDeviceModel,
-    Relay,
-    Siren,
     WSSubscriptionMessage,
 )
 from uiprotect.exceptions import ClientError, NotAuthorized
@@ -85,12 +83,6 @@ class ProtectData:
         self._subscriptions: defaultdict[
             str, set[Callable[[ProtectDeviceType], None]]
         ] = defaultdict(set)
-        self._relay_subscriptions: defaultdict[str, set[Callable[[Relay], None]]] = (
-            defaultdict(set)
-        )
-        self._siren_subscriptions: defaultdict[str, set[Callable[[Siren], None]]] = (
-            defaultdict(set)
-        )
         self._public_event_subscriptions: defaultdict[
             tuple[str, EventType], set[Callable[[ProtectEvent], None]]
         ] = defaultdict(set)
@@ -226,37 +218,24 @@ class ProtectData:
 
         DEVICES_WS_SUBSCRIBED_MODELS is an empty set, which the API client treats
         as "all models", so messages are not pre-filtered. NVR messages signal the
-        private NVR so alarm entities pick up the new arm state. Relay and Siren
-        messages dispatch the merged object by mac so relay-output and siren
-        entities refresh. Any other public device is dispatched generically by mac
-        to entities whose description was migrated to the public path via
-        ``ufp_public_value`` (such as battery and battery_low); the NVR/Relay/Siren
-        returns above intentionally short-circuit that generic path.
+        private NVR so alarm entities pick up the new arm state. Every other
+        public device inherits ``PublicDeviceModel`` and is dispatched by mac.
+        Frames without a merged object dispatch ``None`` and subscribers re-read
+        the public bootstrap: on a delete the library has already removed the
+        object (it reads as missing and entities go unavailable), while a frame
+        the library could not merge leaves the previous object cached.
         """
         new_obj = message.new_obj
         if new_obj is None:
-            # Delete event: notify subscribers so entities can be marked unavailable.
             old_obj = message.old_obj
-            if old_obj is not None and old_obj.model is ModelType.SIREN:
-                self._async_signal_siren_update(cast(Siren, old_obj))
+            if isinstance(old_obj, PublicDeviceModel):
+                self._async_signal_public_update(old_obj.mac, None)
             return
         if new_obj.model is ModelType.NVR:
             self._async_signal_device_update(self.api.bootstrap.nvr)
             return
-        if new_obj.model is ModelType.RELAY:
-            self._async_signal_relay_update(cast(Relay, new_obj))
-            return
-        if new_obj.model is ModelType.SIREN:
-            self._async_signal_siren_update(cast(Siren, new_obj))
-            return
-        # Generic public-device dispatch (e.g. sensor) keyed by mac, for
-        # descriptions migrated to the public path via ``ufp_public_value``.
-        if isinstance(new_obj, PublicDeviceModel) and (
-            public_subscriptions := self._public_subscriptions.get(new_obj.mac)
-        ):
-            _LOGGER.debug("Updating public device: %s (%s)", new_obj.id, new_obj.mac)
-            for update_callback in public_subscriptions:
-                update_callback(new_obj)
+        if isinstance(new_obj, PublicDeviceModel):
+            self._async_signal_public_update(new_obj.mac, new_obj)
 
     @callback
     def _async_process_public_event(
@@ -306,11 +285,7 @@ class ProtectData:
             return
         # The NVR alarm panel reads the public arm_mode, so refresh it too.
         self._async_signal_device_update(api.bootstrap.nvr)
-        for relay in api.public_bootstrap.relays.values():
-            self._async_signal_relay_update(relay)
-        for siren in api.public_bootstrap.sirens.values():
-            self._async_signal_siren_update(siren)
-        # Migrated entities (e.g. battery) recompute from their cached object.
+        # Subscribers recompute from the public bootstrap on ``None``.
         for subscriptions in self._public_subscriptions.values():
             for update_callback in subscriptions:
                 update_callback(None)
@@ -515,40 +490,6 @@ class ProtectData:
             del self._subscriptions[mac]
 
     @callback
-    def async_subscribe_relay(
-        self, mac: str, update_callback: Callable[[Relay], None]
-    ) -> CALLBACK_TYPE:
-        """Add a callback subscriber for relay updates."""
-        self._relay_subscriptions[mac].add(update_callback)
-        return partial(self._async_unsubscribe_relay, mac, update_callback)
-
-    @callback
-    def _async_unsubscribe_relay(
-        self, mac: str, update_callback: Callable[[Relay], None]
-    ) -> None:
-        """Remove a relay callback subscriber."""
-        self._relay_subscriptions[mac].remove(update_callback)
-        if not self._relay_subscriptions[mac]:
-            del self._relay_subscriptions[mac]
-
-    @callback
-    def async_subscribe_siren(
-        self, mac: str, update_callback: Callable[[Siren], None]
-    ) -> CALLBACK_TYPE:
-        """Add a callback subscriber for siren updates."""
-        self._siren_subscriptions[mac].add(update_callback)
-        return partial(self._async_unsubscribe_siren, mac, update_callback)
-
-    @callback
-    def _async_unsubscribe_siren(
-        self, mac: str, update_callback: Callable[[Siren], None]
-    ) -> None:
-        """Remove a siren callback subscriber."""
-        self._siren_subscriptions[mac].remove(update_callback)
-        if not self._siren_subscriptions[mac]:
-            del self._siren_subscriptions[mac]
-
-    @callback
     def async_subscribe_public_event(
         self,
         mac: str,
@@ -614,24 +555,22 @@ class ProtectData:
             update_callback(device)
 
     @callback
-    def _async_signal_relay_update(self, relay: Relay) -> None:
-        """Call the callbacks for a relay mac."""
-        mac = relay.mac
-        if not (subscriptions := self._relay_subscriptions.get(mac)):
-            return
-        _LOGGER.debug("Updating relay: %s (%s)", relay.name, mac)
-        for update_callback in subscriptions:
-            update_callback(relay)
+    def _async_signal_public_update(
+        self, mac: str, obj: PublicDeviceModel | None
+    ) -> None:
+        """Call the public-device callbacks for a mac.
 
-    @callback
-    def _async_signal_siren_update(self, siren: Siren) -> None:
-        """Call the callbacks for a siren mac."""
-        mac = siren.mac
-        if not (subscriptions := self._siren_subscriptions.get(mac)):
+        ``None`` means the object is gone from (or must be re-read from) the
+        public bootstrap.
+        """
+        if not (subscriptions := self._public_subscriptions.get(mac)):
             return
-        _LOGGER.debug("Updating siren: %s (%s)", siren.name, mac)
+        if obj is not None:
+            _LOGGER.debug("Updating public device: %s (%s)", obj.id, mac)
+        else:
+            _LOGGER.debug("Re-reading public device from bootstrap: %s", mac)
         for update_callback in subscriptions:
-            update_callback(siren)
+            update_callback(obj)
 
 
 @callback

--- a/homeassistant/components/unifiprotect/entity.py
+++ b/homeassistant/components/unifiprotect/entity.py
@@ -286,10 +286,12 @@ class BaseProtectEntity(Entity):
     def _async_public_updated(self, obj: PublicDeviceModel | None) -> None:
         """Handle a public devices WS update for a migrated value.
 
-        ``obj`` is the refreshed public object from a WS message; ``None`` on a
-        public websocket state change (e.g. reconnect), where the cached object
-        is re-read from the bootstrap so a value that changed during the outage
-        is picked up — mirroring the relay/siren re-signal.
+        ``obj`` is the refreshed public object from a WS message; ``None`` when
+        there is no object to pass (a websocket state change, a delete event,
+        or a frame the library could not merge). The object is then re-read
+        from the bootstrap: a deleted device reads as missing (the entity goes
+        unavailable), and after a reconnect a value that changed during the
+        outage is picked up.
         """
         self._ufp_public_obj = (
             obj if obj is not None else self.data.async_get_public_device(self.device)

--- a/homeassistant/components/unifiprotect/siren.py
+++ b/homeassistant/components/unifiprotect/siren.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import logging
 from typing import Any, override
 
-from uiprotect.data import Siren, SirenDuration
+from uiprotect.data import PublicDeviceModel, Siren, SirenDuration
 
 from homeassistant.components.siren import (
     ATTR_DURATION,
@@ -95,45 +95,46 @@ class ProtectSiren(SirenEntity):
         self._attr_is_on = siren.is_active
 
     @callback
-    def _async_updated(self, siren: Siren) -> None:
-        """Handle a public devices WS update for this siren."""
+    def _async_updated(self, _obj: PublicDeviceModel | None) -> None:
+        """Handle a public devices WS update for this siren.
+
+        The state is always re-read from the public bootstrap: the library
+        merges WS updates into it before dispatching, and ``None`` carries no
+        object to read.
+        """
         # Cancel any previous auto-off timer before scheduling a new one.
         self._cancel_off_timer()
 
         prev_state = (self._attr_available, self._attr_is_on)
 
-        # If the siren is no longer in the public bootstrap (delete event),
-        # mark it unavailable and off, then bail out.
-        if self._siren is None:
+        if (siren := self._siren) is None:
+            # Gone from the bootstrap (delete event): mark unavailable and off.
             self._attr_available = False
             self._attr_is_on = False
-            if (self._attr_available, self._attr_is_on) != prev_state:
-                self.async_write_ha_state()
-            return
+        else:
+            self._update_from_siren(siren)
 
-        self._update_from_siren(siren)
-
-        # The server never emits a WS message when a timed run expires, so we
-        # must schedule our own callback.  Both activated_at and duration are
-        # in milliseconds in the WS payload.
-        status = siren.siren_status
-        if (
-            status.is_active
-            and status.activated_at is not None
-            and status.duration is not None
-        ):
-            delay = (
-                status.activated_at + status.duration
-            ) / 1000 - dt_util.utcnow().timestamp()
-            if delay <= 0:
-                # Already expired (e.g. stale bootstrap after a reconnect):
-                # override the is_active=True from the payload immediately so
-                # we never briefly write ON into the state machine.
-                self._attr_is_on = False
-            else:
-                self._cancel_scheduled_off = async_call_later(
-                    self.hass, delay, self._async_scheduled_off
-                )
+            # The server never emits a WS message when a timed run expires, so
+            # we must schedule our own callback.  Both activated_at and
+            # duration are in milliseconds in the WS payload.
+            status = siren.siren_status
+            if (
+                status.is_active
+                and status.activated_at is not None
+                and status.duration is not None
+            ):
+                delay = (
+                    status.activated_at + status.duration
+                ) / 1000 - dt_util.utcnow().timestamp()
+                if delay <= 0:
+                    # Already expired (e.g. stale bootstrap after a reconnect):
+                    # override the is_active=True from the payload immediately
+                    # so we never briefly write ON into the state machine.
+                    self._attr_is_on = False
+                else:
+                    self._cancel_scheduled_off = async_call_later(
+                        self.hass, delay, self._async_scheduled_off
+                    )
 
         if (self._attr_available, self._attr_is_on) != prev_state:
             self.async_write_ha_state()
@@ -150,13 +151,14 @@ class ProtectSiren(SirenEntity):
         """Subscribe to public WS updates dispatched by ProtectData."""
         await super().async_added_to_hass()
         self.async_on_remove(
-            self.data.async_subscribe_siren(self._siren_mac, self._async_updated)
+            self.data.async_subscribe_public(self._siren_mac, self._async_updated)
         )
         self.async_on_remove(self._cancel_off_timer)
-        # Schedule the auto-off timer for any already-active timed run so
+        # Refresh from the bootstrap: a WS update or delete that landed between
+        # entity construction and this subscription would otherwise be missed,
+        # and an already-active timed run needs its auto-off timer scheduled so
         # a siren that was running when HA started does not remain stuck ON.
-        if (siren := self._siren) is not None:
-            self._async_updated(siren)
+        self._async_updated(None)
 
     @callback
     def _cancel_off_timer(self) -> None:

--- a/homeassistant/components/unifiprotect/switch.py
+++ b/homeassistant/components/unifiprotect/switch.py
@@ -9,6 +9,7 @@ from uiprotect.data import (
     Camera,
     ModelType,
     ProtectAdoptableDeviceModel,
+    PublicDeviceModel,
     PublicHdrMode,
     PublicRelayOutput,
     RecordingMode,
@@ -646,14 +647,19 @@ class ProtectRelayOutputSwitch(SwitchEntity):
         )
 
     @callback
-    def _async_updated(self, relay: Relay) -> None:
-        """Handle a public relay WS update for this relay."""
+    def _async_updated(self, _obj: PublicDeviceModel | None) -> None:
+        """Handle a public devices WS update for this relay.
+
+        The state is always re-read from the public bootstrap: the library
+        merges WS updates into it before dispatching, and ``None`` carries no
+        object to read.
+        """
         prev_state = (self._attr_available, self._attr_is_on)
-        self._update_from_relay(relay)
-        # If the relay was removed from the bootstrap while the WS update
-        # was in flight, mark unavailable so commands cannot succeed.
-        if self._relay is None:
+        if (relay := self._relay) is None:
+            # Gone from the bootstrap (delete event): commands cannot succeed.
             self._attr_available = False
+        else:
+            self._update_from_relay(relay)
         if (self._attr_available, self._attr_is_on) != prev_state:
             self.async_write_ha_state()
 
@@ -662,8 +668,11 @@ class ProtectRelayOutputSwitch(SwitchEntity):
         """Subscribe to public relay WS updates dispatched by ProtectData."""
         await super().async_added_to_hass()
         self.async_on_remove(
-            self.data.async_subscribe_relay(self._relay_mac, self._async_updated)
+            self.data.async_subscribe_public(self._relay_mac, self._async_updated)
         )
+        # Refresh from the bootstrap: a WS update or delete that landed between
+        # entity construction and this subscription would otherwise be missed.
+        self._async_updated(None)
 
     async def _activate_output(self, state: Literal["on", "off"]) -> None:
         """Send activate_output to the relay, raising if unavailable."""

--- a/tests/components/unifiprotect/test_relay.py
+++ b/tests/components/unifiprotect/test_relay.py
@@ -1,5 +1,6 @@
 """Tests for the UniFi Protect relay (Public API) switch entities."""
 
+from collections.abc import Callable
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -454,11 +455,11 @@ async def test_public_ws_state_change_without_public_bootstrap(
     assert data.last_public_update_success is False
 
 
-async def test_relay_public_ws_message_with_none_new_obj(
+async def test_relay_public_ws_message_without_public_old_obj(
     hass: HomeAssistant,
     ufp_with_relay: tuple[MockUFPFixture, Mock],
 ) -> None:
-    """Public WS message with new_obj=None is silently ignored."""
+    """A new_obj=None message without a PublicDeviceModel old_obj is ignored."""
     ufp, _ = ufp_with_relay
     await init_entry(hass, ufp, [])
 
@@ -467,6 +468,7 @@ async def test_relay_public_ws_message_with_none_new_obj(
 
     mock_msg = Mock()
     mock_msg.new_obj = None
+    mock_msg.old_obj = None
 
     assert ufp.devices_ws_subscription is not None
     ufp.devices_ws_subscription(mock_msg)
@@ -476,26 +478,57 @@ async def test_relay_public_ws_message_with_none_new_obj(
     assert hass.states.get(SWITCH_ENTITY_ID) == state_before
 
 
-async def test_relay_switch_output_removed_from_relay_update(
+def _outputs_removed_ws_message(ufp: MockUFPFixture, relay: Mock) -> Mock:
+    """Build an update whose merged relay no longer contains any outputs.
+
+    The library merges the update into the public bootstrap before
+    dispatching, so mirror that here: entities re-read the bootstrap on
+    dispatch.
+    """
+    relay_no_outputs = _make_relay(outputs=[])
+    relay_no_outputs.id = relay.id
+    relay_no_outputs.mac = relay.mac
+    ufp.api.public_bootstrap.relays[relay.id] = relay_no_outputs
+
+    mock_msg = Mock()
+    mock_msg.new_obj = relay_no_outputs
+    return mock_msg
+
+
+def _relay_deleted_ws_message(ufp: MockUFPFixture, relay: Mock) -> Mock:
+    """Build a delete event (new_obj=None) for the relay.
+
+    The library removes the object from the bootstrap before dispatching;
+    data.py dispatches None and the entity re-reads the relay as missing.
+    """
+    del ufp.api.public_bootstrap.relays[relay.id]
+
+    mock_msg = Mock()
+    mock_msg.old_obj = relay
+    mock_msg.new_obj = None
+    return mock_msg
+
+
+@pytest.mark.parametrize(
+    "make_ws_message",
+    [
+        pytest.param(_outputs_removed_ws_message, id="outputs_removed"),
+        pytest.param(_relay_deleted_ws_message, id="relay_deleted"),
+    ],
+)
+async def test_relay_switch_unavailable_after_ws_message(
     hass: HomeAssistant,
     ufp_with_relay: tuple[MockUFPFixture, Mock],
+    make_ws_message: Callable[[MockUFPFixture, Mock], Mock],
 ) -> None:
-    """WS update where the output is no longer present marks the entity unavailable."""
+    """WS messages that leave no usable relay output mark the entity unavailable."""
     ufp, relay = ufp_with_relay
     relay.outputs[0].state = RelayOutputState.ON
     await init_entry(hass, ufp, [])
 
     assert hass.states.get(SWITCH_ENTITY_ID).state == STATE_ON  # type: ignore[union-attr]
 
-    # Build a relay WS update that no longer contains any outputs.
-    relay_no_outputs = _make_relay(outputs=[])
-    relay_no_outputs.id = relay.id
-    relay_no_outputs.mac = relay.mac
-
-    mock_msg = Mock()
-    mock_msg.changed_data = {}
-    mock_msg.old_obj = relay_no_outputs
-    mock_msg.new_obj = relay_no_outputs
+    mock_msg = make_ws_message(ufp, relay)
 
     assert ufp.devices_ws_subscription is not None
     ufp.devices_ws_subscription(mock_msg)

--- a/tests/components/unifiprotect/test_siren.py
+++ b/tests/components/unifiprotect/test_siren.py
@@ -590,10 +590,10 @@ async def test_siren_unavailable_on_delete_event(
 ) -> None:
     """Entity becomes UNAVAILABLE when the siren is removed via a WS delete event.
 
-    When the public bootstrap sends new_obj=None (device deleted), data.py
-    dispatches the last-known Siren object (old_obj) to subscriptions.
-    The entity then checks self._siren; if it is no longer in the bootstrap
-    it must override _attr_available to False.
+    On a delete event (new_obj=None) data.py dispatches None to the public
+    subscriptions for the old object's mac. The entity re-reads self._siren;
+    since it is no longer in the bootstrap it must override _attr_available
+    to False.
     """
     await init_entry(hass, ufp_with_siren, [])
 


### PR DESCRIPTION
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When a UniFi Protect device that is only exposed through the public API is deleted from the console, its Home Assistant entities were not notified: the delete branch of the public devices websocket handler only dispatched siren deletions. A deleted relay left its output switches available with stale state forever (relays have no private-websocket removal path as fallback), and entities migrated to the public API via `ufp_public_value` were likewise never told about deletions.

Fix: route all public-device websocket messages — updates and deletions — through the generic public-device subscription path. uiprotect 15.4.0 (already in `dev`) unified all public device models under the shared `PublicDeviceModel` base, so the bespoke relay/siren subscription registries, their subscribe/unsubscribe helpers and per-model dispatch methods in `data.py` are replaced by the existing generic mac-keyed path. Delete events now dispatch `None`; subscribers re-read the public bootstrap (the library merges every frame into it before dispatching), so a deleted device reads as missing and the entity goes unavailable.

The relay switch additionally gained the same initial refresh after subscribing that the siren already had, closing the window where a websocket update or deletion between entity construction and subscription was permanently missed.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #172164
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
