### PR TITLE
Fix BleBox action tests to assert library calls instead of faking state

### DIFF
--- a/tests/components/blebox/test_climate.py
+++ b/tests/components/blebox/test_climate.py
@@ -135,53 +135,13 @@ async def test_update(saunabox, hass: HomeAssistant, config) -> None:
     assert state.state == HVACMode.OFF
 
 
-async def test_on_when_below_desired(saunabox, hass: HomeAssistant) -> None:
-    """Test when temperature is below desired."""
+async def test_set_hvac_mode_heat(saunabox, hass: HomeAssistant) -> None:
+    """Test that setting HVAC mode to heat calls async_on."""
 
     feature_mock, entity_id = saunabox
 
-    feature_mock.is_on = False
-    await async_setup_entity(hass, entity_id)
-
-    def turn_on():
-        feature_mock.is_on = True
-        feature_mock.is_heating = True
-        feature_mock.desired = 64.8
-        feature_mock.current = 25.7
-
     feature_mock.mode = 1
-    feature_mock.async_on = AsyncMock(side_effect=turn_on)
-    await hass.services.async_call(
-        "climate",
-        SERVICE_SET_HVAC_MODE,
-        {"entity_id": entity_id, ATTR_HVAC_MODE: HVACMode.HEAT},
-        blocking=True,
-    )
-    feature_mock.async_off.assert_not_called()
-    state = hass.states.get(entity_id)
-
-    assert state.attributes[ATTR_HVAC_ACTION] == HVACAction.HEATING
-    assert state.attributes[ATTR_TEMPERATURE] == 64.8
-    assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 25.7
-    assert state.state == HVACMode.HEAT
-
-
-async def test_on_when_above_desired(saunabox, hass: HomeAssistant) -> None:
-    """Test when temperature is below desired."""
-
-    feature_mock, entity_id = saunabox
-
-    feature_mock.is_on = False
     await async_setup_entity(hass, entity_id)
-
-    def turn_on():
-        feature_mock.is_on = True
-        feature_mock.is_heating = False
-        feature_mock.desired = 23.4
-        feature_mock.current = 28.7
-
-    feature_mock.mode = 1
-    feature_mock.async_on = AsyncMock(side_effect=turn_on)
 
     await hass.services.async_call(
         "climate",
@@ -189,74 +149,44 @@ async def test_on_when_above_desired(saunabox, hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_HVAC_MODE: HVACMode.HEAT},
         blocking=True,
     )
+
+    feature_mock.async_on.assert_called_once_with()
     feature_mock.async_off.assert_not_called()
-    state = hass.states.get(entity_id)
-
-    assert state.attributes[ATTR_TEMPERATURE] == 23.4
-    assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 28.7
-    assert state.attributes[ATTR_HVAC_ACTION] == HVACAction.IDLE
-    assert state.state == HVACMode.HEAT
 
 
-async def test_off(saunabox, hass: HomeAssistant) -> None:
-    """Test turning off."""
+async def test_set_hvac_mode_off(saunabox, hass: HomeAssistant) -> None:
+    """Test that setting HVAC mode to off calls async_off."""
 
     feature_mock, entity_id = saunabox
 
-    feature_mock.is_on = True
-    feature_mock.is_heating = False
     await async_setup_entity(hass, entity_id)
 
-    def turn_off():
-        feature_mock.is_on = False
-        feature_mock.is_heating = False
-        feature_mock.desired = 29.8
-        feature_mock.current = 22.7
-
-    feature_mock.async_off = AsyncMock(side_effect=turn_off)
     await hass.services.async_call(
         "climate",
         SERVICE_SET_HVAC_MODE,
         {"entity_id": entity_id, ATTR_HVAC_MODE: HVACMode.OFF},
         blocking=True,
     )
-    feature_mock.async_on.assert_not_called()
-    state = hass.states.get(entity_id)
 
-    assert state.attributes[ATTR_HVAC_ACTION] == HVACAction.OFF
-    assert state.attributes[ATTR_TEMPERATURE] == 29.8
-    assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 22.7
-    assert state.state == HVACMode.OFF
+    feature_mock.async_off.assert_called_once_with()
+    feature_mock.async_on.assert_not_called()
 
 
 async def test_set_thermo(saunabox, hass: HomeAssistant) -> None:
