### PR TITLE
Forward from_recorder in recorder EventTypeManager.get

### DIFF
--- a/homeassistant/components/recorder/table_managers/event_types.py
+++ b/homeassistant/components/recorder/table_managers/event_types.py
@@ -56,7 +56,7 @@ class EventTypeManager(BaseLRUTableManager[EventTypes]):
         This call is not thread-safe and must be called from the
         recorder thread.
         """
-        return self.get_many((event_type,), session)[event_type]
+        return self.get_many((event_type,), session, from_recorder)[event_type]
 
     def get_many(
         self,

--- a/tests/components/recorder/table_managers/test_event_types.py
+++ b/tests/components/recorder/table_managers/test_event_types.py
@@ -1,0 +1,39 @@
+"""The tests for the recorder event types manager."""
+
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.recorder.util import session_scope
+from homeassistant.core import HomeAssistant
+
+from tests.typing import RecorderInstanceGenerator
+
+
+@pytest.mark.parametrize(
+    ("from_recorder", "expected_task_queued"),
+    [
+        pytest.param(True, False, id="from_recorder"),
+        pytest.param(False, True, id="not_from_recorder"),
+    ],
+)
+async def test_get_non_existent_event_type(
+    async_setup_recorder_instance: RecorderInstanceGenerator,
+    hass: HomeAssistant,
+    from_recorder: bool,
+    expected_task_queued: bool,
+) -> None:
+    """Test getting a non-existent event type only queues a refresh when needed."""
+    instance = await async_setup_recorder_instance(hass)
+    manager = instance.event_type_manager
+
+    with (
+        session_scope(session=instance.get_session()) as session,
+        patch.object(instance, "queue_task") as mock_queue_task,
+    ):
+        assert manager.get("unknown_event_type", session, from_recorder) is None
+
+    assert mock_queue_task.called == expected_task_queued
+    assert ("unknown_event_type" in manager._non_existent_event_types) is (
+        not expected_task_queued
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`EventTypeManager.get()` accepts a `from_recorder` argument but never passed it on to `get_many()`. The only caller (`Recorder._process_non_state_changed_event_into_session`) passes `from_recorder=True`, so the flag was silently dropped.

As a result, every event type seen for the first time that is not yet in the database took the non-recorder path in `get_many()`: it queued a `RefreshEventTypesTask`, which forces a commit of the open event session (`commit_before = True`) and re-runs a SELECT. The recorder-thread path would have simply recorded the event type in the non-existent LRU cache directly.

This forwards the argument, matching what `StatesMetaManager.get()` already does. Saves a forced commit plus a redundant SELECT for each newly seen event type.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
