### PR TITLE
fix(smartthings): retry subscription connection errors

### DIFF
--- a/homeassistant/components/smartthings/__init__.py
+++ b/homeassistant/components/smartthings/__init__.py
@@ -193,7 +193,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: SmartThingsConfigEntry) 
             entry.data[CONF_TOKEN][CONF_INSTALLED_APP_ID],
         )
     except SmartThingsConnectionError as err:
-        raise ConfigEntryNotReady("Could not create new subscription") from err
+        raise ConfigEntryNotReady(f"Could not create new subscription: {err}") from err
     except SmartThingsSinkError as err:
         _LOGGER.exception("Couldn't create a new subscription")
         raise ConfigEntryNotReady from err

--- a/homeassistant/components/smartthings/__init__.py
+++ b/homeassistant/components/smartthings/__init__.py
@@ -192,6 +192,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: SmartThingsConfigEntry) 
             entry.data[CONF_LOCATION_ID],
             entry.data[CONF_TOKEN][CONF_INSTALLED_APP_ID],
         )
+    except SmartThingsConnectionError as err:
+        raise ConfigEntryNotReady("Could not create new subscription") from err
     except SmartThingsSinkError as err:
         _LOGGER.exception("Couldn't create a new subscription")
         raise ConfigEntryNotReady from err

--- a/tests/components/smartthings/test_init.py
+++ b/tests/components/smartthings/test_init.py
@@ -199,6 +199,27 @@ async def test_create_subscription_sink_error(
 
 
 @pytest.mark.parametrize("device_fixture", ["da_ac_rac_000001"])
+async def test_create_subscription_connection_error(
+    hass: HomeAssistant,
+    devices: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test handling a connection error when creating a subscription."""
+    assert CONF_SUBSCRIPTION_ID not in mock_config_entry.data
+
+    devices.create_subscription.side_effect = SmartThingsConnectionError(
+        "Connection error"
+    )
+
+    await setup_integration(hass, mock_config_entry)
+
+    devices.subscribe.assert_not_called()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert CONF_SUBSCRIPTION_ID not in mock_config_entry.data
+
+
+@pytest.mark.parametrize("device_fixture", ["da_ac_rac_000001"])
 async def test_update_subscription_identifier(
     hass: HomeAssistant,
     devices: AsyncMock,

--- a/tests/components/smartthings/test_init.py
+++ b/tests/components/smartthings/test_init.py
@@ -216,6 +216,10 @@ async def test_create_subscription_connection_error(
     devices.subscribe.assert_not_called()
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert (
+        mock_config_entry.reason
+        == "Could not create new subscription: Connection error"
+    )
     assert CONF_SUBSCRIPTION_ID not in mock_config_entry.data
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
None.

## Proposed change
Treat `SmartThingsConnectionError` while creating the SmartThings subscription as retryable during config entry setup.

The old-subscription deletion path already raises `ConfigEntryNotReady` for `SmartThingsConnectionError`, but the new-subscription creation path only handled `SmartThingsSinkError`. If SmartThings times out while `create_subscription(...)` is called, the exception currently bubbles out as `setup_error` and the integration remains unavailable until a manual reload.

This adds the missing retry handling and a regression test covering the `create_subscription(...)` connection-error path.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #175505
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Validation run locally:

```bash
uv run --python 3.14 python -m pytest tests/components/smartthings/test_init.py -k 'test_create_subscription_sink_error or test_create_subscription_connection_error'
uv run --python 3.14 ruff check homeassistant/components/smartthings/__init__.py tests/components/smartthings/test_init.py
uv run --python 3.14 ruff format --check homeassistant/components/smartthings/__init__.py tests/components/smartthings/test_init.py
uv run --python 3.14 python -m script.hassfest --integration-path homeassistant/components/smartthings
```

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
