### PR TITLE
Infrared fix naming by device class for derived entities

### DIFF
--- a/homeassistant/components/infrared/entity.py
+++ b/homeassistant/components/infrared/entity.py
@@ -49,6 +49,14 @@ class InfraredEmitterEntity(RestoreEntity):
 
     __last_command_sent: str | None = None
 
+    @override
+    def _default_to_device_class_name(self) -> bool:
+        """Return True if an unnamed entity should be named by its device class.
+
+        For infrared emitters this is True if the entity has a device class.
+        """
+        return self.device_class is not None
+
     @property
     @final
     @override
@@ -100,6 +108,14 @@ class InfraredReceiverEntity(RestoreEntity):
     _attr_state: None = None
 
     __last_signal_received: str | None = None
+
+    @override
+    def _default_to_device_class_name(self) -> bool:
+        """Return True if an unnamed entity should be named by its device class.
+
+        For infrared receivers this is True if the entity has a device class.
+        """
+        return self.device_class is not None
 
     @cached_property
     def __signal_callbacks(self) -> set[Callable[[InfraredReceivedSignal], None]]:

--- a/homeassistant/components/infrared/strings.json
+++ b/homeassistant/components/infrared/strings.json
@@ -1,6 +1,6 @@
 {
   "entity_component": {
-    "_": {
+    "emitter": {
       "name": "Infrared emitter"
     },
     "receiver": {

--- a/tests/components/infrared/common.py
+++ b/tests/components/infrared/common.py
@@ -33,11 +33,12 @@ class MockInfraredEmitterEntity(InfraredEmitterEntity):
     """Mock infrared emitter entity for testing."""
 
     _attr_has_entity_name = True
-    _attr_name = "Test IR emitter"
 
-    def __init__(self, unique_id: str) -> None:
+    def __init__(self, unique_id: str, name: str | None = "Test IR emitter") -> None:
         """Initialize mock entity."""
         self._attr_unique_id = unique_id
+        if name is not None:
+            self._attr_name = name
         self.send_command_calls: list[InfraredCommand] = []
 
     async def async_send_command(self, command: InfraredCommand) -> None:
@@ -49,11 +50,12 @@ class MockInfraredReceiverEntity(InfraredReceiverEntity):
     """Mock infrared receiver entity for testing."""
 
     _attr_has_entity_name = True
-    _attr_name = "Test IR receiver"
 
-    def __init__(self, unique_id: str) -> None:
+    def __init__(self, unique_id: str, name: str | None = "Test IR receiver") -> None:
         """Initialize mock receiver entity."""
         self._attr_unique_id = unique_id
+        if name is not None:
+            self._attr_name = name
 
 
 async def init_infrared_fixture_helper(hass: HomeAssistant) -> None:

--- a/tests/components/infrared/test_init.py
+++ b/tests/components/infrared/test_init.py
@@ -16,15 +16,27 @@ from homeassistant.components.infrared import (
     async_send_command,
     async_subscribe_receiver,
 )
-from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.config_entries import ConfigEntry, ConfigFlow
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant, State
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
 from .common import MockInfraredEmitterEntity, MockInfraredReceiverEntity
 
-from tests.common import mock_restore_cache
+from tests.common import (
+    MockConfigEntry,
+    MockModule,
+    MockPlatform,
+    mock_config_flow,
+    mock_integration,
+    mock_platform,
+    mock_restore_cache,
+)
+
+TEST_DOMAIN = "test"
 
 TEST_COMMAND = NECCommand(address=0x04FB, command=0x08F7, modulation=38000)
 
@@ -293,3 +305,91 @@ async def test_async_subscribe_receiver_component_not_loaded(
     """Test async_subscribe_receiver raises error when component not loaded."""
     with pytest.raises(HomeAssistantError, match="component_not_loaded"):
         async_subscribe_receiver(hass, "infrared.some_entity", lambda _: None)
+
+
+@pytest.mark.usefixtures("init_infrared")
+async def test_name(hass: HomeAssistant) -> None:
+    """Test entity name / device class naming fallback."""
+
+    async def async_setup_entry_init(
+        hass: HomeAssistant, config_entry: ConfigEntry
+    ) -> bool:
+        """Set up test config entry."""
+        await hass.config_entries.async_forward_entry_setups(
+            config_entry, [Platform.INFRARED]
+        )
+        return True
+
+    class MockFlow(ConfigFlow):
+        """Test flow."""
+
+    mock_platform(hass, f"{TEST_DOMAIN}.config_flow")
+    mock_integration(
+        hass,
+        MockModule(
+            TEST_DOMAIN,
+            async_setup_entry=async_setup_entry_init,
+        ),
+    )
+
+    # Unnamed emitter without has_entity_name -> no name
+    emitter1 = MockInfraredEmitterEntity("test_emitter1", name=None)
+    emitter1.entity_id = "infrared.test_emitter1"
+    emitter1._attr_has_entity_name = False
+
+    # Unnamed emitter with has_entity_name True -> name set from device class
+    emitter2 = MockInfraredEmitterEntity("test_emitter2", name=None)
+    emitter2.entity_id = "infrared.test_emitter2"
+    emitter2._attr_has_entity_name = True
+
+    # Unnamed receiver without has_entity_name -> no name
+    receiver1 = MockInfraredReceiverEntity("test_receiver1", name=None)
+    receiver1.entity_id = "infrared.test_receiver1"
+    receiver1._attr_has_entity_name = False
+
+    # Unnamed receiver with has_entity_name True -> name set from device class
+    receiver2 = MockInfraredReceiverEntity("test_receiver2", name=None)
+    receiver2.entity_id = "infrared.test_receiver2"
+    receiver2._attr_has_entity_name = True
+
+    async def async_setup_entry_platform(
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        async_add_entities: AddConfigEntryEntitiesCallback,
+    ) -> None:
+        """Set up test infrared platform via config entry."""
+        async_add_entities([emitter1, emitter2, receiver1, receiver2])
+
+    mock_platform(
+        hass,
+        f"{TEST_DOMAIN}.{DOMAIN}",
+        MockPlatform(async_setup_entry=async_setup_entry_platform),
+    )
+
+    config_entry = MockConfigEntry(domain=TEST_DOMAIN)
+    config_entry.add_to_hass(hass)
+    with mock_config_flow(TEST_DOMAIN, MockFlow):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    state1 = hass.states.get("infrared.test_emitter1")
+    assert state1 is not None
+    assert state1.attributes == {"device_class": "emitter"}
+
+    state2 = hass.states.get("infrared.test_emitter2")
+    assert state2 is not None
+    assert state2.attributes == {
+        "device_class": "emitter",
+        "friendly_name": "Infrared emitter",
+    }
+
+    state3 = hass.states.get("infrared.test_receiver1")
+    assert state3 is not None
+    assert state3.attributes == {"device_class": "receiver"}
+
+    state4 = hass.states.get("infrared.test_receiver2")
+    assert state4 is not None
+    assert state4.attributes == {
+        "device_class": "receiver",
+        "friendly_name": "Infrared receiver",
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Derived entities of `InfraredReceiverEntity` and `InfraredEmitterEntity` fallback to the parent device name instead of generating correct translation suffixes unless a custom `_attr_translation_key` is declared.

Provide required overrides for `_default_to_device_class_name() to dynamically build translated name suffixes based on their device_class. This aligns with how other core entities are defined.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #175188 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
