### PR TITLE
Include config entry groups in groups_with_entity

### DIFF
--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -146,7 +146,7 @@ def groups_with_entity(hass: HomeAssistant, entity_id: str) -> list[str]:
     for entry in hass.config_entries.async_entries(DOMAIN):
         members = [
             er.async_resolve_entity_id(entity_registry, member) or member
-            for member in entry.options.get(CONF_ENTITIES, [])
+            for member in entry.options[CONF_ENTITIES]
         ]
         if entity_id not in members:
             continue

--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -23,6 +23,7 @@ from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.group import (
     expand_entity_ids as _expand_entity_ids,
     get_entity_ids as _get_entity_ids,
+    get_group_entities,
 )
 from homeassistant.helpers.reload import async_reload_integration_platforms
 from homeassistant.helpers.typing import ConfigType
@@ -122,14 +123,42 @@ def groups_with_entity(hass: HomeAssistant, entity_id: str) -> list[str]:
 
     Async friendly.
     """
-    if DOMAIN not in hass.data:
-        return []
+    groups: list[str] = []
 
-    return [
-        group.entity_id
-        for group in hass.data[DATA_COMPONENT].entities
-        if entity_id in group.tracking
-    ]
+    if DOMAIN in hass.data:
+        groups.extend(
+            group.entity_id
+            for group in hass.data[DATA_COMPONENT].entities
+            if entity_id in group.tracking
+        )
+
+    groups.extend(
+        group_entity_id
+        for group_entity_id, entity in get_group_entities(hass).items()
+        if entity.group is not None
+        and entity_id in entity.group.member_entity_ids
+        and group_entity_id not in groups
+    )
+
+    # Config entry groups whose platform does not (yet) register in
+    # the group entities registry of the group helper.
+    entity_registry = er.async_get(hass)
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        members = [
+            er.async_resolve_entity_id(entity_registry, member) or member
+            for member in entry.options.get(CONF_ENTITIES, [])
+        ]
+        if entity_id not in members:
+            continue
+        groups.extend(
+            registry_entry.entity_id
+            for registry_entry in er.async_entries_for_config_entry(
+                entity_registry, entry.entry_id
+            )
+            if registry_entry.entity_id not in groups
+        )
+
+    return groups
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -1999,6 +1999,59 @@ async def test_setup_and_remove_config_entry(
     assert entity_registry.async_get(f"{group_type}.bed_room") is None
 
 
+async def test_groups_with_entity(hass: HomeAssistant) -> None:
+    """Test groups_with_entity finds legacy groups."""
+    assert await async_setup_component(
+        hass,
+        "group",
+        {"group": {"living_room": {"entities": ["light.one", "light.two"]}}},
+    )
+    await hass.async_block_till_done()
+
+    assert group.groups_with_entity(hass, "light.one") == ["group.living_room"]
+    assert group.groups_with_entity(hass, "light.three") == []
+
+
+@pytest.mark.parametrize(
+    ("group_type", "member_state", "extra_options"),
+    [
+        pytest.param("light", "on", {"all": False}, id="light"),
+        pytest.param("lock", "locked", {}, id="lock"),
+    ],
+)
+async def test_groups_with_entity_config_entry(
+    hass: HomeAssistant,
+    group_type: str,
+    member_state: str,
+    extra_options: dict[str, Any],
+) -> None:
+    """Test groups_with_entity finds config entry groups."""
+    members = [f"{group_type}.one", f"{group_type}.two"]
+
+    for member in members:
+        hass.states.async_set(member, member_state, {})
+
+    group_config_entry = MockConfigEntry(
+        data={},
+        domain=group.DOMAIN,
+        options={
+            "entities": members,
+            "group_type": group_type,
+            "name": "Bed Room",
+            **extra_options,
+        },
+        title="Bed Room",
+    )
+    group_config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(group_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert group.groups_with_entity(hass, f"{group_type}.one") == [
+        f"{group_type}.bed_room"
+    ]
+    assert group.groups_with_entity(hass, f"{group_type}.three") == []
+
+
 @pytest.mark.parametrize(
     ("hide_members", "hidden_by_initial", "hidden_by"),
     [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`group.groups_with_entity` only iterates the legacy `group.*` entities of the group entity component. Groups created through the group helper (config entry based light groups, switch groups, and so on) are invisible to it. Its only consumer is the search integration, which even documents the limitation in `_async_search_group` ("We currently only support the classic groups"). In practice this means the related dialog of a member entity never shows the helper groups it belongs to, while the UI has been steering users towards helper groups for years.

This change makes `groups_with_entity` aggregate three sources:

- The legacy group entities (unchanged behavior).
- The group entities registry from the recent group entities improvement (#160860), which covers platforms already migrated to the new `Entity.group` infrastructure (for example lock groups) as well as integration specific groups (mqtt, wled, zha).
- Group helper config entries whose platform has not (yet) migrated to that registry, by matching the member list in the config entry options. Member ids are resolved through `er.async_resolve_entity_id` since they can be registry ids.

Results are deduplicated between the last two sources, which matters for platforms like lock that appear in both.

`get_entity_ids` needs no change: it is state based and already handles helper groups.

Tests: `groups_with_entity` had no tests at all. This adds `test_groups_with_entity` (legacy YAML group, locks in current behavior) and `test_groups_with_entity_config_entry` parametrized over `light` (config entry fallback path) and `lock` (registry path plus deduplication). Both config entry cases fail without the fix.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
