### PR TITLE
Fix KNX telegram history migration for data of 2026.3 and earlier

### DIFF
--- a/homeassistant/components/knx/telegrams.py
+++ b/homeassistant/components/knx/telegrams.py
@@ -339,7 +339,20 @@ class Telegrams:
             )
             return
 
-        stored_telegrams = [self.dict_to_model(t) for t in json_data]
+        # Legacy JSON data from older HA instances might miss fields added later
+        # (e.g., data_secure was added in 2026.3, value, payload, dpt_main/sub, names might also be missing)
+        default_migration_values = {
+            "value": None,
+            "payload": None,
+            "dpt_main": None,
+            "dpt_sub": None,
+            "source_name": "",
+            "destination_name": "",
+            "data_secure": False,
+        }
+        stored_telegrams = [
+            self.dict_to_model(default_migration_values | t) for t in json_data
+        ]
         try:
             if stored_telegrams:
                 await self.store.store_many(stored_telegrams)

--- a/tests/components/knx/test_telegrams_migration.py
+++ b/tests/components/knx/test_telegrams_migration.py
@@ -6,6 +6,7 @@ import os
 from typing import Any
 
 from knx_telegram_store import TelegramQuery
+import pytest
 
 from homeassistant.components.knx.const import DOMAIN, KNX_MODULE_KEY
 from homeassistant.core import HomeAssistant
@@ -86,3 +87,70 @@ async def test_migrate_telegrams_json_to_sqlite(
 
     # Verify legacy file removal
     assert not os.path.exists(legacy_path)
+
+
+async def test_migrate_telegrams_json_missing_keys(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+) -> None:
+    """Test migrating telegrams from legacy JSON missing fields (e.g., data_secure)."""
+    store = Store[dict[str, Any]](hass, version=1, key="knx/telegrams_history.json")
+    legacy_path = store.path
+
+    legacy_data = [
+        {
+            "destination": "3/2/100",
+            "source": "1.0.6",
+            "direction": "Incoming",
+            "payload": [0],
+            "telegramtype": "GroupValueWrite",
+            "timestamp": "2026-05-07T23:34:45.127015+02:00",
+            "value": 0,
+        }
+    ]
+
+    await store.async_save(legacy_data)
+
+    await knx.setup_integration()
+    telegrams_module = hass.data[KNX_MODULE_KEY].telegrams
+
+    await hass.async_block_till_done()
+
+    # Verify migration
+    assert telegrams_module.store is not None
+    result = await telegrams_module.store.query(TelegramQuery(order_descending=False))
+    assert len(result.telegrams) == 1
+
+    # Check that data_secure defaults to False/None as appropriate, and others default to None or empty string
+    assert result.telegrams[0].destination == "3/2/100"
+    assert result.telegrams[0].data_secure is False
+    assert result.telegrams[0].source_name == ""
+    assert result.telegrams[0].destination_name == ""
+    assert result.telegrams[0].dpt_main is None
+    assert result.telegrams[0].dpt_sub is None
+
+    # Verify legacy file removal
+    assert not os.path.exists(legacy_path)
+
+
+async def test_dict_to_model_strict_key_requirements(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+) -> None:
+    """Test that dict_to_model strictly raises KeyError if keys are missing from the dict."""
+    await knx.setup_integration()
+    telegrams_module = hass.data[KNX_MODULE_KEY].telegrams
+
+    incomplete_dict: Any = {
+        "destination": "3/2/100",
+        "source": "1.0.6",
+        "direction": "Incoming",
+        "payload": [0],
+        "telegramtype": "GroupValueWrite",
+        "timestamp": "2026-05-07T23:34:45.127015+02:00",
+        "value": 0,
+        # missing data_secure, source_name, destination_name, dpt_main, dpt_sub
+    }
+
+    with pytest.raises(KeyError, match="dpt_main"):
+        telegrams_module.dict_to_model(incomplete_dict)

--- a/tests/components/knx/test_telegrams_migration.py
+++ b/tests/components/knx/test_telegrams_migration.py
@@ -6,7 +6,6 @@ import os
 from typing import Any
 
 from knx_telegram_store import TelegramQuery
-import pytest
 
 from homeassistant.components.knx.const import DOMAIN, KNX_MODULE_KEY
 from homeassistant.core import HomeAssistant
@@ -131,26 +130,3 @@ async def test_migrate_telegrams_json_missing_keys(
 
     # Verify legacy file removal
     assert not os.path.exists(legacy_path)
-
-
-async def test_dict_to_model_strict_key_requirements(
-    hass: HomeAssistant,
-    knx: KNXTestKit,
-) -> None:
-    """Test that dict_to_model strictly raises KeyError if keys are missing from the dict."""
-    await knx.setup_integration()
-    telegrams_module = hass.data[KNX_MODULE_KEY].telegrams
-
-    incomplete_dict: Any = {
-        "destination": "3/2/100",
-        "source": "1.0.6",
-        "direction": "Incoming",
-        "payload": [0],
-        "telegramtype": "GroupValueWrite",
-        "timestamp": "2026-05-07T23:34:45.127015+02:00",
-        "value": 0,
-        # missing data_secure, source_name, destination_name, dpt_main, dpt_sub
-    }
-
-    with pytest.raises(KeyError, match="dpt_main"):
-        telegrams_module.dict_to_model(incomplete_dict)


### PR DESCRIPTION
## Breaking change
None

## Proposed change
When migrating old KNX telegram data from JSON  -> SQLite DB, fall back to default values. We introduced data_secure field in 2026.3 and this change guards against missing fields like this.

## Type of change
Migration fix.

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #175346

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:
n/a

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:
n/a
- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
