### PR TITLE
Check supervisor Unix socket once per request, cheapest condition first

### DIFF
--- a/homeassistant/components/http/const.py
+++ b/homeassistant/components/http/const.py
@@ -10,15 +10,28 @@ DOMAIN: Final = "http"
 
 KEY_HASS_USER: Final = "hass_user"
 KEY_HASS_REFRESH_TOKEN_ID: Final = "hass_refresh_token_id"
+KEY_SUPERVISOR_UNIX_SOCKET: Final = "ha_supervisor_unix_socket"
 
 
 def is_supervisor_unix_socket_request(request: Request) -> bool:
-    """Check if request arrived over the Supervisor Unix socket."""
-    if (transport := request.transport) is None:
-        return False
-    if (http := request.app[KEY_HASS].http) is None or (
-        supervisor_path := http.supervisor_unix_socket_path
-    ) is None:
-        return False
-    sockname: str | None = transport.get_extra_info("sockname")
-    return sockname == str(supervisor_path)
+    """Check if request arrived over the Supervisor Unix socket.
+
+    The result is cached on the request since it is checked by both the ban
+    and auth middlewares.
+    """
+    cached: bool | None = request.get(KEY_SUPERVISOR_UNIX_SOCKET)
+    if cached is not None:
+        return cached
+    # Cheapest check first: without a configured socket path this can never be
+    # a Supervisor Unix socket request, so we avoid probing the transport.
+    if (
+        (http := request.app[KEY_HASS].http) is None
+        or (supervisor_path := http.supervisor_unix_socket_path) is None
+        or (transport := request.transport) is None
+    ):
+        result = False
+    else:
+        sockname: str | None = transport.get_extra_info("sockname")
+        result = sockname == str(supervisor_path)
+    request[KEY_SUPERVISOR_UNIX_SOCKET] = result
+    return result

--- a/tests/components/http/test_const.py
+++ b/tests/components/http/test_const.py
@@ -1,0 +1,52 @@
+"""Tests for the HTTP const helpers."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
+
+from homeassistant.components.http.const import (
+    KEY_SUPERVISOR_UNIX_SOCKET,
+    is_supervisor_unix_socket_request,
+)
+from homeassistant.helpers.http import KEY_HASS
+
+
+def _make_request(supervisor_path: Path | None, sockname: str | None) -> web.Request:
+    """Build a mocked request with the given supervisor socket configuration."""
+    app = web.Application()
+    hass = MagicMock()
+    hass.http.supervisor_unix_socket_path = supervisor_path
+    app[KEY_HASS] = hass
+    transport = MagicMock()
+    transport.get_extra_info.return_value = sockname
+    return make_mocked_request("GET", "/", app=app, transport=transport)
+
+
+def test_supervisor_unix_socket_request_matches() -> None:
+    """Test a request over the Supervisor Unix socket is detected."""
+    path = Path("/run/supervisor.sock")
+    request = _make_request(path, str(path))
+    assert is_supervisor_unix_socket_request(request) is True
+
+
+def test_supervisor_unix_socket_request_no_path_skips_transport() -> None:
+    """Test the transport is not probed when no socket path is configured."""
+    request = _make_request(None, "/run/supervisor.sock")
+    transport = request.transport
+    transport.get_extra_info.reset_mock()
+    assert is_supervisor_unix_socket_request(request) is False
+    transport.get_extra_info.assert_not_called()
+
+
+def test_supervisor_unix_socket_request_is_cached() -> None:
+    """Test the result is computed once and cached on the request."""
+    path = Path("/run/supervisor.sock")
+    request = _make_request(path, str(path))
+    transport = request.transport
+    transport.get_extra_info.reset_mock()
+    assert is_supervisor_unix_socket_request(request) is True
+    assert is_supervisor_unix_socket_request(request) is True
+    transport.get_extra_info.assert_called_once_with("sockname")
+    assert request[KEY_SUPERVISOR_UNIX_SOCKET] is True


### PR DESCRIPTION
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`is_supervisor_unix_socket_request()` is called on every request by **both**
the ban middleware and the auth middleware, so it ran twice per request. It
also fetched `request.transport` and probed
`transport.get_extra_info("sockname")` before checking the cheapest condition
(whether a Supervisor socket path is even configured).

Two small changes:

- **Check the configured socket path first.** On installs without a Supervisor
  Unix socket (no path configured) the function now returns early and never
  touches the transport.
- **Cache the result on the request.** The two middlewares now share a single
  computation per request instead of each recomputing it (which, on Supervisor
  installs, meant two `transport.get_extra_info("sockname")` probes per
  request).

Behavior is unchanged — the same requests are detected as Supervisor Unix
socket requests as before.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXQwLpKCf8FvhWoSc2Jw61)_