### PR TITLE
Move Genius Hub services to async_setup

### DIFF
--- a/homeassistant/components/geniushub/__init__.py
+++ b/homeassistant/components/geniushub/__init__.py
@@ -71,6 +71,8 @@ PLATFORMS = [
 
 type GeniusHubConfigEntry = ConfigEntry[GeniusBroker]
 
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up Genius Hub services."""

--- a/homeassistant/components/geniushub/__init__.py
+++ b/homeassistant/components/geniushub/__init__.py
@@ -5,12 +5,9 @@ import logging
 
 import aiohttp
 from geniushubclient import GeniusHub
-import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    ATTR_TEMPERATURE,
     CONF_HOST,
     CONF_MAC,
     CONF_PASSWORD,
@@ -18,15 +15,15 @@ from homeassistant.const import (
     CONF_USERNAME,
     Platform,
 )
-from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
-from homeassistant.helpers.service import verify_domain_control
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN
+from .services import setup_service_functions
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,31 +31,6 @@ _LOGGER = logging.getLogger(__name__)
 SCAN_INTERVAL = timedelta(seconds=60)
 
 MAC_ADDRESS_REGEXP = r"^([0-9A-F]{2}:){5}([0-9A-F]{2})$"
-
-ATTR_ZONE_MODE = "mode"
-ATTR_DURATION = "duration"
-
-SVC_SET_ZONE_MODE = "set_zone_mode"
-SVC_SET_ZONE_OVERRIDE = "set_zone_override"
-
-SET_ZONE_MODE_SCHEMA = vol.Schema(
-    {
-        vol.Required(ATTR_ENTITY_ID): cv.entity_id,
-        vol.Required(ATTR_ZONE_MODE): vol.In(["off", "timer", "footprint"]),
-    }
-)
-SET_ZONE_OVERRIDE_SCHEMA = vol.Schema(
-    {
-        vol.Required(ATTR_ENTITY_ID): cv.entity_id,
-        vol.Required(ATTR_TEMPERATURE): vol.All(
-            vol.Coerce(float), vol.Range(min=4, max=28)
-        ),
-        vol.Optional(ATTR_DURATION): vol.All(
-            cv.time_period,
-            vol.Range(min=timedelta(minutes=5), max=timedelta(days=1)),
-        ),
-    }
-)
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,
@@ -123,40 +95,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: GeniusHubConfigEntry) ->
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
-
-
-@callback
-def setup_service_functions(hass: HomeAssistant) -> None:
-    """Set up the service functions."""
-
-    @verify_domain_control(DOMAIN)
-    async def set_zone_mode(call: ServiceCall) -> None:
-        """Set the system mode."""
-        entity_id = call.data[ATTR_ENTITY_ID]
-
-        registry = er.async_get(hass)
-        registry_entry = registry.async_get(entity_id)
-
-        if registry_entry is None or registry_entry.platform != DOMAIN:
-            raise ValueError(f"'{entity_id}' is not a known {DOMAIN} entity")
-
-        if registry_entry.domain != "climate":
-            raise ValueError(f"'{entity_id}' is not an {DOMAIN} zone")
-
-        payload = {
-            "unique_id": registry_entry.unique_id,
-            "service": call.service,
-            "data": call.data,
-        }
-
-        async_dispatcher_send(hass, DOMAIN, payload)
-
-    hass.services.async_register(
-        DOMAIN, SVC_SET_ZONE_MODE, set_zone_mode, schema=SET_ZONE_MODE_SCHEMA
-    )
-    hass.services.async_register(
-        DOMAIN, SVC_SET_ZONE_OVERRIDE, set_zone_mode, schema=SET_ZONE_OVERRIDE_SCHEMA
-    )
 
 
 class GeniusBroker:

--- a/homeassistant/components/geniushub/__init__.py
+++ b/homeassistant/components/geniushub/__init__.py
@@ -24,6 +24,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.service import verify_domain_control
+from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN
 
@@ -71,6 +72,12 @@ PLATFORMS = [
 type GeniusHubConfigEntry = ConfigEntry[GeniusBroker]
 
 
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up Genius Hub services."""
+    setup_service_functions(hass)
+    return True
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: GeniusHubConfigEntry) -> bool:
     """Create a Genius Hub system."""
     if CONF_TOKEN in entry.data and CONF_MAC in entry.data:
@@ -111,15 +118,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: GeniusHubConfigEntry) ->
 
     async_track_time_interval(hass, broker.async_update, SCAN_INTERVAL)
 
-    setup_service_functions(hass, broker)
-
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
 @callback
-def setup_service_functions(hass: HomeAssistant, broker):
+def setup_service_functions(hass: HomeAssistant) -> None:
     """Set up the service functions."""
 
     @verify_domain_control(DOMAIN)
@@ -144,11 +149,9 @@ def setup_service_functions(hass: HomeAssistant, broker):
 
         async_dispatcher_send(hass, DOMAIN, payload)
 
-    # pylint: disable-next=home-assistant-service-registered-in-setup-entry
     hass.services.async_register(
         DOMAIN, SVC_SET_ZONE_MODE, set_zone_mode, schema=SET_ZONE_MODE_SCHEMA
     )
-    # pylint: disable-next=home-assistant-service-registered-in-setup-entry
     hass.services.async_register(
         DOMAIN, SVC_SET_ZONE_OVERRIDE, set_zone_mode, schema=SET_ZONE_OVERRIDE_SCHEMA
     )

--- a/homeassistant/components/geniushub/const.py
+++ b/homeassistant/components/geniushub/const.py
@@ -6,6 +6,12 @@ from homeassistant.const import Platform
 
 DOMAIN = "geniushub"
 
