### PR TITLE
Pass API ID to LLM tools platforms and let them opt out

### DIFF
--- a/homeassistant/components/calendar/llm.py
+++ b/homeassistant/components/calendar/llm.py
@@ -86,7 +86,9 @@ class CalendarGetEventsTool(Tool):
 
 
 @callback
-def async_get_tools(hass: HomeAssistant, llm_context: LLMContext) -> LLMTools:
+def async_get_tools(
+    hass: HomeAssistant, llm_context: LLMContext, api_id: str
+) -> LLMTools:
     """Return the calendar LLM tools when a calendar is exposed."""
     entity_registry = er.async_get(hass)
     names: list[str] = []

--- a/homeassistant/components/calendar/llm.py
+++ b/homeassistant/components/calendar/llm.py
@@ -10,7 +10,7 @@ from homeassistant.components.homeassistant import async_should_expose
 from homeassistant.components.llm import LLMTools
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er, intent
-from homeassistant.helpers.llm import LLMContext, Tool, ToolInput
+from homeassistant.helpers.llm import LLM_API_ASSIST, LLMContext, Tool, ToolInput
 from homeassistant.util import dt as dt_util
 from homeassistant.util.json import JsonObjectType
 
@@ -88,8 +88,11 @@ class CalendarGetEventsTool(Tool):
 @callback
 def async_get_tools(
     hass: HomeAssistant, llm_context: LLMContext, api_id: str
-) -> LLMTools:
+) -> LLMTools | None:
     """Return the calendar LLM tools when a calendar is exposed."""
+    if api_id != LLM_API_ASSIST:
+        return None
+
     entity_registry = er.async_get(hass)
     names: list[str] = []
     for state in sorted(hass.states.async_all(DOMAIN), key=attrgetter("name")):

