### PR TITLE
Add GetDateTime LLM tool to the llm integration

### DIFF
--- a/homeassistant/components/llm/llm.py
+++ b/homeassistant/components/llm/llm.py
@@ -1,0 +1,43 @@
+"""LLM tools provided by the llm integration."""
+
+from typing import override
+
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.llm import LLMContext, Tool, ToolInput
+from homeassistant.util import dt as dt_util
+from homeassistant.util.json import JsonObjectType
+
+from . import LLMTools
+
+
+class GetDateTimeTool(Tool):
+    """Tool for getting the current date and time."""
+
+    name = "GetDateTime"
+    description = "Provides the current date and time."
+
+    @override
+    async def async_call(
+        self,
+        hass: HomeAssistant,
+        tool_input: ToolInput,
+        llm_context: LLMContext,
+    ) -> JsonObjectType:
+        """Get the current date and time."""
+        now = dt_util.now()
+
+        return {
+            "success": True,
+            "result": {
+                "date": now.strftime("%Y-%m-%d"),
+                "time": now.strftime("%H:%M:%S"),
+                "timezone": now.strftime("%Z"),
+                "weekday": now.strftime("%A"),
+            },
+        }
+
+
+@callback
+def async_get_tools(hass: HomeAssistant, llm_context: LLMContext) -> LLMTools:
+    """Return the always-available LLM tools."""
+    return LLMTools(tools=[GetDateTimeTool()])

--- a/tests/components/llm/test_init.py
+++ b/tests/components/llm/test_init.py
@@ -71,18 +71,19 @@ async def test_get_tools(hass: HomeAssistant, llm_context: llm.LLMContext) -> No
     assert await async_setup_component(hass, "llm", {})
 
     result = await async_get_tools(hass, llm_context)
-    assert result.tools == [tool]
+    # The llm integration also exposes its own GetDateTime tool (domain "llm").
+    assert [tool.name for tool in result.tools] == ["GetDateTime", "my_tool"]
     assert result.prompt == "use my_tool wisely"
 
 
 async def test_get_tools_empty(
     hass: HomeAssistant, llm_context: llm.LLMContext
 ) -> None:
-    """Test that no platforms yields no tools."""
+    """Test that only the llm integration's own tools are returned by default."""
     assert await async_setup_component(hass, "llm", {})
 
     result = await async_get_tools(hass, llm_context)
-    assert result.tools == []
+    assert [tool.name for tool in result.tools] == ["GetDateTime"]
     assert result.prompt is None
 
 
