### PR TITLE
Downgrade per-step script execution log messages to debug level

### DIFF
--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -450,7 +450,12 @@ class _ScriptRun:
         _timeout = (
             "" if timeout is None else f" (timeout: {timedelta(seconds=timeout)})"
         )
-        self._log("Executing step %s%s", self._script.last_action, _timeout)
+        self._log(
+            "Executing step %s%s",
+            self._script.last_action,
+            _timeout,
+            level=logging.DEBUG,
+        )
 
     async def async_run(self) -> ScriptRunResult | None:
         """Run script."""
@@ -463,7 +468,11 @@ class _ScriptRun:
         response = None
 
         try:
-            self._log("Running %s", self._script.running_description)
+            self._log(
+                "Running %s",
+                self._script.running_description,
+                level=logging.INFO if self._script.top_level else logging.DEBUG,
+            )
             for self._step, self._action in enumerate(self._script.sequence):  # noqa: B020
                 if self._stop.done():
                     script_execution_set("cancelled")
@@ -531,6 +540,7 @@ class _ScriptRun:
                         self._log(
                             "Skipped disabled step %s",
                             self._action.get(CONF_ALIAS, action),
+                            level=logging.DEBUG,
                         )
                         trace_set_result(enabled=False)
                         return
@@ -777,7 +787,12 @@ class _ScriptRun:
             self._log("Error in 'condition' evaluation:\n%s", ex, level=logging.WARNING)
             check = False
 
-        self._log("Test condition %s: %s", self._script.last_action, check)
+        self._log(
+            "Test condition %s: %s",
+            self._script.last_action,
+            check,
+            level=logging.DEBUG,
+        )
         trace_update_result(result=check)
         if not check:
             raise _ConditionFail
@@ -822,7 +837,13 @@ class _ScriptRun:
         warned_too_many_loops = False
 
         async def async_run_sequence(iteration: int, extra_msg: str = "") -> None:
-            self._log("Repeating %s: Iteration %i%s", description, iteration, extra_msg)
+            self._log(
+                "Repeating %s: Iteration %i%s",
+                description,
+                iteration,
+                extra_msg,
+                level=logging.DEBUG,
+            )
             with trace_path("sequence"):
                 await self._async_run_script(script)
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The script and automation engine logs an INFO record for every executed step, every evaluated condition, every repeat iteration, every skipped disabled step, and every nested sequence run ("Executing step ...", "Test condition ...", "Repeating ...: Iteration ...", "Skipped disabled step ...", "Running ..."). A single automation run easily produces dozens of records.

Nothing consumes these records programmatically: `system_log` only captures WARNING and above, and the trace UI gets its per-step data from the trace machinery, not from logging. The records exist purely as text in `home-assistant.log`, a debugging use case that script/automation traces have covered in the UI (with variables and results per step) since 2021.

Producing them is not free. Each record pays for `LogRecord` creation, `findCaller` stack walking, formatting, and a write to the log file, on the hot path of every script and automation step, at the default log level.

This PR downgrades the per-step, per-condition, per-iteration, skipped-step, and nested sub-script "Running" messages to DEBUG. The top-level "Running <script>" message stays at INFO, so the log keeps a one-line-per-run audit trail. Anyone who wants the per-step detail back can enable debug logging for `homeassistant.helpers.script` via the `logger` integration, or use script debug logging in the UI, which restores the exact same messages.

Benchmark: a representative script (variable assignments, a state condition, events, a 5x repeat loop with a template condition), 3000 runs per measurement, interleaved A/B/A/B ordering, measured with a `NullHandler` so the numbers below exclude the cost of actually writing to the log file:

| | before | after |
| --- | --- | --- |
| time per run | ~925 µs | ~685 µs (~26% faster) |

For comparison, running the "before" code with the script logger set to WARNING measures ~625 µs, so nearly all of the logging overhead is removed while keeping the run-level INFO record. On production installs with a real file handler the gain is larger, since every record was also formatted and written to disk.

<details>
<summary>Benchmark script</summary>

```python
import asyncio
import logging
import sys
import time

sys.path.insert(0, "/path/to/core")

from tests.common import async_test_home_assistant
from homeassistant.core import Context
from homeassistant.helpers import config_validation as cv, script

RUNS = 3000
SCRIPT_CONFIG = [
    {"variables": {"a": 1, "b": "static", "c": [1, 2, 3]}},
    {"condition": "state", "entity_id": "sensor.test", "state": "on"},
    {"event": "test_event", "event_data": {"some": "data"}},
    {"repeat": {"count": 5, "sequence": [
        {"event": "test_event"},
        {"condition": "template", "value_template": "{{ repeat.index < 99 }}"},
    ]}},
    {"variables": {"d": 42}},
    {"event": "test_event"},
]

async def main() -> None:
    async with async_test_home_assistant(asyncio.get_running_loop()) as hass:
        hass.states.async_set("sensor.test", "on")
        sequence = cv.SCRIPT_SCHEMA(SCRIPT_CONFIG)
        obj = script.Script(hass, sequence, "bench", "bench_domain")
        for _ in range(100):
            await obj.async_run(context=Context())
        for level_name in ("INFO", "WARNING", "INFO", "WARNING"):
            logging.getLogger("homeassistant.helpers.script").setLevel(level_name)
            t0 = time.perf_counter()
            for _ in range(RUNS):
                await obj.async_run(context=Context())
            t1 = time.perf_counter()
            print(f"level={level_name}: {(t1 - t0) / RUNS * 1e6:.1f} us/run")

logging.getLogger().setLevel(logging.INFO)
logging.getLogger().handlers = [logging.NullHandler()]
asyncio.run(main())
```

</details>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
