### PR TITLE
Add calendar LLM tools platform

### DIFF
--- a/homeassistant/components/calendar/llm.py
+++ b/homeassistant/components/calendar/llm.py
@@ -1,0 +1,101 @@
+"""LLM tools for the calendar integration."""
+
+from datetime import timedelta
+from typing import cast, override
+
+import voluptuous as vol
+
+from homeassistant.components.llm import LLMTools
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import intent
+from homeassistant.helpers.llm import LLMContext, Tool, ToolInput, _get_exposed_entities
+from homeassistant.util import dt as dt_util
+from homeassistant.util.json import JsonObjectType
+
+from . import SERVICE_GET_EVENTS
+from .const import DOMAIN
+
+
+class CalendarGetEventsTool(Tool):
+    """LLM Tool allowing querying a calendar."""
+
+    name = "calendar_get_events"
+    description = (
+        "Get events from a calendar. "
+        "When asked if something happens, search the whole week. "
+        "Results are RFC 5545 which means 'end' is exclusive."
+    )
+
+    def __init__(self, calendars: list[str]) -> None:
+        """Init the get events tool."""
+        self.parameters = vol.Schema(
+            {
+                vol.Required("calendar"): vol.In(calendars),
+                vol.Required("range"): vol.In(["today", "week"]),
+            }
+        )
+
+    @override
+    async def async_call(
+        self, hass: HomeAssistant, tool_input: ToolInput, llm_context: LLMContext
+    ) -> JsonObjectType:
+        """Query a calendar."""
+        data = self.parameters(tool_input.tool_args)
+        result = intent.async_match_targets(
+            hass,
+            intent.MatchTargetsConstraints(
+                name=data["calendar"],
+                domains=[DOMAIN],
+                assistant=llm_context.assistant,
+            ),
+        )
+        if not result.is_match:
+            return {"success": False, "error": "Calendar not found"}
+
+        entity_id = result.states[0].entity_id
+        if data["range"] == "today":
+            start = dt_util.now()
+            end = dt_util.start_of_local_day() + timedelta(days=1)
+        elif data["range"] == "week":
+            start = dt_util.now()
+            end = dt_util.start_of_local_day() + timedelta(days=7)
+
+        service_data = {
+            "entity_id": entity_id,
+            "start_date_time": start.isoformat(),
+            "end_date_time": end.isoformat(),
+        }
+
+        service_result = await hass.services.async_call(
+            DOMAIN,
+            SERVICE_GET_EVENTS,
+            service_data,
+            context=llm_context.context,
+            blocking=True,
+            return_response=True,
+        )
+
+        events = [
+            event if "T" in event["start"] else {**event, "all_day": True}
+            for event in cast(dict, service_result)[entity_id]["events"]
+        ]
+
+        return {"success": True, "result": events}
+
+
+@callback
+def async_get_tools(hass: HomeAssistant, llm_context: LLMContext) -> LLMTools:
+    """Return the calendar LLM tools for the exposed calendars."""
+    if not llm_context.assistant:
+        return LLMTools(tools=[])
+
+    exposed_entities = _get_exposed_entities(
+        hass, llm_context.assistant, include_state=False
+    )
+    if not exposed_entities[DOMAIN]:
+        return LLMTools(tools=[])
+
+    names: list[str] = []
+    for info in exposed_entities[DOMAIN].values():
+        names.extend(info["names"].split(", "))
+    return LLMTools(tools=[CalendarGetEventsTool(names)])

