### PR TITLE
Pin recently compiled template code objects in a bounded LRU

### DIFF
--- a/homeassistant/helpers/template/__init__.py
+++ b/homeassistant/helpers/template/__init__.py
@@ -19,6 +19,7 @@ import jinja2
 from jinja2.runtime import AsyncLoopContext, LoopContext
 from jinja2.sandbox import ImmutableSandboxedEnvironment
 from jinja2.utils import Namespace
+from lru import LRU
 
 from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant, callback
@@ -98,6 +99,12 @@ _HASS_LOADER = "template.hass_loader"
 _IS_NUMERIC = re.compile(r"^[+-]?(?!0\d)\d*(?:\.\d*)?$")
 
 EVAL_CACHE_SIZE = 512
+
+# Number of recently compiled template code objects to keep alive per
+# environment, so short-lived Template objects (REST API, config validation)
+# can reuse them via the weak cache. Bounded so one-off template strings
+# (like template editor keystrokes) cannot grow it indefinitely.
+COMPILED_CODE_PIN_SIZE = 256
 
 MAX_CUSTOM_TEMPLATE_SIZE = 5 * 1024 * 1024
 MAX_TEMPLATE_OUTPUT = 256 * 1024  # 256KiB
@@ -327,14 +334,20 @@ class Template:
         if self.is_static or self._compiled_code is not None:
             return
 
-        if compiled := self._env.template_cache.get(self.template):
+        env = self._env
+        if compiled := env.template_cache.get(self.template):
             self._compiled_code = compiled
+            # Refresh recency only when the pin is what keeps this code
+            # alive, so templates that are alive anyway do not take up
+            # pin slots.
+            if self.template in env.compiled_code_pin:
+                env.compiled_code_pin[self.template] = compiled
             return
 
         with template_context_manager as cm:
             cm.set_template(self.template, "compiling")
             try:
-                self._compiled_code = self._env.compile(self.template)
+                self._compiled_code = env.compile(self.template)
             except jinja2.TemplateError as err:
                 raise TemplateError(err) from err
 
@@ -763,6 +776,9 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.template_cache: weakref.WeakValueDictionary[
             str | jinja2.nodes.Template, CodeType | None
         ] = weakref.WeakValueDictionary()
+        self.compiled_code_pin: LRU[str | jinja2.nodes.Template, CodeType] = LRU(
+            COMPILED_CODE_PIN_SIZE
+        )
         self.add_extension("jinja2.ext.loopcontrols")
         self.add_extension("jinja2.ext.do")
         self.add_extension(AreaExtension)
@@ -859,4 +875,5 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
 
         compiled = super().compile(source)
         self.template_cache[source] = compiled
+        self.compiled_code_pin[source] = compiled
         return compiled

--- a/tests/helpers/template/test_init.py
+++ b/tests/helpers/template/test_init.py
@@ -1,6 +1,7 @@
 """Test Home Assistant template helper methods."""
 
 from datetime import datetime
+import gc
 from unittest.mock import patch
 
 from freezegun import freeze_time
@@ -597,8 +598,8 @@ def test_render_complex_handling_non_template_values(hass: HomeAssistant) -> Non
     ) == {True: 1, False: 2}
 
 
-async def test_cache_garbage_collection(hass: HomeAssistant) -> None:
-    """Test caching a template."""
+async def test_compiled_code_cache(hass: HomeAssistant) -> None:
+    """Test the compiled code cache outlives the Template object."""
     template_string = (
         "{% set dict = {'foo': 'x&y', 'bar': 42} %} {{ dict | urlencode }}"
     )
@@ -610,17 +611,59 @@ async def test_cache_garbage_collection(hass: HomeAssistant) -> None:
     env = tpl._env
     assert env.template_cache.get(template_string)
 
-    tpl2 = template.Template(
-        (template_string),
-        hass,
-    )
-    tpl2.ensure_valid()
+    del tpl
+    gc.collect()
     assert env.template_cache.get(template_string)
 
