### PR TITLE
Move SimpliSafe services to async_setup

### DIFF
--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -62,6 +62,7 @@ from homeassistant.helpers.service import (
     async_register_admin_service,
     verify_domain_control,
 )
+from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from .const import (
@@ -125,12 +126,6 @@ SERVICE_NAME_REMOVE_PIN = "remove_pin"
 SERVICE_NAME_SET_PIN = "set_pin"
 SERVICE_NAME_SET_SYSTEM_PROPERTIES = "set_system_properties"
 
-SERVICES = (
-    SERVICE_NAME_REMOVE_PIN,
-    SERVICE_NAME_SET_PIN,
-    SERVICE_NAME_SET_SYSTEM_PROPERTIES,
-)
-
 SERVICE_REMOVE_PIN_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_DEVICE_ID): cv.string,
@@ -192,6 +187,68 @@ WEBSOCKET_EVENTS_TO_FIRE_HASS_EVENT = [
     EVENT_SENSOR_PAIRED_AND_NAMED,
     EVENT_USER_INITIATED_TEST,
 ]
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up SimpliSafe."""
+    _verify_domain_control = verify_domain_control(DOMAIN)
+
+    @callback
+    def extract_system(
+        func: Callable[[ServiceCall, SystemType], Coroutine[Any, Any, None]],
+    ) -> Callable[[ServiceCall], Coroutine[Any, Any, None]]:
+        """Define a decorator to get the correct system for a service call."""
+
+        async def wrapper(call: ServiceCall) -> None:
+            """Wrap the service function."""
+            system = _async_get_system_for_service_call(hass, call)
+
+            try:
+                await func(call, system)
+            except SimplipyError as err:
+                raise HomeAssistantError(
+                    f'Error while executing "{call.service}": {err}'
+                ) from err
+
+        return wrapper
+
+    @_verify_domain_control
+    @extract_system
+    async def async_remove_pin(call: ServiceCall, system: SystemType) -> None:
+        """Remove a PIN."""
+        await system.async_remove_pin(call.data[ATTR_PIN_LABEL_OR_VALUE])
+
+    @_verify_domain_control
+    @extract_system
+    async def async_set_pin(call: ServiceCall, system: SystemType) -> None:
+        """Set a PIN."""
+        await system.async_set_pin(call.data[ATTR_PIN_LABEL], call.data[ATTR_PIN_VALUE])
+
+    @_verify_domain_control
+    @extract_system
+    async def async_set_system_properties(
+        call: ServiceCall, system: SystemType
+    ) -> None:
+        """Set one or more system parameters."""
+        if not isinstance(system, SystemV3):
+            raise HomeAssistantError("Can only set system properties on V3 systems")
+
+        await system.async_set_properties(
+            {prop: value for prop, value in call.data.items() if prop != ATTR_DEVICE_ID}
+        )
+
+    for service, method, schema in (
+        (SERVICE_NAME_REMOVE_PIN, async_remove_pin, SERVICE_REMOVE_PIN_SCHEMA),
+        (SERVICE_NAME_SET_PIN, async_set_pin, SERVICE_SET_PIN_SCHEMA),
+        (
+            SERVICE_NAME_SET_SYSTEM_PROPERTIES,
+            async_set_system_properties,
+            SERVICE_SET_SYSTEM_PROPERTIES_SCHEMA,
+        ),
+    ):
+        async_register_admin_service(hass, DOMAIN, service, method, schema=schema)
+
+    return True
 
 
 @callback
@@ -295,7 +352,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: SimpliSafeConfigEntry) -
     """Set up SimpliSafe as config entry."""
     _async_standardize_config_entry(hass, entry)
 
-    _verify_domain_control = verify_domain_control(DOMAIN)
     websession = aiohttp_client.async_get_clientsession(hass)
 
     try:
@@ -318,64 +374,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: SimpliSafeConfigEntry) -
     entry.runtime_data = simplisafe
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-
-    @callback
-    def extract_system(
-        func: Callable[[ServiceCall, SystemType], Coroutine[Any, Any, None]],
-    ) -> Callable[[ServiceCall], Coroutine[Any, Any, None]]:
-        """Define a decorator to get the correct system for a service call."""
-
-        async def wrapper(call: ServiceCall) -> None:
-            """Wrap the service function."""
-            system = _async_get_system_for_service_call(hass, call)
-
-            try:
-                await func(call, system)
-            except SimplipyError as err:
-                raise HomeAssistantError(
-                    f'Error while executing "{call.service}": {err}'
-                ) from err
-
-        return wrapper
-
-    @_verify_domain_control
-    @extract_system
-    async def async_remove_pin(call: ServiceCall, system: SystemType) -> None:
-        """Remove a PIN."""
-        await system.async_remove_pin(call.data[ATTR_PIN_LABEL_OR_VALUE])
-
-    @_verify_domain_control
-    @extract_system
-    async def async_set_pin(call: ServiceCall, system: SystemType) -> None:
-        """Set a PIN."""
-        await system.async_set_pin(call.data[ATTR_PIN_LABEL], call.data[ATTR_PIN_VALUE])
-
-    @_verify_domain_control
-    @extract_system
-    async def async_set_system_properties(
-        call: ServiceCall, system: SystemType
-    ) -> None:
-        """Set one or more system parameters."""
-        if not isinstance(system, SystemV3):
-            raise HomeAssistantError("Can only set system properties on V3 systems")
-
-        await system.async_set_properties(
-            {prop: value for prop, value in call.data.items() if prop != ATTR_DEVICE_ID}
-        )
-
-    for service, method, schema in (
-        (SERVICE_NAME_REMOVE_PIN, async_remove_pin, SERVICE_REMOVE_PIN_SCHEMA),
-        (SERVICE_NAME_SET_PIN, async_set_pin, SERVICE_SET_PIN_SCHEMA),
-        (
-            SERVICE_NAME_SET_SYSTEM_PROPERTIES,
-            async_set_system_properties,
-            SERVICE_SET_SYSTEM_PROPERTIES_SCHEMA,
-        ),
-    ):
-        if hass.services.has_service(DOMAIN, service):
-            continue
-        # pylint: disable-next=home-assistant-service-registered-in-setup-entry
-        async_register_admin_service(hass, DOMAIN, service, method, schema=schema)
 
     current_options = {**entry.options}
 
@@ -403,15 +401,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: SimpliSafeConfigEntry) -
 
 async def async_unload_entry(hass: HomeAssistant, entry: SimpliSafeConfigEntry) -> bool:
     """Unload a SimpliSafe config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-
-    if not hass.config_entries.async_loaded_entries(DOMAIN):
-        # If this is the last loaded instance of SimpliSafe, deregister any services
-        # defined during integration setup:
-        for service_name in SERVICES:
-            hass.services.async_remove(DOMAIN, service_name)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
 class SimpliSafe:

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -188,6 +188,8 @@ WEBSOCKET_EVENTS_TO_FIRE_HASS_EVENT = [
     EVENT_USER_INITIATED_TEST,
 ]
 
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up SimpliSafe."""


### PR DESCRIPTION
﻿<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Move SimpliSafe service registration from async_setup_entry to async_setup.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170747
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

