### PR TITLE
Share HomeKit climate fan, swing, and temperature helpers

### DIFF
--- a/homeassistant/components/homekit/climate_base.py
+++ b/homeassistant/components/homekit/climate_base.py
@@ -1,0 +1,220 @@
+"""Base class shared by the climate accessory types."""
+
+from collections.abc import Mapping
+import logging
+from typing import Any
+
+from pyhap.characteristic import Characteristic
+from pyhap.const import CATEGORY_THERMOSTAT
+from pyhap.service import Service
+
+from homeassistant.components.climate import (
+    ATTR_CURRENT_TEMPERATURE,
+    ATTR_FAN_MODE,
+    ATTR_FAN_MODES,
+    ATTR_HVAC_MODES,
+    ATTR_MAX_TEMP,
+    ATTR_MIN_TEMP,
+    ATTR_SWING_MODE,
+    ATTR_SWING_MODES,
+    ATTR_TARGET_TEMP_HIGH,
+    ATTR_TARGET_TEMP_LOW,
+    DEFAULT_MAX_TEMP,
+    DEFAULT_MIN_TEMP,
+    DOMAIN as CLIMATE_DOMAIN,
+    SERVICE_SET_FAN_MODE,
+    SERVICE_SET_SWING_MODE,
+    SWING_OFF,
+    ClimateEntityFeature,
+    HVACMode,
+)
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_SUPPORTED_FEATURES
+from homeassistant.core import State
+
+from .accessories import HomeAccessory
+from .climate_util import (
+    fan_mode_to_speed,
+    fan_speed_to_mode,
+    get_fan_modes_and_speeds,
+    get_swing_off_mode,
+    get_swing_on_mode,
+    get_temperature_range_from_state,
+    is_swing_on,
+    resolve_target_temp_range,
+    temperature_attribute_to_homekit,
+)
+from .const import CHAR_CURRENT_TEMPERATURE, PROP_MAX_VALUE, PROP_MIN_VALUE
+from .util import temperature_to_homekit, temperature_to_states
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class HomeKitClimateAccessory(HomeAccessory):
+    """Base class for the Thermostat and HeaterCooler accessories."""
+
+    # Configured by subclasses only when the entity exposes the mode.
+    char_speed: Characteristic
+    char_swing: Characteristic
+
+    char_current_temp: Characteristic
+
+    def __init__(self, *args: Any) -> None:
+        """Initialize the shared climate accessory state."""
+        super().__init__(*args, category=CATEGORY_THERMOSTAT)
+        self._unit = self.hass.config.units.temperature_unit
+
+        state = self.hass.states.get(self.entity_id)
+        assert state
+        attributes = state.attributes
+        features = attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+
+        # ``fan_modes`` maps lowercased names to their original casing;
+        # ``ordered_fan_speeds`` holds the predefined speeds in HomeKit order.
+        self.fan_modes: dict[str, str] = {}
+        self.ordered_fan_speeds: list[str] = []
+        if features & ClimateEntityFeature.FAN_MODE:
+            self.fan_modes, self.ordered_fan_speeds = get_fan_modes_and_speeds(
+                attributes
+            )
+
+        self.swing_on_mode: str | None = None
+        self.swing_off_mode: str = SWING_OFF
+        if features & ClimateEntityFeature.SWING_MODE:
+            self.swing_on_mode = get_swing_on_mode(attributes)
+            self.swing_off_mode = get_swing_off_mode(attributes)
+
+        # These attributes drive the characteristic set and valid values, so
+        # reload the accessory when any of them change.
+        self._reload_on_change_attrs.extend(
+            (
+                ATTR_MIN_TEMP,
+                ATTR_MAX_TEMP,
+                ATTR_FAN_MODES,
+                ATTR_SWING_MODES,
+                ATTR_HVAC_MODES,
+            )
+        )
+
+    def get_temperature_range(self, state: State) -> tuple[float, float]:
+        """Return the min and max temperature range."""
+        return get_temperature_range_from_state(
+            state, self._unit, DEFAULT_MIN_TEMP, DEFAULT_MAX_TEMP
+        )
+
+    def _configure_current_temperature_char(self, serv: Service) -> None:
+        """Configure the shared current temperature characteristic."""
+        self.char_current_temp = serv.configure_char(
+            CHAR_CURRENT_TEMPERATURE, value=21.0
+        )
+
+    def _configure_target_mode_char(
+        self,
+        serv: Service,
+        char_name: str,
+        value: int,
+        valid_values: dict[HVACMode, int],
+    ) -> Characteristic:
+        """Configure a target mode characteristic scoped to the supported modes.
+
+        The value must be set before ``valid_values`` because pyhap applies the
+        valid values first and would reject a default outside that set.
+        """
+        char = serv.configure_char(char_name, value=value)
+        char.override_properties(valid_values=valid_values)
+        char.allow_invalid_client_values = True
+        return char
+
+    def _update_temperature_char(
+        self, char: Characteristic, state: State, attr: str
+    ) -> None:
+        """Set a temperature characteristic from a state attribute, if present."""
+        if (
+            value := temperature_attribute_to_homekit(state, attr, self._unit)
+        ) is not None:
+            char.set_value(value)
+
+    def _update_current_temperature_char(self, state: State) -> None:
+        """Update the current temperature characteristic from the entity state."""
+        self._update_temperature_char(
+            self.char_current_temp, state, ATTR_CURRENT_TEMPERATURE
+        )
+
+    def _dual_setpoint_params(
+        self,
+        cool_char: Characteristic,
+        heat_char: Characteristic,
+        new_high: float | None,
+        new_low: float | None,
+    ) -> dict[str, float]:
+        """Return an ordered high/low target temperature pair for a range write.
+
+        Fills the unchanged side from the current characteristic value and
+        enforces the deadband, so the entity always gets a consistent pair.
+        """
+        high, low = resolve_target_temp_range(
+            cool_char.value,
+            heat_char.value,
+            new_high,
+            new_low,
+            cool_char.properties[PROP_MIN_VALUE],
+            cool_char.properties[PROP_MAX_VALUE],
+        )
+        return {
+            ATTR_TARGET_TEMP_HIGH: self._temperature_to_states(high),
+            ATTR_TARGET_TEMP_LOW: self._temperature_to_states(low),
+        }
+
+    def _temperature_to_homekit(self, temp: float) -> float:
+        """Convert a temperature in the entity's unit to the HomeKit unit."""
+        return temperature_to_homekit(temp, self._unit)
+
+    def _temperature_to_states(self, temp: float) -> float:
+        """Convert a temperature in the HomeKit unit to the entity's unit."""
+        return temperature_to_states(temp, self._unit)
+
+    def _set_fan_speed(self, speed: int) -> None:
+        """Send the climate fan mode for a HomeKit rotation speed."""
+        _LOGGER.debug("%s: Set fan speed to %s", self.entity_id, speed)
+        if not self.ordered_fan_speeds or not 0 < speed <= 100:
+            return
+        mode = fan_speed_to_mode(self.ordered_fan_speeds, self.fan_modes, speed)
+        self.async_call_service(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_FAN_MODE,
+            {ATTR_ENTITY_ID: self.entity_id, ATTR_FAN_MODE: mode},
+        )
+
+    def _set_swing_mode(self, swing_on: int) -> None:
+        """Send the climate swing mode for a HomeKit swing toggle."""
+        if self.swing_on_mode is None:
+            return
+        _LOGGER.debug("%s: Set swing mode to %s", self.entity_id, swing_on)
+        mode = self.swing_on_mode if swing_on else self.swing_off_mode
+        self.async_call_service(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_SWING_MODE,
+            {ATTR_ENTITY_ID: self.entity_id, ATTR_SWING_MODE: mode},
+        )
+
+    def _update_fan_speed_char(self, attributes: Mapping[str, Any]) -> None:
+        """Update the rotation speed characteristic from the current fan mode."""
+        # Modes with no predefined speed (e.g. fan auto) keep the last value;
+        # HomeKit's slider has no position to represent them.
+        if (
+            self.ordered_fan_speeds
+            and (
+                speed := fan_mode_to_speed(
+                    self.ordered_fan_speeds, attributes.get(ATTR_FAN_MODE)
+                )
+            )
+            is not None
+        ):
+            self.char_speed.set_value(speed)
+
+    def _update_swing_char(self, attributes: Mapping[str, Any]) -> None:
+        """Update the swing characteristic from the current swing mode."""
+        # An absent swing mode keeps the last value; there is nothing to show.
+        if self.swing_on_mode is not None and (
+            swing_mode := attributes.get(ATTR_SWING_MODE)
+        ):
+            self.char_swing.set_value(1 if is_swing_on(swing_mode) else 0)