+    with patch.object(
+        template.TemplateEnvironment, "compile", side_effect=AssertionError
+    ):
+        tpl2 = template.Template(
+            (template_string),
+            hass,
+        )
+        tpl2.ensure_valid()
+    assert tpl2.async_render() == "foo=x%26y&bar=42"
+
+
+async def test_compiled_code_cache_is_bounded(hass: HomeAssistant) -> None:
+    """Test the compiled code cache does not grow without bound."""
+    tpl = template.Template("{{ 'env getter' }}", hass)
+    tpl.ensure_valid()
+    env = tpl._env
     del tpl
-    assert env.template_cache.get(template_string)
-    del tpl2
-    assert not env.template_cache.get(template_string)
+    for i in range(template.COMPILED_CODE_PIN_SIZE + 10):
+        template.Template(f"{{{{ {i} }}}}", hass).ensure_valid()
+    gc.collect()
+    assert len(env.compiled_code_pin) == template.COMPILED_CODE_PIN_SIZE
+    assert len(env.template_cache) == template.COMPILED_CODE_PIN_SIZE
+
+
+async def test_compiled_code_cache_alive_templates(hass: HomeAssistant) -> None:
+    """Test live Template objects keep their cache entries beyond the pin size."""
+    template_string = "{{ 'kept alive' }}"
+    tpl = template.Template(template_string, hass)
+    tpl.ensure_valid()
+    env = tpl._env
+
+    # Overflow the strong pin with other templates
+    for i in range(template.COMPILED_CODE_PIN_SIZE + 10):
+        template.Template(f"{{{{ {i} }}}}", hass).ensure_valid()
+    gc.collect()
+    assert template_string not in env.compiled_code_pin
+
+    # The live Template still keeps the weak cache entry alive,
+    # so an identical template does not recompile.
+    with patch.object(
+        template.TemplateEnvironment, "compile", side_effect=AssertionError
+    ):
+        tpl2 = template.Template(template_string, hass)
+        tpl2.ensure_valid()
+    assert tpl2.async_render() == "kept alive"
+
+    # A cache hit for a template that is alive anyway does not
+    # take up a pin slot.
+    assert template_string not in env.compiled_code_pin
 
 
 def test_is_template_string() -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The compiled template code cache (`TemplateEnvironment.template_cache`) is a `WeakValueDictionary` keyed on template source, holding `CodeType` values. The only strong reference to a cached code object is the `Template` instance that compiled it, so the cache entry dies the moment that `Template` is garbage collected. In other words: the cache only hits while another live `Template` object with the same source exists. Any short-lived `Template` recompiles its source from scratch, every single time.

This affects repeated ad-hoc construction of the same template source: every `POST /api/template` request (which dashboards and scripts poll) and repeated `cv.template` validation of the same strings. Measured: 2000 renders through freshly created `Template` objects with identical source trigger 2000 full Jinja compiles at 290 us per render. With this change it is 1 compile and 10.6 us per render.

The fix keeps the weak cache as the lookup and adds a small bounded LRU (`compiled_code_pin`, 256 entries, using `lru-dict` which this module already uses for the `TemplateState` caches) that holds a strong reference to the most recently compiled code objects. A weak cache hit refreshes the pin's recency only when the pin already owns the entry; templates that are alive through their own `Template` objects never take up pin slots. One-off template strings (like template editor keystrokes) can at most cycle the 256 slots, so growth stays bounded.

What this intentionally does not change: reloading YAML while running was already fast on dev (the outgoing config holds all `Template` objects alive during validation, so the weak cache hits; measured 0 recompiles for 2000 templates both before and after), and the pin does not help bulk re-creation of more than 256 distinct sources from scratch, since sequential compiles cycle the pin before the entries can be reused. The weak cache layer is kept precisely so the reload case keeps working at any config size.

Some history: the cache was introduced in #38469 to speed up YAML reload and check configuration, and that PR actually started out with an LRU before switching to a `WeakValueDictionary` during review. This PR combines both approaches.

Fun side note for reviewer trying to reproduce this: the recompile behavior is invisible under cProfile, because the profiler keeps a strong reference to every code object it sees, which keeps the weak cache alive. A compile counter or wall-clock timing shows it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
