### PR TITLE
Rename Modbus integration to "Manual Modbus"

### DIFF
--- a/homeassistant/components/modbus/manifest.json
+++ b/homeassistant/components/modbus/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "modbus",
-  "name": "Modbus",
+  "name": "Manual Modbus",
   "codeowners": [],
   "documentation": "https://www.home-assistant.io/integrations/modbus",
   "iot_class": "local_polling",

--- a/homeassistant/components/modbus/strings.json
+++ b/homeassistant/components/modbus/strings.json
@@ -1,5 +1,4 @@
 {
-  "title": "Manual Modbus",
   "issues": {
     "duplicate_entity_entry": {
       "description": "An address can only be associated with one entity. Please correct the entry in your configuration.yaml file and restart Home Assistant to fix this issue.",
@@ -91,5 +90,6 @@
       },
       "name": "Write register"
     }
-  }
+  },
+  "title": "Manual Modbus"
 }

--- a/homeassistant/components/modbus/strings.json
+++ b/homeassistant/components/modbus/strings.json
@@ -1,4 +1,5 @@
 {
+  "title": "Manual Modbus",
   "issues": {
     "duplicate_entity_entry": {
       "description": "An address can only be associated with one entity. Please correct the entry in your configuration.yaml file and restart Home Assistant to fix this issue.",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -4364,7 +4364,7 @@
       "iot_class": "local_polling"
     },
     "modbus": {
-      "name": "Modbus",
+      "name": "Manual Modbus",
       "integration_type": "hub",
       "config_flow": false,
       "iot_class": "local_polling"

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -4364,7 +4364,6 @@
       "iot_class": "local_polling"
     },
     "modbus": {
-      "name": "Manual Modbus",
       "integration_type": "hub",
       "config_flow": false,
       "iot_class": "local_polling"
@@ -8488,6 +8487,7 @@
     "local_todo",
     "min_max",
     "mobile_app",
+    "modbus",
     "moehlenhoff_alpha2",
     "mold_indicator",
     "moon",

--- a/script/hassfest/translations.py
+++ b/script/hassfest/translations.py
@@ -45,6 +45,7 @@ ALLOW_NAME_TRANSLATION = {
     "local_calendar",
     "local_ip",
     "local_todo",
+    "modbus",
     "nmap_tracker",
     "remote_calendar",
     "rpi_power",


### PR DESCRIPTION
## Breaking change


## Proposed change

Renames the `modbus` integration's display name from "Modbus" to "Manual Modbus" to make it clear that this integration is meant for manually configuring Modbus entities (via `configuration.yaml`), as opposed to integrations that talk to a specific Modbus device out of the box.

The name is added as a translatable `title` in `strings.json` (rather than only in the manifest) because "Manual" is a word that needs translation. This required:
- Adding `"title": "Manual Modbus"` to `strings.json`.
- Adding `modbus` to `ALLOW_NAME_TRANSLATION` in `script/hassfest/translations.py`, since the translated title intentionally matches the manifest name.
- Regenerating `homeassistant/generated/integrations.json` (the hardcoded `name` is now dropped and `modbus` is listed under `translated_name`).

The `domain` stays `modbus`, so this is not a breaking change for existing configurations.

This implements section 6 of https://github.com/home-assistant/architecture/discussions/1418

Docs PR:  https://github.com/home-assistant/home-assistant.io/pull/46629

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnaFiH7reHybPiJVmdRqv3

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnaFiH7reHybPiJVmdRqv3)_