### PR TITLE
Bump tesla-fleet-api to 1.5.2

### DIFF
--- a/homeassistant/components/tesla_fleet/manifest.json
+++ b/homeassistant/components/tesla_fleet/manifest.json
@@ -8,5 +8,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "loggers": ["tesla-fleet-api"],
-  "requirements": ["tesla-fleet-api==1.4.7"]
+  "requirements": ["tesla-fleet-api==1.5.2"]
 }

--- a/homeassistant/components/tesla_fleet/switch.py
+++ b/homeassistant/components/tesla_fleet/switch.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from itertools import chain
 from typing import Any, override
 
-from tesla_fleet_api.const import AutoSeat, Scope, Seat
+from tesla_fleet_api.const import AutoSeat, Scope
 
 from homeassistant.components.switch import (
     SwitchDeviceClass,
@@ -48,7 +48,7 @@ VEHICLE_DESCRIPTIONS: tuple[TeslaFleetSwitchEntityDescription, ...] = (
             AutoSeat.FRONT_LEFT, True
         ),
         off_func=lambda api: api.remote_auto_seat_climate_request(
-            Seat.FRONT_LEFT, False
+            AutoSeat.FRONT_LEFT, False
         ),
         scopes=[Scope.VEHICLE_CMDS],
     ),

--- a/homeassistant/components/teslemetry/manifest.json
+++ b/homeassistant/components/teslemetry/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["tesla-fleet-api"],
   "quality_scale": "platinum",
-  "requirements": ["tesla-fleet-api==1.4.7", "teslemetry-stream==0.9.1"]
+  "requirements": ["tesla-fleet-api==1.5.2", "teslemetry-stream==0.9.1"]
 }

--- a/homeassistant/components/tessie/manifest.json
+++ b/homeassistant/components/tessie/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["tessie", "tesla-fleet-api"],
   "quality_scale": "silver",
-  "requirements": ["tessie-api==0.1.3", "tesla-fleet-api==1.4.7"]
+  "requirements": ["tessie-api==0.1.3", "tesla-fleet-api==1.5.2"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3143,7 +3143,7 @@ temperusb==1.6.1
 # homeassistant.components.tesla_fleet
 # homeassistant.components.teslemetry
 # homeassistant.components.tessie
-tesla-fleet-api==1.4.7
+tesla-fleet-api==1.5.2
 
 # homeassistant.components.powerwall
 tesla-powerwall==0.5.3

--- a/tests/components/tesla_fleet/test_switch.py
+++ b/tests/components/tesla_fleet/test_switch.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from tesla_fleet_api.const import AutoSeat
 from tesla_fleet_api.exceptions import VehicleOffline
 
 from homeassistant.components.switch import (
@@ -148,6 +149,27 @@ async def test_switch_services(
         state = hass.states.get(entity_id)
         assert state.state == STATE_OFF
         call.assert_called_once()
+
+
+async def test_switch_auto_seat_climate_off_seat_position(
+    hass: HomeAssistant,
+    normal_config_entry: MockConfigEntry,
+) -> None:
+    """Tests that turning off auto seat climate sends the 1-indexed AutoSeat position."""
+
+    await setup_platform(hass, normal_config_entry, [Platform.SWITCH])
+
+    with patch(
+        "tesla_fleet_api.tesla.VehicleFleet.remote_auto_seat_climate_request",
+        return_value=COMMAND_OK,
+    ) as call:
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: "switch.test_auto_seat_climate_left"},
+            blocking=True,
+        )
+        call.assert_called_once_with(AutoSeat.FRONT_LEFT, False)
 
 
 async def test_switch_no_scope(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bumps `tesla-fleet-api` from 1.4.7 to 1.5.2 for the `tesla_fleet`, `teslemetry`, and `tessie` integrations.

- Release notes: https://github.com/Teslemetry/python-tesla-fleet-api/releases/tag/v1.5.2
- Diff: https://github.com/Teslemetry/python-tesla-fleet-api/compare/v1.4.7...v1.5.2

Notable changes since 1.4.7 include (per the 1.5.2 release notes):
- Pin protobuf gencode to 6.32.0
- Fix 1-indexed AutoSeat
- Add low power mode and keep accessory power signed commands

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