--- a/tests/components/calendar/test_llm.py
+++ b/tests/components/calendar/test_llm.py
@@ -1,0 +1,117 @@
+"""Tests for the calendar LLM tools platform."""
+
+from datetime import timedelta
+
+from freezegun import freeze_time
+
+from homeassistant.components import calendar, llm as llm_component
+from homeassistant.components.homeassistant.exposed_entities import async_expose_entity
+from homeassistant.core import Context, HomeAssistant, SupportsResponse
+from homeassistant.helpers import llm
+from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
+
+from tests.common import async_mock_service
+
+
+def _llm_context() -> llm.LLMContext:
+    """Return an LLM context for the conversation assistant."""
+    return llm.LLMContext(
+        platform="test_platform",
+        context=Context(),
+        language="*",
+        assistant="conversation",
+        device_id=None,
+    )
+
+
+async def test_get_tools_no_exposed_calendar(hass: HomeAssistant) -> None:
+    """Test no calendar tool is offered when no calendar is exposed."""
+    assert await async_setup_component(hass, "homeassistant", {})
+    assert await async_setup_component(hass, "calendar", {})
+    assert await async_setup_component(hass, "llm", {})
+
+    result = await llm_component.async_get_tools(hass, _llm_context())
+    assert [tool.name for tool in result.tools] == []
+
+
+async def test_calendar_get_events_tool(hass: HomeAssistant) -> None:
+    """Test the calendar get events tool is exposed and works via the platform."""
+    assert await async_setup_component(hass, "homeassistant", {})
+    assert await async_setup_component(hass, "calendar", {})
+    assert await async_setup_component(hass, "llm", {})
+    hass.states.async_set(
+        "calendar.test_calendar", "on", {"friendly_name": "Mock Calendar Name"}
+    )
+    async_expose_entity(hass, "conversation", "calendar.test_calendar", True)
+
+    llm_context = _llm_context()
+    result = await llm_component.async_get_tools(hass, llm_context)
+    tool = next(
+        (tool for tool in result.tools if tool.name == "calendar_get_events"), None
+    )
+    assert tool is not None
+    assert tool.parameters.schema["calendar"].container == ["Mock Calendar Name"]
+
+    calls = async_mock_service(
+        hass,
+        domain=calendar.DOMAIN,
+        service=calendar.SERVICE_GET_EVENTS,
+        schema=calendar.SERVICE_GET_EVENTS_SCHEMA,
+        response={
+            "calendar.test_calendar": {
+                "events": [
+                    {
+                        "start": "2025-09-17",
+                        "end": "2025-09-18",
+                        "summary": "Home Assistant 12th birthday",
+                        "description": "",
+                    },
+                    {
+                        "start": "2025-09-17T14:00:00-05:00",
+                        "end": "2025-09-18T15:00:00-05:00",
+                        "summary": "Champagne",
+                        "description": "",
+                    },
+                ]
+            }
+        },
+        supports_response=SupportsResponse.ONLY,
+    )
+
+    tool_input = llm.ToolInput(
+        tool_name="calendar_get_events",
+        tool_args={"calendar": "Mock Calendar Name", "range": "today"},
+    )
+    now = dt_util.now()
+    with freeze_time(now):
+        response = await tool.async_call(hass, tool_input, llm_context)
+
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.domain == calendar.DOMAIN
+    assert call.service == calendar.SERVICE_GET_EVENTS
+    assert call.data == {
+        "entity_id": ["calendar.test_calendar"],
+        "start_date_time": now,
+        "end_date_time": dt_util.start_of_local_day() + timedelta(days=1),
+    }
+
+    assert response == {
+        "success": True,
+        "result": [
+            {
+                "start": "2025-09-17",
+                "end": "2025-09-18",
+                "summary": "Home Assistant 12th birthday",
+                "description": "",
+                "all_day": True,
+            },
+            {
+                "start": "2025-09-17T14:00:00-05:00",
+                "end": "2025-09-18T15:00:00-05:00",
+                "summary": "Champagne",
+                "description": "",
+            },
+        ],
+    }


### PR DESCRIPTION
## Proposed change

Part of the LLM tool platform migration ([architecture #1412](https://github.com/home-assistant/architecture/discussions/1412), foundation merged in #174253). This moves the calendar tool into a `calendar/llm.py` platform.

**Strategy (applies to this whole PR series):** each built-in LLM tool currently hardcoded in `homeassistant/helpers/llm.py` (`AssistAPI`) is **copied** into an `<integration>/llm.py` tool platform exposing `async_get_tools(hass, llm_context)`, together with its tests. The tool is **intentionally left in `helpers/llm.py` for now** — `AssistAPI` still builds it — so there is no behavior change and each integration can be reviewed independently. Once every tool has moved to a platform, a **final pass** removes the tools from `helpers/llm.py` and wires `AssistAPI` to pull all tools from the platforms. The end state: `AssistAPI` gets all tools from tool platforms, and no tools remain in `helpers/llm.py`.

This PR:
- Adds `homeassistant/components/calendar/llm.py` with `CalendarGetEventsTool` (copied from `helpers/llm.py`) and an `async_get_tools` hook that offers the tool for exposed calendars.
- Adds `tests/components/calendar/test_llm.py`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to: #174253, architecture discussion home-assistant/architecture#1412

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.