### PR TITLE
Expose Mac address for matter devices

### DIFF
--- a/homeassistant/components/matter/adapter.py
+++ b/homeassistant/components/matter/adapter.py
@@ -28,14 +28,15 @@ def get_clean_name(name: str | None) -> str | None:
     return name.strip() or None
 
 
-def _get_mac_address(node: MatterNode) -> str | None:
-    """Return the MAC address of the node's operational WiFi/Ethernet interface, if any."""
+def _get_mac_addresses(node: MatterNode) -> set[str]:
+    """Return the MAC addresses of the node's operational WiFi/Ethernet interfaces."""
     interfaces = node.get_attribute_value(
         0,
         clusters.GeneralDiagnostics,
         clusters.GeneralDiagnostics.Attributes.NetworkInterfaces,
     )
     interface_type = clusters.GeneralDiagnostics.Enums.InterfaceTypeEnum
+    mac_addresses: set[str] = set()
     for interface in interfaces or []:
         if not interface.isOperational:
             continue
@@ -48,8 +49,8 @@ def _get_mac_address(node: MatterNode) -> str | None:
             or interface.hardwareAddress == b"\x00" * 6
         ):
             continue
-        return dr.format_mac(interface.hardwareAddress.hex())
-    return None
+        mac_addresses.add(dr.format_mac(interface.hardwareAddress.hex()))
+    return mac_addresses
 
 
 class MatterAdapter:
@@ -237,10 +238,11 @@ class MatterAdapter:
             model_id = str(product_id) if (product_id := basic_info.productID) else None
 
         connections: set[tuple[str, str]] = set()
