### PR TITLE
Trim cached websocket event payload once per event instead of per subscriber

### DIFF
--- a/homeassistant/components/websocket_api/messages.py
+++ b/homeassistant/components/websocket_api/messages.py
@@ -131,7 +131,7 @@ def cached_event_message(message_id_as_bytes: bytes, event: Event) -> bytes:
     """
     return b"".join(
         (
-            _partial_cached_event_message(event)[:-1],
+            _partial_cached_event_message(event),
             b',"id":',
             message_id_as_bytes,
             b"}",
@@ -143,13 +143,14 @@ def cached_event_message(message_id_as_bytes: bytes, event: Event) -> bytes:
 def _partial_cached_event_message(event: Event) -> bytes:
     """Cache and serialize the event to json.
 
-    The message is constructed without the id which appended
-    in cached_event_message.
+    The message is cached without the trailing "}" and without the id, both of
+    which are appended in cached_event_message. Trimming here means the slice
+    happens once per event instead of once per subscriber.
     """
     return (
         _message_to_json_bytes_or_none({"type": "event", "event": event.json_fragment})
         or INVALID_JSON_PARTIAL_MESSAGE
-    )
+    )[:-1]
 
 
 def cached_state_diff_message(
@@ -165,7 +166,7 @@ def cached_state_diff_message(
     """
     return b"".join(
         (
-            _partial_cached_state_diff_message(event)[:-1],
+            _partial_cached_state_diff_message(event),
             b',"id":',
             message_id_as_bytes,
             b"}",
@@ -177,15 +178,16 @@ def cached_state_diff_message(
 def _partial_cached_state_diff_message(event: Event[EventStateChangedData]) -> bytes:
     """Cache and serialize the event to json.
 
-    The message is constructed without the id which
-    will be appended in cached_state_diff_message
+    The message is cached without the trailing "}" and without the id, both of
+    which are appended in cached_state_diff_message. Trimming here means the
+    slice happens once per event instead of once per subscriber.
     """
     return (
         _message_to_json_bytes_or_none(
             {"type": "event", "event": _state_diff_event(event)}
         )
         or INVALID_JSON_PARTIAL_MESSAGE
-    )
+    )[:-1]
 
 
 def _state_diff_event(

--- a/tests/components/websocket_api/test_messages.py
+++ b/tests/components/websocket_api/test_messages.py
@@ -10,6 +10,7 @@ from homeassistant.components.websocket_api.messages import (
 )
 from homeassistant.const import EVENT_STATE_CHANGED
 from homeassistant.core import Context, Event, HomeAssistant, State, callback
+from homeassistant.util.json import json_loads
 
 from tests.common import async_capture_events
 
@@ -50,6 +51,19 @@ async def test_cached_event_message(hass: HomeAssistant) -> None:
     assert cache_info.hits == 3
     assert cache_info.misses == 2
     assert cache_info.currsize == 2
+
+
+async def test_cached_event_message_is_valid_json(hass: HomeAssistant) -> None:
+    """Test the cached event message is valid JSON with the id appended."""
+    events = async_capture_events(hass, EVENT_STATE_CHANGED)
+    hass.states.async_set("light.window", "on")
+    await hass.async_block_till_done()
+
+    parsed = json_loads(cached_event_message(b"2", events[0]))
+
+    assert parsed["id"] == 2
+    assert parsed["type"] == "event"
+    assert parsed["event"]["event_type"] == EVENT_STATE_CHANGED
 
 
 async def test_cached_event_message_with_different_idens(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`cached_event_message` and `cached_state_diff_message` slice the lru-cached
partial payload with `[:-1]` on **every** call, to drop the trailing `}` before
appending `,"id":<id>}`. Because the same event is fanned out to many
subscribers (mostly `state_changed`), that slice produces a full copy of the
serialized event once per subscriber per event.

Move the slice into the `@lru_cache`-backed `_partial_cached_event_message` /
`_partial_cached_state_diff_message` helpers so the cached payload is already
trimmed. The trailing `}` removal now happens once per event instead of once
per event per subscriber. The emitted bytes are unchanged.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXQwLpKCf8FvhWoSc2Jw61)_