@@ -99,7 +100,7 @@ async def test_get_tools_merges_sorted(
     assert await async_setup_component(hass, "llm", {})
 
     result = await async_get_tools(hass, llm_context)
-    assert result.tools == [tool_a, tool_b]
+    assert [tool.name for tool in result.tools] == ["GetDateTime", "tool_a", "tool_b"]
     assert result.prompt == "prompt a\nprompt b"
 
 
@@ -116,6 +117,6 @@ async def test_get_tools_isolates_failing_platform(
     assert await async_setup_component(hass, "llm", {})
 
     result = await async_get_tools(hass, llm_context)
-    assert result.tools == [tool]
+    assert [tool.name for tool in result.tools] == ["GetDateTime", "good_tool"]
     assert result.prompt == "prompt"
     assert "Error getting tools from LLM platform test_bad" in caplog.text

--- a/tests/components/llm/test_tools.py
+++ b/tests/components/llm/test_tools.py
@@ -1,0 +1,38 @@
+"""Tests for the LLM integration's own tools platform."""
+
+from freezegun import freeze_time
+
+from homeassistant.components import llm as llm_component
+from homeassistant.core import Context, HomeAssistant
+from homeassistant.helpers import llm
+from homeassistant.setup import async_setup_component
+
+
+def _llm_context() -> llm.LLMContext:
+    """Return an LLM context for the conversation assistant."""
+    return llm.LLMContext(
+        platform="test_platform",
+        context=Context(),
+        language="*",
+        assistant="conversation",
+        device_id=None,
+    )
+
+
+async def test_get_datetime_tool(hass: HomeAssistant) -> None:
+    """Test the GetDateTime tool is always offered and works."""
+    assert await async_setup_component(hass, "homeassistant", {})
+    assert await async_setup_component(hass, "llm", {})
+
+    llm_context = _llm_context()
+    result = await llm_component.async_get_tools(hass, llm_context)
+    tool = next((tool for tool in result.tools if tool.name == "GetDateTime"), None)
+    assert tool is not None
+
+    with freeze_time("2025-09-17 13:00:00-05:00"):
+        response = await tool.async_call(
+            hass, llm.ToolInput("GetDateTime", {}), llm_context
+        )
+
+    assert response["success"] is True
+    assert set(response["result"]) == {"date", "time", "timezone", "weekday"}

--- a/tests/components/llm/test_tools.py
+++ b/tests/components/llm/test_tools.py
@@ -1,11 +1,21 @@
 """Tests for the LLM integration's own tools platform."""
 
 from freezegun import freeze_time
+import pytest
 
 from homeassistant.components import llm as llm_component
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers import llm
 from homeassistant.setup import async_setup_component
+
+
+@pytest.fixture(autouse=True)
+async def setup_integrations(hass: HomeAssistant) -> None:
+    """Set up the integrations for the llm tools platform."""
+    assert await async_setup_component(hass, "homeassistant", {})
+    assert await async_setup_component(hass, "llm", {})
+    await hass.config.async_set_time_zone("UTC")
+    await hass.async_block_till_done()
 
 
 def _llm_context() -> llm.LLMContext:
@@ -20,19 +30,23 @@ def _llm_context() -> llm.LLMContext:
 
 
 async def test_get_datetime_tool(hass: HomeAssistant) -> None:
-    """Test the GetDateTime tool is always offered and works."""
-    assert await async_setup_component(hass, "homeassistant", {})
-    assert await async_setup_component(hass, "llm", {})
-
+    """Test the GetDateTime tool is always offered and returns the current time."""
     llm_context = _llm_context()
     result = await llm_component.async_get_tools(hass, llm_context)
     tool = next((tool for tool in result.tools if tool.name == "GetDateTime"), None)
     assert tool is not None
 
-    with freeze_time("2025-09-17 13:00:00-05:00"):
+    with freeze_time("2025-09-17 13:00:00"):
         response = await tool.async_call(
             hass, llm.ToolInput("GetDateTime", {}), llm_context
         )
 
-    assert response["success"] is True
-    assert set(response["result"]) == {"date", "time", "timezone", "weekday"}
+    assert response == {
+        "success": True,
+        "result": {
+            "date": "2025-09-17",
+            "time": "13:00:00",
+            "timezone": "UTC",
+            "weekday": "Wednesday",
+        },
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Part of moving LLM tools out of the central `homeassistant/helpers/llm.py` and into the integrations that own them, following the [LLM Tool Platform architecture](https://github.com/home-assistant/architecture/discussions/1412) and building on the `llm` integration foundation merged in #174253.

**Strategy for this whole PR series:** each built-in LLM tool is currently hardcoded in `AssistAPI` inside `helpers/llm.py`. Each is **copied** into an `<integration>/llm.py` tool platform that exposes `async_get_tools(hass, llm_context)` (discovered lazily by the `llm` integration), together with its tests. The tool is **intentionally left in `helpers/llm.py` for now** — `AssistAPI` still builds it — so there is **no behavior change** and each integration can be reviewed independently. Once every tool has moved, a final pass removes the tools from `helpers/llm.py` and wires `AssistAPI` to pull all tools from the platforms. **End state:** `AssistAPI` gets all its tools from tool platforms and no tools remain in `helpers/llm.py`.

This PR moves `GetDateTimeTool` into the `llm` integration's own `llm/llm.py` platform.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: home-assistant/architecture#1412, #174253
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
