### PR TITLE
Move Sure Petcare services to async_setup

### DIFF
--- a/homeassistant/components/surepetcare/__init__.py
+++ b/homeassistant/components/surepetcare/__init__.py
@@ -32,6 +32,8 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORMS = [Platform.BINARY_SENSOR, Platform.LOCK, Platform.SENSOR]
 SCAN_INTERVAL = timedelta(minutes=3)
 
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up Sure Petcare services."""

--- a/homeassistant/components/surepetcare/__init__.py
+++ b/homeassistant/components/surepetcare/__init__.py
@@ -8,9 +8,14 @@ from surepy.exceptions import SurePetcareAuthenticationError, SurePetcareError
 import voluptuous as vol
 
 from homeassistant.const import ATTR_LOCATION, Platform
-from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryNotReady,
+    HomeAssistantError,
+)
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.typing import ConfigType
 
 from .const import (
     ATTR_FLAP_ID,
@@ -28,6 +33,71 @@ PLATFORMS = [Platform.BINARY_SENSOR, Platform.LOCK, Platform.SENSOR]
 SCAN_INTERVAL = timedelta(minutes=3)
 
 
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up Sure Petcare services."""
+
+    async def handle_set_lock_state(call: ServiceCall) -> None:
+        """Set lock state for a flap."""
+        flap_id = call.data[ATTR_FLAP_ID]
+        for entry in hass.config_entries.async_loaded_entries(DOMAIN):
+            coordinator: SurePetcareDataCoordinator = entry.runtime_data
+            if flap_id in coordinator.data:
+                await coordinator.handle_set_lock_state(call)
+                return
+        raise HomeAssistantError(f"Unknown Sure Petcare flap ID: {flap_id}")
+
+    async def handle_set_pet_location(call: ServiceCall) -> None:
+        """Set pet location."""
+        pet_name = call.data[ATTR_PET_NAME]
+        for entry in hass.config_entries.async_loaded_entries(DOMAIN):
+            coordinator: SurePetcareDataCoordinator = entry.runtime_data
+            if pet_name in coordinator.get_pets():
+                await coordinator.handle_set_pet_location(call)
+                return
+        raise HomeAssistantError(f"Unknown Sure Petcare pet: {pet_name}")
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_LOCK_STATE,
+        handle_set_lock_state,
+        schema=vol.Schema(
+            {
+                vol.Required(ATTR_FLAP_ID): cv.positive_int,
+                vol.Required(ATTR_LOCK_STATE): vol.All(
+                    cv.string,
+                    vol.Lower,
+                    vol.In(
+                        [
+                            "unlocked",
+                            "locked_in",
+                            "locked_out",
+                            "locked_all",
+                        ]
+                    ),
+                ),
+            }
+        ),
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_PET_LOCATION,
+        handle_set_pet_location,
+        schema=vol.Schema(
+            {
+                vol.Required(ATTR_PET_NAME): cv.string,
+                vol.Required(ATTR_LOCATION): vol.In(
+                    [
+                        Location.INSIDE.name.title(),
+                        Location.OUTSIDE.name.title(),
+                    ]
+                ),
+            }
+        ),
+    )
+
+    return True
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: SurePetcareConfigEntry) -> bool:
     """Set up Sure Petcare from a config entry."""
     try:
@@ -42,45 +112,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: SurePetcareConfigEntry) 
 
     entry.runtime_data = coordinator
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-
-    lock_state_service_schema = vol.Schema(
-        {
-            vol.Required(ATTR_FLAP_ID): vol.All(
-                cv.positive_int, vol.In(coordinator.data.keys())
-            ),
-            vol.Required(ATTR_LOCK_STATE): vol.All(
-                cv.string,
-                vol.Lower,
-                vol.In(coordinator.lock_states_callbacks.keys()),
-            ),
-        }
-    )
-    # pylint: disable-next=home-assistant-service-registered-in-setup-entry
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_SET_LOCK_STATE,
-        coordinator.handle_set_lock_state,
-        schema=lock_state_service_schema,
-    )
-
-    set_pet_location_schema = vol.Schema(
-        {
-            vol.Required(ATTR_PET_NAME): vol.In(coordinator.get_pets().keys()),
-            vol.Required(ATTR_LOCATION): vol.In(
-                [
-                    Location.INSIDE.name.title(),
-                    Location.OUTSIDE.name.title(),
-                ]
-            ),
-        }
-    )
-    # pylint: disable-next=home-assistant-service-registered-in-setup-entry
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_SET_PET_LOCATION,
-        coordinator.handle_set_pet_location,
-        schema=set_pet_location_schema,
-    )
 
     return True
 

