### PR TITLE
Resolve person member entities in search

### DIFF
--- a/homeassistant/components/search/__init__.py
+++ b/homeassistant/components/search/__init__.py
@@ -420,7 +420,7 @@ class Searcher:
     @callback
     def _async_search_person(self, person_entity_id: str) -> None:
         """Find results for a person."""
-        # Up resolve the scene entity itself
+        # Up resolve the person entity itself
         if entity_entry := self._async_resolve_up_entity(person_entity_id):
             # Add labels of this person entity
             self._add(ItemType.LABEL, entity_entry.labels)
@@ -437,9 +437,9 @@ class Searcher:
         )
 
         # Add all member entities of this person
-        self._add(
-            ItemType.ENTITY, person.entities_in_person(self.hass, person_entity_id)
-        )
+        for entity_id in person.entities_in_person(self.hass, person_entity_id):
+            self._add(ItemType.ENTITY, entity_id)
+            self._async_resolve_up_entity(entity_id)
 
     @callback
     def _async_search_scene(self, scene_entity_id: str) -> None:

--- a/tests/components/search/test_init.py
+++ b/tests/components/search/test_init.py
@@ -136,6 +136,23 @@ async def test_search(
         labels={label_other.label_id},
     )
 
+    # Device tracker of the person, provided by a config entry with a device
+    mobile_app_config_entry = MockConfigEntry(domain="mobile_app")
+    mobile_app_config_entry.add_to_hass(hass)
+    mobile_app_device = device_registry.async_get_or_create(
+        config_entry_id=mobile_app_config_entry.entry_id,
+        name="Paulus iPhone",
+        identifiers={("mobile_app", "phone-1")},
+    )
+    entity_registry.async_get_or_create(
+        "device_tracker",
+        "mobile_app",
+        "phone-1-tracker",
+        suggested_object_id="paulus_iphone",
+        config_entry=mobile_app_config_entry,
+        device_id=mobile_app_device.id,
+    )
+
     script_scene_entity = entity_registry.async_get_or_create(
         "script",
         "script",
@@ -725,6 +742,9 @@ async def test_search(
         ItemType.SCRIPT: {script_scene_entity.entity_id},
     }
     assert search(ItemType.ENTITY, "device_tracker.paulus_iphone") == {
+        ItemType.CONFIG_ENTRY: {mobile_app_config_entry.entry_id},
+        ItemType.DEVICE: {mobile_app_device.id},
+        ItemType.INTEGRATION: {"mobile_app"},
         ItemType.PERSON: {person_paulus_entity.entity_id},
     }
     assert search(ItemType.ENTITY, "light.wled_config_entry_source") == {
@@ -840,8 +860,11 @@ async def test_search(
     assert not search(ItemType.PERSON, "person.unknown")
     assert search(ItemType.PERSON, person_paulus_entity.entity_id) == {
         ItemType.AREA: {bedroom_area.id},
+        ItemType.CONFIG_ENTRY: {mobile_app_config_entry.entry_id},
+        ItemType.DEVICE: {mobile_app_device.id},
         ItemType.ENTITY: {"device_tracker.paulus_iphone"},
         ItemType.FLOOR: {second_floor.floor_id},
+        ItemType.INTEGRATION: {"mobile_app"},
         ItemType.LABEL: {label_other.label_id},
     }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Every search path in the search integration that walks member or referenced entities (scene, group, automation, script) resolves each entity up to its device, area, floor, config entry, and integration. Person search is the exception: it adds the member device trackers flat. As a result, searching a person never surfaces the device behind their phone tracker, the mobile_app config entry, or the integration providing it.

This change resolves each person member entity up, using the exact same loop pattern scene search uses for its entities. It also fixes a copy/paste comment in the same method (the person method claimed to up resolve "the scene entity").

Tests: the fixture now registers `device_tracker.paulus_iphone` properly, behind a `mobile_app` config entry with a device, instead of using an unregistered entity id string. The person search assertion gains the device, config entry, and integration, and the entity search assertion for the tracker picks up the same three from the richer fixture. Fails without the fix.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
