### PR TITLE
Add numeric fast path for template result parsing

### DIFF
--- a/homeassistant/helpers/template/__init__.py
+++ b/homeassistant/helpers/template/__init__.py
@@ -231,8 +231,31 @@ RESULT_WRAPPERS: dict[type, type] = {kls: gen_result_wrapper(kls) for kls in _ty
 RESULT_WRAPPERS[tuple] = TupleWrapper
 
 
-@lru_cache(maxsize=EVAL_CACHE_SIZE)
 def _parse_result(render_result: str) -> Any:
+    """Parse a rendered result.
+
+    Continuously changing numeric results, like sensor values, produce
+    a new string on every render and would always miss the eval cache,
+    paying for a full literal_eval. Convert them directly instead.
+    Anything the fast path cannot convert falls through to the cached
+    path, which handles the edge cases ("", ".", "+") identically.
+    """
+    if _IS_NUMERIC.match(render_result):
+        if "." in render_result:
+            try:
+                return float(render_result)
+            except ValueError:
+                pass
+        else:
+            try:
+                return int(render_result)
+            except ValueError:
+                pass
+    return _cached_parse_result(render_result)
+
+
+@lru_cache(maxsize=EVAL_CACHE_SIZE)
+def _cached_parse_result(render_result: str) -> Any:
     """Parse a result and cache the result."""
     # lru_cache does not memoize raised exceptions. The most common template
     # results, plain string states such as "on", "off" or "unavailable", are

--- a/tests/helpers/template/test_init.py
+++ b/tests/helpers/template/test_init.py
@@ -863,6 +863,13 @@ async def test_parse_result(hass: HomeAssistant) -> None:
         ("-1.0", -1.0),
         ("+1", 1),
         ("5.", 5.0),
+        ("-0", 0),
+        ("-0.0", -0.0),
+        ("+", "+"),
+        ("-", "-"),
+        (".", "."),
+        # Exceeds the int digit limit for both int() and literal_eval
+        ("9" * 5000, "9" * 5000),
         ("123_123_123", "123_123_123"),
         # ("+48100200300", "+48100200300"),  # phone number
         ("010", "010"),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`_parse_result` converts every rendered template result through `literal_eval`, memoized with an `lru_cache`. That cache works well for repeating results like `on` and `off`, but a continuously changing numeric result (a power sensor, a temperature, any numeric template sensor) produces a new string on every render, so it misses the cache every single time and pays for a full `literal_eval`: an AST parse plus compile, around 9 us on a render that otherwise costs around 11 us.

This PR adds a fast path in front of the cached `literal_eval`: results matching the existing `_IS_NUMERIC` regex are converted directly with `float()` (when they contain a dot) or `int()` (digits only). Measured with a standalone benchmark (Python 3.14.5, 1000 entities): rendering `{{ states('sensor.x') }}` while the sensor value changes on every render drops from 20.1 to 12.1 us per render, 40% faster. Scenarios with repeating or non-numeric results are unaffected (full benchmark suite within noise).

Semantics are unchanged. The fast path only handles inputs where `int()`/`float()` provably agree with `literal_eval`, verified for the edge cases: `+5`, `-0`, `5.`, `.5`, `-0.0`, and huge dotted numbers (both saturate to `inf`). Everything the fast path cannot convert (`""`, `"."`, `"+"`, digits-only strings beyond the int digit conversion limit where `literal_eval` also raises) raises `ValueError` and falls through to the existing cached path, which handles those exactly as before. The existing `test_parse_result` covers this table and is extended with the fast path edge cases.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
