### PR TITLE
Streamline security filter per-request work

### DIFF
--- a/homeassistant/components/http/security_filter.py
+++ b/homeassistant/components/http/security_filter.py
@@ -36,7 +36,7 @@ FILTERS: Final = re.compile(
 # fmt: on
 
 # Unsafe bytes to be removed per WHATWG spec
-UNSAFE_URL_BYTES: Final = re.compile(r"[\t\r\n]")
+UNSAFE_URL_BYTES = ["\t", "\r", "\n"]
 
 
 @callback
@@ -63,18 +63,19 @@ def setup_security_filter(app: Application) -> None:
         else:
             path_with_query_string = request.path
 
-        if UNSAFE_URL_BYTES.search(path_with_query_string):
-            if UNSAFE_URL_BYTES.search(query_string):
+        for unsafe_byte in UNSAFE_URL_BYTES:
+            if unsafe_byte in path_with_query_string:
+                if unsafe_byte in query_string:
+                    _LOGGER.warning(
+                        "Filtered a request with unsafe byte query string: %s",
+                        request.raw_path,
+                    )
+                    raise HTTPBadRequest
                 _LOGGER.warning(
-                    "Filtered a request with unsafe byte query string: %s",
+                    "Filtered a request with an unsafe byte in path: %s",
                     request.raw_path,
                 )
                 raise HTTPBadRequest
-            _LOGGER.warning(
-                "Filtered a request with an unsafe byte in path: %s",
-                request.raw_path,
-            )
-            raise HTTPBadRequest
 
         if FILTERS.search(_recursive_unquote(path_with_query_string)):
             # Check the full path with query string first, if its

--- a/homeassistant/components/http/security_filter.py
+++ b/homeassistant/components/http/security_filter.py
@@ -36,7 +36,7 @@ FILTERS: Final = re.compile(
 # fmt: on
 
 # Unsafe bytes to be removed per WHATWG spec
-UNSAFE_URL_BYTES = ["\t", "\r", "\n"]
+UNSAFE_URL_BYTES: Final = re.compile(r"[\t\r\n]")
 
 
 @callback
@@ -55,27 +55,32 @@ def setup_security_filter(app: Application) -> None:
         request: Request, handler: Callable[[Request], Awaitable[StreamResponse]]
     ) -> StreamResponse:
         """Process request and block commonly known exploit attempts."""
-        path_with_query_string = f"{request.path}?{request.query_string}"
+        query_string = request.query_string
+        # Most requests (WebSocket/API traffic) have no query string; avoid the
+        # concat and only scan the path in that case.
+        if query_string:
+            path_with_query_string = f"{request.path}?{query_string}"
+        else:
+            path_with_query_string = request.path
 
-        for unsafe_byte in UNSAFE_URL_BYTES:
-            if unsafe_byte in path_with_query_string:
-                if unsafe_byte in request.query_string:
-                    _LOGGER.warning(
-                        "Filtered a request with unsafe byte query string: %s",
-                        request.raw_path,
-                    )
-                    raise HTTPBadRequest
+        if UNSAFE_URL_BYTES.search(path_with_query_string):
+            if UNSAFE_URL_BYTES.search(query_string):
                 _LOGGER.warning(
-                    "Filtered a request with an unsafe byte in path: %s",
+                    "Filtered a request with unsafe byte query string: %s",
                     request.raw_path,
                 )
                 raise HTTPBadRequest
+            _LOGGER.warning(
+                "Filtered a request with an unsafe byte in path: %s",
+                request.raw_path,
+            )
+            raise HTTPBadRequest
 
         if FILTERS.search(_recursive_unquote(path_with_query_string)):
             # Check the full path with query string first, if its
             # a hit, than check just the query string to give a more
             # specific warning.
-            if FILTERS.search(_recursive_unquote(request.query_string)):
+            if FILTERS.search(_recursive_unquote(query_string)):
                 _LOGGER.warning(
                     "Filtered a request with a potential harmful query string: %s",
                     request.raw_path,


### PR DESCRIPTION
## Breaking change




## Proposed change


The security filter middleware runs on every single request. This makes one
small, behavior-preserving reduction to that per-request work:

- **Skip the `path?query` concatenation when there is no query string.** The
  vast majority of requests (WebSocket and REST API traffic) carry no query
  string, so in that case we now scan only `request.path` instead of building
  an f-string with a trailing `?`.

The unsafe-byte scan stays as the original per-byte `in` substring checks over
`\t`, `\r`, `\n`. An earlier revision of this PR replaced them with a single
precompiled regex, but the substring `in` checks are faster (they use
`str.__contains__`'s optimized C scan), so that change was reverted.

Behavior is intentionally preserved:
- The unsafe-byte check still runs against the **raw** (non-unquoted) value, so
  percent-encoded control characters (e.g. `%0A`) are **not** newly blocked.
- The `FILTERS` pass still runs against the **recursively unquoted** value.
- Every request that was rejected before is still rejected with the same
  `HTTPBadRequest`, and every request that passed before still passes.

All existing security-filter tests pass unchanged.

## Type of change


- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information


- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist


- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.



To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ```''https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure''```


[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)