### PR TITLE
Add intent_script LLM tools platform

### DIFF
--- a/homeassistant/components/intent_script/llm.py
+++ b/homeassistant/components/intent_script/llm.py
@@ -1,5 +1,7 @@
 """LLM tools for the intent_script integration."""
 
+import slugify as unicode_slug
+
 from homeassistant.components.homeassistant import async_should_expose
 from homeassistant.components.llm import LLMTools
 from homeassistant.core import HomeAssistant, callback
@@ -30,7 +32,13 @@ def async_get_tools(hass: HomeAssistant, llm_context: LLMContext) -> LLMTools:
             if handler.platforms is None or handler.platforms & exposed_domains
         ]
 
+    # Intent script names come from user configuration, so slugify them into
+    # valid tool names.
     tools: list[Tool] = [
-        IntentTool(handler.intent_type, handler) for handler in handlers
+        IntentTool(
+            unicode_slug.slugify(handler.intent_type, separator="_", lowercase=False),
+            handler,
+        )
+        for handler in handlers
     ]
     return LLMTools(tools=tools)

--- a/homeassistant/components/intent_script/llm.py
+++ b/homeassistant/components/intent_script/llm.py
@@ -1,0 +1,36 @@
+"""LLM tools for the intent_script integration."""
+
+from homeassistant.components.homeassistant import async_should_expose
+from homeassistant.components.llm import LLMTools
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import intent
+from homeassistant.helpers.llm import IntentTool, LLMContext, Tool
+
+from . import ScriptIntentHandler
+
+
+@callback
+def async_get_tools(hass: HomeAssistant, llm_context: LLMContext) -> LLMTools:
+    """Return an LLM tool for each configured intent script."""
+    handlers = [
+        handler
+        for handler in intent.async_get(hass)
+        if isinstance(handler, ScriptIntentHandler)
+    ]
+
+    if llm_context.assistant is not None:
+        exposed_domains = {
+            state.domain
+            for state in hass.states.async_all()
+            if async_should_expose(hass, llm_context.assistant, state.entity_id)
+        }
+        handlers = [
+            handler
+            for handler in handlers
+            if handler.platforms is None or handler.platforms & exposed_domains
+        ]
+
+    tools: list[Tool] = [
+        IntentTool(handler.intent_type, handler) for handler in handlers
+    ]
+    return LLMTools(tools=tools)

--- a/tests/components/intent_script/test_llm.py
+++ b/tests/components/intent_script/test_llm.py
@@ -1,0 +1,72 @@
+"""Tests for the intent_script LLM tools platform."""
+
+import pytest
+
+from homeassistant.components import llm as llm_component
+from homeassistant.components.homeassistant.exposed_entities import async_expose_entity
+from homeassistant.core import Context, HomeAssistant
+from homeassistant.helpers import llm
+from homeassistant.setup import async_setup_component
+
+LIGHT_ENTITY_ID = "light.kitchen"
+
+
+@pytest.fixture(autouse=True)
+async def setup_integrations(hass: HomeAssistant) -> None:
+    """Set up the integrations and configure intent scripts."""
+    assert await async_setup_component(hass, "homeassistant", {})
+    assert await async_setup_component(hass, "intent", {})
+    assert await async_setup_component(
+        hass,
+        "intent_script",
+        {
+            "intent_script": {
+                "TellJoke": {
+                    "description": "Tell a joke",
+                    "speech": {"text": "Why did the chicken cross the road?"},
+                },
+                "LightAction": {
+                    "description": "Do a light thing",
+                    "platforms": ["light"],
+                    "speech": {"text": "Done"},
+                },
+            }
+        },
+    )
+    assert await async_setup_component(hass, "llm", {})
+    hass.states.async_set(LIGHT_ENTITY_ID, "on", {"friendly_name": "Kitchen Light"})
+    async_expose_entity(hass, "conversation", LIGHT_ENTITY_ID, True)
+    await hass.async_block_till_done()
+
+
+def _llm_context() -> llm.LLMContext:
+    """Return an LLM context for the conversation assistant."""
+    return llm.LLMContext(
+        platform="test_platform",
+        context=Context(),
+        language="*",
+        assistant="conversation",
+        device_id=None,
+    )
+
+
+async def _tool_names(hass: HomeAssistant) -> set[str]:
+    """Return the names of the tools offered by the intent_script platform."""
+    result = await llm_component.async_get_tools(hass, _llm_context())
+    return {tool.name for tool in result.tools}
+
+
+async def test_intent_scripts_exposed(hass: HomeAssistant) -> None:
+    """Test intent scripts are exposed as LLM tools."""
+    names = await _tool_names(hass)
+    assert "TellJoke" in names
+    assert "LightAction" in names
+
+
+async def test_intent_script_platform_filtered(hass: HomeAssistant) -> None:
+    """Test a platform-restricted intent script requires an exposed entity."""
+    async_expose_entity(hass, "conversation", LIGHT_ENTITY_ID, False)
+    names = await _tool_names(hass)
+    assert "LightAction" not in names
+    # Unrestricted intent scripts stay exposed.
+    assert "TellJoke" in names

--- a/tests/components/intent_script/test_llm.py
+++ b/tests/components/intent_script/test_llm.py
@@ -21,7 +21,7 @@ async def setup_integrations(hass: HomeAssistant) -> None:
         "intent_script",
         {
             "intent_script": {
-                "TellJoke": {
+                "Tell a joke": {
                     "description": "Tell a joke",
                     "speech": {"text": "Why did the chicken cross the road?"},
                 },
@@ -57,9 +57,10 @@ async def _tool_names(hass: HomeAssistant) -> set[str]:
 
 
 async def test_intent_scripts_exposed(hass: HomeAssistant) -> None:
-    """Test intent scripts are exposed as LLM tools."""
+    """Test intent scripts are exposed as LLM tools with slugified names."""
     names = await _tool_names(hass)
-    assert "TellJoke" in names
+    # The user-provided "Tell a joke" name is slugified into a valid tool name.
+    assert "Tell_a_joke" in names
     assert "LightAction" in names
 
 
@@ -69,4 +70,4 @@ async def test_intent_script_platform_filtered(hass: HomeAssistant) -> None:
     names = await _tool_names(hass)
     assert "LightAction" not in names
     # Unrestricted intent scripts stay exposed.
-    assert "TellJoke" in names
+    assert "Tell_a_joke" in names


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Part of moving LLM tools out of the central `homeassistant/helpers/llm.py` and into the integrations that own them, following the [LLM Tool Platform architecture](https://github.com/home-assistant/architecture/discussions/1412) and building on the `llm` integration foundation merged in #174253.

**Strategy for this whole PR series:** each built-in LLM tool is currently hardcoded in `AssistAPI` inside `helpers/llm.py`. Each is **copied** into an `<integration>/llm.py` tool platform that exposes `async_get_tools(hass, llm_context)` (discovered lazily by the `llm` integration), together with its tests. The tool is **intentionally left in `helpers/llm.py` for now** — `AssistAPI` still builds it — so there is **no behavior change** and each integration can be reviewed independently. Once every tool has moved, a final pass removes the tools from `helpers/llm.py` and wires `AssistAPI` to pull all tools from the platforms. **End state:** `AssistAPI` gets all its tools from tool platforms and no tools remain in `helpers/llm.py`.

This PR adds `intent_script/llm.py`, exposing each configured intent script as an LLM tool (previously covered by the blanket intent auto-wrap).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: home-assistant/architecture#1412, #174253
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
