### PR TITLE
Expose all LLM APIs on the MCP server keyed by API ID

### DIFF
--- a/homeassistant/components/mcp_server/http.py
+++ b/homeassistant/components/mcp_server/http.py
@@ -8,10 +8,11 @@ The Streamable HTTP protocol uses these HTTP endpoints:
 - /api/mcp: The Streamable HTTP endpoint currently implements the
   stateless protocol for simplicity. This receives client requests and
   sends them to the MCP server, then waits for a response to send back to
-  the client. This serves the configured Assist API and does not require
+  the client. This serves the configured LLM APIs and does not require
   admin access.
 - /api/mcp/<API ID>: The same Streamable HTTP endpoint, but exposing a
-  specific LLM API selected by its ID. These endpoints require admin access.
+  specific LLM API selected by its ID. These endpoints require admin access,
+  except for the Assist API.
 
 The older SSE protocol has two HTTP endpoints:
 
@@ -43,9 +44,10 @@ from mcp.server import InitializationOptions, Server
 from mcp.shared.message import SessionMessage
 
 from homeassistant.components import conversation
-from homeassistant.components.http import KEY_HASS, HomeAssistantView, require_admin
+from homeassistant.components.http import KEY_HASS, HomeAssistantView
 from homeassistant.const import CONF_LLM_HASS_API, CONTENT_TYPE_JSON
 from homeassistant.core import Context, HomeAssistant, callback
+from homeassistant.exceptions import Unauthorized
 from homeassistant.helpers import llm
 
 from .const import DOMAIN