--- a/homeassistant/components/homekit/climate_util.py
+++ b/homeassistant/components/homekit/climate_util.py
@@ -1,0 +1,189 @@
+"""Shared fan, swing, and temperature helpers for the climate accessory types."""
+
+from collections.abc import Iterable
+from typing import Any
+
+from homeassistant.components.climate import (
+    ATTR_FAN_MODES,
+    ATTR_MAX_TEMP,
+    ATTR_MIN_TEMP,
+    ATTR_SWING_MODES,
+    FAN_HIGH,
+    FAN_LOW,
+    FAN_MEDIUM,
+    FAN_MIDDLE,
+    SWING_BOTH,
+    SWING_HORIZONTAL,
+    SWING_OFF,
+    SWING_ON,
+    SWING_VERTICAL,
+)
+from homeassistant.core import State
+from homeassistant.util.percentage import (
+    ordered_list_item_to_percentage,
+    percentage_to_ordered_list_item,
+)
+
+from .util import get_min_max, temperature_to_homekit
+
+ORDERED_FAN_SPEEDS = [FAN_LOW, FAN_MIDDLE, FAN_MEDIUM, FAN_HIGH]
+PRE_DEFINED_FAN_MODES = set(ORDERED_FAN_SPEEDS)
+SWING_MODE_PREFERRED_ORDER = [SWING_ON, SWING_BOTH, SWING_HORIZONTAL, SWING_VERTICAL]
+PRE_DEFINED_SWING_MODES = set(SWING_MODE_PREFERRED_ORDER)
+
+# Minimum gap kept between the low and high set points of a range.
+HEAT_COOL_DEADBAND = 5
+
+
+def _lower_to_original(modes: Iterable[Any]) -> dict[str, str]:
+    """Map each string mode to its original casing, keyed by the lowercase form."""
+    return {mode.lower(): mode for mode in modes if isinstance(mode, str)}
+
+
+def get_fan_modes_and_speeds(
+    attributes: dict[str, Any],
+) -> tuple[dict[str, str], list[str]]:
+    """Return the fan modes and ordered predefined speeds for a climate entity.
+
+    ``fan_modes`` maps each lowercased fan mode to its original casing.
+    ``ordered_fan_speeds`` is the subset of predefined speeds the entity
+    exposes, in HomeKit rotation-speed order; it is empty when the entity only
+    advertises custom fan mode names.
+    """
+    fan_modes = _lower_to_original(attributes.get(ATTR_FAN_MODES) or [])
+    ordered_fan_speeds: list[str] = []
+    if PRE_DEFINED_FAN_MODES.intersection(fan_modes):
+        ordered_fan_speeds = [
+            speed for speed in ORDERED_FAN_SPEEDS if speed in fan_modes
+        ]
+    return fan_modes, ordered_fan_speeds
+
+
+def get_swing_on_mode(attributes: dict[str, Any]) -> str | None:
+    """Return the preferred swing-on mode for a climate entity, if any.
+
+    The match is case insensitive and the entity's original casing is
+    returned so it can be sent back to the service. Returns ``None`` when the
+    entity exposes no predefined swing modes.
+    """
+    if not (swing_modes := attributes.get(ATTR_SWING_MODES)):
+        return None
+    lower_to_original = _lower_to_original(swing_modes)
+    return next(
+        (
+            lower_to_original[swing_mode]
+            for swing_mode in SWING_MODE_PREFERRED_ORDER
+            if swing_mode in lower_to_original
+        ),
+        None,
+    )
+
+
+def get_swing_off_mode(attributes: dict[str, Any]) -> str:
+    """Return the entity's off swing mode, preserving its original casing."""
+    swing_modes = attributes.get(ATTR_SWING_MODES) or []
+    return _lower_to_original(swing_modes).get(SWING_OFF, SWING_OFF)
+
+
+def fan_speed_to_mode(
+    ordered_fan_speeds: list[str], fan_modes: dict[str, str], speed: int
+) -> str:
+    """Return the climate fan mode for a HomeKit rotation speed percentage.
+
+    The percentage is offset by one so the lowest slider step maps to the
+    first ordered speed.
+    """
+    speed_key = percentage_to_ordered_list_item(ordered_fan_speeds, speed - 1)
+    return fan_modes[speed_key]
+
+
+def fan_mode_to_speed(ordered_fan_speeds: list[str], fan_mode: Any) -> int | None:
+    """Return the HomeKit rotation speed percentage for a climate fan mode.
+
+    Returns ``None`` when the mode is not one of the ordered predefined speeds.
+    """
+    if (
+        not isinstance(fan_mode, str)
+        or (fan_mode_lower := fan_mode.lower()) not in ordered_fan_speeds
+    ):
+        return None
+    return ordered_list_item_to_percentage(ordered_fan_speeds, fan_mode_lower)
+
+
+def is_swing_on(swing_mode: Any) -> bool:
+    """Return whether a climate swing mode maps to HomeKit swing on."""
+    return isinstance(swing_mode, str) and swing_mode.lower() in PRE_DEFINED_SWING_MODES
+
+
+def get_temperature_range_from_state(
+    state: State, unit: str, default_min: float, default_max: float
+) -> tuple[float, float]:
+    """Return the HomeKit min and max temperature range for a climate state.
+
+    Attribute values are in the entity's unit and converted to Celsius; the
+    defaults are already Celsius and used as-is. The minimum is clamped to zero
+    because the Home app crashes on negative bounds.
+    """
+    if (min_temp := state.attributes.get(ATTR_MIN_TEMP)) is not None:
+        min_temp = round(temperature_to_homekit(min_temp, unit) * 2) / 2
+    else:
+        min_temp = default_min
+
+    if (max_temp := state.attributes.get(ATTR_MAX_TEMP)) is not None:
+        max_temp = round(temperature_to_homekit(max_temp, unit) * 2) / 2
+    else:
+        max_temp = default_max
+
+    # Handle a reversed temperature range
+    min_temp, max_temp = get_min_max(min_temp, max_temp)
+
+    min_temp = max(min_temp, 0)
+    max_temp = max(max_temp, min_temp)
+
+    return min_temp, max_temp
+
+
+def temperature_attribute_to_homekit(state: State, key: str, unit: str) -> float | None:
+    """Return a numeric temperature attribute converted to the HomeKit unit."""
+    value = state.attributes.get(key)
+    if isinstance(value, (int, float)):
+        return temperature_to_homekit(value, unit)
+    return None
+
+
+def resolve_target_temp_range(
+    current_high: float,
+    current_low: float,
+    new_high: float | None,
+    new_low: float | None,
+    min_temp: float,
+    max_temp: float,
+) -> tuple[float, float]:
+    """Return an ordered (high, low) target range within the temperature bounds.
+
+    The unchanged side keeps its current value and a deadband is enforced so
+    the range is never inverted.
+    """
+    high = current_high
+    low = current_low
+    deadband_enforced = False
+    if new_high is not None:
+        high = new_high
+        if high < low:
+            low = high - HEAT_COOL_DEADBAND
+            deadband_enforced = True
+    if new_low is not None:
+        low = new_low
+        if low > high:
+            high = low + HEAT_COOL_DEADBAND
+            deadband_enforced = True
+    high = min(high, max_temp)
+    low = max(low, min_temp)
+    # Clamping a deadband-adjusted setpoint to a bound can erase the gap it just
+    # enforced; restore it by moving the setpoint that is not pinned to the bound.
+    if deadband_enforced and high - low < HEAT_COOL_DEADBAND:
+        if high >= max_temp:
+            low = max(min_temp, high - HEAT_COOL_DEADBAND)
+        else:
+            high = min(max_temp, low + HEAT_COOL_DEADBAND)
+    return high, low

