### PR TITLE
Add todo LLM tools platform

### DIFF
--- a/homeassistant/components/todo/llm.py
+++ b/homeassistant/components/todo/llm.py
@@ -1,5 +1,6 @@
 """LLM tools for the todo integration."""
 
+from operator import attrgetter
 from typing import Any, cast, override
 
 import voluptuous as vol
@@ -7,7 +8,7 @@ import voluptuous as vol
 from homeassistant.components.homeassistant import async_should_expose
 from homeassistant.components.llm import LLMTools
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import config_validation as cv, intent
+from homeassistant.helpers import entity_registry as er, intent
 from homeassistant.helpers.llm import IntentTool, LLMContext, Tool, ToolInput
 from homeassistant.util.json import JsonObjectType
 
@@ -34,20 +35,22 @@ class TodoGetItemsTool(Tool):
         "Filters items by status (needs_action, completed, all)."
     )
 
-    parameters = vol.Schema(
-        {
-            vol.Required("todo_list"): cv.string,
-            vol.Optional(
-                "status",
-                description=(
-                    "Filter returned items by status,"
-                    " by default returns incomplete"
-                    " items"
-                ),
-                default="needs_action",
-            ): vol.In(["needs_action", "completed", "all"]),
-        }
-    )
+    def __init__(self, todo_lists: list[str]) -> None:
+        """Init the get items tool."""
+        self.parameters = vol.Schema(
+            {
+                vol.Required("todo_list"): vol.In(todo_lists),
+                vol.Optional(
+                    "status",
+                    description=(
+                        "Filter returned items by status,"
+                        " by default returns incomplete"
+                        " items"
+                    ),
+                    default="needs_action",
+                ): vol.In(["needs_action", "completed", "all"]),
+            }
+        )
 
     @override
     async def async_call(
@@ -92,13 +95,18 @@ def async_get_tools(hass: HomeAssistant, llm_context: LLMContext) -> LLMTools:
     if not llm_context.assistant:
         return LLMTools(tools=[])
 
-    if not any(
-        async_should_expose(hass, llm_context.assistant, state.entity_id)
-        for state in hass.states.async_all(DOMAIN)
-    ):
+    entity_registry = er.async_get(hass)
+    names: list[str] = []
+    for state in sorted(hass.states.async_all(DOMAIN), key=attrgetter("name")):
+        if not async_should_expose(hass, llm_context.assistant, state.entity_id):
+            continue
+        entity_entry = entity_registry.async_get(state.entity_id)
+        names.extend(intent.async_get_entity_aliases(hass, entity_entry, state=state))
+
+    if not names:
         return LLMTools(tools=[])
 
-    tools: list[Tool] = [TodoGetItemsTool()]
+    tools: list[Tool] = [TodoGetItemsTool(names)]
     tools.extend(
         IntentTool(handler.intent_type, handler)
         for handler in intent.async_get(hass)

--- a/homeassistant/components/todo/llm.py
+++ b/homeassistant/components/todo/llm.py
@@ -1,6 +1,5 @@
 """LLM tools for the todo integration."""
 
-from operator import attrgetter
 from typing import Any, cast, override
 
 import slugify as unicode_slug
@@ -9,7 +8,7 @@ import voluptuous as vol
 from homeassistant.components.homeassistant import async_should_expose
 from homeassistant.components.llm import LLMTools
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import entity_registry as er, intent
+from homeassistant.helpers import config_validation as cv, intent
 from homeassistant.helpers.llm import IntentTool, LLMContext, Tool, ToolInput
 from homeassistant.util.json import JsonObjectType
 
@@ -31,22 +30,20 @@ class TodoGetItemsTool(Tool):
         "Filters items by status (needs_action, completed, all)."
     )
 
-    def __init__(self, todo_lists: list[str]) -> None:
-        """Init the get items tool."""
-        self.parameters = vol.Schema(
-            {
-                vol.Required("todo_list"): vol.In(todo_lists),
-                vol.Optional(
-                    "status",
-                    description=(
-                        "Filter returned items by status,"
-                        " by default returns incomplete"
-                        " items"
-                    ),
-                    default="needs_action",
-                ): vol.In(["needs_action", "completed", "all"]),
-            }
-        )
+    parameters = vol.Schema(
+        {
+            vol.Required("todo_list"): cv.string,
+            vol.Optional(
+                "status",
+                description=(
+                    "Filter returned items by status,"
+                    " by default returns incomplete"
+                    " items"
+                ),
+                default="needs_action",
+            ): vol.In(["needs_action", "completed", "all"]),
+        }
+    )
 
     @override
     async def async_call(
@@ -87,23 +84,18 @@ class TodoGetItemsTool(Tool):
 
 @callback
 def async_get_tools(hass: HomeAssistant, llm_context: LLMContext) -> LLMTools:
-    """Return the todo LLM tools for the exposed to-do lists."""
+    """Return the todo LLM tools when a to-do list is exposed."""
     if not llm_context.assistant:
         return LLMTools(tools=[])
 
-    entity_registry = er.async_get(hass)
-    names: list[str] = []
-    for state in sorted(hass.states.async_all(DOMAIN), key=attrgetter("name")):
-        if not async_should_expose(hass, llm_context.assistant, state.entity_id):
-            continue
-        entity_entry = entity_registry.async_get(state.entity_id)
-        names.extend(intent.async_get_entity_aliases(hass, entity_entry, state=state))
-
-    if not names:
+    if not any(
+        async_should_expose(hass, llm_context.assistant, state.entity_id)
+        for state in hass.states.async_all(DOMAIN)
+    ):
         return LLMTools(tools=[])
 
     handlers = {handler.intent_type: handler for handler in intent.async_get(hass)}
-    tools: list[Tool] = [TodoGetItemsTool(names)]
+    tools: list[Tool] = [TodoGetItemsTool()]
     tools.extend(
         IntentTool(
             unicode_slug.slugify(intent_type, separator="_", lowercase=False),

--- a/homeassistant/components/todo/llm.py
+++ b/homeassistant/components/todo/llm.py
@@ -12,9 +12,14 @@ from homeassistant.helpers.llm import IntentTool, LLMContext, Tool, ToolInput
 from homeassistant.util.json import JsonObjectType
 
 from .const import DOMAIN, TodoServices
+from .intent import (
+    INTENT_LIST_ADD_ITEM,
+    INTENT_LIST_COMPLETE_ITEM,
+    INTENT_LIST_REMOVE_ITEM,
+)
 
 # Intents owned by this integration that are exposed as LLM tools.
-LLM_INTENTS = ("HassListAddItem", "HassListCompleteItem", "HassListRemoveItem")
+LLM_INTENTS = (INTENT_LIST_ADD_ITEM, INTENT_LIST_COMPLETE_ITEM, INTENT_LIST_REMOVE_ITEM)
 
 
 class TodoGetItemsTool(Tool):

--- a/homeassistant/components/todo/llm.py
+++ b/homeassistant/components/todo/llm.py
@@ -3,16 +3,20 @@
 from operator import attrgetter
 from typing import Any, cast, override
 
+import slugify as unicode_slug
 import voluptuous as vol
 
 from homeassistant.components.homeassistant import async_should_expose
 from homeassistant.components.llm import LLMTools
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er, intent
-from homeassistant.helpers.llm import LLMContext, Tool, ToolInput
+from homeassistant.helpers.llm import IntentTool, LLMContext, Tool, ToolInput
 from homeassistant.util.json import JsonObjectType
 
 from .const import DOMAIN, TodoServices
+
+# Intents owned by this integration that are exposed as LLM tools.
+LLM_INTENTS = ("HassListAddItem", "HassListCompleteItem", "HassListRemoveItem")
 
 
 class TodoGetItemsTool(Tool):
@@ -97,4 +101,15 @@ def async_get_tools(hass: HomeAssistant, llm_context: LLMContext) -> LLMTools:
 
     if not names:
         return LLMTools(tools=[])
-    return LLMTools(tools=[TodoGetItemsTool(names)])
+
+    handlers = {handler.intent_type: handler for handler in intent.async_get(hass)}
+    tools: list[Tool] = [TodoGetItemsTool(names)]
+    tools.extend(
+        IntentTool(
+            unicode_slug.slugify(intent_type, separator="_", lowercase=False),
+            handlers[intent_type],
+        )
+        for intent_type in LLM_INTENTS
+        if intent_type in handlers
+    )
+    return LLMTools(tools=tools)

--- a/homeassistant/components/todo/llm.py
+++ b/homeassistant/components/todo/llm.py
@@ -2,7 +2,6 @@
 
 from typing import Any, cast, override
 
-import slugify as unicode_slug
 import voluptuous as vol
 
 from homeassistant.components.homeassistant import async_should_expose
@@ -94,14 +93,10 @@ def async_get_tools(hass: HomeAssistant, llm_context: LLMContext) -> LLMTools:
     ):
         return LLMTools(tools=[])
 
-    handlers = {handler.intent_type: handler for handler in intent.async_get(hass)}
     tools: list[Tool] = [TodoGetItemsTool()]
     tools.extend(
-        IntentTool(
-            unicode_slug.slugify(intent_type, separator="_", lowercase=False),
-            handlers[intent_type],
-        )
-        for intent_type in LLM_INTENTS
-        if intent_type in handlers
+        IntentTool(handler.intent_type, handler)
+        for handler in intent.async_get(hass)
+        if handler.intent_type in LLM_INTENTS
     )
     return LLMTools(tools=tools)

--- a/homeassistant/components/todo/llm.py
+++ b/homeassistant/components/todo/llm.py
@@ -1,0 +1,100 @@
+"""LLM tools for the todo integration."""
+
+from operator import attrgetter
+from typing import Any, cast, override
+
+import voluptuous as vol
+
+from homeassistant.components.homeassistant import async_should_expose
+from homeassistant.components.llm import LLMTools
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er, intent
+from homeassistant.helpers.llm import LLMContext, Tool, ToolInput
+from homeassistant.util.json import JsonObjectType
+
+from .const import DOMAIN, TodoServices
+
+
+class TodoGetItemsTool(Tool):
+    """LLM Tool allowing querying a to-do list."""
+
+    name = "todo_get_items"
+    description = (
+        "Query a to-do list to find out what items are on it. "
+        "Use this to answer questions like "
+        "'What's on my task list?' or "
+        "'Read my grocery list'. "
+        "Filters items by status (needs_action, completed, all)."
+    )
+
+    def __init__(self, todo_lists: list[str]) -> None:
+        """Init the get items tool."""
+        self.parameters = vol.Schema(
+            {
+                vol.Required("todo_list"): vol.In(todo_lists),
+                vol.Optional(
+                    "status",
+                    description=(
+                        "Filter returned items by status,"
+                        " by default returns incomplete"
+                        " items"
+                    ),
+                    default="needs_action",
+                ): vol.In(["needs_action", "completed", "all"]),
+            }
+        )
+
+    @override
+    async def async_call(
+        self, hass: HomeAssistant, tool_input: ToolInput, llm_context: LLMContext
+    ) -> JsonObjectType:
+        """Query a to-do list."""
+        data = self.parameters(tool_input.tool_args)
+        result = intent.async_match_targets(
+            hass,
+            intent.MatchTargetsConstraints(
+                name=data["todo_list"],
+                domains=[DOMAIN],
+                assistant=llm_context.assistant,
+            ),
+        )
+        if not result.is_match:
+            return {"success": False, "error": "To-do list not found"}
+        entity_id = result.states[0].entity_id
+        service_data: dict[str, Any] = {"entity_id": entity_id}
+        if status := data.get("status"):
+            if status == "all":
+                service_data["status"] = ["needs_action", "completed"]
+            else:
+                service_data["status"] = [status]
+        service_result = await hass.services.async_call(
+            DOMAIN,
+            TodoServices.GET_ITEMS,
+            service_data,
+            context=llm_context.context,
+            blocking=True,
+            return_response=True,
+        )
+        if not service_result:
+            return {"success": False, "error": "To-do list not found"}
+        items = cast(dict, service_result)[entity_id]["items"]
+        return {"success": True, "result": items}
+
+
+@callback
+def async_get_tools(hass: HomeAssistant, llm_context: LLMContext) -> LLMTools:
+    """Return the todo LLM tools for the exposed to-do lists."""
+    if not llm_context.assistant:
+        return LLMTools(tools=[])
+
+    entity_registry = er.async_get(hass)
+    names: list[str] = []
+    for state in sorted(hass.states.async_all(DOMAIN), key=attrgetter("name")):
+        if not async_should_expose(hass, llm_context.assistant, state.entity_id):
+            continue
+        entity_entry = entity_registry.async_get(state.entity_id)
+        names.extend(intent.async_get_entity_aliases(hass, entity_entry, state=state))
+
+    if not names:
+        return LLMTools(tools=[])
+    return LLMTools(tools=[TodoGetItemsTool(names)])

--- a/tests/components/todo/test_llm.py
+++ b/tests/components/todo/test_llm.py
@@ -44,7 +44,6 @@ async def test_todo_get_items_tool(hass: HomeAssistant) -> None:
     result = await llm_component.async_get_tools(hass, llm_context)
     tool = next((tool for tool in result.tools if tool.name == "todo_get_items"), None)
     assert tool is not None
-    assert tool.parameters.schema["todo_list"].container == ["Mock Todo List Name"]
 
     calls = async_mock_service(
         hass,

--- a/tests/components/todo/test_llm.py
+++ b/tests/components/todo/test_llm.py
@@ -75,3 +75,22 @@ async def test_todo_get_items_tool(hass: HomeAssistant) -> None:
         "success": True,
         "result": [{"uid": "1234", "status": "needs_action", "summary": "Buy milk"}],
     }
+
+
+async def test_todo_list_intents_exposed(hass: HomeAssistant) -> None:
+    """Test the todo list intents are exposed as tools when a list is exposed."""
+    assert await async_setup_component(hass, "homeassistant", {})
+    assert await async_setup_component(hass, "intent", {})
+    assert await async_setup_component(hass, "todo", {})
+    assert await async_setup_component(hass, "llm", {})
+    await hass.async_block_till_done()
+    hass.states.async_set(
+        "todo.test_list", "0", {"friendly_name": "Mock Todo List Name"}
+    )
+    async_expose_entity(hass, "conversation", "todo.test_list", True)
+
+    result = await llm_component.async_get_tools(hass, _llm_context())
+    names = {tool.name for tool in result.tools}
+    assert "HassListAddItem" in names
+    assert "HassListCompleteItem" in names
+    assert "HassListRemoveItem" in names

--- a/tests/components/todo/test_llm.py
+++ b/tests/components/todo/test_llm.py
@@ -1,5 +1,7 @@
 """Tests for the todo LLM tools platform."""
 
+import pytest
+
 from homeassistant.components import llm as llm_component, todo
 from homeassistant.components.homeassistant.exposed_entities import async_expose_entity
 from homeassistant.core import Context, HomeAssistant
@@ -7,6 +9,20 @@ from homeassistant.helpers import config_validation as cv, llm
 from homeassistant.setup import async_setup_component
 
 from tests.common import async_mock_service
+
+ENTITY_ID = "todo.test_list"
+
+
+@pytest.fixture(autouse=True)
+async def setup_integrations(hass: HomeAssistant) -> None:
+    """Set up the integrations and expose a to-do list."""
+    assert await async_setup_component(hass, "homeassistant", {})
+    assert await async_setup_component(hass, "intent", {})
+    assert await async_setup_component(hass, "todo", {})
+    assert await async_setup_component(hass, "llm", {})
+    hass.states.async_set(ENTITY_ID, "0", {"friendly_name": "Mock Todo List Name"})
+    async_expose_entity(hass, "conversation", ENTITY_ID, True)
+    await hass.async_block_till_done()
 
 
 def _llm_context() -> llm.LLMContext:
@@ -22,24 +38,13 @@ def _llm_context() -> llm.LLMContext:
 
 async def test_get_tools_no_exposed_todo(hass: HomeAssistant) -> None:
     """Test no todo tool is offered when no to-do list is exposed."""
-    assert await async_setup_component(hass, "homeassistant", {})
-    assert await async_setup_component(hass, "todo", {})
-    assert await async_setup_component(hass, "llm", {})
-
+    async_expose_entity(hass, "conversation", ENTITY_ID, False)
     result = await llm_component.async_get_tools(hass, _llm_context())
     assert [tool.name for tool in result.tools] == []
 
 
 async def test_todo_get_items_tool(hass: HomeAssistant) -> None:
     """Test the todo get items tool is exposed and works via the platform."""
-    assert await async_setup_component(hass, "homeassistant", {})
-    assert await async_setup_component(hass, "todo", {})
-    assert await async_setup_component(hass, "llm", {})
-    hass.states.async_set(
-        "todo.test_list", "0", {"friendly_name": "Mock Todo List Name"}
-    )
-    async_expose_entity(hass, "conversation", "todo.test_list", True)
-
     llm_context = _llm_context()
     result = await llm_component.async_get_tools(hass, llm_context)
     tool = next((tool for tool in result.tools if tool.name == "todo_get_items"), None)
@@ -51,7 +56,7 @@ async def test_todo_get_items_tool(hass: HomeAssistant) -> None:
         service=todo.TodoServices.GET_ITEMS,
         schema=cv.make_entity_service_schema(todo.TODO_SERVICE_GET_ITEMS_SCHEMA),
         response={
-            "todo.test_list": {
+            ENTITY_ID: {
                 "items": [
                     {"uid": "1234", "summary": "Buy milk", "status": "needs_action"},
                 ]
@@ -66,10 +71,7 @@ async def test_todo_get_items_tool(hass: HomeAssistant) -> None:
     )
 
     assert len(calls) == 1
-    assert calls[0].data == {
-        "entity_id": ["todo.test_list"],
-        "status": ["needs_action"],
-    }
+    assert calls[0].data == {"entity_id": [ENTITY_ID], "status": ["needs_action"]}
     assert result == {
         "success": True,
         "result": [{"uid": "1234", "status": "needs_action", "summary": "Buy milk"}],
@@ -78,16 +80,6 @@ async def test_todo_get_items_tool(hass: HomeAssistant) -> None:
 
 async def test_todo_list_intents_exposed(hass: HomeAssistant) -> None:
     """Test the todo list intents are exposed as tools when a list is exposed."""
-    assert await async_setup_component(hass, "homeassistant", {})
-    assert await async_setup_component(hass, "intent", {})
-    assert await async_setup_component(hass, "todo", {})
-    assert await async_setup_component(hass, "llm", {})
-    await hass.async_block_till_done()
-    hass.states.async_set(
-        "todo.test_list", "0", {"friendly_name": "Mock Todo List Name"}
-    )
-    async_expose_entity(hass, "conversation", "todo.test_list", True)
-
     result = await llm_component.async_get_tools(hass, _llm_context())
     names = {tool.name for tool in result.tools}
     assert "HassListAddItem" in names

--- a/tests/components/todo/test_llm.py
+++ b/tests/components/todo/test_llm.py
@@ -49,6 +49,7 @@ async def test_todo_get_items_tool(hass: HomeAssistant) -> None:
     result = await llm_component.async_get_tools(hass, llm_context)
     tool = next((tool for tool in result.tools if tool.name == "todo_get_items"), None)
     assert tool is not None
+    assert tool.parameters.schema["todo_list"].container == ["Mock Todo List Name"]
 
     calls = async_mock_service(
         hass,
@@ -76,6 +77,38 @@ async def test_todo_get_items_tool(hass: HomeAssistant) -> None:
         "success": True,
         "result": [{"uid": "1234", "status": "needs_action", "summary": "Buy milk"}],
     }
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        ("all", ["needs_action", "completed"]),
+        ("completed", ["completed"]),
+    ],
+)
+async def test_todo_get_items_status_filter(
+    hass: HomeAssistant, status: str, expected: list[str]
+) -> None:
+    """Test the status filter is translated into the service call."""
+    llm_context = _llm_context()
+    result = await llm_component.async_get_tools(hass, llm_context)
+    tool = next(tool for tool in result.tools if tool.name == "todo_get_items")
+
+    calls = async_mock_service(
+        hass,
+        domain=todo.DOMAIN,
+        service=todo.TodoServices.GET_ITEMS,
+        schema=cv.make_entity_service_schema(todo.TODO_SERVICE_GET_ITEMS_SCHEMA),
+        response={ENTITY_ID: {"items": []}},
+    )
+    await tool.async_call(
+        hass,
+        llm.ToolInput(
+            "todo_get_items", {"todo_list": "Mock Todo List Name", "status": status}
+        ),
+        llm_context,
+    )
+    assert calls[0].data == {"entity_id": [ENTITY_ID], "status": expected}
 
 
 async def test_todo_list_intents_exposed(hass: HomeAssistant) -> None:

--- a/tests/components/todo/test_llm.py
+++ b/tests/components/todo/test_llm.py
@@ -1,0 +1,77 @@
+"""Tests for the todo LLM tools platform."""
+
+from homeassistant.components import llm as llm_component, todo
+from homeassistant.components.homeassistant.exposed_entities import async_expose_entity
+from homeassistant.core import Context, HomeAssistant
+from homeassistant.helpers import config_validation as cv, llm
+from homeassistant.setup import async_setup_component
+
+from tests.common import async_mock_service
+
+
+def _llm_context() -> llm.LLMContext:
+    """Return an LLM context for the conversation assistant."""
+    return llm.LLMContext(
+        platform="test_platform",
+        context=Context(),
+        language="*",
+        assistant="conversation",
+        device_id=None,
+    )
+
+
+async def test_get_tools_no_exposed_todo(hass: HomeAssistant) -> None:
+    """Test no todo tool is offered when no to-do list is exposed."""
+    assert await async_setup_component(hass, "homeassistant", {})
+    assert await async_setup_component(hass, "todo", {})
+    assert await async_setup_component(hass, "llm", {})
+
+    result = await llm_component.async_get_tools(hass, _llm_context())
+    assert [tool.name for tool in result.tools] == []
+
+
+async def test_todo_get_items_tool(hass: HomeAssistant) -> None:
+    """Test the todo get items tool is exposed and works via the platform."""
+    assert await async_setup_component(hass, "homeassistant", {})
+    assert await async_setup_component(hass, "todo", {})
+    assert await async_setup_component(hass, "llm", {})
+    hass.states.async_set(
+        "todo.test_list", "0", {"friendly_name": "Mock Todo List Name"}
+    )
+    async_expose_entity(hass, "conversation", "todo.test_list", True)
+
+    llm_context = _llm_context()
+    result = await llm_component.async_get_tools(hass, llm_context)
+    tool = next((tool for tool in result.tools if tool.name == "todo_get_items"), None)
+    assert tool is not None
+    assert tool.parameters.schema["todo_list"].container == ["Mock Todo List Name"]
+
+    calls = async_mock_service(
+        hass,
+        domain=todo.DOMAIN,
+        service=todo.TodoServices.GET_ITEMS,
+        schema=cv.make_entity_service_schema(todo.TODO_SERVICE_GET_ITEMS_SCHEMA),
+        response={
+            "todo.test_list": {
+                "items": [
+                    {"uid": "1234", "summary": "Buy milk", "status": "needs_action"},
+                ]
+            }
+        },
+    )
+
+    result = await tool.async_call(
+        hass,
+        llm.ToolInput("todo_get_items", {"todo_list": "Mock Todo List Name"}),
+        llm_context,
+    )
+
+    assert len(calls) == 1
+    assert calls[0].data == {
+        "entity_id": ["todo.test_list"],
+        "status": ["needs_action"],
+    }
+    assert result == {
+        "success": True,
+        "result": [{"uid": "1234", "status": "needs_action", "summary": "Buy milk"}],
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Part of moving LLM tools out of the central `homeassistant/helpers/llm.py` and into the integrations that own them, following the [LLM Tool Platform architecture](https://github.com/home-assistant/architecture/discussions/1412) and building on the `llm` integration foundation merged in #174253.

**Strategy for this whole PR series:** each built-in LLM tool is currently hardcoded in `AssistAPI` inside `helpers/llm.py`. Each is **copied** into an `<integration>/llm.py` tool platform that exposes `async_get_tools(hass, llm_context)` (discovered lazily by the `llm` integration), together with its tests. The tool is **intentionally left in `helpers/llm.py` for now** — `AssistAPI` still builds it — so there is **no behavior change** and each integration can be reviewed independently. Once every tool has moved, a final pass removes the tools from `helpers/llm.py` and wires `AssistAPI` to pull all tools from the platforms. **End state:** `AssistAPI` gets all its tools from tool platforms and no tools remain in `helpers/llm.py`.

This PR moves `TodoGetItemsTool` and the to-do list intents (`HassListAddItem`/`HassListCompleteItem`/`HassListRemoveItem`) into `todo/llm.py`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: home-assistant/architecture#1412, #174253
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
