### PR TITLE
Add reconfigure flow to WattWächter Plus

### DIFF
--- a/homeassistant/components/wattwaechter/config_flow.py
+++ b/homeassistant/components/wattwaechter/config_flow.py
@@ -247,3 +247,38 @@ class WattwaechterConfigFlow(ConfigFlow, domain=DOMAIN):
             description_placeholders={"host": reauth_entry.data[CONF_HOST]},
             errors=errors,
         )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reconfiguration of the host and token."""
+        reconfigure_entry = self._get_reconfigure_entry()
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            # Keep the stored token when the field is left empty.
+            token = user_input.get(CONF_TOKEN) or reconfigure_entry.data.get(CONF_TOKEN)
+            errors, system_info, _ = await self._async_test_connection(
+                user_input[CONF_HOST], token
+            )
+            if not errors:
+                assert system_info is not None
+                await self.async_set_unique_id(system_info.get_value("esp", "esp_id"))
+                self._abort_if_unique_id_mismatch(reason="wrong_device")
+                return self.async_update_reload_and_abort(
+                    reconfigure_entry,
+                    data_updates={CONF_HOST: user_input[CONF_HOST], CONF_TOKEN: token},
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_HOST, default=reconfigure_entry.data[CONF_HOST]
+                    ): str,
+                    vol.Optional(CONF_TOKEN): str,
+                }
+            ),
+            errors=errors,
+        )

--- a/homeassistant/components/wattwaechter/config_flow.py
+++ b/homeassistant/components/wattwaechter/config_flow.py
@@ -270,15 +270,19 @@ class WattwaechterConfigFlow(ConfigFlow, domain=DOMAIN):
                     data_updates={CONF_HOST: user_input[CONF_HOST], CONF_TOKEN: token},
                 )
 
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_HOST): str,
+                vol.Optional(CONF_TOKEN): str,
+            }
+        )
+        # Preserve the entered host across validation errors without
+        # pre-filling the token field with the stored value.
+        suggested_host = (user_input or reconfigure_entry.data)[CONF_HOST]
         return self.async_show_form(
             step_id="reconfigure",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(
-                        CONF_HOST, default=reconfigure_entry.data[CONF_HOST]
-                    ): str,
-                    vol.Optional(CONF_TOKEN): str,
-                }
+            data_schema=self.add_suggested_values_to_schema(
+                schema, {CONF_HOST: suggested_host}
             ),
             errors=errors,
         )

--- a/homeassistant/components/wattwaechter/config_flow.py
+++ b/homeassistant/components/wattwaechter/config_flow.py
@@ -21,6 +21,11 @@ from homeassistant.const import (
     CONF_TOKEN,
 )
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.selector import (
+    TextSelector,
+    TextSelectorConfig,
+    TextSelectorType,
+)
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .const import CONF_FW_VERSION, DOMAIN
@@ -256,8 +261,7 @@ class WattwaechterConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            # Keep the stored token when the field is left empty.
-            token = user_input.get(CONF_TOKEN) or reconfigure_entry.data.get(CONF_TOKEN)
+            token = user_input.get(CONF_TOKEN)
             errors, system_info, _ = await self._async_test_connection(
                 user_input[CONF_HOST], token
             )
@@ -273,16 +277,15 @@ class WattwaechterConfigFlow(ConfigFlow, domain=DOMAIN):
         schema = vol.Schema(
             {
                 vol.Required(CONF_HOST): str,
-                vol.Optional(CONF_TOKEN): str,
+                vol.Optional(CONF_TOKEN): TextSelector(
+                    TextSelectorConfig(type=TextSelectorType.PASSWORD)
+                ),
             }
         )
-        # Preserve the entered host across validation errors without
-        # pre-filling the token field with the stored value.
-        suggested_host = (user_input or reconfigure_entry.data)[CONF_HOST]
         return self.async_show_form(
             step_id="reconfigure",
             data_schema=self.add_suggested_values_to_schema(
-                schema, {CONF_HOST: suggested_host}
+                schema, user_input or reconfigure_entry.data
             ),
             errors=errors,
         )

--- a/homeassistant/components/wattwaechter/config_flow.py
+++ b/homeassistant/components/wattwaechter/config_flow.py
@@ -261,7 +261,9 @@ class WattwaechterConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            token = user_input.get(CONF_TOKEN)
+            # Normalize a cleared token field to None, matching how token-less
+            # devices are stored everywhere else in the integration.
+            token = user_input.get(CONF_TOKEN) or None
             errors, system_info, _ = await self._async_test_connection(
                 user_input[CONF_HOST], token
             )

--- a/homeassistant/components/wattwaechter/quality_scale.yaml
+++ b/homeassistant/components/wattwaechter/quality_scale.yaml
@@ -68,7 +68,7 @@ rules:
   entity-translations: done
   exception-translations: done
   icon-translations: done
-  reconfiguration-flow: todo
+  reconfiguration-flow: done
   repair-issues:
     status: exempt
     comment: No actionable repair scenarios for this device type.

--- a/homeassistant/components/wattwaechter/strings.json
+++ b/homeassistant/components/wattwaechter/strings.json
@@ -4,7 +4,8 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
-      "wrong_device": "The re-authenticated device does not match the original WattWächter Plus device."
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
+      "wrong_device": "The device does not match the original WattWächter Plus device."
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
@@ -30,6 +31,17 @@
         },
         "description": "The API token for {host} is no longer valid. Enter a new token to reconnect.",
         "title": "Re-authenticate WattWächter Plus"
+      },
+      "reconfigure": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "token": "[%key:common::config_flow::data::api_token%]"
+        },
+        "data_description": {
+          "host": "[%key:component::wattwaechter::config::step::user::data_description::host%]",
+          "token": "Leave empty to keep the current API token."
+        },
+        "title": "Reconfigure WattWächter Plus"
       },
       "user": {
         "data": {

--- a/homeassistant/components/wattwaechter/strings.json
+++ b/homeassistant/components/wattwaechter/strings.json
@@ -39,7 +39,7 @@
         },
         "data_description": {
           "host": "[%key:component::wattwaechter::config::step::user::data_description::host%]",
-          "token": "Leave empty to keep the current API token."
+          "token": "[%key:component::wattwaechter::config::step::auth::data_description::token%]"
         },
         "title": "Reconfigure WattWächter Plus"
       },

--- a/tests/components/wattwaechter/test_config_flow.py
+++ b/tests/components/wattwaechter/test_config_flow.py
@@ -479,3 +479,85 @@ async def test_reauth_flow_wrong_device(
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "wrong_device"
     assert mock_config_entry.data[CONF_TOKEN] == MOCK_TOKEN
+
+
+async def test_reconfigure_flow_success(
+    hass: HomeAssistant,
+    mock_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reconfiguring the host updates the entry and keeps the token."""
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    new_host = "192.168.1.222"
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: new_host}
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert mock_config_entry.data[CONF_HOST] == new_host
+    # Token is preserved when the field is left empty
+    assert mock_config_entry.data[CONF_TOKEN] == MOCK_TOKEN
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "expected_error"),
+    [
+        (WattwaechterAuthenticationError("Invalid token"), "invalid_auth"),
+        (WattwaechterConnectionError("Connection lost"), "cannot_connect"),
+    ],
+)
+async def test_reconfigure_flow_errors(
+    hass: HomeAssistant,
+    mock_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    side_effect: Exception,
+    expected_error: str,
+) -> None:
+    """Test reconfigure recovers after an invalid token or connection failure."""
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+    assert result["step_id"] == "reconfigure"
+
+    mock_client.system_info.side_effect = side_effect
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: MOCK_HOST}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+    assert result["errors"]["base"] == expected_error
+
+    # Retry succeeds once the device is reachable again
+    mock_client.system_info.side_effect = None
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: MOCK_HOST}
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+
+
+async def test_reconfigure_flow_wrong_device(
+    hass: HomeAssistant,
+    mock_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reconfigure aborts when the host points to a different device."""
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+    assert result["step_id"] == "reconfigure"
+
+    mock_client.system_info.return_value = MagicMock(
+        **{"get_value.return_value": "WRONG-DEVICE"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: "192.168.1.222"}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "wrong_device"
+    assert mock_config_entry.data[CONF_HOST] == MOCK_HOST

--- a/tests/components/wattwaechter/test_config_flow.py
+++ b/tests/components/wattwaechter/test_config_flow.py
@@ -492,15 +492,15 @@ async def test_reconfigure_flow_success(
     assert result["step_id"] == "reconfigure"
 
     new_host = "192.168.1.222"
+    # The token field is pre-filled with the stored token and submitted as-is
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {CONF_HOST: new_host}
+        result["flow_id"], {CONF_HOST: new_host, CONF_TOKEN: MOCK_TOKEN}
     )
     await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
     assert mock_config_entry.data[CONF_HOST] == new_host
-    # Token is preserved when the field is left empty
     assert mock_config_entry.data[CONF_TOKEN] == MOCK_TOKEN
 
 

--- a/tests/components/wattwaechter/test_config_flow.py
+++ b/tests/components/wattwaechter/test_config_flow.py
@@ -504,6 +504,25 @@ async def test_reconfigure_flow_success(
     assert mock_config_entry.data[CONF_TOKEN] == MOCK_TOKEN
 
 
+async def test_reconfigure_flow_clear_token(
+    hass: HomeAssistant,
+    mock_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test clearing the token field stores None instead of an empty string."""
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+    assert result["step_id"] == "reconfigure"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: MOCK_HOST, CONF_TOKEN: ""}
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert mock_config_entry.data[CONF_TOKEN] is None
+
+
 @pytest.mark.parametrize(
     ("side_effect", "expected_error"),
     [


### PR DESCRIPTION
## Proposed change

Adds a reconfigure flow to the WattWächter Plus integration, completing the gold `reconfiguration-flow` quality scale rule.

Users can reconfigure an existing entry's host and API token without removing and re-adding the device. The flow validates the connection, verifies the device identity (`esp_id`) against the existing entry — aborting with `wrong_device` if the host now points to a different device — and reloads the entry. The stored token is kept when the token field is left empty, so changing only the host does not clear it.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
