### PR TITLE
Migrate UniFi Protect sense sensors to the public API and derive entities from the sensor capability map

### DIFF
--- a/homeassistant/components/unifiprotect/binary_sensor.py
+++ b/homeassistant/components/unifiprotect/binary_sensor.py
@@ -26,7 +26,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
-from homeassistant.const import EntityCategory
+from homeassistant.const import EntityCategory, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -41,6 +41,7 @@ from .entity import (
     ProtectIsOnEntity,
     ProtectNVREntity,
     async_all_device_entities,
+    async_remove_unsupported_sense_entities,
 )
 
 _KEY_DOOR = "door"
@@ -341,6 +342,7 @@ MOUNTABLE_SENSE_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
         device_class=BinarySensorDeviceClass.DOOR,
         ufp_public_value="is_opened",
         ufp_public_enabled_fn=_async_contact_sensor_enabled_public,
+        ufp_capability=SensorFeatureCapability.OPEN,
     ),
 )
 
@@ -350,6 +352,7 @@ SENSE_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
         device_class=BinarySensorDeviceClass.MOISTURE,
         ufp_public_value="is_leak_detected",
         ufp_public_enabled_fn=_async_leak_sensor_enabled_public,
+        ufp_capability=SensorFeatureCapability.WATER_LEAK,
     ),
     ProtectBinaryEntityDescription(
         key="battery_low",
@@ -362,11 +365,13 @@ SENSE_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
         device_class=BinarySensorDeviceClass.MOTION,
         ufp_public_value="is_motion_detected",
         ufp_public_enabled_fn=_async_motion_sensor_enabled_public,
+        ufp_capability=SensorFeatureCapability.MOTION,
     ),
     ProtectBinaryEntityDescription(
         key="tampering",
         device_class=BinarySensorDeviceClass.TAMPER,
         ufp_public_value="is_tampering_detected",
+        ufp_capability=SensorFeatureCapability.TAMPER,
     ),
     ProtectBinaryEntityDescription(
         key="status_light",
@@ -380,6 +385,7 @@ SENSE_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
         translation_key="motion_detection_enabled",
         entity_category=EntityCategory.DIAGNOSTIC,
         ufp_value="motion_settings.is_enabled",
+        ufp_capability=SensorFeatureCapability.MOTION,
         ufp_perm=PermRequired.NO_WRITE,
     ),
     ProtectBinaryEntityDescription(
@@ -762,6 +768,9 @@ async def async_setup_entry(
 ) -> None:
     """Set up binary sensors for UniFi Protect integration."""
     data = entry.runtime_data
+    async_remove_unsupported_sense_entities(
+        hass, Platform.BINARY_SENSOR, data, (*SENSE_SENSORS, *MOUNTABLE_SENSE_SENSORS)
+    )
 
     @callback
     def _add_new_device(device: ProtectAdoptableDeviceModel) -> None:

--- a/homeassistant/components/unifiprotect/binary_sensor.py
+++ b/homeassistant/components/unifiprotect/binary_sensor.py
@@ -15,7 +15,11 @@ from uiprotect.data import (
     SmartDetectObjectType,
 )
 from uiprotect.data.nvr import UOSDisk
-from uiprotect.data.public_devices import PublicDeviceModel, PublicSensor
+from uiprotect.data.public_devices import (
+    PublicDeviceModel,
+    PublicSensor,
+    SensorFeatureCapability,
+)
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -47,6 +51,26 @@ def _async_motion_sensor_enabled_public(obj: PublicDeviceModel) -> bool:
     # Mirrors Sensor.is_motion_sensor_enabled over the public API.
     sensor = cast(PublicSensor, obj)
     return sensor.mount_type is not MountType.LEAK and sensor.motion_settings.is_enabled
+
+
+def _async_contact_sensor_enabled_public(obj: PublicDeviceModel) -> bool:
+    # Mirrors Sensor.is_contact_sensor_enabled over the public API.
+    return cast(PublicSensor, obj).is_contact_sensor_enabled
+
+
+def _async_leak_sensor_enabled_public(obj: PublicDeviceModel) -> bool:
+    # Leak-mounted (UP Sense), or the capability map advertises water_leak with a
+    # leak channel enabled — the USL family detects leaks without a leak mount.
+    # Settings alone are not a valid gate: sensors without the capability report
+    # inert default leak settings.
+    sensor = cast(PublicSensor, obj)
+    return sensor.is_leak_sensor_enabled or (
+        sensor.supports(SensorFeatureCapability.WATER_LEAK)
+        and (
+            sensor.leak_settings.is_internal_enabled
+            or sensor.leak_settings.is_external_enabled
+        )
+    )
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
@@ -315,8 +339,8 @@ MOUNTABLE_SENSE_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
         key=_KEY_DOOR,
         translation_key="contact",
         device_class=BinarySensorDeviceClass.DOOR,
-        ufp_value="is_opened",
-        ufp_enabled="is_contact_sensor_enabled",
+        ufp_public_value="is_opened",
+        ufp_public_enabled_fn=_async_contact_sensor_enabled_public,
     ),
 )
 
