### PR TITLE
Include referenced labels when searching automations and scripts

### DIFF
--- a/homeassistant/components/search/__init__.py
+++ b/homeassistant/components/search/__init__.py
@@ -220,6 +220,12 @@ class Searcher:
             automation.blueprint_in_automation(self.hass, automation_entity_id),
         )
 
+        # Labels referenced in this automation
+        self._add(
+            ItemType.LABEL,
+            automation.labels_in_automation(self.hass, automation_entity_id),
+        )
+
         # Floors referenced in this automation
         self._add(
             ItemType.FLOOR,
@@ -482,6 +488,9 @@ class Searcher:
             ItemType.SCRIPT_BLUEPRINT,
             script.blueprint_in_script(self.hass, script_entity_id),
         )
+
+        # Labels referenced in this script
+        self._add(ItemType.LABEL, script.labels_in_script(self.hass, script_entity_id))
 
         # Floors referenced in this script
         self._add(ItemType.FLOOR, script.floors_in_script(self.hass, script_entity_id))

--- a/tests/components/search/test_init.py
+++ b/tests/components/search/test_init.py
@@ -544,6 +544,9 @@ async def test_search(
         ItemType.AREA: {kitchen_area.id},
         ItemType.FLOOR: {first_floor.floor_id},
     }
+    assert search(ItemType.AUTOMATION, "automation.label") == {
+        ItemType.LABEL: {label_christmas.label_id},
+    }
     assert search(ItemType.AUTOMATION, "automation.group") == {
         ItemType.AREA: {bedroom_area.id, living_room_area.id, kitchen_area.id},
         ItemType.CONFIG_ENTRY: {wled_config_entry.entry_id, hue_config_entry.entry_id},
@@ -918,6 +921,9 @@ async def test_search(
     assert search(ItemType.SCRIPT, "script.area") == {
         ItemType.AREA: {kitchen_area.id},
         ItemType.FLOOR: {first_floor.floor_id},
+    }
+    assert search(ItemType.SCRIPT, "script.label") == {
+        ItemType.LABEL: {label_other.label_id},
     }
     assert search(ItemType.SCRIPT, "script.group") == {
         ItemType.AREA: {bedroom_area.id, living_room_area.id, kitchen_area.id},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Searching a label in the search integration returns the automations and scripts that target it, through `automations_with_label` and `scripts_with_label`. The reverse direction is missing: searching an automation or script returns the floors, areas, devices, and entities it targets, but not the labels it targets, even though the `labels_in_automation` and `labels_in_script` helpers exist. The label edge only worked one way.

This change adds the missing lookups to `_async_search_automation` and `_async_search_script`, following the exact same pattern the floor lookups already use. Since `_async_search_script` is also invoked for scripts embedded in automations and for nested scripts, those cases inherit the targeted labels as well.

Tests: new assertions for searching `automation.label` and `script.label`, fixtures that already existed in the test but were never searched from this direction. Both fail without the fix.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
