### PR TITLE
Add integration item type support to search

### DIFF
--- a/homeassistant/components/search/__init__.py
+++ b/homeassistant/components/search/__init__.py
@@ -291,6 +291,19 @@ class Searcher:
             self._async_search_entity(entity_entry.entity_id, entry_point=False)
 
     @callback
+    def _async_search_integration(self, domain: str) -> None:
+        """Find results for an integration."""
+        for entry in self.hass.config_entries.async_entries(domain):
+            self._add(ItemType.CONFIG_ENTRY, entry.entry_id)
+            self._async_search_config_entry(entry.entry_id)
+
+        for entity_id, source in self._entity_sources.items():
+            if source["domain"] != domain:
+                continue
+            self._add(ItemType.ENTITY, entity_id)
+            self._async_search_entity(entity_id, entry_point=False)
+
+    @callback
     def _async_search_device(self, device_id: str, *, entry_point: bool = True) -> None:
         """Find results for a device."""
         if not (device_entry := self._async_resolve_up_device(device_id)):

--- a/tests/components/search/test_init.py
+++ b/tests/components/search/test_init.py
@@ -817,6 +817,37 @@ async def test_search(
         ItemType.SCRIPT: {"script.group"},
     }
 
+    assert not search(ItemType.INTEGRATION, "unknown")
+    assert search(ItemType.INTEGRATION, "wled") == {
+        ItemType.AREA: {bedroom_area.id, living_room_area.id},
+        ItemType.AUTOMATION: {"automation.wled_entity", "automation.wled_device"},
+        ItemType.CONFIG_ENTRY: {wled_config_entry.entry_id},
+        ItemType.DEVICE: {wled_device.id},
+        ItemType.ENTITY: {
+            wled_segment_1_entity.entity_id,
+            wled_segment_2_entity.entity_id,
+            "light.wled_platform_config_source",
+            "light.wled_config_entry_source",
+        },
+        ItemType.FLOOR: {first_floor.floor_id, second_floor.floor_id},
+        ItemType.GROUP: {"group.wled", "group.wled_hue"},
+        ItemType.SCENE: {"scene.scene_wled_seg_1", scene_wled_hue_entity.entity_id},
+        ItemType.SCRIPT: {"script.wled"},
+    }
+    assert search(ItemType.INTEGRATION, "hue") == {
+        ItemType.AREA: {kitchen_area.id},
+        ItemType.CONFIG_ENTRY: {hue_config_entry.entry_id},
+        ItemType.DEVICE: {hue_device.id},
+        ItemType.ENTITY: {
+            hue_segment_1_entity.entity_id,
+            hue_segment_2_entity.entity_id,
+        },
+        ItemType.FLOOR: {first_floor.floor_id},
+        ItemType.GROUP: {"group.hue", "group.wled_hue"},
+        ItemType.SCENE: {"scene.scene_hue_seg_1", scene_wled_hue_entity.entity_id},
+        ItemType.SCRIPT: {"script.device", "script.hue"},
+    }
+
     assert not search(ItemType.LABEL, "unknown")
     assert search(ItemType.LABEL, label_christmas.label_id) == {
         ItemType.AUTOMATION: {"automation.label"},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

#121765 added `integration` as an item type to the search integration, but only as an output: search results can contain integrations, yet there is no `_async_search_integration` method. The websocket command schema happily accepts `item_type: integration` (via `vol.Coerce(ItemType)`), after which the `getattr` based dispatch raises `AttributeError` and the client receives an `unknown_error` response.

This change implements searching for an integration:

- All config entries of the integration are added and searched, recursing down into their devices and entities exactly like a config entry search does.
- Entities provided by the integration without an entity registry entry are found through the entity sources and searched as well. This mirrors the existing entity sources fallback in `_async_resolve_up_entity`, so the integration to entity edge now works in both directions.

Tests are extended with assertions for searching the `wled` and `hue` integrations (including the entity sources fallback path) plus the unknown integration case. Without the fix, the test fails with the exact `AttributeError` described above.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