@@ -324,8 +348,8 @@ SENSE_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
     ProtectBinaryEntityDescription(
         key="leak",
         device_class=BinarySensorDeviceClass.MOISTURE,
-        ufp_value="is_leak_detected",
-        ufp_enabled="is_leak_sensor_enabled",
+        ufp_public_value="is_leak_detected",
+        ufp_public_enabled_fn=_async_leak_sensor_enabled_public,
     ),
     ProtectBinaryEntityDescription(
         key="battery_low",
@@ -342,7 +366,7 @@ SENSE_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
     ProtectBinaryEntityDescription(
         key="tampering",
         device_class=BinarySensorDeviceClass.TAMPER,
-        ufp_value="is_tampering_detected",
+        ufp_public_value="is_tampering_detected",
     ),
     ProtectBinaryEntityDescription(
         key="status_light",
@@ -568,8 +592,13 @@ class MountableProtectDeviceBinarySensor(ProtectDeviceBinarySensor):
     def _async_update_device_from_protect(self, device: ProtectDeviceType) -> None:
         super()._async_update_device_from_protect(device)
         # UP Sense can be any of the 3 contact sensor device classes
+        mount_type = (
+            cast(PublicSensor, public).mount_type
+            if (public := self._ufp_public_obj) is not None
+            else self.device.mount_type
+        )
         self._attr_device_class = MOUNT_DEVICE_CLASS_MAP.get(
-            self.device.mount_type, BinarySensorDeviceClass.DOOR
+            mount_type, BinarySensorDeviceClass.DOOR
         )
 
 

--- a/homeassistant/components/unifiprotect/entity.py
+++ b/homeassistant/components/unifiprotect/entity.py
@@ -20,9 +20,11 @@ from uiprotect.data import (
     SmartDetectObjectType,
     StateType,
 )
+from uiprotect.data.public_devices import PublicSensor, SensorFeatureCapability
 
-from homeassistant.core import callback
-from homeassistant.helpers import device_registry as dr
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity, EntityDescription
 
@@ -46,6 +48,46 @@ class PermRequired(int, Enum):
     NO_WRITE = 1
     WRITE = 2
     DELETE = 3
+
+
+@callback
+def _async_capability_supported(
+    data: ProtectData,
+    device: ProtectAdoptableDeviceModel,
+    description: ProtectEntityDescription,
+) -> bool:
+    """Whether the device advertises the description's required sensor capability."""
+    if (capability := description.ufp_capability) is None:
+        return True
+    public = data.async_get_public_device(device)
+    if not isinstance(public, PublicSensor) or not public.has_feature_flags:
+        return True
+    return public.supports(capability)
+
+
+@callback
+def async_remove_unsupported_sense_entities(
+    hass: HomeAssistant,
+    platform: Platform,
+    data: ProtectData,
+    descs: Sequence[ProtectEntityDescription],
+) -> None:
+    """Remove registry entries for sense entities the device cannot support.
+
+    Only acts when a public capability map is present (newer firmware); a console
+    upgrade then drops the never-functional entities created before the map existed.
+    """
+    entity_registry = er.async_get(hass)
+    for device in data.get_by_types({ModelType.SENSOR}):
+        for description in descs:
+            if description.ufp_capability is None or _async_capability_supported(
+                data, device, description
+            ):
+                continue
+            if entity_id := entity_registry.async_get_entity_id(
+                platform, DOMAIN, f"{device.mac}_{description.key}"
+            ):
+                entity_registry.async_remove(entity_id)
 
 
 @callback
@@ -99,6 +141,9 @@ def _async_device_entities(
                     continue
 
             if not description.has_required(device):
+                continue
+
+            if not _async_capability_supported(data, device, description):
                 continue
 
             entities.append(
@@ -440,6 +485,10 @@ class ProtectEntityDescription(EntityDescription, Generic[T]):  # noqa: UP046
     # Public counterpart of ``ufp_enabled``; a callable because public enablement
     # is often compound (e.g. mount type plus a settings flag).
     ufp_public_enabled_fn: Callable[[PublicDeviceModel], bool] | None = None
+    # Sensor capability required to create the entity, checked against the public
+    # capability map. Without a capability map (older firmware) every description
+    # is created, matching the pre-capability behavior.
+    ufp_capability: SensorFeatureCapability | None = None
     ufp_perm: PermRequired | None = None
 
     # The below are set in __post_init__

--- a/homeassistant/components/unifiprotect/number.py
+++ b/homeassistant/components/unifiprotect/number.py
@@ -7,10 +7,14 @@ import logging
 from typing import cast, override
 
 from uiprotect.data import Camera, Chime, Light, ModelType, ProtectAdoptableDeviceModel
-from uiprotect.data.public_devices import PublicDeviceModel, PublicLight
+from uiprotect.data.public_devices import (
+    PublicDeviceModel,
+    PublicLight,
+    SensorFeatureCapability,
+)
 
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
-from homeassistant.const import PERCENTAGE, EntityCategory, UnitOfTime
+from homeassistant.const import PERCENTAGE, EntityCategory, Platform, UnitOfTime
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -22,6 +26,7 @@ from .entity import (
     ProtectSettableKeysMixin,
     T,
     async_all_device_entities,
+    async_remove_unsupported_sense_entities,
 )
 from .utils import async_ufp_instance_command
 
@@ -198,6 +203,7 @@ SENSE_NUMBERS: tuple[ProtectNumberEntityDescription, ...] = (
         ufp_step=1,
         ufp_value="motion_settings.sensitivity",
         ufp_set_method="set_motion_sensitivity",
+        ufp_capability=SensorFeatureCapability.MOTION,
         ufp_perm=PermRequired.WRITE,
     ),
 )
@@ -276,6 +282,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up number entities for UniFi Protect integration."""
     data = entry.runtime_data
+    async_remove_unsupported_sense_entities(hass, Platform.NUMBER, data, SENSE_NUMBERS)
 
     @callback
     def _add_new_device(device: ProtectAdoptableDeviceModel) -> None:

--- a/homeassistant/components/unifiprotect/select.py
+++ b/homeassistant/components/unifiprotect/select.py
@@ -25,10 +25,11 @@ from uiprotect.data import (
     Sensor,
     Viewer,
 )
+from uiprotect.data.public_devices import SensorFeatureCapability
 from uiprotect.exceptions import GlobalAlarmManagerError
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
-from homeassistant.const import EntityCategory
+from homeassistant.const import EntityCategory, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import EntityDescription
@@ -44,6 +45,7 @@ from .entity import (
     ProtectSettableKeysMixin,
     T,
     async_all_device_entities,
+    async_remove_unsupported_sense_entities,
 )
 from .utils import async_get_light_motion_current, async_ufp_instance_command
 
@@ -316,6 +318,7 @@ SENSE_SELECTS: tuple[ProtectSelectEntityDescription, ...] = (
         ufp_enum_type=MountType,
         ufp_value="mount_type",
         ufp_set_method="set_mount_type",
+        ufp_capability=SensorFeatureCapability.OPEN,
         ufp_perm=PermRequired.WRITE,
     ),
     ProtectSelectEntityDescription[Sensor](
@@ -355,6 +358,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up number entities for UniFi Protect integration."""
     data = entry.runtime_data
+    async_remove_unsupported_sense_entities(hass, Platform.SELECT, data, SENSE_SELECTS)
 
     @callback
     def _add_new_device(device: ProtectAdoptableDeviceModel) -> None:

--- a/homeassistant/components/unifiprotect/sensor.py
+++ b/homeassistant/components/unifiprotect/sensor.py
@@ -16,6 +16,7 @@ from uiprotect.data import (
     ProtectDeviceModel,
     Sensor,
 )
+from uiprotect.data.public_devices import SensorFeatureCapability
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -28,6 +29,7 @@ from homeassistant.const import (
     PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     EntityCategory,
+    Platform,
     UnitOfDataRate,
     UnitOfElectricPotential,
     UnitOfInformation,
@@ -48,6 +50,7 @@ from .entity import (
     ProtectNVREntity,
     T,
     async_all_device_entities,
+    async_remove_unsupported_sense_entities,
 )
 from .utils import async_get_light_motion_current
 
@@ -310,6 +313,7 @@ SENSE_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         ufp_value="stats.light.value",
         ufp_enabled="is_light_sensor_enabled",
+        ufp_capability=SensorFeatureCapability.LIGHT,
     ),
     ProtectSensorEntityDescription(
         key="humidity_level",
@@ -318,6 +322,7 @@ SENSE_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         ufp_value="stats.humidity.value",
         ufp_enabled="is_humidity_sensor_enabled",
+        ufp_capability=SensorFeatureCapability.HUMIDITY,
     ),
     ProtectSensorEntityDescription(
         key="temperature_level",
@@ -326,18 +331,21 @@ SENSE_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         ufp_value="stats.temperature.value",
         ufp_enabled="is_temperature_sensor_enabled",
+        ufp_capability=SensorFeatureCapability.TEMPERATURE,
     ),
     ProtectSensorEntityDescription[Sensor](
         key="alarm_sound",
         translation_key="alarm_sound_detected",
         ufp_value_fn=_get_alarm_sound,
         ufp_enabled="is_alarm_sensor_enabled",
+        ufp_capability=SensorFeatureCapability.SMOKE,
     ),
     ProtectSensorEntityDescription(
         key="door_last_trip_time",
         translation_key="last_open",
         device_class=SensorDeviceClass.TIMESTAMP,
         ufp_value="open_status_changed_at",
+        ufp_capability=SensorFeatureCapability.OPEN,
         entity_registry_enabled_default=False,
     ),
     ProtectSensorEntityDescription(
@@ -345,11 +353,13 @@ SENSE_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
         translation_key="last_motion_detected",
         device_class=SensorDeviceClass.TIMESTAMP,
         ufp_value="motion_detected_at",
+        ufp_capability=SensorFeatureCapability.MOTION,
         entity_registry_enabled_default=False,
     ),
     ProtectSensorEntityDescription(
         key="tampering_last_trip_time",
         translation_key="last_tampering_detected",
+        ufp_capability=SensorFeatureCapability.TAMPER,
         device_class=SensorDeviceClass.TIMESTAMP,
         ufp_value="tampering_detected_at",
         entity_registry_enabled_default=False,
@@ -360,6 +370,7 @@ SENSE_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
         native_unit_of_measurement=PERCENTAGE,
         entity_category=EntityCategory.DIAGNOSTIC,
         ufp_value="motion_settings.sensitivity",
+        ufp_capability=SensorFeatureCapability.MOTION,
         ufp_perm=PermRequired.NO_WRITE,
     ),
     ProtectSensorEntityDescription(
@@ -367,6 +378,7 @@ SENSE_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
         translation_key="mount_type",
         entity_category=EntityCategory.DIAGNOSTIC,
         ufp_value="mount_type",
+        ufp_capability=SensorFeatureCapability.OPEN,
         ufp_perm=PermRequired.NO_WRITE,
     ),
     ProtectSensorEntityDescription(
@@ -576,6 +588,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up sensors for UniFi Protect integration."""
     data = entry.runtime_data
+    async_remove_unsupported_sense_entities(hass, Platform.SENSOR, data, SENSE_SENSORS)
 
     @callback
     def _add_new_device(device: ProtectAdoptableDeviceModel) -> None:

--- a/tests/components/unifiprotect/test_binary_sensor.py
+++ b/tests/components/unifiprotect/test_binary_sensor.py
@@ -25,6 +25,7 @@ from homeassistant.components.unifiprotect.binary_sensor import (
     LIGHT_SENSORS,
     MOUNTABLE_SENSE_SENSORS,
     SENSE_SENSORS,
+    ProtectBinaryEntityDescription,
 )
 from homeassistant.components.unifiprotect.const import (
     ATTR_EVENT_SCORE,
@@ -60,6 +61,9 @@ LIGHT_SENSOR_WRITE = LIGHT_SENSORS[:2]
 SENSE_SENSORS_WRITE = SENSE_SENSORS[:3]
 BATTERY_LOW = next(d for d in SENSE_SENSORS if d.key == "battery_low")
 SENSE_MOTION = next(d for d in SENSE_SENSORS if d.key == "motion")
+SENSE_DOOR = MOUNTABLE_SENSE_SENSORS[0]
+SENSE_LEAK = next(d for d in SENSE_SENSORS if d.key == "leak")
+SENSE_TAMPERING = next(d for d in SENSE_SENSORS if d.key == "tampering")
 
 
 async def test_binary_sensor_camera_remove(
@@ -382,6 +386,188 @@ async def test_binary_sensor_sense_motion_unavailable_without_public(
 
     _, entity_id = await ids_from_device_description(
         hass, Platform.BINARY_SENSOR, sensor_all, SENSE_MOTION
+    )
+    assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
+
+
+async def test_binary_sensor_sense_door_public_value(
+    hass: HomeAssistant, ufp: MockUFPFixture, sensor_all: Sensor
+) -> None:
+    """The contact sensor reads is_opened from a public WS update."""
+    setup_public_sensor(ufp)
+    await init_entry(hass, ufp, [sensor_all])
+
+    _, entity_id = await ids_from_device_description(
+        hass, Platform.BINARY_SENSOR, sensor_all, SENSE_DOOR
+    )
+    assert hass.states.get(entity_id).state == STATE_OFF
+
+    public = make_public_sensor(sensor_all, is_opened=True)
+    ufp.devices_ws_subscription(public_device_ws_message(public))
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == STATE_ON
+
+
+async def test_binary_sensor_sense_door_unmounted_unavailable(
+    hass: HomeAssistant, ufp: MockUFPFixture, sensor_all: Sensor
+) -> None:
+    """A sensor without a contact mount reports the contact sensor unavailable."""
+    setup_public_sensor(ufp)
+    await init_entry(hass, ufp, [sensor_all])
+
+    _, entity_id = await ids_from_device_description(
+        hass, Platform.BINARY_SENSOR, sensor_all, SENSE_DOOR
+    )
+    assert hass.states.get(entity_id).state != STATE_UNAVAILABLE
+
+    public = make_public_sensor(sensor_all, mount_type=MountType.NONE)
+    ufp.devices_ws_subscription(public_device_ws_message(public))
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
+
+
+async def test_binary_sensor_sense_door_device_class_follows_public_mount(
+    hass: HomeAssistant, ufp: MockUFPFixture, sensor_all: Sensor
+) -> None:
+    """The contact sensor derives its device class from the public mount type."""
+    setup_public_sensor(ufp)
+    await init_entry(hass, ufp, [sensor_all])
+
+    _, entity_id = await ids_from_device_description(
+        hass, Platform.BINARY_SENSOR, sensor_all, SENSE_DOOR
+    )
+    state = hass.states.get(entity_id)
+    assert state.attributes[ATTR_DEVICE_CLASS] == BinarySensorDeviceClass.DOOR.value
+
+    public = make_public_sensor(sensor_all, mount_type=MountType.WINDOW)
+    ufp.devices_ws_subscription(public_device_ws_message(public))
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state.attributes[ATTR_DEVICE_CLASS] == BinarySensorDeviceClass.WINDOW.value
+
+
+async def test_binary_sensor_sense_leak_public_value(
+    hass: HomeAssistant, ufp: MockUFPFixture, sensor_all: Sensor
+) -> None:
+    """The leak sensor reads is_leak_detected from a public WS update."""
+    setup_public_sensor(ufp)
+    await init_entry(hass, ufp, [sensor_all])
+
+    _, entity_id = await ids_from_device_description(
+        hass, Platform.BINARY_SENSOR, sensor_all, SENSE_LEAK
+    )
+
+    public = make_public_sensor(
+        sensor_all, mount_type=MountType.LEAK, is_leak_detected=True
+    )
+    ufp.devices_ws_subscription(public_device_ws_message(public))
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == STATE_ON
+
+
+@pytest.mark.parametrize(
+    ("mount_type", "supports_water_leak", "internal", "external", "expected"),
+    [
+        pytest.param(
+            MountType.LEAK, False, False, False, STATE_OFF, id="leak-mount-parity"
+        ),
+        pytest.param(
+            MountType.NONE, True, True, False, STATE_OFF, id="capability-internal"
+        ),
+        pytest.param(
+            MountType.NONE, True, False, True, STATE_OFF, id="capability-external"
+        ),
+        pytest.param(
+            MountType.NONE,
+            False,
+            True,
+            True,
+            STATE_UNAVAILABLE,
+            id="settings-without-capability",
+        ),
+        pytest.param(
+            MountType.NONE,
+            True,
+            False,
+            False,
+            STATE_UNAVAILABLE,
+            id="capability-without-channel",
+        ),
+    ],
+)
+async def test_binary_sensor_sense_leak_enablement_gate(
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+    sensor_all: Sensor,
+    mount_type: MountType,
+    supports_water_leak: bool,
+    internal: bool,
+    external: bool,
+    expected: str,
+) -> None:
+    """The leak gate honors leak mount, water_leak capability and channel settings."""
+    setup_public_sensor(ufp)
+    await init_entry(hass, ufp, [sensor_all])
+
+    _, entity_id = await ids_from_device_description(
+        hass, Platform.BINARY_SENSOR, sensor_all, SENSE_LEAK
+    )
+
+    public = make_public_sensor(
+        sensor_all,
+        mount_type=mount_type,
+        supports_water_leak=supports_water_leak,
+        leak_internal_enabled=internal,
+        leak_external_enabled=external,
+    )
+    ufp.devices_ws_subscription(public_device_ws_message(public))
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == expected
+
+
+async def test_binary_sensor_sense_tampering_public_value(
+    hass: HomeAssistant, ufp: MockUFPFixture, sensor_all: Sensor
+) -> None:
+    """The tampering sensor reads is_tampering_detected from a public WS update."""
+    setup_public_sensor(ufp)
+    await init_entry(hass, ufp, [sensor_all])
+
+    _, entity_id = await ids_from_device_description(
+        hass, Platform.BINARY_SENSOR, sensor_all, SENSE_TAMPERING
+    )
+    assert hass.states.get(entity_id).state == STATE_OFF
+
+    public = make_public_sensor(sensor_all, is_tampering_detected=True)
+    ufp.devices_ws_subscription(public_device_ws_message(public))
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == STATE_ON
+
+
+@pytest.mark.parametrize(
+    "description",
+    [
+        pytest.param(SENSE_DOOR, id="door"),
+        pytest.param(SENSE_LEAK, id="leak"),
+        pytest.param(SENSE_TAMPERING, id="tampering"),
+    ],
+)
+async def test_binary_sensor_sense_unavailable_without_public(
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+    sensor_all: Sensor,
+    description: ProtectBinaryEntityDescription,
+) -> None:
+    """The migrated sense sensors are unavailable without a public object."""
+    await init_entry(hass, ufp, [sensor_all])
+
+    _, entity_id = await ids_from_device_description(
+        hass, Platform.BINARY_SENSOR, sensor_all, description
     )
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
 

--- a/tests/components/unifiprotect/test_binary_sensor.py
+++ b/tests/components/unifiprotect/test_binary_sensor.py
@@ -16,6 +16,7 @@ from uiprotect.data import (
     SmartDetectObjectType,
 )
 from uiprotect.data.nvr import EventMetadata
+from uiprotect.data.public_devices import SensorFeatureCapability
 from uiprotect.websocket import WebsocketState
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
@@ -30,6 +31,7 @@ from homeassistant.components.unifiprotect.binary_sensor import (
 from homeassistant.components.unifiprotect.const import (
     ATTR_EVENT_SCORE,
     DEFAULT_ATTRIBUTION,
+    DOMAIN,
 )
 from homeassistant.const import (
     ATTR_ATTRIBUTION,
@@ -470,20 +472,38 @@ async def test_binary_sensor_sense_leak_public_value(
 
 
 @pytest.mark.parametrize(
-    ("mount_type", "supports_water_leak", "internal", "external", "expected"),
+    ("mount_type", "capabilities", "internal", "external", "expected"),
     [
         pytest.param(
-            MountType.LEAK, False, False, False, STATE_OFF, id="leak-mount-parity"
-        ),
-        pytest.param(
-            MountType.NONE, True, True, False, STATE_OFF, id="capability-internal"
-        ),
-        pytest.param(
-            MountType.NONE, True, False, True, STATE_OFF, id="capability-external"
+            MountType.LEAK, None, False, False, STATE_OFF, id="leak-mount-parity"
         ),
         pytest.param(
             MountType.NONE,
+            {SensorFeatureCapability.WATER_LEAK},
+            True,
             False,
+            STATE_OFF,
+            id="capability-internal",
+        ),
+        pytest.param(
+            MountType.NONE,
+            {SensorFeatureCapability.WATER_LEAK},
+            False,
+            True,
+            STATE_OFF,
+            id="capability-external",
+        ),
+        pytest.param(
+            MountType.NONE,
+            None,
+            True,
+            True,
+            STATE_UNAVAILABLE,
+            id="settings-without-capability-map",
+        ),
+        pytest.param(
+            MountType.NONE,
+            set(),
             True,
             True,
             STATE_UNAVAILABLE,
@@ -491,7 +511,7 @@ async def test_binary_sensor_sense_leak_public_value(
         ),
         pytest.param(
             MountType.NONE,
-            True,
+            {SensorFeatureCapability.WATER_LEAK},
             False,
             False,
             STATE_UNAVAILABLE,
@@ -504,7 +524,7 @@ async def test_binary_sensor_sense_leak_enablement_gate(
     ufp: MockUFPFixture,
     sensor_all: Sensor,
     mount_type: MountType,
-    supports_water_leak: bool,
+    capabilities: set[SensorFeatureCapability] | None,
     internal: bool,
     external: bool,
     expected: str,
@@ -520,7 +540,7 @@ async def test_binary_sensor_sense_leak_enablement_gate(
     public = make_public_sensor(
         sensor_all,
         mount_type=mount_type,
-        supports_water_leak=supports_water_leak,
+        capabilities=capabilities,
         leak_internal_enabled=internal,
         leak_external_enabled=external,
     )
@@ -528,6 +548,71 @@ async def test_binary_sensor_sense_leak_enablement_gate(
     await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == expected
+
+
+async def test_binary_sensor_sense_capability_creation_filter(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    ufp: MockUFPFixture,
+    sensor_all: Sensor,
+) -> None:
+    """A capability map limits entity creation to the advertised capabilities."""
+    setup_public_sensor(
+        ufp,
+        capabilities={SensorFeatureCapability.OPEN, SensorFeatureCapability.TAMPER},
+    )
+    await init_entry(hass, ufp, [sensor_all])
+
+    for description in (SENSE_DOOR, SENSE_TAMPERING, BATTERY_LOW):
+        _, entity_id = await ids_from_device_description(
+            hass, Platform.BINARY_SENSOR, sensor_all, description
+        )
+        assert entity_registry.async_get(entity_id) is not None
+
+    for description in (SENSE_MOTION, SENSE_LEAK):
+        _, entity_id = await ids_from_device_description(
+            hass, Platform.BINARY_SENSOR, sensor_all, description
+        )
+        assert entity_registry.async_get(entity_id) is None
+
+
+async def test_binary_sensor_sense_capability_registry_cleanup(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    ufp: MockUFPFixture,
+    sensor_all: Sensor,
+) -> None:
+    """A console upgrade removes registry entries for unsupported capabilities."""
+    stale = entity_registry.async_get_or_create(
+        Platform.BINARY_SENSOR,
+        DOMAIN,
+        f"{sensor_all.mac}_{SENSE_LEAK.key}",
+        config_entry=ufp.entry,
+    )
+    setup_public_sensor(
+        ufp,
+        capabilities={SensorFeatureCapability.OPEN, SensorFeatureCapability.TAMPER},
+    )
+    await init_entry(hass, ufp, [sensor_all], regenerate_ids=False)
+
+    assert entity_registry.async_get(stale.entity_id) is None
+
+
+async def test_binary_sensor_sense_no_capability_map_creates_all(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    ufp: MockUFPFixture,
+    sensor_all: Sensor,
+) -> None:
+    """Without a capability map (older firmware) every sense entity is created."""
+    setup_public_sensor(ufp)
+    await init_entry(hass, ufp, [sensor_all])
+
+    for description in (SENSE_DOOR, SENSE_TAMPERING, SENSE_MOTION, SENSE_LEAK):
+        _, entity_id = await ids_from_device_description(
+            hass, Platform.BINARY_SENSOR, sensor_all, description
+        )
+        assert entity_registry.async_get(entity_id) is not None
 
 
 async def test_binary_sensor_sense_tampering_public_value(

--- a/tests/components/unifiprotect/test_sensor.py
+++ b/tests/components/unifiprotect/test_sensor.py
@@ -15,6 +15,7 @@ from uiprotect.data import (
     Sensor,
 )
 from uiprotect.data.nvr import EventMetadata
+from uiprotect.data.public_devices import SensorFeatureCapability
 from uiprotect.websocket import WebsocketState
 
 from homeassistant.components.unifiprotect.const import DEFAULT_ATTRIBUTION
@@ -92,6 +93,36 @@ async def test_sensor_sensor_remove(
     assert_entity_counts(hass, Platform.SENSOR, 12, 9)
     await adopt_devices(hass, ufp, [sensor_all])
     assert_entity_counts(hass, Platform.SENSOR, 22, 14)
+
+
+async def test_sensor_sense_capability_creation_filter(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    ufp: MockUFPFixture,
+    sensor_all: Sensor,
+) -> None:
+    """A capability map limits sensor entity creation to the advertised capabilities."""
+    setup_public_sensor(
+        ufp,
+        capabilities={SensorFeatureCapability.OPEN, SensorFeatureCapability.TAMPER},
+    )
+    await init_entry(hass, ufp, [sensor_all])
+
+    for key, created in (
+        ("battery_level", True),
+        ("door_last_trip_time", True),
+        ("tampering_last_trip_time", True),
+        ("temperature_level", False),
+        ("humidity_level", False),
+        ("light_level", False),
+        ("alarm_sound", False),
+        ("motion_last_trip_time", False),
+    ):
+        description = next(d for d in SENSE_SENSORS if d.key == key)
+        _, entity_id = await ids_from_device_description(
+            hass, Platform.SENSOR, sensor_all, description
+        )
+        assert (entity_registry.async_get(entity_id) is not None) is created, key
 
 
 async def test_sensor_setup_sensor(

--- a/tests/components/unifiprotect/utils.py
+++ b/tests/components/unifiprotect/utils.py
@@ -26,9 +26,11 @@ from uiprotect.data.public_devices import (
     PublicLight,
     PublicLightDeviceSettings,
     PublicSensor,
+    PublicSensorLeakSettings,
     PublicSensorMotionSettingsRead,
     PublicWirelessBatteryStatus,
     PublicWirelessConnectionState,
+    SensorFeatureCapability,
 )
 from uiprotect.test_util.anonymize import random_hex
 from uiprotect.websocket import WebsocketState
@@ -234,13 +236,21 @@ def make_public_sensor(
     is_motion_detected: bool | None = None,
     motion_enabled: bool | None = None,
     mount_type: MountType | None = None,
+    is_opened: bool | None = None,
+    is_leak_detected: bool | None = None,
+    is_tampering_detected: bool | None = None,
+    supports_water_leak: bool = False,
+    leak_internal_enabled: bool = False,
+    leak_external_enabled: bool = False,
 ) -> Mock:
     """Build a public-API sensor mirroring a private sensor's migrated fields.
 
-    Real ``wireless_connection_state`` / ``motion_settings`` models back the
-    migrated value paths so a wrong ``ufp_public_value`` path fails the test;
-    identifiers come from the (synthetic) private sensor fixture, never from real
-    capture data. Each ``*`` override lets a test diverge from the private value.
+    Real ``wireless_connection_state`` / ``motion_settings`` / ``leak_settings``
+    models back the migrated value paths so a wrong ``ufp_public_value`` path
+    fails the test; identifiers come from the (synthetic) private sensor fixture,
+    never from real capture data. Each ``*`` override lets a test diverge from
+    the private value. The mount-derived enablement properties are computed from
+    the resolved mount type so a ``mount_type`` override stays consistent.
     """
     public = Mock(spec=PublicSensor)
     public.id = sensor.id
@@ -248,6 +258,30 @@ def make_public_sensor(
     public.model = ModelType.SENSOR
     public.state = DeviceState[sensor.state.name] if state is None else state
     public.mount_type = sensor.mount_type if mount_type is None else mount_type
+    public.is_contact_sensor_enabled = public.mount_type in {
+        MountType.DOOR,
+        MountType.WINDOW,
+        MountType.GARAGE,
+    }
+    public.is_leak_sensor_enabled = public.mount_type is MountType.LEAK
+    public.is_opened = sensor.is_opened if is_opened is None else is_opened
+    public.is_leak_detected = (
+        sensor.is_leak_detected if is_leak_detected is None else is_leak_detected
+    )
+    public.is_tampering_detected = (
+        sensor.is_tampering_detected
+        if is_tampering_detected is None
+        else is_tampering_detected
+    )
+    public.supports = Mock(
+        side_effect=lambda capability: (
+            supports_water_leak and capability is SensorFeatureCapability.WATER_LEAK
+        )
+    )
+    public.leak_settings = PublicSensorLeakSettings(
+        is_internal_enabled=leak_internal_enabled,
+        is_external_enabled=leak_external_enabled,
+    )
     public.is_motion_detected = (
         sensor.is_motion_detected if is_motion_detected is None else is_motion_detected
     )

--- a/tests/components/unifiprotect/utils.py
+++ b/tests/components/unifiprotect/utils.py
@@ -239,7 +239,7 @@ def make_public_sensor(
     is_opened: bool | None = None,
     is_leak_detected: bool | None = None,
     is_tampering_detected: bool | None = None,
-    supports_water_leak: bool = False,
+    capabilities: set[SensorFeatureCapability] | None = None,
     leak_internal_enabled: bool = False,
     leak_external_enabled: bool = False,
 ) -> Mock:
@@ -251,6 +251,8 @@ def make_public_sensor(
     never from real capture data. Each ``*`` override lets a test diverge from
     the private value. The mount-derived enablement properties are computed from
     the resolved mount type so a ``mount_type`` override stays consistent.
+    ``capabilities`` mimics the capability map of newer firmware; ``None`` (the
+    default) models older firmware without a map, where every entity is created.
     """
     public = Mock(spec=PublicSensor)
     public.id = sensor.id
@@ -273,9 +275,10 @@ def make_public_sensor(
         if is_tampering_detected is None
         else is_tampering_detected
     )
+    public.has_feature_flags = capabilities is not None
     public.supports = Mock(
         side_effect=lambda capability: (
-            supports_water_leak and capability is SensorFeatureCapability.WATER_LEAK
+            capabilities is not None and capability in capabilities
         )
     )
     public.leak_settings = PublicSensorLeakSettings(
@@ -334,12 +337,16 @@ def make_public_light(
     return public
 
 
-def setup_public_sensor(ufp: MockUFPFixture) -> None:
+def setup_public_sensor(
+    ufp: MockUFPFixture,
+    capabilities: set[SensorFeatureCapability] | None = None,
+) -> None:
     """Expose private sensors over the public API via a real ``PublicBootstrap``.
 
     Lookups go through the real ``PublicBootstrap.get``; the mirror resolves
     against the private bootstrap at call time, so it is robust to ``init_entry``
-    regenerating device ids.
+    regenerating device ids. ``capabilities`` is forwarded to the mirror to model
+    newer firmware with a capability map.
     """
     public_bootstrap = PublicBootstrap()
     pb = Mock(spec=PublicBootstrap)
@@ -354,7 +361,9 @@ def setup_public_sensor(ufp: MockUFPFixture) -> None:
             model is ModelType.SENSOR
             and (private := ufp.api.bootstrap.sensors.get(obj_id)) is not None
         ):
-            public_bootstrap.sensors[obj_id] = make_public_sensor(private)
+            public_bootstrap.sensors[obj_id] = make_public_sensor(
+                private, capabilities=capabilities
+            )
         return public_bootstrap.get(model, obj_id)
 
     pb.get = _get


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Two closely related steps for the UP Sense / USL sensor family. On Protect releases newer than 7.1 — which introduce the per-sensor capability map on the public API — this unlocks proper USL sensor support: USL Entry, USL Environmental and USL GlassBreak get exactly the entities their hardware supports, and the USL Environmental leak sensor becomes functional.

**1. Migrate the contact (`door`), `leak` and `tampering` binary sensors to the public Integration API**, following the pattern established by the sense motion migration: values come from `ufp_public_value` (`is_opened`, `is_leak_detected`, `is_tampering_detected` on `PublicSensor`) and are driven by the public devices websocket; the private read path is dropped in the same change.

Enablement is evaluated per sensor via `ufp_public_enabled_fn`:

- **contact** mirrors `Sensor.is_contact_sensor_enabled` (door/window/garage mount).
- **leak** is available on a leak mount (UP Sense parity — the console disables every other capability in that mode), or when the sensor's capability map advertises `water_leak` with a leak channel enabled: the USL family (e.g. USL Environmental) detects leaks without a leak mount, which the mount-only private gate could never surface. Channel settings alone are deliberately not a gate; sensors without the capability report inert default leak settings, and a leak-mounted UP Sense reports its channels disabled.
- **tampering** stays ungated (parity).

`is_leak_detected` covers both the internal and the external probe channel; Protect raises the same water-leak detection for either (the external one only annotated with `source: "external"`), so a single moisture entity mirrors the console behavior.

The mountable contact sensor now derives its runtime device class (door/window/garage) from the public object's mount type when present, falling back to the private mount type.

**2. Derive sense entity creation from the sensor capability map.** New `ufp_capability` description axis: when the public sensor reports a capability map, a description tagged with a capability is only created if the sensor advertises it (`PublicSensor.supports`); matching stale registry entries are cleaned up on setup. Without a capability map every description is created, exactly as before — the gate is the *presence* of the map, never a firmware version. The sense entity set has always been modeled on the UP Sense; sensors deviating from it (the USL family, the air-quality sensor) were never supported and got entities that could not produce a value on that hardware. The capability map makes those devices first-class: they now get exactly the entities they support, and the never-functional leftovers are cleaned up. Tagged: contact/leak/tampering/motion binaries, the motion-enabled diagnostic, temperature/humidity/light/alarm-sound sensors, the trip-time sensors, motion sensitivity number, and the mount-type select/diagnostic.

Validated against a live console: open/close, tamper and water-leak stimuli all arrive over the public devices websocket (`isOpened` toggling, `tamperingDetectedAt` and `leakDetectedAt` set and cleared), including live mount-type changes and the console-side capability disabling on leak mounts. The websocket delivery of these state fields was additionally verified for the oldest supported firmware line, which predates the sensor capability map.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #172164, #173369, #151804, #166768
- Link to documentation pull request: home-assistant/home-assistant.io#46666
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