--- a/homeassistant/components/homekit/type_thermostats.py
+++ b/homeassistant/components/homekit/type_thermostats.py
@@ -9,7 +9,6 @@ from homeassistant.components.climate import (
     ATTR_CURRENT_HUMIDITY,
     ATTR_CURRENT_TEMPERATURE,
     ATTR_FAN_MODE,
-    ATTR_FAN_MODES,
     ATTR_HUMIDITY,
     ATTR_HVAC_ACTION,
     ATTR_HVAC_MODE,
@@ -18,32 +17,18 @@ from homeassistant.components.climate import (
     ATTR_MAX_TEMP,
     ATTR_MIN_HUMIDITY,
     ATTR_MIN_TEMP,
-    ATTR_SWING_MODE,
-    ATTR_SWING_MODES,
     ATTR_TARGET_TEMP_HIGH,
     ATTR_TARGET_TEMP_LOW,
     DEFAULT_MAX_HUMIDITY,
-    DEFAULT_MAX_TEMP,
     DEFAULT_MIN_HUMIDITY,
-    DEFAULT_MIN_TEMP,
     DOMAIN as CLIMATE_DOMAIN,
     FAN_AUTO,
-    FAN_HIGH,
-    FAN_LOW,
-    FAN_MEDIUM,
-    FAN_MIDDLE,
     FAN_OFF,
     FAN_ON,
     SERVICE_SET_FAN_MODE,
     SERVICE_SET_HUMIDITY,
     SERVICE_SET_HVAC_MODE as SERVICE_SET_HVAC_MODE_THERMOSTAT,
-    SERVICE_SET_SWING_MODE,
     SERVICE_SET_TEMPERATURE as SERVICE_SET_TEMPERATURE_THERMOSTAT,
-    SWING_BOTH,
-    SWING_HORIZONTAL,
-    SWING_OFF,
-    SWING_ON,
-    SWING_VERTICAL,
     ClimateEntityFeature,
     HVACAction,
     HVACMode,
@@ -70,12 +55,14 @@ from homeassistant.const import (
 )
 from homeassistant.core import State, callback
 from homeassistant.util.enum import try_parse_enum
-from homeassistant.util.percentage import (
-    ordered_list_item_to_percentage,
-    percentage_to_ordered_list_item,
-)
+from homeassistant.util.percentage import percentage_to_ordered_list_item
 
 from .accessories import TYPES, HomeAccessory
+from .climate_base import HomeKitClimateAccessory
+from .climate_util import (
+    get_temperature_range_from_state,
+    temperature_attribute_to_homekit,
+)
 from .const import (
     CHAR_ACTIVE,
     CHAR_COOLING_THRESHOLD_TEMPERATURE,
@@ -99,7 +86,7 @@ from .const import (
     SERV_FANV2,
     SERV_THERMOSTAT,
 )
-from .util import get_min_max, temperature_to_homekit, temperature_to_states
+from .util import get_min_max, temperature_to_states
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -131,11 +118,6 @@ HC_HEAT_COOL_PREFER_COOL = [
     HC_HEAT_COOL_HEAT,
     HC_HEAT_COOL_OFF,
 ]
-
-ORDERED_FAN_SPEEDS = [FAN_LOW, FAN_MIDDLE, FAN_MEDIUM, FAN_HIGH]
-PRE_DEFINED_FAN_MODES = set(ORDERED_FAN_SPEEDS)
-SWING_MODE_PREFERRED_ORDER = [SWING_ON, SWING_BOTH, SWING_HORIZONTAL, SWING_VERTICAL]
-PRE_DEFINED_SWING_MODES = set(SWING_MODE_PREFERRED_ORDER)
 
 HC_MIN_TEMP = 10
 HC_MAX_TEMP = 38
@@ -178,8 +160,6 @@ HC_HASS_TO_HOMEKIT_FAN_STATE = {
     HVACAction.DEFROSTING: FAN_STATE_IDLE,
 }
 
-HEAT_COOL_DEADBAND = 5
-
 
 def _hk_hvac_mode_from_state(state: State) -> int | None:
     """Return the equivalent HomeKit HVAC mode for a given state."""
@@ -194,25 +174,17 @@ def _hk_hvac_mode_from_state(state: State) -> int | None:
 
 
 @TYPES.register("Thermostat")
-class Thermostat(HomeAccessory):
+class Thermostat(HomeKitClimateAccessory):
     """Generate a Thermostat accessory for a climate."""
 
     def __init__(self, *args: Any) -> None:
         """Initialize a Thermostat accessory object."""
-        super().__init__(*args, category=CATEGORY_THERMOSTAT)
-        self._unit = self.hass.config.units.temperature_unit
+        super().__init__(*args)
         state = self.hass.states.get(self.entity_id)
         assert state
         hc_min_temp, hc_max_temp = self.get_temperature_range(state)
-        self._reload_on_change_attrs.extend(
-            (
-                ATTR_MIN_HUMIDITY,
-                ATTR_MAX_TEMP,
-                ATTR_MIN_TEMP,
-                ATTR_FAN_MODES,
-                ATTR_HVAC_MODES,
-            )
-        )
+        # The common climate reload attributes are added by the base class.
+        self._reload_on_change_attrs.append(ATTR_MIN_HUMIDITY)
 
         # Add additional characteristics if auto mode is supported
         self.chars: list[str] = []
@@ -248,22 +220,14 @@ class Thermostat(HomeAccessory):
         )
 
         self._configure_hvac_modes(state)
-        # Must set the value first as setting
-        # valid_values happens before setting
-        # the value and if 0 is not a valid
-        # value this will throw
-        self.char_target_heat_cool = serv_thermostat.configure_char(
-            CHAR_TARGET_HEATING_COOLING, value=list(self.hc_homekit_to_hass)[0]
+        self.char_target_heat_cool = self._configure_target_mode_char(
+            serv_thermostat,
+            CHAR_TARGET_HEATING_COOLING,
+            list(self.hc_homekit_to_hass)[0],
+            self.hc_hass_to_homekit,
         )
-        self.char_target_heat_cool.override_properties(
-            valid_values=self.hc_hass_to_homekit
-        )
-        self.char_target_heat_cool.allow_invalid_client_values = True
-        # Current and target temperature characteristics
 
-        self.char_current_temp = serv_thermostat.configure_char(
-            CHAR_CURRENT_TEMPERATURE, value=21.0
-        )
+        self._configure_current_temperature_char(serv_thermostat)
 
         self.char_target_temp = serv_thermostat.configure_char(
             CHAR_TARGET_TEMPERATURE,
@@ -318,36 +282,16 @@ class Thermostat(HomeAccessory):
                 CHAR_CURRENT_HUMIDITY, value=50
             )
 
-        fan_modes: dict[str, str] = {}
-        self.ordered_fan_speeds: list[str] = []
+        # Fan/swing modes are detected in the base class.
+        if self.ordered_fan_speeds:
+            self.fan_chars.append(CHAR_ROTATION_SPEED)
 
-        if features & ClimateEntityFeature.FAN_MODE:
-            fan_modes = {
-                fan_mode.lower(): fan_mode
-                for fan_mode in attributes.get(ATTR_FAN_MODES) or []
-            }
-            if fan_modes and PRE_DEFINED_FAN_MODES.intersection(fan_modes):
-                self.ordered_fan_speeds = [
-                    speed for speed in ORDERED_FAN_SPEEDS if speed in fan_modes
-                ]
-                self.fan_chars.append(CHAR_ROTATION_SPEED)
-
-        if FAN_AUTO in fan_modes and (FAN_ON in fan_modes or self.ordered_fan_speeds):
+        if FAN_AUTO in self.fan_modes and (
+            FAN_ON in self.fan_modes or self.ordered_fan_speeds
+        ):
             self.fan_chars.append(CHAR_TARGET_FAN_STATE)
 
-        self.fan_modes = fan_modes
-        if (
-            features & ClimateEntityFeature.SWING_MODE
-            and (swing_modes := attributes.get(ATTR_SWING_MODES))
-            and PRE_DEFINED_SWING_MODES.intersection(swing_modes)
-        ):
-            self.swing_on_mode = next(
-                iter(
-                    swing_mode
-                    for swing_mode in SWING_MODE_PREFERRED_ORDER
-                    if swing_mode in swing_modes
-                )
-            )
+        if self.swing_on_mode:
             self.fan_chars.append(CHAR_SWING_MODE)
 
         if self.fan_chars:
@@ -362,7 +306,7 @@ class Thermostat(HomeAccessory):
                 self.char_swing = serv_fan.configure_char(
                     CHAR_SWING_MODE,
                     value=0,
-                    setter_callback=self._set_fan_swing_mode,
+                    setter_callback=self._set_swing_mode,
                 )
                 self.char_swing.display_name = "Swing Mode"
             if CHAR_ROTATION_SPEED in self.fan_chars:
@@ -391,19 +335,6 @@ class Thermostat(HomeAccessory):
 
         serv_thermostat.setter_callback = self._set_chars
 
-    def _set_fan_swing_mode(self, swing_on: int) -> None:
-        _LOGGER.debug("%s: Set swing mode to %s", self.entity_id, swing_on)
-        mode = self.swing_on_mode if swing_on else SWING_OFF
-        params = {ATTR_ENTITY_ID: self.entity_id, ATTR_SWING_MODE: mode}
-        self.async_call_service(CLIMATE_DOMAIN, SERVICE_SET_SWING_MODE, params)
-
-    def _set_fan_speed(self, speed: int) -> None:
-        _LOGGER.debug("%s: Set fan speed to %s", self.entity_id, speed)
-        speed_key = percentage_to_ordered_list_item(self.ordered_fan_speeds, speed - 1)
-        mode = self.fan_modes[speed_key]
-        params = {ATTR_ENTITY_ID: self.entity_id, ATTR_FAN_MODE: mode}
-        self.async_call_service(CLIMATE_DOMAIN, SERVICE_SET_FAN_MODE, params)
-
     def _get_on_mode(self) -> str:
         if self.ordered_fan_speeds:
             speed_key = percentage_to_ordered_list_item(self.ordered_fan_speeds, 50)
@@ -429,12 +360,6 @@ class Thermostat(HomeAccessory):
         params = {ATTR_ENTITY_ID: self.entity_id, ATTR_FAN_MODE: mode}
         self.async_call_service(CLIMATE_DOMAIN, SERVICE_SET_FAN_MODE, params)
 
-    def _temperature_to_homekit(self, temp: float) -> float:
-        return temperature_to_homekit(temp, self._unit)
-
-    def _temperature_to_states(self, temp: float) -> float:
-        return temperature_to_states(temp, self._unit)
-
     def _set_chars(self, char_values: dict[str, Any]) -> None:
         _LOGGER.debug("Thermostat _set_chars: %s", char_values)
         events = []
@@ -458,7 +383,9 @@ class Thermostat(HomeAccessory):
                 # siri will always send HC_HEAT_COOL_AUTO in this case
                 # and hope for the best.
                 hc_target_temp = char_values.get(CHAR_TARGET_TEMPERATURE)
-                hc_current_temp = _get_current_temperature(state, self._unit)
+                hc_current_temp = temperature_attribute_to_homekit(
+                    state, ATTR_CURRENT_TEMPERATURE, self._unit
+                )
                 hc_fallback_order = HC_HEAT_COOL_PREFER_HEAT
                 if (
                     hc_target_temp is not None
@@ -531,38 +458,20 @@ class Thermostat(HomeAccessory):
             assert self.char_cooling_thresh_temp
             assert self.char_heating_thresh_temp
             service = SERVICE_SET_TEMPERATURE_THERMOSTAT
-            high = self.char_cooling_thresh_temp.value
-            low = self.char_heating_thresh_temp.value
-            min_temp, max_temp = self.get_temperature_range(state)
-            if CHAR_COOLING_THRESHOLD_TEMPERATURE in char_values:
-                events.append(
-                    f"{CHAR_COOLING_THRESHOLD_TEMPERATURE} to"
-                    f" {char_values[CHAR_COOLING_THRESHOLD_TEMPERATURE]}°C"
-                )
-                high = char_values[CHAR_COOLING_THRESHOLD_TEMPERATURE]
-                # If the device doesn't support TARGET_TEMPATURE
-                # this can happen
-                if high < low:
-                    low = high - HEAT_COOL_DEADBAND
-            if CHAR_HEATING_THRESHOLD_TEMPERATURE in char_values:
-                events.append(
-                    f"{CHAR_HEATING_THRESHOLD_TEMPERATURE} to"
-                    f" {char_values[CHAR_HEATING_THRESHOLD_TEMPERATURE]}°C"
-                )
-                low = char_values[CHAR_HEATING_THRESHOLD_TEMPERATURE]
-                # If the device doesn't support TARGET_TEMPATURE
-                # this can happen
-                if low > high:
-                    high = low + HEAT_COOL_DEADBAND
-
-            high = min(high, max_temp)
-            low = max(low, min_temp)
-
+            new_high = char_values.get(CHAR_COOLING_THRESHOLD_TEMPERATURE)
+            new_low = char_values.get(CHAR_HEATING_THRESHOLD_TEMPERATURE)
+            if new_high is not None:
+                events.append(f"{CHAR_COOLING_THRESHOLD_TEMPERATURE} to {new_high}°C")
+            if new_low is not None:
+                events.append(f"{CHAR_HEATING_THRESHOLD_TEMPERATURE} to {new_low}°C")
+            # A device without TARGET_TEMPERATURE can send an inverted pair.
             params.update(
-                {
-                    ATTR_TARGET_TEMP_HIGH: self._temperature_to_states(high),
-                    ATTR_TARGET_TEMP_LOW: self._temperature_to_states(low),
-                }
+                self._dual_setpoint_params(
+                    self.char_cooling_thresh_temp,
+                    self.char_heating_thresh_temp,
+                    new_high,
+                    new_low,
+                )
             )
 
         if service:
@@ -604,15 +513,6 @@ class Thermostat(HomeAccessory):
         }
         self.hc_hass_to_homekit = {k: v for v, k in self.hc_homekit_to_hass.items()}
 
-    def get_temperature_range(self, state: State) -> tuple[float, float]:
-        """Return min and max temperature range."""
-        return _get_temperature_range_from_state(
-            state,
-            self._unit,
-            DEFAULT_MIN_TEMP,
-            DEFAULT_MAX_TEMP,
-        )
-
     def set_target_humidity(self, value: float) -> None:
         """Set target humidity to value if call came from HomeKit."""
         _LOGGER.debug("%s: Set target humidity to %d", self.entity_id, value)
@@ -648,10 +548,7 @@ class Thermostat(HomeAccessory):
                 HC_HASS_TO_HOMEKIT_ACTION.get(hvac_action, HC_HEAT_COOL_OFF)
             )
 
-        # Update current temperature
-        current_temp = _get_current_temperature(new_state, self._unit)
-        if current_temp is not None:
-            self.char_current_temp.set_value(current_temp)
+        self._update_current_temperature_char(new_state)
 
         # Update current humidity
         if CHAR_CURRENT_HUMIDITY in self.chars:
@@ -667,22 +564,20 @@ class Thermostat(HomeAccessory):
             if isinstance(target_humdity, (int, float)):
                 self.char_target_humidity.set_value(target_humdity)
 
-        # Update cooling threshold temperature if characteristic exists
+        # Update threshold temperatures if the characteristics exist
         if self.char_cooling_thresh_temp:
-            cooling_thresh = attributes.get(ATTR_TARGET_TEMP_HIGH)
-            if isinstance(cooling_thresh, (int, float)):
-                cooling_thresh = self._temperature_to_homekit(cooling_thresh)
-                self.char_cooling_thresh_temp.set_value(cooling_thresh)
-
-        # Update heating threshold temperature if characteristic exists
+            self._update_temperature_char(
+                self.char_cooling_thresh_temp, new_state, ATTR_TARGET_TEMP_HIGH
+            )
         if self.char_heating_thresh_temp:
-            heating_thresh = attributes.get(ATTR_TARGET_TEMP_LOW)
-            if isinstance(heating_thresh, (int, float)):
-                heating_thresh = self._temperature_to_homekit(heating_thresh)
-                self.char_heating_thresh_temp.set_value(heating_thresh)
+            self._update_temperature_char(
+                self.char_heating_thresh_temp, new_state, ATTR_TARGET_TEMP_LOW
+            )
 
         # Update target temperature
-        target_temp = _get_target_temperature(new_state, self._unit)
+        target_temp = temperature_attribute_to_homekit(
+            new_state, ATTR_TEMPERATURE, self._unit
+        )
         if (
             target_temp is None
             and features & ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
@@ -714,22 +609,11 @@ class Thermostat(HomeAccessory):
         """Update state without rechecking the device features."""
         attributes = new_state.attributes
 
-        if CHAR_SWING_MODE in self.fan_chars and (
-            swing_mode := attributes.get(ATTR_SWING_MODE)
-        ):
-            swing = 1 if swing_mode in PRE_DEFINED_SWING_MODES else 0
-            self.char_swing.set_value(swing)
+        self._update_swing_char(attributes)
+        self._update_fan_speed_char(attributes)
 
         fan_mode = attributes.get(ATTR_FAN_MODE)
         fan_mode_lower = fan_mode.lower() if isinstance(fan_mode, str) else None
-        if (
-            CHAR_ROTATION_SPEED in self.fan_chars
-            and fan_mode_lower in self.ordered_fan_speeds
-        ):
-            self.char_speed.set_value(
-                ordered_list_item_to_percentage(self.ordered_fan_speeds, fan_mode_lower)
-            )
-
         if CHAR_TARGET_FAN_STATE in self.fan_chars:
             self.char_target_fan_state.set_value(1 if fan_mode_lower == FAN_AUTO else 0)
 
@@ -811,7 +695,7 @@ class WaterHeater(HomeAccessory):
 
     def get_temperature_range(self, state: State) -> tuple[float, float]:
         """Return min and max temperature range."""
-        return _get_temperature_range_from_state(
+        return get_temperature_range_from_state(
             state,
             self._unit,
             DEFAULT_MIN_TEMP_WATER_HEATER,
@@ -881,11 +765,15 @@ class WaterHeater(HomeAccessory):
     def async_update_state(self, new_state: State) -> None:
         """Update water_heater state after state change."""
         # Update current and target temperature
-        target_temperature = _get_target_temperature(new_state, self._unit)
+        target_temperature = temperature_attribute_to_homekit(
+            new_state, ATTR_TEMPERATURE, self._unit
+        )
         if target_temperature is not None:
             self.char_target_temp.set_value(target_temperature)
 
-        current_temperature = _get_current_temperature(new_state, self._unit)
+        current_temperature = temperature_attribute_to_homekit(
+            new_state, ATTR_CURRENT_TEMPERATURE, self._unit
+        )
         if current_temperature is not None:
             self.char_current_temp.set_value(current_temperature)
 
@@ -902,45 +790,3 @@ class WaterHeater(HomeAccessory):
             else:
                 self.char_target_heat_cool.set_value(HC_HEAT_COOL_HEAT)
                 self.char_current_heat_cool.set_value(HC_HEAT_COOL_HEAT)
-
-
-def _get_temperature_range_from_state(
-    state: State, unit: str, default_min: float, default_max: float
-) -> tuple[float, float]:
-    """Calculate the temperature range from a state."""
-    if min_temp := state.attributes.get(ATTR_MIN_TEMP):
-        min_temp = round(temperature_to_homekit(min_temp, unit) * 2) / 2
-    else:
-        min_temp = default_min
-
-    if max_temp := state.attributes.get(ATTR_MAX_TEMP):
-        max_temp = round(temperature_to_homekit(max_temp, unit) * 2) / 2
-    else:
-        max_temp = default_max
-
-    # Handle reversed temperature range
-    min_temp, max_temp = get_min_max(min_temp, max_temp)
-
-    # Homekit only supports 10-38, overwriting
-    # the max to appears to work, but less than 0 causes
-    # a crash on the home app
-    min_temp = max(min_temp, 0)
-    max_temp = max(max_temp, min_temp)
-
-    return min_temp, max_temp
-
-
-def _get_target_temperature(state: State, unit: str) -> float | None:
-    """Calculate the target temperature from a state."""
-    target_temp = state.attributes.get(ATTR_TEMPERATURE)
-    if isinstance(target_temp, (int, float)):
-        return temperature_to_homekit(target_temp, unit)
-    return None
-
-
-def _get_current_temperature(state: State, unit: str) -> float | None:
-    """Calculate the current temperature from a state."""
-    current_temp = state.attributes.get(ATTR_CURRENT_TEMPERATURE)
-    if isinstance(current_temp, (int, float)):
-        return temperature_to_homekit(current_temp, unit)
-    return None

--- a/tests/components/homekit/test_climate_util.py
+++ b/tests/components/homekit/test_climate_util.py
@@ -1,0 +1,94 @@
+"""Test the HomeKit climate helper functions."""
+
+import pytest
+
+from homeassistant.components.climate import (
+    ATTR_FAN_MODES,
+    ATTR_MAX_TEMP,
+    ATTR_MIN_TEMP,
+    ATTR_SWING_MODES,
+)
+from homeassistant.components.homekit.climate_util import (
+    HEAT_COOL_DEADBAND,
+    get_fan_modes_and_speeds,
+    get_swing_on_mode,
+    get_temperature_range_from_state,
+    resolve_target_temp_range,
+)
+from homeassistant.const import UnitOfTemperature
+from homeassistant.core import State
+
+
+@pytest.mark.parametrize(
+    ("current_high", "current_low", "new_high", "new_low", "expected"),
+    [
+        # Ordered pair within bounds is returned unchanged.
+        (24.0, 20.0, 25.0, None, (25.0, 20.0)),
+        (24.0, 20.0, None, 21.0, (24.0, 21.0)),
+        # A narrow but ordered band is preserved; the deadband is not forced.
+        (24.0, 20.0, None, 23.0, (24.0, 23.0)),
+        # New high crossing below the low enforces the deadband.
+        (24.0, 20.0, 18.0, None, (18.0, 18.0 - HEAT_COOL_DEADBAND)),
+        # New low crossing above the high enforces the deadband.
+        (20.0, 16.0, None, 22.0, (22.0 + HEAT_COOL_DEADBAND, 22.0)),
+        # Low dragged to the max: the deadband survives the clamp by moving high.
+        (20.0, 18.0, None, 30.0, (30.0, 30.0 - HEAT_COOL_DEADBAND)),
+        # High dragged to the min: the deadband survives by moving high up.
+        (24.0, 20.0, 7.0, None, (7.0 + HEAT_COOL_DEADBAND, 7.0)),
+    ],
+)
+def test_resolve_target_temp_range(
+    current_high: float,
+    current_low: float,
+    new_high: float | None,
+    new_low: float | None,
+    expected: tuple[float, float],
+) -> None:
+    """Test the range resolver keeps an ordered, in-bounds pair with a deadband."""
+    assert (
+        resolve_target_temp_range(
+            current_high, current_low, new_high, new_low, 7.0, 30.0
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("attrs", "expected"),
+    [
+        # A reported bound of exactly 0 is honored, not treated as missing.
+        ({ATTR_MIN_TEMP: 0, ATTR_MAX_TEMP: 25}, (0.0, 25.0)),
+        # A missing minimum falls back to the default.
+        ({ATTR_MAX_TEMP: 25}, (7.0, 25.0)),
+        # A missing maximum falls back to the default.
+        ({ATTR_MIN_TEMP: 10}, (10.0, 35.0)),
+        # Both missing use both defaults.
+        ({}, (7.0, 35.0)),
+    ],
+)
+def test_get_temperature_range_from_state(
+    attrs: dict[str, float], expected: tuple[float, float]
+) -> None:
+    """Test reported bounds are honored, including an explicit 0, else defaults."""
+    state = State("climate.test", "cool", attrs)
+    assert (
+        get_temperature_range_from_state(state, UnitOfTemperature.CELSIUS, 7.0, 35.0)
+        == expected
+    )
+
+
+def test_get_fan_modes_and_speeds_ignores_non_string() -> None:
+    """Test non-string fan modes are ignored rather than raising."""
+    fan_modes, speeds = get_fan_modes_and_speeds(
+        {ATTR_FAN_MODES: ["low", None, "high", 3]}
+    )
+    assert fan_modes == {"low": "low", "high": "high"}
+    assert speeds == ["low", "high"]
+
+
+def test_get_swing_on_mode_none_when_no_swing_modes() -> None:
+    """Test the swing helper returns None when the entity has no swing modes."""
+    assert get_swing_on_mode({}) is None
+    assert get_swing_on_mode({ATTR_SWING_MODES: []}) is None
+    assert get_swing_on_mode({ATTR_SWING_MODES: ["custom"]}) is None
+    assert get_swing_on_mode({ATTR_SWING_MODES: ["off", "vertical"]}) == "vertical"

--- a/tests/components/homekit/test_type_thermostats.py
+++ b/tests/components/homekit/test_type_thermostats.py
@@ -2968,3 +2968,35 @@ async def test_thermostat_with_capitalized_fan_modes(
     assert len(call_set_fan_mode) == 2
     assert call_set_fan_mode[-1].data[ATTR_ENTITY_ID] == entity_id
     assert call_set_fan_mode[-1].data[ATTR_FAN_MODE] == "Low"
+
+
+async def test_climate_base_fan_swing_guards(hass: HomeAssistant, hk_driver) -> None:
+    """Test the shared fan and swing setters no-op without predefined modes."""
+    entity_id = "climate.test"
+    hass.states.async_set(
+        entity_id,
+        HVACMode.HEAT,
+        {
+            ATTR_SUPPORTED_FEATURES: ClimateEntityFeature.TARGET_TEMPERATURE,
+            ATTR_HVAC_MODES: [HVACMode.HEAT, HVACMode.OFF],
+        },
+    )
+    await hass.async_block_till_done()
+    acc = Thermostat(hass, hk_driver, "Climate", entity_id, 1, None)
+    hk_driver.add_accessory(acc)
+    acc.run()
+    await hass.async_block_till_done()
+
+    call_set_fan_mode = async_mock_service(hass, CLIMATE_DOMAIN, SERVICE_SET_FAN_MODE)
+    call_set_swing_mode = async_mock_service(
+        hass, CLIMATE_DOMAIN, SERVICE_SET_SWING_MODE
+    )
+
+    # No predefined fan speeds, so a fan speed write is ignored.
+    acc._set_fan_speed(50)
+    # No swing mode, so a swing write is ignored.
+    acc._set_swing_mode(1)
+    await hass.async_block_till_done()
+
+    assert len(call_set_fan_mode) == 0
+    assert len(call_set_swing_mode) == 0


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

While working on the native HeaterCooler accessory in #148231 we found several bugs in the existing HomeKit Thermostat handling, and we want to save those fixes even though the larger PR is not moving forward.

The fixes: a reported minimum or maximum temperature of exactly zero is now honored instead of being treated as missing and replaced by the default; the target range deadband survives being clamped to the temperature bounds instead of collapsing at the extremes; and non string fan modes are ignored instead of raising during setup.

To carry these cleanly, the fan, swing, and temperature handling is pulled out of the Thermostat into two shared modules, climate_base for the accessory base class and climate_util for the pure helpers. Behavior for the existing Thermostat and water heater accessories is otherwise unchanged, and the shared modules can be reused by other climate accessory types.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #148231
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