-    """Test setting thermostat."""
+    """Test that setting the temperature calls async_set_temperature."""
 
     feature_mock, entity_id = saunabox
 
-    feature_mock.is_on = False
-    feature_mock.is_heating = False
     await async_setup_entity(hass, entity_id)
 
-    def set_temp(temp):
-        feature_mock.is_on = True
-        feature_mock.is_heating = True
-        feature_mock.desired = 29.2
-        feature_mock.current = 29.1
-
-    feature_mock.async_set_temperature = AsyncMock(side_effect=set_temp)
     await hass.services.async_call(
         "climate",
         SERVICE_SET_TEMPERATURE,
         {"entity_id": entity_id, ATTR_TEMPERATURE: 43.21},
         blocking=True,
     )
-    state = hass.states.get(entity_id)
 
-    assert state.attributes[ATTR_TEMPERATURE] == 29.2
-    assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 29.1
-    assert state.attributes[ATTR_HVAC_ACTION] == HVACAction.HEATING
-    assert state.state == HVACMode.HEAT
+    feature_mock.async_set_temperature.assert_called_once_with(43.21)
 
 
 async def test_update_failure(
@@ -280,55 +210,30 @@ async def test_update_failure(
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_reding_hvac_actions(
-    saunabox, hass: HomeAssistant, caplog: pytest.LogCaptureFixture
-) -> None:
-    """Test hvac action for given device(mock) state."""
-
-    caplog.set_level(logging.ERROR)
+async def test_hvac_action_heating(saunabox, hass: HomeAssistant) -> None:
+    """Test hvac_action reflects a heating device state."""
 
     feature_mock, entity_id = saunabox
+
+    feature_mock.is_on = True
+    feature_mock.hvac_action = 1
+    feature_mock.mode = 1
     await async_setup_entity(hass, entity_id)
 
-    def set_temperature(temp):
-        feature_mock.is_on = True
-        feature_mock.hvac_action = 1
-        feature_mock.mode = 1
-
-    feature_mock.async_set_temperature = AsyncMock(side_effect=set_temperature)
-
-    await hass.services.async_call(
-        "climate",
-        SERVICE_SET_TEMPERATURE,
-        {"entity_id": entity_id, ATTR_TEMPERATURE: 43.21},
-        blocking=True,
-    )
     state = hass.states.get(entity_id)
     assert state.attributes[ATTR_HVAC_ACTION] == HVACAction.HEATING
     assert state.attributes[ATTR_HVAC_MODES] == [HVACMode.OFF, HVACMode.HEAT]
 
 
-async def test_thermo_off(
-    thermobox, hass: HomeAssistant, caplog: pytest.LogCaptureFixture
-) -> None:
-    """Test hvac action off fir given device state."""
-    caplog.set_level(logging.ERROR)
+async def test_hvac_action_off(thermobox, hass: HomeAssistant) -> None:
+    """Test hvac_action reflects a device that is off."""
 
     feature_mock, entity_id = thermobox
+
+    feature_mock.is_on = False
+    feature_mock.hvac_action = 0
     await async_setup_entity(hass, entity_id)
 
-    def set_off():
-        feature_mock.is_on = False
-        feature_mock.hvac_action = 0
-
-    feature_mock.async_off = AsyncMock(side_effect=set_off)
-
-    await hass.services.async_call(
-        "climate",
-        SERVICE_SET_HVAC_MODE,
-        {"entity_id": entity_id, ATTR_HVAC_MODE: HVACMode.OFF},
-        blocking=True,
-    )
     state = hass.states.get(entity_id)
     assert state.attributes[ATTR_HVAC_ACTION] == HVACAction.OFF
     assert state.attributes[ATTR_HVAC_MODES] == [HVACMode.OFF, HVACMode.COOL]

--- a/tests/components/blebox/test_cover.py
+++ b/tests/components/blebox/test_cover.py
@@ -259,21 +259,16 @@ async def test_open(feature, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = feature
 
-    feature_mock.state = 3  # manually stopped
     await async_setup_entity(hass, entity_id)
-    assert hass.states.get(entity_id).state == CoverState.CLOSED
 
-    def open_gate():
-        feature_mock.state = 1  # opening
-
-    feature_mock.async_open = AsyncMock(side_effect=open_gate)
     await hass.services.async_call(
         "cover",
         SERVICE_OPEN_COVER,
         {"entity_id": entity_id},
         blocking=True,
     )
-    assert hass.states.get(entity_id).state == CoverState.OPENING
+
+    feature_mock.async_open.assert_called_once_with()
 
 
 @pytest.mark.parametrize("feature", ALL_COVER_FIXTURES, indirect=["feature"])
@@ -282,18 +277,13 @@ async def test_close(feature, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = feature
 
-    feature_mock.state = 4  # open
     await async_setup_entity(hass, entity_id)
-    assert hass.states.get(entity_id).state == CoverState.OPEN
 
-    def close():
-        feature_mock.state = 0  # closing
-
-    feature_mock.async_close = AsyncMock(side_effect=close)
     await hass.services.async_call(
         "cover", SERVICE_CLOSE_COVER, {"entity_id": entity_id}, blocking=True
     )
-    assert hass.states.get(entity_id).state == CoverState.CLOSING
+
+    feature_mock.async_close.assert_called_once_with()
 
 
 @pytest.mark.parametrize("feature", FIXTURES_SUPPORTING_STOP, indirect=["feature"])
@@ -302,18 +292,13 @@ async def test_stop(feature, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = feature
 
-    feature_mock.state = 1  # opening
     await async_setup_entity(hass, entity_id)
-    assert hass.states.get(entity_id).state == CoverState.OPENING
 
-    def stop():
-        feature_mock.state = 2  # manually stopped
-
-    feature_mock.async_stop = AsyncMock(side_effect=stop)
     await hass.services.async_call(
         "cover", SERVICE_STOP_COVER, {"entity_id": entity_id}, blocking=True
     )
-    assert hass.states.get(entity_id).state == CoverState.OPEN
+
+    feature_mock.async_stop.assert_called_once_with()
 
 
 @pytest.mark.parametrize(
@@ -355,23 +340,16 @@ async def test_set_position(feature, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = feature
 
-    feature_mock.state = 3  # closed
     await async_setup_entity(hass, entity_id)
-    assert hass.states.get(entity_id).state == CoverState.CLOSED
 
-    def set_position(position):
-        assert position == 99  # inverted
-        feature_mock.state = 1  # opening
-        # feature_mock.current = position
-
-    feature_mock.async_set_position = AsyncMock(side_effect=set_position)
     await hass.services.async_call(
         "cover",
         SERVICE_SET_COVER_POSITION,
         {"entity_id": entity_id, ATTR_POSITION: 1},
         blocking=True,
     )  # almost closed
-    assert hass.states.get(entity_id).state == CoverState.OPENING
+
+    feature_mock.async_set_position.assert_called_once_with(99)  # inverted
 
 
 async def test_unknown_position(shutterbox, hass: HomeAssistant) -> None:
@@ -540,29 +518,23 @@ async def test_set_tilt_position(shutterbox, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = shutterbox
 
-    feature_mock.state = 3
     await async_setup_entity(hass, entity_id)
-    assert hass.states.get(entity_id).state == CoverState.CLOSED
 
-    def set_tilt(tilt_position):
-        assert tilt_position == 20
-        feature_mock.state = 1
-
-    feature_mock.async_set_tilt_position = AsyncMock(side_effect=set_tilt)
     await hass.services.async_call(
         "cover",
         SERVICE_SET_COVER_TILT_POSITION,
         {"entity_id": entity_id, ATTR_TILT_POSITION: 80},
         blocking=True,
     )
-    assert hass.states.get(entity_id).state == CoverState.OPENING
+
+    feature_mock.async_set_tilt_position.assert_called_once_with(20)
 
 
 @pytest.mark.parametrize(
-    ("is_tilt_180", "expected_tilt_position", "expected_tilt_reported"),
+    ("is_tilt_180", "expected_tilt_position"),
     [
-        pytest.param(False, 0, 100, id="tilt_90"),
-        pytest.param(True, 50, 50, id="tilt_180"),
+        pytest.param(False, 0, id="tilt_90"),
+        pytest.param(True, 50, id="tilt_180"),
     ],
 )
 async def test_open_tilt(
@@ -570,7 +542,6 @@ async def test_open_tilt(
     hass: HomeAssistant,
     is_tilt_180: bool,
     expected_tilt_position: int,
-    expected_tilt_reported: int,
 ) -> None:
     """Test opening tilt for 90-degree and 180-degree tilt shutters."""
     feature_mock, entity_id = shutterbox
@@ -578,36 +549,21 @@ async def test_open_tilt(
     feature_mock.tilt_current = 100
     await async_setup_entity(hass, entity_id)
 
-    def set_tilt_position(tilt_position):
-        assert tilt_position == expected_tilt_position
-        feature_mock.tilt_current = tilt_position
-
-    feature_mock.async_set_tilt_position = AsyncMock(side_effect=set_tilt_position)
-
     await hass.services.async_call(
         "cover",
         SERVICE_OPEN_COVER_TILT,
         {"entity_id": entity_id},
         blocking=True,
     )
-    state = hass.states.get(entity_id)
-    assert (
-        state.attributes[ATTR_CURRENT_TILT_POSITION] == expected_tilt_reported
-    )  # inverted
+
+    feature_mock.async_set_tilt_position.assert_called_once_with(expected_tilt_position)
 
 
 async def test_close_tilt(shutterbox, hass: HomeAssistant) -> None:
     """Test closing tilt."""
     feature_mock, entity_id = shutterbox
 
-    feature_mock.tilt_current = 0
     await async_setup_entity(hass, entity_id)
-
-    def set_tilt_position(tilt_position):
-        assert tilt_position == 100
-        feature_mock.tilt_current = tilt_position
-
-    feature_mock.async_set_tilt_position = AsyncMock(side_effect=set_tilt_position)
 
     await hass.services.async_call(
         "cover",
@@ -615,5 +571,5 @@ async def test_close_tilt(shutterbox, hass: HomeAssistant) -> None:
         {"entity_id": entity_id},
         blocking=True,
     )
-    state = hass.states.get(entity_id)
-    assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 0  # inverted
+
+    feature_mock.async_set_tilt_position.assert_called_once_with(100)

--- a/tests/components/blebox/test_light.py
+++ b/tests/components/blebox/test_light.py
@@ -6,7 +6,6 @@ from unittest.mock import AsyncMock, MagicMock, PropertyMock
 import blebox_uniapi
 import pytest
 
-from homeassistant.components.blebox.const import LIGHT_MAX_KELVINS, LIGHT_MIN_KELVINS
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_COLOR_TEMP_KELVIN,
@@ -19,7 +18,6 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
-    STATE_OFF,
     STATE_ON,
     STATE_UNKNOWN,
 )
@@ -103,20 +101,9 @@ async def test_dimmer_on(dimmer, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = dimmer
 
-    feature_mock.is_on = False
-    feature_mock.brightness = 0  # off
     feature_mock.sensible_on_value = 254
     await async_setup_entity(hass, entity_id)
 
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_OFF
-
-    def turn_on(brightness):
-        assert brightness == 254
-        feature_mock.brightness = 254  # on
-        feature_mock.is_on = True  # on
-
-    feature_mock.async_on = AsyncMock(side_effect=turn_on)
     await hass.services.async_call(
         "light",
         SERVICE_TURN_ON,
@@ -124,9 +111,7 @@ async def test_dimmer_on(dimmer, hass: HomeAssistant) -> None:
         blocking=True,
     )
 
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_ON
-    assert state.attributes[ATTR_BRIGHTNESS] == 254
+    feature_mock.async_on.assert_called_once_with(254)
 
 
 async def test_dimmer_on_with_brightness(dimmer, hass: HomeAssistant) -> None:
@@ -134,20 +119,8 @@ async def test_dimmer_on_with_brightness(dimmer, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = dimmer
 
-    feature_mock.is_on = False
-    feature_mock.brightness = 0  # off
     feature_mock.sensible_on_value = 254
     await async_setup_entity(hass, entity_id)
-
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_OFF
-
-    def turn_on(brightness):
-        assert brightness == 202
-        feature_mock.brightness = 202  # on
-        feature_mock.is_on = True  # on
-
-    feature_mock.async_on = AsyncMock(side_effect=turn_on)
 
     def apply(value, brightness):
         assert value == 254
@@ -161,9 +134,7 @@ async def test_dimmer_on_with_brightness(dimmer, hass: HomeAssistant) -> None:
         blocking=True,
     )
 
-    state = hass.states.get(entity_id)
-    assert state.attributes[ATTR_BRIGHTNESS] == 202
-    assert state.state == STATE_ON
+    feature_mock.async_on.assert_called_once_with(202)
 
 
 async def test_dimmer_off(dimmer, hass: HomeAssistant) -> None:
@@ -171,17 +142,8 @@ async def test_dimmer_off(dimmer, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = dimmer
 
-    feature_mock.is_on = True
     await async_setup_entity(hass, entity_id)
 
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_ON
-
-    def turn_off():
-        feature_mock.is_on = False
-        feature_mock.brightness = 0  # off
-
-    feature_mock.async_off = AsyncMock(side_effect=turn_off)
     await hass.services.async_call(
         "light",
         SERVICE_TURN_OFF,
@@ -189,9 +151,7 @@ async def test_dimmer_off(dimmer, hass: HomeAssistant) -> None:
         blocking=True,
     )
 
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_OFF
-    assert state.attributes[ATTR_BRIGHTNESS] is None
+    feature_mock.async_off.assert_called_once_with()
 
 
 @pytest.fixture(name="wlightbox_s")
@@ -264,19 +224,9 @@ async def test_wlightbox_s_on(wlightbox_s, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = wlightbox_s
 
-    feature_mock.is_on = False
     feature_mock.sensible_on_value = 254
     await async_setup_entity(hass, entity_id)
 
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_OFF
-
-    def turn_on(brightness):
-        assert brightness == 254
-        feature_mock.brightness = 254  # on
-        feature_mock.is_on = True  # on
-
-    feature_mock.async_on = AsyncMock(side_effect=turn_on)
     await hass.services.async_call(
         "light",
         SERVICE_TURN_ON,
@@ -284,9 +234,7 @@ async def test_wlightbox_s_on(wlightbox_s, hass: HomeAssistant) -> None:
         blocking=True,
     )
 
-    state = hass.states.get(entity_id)
-    assert state.attributes[ATTR_BRIGHTNESS] == 254
-    assert state.state == STATE_ON
+    feature_mock.async_on.assert_called_once_with(254)
 
 
 @pytest.fixture(name="wlightbox")
@@ -360,12 +308,7 @@ async def test_wlightbox_on_color_temp(
         transient_temp = value
         return [0x00, 0x39, 0xB0, 0xFF]
 
-    def turn_on(_: list[int]) -> None:
-        feature_mock.is_on = True
-        feature_mock.color_temp = transient_temp
-
     feature_mock.return_color_temp_with_brightness = return_color_temp_with_brightness
-    feature_mock.async_on = AsyncMock(side_effect=turn_on)
 
     await async_setup_entity(hass, entity_id)
     await hass.services.async_call(
@@ -375,12 +318,8 @@ async def test_wlightbox_on_color_temp(
         blocking=True,
     )
 
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_ON
     assert 0 <= transient_temp <= 255
-
-    kelvin_actual = state.attributes[ATTR_COLOR_TEMP_KELVIN]
-    assert LIGHT_MIN_KELVINS <= kelvin_actual <= LIGHT_MAX_KELVINS
+    feature_mock.async_on.assert_called_once_with([0x00, 0x39, 0xB0, 0xFF])
 
 
 async def test_wlightbox_init(
@@ -431,34 +370,7 @@ async def test_wlightbox_on_rgbw(wlightbox, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = wlightbox
 
-    feature_mock.is_on = False
     await async_setup_entity(hass, entity_id)
-
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_OFF
-
-    def turn_on(value):
-        feature_mock.is_on = True
-        assert value == [193, 210, 243, 199]
-        feature_mock.white_value = 0xC7  # on
-        feature_mock.rgbw_hex = "c1d2f3c7"
-
-    feature_mock.async_on = AsyncMock(side_effect=turn_on)
-
-    def apply_white(value, white):
-        assert value == "00010203"
-        assert white == 0xC7
-        return "000102c7"
-
-    feature_mock.apply_white = apply_white
-
-    def apply_color(value, color_value):
-        assert value == "000102c7"
-        assert color_value == "c1d2f3"
-        return "c1d2f3c7"
-
-    feature_mock.apply_color = apply_color
-    feature_mock.sensible_on_value = "00010203"
 
     await hass.services.async_call(
         "light",
@@ -467,9 +379,7 @@ async def test_wlightbox_on_rgbw(wlightbox, hass: HomeAssistant) -> None:
         blocking=True,
     )
 
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_ON
-    assert state.attributes[ATTR_RGBW_COLOR] == (0xC1, 0xD2, 0xF3, 0xC7)
+    feature_mock.async_on.assert_called_once_with([193, 210, 243, 199])
 
 
 async def test_wlightbox_on_to_last_color(wlightbox, hass: HomeAssistant) -> None:
@@ -477,20 +387,8 @@ async def test_wlightbox_on_to_last_color(wlightbox, hass: HomeAssistant) -> Non
 
     feature_mock, entity_id = wlightbox
 
-    feature_mock.is_on = False
-    await async_setup_entity(hass, entity_id)
-
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_OFF
-
-    def turn_on(value):
-        feature_mock.is_on = True
-        assert value == "f1e2d3e4"
-        feature_mock.white_value = 0xE4
-        feature_mock.rgbw_hex = value
-
-    feature_mock.async_on = AsyncMock(side_effect=turn_on)
     feature_mock.sensible_on_value = "f1e2d3e4"
+    await async_setup_entity(hass, entity_id)
 
     await hass.services.async_call(
         "light",
@@ -499,9 +397,7 @@ async def test_wlightbox_on_to_last_color(wlightbox, hass: HomeAssistant) -> Non
         blocking=True,
     )
 
-    state = hass.states.get(entity_id)
-    assert state.attributes[ATTR_RGBW_COLOR] == (0xF1, 0xE2, 0xD3, 0xE4)
-    assert state.state == STATE_ON
+    feature_mock.async_on.assert_called_once_with("f1e2d3e4")
 
 
 async def test_wlightbox_turn_on_with_zero_brightness_turns_off(
@@ -511,22 +407,7 @@ async def test_wlightbox_turn_on_with_zero_brightness_turns_off(
 
     feature_mock, entity_id = wlightbox
 
-    feature_mock.is_on = True
-    feature_mock.rgbw_hex = "c1d2f3c7"
-    feature_mock.white_value = 0xC7
     await async_setup_entity(hass, entity_id)
-
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_ON
-
-    feature_mock.apply_brightness = MagicMock(return_value=[0, 0, 0, 0])
-
-    def turn_off():
-        feature_mock.is_on = False
-        feature_mock.white_value = 0x0
-        feature_mock.rgbw_hex = "00000000"
-
-    feature_mock.async_off = AsyncMock(side_effect=turn_off)
 
     await hass.services.async_call(
         "light",
@@ -535,11 +416,8 @@ async def test_wlightbox_turn_on_with_zero_brightness_turns_off(
         blocking=True,
     )
 
-    feature_mock.async_off.assert_called_once()
+    feature_mock.async_off.assert_called_once_with()
     feature_mock.async_on.assert_not_called()
-
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_OFF
 
 
 async def test_wlightbox_off(wlightbox, hass: HomeAssistant) -> None:
@@ -547,18 +425,7 @@ async def test_wlightbox_off(wlightbox, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = wlightbox
 
-    feature_mock.is_on = True
     await async_setup_entity(hass, entity_id)
-
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_ON
-
-    def turn_off():
-        feature_mock.is_on = False
-        feature_mock.white_value = 0x0
-        feature_mock.rgbw_hex = "00000000"
-
-    feature_mock.async_off = AsyncMock(side_effect=turn_off)
 
     await hass.services.async_call(
         "light",
@@ -567,9 +434,7 @@ async def test_wlightbox_off(wlightbox, hass: HomeAssistant) -> None:
         blocking=True,
     )
 
-    state = hass.states.get(entity_id)
-    assert state.attributes[ATTR_RGBW_COLOR] is None
-    assert state.state == STATE_OFF
+    feature_mock.async_off.assert_called_once_with()
 
 
 @pytest.mark.parametrize("feature", ALL_LIGHT_FIXTURES, indirect=["feature"])
@@ -623,17 +488,7 @@ async def test_wlightbox_on_effect(wlightbox, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = wlightbox
 
-    feature_mock.is_on = False
     await async_setup_entity(hass, entity_id)
-
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_OFF
-
-    def turn_on(value):
-        feature_mock.is_on = True
-        feature_mock.effect = "POLICE"
-
-    feature_mock.async_on = AsyncMock(side_effect=turn_on)
 
     with pytest.raises(HomeAssistantError) as info:
         await hass.services.async_call(
@@ -644,6 +499,7 @@ async def test_wlightbox_on_effect(wlightbox, hass: HomeAssistant) -> None:
         )
 
     assert info.value.translation_key == "effect_not_found"
+    feature_mock.async_api_command.assert_not_called()
 
     await hass.services.async_call(
         "light",
@@ -652,8 +508,7 @@ async def test_wlightbox_on_effect(wlightbox, hass: HomeAssistant) -> None:
         blocking=True,
     )
 
-    state = hass.states.get(entity_id)
-    assert state.attributes[ATTR_EFFECT] == "POLICE"
+    feature_mock.async_api_command.assert_called_once_with("effect", 2)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/blebox/test_sensor.py
+++ b/tests/components/blebox/test_sensor.py
@@ -304,10 +304,7 @@ async def test_open_status_sensor_none_value(
     """Test that a None native_value yields an unknown state."""
     feature_mock, entity_id = open_status_sensor
 
-    def set_none():
-        feature_mock.native_value = None
-
-    feature_mock.async_update = AsyncMock(side_effect=set_none)
+    feature_mock.native_value = None
     await async_setup_entity(hass, entity_id)
 
     state = hass.states.get(entity_id)
@@ -380,10 +377,7 @@ async def test_co2_definition_sensor_none_value(
     """Test that a None native_value yields an unknown state."""
     feature_mock, entity_id = co2_definition_sensor
 
-    def set_none():
-        feature_mock.native_value = None
-
-    feature_mock.async_update = AsyncMock(side_effect=set_none)
+    feature_mock.native_value = None
     await async_setup_entity(hass, entity_id)
 
     state = hass.states.get(entity_id)

--- a/tests/components/blebox/test_switch.py
+++ b/tests/components/blebox/test_switch.py
@@ -106,13 +106,7 @@ async def test_switchbox_on(switchbox, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = switchbox
 
-    feature_mock.is_on = False
     await async_setup_entity(hass, entity_id)
-
-    def turn_on():
-        feature_mock.is_on = True
-
-    feature_mock.async_turn_on = AsyncMock(side_effect=turn_on)
 
     await hass.services.async_call(
         "switch",
@@ -121,8 +115,7 @@ async def test_switchbox_on(switchbox, hass: HomeAssistant) -> None:
         blocking=True,
     )
 
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_ON
+    feature_mock.async_turn_on.assert_called_once_with()
 
 
 async def test_switchbox_off(switchbox, hass: HomeAssistant) -> None:
@@ -130,13 +123,7 @@ async def test_switchbox_off(switchbox, hass: HomeAssistant) -> None:
 
     feature_mock, entity_id = switchbox
 
-    feature_mock.is_on = True
     await async_setup_entity(hass, entity_id)
-
-    def turn_off():
-        feature_mock.is_on = False
-
-    feature_mock.async_turn_off = AsyncMock(side_effect=turn_off)
 
     await hass.services.async_call(
         "switch",
@@ -144,8 +131,8 @@ async def test_switchbox_off(switchbox, hass: HomeAssistant) -> None:
         {"entity_id": entity_id},
         blocking=True,
     )
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_OFF
+
+    feature_mock.async_turn_off.assert_called_once_with()
 
 
 def relay_mock(relay_id=0):
@@ -263,14 +250,8 @@ async def test_switchbox_d_turn_first_on(switchbox_d, hass: HomeAssistant) -> No
 
     feature_mocks, entity_ids = switchbox_d
 
-    feature_mocks[0].is_on = False
-    feature_mocks[1].is_on = False
     await async_setup_entities(hass, entity_ids)
 
-    def turn_on0():
-        feature_mocks[0].is_on = True
-
-    feature_mocks[0].async_turn_on = AsyncMock(side_effect=turn_on0)
     await hass.services.async_call(
         "switch",
         SERVICE_TURN_ON,
@@ -278,8 +259,8 @@ async def test_switchbox_d_turn_first_on(switchbox_d, hass: HomeAssistant) -> No
         blocking=True,
     )
 
-    assert hass.states.get(entity_ids[0]).state == STATE_ON
-    assert hass.states.get(entity_ids[1]).state == STATE_OFF
+    feature_mocks[0].async_turn_on.assert_called_once_with()
+    feature_mocks[1].async_turn_on.assert_not_called()
 
 
 async def test_switchbox_d_second_on(switchbox_d, hass: HomeAssistant) -> None:
@@ -287,14 +268,8 @@ async def test_switchbox_d_second_on(switchbox_d, hass: HomeAssistant) -> None:
 
     feature_mocks, entity_ids = switchbox_d
 
-    feature_mocks[0].is_on = False
-    feature_mocks[1].is_on = False
     await async_setup_entities(hass, entity_ids)
 
-    def turn_on1():
-        feature_mocks[1].is_on = True
-
-    feature_mocks[1].async_turn_on = AsyncMock(side_effect=turn_on1)
     await hass.services.async_call(
         "switch",
         SERVICE_TURN_ON,
@@ -302,8 +277,8 @@ async def test_switchbox_d_second_on(switchbox_d, hass: HomeAssistant) -> None:
         blocking=True,
     )
 
-    assert hass.states.get(entity_ids[0]).state == STATE_OFF
-    assert hass.states.get(entity_ids[1]).state == STATE_ON
+    feature_mocks[0].async_turn_on.assert_not_called()
+    feature_mocks[1].async_turn_on.assert_called_once_with()
 
 
 async def test_switchbox_d_first_off(switchbox_d, hass: HomeAssistant) -> None:
@@ -311,14 +286,8 @@ async def test_switchbox_d_first_off(switchbox_d, hass: HomeAssistant) -> None:
 
     feature_mocks, entity_ids = switchbox_d
 
-    feature_mocks[0].is_on = True
-    feature_mocks[1].is_on = True
     await async_setup_entities(hass, entity_ids)
 
-    def turn_off0():
-        feature_mocks[0].is_on = False
-
-    feature_mocks[0].async_turn_off = AsyncMock(side_effect=turn_off0)
     await hass.services.async_call(
         "switch",
         SERVICE_TURN_OFF,
@@ -326,8 +295,8 @@ async def test_switchbox_d_first_off(switchbox_d, hass: HomeAssistant) -> None:
         blocking=True,
     )
 
-    assert hass.states.get(entity_ids[0]).state == STATE_OFF
-    assert hass.states.get(entity_ids[1]).state == STATE_ON
+    feature_mocks[0].async_turn_off.assert_called_once_with()
+    feature_mocks[1].async_turn_off.assert_not_called()
 
 
 async def test_switchbox_d_second_off(switchbox_d, hass: HomeAssistant) -> None:
@@ -335,22 +304,17 @@ async def test_switchbox_d_second_off(switchbox_d, hass: HomeAssistant) -> None:
 
     feature_mocks, entity_ids = switchbox_d
 
-    feature_mocks[0].is_on = True
-    feature_mocks[1].is_on = True
     await async_setup_entities(hass, entity_ids)
 
-    def turn_off1():
-        feature_mocks[1].is_on = False
-
-    feature_mocks[1].async_turn_off = AsyncMock(side_effect=turn_off1)
     await hass.services.async_call(
         "switch",
         SERVICE_TURN_OFF,
         {"entity_id": entity_ids[1]},
         blocking=True,
     )
-    assert hass.states.get(entity_ids[0]).state == STATE_ON
-    assert hass.states.get(entity_ids[1]).state == STATE_OFF
+
+    feature_mocks[0].async_turn_off.assert_not_called()
+    feature_mocks[1].async_turn_off.assert_called_once_with()
 
 
 async def test_switchbox_with_name(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Action tests for BleBox entities (switch/cover/climate/light/sensor) faked state changes via side_effect instead of verifying the library was called correctly. This PR replaces those with `assert_called_once_with()` on the library mock.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: https://github.com/home-assistant/core/pull/175368#discussion_r3514298966


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
