### PR TITLE
Fix Overkiz Rexel gateway setup failing with Local API

### DIFF
--- a/homeassistant/components/overkiz/__init__.py
+++ b/homeassistant/components/overkiz/__init__.py
@@ -102,18 +102,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: OverkizDataConfigEntry) 
     client: OverkizClient | None = None
     api_type = entry.data.get(CONF_API_TYPE, APIType.CLOUD)
 
-    # Rexel Cloud API (OAuth2)
-    if entry.data.get(CONF_HUB) == Server.REXEL:
-        client = await create_rexel_client(hass, entry)
-
     # Local API
-    elif api_type == APIType.LOCAL:
+    if api_type == APIType.LOCAL:
         client = create_local_client(
             hass,
             host=entry.data[CONF_HOST],
             token=entry.data[CONF_TOKEN],
             verify_ssl=entry.data[CONF_VERIFY_SSL],
         )
+
+    # Rexel Cloud API (OAuth2)
+    elif entry.data.get(CONF_HUB) == Server.REXEL:
+        client = await create_rexel_client(hass, entry)
 
     # Overkiz Cloud API
     else:

--- a/tests/components/overkiz/conftest.py
+++ b/tests/components/overkiz/conftest.py
@@ -137,6 +137,22 @@ def mock_rexel_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
+def mock_rexel_local_config_entry() -> MockConfigEntry:
+    """Return a Rexel config entry set up via the Local API."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=TEST_GATEWAY_ID,
+        data={
+            "host": "gateway-1234-5678-9123.local:8443",
+            "token": "1234123412341234",
+            "verify_ssl": True,
+            "hub": "rexel",
+            "api_type": "local",
+        },
+    )
+
+
+@pytest.fixture
 def mock_client() -> MockOverkizClient:
     """Return a configurable mock Overkiz client."""
     return MockOverkizClient()

--- a/tests/components/overkiz/test_init.py
+++ b/tests/components/overkiz/test_init.py
@@ -21,6 +21,7 @@ from homeassistant.exceptions import (
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
+from .conftest import MockOverkizClient
 from .test_config_flow import TEST_EMAIL, TEST_GATEWAY_ID, TEST_PASSWORD, TEST_SERVER
 
 from tests.common import MockConfigEntry, RegistryEntryWithDefaults, mock_registry
@@ -110,6 +111,36 @@ async def test_unique_id_migration(hass: HomeAssistant) -> None:
 
     # Test if the config entry is migrated to the latest minor version
     assert mock_entry.minor_version == 2
+
+
+async def test_setup_rexel_local_uses_local_client(
+    hass: HomeAssistant,
+    mock_rexel_local_config_entry: MockConfigEntry,
+    mock_client: MockOverkizClient,
+) -> None:
+    """A Rexel gateway configured via the Local API must not use OAuth2."""
+    mock_rexel_local_config_entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.overkiz.create_local_client",
+            return_value=mock_client,
+        ) as mock_create_local_client,
+        patch(
+            "homeassistant.components.overkiz.create_rexel_client"
+        ) as mock_create_rexel_client,
+    ):
+        await hass.config_entries.async_setup(mock_rexel_local_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    mock_create_local_client.assert_called_once_with(
+        hass,
+        host="gateway-1234-5678-9123.local:8443",
+        token="1234123412341234",
+        verify_ssl=True,
+    )
+    mock_create_rexel_client.assert_not_called()
+    assert mock_rexel_local_config_entry.state is ConfigEntryState.LOADED
 
 
 async def test_setup_token_reauth_error_starts_reauth(


### PR DESCRIPTION
## Proposed change

Fixes a crash when setting up a Rexel Energeasy Connect gateway via the Overkiz **Local API**.

`async_setup_entry` picked the client factory by checking `CONF_HUB == Server.REXEL` before checking `api_type == APIType.LOCAL`. Rexel is one of the `SERVERS_WITH_LOCAL_API`, so a Rexel gateway configured through the local config flow ends up with `hub: rexel` but none of the OAuth2 data (`auth_implementation`, `token`) that `create_rexel_client()` needs — it was always routed to the OAuth2 branch and setup failed with:

```
KeyError: 'auth_implementation'
```

The fix checks the local API branch first, so a Rexel gateway configured locally uses `create_local_client()` like any other local-API gateway. The OAuth2 (cloud) Rexel flow is untouched.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr