### PR TITLE
Add seat coolers to Teslemetry

### DIFF
--- a/homeassistant/components/teslemetry/select.py
+++ b/homeassistant/components/teslemetry/select.py
@@ -169,10 +169,33 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySelectEntityDescription, ...] = (
         select_fn=lambda api, level: api.remote_steering_wheel_heat_level_request(
             level
         ),
+        supported_fn=lambda self: self.get("has_seat_cooling"),
         streaming_listener=lambda x, y: x.listen_HvacSteeringWheelHeatLevel(y),
         options=[
             OFF,
             LOW,
+            HIGH,
+        ],
+    ),
+    TeslemetrySelectEntityDescription(
+        key="climate_state_seat_cooler_left",
+        select_fn=lambda api, level: api.remote_seat_cooler_request(1, level),
+        streaming_listener=lambda x, y: x.listen_ClimateSeatCoolingFrontLeft(y),
+        options=[
+            OFF,
+            LOW,
+            MEDIUM,
+            HIGH,
+        ],
+    ),
+    TeslemetrySelectEntityDescription(
+        key="climate_state_seat_cooler_right",
+        select_fn=lambda api, level: api.remote_seat_cooler_request(2, level),
+        streaming_listener=lambda x, y: x.listen_ClimateSeatCoolingFrontRight(y),
+        options=[
+            OFF,
+            LOW,
+            MEDIUM,
             HIGH,
         ],
     ),

--- a/homeassistant/components/teslemetry/select.py
+++ b/homeassistant/components/teslemetry/select.py
@@ -169,7 +169,6 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySelectEntityDescription, ...] = (
         select_fn=lambda api, level: api.remote_steering_wheel_heat_level_request(
             level
         ),
-        supported_fn=lambda self: self.get("has_seat_cooling"),
         streaming_listener=lambda x, y: x.listen_HvacSteeringWheelHeatLevel(y),
         options=[
             OFF,
@@ -180,6 +179,7 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySelectEntityDescription, ...] = (
     TeslemetrySelectEntityDescription(
         key="climate_state_seat_cooler_left",
         select_fn=lambda api, level: api.remote_seat_cooler_request(1, level),
+        supported_fn=lambda data: bool(data.get("has_seat_cooling")),
         streaming_listener=lambda x, y: x.listen_ClimateSeatCoolingFrontLeft(y),
         options=[
             OFF,
@@ -191,6 +191,7 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySelectEntityDescription, ...] = (
     TeslemetrySelectEntityDescription(
         key="climate_state_seat_cooler_right",
         select_fn=lambda api, level: api.remote_seat_cooler_request(2, level),
+        supported_fn=lambda data: bool(data.get("has_seat_cooling")),
         streaming_listener=lambda x, y: x.listen_ClimateSeatCoolingFrontRight(y),
         options=[
             OFF,

--- a/homeassistant/components/teslemetry/select.py
+++ b/homeassistant/components/teslemetry/select.py
@@ -177,7 +177,10 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySelectEntityDescription, ...] = (
         ],
     ),
     TeslemetrySelectEntityDescription(
-        key="climate_state_seat_cooler_left",
+        # remote_seat_cooler_request uses 1-indexed positions (front-left=1,
+        # front-right=2), unlike the 0-indexed Seat enum used for heaters.
+        # Polled state comes from the seat_fan_front_* vehicle_data fields.
+        key="climate_state_seat_fan_front_left",
         select_fn=lambda api, level: api.remote_seat_cooler_request(1, level),
         supported_fn=lambda data: bool(data.get("has_seat_cooling")),
         streaming_listener=lambda x, y: x.listen_ClimateSeatCoolingFrontLeft(y),
@@ -189,7 +192,7 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySelectEntityDescription, ...] = (
         ],
     ),
     TeslemetrySelectEntityDescription(
-        key="climate_state_seat_cooler_right",
+        key="climate_state_seat_fan_front_right",
         select_fn=lambda api, level: api.remote_seat_cooler_request(2, level),
         supported_fn=lambda data: bool(data.get("has_seat_cooling")),
         streaming_listener=lambda x, y: x.listen_ClimateSeatCoolingFrontRight(y),

--- a/homeassistant/components/teslemetry/strings.json
+++ b/homeassistant/components/teslemetry/strings.json
@@ -363,6 +363,24 @@
       }
     },
     "select": {
+      "climate_state_seat_fan_front_left": {
+        "name": "Seat cooler front left",
+        "state": {
+          "high": "[%key:common::state::high%]",
+          "low": "[%key:common::state::low%]",
+          "medium": "[%key:common::state::medium%]",
+          "off": "[%key:common::state::off%]"
+        }
+      },
+      "climate_state_seat_fan_front_right": {
+        "name": "Seat cooler front right",
+        "state": {
+          "high": "[%key:common::state::high%]",
+          "low": "[%key:common::state::low%]",
+          "medium": "[%key:common::state::medium%]",
+          "off": "[%key:common::state::off%]"
+        }
+      },
       "climate_state_seat_heater_left": {
         "name": "Seat heater front left",
         "state": {

--- a/tests/components/teslemetry/test_select.py
+++ b/tests/components/teslemetry/test_select.py
@@ -16,7 +16,7 @@ from homeassistant.components.select import (
     SERVICE_SELECT_OPTION,
 )
 from homeassistant.components.teslemetry.coordinator import ENERGY_INFO_INTERVAL
-from homeassistant.components.teslemetry.select import LOW
+from homeassistant.components.teslemetry.select import LEVEL, LOW, MEDIUM, OFF
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -181,6 +181,68 @@ async def test_select_services(hass: HomeAssistant, mock_vehicle_data) -> None:
         state = hass.states.get(entity_id)
         assert state.state == EnergyExportMode.BATTERY_OK.value
         call.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "seat_position"),
+    [
+        ("select.test_seat_cooler_front_left", 1),
+        ("select.test_seat_cooler_front_right", 2),
+    ],
+)
+async def test_seat_cooler_services(
+    hass: HomeAssistant,
+    mock_metadata: AsyncMock,
+    mock_vehicle_data: AsyncMock,
+    entity_id: str,
+    seat_position: int,
+) -> None:
+    """Test the seat cooler entities send the 1-indexed seat position.
+
+    remote_seat_cooler_request is 1-indexed (front-left=1, front-right=2),
+    unlike the 0-indexed Seat enum used for the seat heaters.
+    """
+    mock_vehicle_data.return_value = VEHICLE_DATA_ALT
+    metadata = deepcopy(METADATA)
+    metadata["vehicles"][VEHICLE_VIN]["config"] = {"has_seat_cooling": True}
+    mock_metadata.return_value = metadata
+
+    await setup_platform(hass, [Platform.SELECT])
+
+    with patch(
+        "tesla_fleet_api.teslemetry.Vehicle.remote_seat_cooler_request",
+        return_value=COMMAND_OK,
+    ) as call:
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {ATTR_ENTITY_ID: entity_id, ATTR_OPTION: LOW},
+            blocking=True,
+        )
+        assert hass.states.get(entity_id).state == LOW
+        call.assert_called_once_with(seat_position, LEVEL[LOW])
+
+
+async def test_seat_cooler_polling(
+    hass: HomeAssistant,
+    mock_metadata: AsyncMock,
+    mock_vehicle_data: AsyncMock,
+) -> None:
+    """Test the seat cooler entities read polled state from seat_fan_front_*."""
+    metadata = deepcopy(METADATA)
+    metadata["vehicles"][VEHICLE_VIN]["polling"] = True
+    metadata["vehicles"][VEHICLE_VIN]["config"] = {"has_seat_cooling": True}
+    mock_metadata.return_value = metadata
+
+    data = deepcopy(VEHICLE_DATA_ALT)
+    data["response"]["climate_state"]["seat_fan_front_left"] = 2
+    data["response"]["climate_state"]["seat_fan_front_right"] = 0
+    mock_vehicle_data.return_value = data
+
+    await setup_platform(hass, [Platform.SELECT])
+
+    assert hass.states.get("select.test_seat_cooler_front_left").state == MEDIUM
+    assert hass.states.get("select.test_seat_cooler_front_right").state == OFF
 
 
 @pytest.mark.parametrize("response", COMMAND_ERRORS)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds front seat cooler support to the Teslemetry integration.

- Adds two new `select` entities, `climate_state_seat_cooler_left` and `climate_state_seat_cooler_right`, exposing Off/Low/Medium/High cooling levels for the front seats. They are gated on the vehicle reporting `has_seat_cooling` and controlled via `remote_seat_cooler_request`, with live updates from the `ClimateSeatCoolingFrontLeft`/`ClimateSeatCoolingFrontRight` stream fields.
- Reworks the seat heater `supported_fn` gating to read per-vehicle config from the metadata coordinator (`rear_seat_heaters`, `third_row_seats`) instead of the older `vehicle_config_*` fields, so heater and cooler availability is derived consistently from vehicle metadata.
- Fetches metadata through `TeslemetryMetadataCoordinator` during setup so the coordinator owns the per-vehicle config the platforms read at setup time.

Tests were added/updated in `tests/components/teslemetry` to cover the new seat cooler entities and the rear seat heater configuration gating.

### Dependency note
Requires `teslemetry-stream==0.9.1`. In 0.9.0 the `listen_ClimateSeatCoolingFrontLeft`/`FrontRight` listeners were typed as raw `Callable[[str | None], None]` passthroughs; 0.9.1 fixes them to int-based `make_int` listeners matching the framework field used by the select entity. The manifest and `requirements_all.txt` were updated and `requirements_all.txt` regenerated via `python -m script.gen_requirements_all`.

Note: this branch stacks on a separate PR that bumps `teslemetry-stream`; the bump commit is included here so the change builds and type-checks standalone.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/46635
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
