### PR TITLE
Resolve up labeled areas, devices and entities in search

### DIFF
--- a/homeassistant/components/search/__init__.py
+++ b/homeassistant/components/search/__init__.py
@@ -394,14 +394,17 @@ class Searcher:
         # Areas with this label
         for area_entry in ar.async_entries_for_label(self._area_registry, label_id):
             self._add(ItemType.AREA, area_entry.id)
+            self._async_resolve_up_area(area_entry.id)
 
         # Devices with this label
         for device in dr.async_entries_for_label(self._device_registry, label_id):
             self._add(ItemType.DEVICE, device.id)
+            self._async_resolve_up_device(device.id)
 
         # Entities with this label
         for entity_entry in er.async_entries_for_label(self._entity_registry, label_id):
             self._add(ItemType.ENTITY, entity_entry.entity_id)
+            self._async_resolve_up_entity(entity_entry.entity_id)
 
             # If this entity also exists as a resource, we add it.
             domain = split_entity_id(entity_entry.entity_id)[0]

--- a/tests/components/search/test_init.py
+++ b/tests/components/search/test_init.py
@@ -819,11 +819,20 @@ async def test_search(
 
     assert not search(ItemType.LABEL, "unknown")
     assert search(ItemType.LABEL, label_christmas.label_id) == {
+        ItemType.AREA: {living_room_area.id},
         ItemType.AUTOMATION: {"automation.label"},
+        ItemType.CONFIG_ENTRY: {wled_config_entry.entry_id},
         ItemType.DEVICE: {wled_device.id},
+        ItemType.FLOOR: {first_floor.floor_id},
+        ItemType.INTEGRATION: {"wled"},
     }
     assert search(ItemType.LABEL, label_energy.label_id) == {
+        ItemType.AREA: {kitchen_area.id},
+        ItemType.CONFIG_ENTRY: {hue_config_entry.entry_id},
+        ItemType.DEVICE: {hue_device.id},
         ItemType.ENTITY: {hue_segment_1_entity.entity_id},
+        ItemType.FLOOR: {first_floor.floor_id},
+        ItemType.INTEGRATION: {"hue"},
     }
     assert search(ItemType.LABEL, label_other.label_id) == {
         ItemType.AREA: {bedroom_area.id},
@@ -832,6 +841,7 @@ async def test_search(
             person_paulus_entity.entity_id,
             script_scene_entity.entity_id,
         },
+        ItemType.FLOOR: {second_floor.floor_id},
         ItemType.PERSON: {person_paulus_entity.entity_id},
         ItemType.SCENE: {scene_wled_hue_entity.entity_id},
         ItemType.SCRIPT: {"script.label", script_scene_entity.entity_id},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Label search is the only place in the search integration that adds areas, devices, and entities to the results without resolving them up. Everywhere else, adding an area is paired with `_async_resolve_up_area` (adding its floor), adding a device with `_async_resolve_up_device` (adding its area, floor, config entry, and integration), and adding an entity with `_async_resolve_up_entity`.

The result of that inconsistency: searching a label placed on an area does not show the floor of that area, and a label placed on a device or entity does not show the config entry, integration, area, or floor behind it, while searching those same objects directly does.

This change pairs the three registry loops in `_async_search_label` with their matching resolve up calls. Note this is purely up resolution, adding the containers of the labeled objects. It does not pull in automations or scripts referencing those containers, so it stays away from the indirect reference territory of #167719 / #169471.

Tests: the three existing label assertions now expect the resolved results (floor of the labeled area, and area, floor, config entry, integration of the labeled device and entity). They fail without the fix.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
