### PR TITLE
Extract entities from time triggers and time conditions

### DIFF
--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -57,7 +57,13 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     WEEKDAYS,
 )
-from homeassistant.core import HomeAssistant, State, callback, split_entity_id
+from homeassistant.core import (
+    HomeAssistant,
+    State,
+    callback,
+    split_entity_id,
+    valid_entity_id,
+)
 from homeassistant.exceptions import (
     ConditionError,
     ConditionErrorContainer,
@@ -2118,6 +2124,13 @@ def async_extract_entities(config: ConfigType | Template) -> set[str]:
 
         if condition in ("and", "not", "or"):
             to_process.extend(config["conditions"])
+            continue
+
+        if condition == "time":
+            # The before and after options can be a time or an entity id.
+            for key in (CONF_AFTER, CONF_BEFORE):
+                if isinstance(value := config.get(key), str) and valid_entity_id(value):
+                    referenced.add(value)
             continue
 
         entity_ids = config.get(CONF_ENTITY_ID)

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -28,6 +28,7 @@ from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_UNIT_OF_MEASUREMENT,
     CONF_ALIAS,
+    CONF_AT,
     CONF_DEVICE_ID,
     CONF_ENABLED,
     CONF_ENTITY_ID,
@@ -2052,6 +2053,17 @@ def async_extract_entities(trigger_conf: dict) -> list[str]:
     """Extract entities from a trigger config."""
     if trigger_conf[CONF_PLATFORM] in ("state", "numeric_state"):
         return trigger_conf[CONF_ENTITY_ID]  # type: ignore[no-any-return]
+
+    if trigger_conf[CONF_PLATFORM] == "time":
+        # Each at time can be a time, an entity id, an entity id with
+        # an offset, or a template.
+        entity_ids: list[str] = []
+        for at_time in trigger_conf[CONF_AT]:
+            if isinstance(at_time, str) and valid_entity_id(at_time):
+                entity_ids.append(at_time)
+            elif isinstance(at_time, dict) and CONF_ENTITY_ID in at_time:
+                entity_ids.append(at_time[CONF_ENTITY_ID])
+        return entity_ids
 
     if trigger_conf[CONF_PLATFORM] == "calendar":
         return [trigger_conf[CONF_OPTIONS][CONF_ENTITY_ID]]

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -2134,10 +2134,21 @@ async def test_extract_entities(hass: HomeAssistant) -> None:
                     "entity_id": ["sensor.temperature_9", "sensor.temperature_10"],
                     "below": 110,
                 },
+                {
+                    "condition": "time",
+                    "after": "input_datetime.start",
+                    "before": "sensor.end",
+                },
+                {
+                    "condition": "time",
+                    "after": "08:00:00",
+                },
                 Template("{{ is_state('light.example', 'on') }}", hass),
             ],
         }
     ) == {
+        "input_datetime.start",
+        "sensor.end",
         "sensor.temperature",
         "sensor.temperature_2",
         "sensor.temperature_3",

--- a/tests/helpers/test_trigger.py
+++ b/tests/helpers/test_trigger.py
@@ -5897,6 +5897,23 @@ def mock_test_modern_trigger(hass: HomeAssistant) -> None:
             id="calendar",
         ),
         pytest.param(
+            {"platform": "time", "at": "05:00:00"},
+            [],
+            id="time-plain",
+        ),
+        pytest.param(
+            {
+                "platform": "time",
+                "at": [
+                    "05:00:00",
+                    "input_datetime.alarm",
+                    {"entity_id": "sensor.next_alarm", "offset": "-00:05:00"},
+                ],
+            },
+            ["input_datetime.alarm", "sensor.next_alarm"],
+            id="time-entities",
+        ),
+        pytest.param(
             {
                 "platform": "zone",
                 "options": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

A `time` trigger with `at: input_datetime.alarm` or `at: {entity_id: sensor.next_alarm, offset: ...}`, and a `time` condition with an entity based `before` or `after`, create real runtime dependencies on those entities. The automation fires or evaluates based on their state. Neither contributed anything to the `referenced_entities` of automations and scripts, making these relations invisible to the search integration and the related dialog in the frontend.

This change adds:

- A `time` platform branch to `trigger.async_extract_entities`, extracting entity ids from the `at` list. Each item can be a time, an entity id, an entity id with offset, or a template; plain times and templates are ignored.
- A `time` condition branch to `condition.async_extract_entities`, extracting entity ids from `before` and `after`. Time values fail the `valid_entity_id` guard and are ignored.

Tests: two new parametrized cases in the trigger extraction test (a plain time, and a mixed list of a time, an entity, and an entity with offset, run through real trigger validation), and two time conditions in the condition extraction test (entity based and time based). All fail without the fix.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