--- a/homeassistant/components/calendar/llm.py
+++ b/homeassistant/components/calendar/llm.py
@@ -102,5 +102,5 @@ def async_get_tools(
         names.extend(intent.async_get_entity_aliases(hass, entity_entry, state=state))
 
     if not names:
-        return LLMTools(tools=[])
+        return None
     return LLMTools(tools=[CalendarGetEventsTool(names)])

--- a/homeassistant/components/climate/llm.py
+++ b/homeassistant/components/climate/llm.py
@@ -13,7 +13,9 @@ LLM_INTENTS = (INTENT_SET_TEMPERATURE,)
 
 
 @callback
-def async_get_tools(hass: HomeAssistant, llm_context: LLMContext) -> LLMTools:
+def async_get_tools(
+    hass: HomeAssistant, llm_context: LLMContext, api_id: str
+) -> LLMTools:
     """Return LLM tools for the integration's intents when its domain is exposed."""
     if not llm_context.assistant:
         return LLMTools(tools=[])

--- a/homeassistant/components/climate/llm.py
+++ b/homeassistant/components/climate/llm.py
@@ -21,13 +21,13 @@ def async_get_tools(
         return None
 
     if not llm_context.assistant:
-        return LLMTools(tools=[])
+        return None
 
     if not any(
         async_should_expose(hass, llm_context.assistant, state.entity_id)
         for state in hass.states.async_all(DOMAIN)
     ):
-        return LLMTools(tools=[])
+        return None
 
     tools: list[Tool] = [
         IntentTool(handler.intent_type, handler)

--- a/homeassistant/components/climate/llm.py
+++ b/homeassistant/components/climate/llm.py
@@ -4,7 +4,7 @@ from homeassistant.components.homeassistant import async_should_expose
 from homeassistant.components.llm import LLMTools
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import intent
-from homeassistant.helpers.llm import IntentTool, LLMContext, Tool
+from homeassistant.helpers.llm import LLM_API_ASSIST, IntentTool, LLMContext, Tool
 
 from .const import DOMAIN, INTENT_SET_TEMPERATURE
 
@@ -15,8 +15,11 @@ LLM_INTENTS = (INTENT_SET_TEMPERATURE,)
 @callback
 def async_get_tools(
     hass: HomeAssistant, llm_context: LLMContext, api_id: str
-) -> LLMTools:
+) -> LLMTools | None:
     """Return LLM tools for the integration's intents when its domain is exposed."""
+    if api_id != LLM_API_ASSIST:
+        return None
+
     if not llm_context.assistant:
         return LLMTools(tools=[])
 

--- a/homeassistant/components/fan/llm.py
+++ b/homeassistant/components/fan/llm.py
@@ -14,7 +14,9 @@ LLM_INTENTS = (INTENT_FAN_SET_SPEED,)
 
 
 @callback
-def async_get_tools(hass: HomeAssistant, llm_context: LLMContext) -> LLMTools:
+def async_get_tools(
+    hass: HomeAssistant, llm_context: LLMContext, api_id: str
+) -> LLMTools:
     """Return LLM tools for the integration's intents when its domain is exposed."""
     if not llm_context.assistant:
         return LLMTools(tools=[])

--- a/homeassistant/components/fan/llm.py
+++ b/homeassistant/components/fan/llm.py
@@ -22,13 +22,13 @@ def async_get_tools(
         return None
 
     if not llm_context.assistant:
-        return LLMTools(tools=[])
+        return None
 
     if not any(
         async_should_expose(hass, llm_context.assistant, state.entity_id)
         for state in hass.states.async_all(DOMAIN)
     ):
-        return LLMTools(tools=[])
+        return None
 
     tools: list[Tool] = [
         IntentTool(handler.intent_type, handler)

--- a/homeassistant/components/fan/llm.py
+++ b/homeassistant/components/fan/llm.py
@@ -4,7 +4,7 @@ from homeassistant.components.homeassistant import async_should_expose
 from homeassistant.components.llm import LLMTools
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import intent
-from homeassistant.helpers.llm import IntentTool, LLMContext, Tool
+from homeassistant.helpers.llm import LLM_API_ASSIST, IntentTool, LLMContext, Tool
 
 from . import DOMAIN
 from .intent import INTENT_FAN_SET_SPEED
@@ -16,8 +16,11 @@ LLM_INTENTS = (INTENT_FAN_SET_SPEED,)
 @callback
 def async_get_tools(
     hass: HomeAssistant, llm_context: LLMContext, api_id: str
-) -> LLMTools:
+) -> LLMTools | None:
     """Return LLM tools for the integration's intents when its domain is exposed."""
+    if api_id != LLM_API_ASSIST:
+        return None
+
     if not llm_context.assistant:
         return LLMTools(tools=[])
 

--- a/homeassistant/components/intent_script/llm.py
+++ b/homeassistant/components/intent_script/llm.py
@@ -12,7 +12,9 @@ from . import ScriptIntentHandler
 
 
 @callback
-def async_get_tools(hass: HomeAssistant, llm_context: LLMContext) -> LLMTools:
+def async_get_tools(
+    hass: HomeAssistant, llm_context: LLMContext, api_id: str
+) -> LLMTools:
     """Return an LLM tool for each configured intent script."""
     handlers = [
         handler

--- a/homeassistant/components/intent_script/llm.py
+++ b/homeassistant/components/intent_script/llm.py
@@ -36,6 +36,9 @@ def async_get_tools(
         if handler.platforms is None or handler.platforms & exposed_domains
     ]
 
+    if not handlers:
+        return None
+
     # Intent script names come from user configuration, so slugify them into
     # valid tool names.
     tools: list[Tool] = [

--- a/homeassistant/components/intent_script/llm.py
+++ b/homeassistant/components/intent_script/llm.py
@@ -6,7 +6,7 @@ from homeassistant.components.homeassistant import async_should_expose
 from homeassistant.components.llm import LLMTools
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import intent
-from homeassistant.helpers.llm import IntentTool, LLMContext, Tool
+from homeassistant.helpers.llm import LLM_API_ASSIST, IntentTool, LLMContext, Tool
 
 from . import ScriptIntentHandler
 
@@ -14,8 +14,11 @@ from . import ScriptIntentHandler
 @callback
 def async_get_tools(
     hass: HomeAssistant, llm_context: LLMContext, api_id: str
-) -> LLMTools:
+) -> LLMTools | None:
     """Return an LLM tool for each configured intent script."""
+    if api_id != LLM_API_ASSIST:
+        return None
+
     handlers = [
         handler
         for handler in intent.async_get(hass)

--- a/homeassistant/components/lawn_mower/llm.py
+++ b/homeassistant/components/lawn_mower/llm.py
@@ -14,7 +14,9 @@ LLM_INTENTS = (INTENT_LANW_MOWER_DOCK, INTENT_LANW_MOWER_START_MOWING)
 
 
 @callback
-def async_get_tools(hass: HomeAssistant, llm_context: LLMContext) -> LLMTools:
+def async_get_tools(
+    hass: HomeAssistant, llm_context: LLMContext, api_id: str
+) -> LLMTools:
     """Return LLM tools for the integration's intents when its domain is exposed."""
     if not llm_context.assistant:
         return LLMTools(tools=[])

--- a/homeassistant/components/lawn_mower/llm.py
+++ b/homeassistant/components/lawn_mower/llm.py
@@ -22,13 +22,13 @@ def async_get_tools(
         return None
 
     if not llm_context.assistant:
-        return LLMTools(tools=[])
+        return None
 
     if not any(
         async_should_expose(hass, llm_context.assistant, state.entity_id)
         for state in hass.states.async_all(DOMAIN)
     ):
-        return LLMTools(tools=[])
+        return None
 
     tools: list[Tool] = [
         IntentTool(handler.intent_type, handler)

--- a/homeassistant/components/lawn_mower/llm.py
+++ b/homeassistant/components/lawn_mower/llm.py
@@ -4,7 +4,7 @@ from homeassistant.components.homeassistant import async_should_expose
 from homeassistant.components.llm import LLMTools
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import intent
-from homeassistant.helpers.llm import IntentTool, LLMContext, Tool
+from homeassistant.helpers.llm import LLM_API_ASSIST, IntentTool, LLMContext, Tool
 
 from .const import DOMAIN
 from .intent import INTENT_LANW_MOWER_DOCK, INTENT_LANW_MOWER_START_MOWING
@@ -16,8 +16,11 @@ LLM_INTENTS = (INTENT_LANW_MOWER_DOCK, INTENT_LANW_MOWER_START_MOWING)
 @callback
 def async_get_tools(
     hass: HomeAssistant, llm_context: LLMContext, api_id: str
-) -> LLMTools:
+) -> LLMTools | None:
     """Return LLM tools for the integration's intents when its domain is exposed."""
+    if api_id != LLM_API_ASSIST:
+        return None
+
     if not llm_context.assistant:
         return LLMTools(tools=[])
 

--- a/homeassistant/components/light/llm.py
+++ b/homeassistant/components/light/llm.py
@@ -4,7 +4,7 @@ from homeassistant.components.homeassistant import async_should_expose
 from homeassistant.components.llm import LLMTools
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import intent
-from homeassistant.helpers.llm import IntentTool, LLMContext, Tool
+from homeassistant.helpers.llm import LLM_API_ASSIST, IntentTool, LLMContext, Tool
 
 from .const import DOMAIN
 from .intent import INTENT_SET
@@ -16,8 +16,11 @@ LLM_INTENTS = (INTENT_SET,)
 @callback
 def async_get_tools(
     hass: HomeAssistant, llm_context: LLMContext, api_id: str
-) -> LLMTools:
+) -> LLMTools | None:
     """Return LLM tools for the integration's intents when its domain is exposed."""
+    if api_id != LLM_API_ASSIST:
+        return None
+
     if not llm_context.assistant:
         return LLMTools(tools=[])
 

--- a/homeassistant/components/light/llm.py
+++ b/homeassistant/components/light/llm.py
@@ -14,7 +14,9 @@ LLM_INTENTS = (INTENT_SET,)
 
 
 @callback
-def async_get_tools(hass: HomeAssistant, llm_context: LLMContext) -> LLMTools:
+def async_get_tools(
+    hass: HomeAssistant, llm_context: LLMContext, api_id: str
+) -> LLMTools:
     """Return LLM tools for the integration's intents when its domain is exposed."""
     if not llm_context.assistant:
         return LLMTools(tools=[])

--- a/homeassistant/components/light/llm.py
+++ b/homeassistant/components/light/llm.py
@@ -22,13 +22,13 @@ def async_get_tools(
         return None
 
     if not llm_context.assistant:
-        return LLMTools(tools=[])
+        return None
 
     if not any(
         async_should_expose(hass, llm_context.assistant, state.entity_id)
         for state in hass.states.async_all(DOMAIN)
     ):
-        return LLMTools(tools=[])
+        return None
 
     tools: list[Tool] = [
         IntentTool(handler.intent_type, handler)

--- a/homeassistant/components/llm/__init__.py
+++ b/homeassistant/components/llm/__init__.py
@@ -42,8 +42,11 @@ class LLMToolsPlatformProtocol(Protocol):
     @callback
     def async_get_tools(
         self, hass: HomeAssistant, llm_context: LLMContext, api_id: str
-    ) -> LLMTools:
-        """Return the integration's LLM tools for the given context and API."""
+    ) -> LLMTools | None:
+        """Return the integration's LLM tools for the given context and API.
+
+        Return None when the integration has nothing for the given API.
+        """
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -76,6 +79,8 @@ async def async_get_tools(
             result = platform.async_get_tools(hass, llm_context, api_id)
         except Exception:
             _LOGGER.exception("Error getting tools from LLM platform %s", domain)
+            continue
+        if result is None:
             continue
         tools.extend(result.tools)
         if result.prompt:

--- a/homeassistant/components/llm/__init__.py
+++ b/homeassistant/components/llm/__init__.py
@@ -40,8 +40,10 @@ class LLMToolsPlatformProtocol(Protocol):
     """Define the format that LLM tools platforms can have."""
 
     @callback
-    def async_get_tools(self, hass: HomeAssistant, llm_context: LLMContext) -> LLMTools:
-        """Return the integration's LLM tools for the given context."""
+    def async_get_tools(
+        self, hass: HomeAssistant, llm_context: LLMContext, api_id: str
+    ) -> LLMTools:
+        """Return the integration's LLM tools for the given context and API."""
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -60,7 +62,9 @@ def _process_llm_tools_platform(
     return platform
 
 
-async def async_get_tools(hass: HomeAssistant, llm_context: LLMContext) -> LLMTools:
+async def async_get_tools(
+    hass: HomeAssistant, llm_context: LLMContext, api_id: str
+) -> LLMTools:
     """Return the tools and merged prompt from all integration platforms."""
     platforms = await hass.data[DATA_PLATFORMS].async_get_platforms()
 
@@ -69,7 +73,7 @@ async def async_get_tools(hass: HomeAssistant, llm_context: LLMContext) -> LLMTo
     # Sort by domain so the tool and prompt order is independent of load order.
     for domain, platform in sorted(platforms.items()):
         try:
-            result = platform.async_get_tools(hass, llm_context)
+            result = platform.async_get_tools(hass, llm_context, api_id)
         except Exception:
             _LOGGER.exception("Error getting tools from LLM platform %s", domain)
             continue

--- a/homeassistant/components/llm/llm.py
+++ b/homeassistant/components/llm/llm.py
@@ -38,6 +38,8 @@ class GetDateTimeTool(Tool):
 
 
 @callback
-def async_get_tools(hass: HomeAssistant, llm_context: LLMContext) -> LLMTools:
+def async_get_tools(
+    hass: HomeAssistant, llm_context: LLMContext, api_id: str
+) -> LLMTools:
     """Return the always-available LLM tools."""
     return LLMTools(tools=[GetDateTimeTool()])

--- a/homeassistant/components/llm/llm.py
+++ b/homeassistant/components/llm/llm.py
@@ -3,7 +3,7 @@
 from typing import override
 
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.llm import LLMContext, Tool, ToolInput
+from homeassistant.helpers.llm import LLM_API_ASSIST, LLMContext, Tool, ToolInput
 from homeassistant.util import dt as dt_util
 from homeassistant.util.json import JsonObjectType
 
@@ -40,6 +40,9 @@ class GetDateTimeTool(Tool):
 @callback
 def async_get_tools(
     hass: HomeAssistant, llm_context: LLMContext, api_id: str
-) -> LLMTools:
-    """Return the always-available LLM tools."""
+) -> LLMTools | None:
+    """Return the LLM tools for the Assist API."""
+    if api_id != LLM_API_ASSIST:
+        return None
+
     return LLMTools(tools=[GetDateTimeTool()])

--- a/homeassistant/components/llm/llm.py
+++ b/homeassistant/components/llm/llm.py
@@ -3,7 +3,7 @@
 from typing import override
 
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.llm import LLM_API_ASSIST, LLMContext, Tool, ToolInput
+from homeassistant.helpers.llm import LLMContext, Tool, ToolInput
 from homeassistant.util import dt as dt_util
 from homeassistant.util.json import JsonObjectType
 
@@ -40,9 +40,6 @@ class GetDateTimeTool(Tool):
 @callback
 def async_get_tools(
     hass: HomeAssistant, llm_context: LLMContext, api_id: str
-) -> LLMTools | None:
-    """Return the LLM tools for the Assist API."""
-    if api_id != LLM_API_ASSIST:
-        return None
-
+) -> LLMTools:
+    """Return the always-available LLM tools."""
     return LLMTools(tools=[GetDateTimeTool()])

--- a/homeassistant/components/media_player/llm.py
+++ b/homeassistant/components/media_player/llm.py
@@ -34,7 +34,9 @@ LLM_INTENTS = (
 
 
 @callback
-def async_get_tools(hass: HomeAssistant, llm_context: LLMContext) -> LLMTools:
+def async_get_tools(
+    hass: HomeAssistant, llm_context: LLMContext, api_id: str
+) -> LLMTools:
     """Return LLM tools for the integration's intents when its domain is exposed."""
     if not llm_context.assistant:
         return LLMTools(tools=[])

--- a/homeassistant/components/media_player/llm.py
+++ b/homeassistant/components/media_player/llm.py
@@ -4,7 +4,7 @@ from homeassistant.components.homeassistant import async_should_expose
 from homeassistant.components.llm import LLMTools
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import intent
-from homeassistant.helpers.llm import IntentTool, LLMContext, Tool
+from homeassistant.helpers.llm import LLM_API_ASSIST, IntentTool, LLMContext, Tool
 
 from .const import (
     DOMAIN,
@@ -36,8 +36,11 @@ LLM_INTENTS = (
 @callback
 def async_get_tools(
     hass: HomeAssistant, llm_context: LLMContext, api_id: str
-) -> LLMTools:
+) -> LLMTools | None:
     """Return LLM tools for the integration's intents when its domain is exposed."""
+    if api_id != LLM_API_ASSIST:
+        return None
+
     if not llm_context.assistant:
         return LLMTools(tools=[])
 

--- a/homeassistant/components/media_player/llm.py
+++ b/homeassistant/components/media_player/llm.py
@@ -42,13 +42,13 @@ def async_get_tools(
         return None
 
     if not llm_context.assistant:
-        return LLMTools(tools=[])
+        return None
 
     if not any(
         async_should_expose(hass, llm_context.assistant, state.entity_id)
         for state in hass.states.async_all(DOMAIN)
     ):
-        return LLMTools(tools=[])
+        return None
 
     tools: list[Tool] = [
         IntentTool(handler.intent_type, handler)

--- a/homeassistant/components/todo/llm.py
+++ b/homeassistant/components/todo/llm.py
@@ -104,7 +104,7 @@ def async_get_tools(
         return None
 
     if not llm_context.assistant:
-        return LLMTools(tools=[])
+        return None
 
     entity_registry = er.async_get(hass)
     names: list[str] = []
@@ -115,7 +115,7 @@ def async_get_tools(
         names.extend(intent.async_get_entity_aliases(hass, entity_entry, state=state))
 
     if not names:
-        return LLMTools(tools=[])
+        return None
 
     tools: list[Tool] = [TodoGetItemsTool(names)]
     tools.extend(

--- a/homeassistant/components/todo/llm.py
+++ b/homeassistant/components/todo/llm.py
@@ -9,7 +9,13 @@ from homeassistant.components.homeassistant import async_should_expose
 from homeassistant.components.llm import LLMTools
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er, intent
-from homeassistant.helpers.llm import IntentTool, LLMContext, Tool, ToolInput
+from homeassistant.helpers.llm import (
+    LLM_API_ASSIST,
+    IntentTool,
+    LLMContext,
+    Tool,
+    ToolInput,
+)
 from homeassistant.util.json import JsonObjectType
 
 from .const import DOMAIN, TodoServices
@@ -92,8 +98,11 @@ class TodoGetItemsTool(Tool):
 @callback
 def async_get_tools(
     hass: HomeAssistant, llm_context: LLMContext, api_id: str
-) -> LLMTools:
+) -> LLMTools | None:
     """Return the todo LLM tools when a to-do list is exposed."""
+    if api_id != LLM_API_ASSIST:
+        return None
+
     if not llm_context.assistant:
         return LLMTools(tools=[])
 

--- a/homeassistant/components/todo/llm.py
+++ b/homeassistant/components/todo/llm.py
@@ -90,7 +90,9 @@ class TodoGetItemsTool(Tool):
 
 
 @callback
-def async_get_tools(hass: HomeAssistant, llm_context: LLMContext) -> LLMTools:
+def async_get_tools(
+    hass: HomeAssistant, llm_context: LLMContext, api_id: str
+) -> LLMTools:
     """Return the todo LLM tools when a to-do list is exposed."""
     if not llm_context.assistant:
         return LLMTools(tools=[])

--- a/homeassistant/components/vacuum/llm.py
+++ b/homeassistant/components/vacuum/llm.py
@@ -22,7 +22,9 @@ LLM_INTENTS = (
 
 
 @callback
-def async_get_tools(hass: HomeAssistant, llm_context: LLMContext) -> LLMTools:
+def async_get_tools(
+    hass: HomeAssistant, llm_context: LLMContext, api_id: str
+) -> LLMTools:
     """Return LLM tools for the integration's intents when its domain is exposed."""
     if not llm_context.assistant:
         return LLMTools(tools=[])

--- a/homeassistant/components/vacuum/llm.py
+++ b/homeassistant/components/vacuum/llm.py
@@ -30,13 +30,13 @@ def async_get_tools(
         return None
 
     if not llm_context.assistant:
-        return LLMTools(tools=[])
+        return None
 
     if not any(
         async_should_expose(hass, llm_context.assistant, state.entity_id)
         for state in hass.states.async_all(DOMAIN)
     ):
-        return LLMTools(tools=[])
+        return None
 
     tools: list[Tool] = [
         IntentTool(handler.intent_type, handler)

--- a/homeassistant/components/vacuum/llm.py
+++ b/homeassistant/components/vacuum/llm.py
@@ -4,7 +4,7 @@ from homeassistant.components.homeassistant import async_should_expose
 from homeassistant.components.llm import LLMTools
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import intent
-from homeassistant.helpers.llm import IntentTool, LLMContext, Tool
+from homeassistant.helpers.llm import LLM_API_ASSIST, IntentTool, LLMContext, Tool
 
 from .const import DOMAIN
 from .intent import (
@@ -24,8 +24,11 @@ LLM_INTENTS = (
 @callback
 def async_get_tools(
     hass: HomeAssistant, llm_context: LLMContext, api_id: str
-) -> LLMTools:
+) -> LLMTools | None:
     """Return LLM tools for the integration's intents when its domain is exposed."""
+    if api_id != LLM_API_ASSIST:
+        return None
+
     if not llm_context.assistant:
         return LLMTools(tools=[])
 

--- a/tests/components/calendar/test_llm.py
+++ b/tests/components/calendar/test_llm.py
@@ -42,14 +42,14 @@ def _llm_context() -> llm.LLMContext:
 async def test_get_tools_no_exposed_calendar(hass: HomeAssistant) -> None:
     """Test no calendar tool is offered when no calendar is exposed."""
     async_expose_entity(hass, "conversation", ENTITY_ID, False)
-    result = await llm_component.async_get_tools(hass, _llm_context())
+    result = await llm_component.async_get_tools(hass, _llm_context(), "assist")
     assert "calendar_get_events" not in [tool.name for tool in result.tools]
 
 
 async def test_calendar_get_events_tool(hass: HomeAssistant) -> None:
     """Test the calendar get events tool is exposed and works via the platform."""
     llm_context = _llm_context()
-    result = await llm_component.async_get_tools(hass, llm_context)
+    result = await llm_component.async_get_tools(hass, llm_context, "assist")
     tool = next(
         (tool for tool in result.tools if tool.name == "calendar_get_events"), None
     )
@@ -133,7 +133,7 @@ async def test_calendar_get_events_tool(hass: HomeAssistant) -> None:
 async def test_calendar_get_events_tool_not_found(hass: HomeAssistant) -> None:
     """Test the tool reports when the requested calendar no longer matches."""
     llm_context = _llm_context()
-    result = await llm_component.async_get_tools(hass, llm_context)
+    result = await llm_component.async_get_tools(hass, llm_context, "assist")
     tool = next(tool for tool in result.tools if tool.name == "calendar_get_events")
 
     # Unexpose after the tool (and its calendar enum) was built, so the call-time
@@ -160,6 +160,6 @@ async def test_calendar_get_events_tool_uses_aliases(
     hass.states.async_set(entry.entity_id, "on")
     async_expose_entity(hass, "conversation", entry.entity_id, True)
 
-    result = await llm_component.async_get_tools(hass, _llm_context())
+    result = await llm_component.async_get_tools(hass, _llm_context(), "assist")
     tool = next(tool for tool in result.tools if tool.name == "calendar_get_events")
     assert "Family Calendar" in tool.parameters.schema["calendar"].container

--- a/tests/components/calendar/test_llm.py
+++ b/tests/components/calendar/test_llm.py
@@ -45,6 +45,7 @@ async def test_get_tools_no_exposed_calendar(hass: HomeAssistant) -> None:
     async_expose_entity(hass, "conversation", ENTITY_ID, False)
     result = await llm_component.async_get_tools(hass, _llm_context(), "assist")
     assert "calendar_get_events" not in [tool.name for tool in result.tools]
+    assert calendar_llm.async_get_tools(hass, _llm_context(), "assist") is None
 
 
 async def test_no_tools_for_other_api(hass: HomeAssistant) -> None:

--- a/tests/components/calendar/test_llm.py
+++ b/tests/components/calendar/test_llm.py
@@ -6,6 +6,7 @@ from freezegun import freeze_time
 import pytest
 
 from homeassistant.components import calendar, llm as llm_component
+from homeassistant.components.calendar import llm as calendar_llm
 from homeassistant.components.homeassistant.exposed_entities import async_expose_entity
 from homeassistant.core import Context, HomeAssistant, SupportsResponse
 from homeassistant.helpers import entity_registry as er, llm
@@ -44,6 +45,11 @@ async def test_get_tools_no_exposed_calendar(hass: HomeAssistant) -> None:
     async_expose_entity(hass, "conversation", ENTITY_ID, False)
     result = await llm_component.async_get_tools(hass, _llm_context(), "assist")
     assert "calendar_get_events" not in [tool.name for tool in result.tools]
+
+
+async def test_no_tools_for_other_api(hass: HomeAssistant) -> None:
+    """Test the platform returns None for an unsupported API."""
+    assert calendar_llm.async_get_tools(hass, _llm_context(), "other") is None
 
 
 async def test_calendar_get_events_tool(hass: HomeAssistant) -> None:

--- a/tests/components/climate/test_llm.py
+++ b/tests/components/climate/test_llm.py
@@ -3,6 +3,7 @@
 import pytest
 
 from homeassistant.components import llm as llm_component
+from homeassistant.components.climate import llm as climate_llm
 from homeassistant.components.homeassistant.exposed_entities import async_expose_entity
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers import llm
@@ -49,3 +50,8 @@ async def test_intent_tool_not_exposed(hass: HomeAssistant) -> None:
     """Test the intent tool is hidden when no climate entity is exposed."""
     async_expose_entity(hass, "conversation", ENTITY_ID, False)
     assert "HassClimateSetTemperature" not in await _tool_names(hass)
+
+
+async def test_no_tools_for_other_api(hass: HomeAssistant) -> None:
+    """Test the platform returns None for an unsupported API."""
+    assert climate_llm.async_get_tools(hass, _llm_context(), "other") is None

--- a/tests/components/climate/test_llm.py
+++ b/tests/components/climate/test_llm.py
@@ -50,6 +50,7 @@ async def test_intent_tool_not_exposed(hass: HomeAssistant) -> None:
     """Test the intent tool is hidden when no climate entity is exposed."""
     async_expose_entity(hass, "conversation", ENTITY_ID, False)
     assert "HassClimateSetTemperature" not in await _tool_names(hass)
+    assert climate_llm.async_get_tools(hass, _llm_context(), "assist") is None
 
 
 async def test_no_tools_for_other_api(hass: HomeAssistant) -> None:

--- a/tests/components/climate/test_llm.py
+++ b/tests/components/climate/test_llm.py
@@ -36,7 +36,7 @@ def _llm_context() -> llm.LLMContext:
 
 async def _tool_names(hass: HomeAssistant) -> set[str]:
     """Return the names of the tools offered by the climate platform."""
-    result = await llm_component.async_get_tools(hass, _llm_context())
+    result = await llm_component.async_get_tools(hass, _llm_context(), "assist")
     return {tool.name for tool in result.tools}
 
 

--- a/tests/components/fan/test_llm.py
+++ b/tests/components/fan/test_llm.py
@@ -36,7 +36,7 @@ def _llm_context() -> llm.LLMContext:
 
 async def _tool_names(hass: HomeAssistant) -> set[str]:
     """Return the names of the tools offered by the fan platform."""
-    result = await llm_component.async_get_tools(hass, _llm_context())
+    result = await llm_component.async_get_tools(hass, _llm_context(), "assist")
     return {tool.name for tool in result.tools}
 
 

--- a/tests/components/fan/test_llm.py
+++ b/tests/components/fan/test_llm.py
@@ -50,6 +50,7 @@ async def test_intent_tool_not_exposed(hass: HomeAssistant) -> None:
     """Test the intent tool is hidden when no fan entity is exposed."""
     async_expose_entity(hass, "conversation", ENTITY_ID, False)
     assert "HassFanSetSpeed" not in await _tool_names(hass)
+    assert fan_llm.async_get_tools(hass, _llm_context(), "assist") is None
 
 
 async def test_no_tools_for_other_api(hass: HomeAssistant) -> None:

--- a/tests/components/fan/test_llm.py
+++ b/tests/components/fan/test_llm.py
@@ -3,6 +3,7 @@
 import pytest
 
 from homeassistant.components import llm as llm_component
+from homeassistant.components.fan import llm as fan_llm
 from homeassistant.components.homeassistant.exposed_entities import async_expose_entity
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers import llm
@@ -49,3 +50,8 @@ async def test_intent_tool_not_exposed(hass: HomeAssistant) -> None:
     """Test the intent tool is hidden when no fan entity is exposed."""
     async_expose_entity(hass, "conversation", ENTITY_ID, False)
     assert "HassFanSetSpeed" not in await _tool_names(hass)
+
+
+async def test_no_tools_for_other_api(hass: HomeAssistant) -> None:
+    """Test the platform returns None for an unsupported API."""
+    assert fan_llm.async_get_tools(hass, _llm_context(), "other") is None

--- a/tests/components/intent_script/test_llm.py
+++ b/tests/components/intent_script/test_llm.py
@@ -4,6 +4,7 @@ import pytest
 
 from homeassistant.components import llm as llm_component
 from homeassistant.components.homeassistant.exposed_entities import async_expose_entity
+from homeassistant.components.intent_script import llm as intent_script_llm
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers import llm
 from homeassistant.setup import async_setup_component
@@ -71,3 +72,8 @@ async def test_intent_script_platform_filtered(hass: HomeAssistant) -> None:
     assert "LightAction" not in names
     # Unrestricted intent scripts stay exposed.
     assert "Tell_a_joke" in names
+
+
+async def test_no_tools_for_other_api(hass: HomeAssistant) -> None:
+    """Test the platform returns None for an unsupported API."""
+    assert intent_script_llm.async_get_tools(hass, _llm_context(), "other") is None

--- a/tests/components/intent_script/test_llm.py
+++ b/tests/components/intent_script/test_llm.py
@@ -52,7 +52,7 @@ def _llm_context() -> llm.LLMContext:
 
 async def _tool_names(hass: HomeAssistant) -> set[str]:
     """Return the names of the tools offered by the intent_script platform."""
-    result = await llm_component.async_get_tools(hass, _llm_context())
+    result = await llm_component.async_get_tools(hass, _llm_context(), "assist")
     return {tool.name for tool in result.tools}
 
 

--- a/tests/components/intent_script/test_llm.py
+++ b/tests/components/intent_script/test_llm.py
@@ -1,12 +1,17 @@
 """Tests for the intent_script LLM tools platform."""
 
+from unittest.mock import patch
+
 import pytest
 
 from homeassistant.components import llm as llm_component
 from homeassistant.components.homeassistant.exposed_entities import async_expose_entity
-from homeassistant.components.intent_script import llm as intent_script_llm
+from homeassistant.components.intent_script import (
+    ScriptIntentHandler,
+    llm as intent_script_llm,
+)
 from homeassistant.core import Context, HomeAssistant
-from homeassistant.helpers import llm
+from homeassistant.helpers import intent, llm
 from homeassistant.setup import async_setup_component
 
 LIGHT_ENTITY_ID = "light.kitchen"
@@ -77,3 +82,18 @@ async def test_intent_script_platform_filtered(hass: HomeAssistant) -> None:
 async def test_no_tools_for_other_api(hass: HomeAssistant) -> None:
     """Test the platform returns None for an unsupported API."""
     assert intent_script_llm.async_get_tools(hass, _llm_context(), "other") is None
+
+
+async def test_no_tools_when_no_scripts_match(hass: HomeAssistant) -> None:
+    """Test None is returned when no intent scripts match the exposed domains."""
+    async_expose_entity(hass, "conversation", LIGHT_ENTITY_ID, False)
+    restricted_handlers = [
+        handler
+        for handler in intent.async_get(hass)
+        if isinstance(handler, ScriptIntentHandler) and handler.platforms
+    ]
+    with patch(
+        "homeassistant.components.intent_script.llm.intent.async_get",
+        return_value=restricted_handlers,
+    ):
+        assert intent_script_llm.async_get_tools(hass, _llm_context(), "assist") is None

--- a/tests/components/lawn_mower/test_llm.py
+++ b/tests/components/lawn_mower/test_llm.py
@@ -37,7 +37,7 @@ def _llm_context() -> llm.LLMContext:
 
 async def _tool_names(hass: HomeAssistant) -> set[str]:
     """Return the names of the tools offered by the lawn_mower platform."""
-    result = await llm_component.async_get_tools(hass, _llm_context())
+    result = await llm_component.async_get_tools(hass, _llm_context(), "assist")
     return {tool.name for tool in result.tools}
 
 

--- a/tests/components/lawn_mower/test_llm.py
+++ b/tests/components/lawn_mower/test_llm.py
@@ -51,6 +51,7 @@ async def test_intent_tool_not_exposed(hass: HomeAssistant) -> None:
     """Test the intent tool is hidden when no lawn_mower entity is exposed."""
     async_expose_entity(hass, "conversation", ENTITY_ID, False)
     assert not INTENTS & await _tool_names(hass)
+    assert lawn_mower_llm.async_get_tools(hass, _llm_context(), "assist") is None
 
 
 async def test_no_tools_for_other_api(hass: HomeAssistant) -> None:

--- a/tests/components/lawn_mower/test_llm.py
+++ b/tests/components/lawn_mower/test_llm.py
@@ -4,6 +4,7 @@ import pytest
 
 from homeassistant.components import llm as llm_component
 from homeassistant.components.homeassistant.exposed_entities import async_expose_entity
+from homeassistant.components.lawn_mower import llm as lawn_mower_llm
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers import llm
 from homeassistant.setup import async_setup_component
@@ -50,3 +51,8 @@ async def test_intent_tool_not_exposed(hass: HomeAssistant) -> None:
     """Test the intent tool is hidden when no lawn_mower entity is exposed."""
     async_expose_entity(hass, "conversation", ENTITY_ID, False)
     assert not INTENTS & await _tool_names(hass)
+
+
+async def test_no_tools_for_other_api(hass: HomeAssistant) -> None:
+    """Test the platform returns None for an unsupported API."""
+    assert lawn_mower_llm.async_get_tools(hass, _llm_context(), "other") is None

--- a/tests/components/light/test_llm.py
+++ b/tests/components/light/test_llm.py
@@ -50,6 +50,7 @@ async def test_intent_tool_not_exposed(hass: HomeAssistant) -> None:
     """Test the intent tool is hidden when no light entity is exposed."""
     async_expose_entity(hass, "conversation", ENTITY_ID, False)
     assert "HassLightSet" not in await _tool_names(hass)
+    assert light_llm.async_get_tools(hass, _llm_context(), "assist") is None
 
 
 async def test_no_tools_for_other_api(hass: HomeAssistant) -> None:

--- a/tests/components/light/test_llm.py
+++ b/tests/components/light/test_llm.py
@@ -4,6 +4,7 @@ import pytest
 
 from homeassistant.components import llm as llm_component
 from homeassistant.components.homeassistant.exposed_entities import async_expose_entity
+from homeassistant.components.light import llm as light_llm
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers import llm
 from homeassistant.setup import async_setup_component
@@ -49,3 +50,8 @@ async def test_intent_tool_not_exposed(hass: HomeAssistant) -> None:
     """Test the intent tool is hidden when no light entity is exposed."""
     async_expose_entity(hass, "conversation", ENTITY_ID, False)
     assert "HassLightSet" not in await _tool_names(hass)
+
+
+async def test_no_tools_for_other_api(hass: HomeAssistant) -> None:
+    """Test the platform returns None for an unsupported API."""
+    assert light_llm.async_get_tools(hass, _llm_context(), "other") is None

--- a/tests/components/light/test_llm.py
+++ b/tests/components/light/test_llm.py
@@ -36,7 +36,7 @@ def _llm_context() -> llm.LLMContext:
 
 async def _tool_names(hass: HomeAssistant) -> set[str]:
     """Return the names of the tools offered by the light platform."""
-    result = await llm_component.async_get_tools(hass, _llm_context())
+    result = await llm_component.async_get_tools(hass, _llm_context(), "assist")
     return {tool.name for tool in result.tools}
 
 

--- a/tests/components/llm/test_init.py
+++ b/tests/components/llm/test_init.py
@@ -44,7 +44,7 @@ def llm_context() -> llm.LLMContext:
 
 
 def _mock_tools_platform(
-    hass: HomeAssistant, domain: str, tools: LLMTools | Exception
+    hass: HomeAssistant, domain: str, tools: LLMTools | Exception | None
 ) -> Mock:
     """Register a mock <integration>/llm.py platform returning the given tools."""
     if isinstance(tools, Exception):
@@ -104,6 +104,21 @@ async def test_get_tools_merges_sorted(
     result = await async_get_tools(hass, llm_context, "assist")
     assert [tool.name for tool in result.tools] == ["GetDateTime", "tool_a", "tool_b"]
     assert result.prompt == "prompt a\nprompt b"
+
+
+async def test_get_tools_skips_none_platform(
+    hass: HomeAssistant, llm_context: llm.LLMContext
+) -> None:
+    """Test that a platform returning None for the API is skipped."""
+    tool = _StubTool("good_tool")
+    _mock_tools_platform(hass, "test_none", None)
+    _mock_tools_platform(hass, "test_good", LLMTools(tools=[tool]))
+
+    assert await async_setup_component(hass, "llm", {})
+
+    result = await async_get_tools(hass, llm_context, "assist")
+    assert [tool.name for tool in result.tools] == ["GetDateTime", "good_tool"]
+    assert result.prompt is None
 
 
 async def test_get_tools_isolates_failing_platform(

--- a/tests/components/llm/test_init.py
+++ b/tests/components/llm/test_init.py
@@ -45,7 +45,7 @@ def llm_context() -> llm.LLMContext:
 
 def _mock_tools_platform(
     hass: HomeAssistant, domain: str, tools: LLMTools | Exception
-) -> None:
+) -> Mock:
     """Register a mock <integration>/llm.py platform returning the given tools."""
     if isinstance(tools, Exception):
         async_get_tools = Mock(side_effect=tools)
@@ -53,6 +53,7 @@ def _mock_tools_platform(
         async_get_tools = Mock(return_value=tools)
     hass.config.components.add(domain)
     mock_platform(hass, f"{domain}.llm", Mock(async_get_tools=async_get_tools))
+    return async_get_tools
 
 
 async def test_setup(hass: HomeAssistant) -> None:
@@ -64,16 +65,17 @@ async def test_setup(hass: HomeAssistant) -> None:
 async def test_get_tools(hass: HomeAssistant, llm_context: llm.LLMContext) -> None:
     """Test that tools from an integration platform are returned."""
     tool = _StubTool("my_tool")
-    _mock_tools_platform(
+    platform_get_tools = _mock_tools_platform(
         hass, "test", LLMTools(tools=[tool], prompt="use my_tool wisely")
     )
 
     assert await async_setup_component(hass, "llm", {})
 
-    result = await async_get_tools(hass, llm_context)
+    result = await async_get_tools(hass, llm_context, "assist")
     # The llm integration also exposes its own GetDateTime tool (domain "llm").
     assert [tool.name for tool in result.tools] == ["GetDateTime", "my_tool"]
     assert result.prompt == "use my_tool wisely"
+    platform_get_tools.assert_called_once_with(hass, llm_context, "assist")
 
 
 async def test_get_tools_empty(
@@ -82,7 +84,7 @@ async def test_get_tools_empty(
     """Test that only the llm integration's own tools are returned by default."""
     assert await async_setup_component(hass, "llm", {})
 
-    result = await async_get_tools(hass, llm_context)
+    result = await async_get_tools(hass, llm_context, "assist")
     assert [tool.name for tool in result.tools] == ["GetDateTime"]
     assert result.prompt is None
 
@@ -99,7 +101,7 @@ async def test_get_tools_merges_sorted(
 
     assert await async_setup_component(hass, "llm", {})
 
-    result = await async_get_tools(hass, llm_context)
+    result = await async_get_tools(hass, llm_context, "assist")
     assert [tool.name for tool in result.tools] == ["GetDateTime", "tool_a", "tool_b"]
     assert result.prompt == "prompt a\nprompt b"
 
@@ -116,7 +118,7 @@ async def test_get_tools_isolates_failing_platform(
 
     assert await async_setup_component(hass, "llm", {})
 
-    result = await async_get_tools(hass, llm_context)
+    result = await async_get_tools(hass, llm_context, "assist")
     assert [tool.name for tool in result.tools] == ["GetDateTime", "good_tool"]
     assert result.prompt == "prompt"
     assert "Error getting tools from LLM platform test_bad" in caplog.text

--- a/tests/components/llm/test_tools.py
+++ b/tests/components/llm/test_tools.py
@@ -32,7 +32,7 @@ def _llm_context() -> llm.LLMContext:
 async def test_get_datetime_tool(hass: HomeAssistant) -> None:
     """Test the GetDateTime tool is always offered and returns the current time."""
     llm_context = _llm_context()
-    result = await llm_component.async_get_tools(hass, llm_context)
+    result = await llm_component.async_get_tools(hass, llm_context, "assist")
     tool = next((tool for tool in result.tools if tool.name == "GetDateTime"), None)
     assert tool is not None
 

--- a/tests/components/llm/test_tools.py
+++ b/tests/components/llm/test_tools.py
@@ -4,6 +4,7 @@ from freezegun import freeze_time
 import pytest
 
 from homeassistant.components import llm as llm_component
+from homeassistant.components.llm import llm as llm_platform
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers import llm
 from homeassistant.setup import async_setup_component
@@ -50,3 +51,8 @@ async def test_get_datetime_tool(hass: HomeAssistant) -> None:
             "weekday": "Wednesday",
         },
     }
+
+
+async def test_no_tools_for_other_api(hass: HomeAssistant) -> None:
+    """Test the platform returns None for an unsupported API."""
+    assert llm_platform.async_get_tools(hass, _llm_context(), "other") is None

--- a/tests/components/llm/test_tools.py
+++ b/tests/components/llm/test_tools.py
@@ -4,7 +4,6 @@ from freezegun import freeze_time
 import pytest
 
 from homeassistant.components import llm as llm_component
-from homeassistant.components.llm import llm as llm_platform
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers import llm
 from homeassistant.setup import async_setup_component
@@ -51,8 +50,3 @@ async def test_get_datetime_tool(hass: HomeAssistant) -> None:
             "weekday": "Wednesday",
         },
     }
-
-
-async def test_no_tools_for_other_api(hass: HomeAssistant) -> None:
-    """Test the platform returns None for an unsupported API."""
-    assert llm_platform.async_get_tools(hass, _llm_context(), "other") is None

--- a/tests/components/media_player/test_llm.py
+++ b/tests/components/media_player/test_llm.py
@@ -4,6 +4,7 @@ import pytest
 
 from homeassistant.components import llm as llm_component
 from homeassistant.components.homeassistant.exposed_entities import async_expose_entity
+from homeassistant.components.media_player import llm as media_player_llm
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers import llm
 from homeassistant.setup import async_setup_component
@@ -60,3 +61,8 @@ async def test_intent_tool_not_exposed(hass: HomeAssistant) -> None:
     """Test the intent tool is hidden when no media_player entity is exposed."""
     async_expose_entity(hass, "conversation", ENTITY_ID, False)
     assert not INTENTS & await _tool_names(hass)
+
+
+async def test_no_tools_for_other_api(hass: HomeAssistant) -> None:
+    """Test the platform returns None for an unsupported API."""
+    assert media_player_llm.async_get_tools(hass, _llm_context(), "other") is None

--- a/tests/components/media_player/test_llm.py
+++ b/tests/components/media_player/test_llm.py
@@ -61,6 +61,7 @@ async def test_intent_tool_not_exposed(hass: HomeAssistant) -> None:
     """Test the intent tool is hidden when no media_player entity is exposed."""
     async_expose_entity(hass, "conversation", ENTITY_ID, False)
     assert not INTENTS & await _tool_names(hass)
+    assert media_player_llm.async_get_tools(hass, _llm_context(), "assist") is None
 
 
 async def test_no_tools_for_other_api(hass: HomeAssistant) -> None:

--- a/tests/components/media_player/test_llm.py
+++ b/tests/components/media_player/test_llm.py
@@ -47,7 +47,7 @@ def _llm_context() -> llm.LLMContext:
 
 async def _tool_names(hass: HomeAssistant) -> set[str]:
     """Return the names of the tools offered by the media_player platform."""
-    result = await llm_component.async_get_tools(hass, _llm_context())
+    result = await llm_component.async_get_tools(hass, _llm_context(), "assist")
     return {tool.name for tool in result.tools}
 
 

--- a/tests/components/todo/test_llm.py
+++ b/tests/components/todo/test_llm.py
@@ -4,6 +4,7 @@ import pytest
 
 from homeassistant.components import llm as llm_component, todo
 from homeassistant.components.homeassistant.exposed_entities import async_expose_entity
+from homeassistant.components.todo import llm as todo_llm
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers import config_validation as cv, llm
 from homeassistant.setup import async_setup_component
@@ -41,6 +42,11 @@ async def test_get_tools_no_exposed_todo(hass: HomeAssistant) -> None:
     async_expose_entity(hass, "conversation", ENTITY_ID, False)
     result = await llm_component.async_get_tools(hass, _llm_context(), "assist")
     assert "todo_get_items" not in [tool.name for tool in result.tools]
+
+
+async def test_no_tools_for_other_api(hass: HomeAssistant) -> None:
+    """Test the platform returns None for an unsupported API."""
+    assert todo_llm.async_get_tools(hass, _llm_context(), "other") is None
 
 
 async def test_todo_get_items_tool(hass: HomeAssistant) -> None:

--- a/tests/components/todo/test_llm.py
+++ b/tests/components/todo/test_llm.py
@@ -39,14 +39,14 @@ def _llm_context() -> llm.LLMContext:
 async def test_get_tools_no_exposed_todo(hass: HomeAssistant) -> None:
     """Test no todo tool is offered when no to-do list is exposed."""
     async_expose_entity(hass, "conversation", ENTITY_ID, False)
-    result = await llm_component.async_get_tools(hass, _llm_context())
+    result = await llm_component.async_get_tools(hass, _llm_context(), "assist")
     assert "todo_get_items" not in [tool.name for tool in result.tools]
 
 
 async def test_todo_get_items_tool(hass: HomeAssistant) -> None:
     """Test the todo get items tool is exposed and works via the platform."""
     llm_context = _llm_context()
-    result = await llm_component.async_get_tools(hass, llm_context)
+    result = await llm_component.async_get_tools(hass, llm_context, "assist")
     tool = next((tool for tool in result.tools if tool.name == "todo_get_items"), None)
     assert tool is not None
     assert tool.parameters.schema["todo_list"].container == ["Mock Todo List Name"]
@@ -91,7 +91,7 @@ async def test_todo_get_items_status_filter(
 ) -> None:
     """Test the status filter is translated into the service call."""
     llm_context = _llm_context()
-    result = await llm_component.async_get_tools(hass, llm_context)
+    result = await llm_component.async_get_tools(hass, llm_context, "assist")
     tool = next(tool for tool in result.tools if tool.name == "todo_get_items")
 
     calls = async_mock_service(
@@ -113,7 +113,7 @@ async def test_todo_get_items_status_filter(
 
 async def test_todo_list_intents_exposed(hass: HomeAssistant) -> None:
     """Test the todo list intents are exposed as tools when a list is exposed."""
-    result = await llm_component.async_get_tools(hass, _llm_context())
+    result = await llm_component.async_get_tools(hass, _llm_context(), "assist")
     names = {tool.name for tool in result.tools}
     assert "HassListAddItem" in names
     assert "HassListCompleteItem" in names

--- a/tests/components/todo/test_llm.py
+++ b/tests/components/todo/test_llm.py
@@ -42,6 +42,7 @@ async def test_get_tools_no_exposed_todo(hass: HomeAssistant) -> None:
     async_expose_entity(hass, "conversation", ENTITY_ID, False)
     result = await llm_component.async_get_tools(hass, _llm_context(), "assist")
     assert "todo_get_items" not in [tool.name for tool in result.tools]
+    assert todo_llm.async_get_tools(hass, _llm_context(), "assist") is None
 
 
 async def test_no_tools_for_other_api(hass: HomeAssistant) -> None:

--- a/tests/components/vacuum/test_llm.py
+++ b/tests/components/vacuum/test_llm.py
@@ -37,7 +37,7 @@ def _llm_context() -> llm.LLMContext:
 
 async def _tool_names(hass: HomeAssistant) -> set[str]:
     """Return the names of the tools offered by the vacuum platform."""
-    result = await llm_component.async_get_tools(hass, _llm_context())
+    result = await llm_component.async_get_tools(hass, _llm_context(), "assist")
     return {tool.name for tool in result.tools}
 
 

--- a/tests/components/vacuum/test_llm.py
+++ b/tests/components/vacuum/test_llm.py
@@ -51,6 +51,7 @@ async def test_intent_tool_not_exposed(hass: HomeAssistant) -> None:
     """Test the intent tool is hidden when no vacuum entity is exposed."""
     async_expose_entity(hass, "conversation", ENTITY_ID, False)
     assert not INTENTS & await _tool_names(hass)
+    assert vacuum_llm.async_get_tools(hass, _llm_context(), "assist") is None
 
 
 async def test_no_tools_for_other_api(hass: HomeAssistant) -> None:

--- a/tests/components/vacuum/test_llm.py
+++ b/tests/components/vacuum/test_llm.py
@@ -4,6 +4,7 @@ import pytest
 
 from homeassistant.components import llm as llm_component
 from homeassistant.components.homeassistant.exposed_entities import async_expose_entity
+from homeassistant.components.vacuum import llm as vacuum_llm
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers import llm
 from homeassistant.setup import async_setup_component
@@ -50,3 +51,8 @@ async def test_intent_tool_not_exposed(hass: HomeAssistant) -> None:
     """Test the intent tool is hidden when no vacuum entity is exposed."""
     async_expose_entity(hass, "conversation", ENTITY_ID, False)
     assert not INTENTS & await _tool_names(hass)
+
+
+async def test_no_tools_for_other_api(hass: HomeAssistant) -> None:
+    """Test the platform returns None for an unsupported API."""
+    assert vacuum_llm.async_get_tools(hass, _llm_context(), "other") is None


### PR DESCRIPTION
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Not a breaking change — the LLM tools platform (`<integration>/llm.py`) is new and has not been released yet, so the hook signature can still change freely.

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This implements the second part of the LLM platform architecture proposal.

When the framework gathers tools from the integration platforms, it now tells each platform *which* API it is gathering for:

- The `LLMToolsPlatformProtocol.async_get_tools` hook (and the framework-level `llm.async_get_tools`) gains an `api_id: str` argument identifying the API being assembled.
- The hook return type becomes `LLMTools | None`. A platform returns `None` to indicate it has nothing to contribute for that API, and the framework skips it when aggregating.

The bundled platforms are updated accordingly:

- Every Assist-oriented platform (`light`, `media_player`, `todo`, `calendar`, `lawn_mower`, `intent_script`, `vacuum`, `fan`, `climate`) returns `None` for any API other than `assist`, and also returns `None` when it has nothing to offer (e.g. no entities of its domain are exposed) instead of an empty `LLMTools`.
- The `llm` integration's own `GetDateTime` tool stays always available regardless of the requested API.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014kTmRu2FUFJuoxFHQ4z6tf)_