-        if not endpoint.is_bridged_device and (
-            mac_address := _get_mac_address(endpoint.node)
-        ):
-            connections.add((dr.CONNECTION_NETWORK_MAC, mac_address))
+        if not endpoint.is_bridged_device:
+            connections = {
+                (dr.CONNECTION_NETWORK_MAC, mac_address)
+                for mac_address in _get_mac_addresses(endpoint.node)
+            }
 
         dr.async_get(self.hass).async_get_or_create(
             name=name,

--- a/homeassistant/components/matter/adapter.py
+++ b/homeassistant/components/matter/adapter.py
@@ -28,6 +28,26 @@ def get_clean_name(name: str | None) -> str | None:
     return name.strip() or None
 
 
+def _get_mac_address(node: MatterNode) -> str | None:
+    """Return the MAC address of the node's operational network interface, if any."""
+    interfaces = node.get_attribute_value(
+        0,
+        clusters.GeneralDiagnostics,
+        clusters.GeneralDiagnostics.Attributes.NetworkInterfaces,
+    )
+    for interface in interfaces or []:
+        if not interface.isOperational:
+            continue
+        # Only 6-byte (WiFi/Ethernet) addresses are MAC addresses; Thread
+        # interfaces report an 8-byte EUI-64 with no matching connection type.
+        if len(interface.hardwareAddress) != 6:
+            continue
+        if interface.hardwareAddress == b"\x00" * 6:
+            continue
+        return dr.format_mac(interface.hardwareAddress.hex())
+    return None
+
+
 class MatterAdapter:
     """Connect Matter into Home Assistant."""
 
@@ -212,10 +232,17 @@ class MatterAdapter:
         else:
             model_id = str(product_id) if (product_id := basic_info.productID) else None
 
+        connections: set[tuple[str, str]] = set()
+        if not endpoint.is_bridged_device and (
+            mac_address := _get_mac_address(endpoint.node)
+        ):
+            connections.add((dr.CONNECTION_NETWORK_MAC, mac_address))
+
         dr.async_get(self.hass).async_get_or_create(
             name=name,
             config_entry_id=self.config_entry.entry_id,
             identifiers=identifiers,
+            connections=connections,
             hw_version=basic_info.hardwareVersionString,
             sw_version=basic_info.softwareVersionString,
             manufacturer=basic_info.vendorName or endpoint.node.device_info.vendorName,

--- a/homeassistant/components/matter/adapter.py
+++ b/homeassistant/components/matter/adapter.py
@@ -29,20 +29,24 @@ def get_clean_name(name: str | None) -> str | None:
 
 
 def _get_mac_address(node: MatterNode) -> str | None:
-    """Return the MAC address of the node's operational network interface, if any."""
+    """Return the MAC address of the node's operational WiFi/Ethernet interface, if any."""
     interfaces = node.get_attribute_value(
         0,
         clusters.GeneralDiagnostics,
         clusters.GeneralDiagnostics.Attributes.NetworkInterfaces,
     )
+    interface_type = clusters.GeneralDiagnostics.Enums.InterfaceTypeEnum
     for interface in interfaces or []:
         if not interface.isOperational:
             continue
-        # Only 6-byte (WiFi/Ethernet) addresses are MAC addresses; Thread
-        # interfaces report an 8-byte EUI-64 with no matching connection type.
-        if len(interface.hardwareAddress) != 6:
+        # Thread (and other non-WiFi/Ethernet) interfaces don't have a MAC
+        # address (e.g. Thread reports an 8-byte EUI-64 instead).
+        if interface.type not in (interface_type.kWiFi, interface_type.kEthernet):
             continue
-        if interface.hardwareAddress == b"\x00" * 6:
+        if (
+            len(interface.hardwareAddress) != 6
+            or interface.hardwareAddress == b"\x00" * 6
+        ):
             continue
         return dr.format_mac(interface.hardwareAddress.hex())
     return None

--- a/tests/components/matter/fixtures/nodes/extended_color_light.json
+++ b/tests/components/matter/fixtures/nodes/extended_color_light.json
@@ -96,7 +96,7 @@
         "1": true,
         "2": null,
         "3": null,
-        "4": "ABeILIy4",
+        "4": "AgAAAAAM",
         "5": ["CjwBuw=="],
         "6": [
           "/VqgxiAxQiYCF4j//iyMuA==",

--- a/tests/components/matter/fixtures/nodes/mock_cooktop.json
+++ b/tests/components/matter/fixtures/nodes/mock_cooktop.json
@@ -140,7 +140,7 @@
         "1": true,
         "2": null,
         "3": null,
-        "4": "AAwp/F0T",
+        "4": "AgAAAAAB",
         "5": ["wKgBqA=="],
         "6": [
           "KgEOCgKzOZAP/YMcX0yMLQ==",

--- a/tests/components/matter/fixtures/nodes/mock_door_lock_with_unbolt.json
+++ b/tests/components/matter/fixtures/nodes/mock_door_lock_with_unbolt.json
@@ -149,7 +149,7 @@
         "1": true,
         "2": null,
         "3": null,
-        "4": "/mQDt/2Q",
+        "4": "AgAAAAAN",
         "5": ["CjwBaQ=="],
         "6": [
           "/VqgxiAxQib8ZAP//rf9kA==",

--- a/tests/components/matter/fixtures/nodes/mock_extractor_hood.json
+++ b/tests/components/matter/fixtures/nodes/mock_extractor_hood.json
@@ -133,7 +133,7 @@
         "1": true,
         "2": null,
         "3": null,
-        "4": "AAwp/F0T",
+        "4": "AgAAAAAH",
         "5": ["wKgBqA=="],
         "6": [
           "KgEOCgKzOZDFgY47cQOPog==",

--- a/tests/components/matter/fixtures/nodes/mock_lock.json
+++ b/tests/components/matter/fixtures/nodes/mock_lock.json
@@ -164,7 +164,7 @@
         "1": true,
         "2": null,
         "3": null,
-        "4": "AAwpaqXN",
+        "4": "AgAAAAAL",
         "5": ["wKgBxA=="],
         "6": [
           "KgEOCgKzOZBI/+PPpfBv9Q==",

--- a/tests/components/matter/fixtures/nodes/mock_mounted_dimmable_load_control_fixture.json
+++ b/tests/components/matter/fixtures/nodes/mock_mounted_dimmable_load_control_fixture.json
@@ -136,7 +136,7 @@
         "1": true,
         "2": null,
         "3": null,
-        "4": "AAwp/F0T",
+        "4": "AgAAAAAE",
         "5": ["wKgBqA=="],
         "6": [
           "KgEOCgKzOZBQ8P5SEgahQg==",

--- a/tests/components/matter/fixtures/nodes/mock_oven.json
+++ b/tests/components/matter/fixtures/nodes/mock_oven.json
@@ -139,7 +139,7 @@
         "1": true,
         "2": null,
         "3": null,
-        "4": "AAwp/F0T",
+        "4": "AgAAAAAD",
         "5": ["wKgBqA=="],
         "6": [
           "KgEOCgKzOZAP/YMcX0yMLQ==",

--- a/tests/components/matter/fixtures/nodes/mock_pump.json
+++ b/tests/components/matter/fixtures/nodes/mock_pump.json
@@ -117,7 +117,7 @@
         "1": true,
         "2": null,
         "3": null,
-        "4": "AAwp/F0T",
+        "4": "AgAAAAAG",
         "5": ["wKgBqA=="],
         "6": [
           "KgEOCgKzOZARgk66TFlR1w==",

--- a/tests/components/matter/fixtures/nodes/mock_solar_inverter.json
+++ b/tests/components/matter/fixtures/nodes/mock_solar_inverter.json
@@ -139,7 +139,7 @@
         "1": true,
         "2": null,
         "3": null,
-        "4": "AAwp/F0T",
+        "4": "AgAAAAAC",
         "5": ["wKgBqA=="],
         "6": [
           "KgEOCgKzOZDZEOyJQB4D1w==",

--- a/tests/components/matter/fixtures/nodes/mock_window_covering_full.json
+++ b/tests/components/matter/fixtures/nodes/mock_window_covering_full.json
@@ -117,7 +117,7 @@
         "1": true,
         "2": null,
         "3": null,
-        "4": "JG8olrDo",
+        "4": "AgAAAAAK",
         "5": ["wKgBFw=="],
         "6": ["/oAAAAAAAAAmbyj//paw6A=="],
         "7": 1

--- a/tests/components/matter/fixtures/nodes/mock_window_covering_pa_tilt.json
+++ b/tests/components/matter/fixtures/nodes/mock_window_covering_pa_tilt.json
@@ -117,7 +117,7 @@
         "1": true,
         "2": null,
         "3": null,
-        "4": "JG8olrDo",
+        "4": "AgAAAAAJ",
         "5": ["wKgBFw=="],
         "6": ["/oAAAAAAAAAmbyj//paw6A=="],
         "7": 1

--- a/tests/components/matter/fixtures/nodes/mock_window_covering_tilt.json
+++ b/tests/components/matter/fixtures/nodes/mock_window_covering_tilt.json
@@ -117,7 +117,7 @@
         "1": true,
         "2": null,
         "3": null,
-        "4": "JG8olrDo",
+        "4": "AgAAAAAI",
         "5": ["wKgBFw=="],
         "6": ["/oAAAAAAAAAmbyj//paw6A=="],
         "7": 1

--- a/tests/components/matter/fixtures/nodes/silabs_evse_charging.json
+++ b/tests/components/matter/fixtures/nodes/silabs_evse_charging.json
@@ -137,7 +137,7 @@
         "1": true,
         "2": null,
         "3": null,
-        "4": "AAwp/F0T",
+        "4": "AgAAAAAF",
         "5": ["wKgBpw=="],
         "6": [
           "KgEOCgKzOZCNB+q+Uz0I9w==",

--- a/tests/components/matter/test_adapter.py
+++ b/tests/components/matter/test_adapter.py
@@ -1,6 +1,7 @@
 """Test the adapter."""
 
 import base64
+from typing import Any
 from unittest.mock import MagicMock
 
 from matter_server.common.models import EventType
@@ -105,6 +106,57 @@ async def test_device_registry_bridge_mac_address(
     assert bridged_device_entry is not None
     assert bridged_device_entry.via_device_id == bridge_entry.id
     assert bridged_device_entry.connections == set()
+
+
+@pytest.mark.parametrize(
+    "interface_overrides",
+    [
+        # operational WiFi interface reporting an all-zero address
+        {"1": True, "7": 1, "4": base64.b64encode(bytes(6)).decode()},
+        # non-operational Ethernet interface with an otherwise-valid address
+        {
+            "1": False,
+            "7": 2,
+            "4": base64.b64encode(bytes([0x02, 0x00, 0x00, 0x00, 0x00, 0x03])).decode(),
+        },
+    ],
+    ids=["all_zero_address", "non_operational_interface"],
+)
+async def test_device_registry_mac_address_invalid_entries(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    device_registry: dr.DeviceRegistry,
+    interface_overrides: dict[str, Any],
+) -> None:
+    """Test invalid or non-operational interfaces don't produce a MAC connection."""
+    interface = {
+        "0": "wlan0",
+        "1": True,
+        "2": None,
+        "3": None,
+        "4": "",
+        "5": [],
+        "6": [],
+        "7": 1,
+    }
+    interface.update(interface_overrides)
+    node = create_node_from_fixture("mock_onoff_light", {"0/51/0": [interface]})
+    matter_client.get_nodes.return_value = [node]
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data={"url": "http://mock-matter-server-url"}
+    )
+    config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entry = device_registry.async_get_device(
+        identifiers={
+            (DOMAIN, "deviceid_00000000000004D2-000000000000001E-MatterNodeDevice")
+        }
+    )
+    assert entry is not None
+    assert entry.connections == set()
 
 
 async def test_device_registry_multiple_mac_addresses(

--- a/tests/components/matter/test_adapter.py
+++ b/tests/components/matter/test_adapter.py
@@ -48,6 +48,24 @@ async def test_device_registry_single_node_device(
     assert entry.hw_version == "v1.0"
     assert entry.sw_version == "v1.0"
     assert entry.serial_number == "12345678"
+    # no valid network interface MAC address is present in this fixture
+    assert entry.connections == set()
+
+
+@pytest.mark.usefixtures("matter_node")
+@pytest.mark.parametrize("node_fixture", ["color_temperature_light"])
+async def test_device_registry_mac_address(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test the device's MAC address is added as a connection."""
+    entry = device_registry.async_get_device(
+        identifiers={
+            (DOMAIN, "deviceid_00000000000004D2-0000000000000005-MatterNodeDevice")
+        }
+    )
+    assert entry is not None
+    assert entry.connections == {(dr.CONNECTION_NETWORK_MAC, "00:17:88:2c:8c:b8")}
 
 
 @pytest.mark.usefixtures("matter_node")

--- a/tests/components/matter/test_adapter.py
+++ b/tests/components/matter/test_adapter.py
@@ -82,6 +82,31 @@ async def test_device_registry_mac_address(
         assert entry.connections == {(dr.CONNECTION_NETWORK_MAC, expected_mac)}
 
 
+@pytest.mark.usefixtures("matter_node")
+@pytest.mark.parametrize("node_fixture", ["atios_knx_bridge"])
+async def test_device_registry_bridge_mac_address(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test the bridge's MAC is not also reported for its bridged devices."""
+    bridge_entry = device_registry.async_get_device(
+        identifiers={
+            (DOMAIN, "deviceid_00000000000004D2-000000000000003E-MatterNodeDevice")
+        }
+    )
+    assert bridge_entry is not None
+    assert bridge_entry.connections == {
+        (dr.CONNECTION_NETWORK_MAC, "d0:cf:13:25:b6:70")
+    }
+
+    bridged_device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, "deviceid_00000000000004D2-000000000000003E-29")}
+    )
+    assert bridged_device_entry is not None
+    assert bridged_device_entry.via_device_id == bridge_entry.id
+    assert bridged_device_entry.connections == set()
+
+
 async def test_device_registry_multiple_mac_addresses(
     hass: HomeAssistant,
     matter_client: MagicMock,

--- a/tests/components/matter/test_adapter.py
+++ b/tests/components/matter/test_adapter.py
@@ -1,5 +1,6 @@
 """Test the adapter."""
 
+import base64
 from unittest.mock import MagicMock
 
 from matter_server.common.models import EventType
@@ -79,6 +80,60 @@ async def test_device_registry_mac_address(
         assert entry.connections == set()
     else:
         assert entry.connections == {(dr.CONNECTION_NETWORK_MAC, expected_mac)}
+
+
+async def test_device_registry_multiple_mac_addresses(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test all operational WiFi/Ethernet interfaces are added as connections."""
+    wifi_mac = bytes([0x02, 0x00, 0x00, 0x00, 0x00, 0x01])
+    ethernet_mac = bytes([0x02, 0x00, 0x00, 0x00, 0x00, 0x02])
+    override_attributes = {
+        "0/51/0": [
+            {
+                "0": "wlan0",
+                "1": True,
+                "2": None,
+                "3": None,
+                "4": base64.b64encode(wifi_mac).decode(),
+                "5": [],
+                "6": [],
+                "7": 1,  # InterfaceTypeEnum.kWiFi
+            },
+            {
+                "0": "eth0",
+                "1": True,
+                "2": None,
+                "3": None,
+                "4": base64.b64encode(ethernet_mac).decode(),
+                "5": [],
+                "6": [],
+                "7": 2,  # InterfaceTypeEnum.kEthernet
+            },
+        ]
+    }
+    node = create_node_from_fixture("mock_onoff_light", override_attributes)
+    matter_client.get_nodes.return_value = [node]
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data={"url": "http://mock-matter-server-url"}
+    )
+    config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entry = device_registry.async_get_device(
+        identifiers={
+            (DOMAIN, "deviceid_00000000000004D2-000000000000001E-MatterNodeDevice")
+        }
+    )
+    assert entry is not None
+    assert entry.connections == {
+        (dr.CONNECTION_NETWORK_MAC, "02:00:00:00:00:01"),
+        (dr.CONNECTION_NETWORK_MAC, "02:00:00:00:00:02"),
+    }
 
 
 @pytest.mark.usefixtures("matter_node")

--- a/tests/components/matter/test_adapter.py
+++ b/tests/components/matter/test_adapter.py
@@ -53,19 +53,32 @@ async def test_device_registry_single_node_device(
 
 
 @pytest.mark.usefixtures("matter_node")
-@pytest.mark.parametrize("node_fixture", ["color_temperature_light"])
+@pytest.mark.parametrize(
+    ("node_fixture", "unique_id", "expected_mac"),
+    [
+        # operational Ethernet interface with a valid hardware address
+        ("mock_cooktop", "000000000000002B", "02:00:00:00:00:01"),
+        # operational Thread interface: reports an 8-byte EUI-64, not a MAC
+        ("eve_contact_sensor", "0000000000000009", None),
+    ],
+)
 async def test_device_registry_mac_address(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
+    unique_id: str,
+    expected_mac: str | None,
 ) -> None:
-    """Test the device's MAC address is added as a connection."""
+    """Test the device's MAC address is only added for WiFi/Ethernet interfaces."""
     entry = device_registry.async_get_device(
         identifiers={
-            (DOMAIN, "deviceid_00000000000004D2-0000000000000005-MatterNodeDevice")
+            (DOMAIN, f"deviceid_00000000000004D2-{unique_id}-MatterNodeDevice")
         }
     )
     assert entry is not None
-    assert entry.connections == {(dr.CONNECTION_NETWORK_MAC, "00:17:88:2c:8c:b8")}
+    if expected_mac is None:
+        assert entry.connections == set()
+    else:
+        assert entry.connections == {(dr.CONNECTION_NETWORK_MAC, expected_mac)}
 
 
 @pytest.mark.usefixtures("matter_node")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Currently when a matter device is also available through some other integration, the devices appear duplicated. Home assistant is able to merge the devices if both integrations report the MAC address of the device. The Matter protocol already exposes Mac addresses, the matter integration reports those addresses but not to the device registry.

This pull request extracts the active Mac address of the device and exposes it to the device registry, so devices are correctly integrated. 

Closes #145903, #160109

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

Bridged devices do not report the Mac address because to my understanding they would be reporting the Mac address of the bridge and be merged all together incorrectly.

Some test fixtures were edited because they were generating the same Mac address and being merged together due to this PR. 

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #145903, #160109
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