+ATTR_ZONE_MODE = "mode"
+ATTR_DURATION = "duration"
+
+SVC_SET_ZONE_MODE = "set_zone_mode"
+SVC_SET_ZONE_OVERRIDE = "set_zone_override"
+
 SCAN_INTERVAL = timedelta(seconds=60)
 
 SENSOR_PREFIX = "Genius"

--- a/homeassistant/components/geniushub/entity.py
+++ b/homeassistant/components/geniushub/entity.py
@@ -8,7 +8,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import dt as dt_util
 
-from . import ATTR_DURATION, ATTR_ZONE_MODE, DOMAIN, SVC_SET_ZONE_OVERRIDE
+from .const import ATTR_DURATION, ATTR_ZONE_MODE, DOMAIN, SVC_SET_ZONE_OVERRIDE
 
 # temperature is repeated here, as it gives access to high-precision temps
 GH_ZONE_ATTRS = ["mode", "temperature", "type", "occupied", "override"]

--- a/homeassistant/components/geniushub/services.py
+++ b/homeassistant/components/geniushub/services.py
@@ -1,0 +1,72 @@
+"""Support for Genius Hub services."""
+
+from datetime import timedelta
+
+import voluptuous as vol
+
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_TEMPERATURE
+from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.helpers import config_validation as cv, entity_registry as er
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.service import verify_domain_control
+
+from .const import (
+    ATTR_DURATION,
+    ATTR_ZONE_MODE,
+    DOMAIN,
+    SVC_SET_ZONE_MODE,
+    SVC_SET_ZONE_OVERRIDE,
+)
+
+SET_ZONE_MODE_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_ENTITY_ID): cv.entity_id,
+        vol.Required(ATTR_ZONE_MODE): vol.In(["off", "timer", "footprint"]),
+    }
+)
+SET_ZONE_OVERRIDE_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_ENTITY_ID): cv.entity_id,
+        vol.Required(ATTR_TEMPERATURE): vol.All(
+            vol.Coerce(float), vol.Range(min=4, max=28)
+        ),
+        vol.Optional(ATTR_DURATION): vol.All(
+            cv.time_period,
+            vol.Range(min=timedelta(minutes=5), max=timedelta(days=1)),
+        ),
+    }
+)
+
+
+@callback
+def setup_service_functions(hass: HomeAssistant) -> None:
+    """Set up the service functions."""
+
+    @verify_domain_control(DOMAIN)
+    async def set_zone_mode(call: ServiceCall) -> None:
+        """Set the system mode."""
+        entity_id = call.data[ATTR_ENTITY_ID]
+
+        registry = er.async_get(hass)
+        registry_entry = registry.async_get(entity_id)
+
+        if registry_entry is None or registry_entry.platform != DOMAIN:
+            raise ValueError(f"'{entity_id}' is not a known {DOMAIN} entity")
+
+        if registry_entry.domain != "climate":
+            raise ValueError(f"'{entity_id}' is not an {DOMAIN} zone")
+
+        payload = {
+            "unique_id": registry_entry.unique_id,
+            "service": call.service,
+            "data": call.data,
+        }
+
+        async_dispatcher_send(hass, DOMAIN, payload)
+
+    hass.services.async_register(
+        DOMAIN, SVC_SET_ZONE_MODE, set_zone_mode, schema=SET_ZONE_MODE_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN, SVC_SET_ZONE_OVERRIDE, set_zone_mode, schema=SET_ZONE_OVERRIDE_SCHEMA
+    )

--- a/homeassistant/components/geniushub/services.py
+++ b/homeassistant/components/geniushub/services.py
@@ -6,6 +6,7 @@ import voluptuous as vol
 
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_TEMPERATURE
 from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.service import verify_domain_control
@@ -51,10 +52,18 @@ def setup_service_functions(hass: HomeAssistant) -> None:
         registry_entry = registry.async_get(entity_id)
 
         if registry_entry is None or registry_entry.platform != DOMAIN:
-            raise ValueError(f"'{entity_id}' is not a known {DOMAIN} entity")
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_entity_id",
+                translation_placeholders={"entity_id": entity_id},
+            )
 
         if registry_entry.domain != "climate":
-            raise ValueError(f"'{entity_id}' is not an {DOMAIN} zone")
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_zone",
+                translation_placeholders={"entity_id": entity_id},
+            )
 
         payload = {
             "unique_id": registry_entry.unique_id,

--- a/homeassistant/components/geniushub/strings.json
+++ b/homeassistant/components/geniushub/strings.json
@@ -34,6 +34,14 @@
     }
   },
 
+  "exceptions": {
+    "invalid_entity_id": {
+      "message": "Unknown Genius Hub entity: {entity_id}"
+    },
+    "invalid_zone": {
+      "message": "Unknown Genius Hub zone: {entity_id}"
+    }
+  },
   "services": {
     "set_switch_override": {
       "description": "Overrides switch for a given duration.",

--- a/homeassistant/components/geniushub/switch.py
+++ b/homeassistant/components/geniushub/switch.py
@@ -11,7 +11,8 @@ from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import VolDictType
 
-from . import ATTR_DURATION, GeniusHubConfigEntry
+from . import GeniusHubConfigEntry
+from .const import ATTR_DURATION
 from .entity import GeniusZone
 
 GH_ON_OFF_ZONE = "on / off"


### PR DESCRIPTION
﻿<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Move Genius Hub service registration from async_setup_entry to async_setup.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170736
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