--- a/homeassistant/components/surepetcare/__init__.py
+++ b/homeassistant/components/surepetcare/__init__.py
@@ -3,29 +3,17 @@
 from datetime import timedelta
 import logging
 
-from surepy.enums import Location
 from surepy.exceptions import SurePetcareAuthenticationError, SurePetcareError
-import voluptuous as vol
 
-from homeassistant.const import ATTR_LOCATION, Platform
-from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.exceptions import (
-    ConfigEntryAuthFailed,
-    ConfigEntryNotReady,
-    HomeAssistantError,
-)
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
-from .const import (
-    ATTR_FLAP_ID,
-    ATTR_LOCK_STATE,
-    ATTR_PET_NAME,
-    DOMAIN,
-    SERVICE_SET_LOCK_STATE,
-    SERVICE_SET_PET_LOCATION,
-)
+from .const import DOMAIN
 from .coordinator import SurePetcareConfigEntry, SurePetcareDataCoordinator
+from .services import async_setup_services
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,66 +25,7 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up Sure Petcare services."""
-
-    async def handle_set_lock_state(call: ServiceCall) -> None:
-        """Set lock state for a flap."""
-        flap_id = call.data[ATTR_FLAP_ID]
-        for entry in hass.config_entries.async_loaded_entries(DOMAIN):
-            coordinator: SurePetcareDataCoordinator = entry.runtime_data
-            if flap_id in coordinator.data:
-                await coordinator.handle_set_lock_state(call)
-                return
-        raise HomeAssistantError(f"Unknown Sure Petcare flap ID: {flap_id}")
-
-    async def handle_set_pet_location(call: ServiceCall) -> None:
-        """Set pet location."""
-        pet_name = call.data[ATTR_PET_NAME]
-        for entry in hass.config_entries.async_loaded_entries(DOMAIN):
-            coordinator: SurePetcareDataCoordinator = entry.runtime_data
-            if pet_name in coordinator.get_pets():
-                await coordinator.handle_set_pet_location(call)
-                return
-        raise HomeAssistantError(f"Unknown Sure Petcare pet: {pet_name}")
-
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_SET_LOCK_STATE,
-        handle_set_lock_state,
-        schema=vol.Schema(
-            {
-                vol.Required(ATTR_FLAP_ID): cv.positive_int,
-                vol.Required(ATTR_LOCK_STATE): vol.All(
-                    cv.string,
-                    vol.Lower,
-                    vol.In(
-                        [
-                            "unlocked",
-                            "locked_in",
-                            "locked_out",
-                            "locked_all",
-                        ]
-                    ),
-                ),
-            }
-        ),
-    )
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_SET_PET_LOCATION,
-        handle_set_pet_location,
-        schema=vol.Schema(
-            {
-                vol.Required(ATTR_PET_NAME): cv.string,
-                vol.Required(ATTR_LOCATION): vol.In(
-                    [
-                        Location.INSIDE.name.title(),
-                        Location.OUTSIDE.name.title(),
-                    ]
-                ),
-            }
-        ),
-    )
-
+    async_setup_services(hass)
     return True
 
 

--- a/homeassistant/components/surepetcare/services.py
+++ b/homeassistant/components/surepetcare/services.py
@@ -1,0 +1,85 @@
+"""Support for Sure Petcare services."""
+
+from surepy.enums import Location
+import voluptuous as vol
+
+from homeassistant.const import ATTR_LOCATION
+from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv, service
+
+from .const import (
+    ATTR_FLAP_ID,
+    ATTR_LOCK_STATE,
+    ATTR_PET_NAME,
+    DOMAIN,
+    SERVICE_SET_LOCK_STATE,
+    SERVICE_SET_PET_LOCATION,
+)
+from .coordinator import SurePetcareConfigEntry
+
+
+@callback
+def async_setup_services(hass: HomeAssistant) -> None:
+    """Register Sure Petcare services."""
+
+    async def handle_set_lock_state(call: ServiceCall) -> None:
+        """Set lock state for a flap."""
+        entry: SurePetcareConfigEntry = service.async_get_config_entry(
+            hass, DOMAIN, None
+        )
+        coordinator = entry.runtime_data
+        flap_id = call.data[ATTR_FLAP_ID]
+        if flap_id not in coordinator.data:
+            raise HomeAssistantError(f"Unknown Sure Petcare flap ID: {flap_id}")
+        await coordinator.handle_set_lock_state(call)
+
+    async def handle_set_pet_location(call: ServiceCall) -> None:
+        """Set pet location."""
+        entry: SurePetcareConfigEntry = service.async_get_config_entry(
+            hass, DOMAIN, None
+        )
+        coordinator = entry.runtime_data
+        pet_name = call.data[ATTR_PET_NAME]
+        if pet_name not in coordinator.get_pets():
+            raise HomeAssistantError(f"Unknown Sure Petcare pet: {pet_name}")
+        await coordinator.handle_set_pet_location(call)
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_LOCK_STATE,
+        handle_set_lock_state,
+        schema=vol.Schema(
+            {
+                vol.Required(ATTR_FLAP_ID): cv.positive_int,
+                vol.Required(ATTR_LOCK_STATE): vol.All(
+                    cv.string,
+                    vol.Lower,
+                    vol.In(
+                        [
+                            "unlocked",
+                            "locked_in",
+                            "locked_out",
+                            "locked_all",
+                        ]
+                    ),
+                ),
+            }
+        ),
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_PET_LOCATION,
+        handle_set_pet_location,
+        schema=vol.Schema(
+            {
+                vol.Required(ATTR_PET_NAME): cv.string,
+                vol.Required(ATTR_LOCATION): vol.In(
+                    [
+                        Location.INSIDE.name.title(),
+                        Location.OUTSIDE.name.title(),
+                    ]
+                ),
+            }
+        ),
+    )

--- a/homeassistant/components/surepetcare/services.py
+++ b/homeassistant/components/surepetcare/services.py
@@ -5,7 +5,7 @@ import voluptuous as vol
 
 from homeassistant.const import ATTR_LOCATION
 from homeassistant.core import HomeAssistant, ServiceCall, callback
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import config_validation as cv, service
 
 from .const import (
@@ -31,7 +31,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
         coordinator = entry.runtime_data
         flap_id = call.data[ATTR_FLAP_ID]
         if flap_id not in coordinator.data:
-            raise HomeAssistantError(f"Unknown Sure Petcare flap ID: {flap_id}")
+            raise ServiceValidationError(f"Unknown Sure Petcare flap ID: {flap_id}")
         await coordinator.handle_set_lock_state(call)
 
     async def handle_set_pet_location(call: ServiceCall) -> None:
@@ -42,7 +42,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
         coordinator = entry.runtime_data
         pet_name = call.data[ATTR_PET_NAME]
         if pet_name not in coordinator.get_pets():
-            raise HomeAssistantError(f"Unknown Sure Petcare pet: {pet_name}")
+            raise ServiceValidationError(f"Unknown Sure Petcare pet: {pet_name}")
         await coordinator.handle_set_pet_location(call)
 
     hass.services.async_register(


### PR DESCRIPTION
﻿<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Move Sure Petcare service registration from async_setup_entry to async_setup.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170750
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