@@ -290,20 +292,14 @@ async def _async_handle_streamable_message(
 class ModelContextProtocolStreamableView(HomeAssistantView):
     """Model Context Protocol Streamable HTTP endpoint.
 
-    This serves the configured Assist API and does not require admin access.
+    This serves the configured LLM APIs and does not require admin access.
     """
 
     name = f"{DOMAIN}:streamable"
     url = STREAMABLE_API
 
-    async def get(self, request: web.Request) -> web.StreamResponse:
-        """Handle unsupported methods."""
-        return web.Response(
-            status=HTTPStatus.METHOD_NOT_ALLOWED, text="Only POST method is supported"
-        )
-
     async def post(self, request: web.Request) -> web.StreamResponse:
-        """Process JSON-RPC messages for the configured Assist API."""
+        """Process JSON-RPC messages for the configured LLM APIs."""
         hass = request.app[KEY_HASS]
         entry = async_get_config_entry(hass)
         return await _async_handle_streamable_message(
@@ -315,23 +311,18 @@ class ModelContextProtocolStreamableApiView(HomeAssistantView):
     """Model Context Protocol Streamable HTTP endpoint for a specific LLM API.
 
     The LLM API is selected by its ID in the URL. These endpoints require
-    admin access.
+    admin access, except for the Assist API.
     """
 
     name = f"{DOMAIN}:streamable_api"
     url = f"{STREAMABLE_API}/{{api_id}}"
 
-    async def get(self, request: web.Request, api_id: str) -> web.StreamResponse:
-        """Handle unsupported methods."""
-        return web.Response(
-            status=HTTPStatus.METHOD_NOT_ALLOWED, text="Only POST method is supported"
-        )
-
-    @require_admin
     async def post(self, request: web.Request, api_id: str) -> web.StreamResponse:
         """Process JSON-RPC messages for the LLM API identified by api_id."""
         hass = request.app[KEY_HASS]
         async_get_config_entry(hass)
+        if api_id != llm.LLM_API_ASSIST and not request["hass_user"].is_admin:
+            raise Unauthorized
         if api_id not in {api.id for api in llm.async_get_apis(hass)}:
             raise HTTPNotFound(text=f"Unknown LLM API '{api_id}'")
         return await _async_handle_streamable_message(

--- a/homeassistant/components/mcp_server/http.py
+++ b/homeassistant/components/mcp_server/http.py
@@ -3,12 +3,15 @@
 This registers HTTP endpoints that support the Streamable HTTP protocol as
 well as the older SSE as a transport layer.
 
-The Streamable HTTP protocol uses a single HTTP endpoint:
+The Streamable HTTP protocol uses these HTTP endpoints:
 
-- /api/mcp_server: The Streamable HTTP endpoint currently implements the
+- /api/mcp: The Streamable HTTP endpoint currently implements the
   stateless protocol for simplicity. This receives client requests and
   sends them to the MCP server, then waits for a response to send back to
-  the client.
+  the client. This serves the configured Assist API and does not require
+  admin access.
+- /api/mcp/<API ID>: The same Streamable HTTP endpoint, but exposing a
+  specific LLM API selected by its ID. These endpoints require admin access.
 
 The older SSE protocol has two HTTP endpoints:
 
@@ -40,7 +43,7 @@ from mcp.server import InitializationOptions, Server
 from mcp.shared.message import SessionMessage
 
 from homeassistant.components import conversation
-from homeassistant.components.http import KEY_HASS, HomeAssistantView
+from homeassistant.components.http import KEY_HASS, HomeAssistantView, require_admin
 from homeassistant.const import CONF_LLM_HASS_API, CONTENT_TYPE_JSON
 from homeassistant.core import Context, HomeAssistant, callback
 from homeassistant.helpers import llm
@@ -67,6 +70,7 @@ def async_register(hass: HomeAssistant) -> None:
     hass.http.register_view(ModelContextProtocolSSEView())
     hass.http.register_view(ModelContextProtocolMessagesView())
     hass.http.register_view(ModelContextProtocolStreamableView())
+    hass.http.register_view(ModelContextProtocolStreamableApiView())
 
 
 def async_get_config_entry(hass: HomeAssistant) -> MCPServerConfigEntry:
@@ -127,7 +131,7 @@ async def create_streams() -> AsyncGenerator[Streams]:
 
 
 async def create_mcp_server(
-    hass: HomeAssistant, context: Context, entry: MCPServerConfigEntry
+    hass: HomeAssistant, context: Context, llm_api_id: str | list[str]
 ) -> tuple[Server, InitializationOptions]:
     """Initialize the MCP server to ensure it's ready to handle requests."""
     llm_context = llm.LLMContext(
@@ -137,7 +141,6 @@ async def create_mcp_server(
         assistant=conversation.DOMAIN,
         device_id=None,
     )
-    llm_api_id = entry.data[CONF_LLM_HASS_API]
     server = await create_server(hass, llm_api_id, llm_context)
     options = await hass.async_add_executor_job(
         server.create_initialization_options  # Reads package for version info
@@ -165,7 +168,9 @@ class ModelContextProtocolSSEView(HomeAssistantView):
         entry = async_get_config_entry(hass)
         session_manager = entry.runtime_data
 
-        server, options = await create_mcp_server(hass, self.context(request), entry)
+        server, options = await create_mcp_server(
+            hass, self.context(request), entry.data[CONF_LLM_HASS_API]
+        )
 
         async with (
             create_streams() as streams,
@@ -231,8 +236,62 @@ class ModelContextProtocolMessagesView(HomeAssistantView):
         return web.Response(status=200)
 
 
+async def _async_handle_streamable_message(
+    request: web.Request, context: Context, llm_api_id: str | list[str]
+) -> web.StreamResponse:
+    """Process a single JSON-RPC message for the given LLM API."""
+    hass = request.app[KEY_HASS]
+
+    # The request must include a JSON-RPC message
+    if CONTENT_TYPE_JSON not in request.headers.get("accept", ""):
+        raise HTTPBadRequest(text=f"Client must accept {CONTENT_TYPE_JSON}")
+    if request.content_type != CONTENT_TYPE_JSON:
+        raise HTTPBadRequest(text=f"Content-Type must be {CONTENT_TYPE_JSON}")
+    try:
+        json_data = await request.json()
+        message = types.JSONRPCMessage.model_validate(json_data)
+    except ValueError as err:
+        _LOGGER.debug("Failed to parse message as JSON-RPC message: %s", err)
+        raise HTTPBadRequest(text="Request must be a JSON-RPC message") from err
+
+    _LOGGER.debug("Received client message: %s", message)
+
+    # For notifications and responses only, return 202 Accepted
+    if not isinstance(message.root, JSONRPCRequest):
+        _LOGGER.debug("Notification or response received, returning 202")
+        return web.Response(status=HTTPStatus.ACCEPTED)
+
+    # The MCP server runs as a background task for the duration of the
+    # request. We open a buffered stream pair to communicate with it. The
+    # request is sent to the MCP server and we wait for a single response
+    # then shut down the server.
+    server, options = await create_mcp_server(hass, context, llm_api_id)
+
+    async with create_streams() as streams:
+
+        async def run_server() -> None:
+            await server.run(
+                streams.read_stream, streams.write_stream, options, stateless=True
+            )
+
+        async with asyncio.timeout(TIMEOUT), anyio.create_task_group() as tg:
+            tg.start_soon(run_server)
+
+            await streams.read_stream_writer.send(SessionMessage(message))
+            session_message = await anext(streams.write_stream_reader)
+            tg.cancel_scope.cancel()
+
+        _LOGGER.debug("Sending response: %s", session_message)
+        return web.json_response(
+            data=session_message.message.model_dump(by_alias=True, exclude_none=True),
+        )
+
+
 class ModelContextProtocolStreamableView(HomeAssistantView):
-    """Model Context Protocol Streamable HTTP endpoint."""
+    """Model Context Protocol Streamable HTTP endpoint.
+
+    This serves the configured Assist API and does not require admin access.
+    """
 
     name = f"{DOMAIN}:streamable"
     url = STREAMABLE_API
@@ -244,52 +303,37 @@ class ModelContextProtocolStreamableView(HomeAssistantView):
         )
 
     async def post(self, request: web.Request) -> web.StreamResponse:
-        """Process JSON-RPC messages for the Model Context Protocol."""
+        """Process JSON-RPC messages for the configured Assist API."""
         hass = request.app[KEY_HASS]
         entry = async_get_config_entry(hass)
+        return await _async_handle_streamable_message(
+            request, self.context(request), entry.data[CONF_LLM_HASS_API]
+        )
 
-        # The request must include a JSON-RPC message
-        if CONTENT_TYPE_JSON not in request.headers.get("accept", ""):
-            raise HTTPBadRequest(text=f"Client must accept {CONTENT_TYPE_JSON}")
-        if request.content_type != CONTENT_TYPE_JSON:
-            raise HTTPBadRequest(text=f"Content-Type must be {CONTENT_TYPE_JSON}")
-        try:
-            json_data = await request.json()
-            message = types.JSONRPCMessage.model_validate(json_data)
-        except ValueError as err:
-            _LOGGER.debug("Failed to parse message as JSON-RPC message: %s", err)
-            raise HTTPBadRequest(text="Request must be a JSON-RPC message") from err
 
-        _LOGGER.debug("Received client message: %s", message)
+class ModelContextProtocolStreamableApiView(HomeAssistantView):
+    """Model Context Protocol Streamable HTTP endpoint for a specific LLM API.
 
-        # For notifications and responses only, return 202 Accepted
-        if not isinstance(message.root, JSONRPCRequest):
-            _LOGGER.debug("Notification or response received, returning 202")
-            return web.Response(status=HTTPStatus.ACCEPTED)
+    The LLM API is selected by its ID in the URL. These endpoints require
+    admin access.
+    """
 
-        # The MCP server runs as a background task for the duration of the
-        # request. We open a buffered stream pair to communicate with it. The
-        # request is sent to the MCP server and we wait for a single response
-        # then shut down the server.
-        server, options = await create_mcp_server(hass, self.context(request), entry)
+    name = f"{DOMAIN}:streamable_api"
+    url = f"{STREAMABLE_API}/{{api_id}}"
 
-        async with create_streams() as streams:
+    async def get(self, request: web.Request, api_id: str) -> web.StreamResponse:
+        """Handle unsupported methods."""
+        return web.Response(
+            status=HTTPStatus.METHOD_NOT_ALLOWED, text="Only POST method is supported"
+        )
 
-            async def run_server() -> None:
-                await server.run(
-                    streams.read_stream, streams.write_stream, options, stateless=True
-                )
-
-            async with asyncio.timeout(TIMEOUT), anyio.create_task_group() as tg:
-                tg.start_soon(run_server)
-
-                await streams.read_stream_writer.send(SessionMessage(message))
-                session_message = await anext(streams.write_stream_reader)
-                tg.cancel_scope.cancel()
-
-            _LOGGER.debug("Sending response: %s", session_message)
-            return web.json_response(
-                data=session_message.message.model_dump(
-                    by_alias=True, exclude_none=True
-                ),
-            )
+    @require_admin
+    async def post(self, request: web.Request, api_id: str) -> web.StreamResponse:
+        """Process JSON-RPC messages for the LLM API identified by api_id."""
+        hass = request.app[KEY_HASS]
+        async_get_config_entry(hass)
+        if api_id not in {api.id for api in llm.async_get_apis(hass)}:
+            raise HTTPNotFound(text=f"Unknown LLM API '{api_id}'")
+        return await _async_handle_streamable_message(
+            request, self.context(request), api_id
+        )

--- a/homeassistant/components/mcp_server/http.py
+++ b/homeassistant/components/mcp_server/http.py
@@ -320,7 +320,6 @@ class ModelContextProtocolStreamableApiView(HomeAssistantView):
     async def post(self, request: web.Request, api_id: str) -> web.StreamResponse:
         """Process JSON-RPC messages for the LLM API identified by api_id."""
         hass = request.app[KEY_HASS]
-        async_get_config_entry(hass)
         if api_id != llm.LLM_API_ASSIST and not request["hass_user"].is_admin:
             raise Unauthorized
         if api_id not in {api.id for api in llm.async_get_apis(hass)}:

--- a/tests/components/mcp_server/test_http.py
+++ b/tests/components/mcp_server/test_http.py
@@ -26,7 +26,12 @@ from homeassistant.components.mcp_server.http import (
     STREAMABLE_API,
 )
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import CONF_LLM_HASS_API, STATE_OFF, STATE_ON
+from homeassistant.const import (
+    CONF_LLM_HASS_API,
+    CONTENT_TYPE_JSON,
+    STATE_OFF,
+    STATE_ON,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import (
     area_registry as ar,
@@ -633,3 +638,58 @@ async def test_mcp_tool_call_unicode(
     response_text = result.content[0].text
     assert "这是一个测试" in response_text
     assert "\\u" not in response_text
+
+
+async def test_streamable_api_id_exposes_registered_api(
+    hass: HomeAssistant,
+    setup_integration: None,
+    hass_client: ClientSessionGenerator,
+    hass_supervisor_access_token: str,
+) -> None:
+    """Test the keyed endpoint exposes any registered API, not just the configured one."""
+    llm.async_register_api(
+        hass, MockLLMAPI(hass=hass, id=TEST_LLM_API_ID, name="Test API")
+    )
+
+    client = await hass_client()
+    mcp_url = str(client.make_url(f"{STREAMABLE_API}/{TEST_LLM_API_ID}"))
+
+    async with mcp_streamable_session(
+        hass, mcp_url, hass_supervisor_access_token
+    ) as session:
+        result = await session.list_prompts()
+
+    assert len(result.prompts) == 1
+    assert result.prompts[0].name == "Test API"
+
+
+async def test_streamable_api_id_requires_admin(
+    hass: HomeAssistant,
+    setup_integration: None,
+    hass_client: ClientSessionGenerator,
+    hass_read_only_access_token: str,
+) -> None:
+    """Test the keyed endpoint requires an admin user."""
+    client = await hass_client(hass_read_only_access_token)
+    response = await client.post(
+        f"{STREAMABLE_API}/{llm.LLM_API_ASSIST}",
+        json=INITIALIZE_MESSAGE,
+        headers={"accept": CONTENT_TYPE_JSON},
+    )
+    assert response.status == HTTPStatus.UNAUTHORIZED
+
+
+async def test_streamable_api_id_unknown(
+    hass: HomeAssistant,
+    setup_integration: None,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test the keyed endpoint returns 404 for an unknown API ID."""
+    client = await hass_client()
+    response = await client.post(
+        f"{STREAMABLE_API}/does-not-exist",
+        json=INITIALIZE_MESSAGE,
+        headers={"accept": CONTENT_TYPE_JSON},
+    )
+    assert response.status == HTTPStatus.NOT_FOUND
+    assert "Unknown LLM API" in await response.text()

--- a/tests/components/mcp_server/test_http.py
+++ b/tests/components/mcp_server/test_http.py
@@ -669,14 +669,34 @@ async def test_streamable_api_id_requires_admin(
     hass_client: ClientSessionGenerator,
     hass_read_only_access_token: str,
 ) -> None:
-    """Test the keyed endpoint requires an admin user."""
+    """Test a non-Assist keyed endpoint requires an admin user."""
+    llm.async_register_api(
+        hass, MockLLMAPI(hass=hass, id=TEST_LLM_API_ID, name="Test API")
+    )
+
+    client = await hass_client(hass_read_only_access_token)
+    response = await client.post(
+        f"{STREAMABLE_API}/{TEST_LLM_API_ID}",
+        json=INITIALIZE_MESSAGE,
+        headers={"accept": CONTENT_TYPE_JSON},
+    )
+    assert response.status == HTTPStatus.UNAUTHORIZED
+
+
+async def test_streamable_api_id_assist_allows_non_admin(
+    hass: HomeAssistant,
+    setup_integration: None,
+    hass_client: ClientSessionGenerator,
+    hass_read_only_access_token: str,
+) -> None:
+    """Test the Assist keyed endpoint does not require an admin user."""
     client = await hass_client(hass_read_only_access_token)
     response = await client.post(
         f"{STREAMABLE_API}/{llm.LLM_API_ASSIST}",
         json=INITIALIZE_MESSAGE,
         headers={"accept": CONTENT_TYPE_JSON},
     )
-    assert response.status == HTTPStatus.UNAUTHORIZED
+    assert response.status == HTTPStatus.OK
 
 
 async def test_streamable_api_id_unknown(


### PR DESCRIPTION
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

This is **not** a breaking change. The existing `/api/mcp` endpoint keeps behaving exactly as before, and no configuration changes are required.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Expose every available LLM API on the MCP server, each keyed by its API ID and added onto the existing streamable HTTP endpoint:

- `/api/mcp` — unchanged. Serves the LLM APIs configured on the config entry and does **not** require admin access.
- `/api/mcp/<API ID>` — new. Serves a single LLM API selected by its ID. These endpoints require **admin** access, **except** for the Assist API, which stays available to non-admin users (matching the base endpoint). An unknown API ID returns `404`.

This lets any registered LLM API be reached over MCP without having to pre-select it in the config entry, while keeping the default Assist experience open to non-admins.

### Question for maintainers

Should we deprecate in a future PR the picking which APIs to expose on the "main" `/api/mcp` endpoint? Now that every API is individually addressable at `/api/mcp/<API ID>`, selecting a set of APIs to merge onto the base endpoint isn't the direction we want to move forward in. The idea would be to deprecate the selection (base endpoint becomes just Assist going forward) while keeping existing configurations working for anyone who already relies on it. This PR does not change that behavior yet — flagging it here to decide the path before doing so.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sgz6t67kM4i92GABraXEpK)_