### PR TITLE
Fix HomeKit select accessories not marking the active option as on

### DIFF
--- a/homeassistant/components/homekit/type_switches.py
+++ b/homeassistant/components/homekit/type_switches.py
@@ -556,6 +556,6 @@ class SelectSwitch(HomeAccessory):
     @override
     def async_update_state(self, new_state: State) -> None:
         """Update switch state after state changed."""
-        current_option = cleanup_name_for_homekit(new_state.state)
+        current_option = new_state.state
         for option, char in self.select_chars.items():
             char.set_value(option == current_option)

--- a/tests/components/homekit/test_type_switches.py
+++ b/tests/components/homekit/test_type_switches.py
@@ -5,9 +5,11 @@ from datetime import timedelta
 from freezegun import freeze_time
 import pytest
 
+from homeassistant.components.homekit.accessories import HomeDriver
 from homeassistant.components.homekit.const import (
     ATTR_VALUE,
     CHAR_CONFIGURED_NAME,
+    CHAR_NAME,
     SERV_OUTLET,
     TYPE_FAUCET,
     TYPE_SHOWER,
@@ -616,6 +618,57 @@ async def test_input_select_switch(
     assert acc.select_chars["option1"].value is False
     assert acc.select_chars["option2"].value is False
     assert acc.select_chars["option3"].value is False
+
+
+@pytest.mark.parametrize(
+    "domain",
+    ["input_select", "select"],
+)
+async def test_select_switch_with_options_needing_name_cleanup(
+    hass: HomeAssistant, hk_driver: HomeDriver, events: list[Event], domain: str
+) -> None:
+    """Test select options altered by HomeKit name cleanup still sync state."""
+    entity_id = f"{domain}.test"
+    options = ["always_on", "always on"]
+
+    hass.states.async_set(entity_id, "always_on", {ATTR_OPTIONS: options})
+    await hass.async_block_till_done()
+    acc = SelectSwitch(hass, hk_driver, "SelectSwitch", entity_id, 2, None)
+    acc.run()
+    await hass.async_block_till_done()
+
+    outlets = [serv for serv in acc.services if serv.display_name == SERV_OUTLET]
+    assert [serv.get_characteristic(CHAR_NAME).value for serv in outlets] == [
+        "always on",
+        "always on",
+    ]
+    assert [
+        serv.get_characteristic(CHAR_CONFIGURED_NAME).value for serv in outlets
+    ] == ["always on", "always on"]
+
+    assert {option: char.value for option, char in acc.select_chars.items()} == {
+        "always_on": True,
+        "always on": False,
+    }
+
+    hass.states.async_set(entity_id, "always on", {ATTR_OPTIONS: options})
+    await hass.async_block_till_done()
+    assert {option: char.value for option, char in acc.select_chars.items()} == {
+        "always_on": False,
+        "always on": True,
+    }
+
+    call_select_option = async_mock_service(hass, domain, SERVICE_SELECT_OPTION)
+    acc.select_chars["always_on"].client_update_value(True)
+    await hass.async_block_till_done()
+
+    assert call_select_option
+    assert call_select_option[0].data == {
+        "entity_id": entity_id,
+        "option": "always_on",
+    }
+    assert len(events) == 1
+    assert events[-1].data[ATTR_VALUE] is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`SelectSwitch.async_update_state` ran the current state through `cleanup_name_for_homekit()` before comparing it against the raw option strings that key `self.select_chars`. Any option containing a character the cleanup translates (underscore being the common case, but also characters mapped to `-` and options longer than `MAX_NAME_LENGTH`) could therefore never match, so its outlet never showed as on in the Home app — and when two options collide after cleanup (e.g. `always_on` and `always on`), the wrong outlet lit up. Control in the HomeKit→HA direction was unaffected, since the setter closes over the raw option.

The fix compares raw against raw: a select's state is by contract exactly one of its options, so the cleanup has no business in the comparison. Name cleanup is display-only and is kept for `CHAR_NAME`/`CHAR_CONFIGURED_NAME`, which the new test also asserts.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #175597
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
