### PR TITLE
Classify scene, script and group entities in device and config entry search

### DIFF
--- a/homeassistant/components/search/__init__.py
+++ b/homeassistant/components/search/__init__.py
@@ -327,6 +327,12 @@ class Searcher:
             # Add labels of this entity
             self._add(ItemType.LABEL, entity_entry.labels)
 
+        if not entry_point:
+            # If this entity also exists as a resource, we add it.
+            domain = split_entity_id(entity_id)[0]
+            if domain in self.EXIST_AS_ENTITY:
+                self._add(ItemType(domain), entity_id)
+
         # Automations referencing this entity
         self._add(
             ItemType.AUTOMATION,

--- a/tests/components/search/test_init.py
+++ b/tests/components/search/test_init.py
@@ -111,6 +111,23 @@ async def test_search(
         wled_segment_2_entity.entity_id, area_id=bedroom_area.id
     )
 
+    # Config entry with a device providing a scene entity
+    esphome_config_entry = MockConfigEntry(domain="esphome")
+    esphome_config_entry.add_to_hass(hass)
+    esphome_device = device_registry.async_get_or_create(
+        config_entry_id=esphome_config_entry.entry_id,
+        name="Node",
+        identifiers={("esphome", "esphome-1")},
+    )
+    esphome_scene_entity = entity_registry.async_get_or_create(
+        "scene",
+        "esphome",
+        "esphome-1-scene",
+        suggested_object_id="esphome scene",
+        config_entry=esphome_config_entry,
+        device_id=esphome_device.id,
+    )
+
     scene_wled_hue_entity = entity_registry.async_get_or_create(
         "scene",
         "homeassistant",
@@ -657,6 +674,18 @@ async def test_search(
         ItemType.INTEGRATION: {"hue"},
         ItemType.SCENE: {"scene.scene_hue_seg_1", scene_wled_hue_entity.entity_id},
         ItemType.SCRIPT: {"script.device", "script.hue"},
+    }
+    assert search(ItemType.DEVICE, esphome_device.id) == {
+        ItemType.CONFIG_ENTRY: {esphome_config_entry.entry_id},
+        ItemType.ENTITY: {esphome_scene_entity.entity_id},
+        ItemType.INTEGRATION: {"esphome"},
+        ItemType.SCENE: {esphome_scene_entity.entity_id},
+    }
+    assert search(ItemType.CONFIG_ENTRY, esphome_config_entry.entry_id) == {
+        ItemType.DEVICE: {esphome_device.id},
+        ItemType.ENTITY: {esphome_scene_entity.entity_id},
+        ItemType.INTEGRATION: {"esphome"},
+        ItemType.SCENE: {esphome_scene_entity.entity_id},
     }
 
     assert not search(ItemType.ENTITY, "sensor.unknown")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The search integration maps entities that also exist as a resource (scene, script, group, person, automation) to their own item type through the `EXIST_AS_ENTITY` set. Area, label, automation, and script searches all apply this mapping to the entities they encounter. `_async_search_entity` does not.

Device and config entry searches route their entities through `_async_search_entity`, so a scene or script provided by a device (for example ESPHome scenes) only shows up as a plain entity in the results, never under its scene or script typing.

This change applies the `EXIST_AS_ENTITY` mapping in `_async_search_entity`, guarded on `not entry_point`: when an entity is searched directly, listing that same entity under a second item type as related to itself would be noise. The mapping only kicks in when the entity is reached from a device or config entry search, matching how area search treats its member entities.

Tests: the fixture gains an `esphome` config entry with a device providing a scene entity, and assertions that both the device search and the config entry search return that scene under the scene item type. Fails without the fix.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
