### PR TITLE
Use mimalloc as the Python allocator instead of preloading jemalloc

### DIFF
--- a/rootfs/etc/services.d/home-assistant/run
+++ b/rootfs/etc/services.d/home-assistant/run
@@ -5,9 +5,14 @@
 
 cd /config || bashio::exit.nok "Can't find config folder!"
 
-# Enable mimalloc for Home Assistant Core, unless disabled
-if [[ -z "${DISABLE_JEMALLOC+x}" ]]; then
-  export LD_PRELOAD="/usr/local/lib/libjemalloc.so.2"
-  export MALLOC_CONF="background_thread:true,metadata_thp:auto,dirty_decay_ms:20000,muzzy_decay_ms:20000"
+# Use mimalloc as Python's object allocator by default. It is bundled in CPython
+# (3.13+), so no LD_PRELOAD or extra library is required, and it uses noticeably
+# less memory than the previously preloaded jemalloc. Override or disable via
+# PYTHONMALLOC, e.g. `PYTHONMALLOC=pymalloc` for the default allocator.
+export PYTHONMALLOC="${PYTHONMALLOC:-mimalloc}"
+
+if [[ -n "${DISABLE_JEMALLOC+x}" ]]; then
+  bashio::log.warning "DISABLE_JEMALLOC is set but no longer has any effect: jemalloc has been replaced by mimalloc. Set PYTHONMALLOC=pymalloc to use the default allocator instead."
 fi
+
 exec python3 -m homeassistant --config /config


### PR DESCRIPTION
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

This is not a breaking change for configuration. One behavior note for transparency: the `DISABLE_JEMALLOC` environment variable no longer has any effect (jemalloc is no longer preloaded) and now logs a warning. Users who set it — most commonly on aarch64 systems with 16 KB/64 KB memory pages, where preloaded jemalloc aborted with `Unsupported system page size` — no longer need it, because mimalloc does not have that incompatibility. To fall back to CPython's default allocator, set `PYTHONMALLOC=default` or `PYTHONMALLOC=pymalloc` explicitly.

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Switch the Home Assistant Core container from preloading **jemalloc** process-wide to selecting **mimalloc as CPython's object allocator** via `PYTHONMALLOC=mimalloc`.

In `rootfs/etc/services.d/home-assistant/run`:

```diff
-# Enable mimalloc for Home Assistant Core, unless disabled
-if [[ -z "${DISABLE_JEMALLOC+x}" ]]; then
-  export LD_PRELOAD="/usr/local/lib/libjemalloc.so.2"
-  export MALLOC_CONF="background_thread:true,metadata_thp:auto,dirty_decay_ms:20000,muzzy_decay_ms:20000"
-fi
+# Use mimalloc as Python's object allocator by default. It is bundled in CPython
+# (3.13+), so no LD_PRELOAD or extra library is required, and it uses noticeably
+# less memory than the previously preloaded jemalloc. Override or disable via
+# PYTHONMALLOC, e.g. `PYTHONMALLOC=pymalloc` for the default allocator.
+export PYTHONMALLOC="${PYTHONMALLOC:-mimalloc}"
+
+if [[ -n "${DISABLE_JEMALLOC+x}" ]]; then
+  bashio::log.warning "DISABLE_JEMALLOC is set but no longer has any effect: jemalloc has been replaced by mimalloc. Set PYTHONMALLOC=pymalloc to use the default allocator instead."
+fi
```

`PYTHONMALLOC=mimalloc` uses the mimalloc that is already bundled in CPython 3.13+ (`--with-mimalloc`, enabled by default), so no `LD_PRELOAD` and no external allocator library are needed. `PYTHONMALLOC` stays fully user-overridable, so it doubles as the opt-out (`PYTHONMALLOC=pymalloc`) and replaces the single-purpose `DISABLE_JEMALLOC` flag.

### Motivation

jemalloc was originally adopted to work around the slow musl allocator, as documented in the 2020 developer blog post: https://developers.home-assistant.io/blog/2020/07/13/alpine-python/. That was measured against musl's old allocator; musl has since shipped `mallocng` (default since musl 1.2.1), and the picture has changed.

**jemalloc no longer earns its keep here, and it carries a real portability hazard:**

1. **Page-size incompatibility on aarch64.** jemalloc bakes the page size in at build time. A build assuming 4 KB pages aborts with `<jemalloc>: Unsupported system page size` on kernels using 16 KB (Raspberry Pi 5, Apple Silicon) or 64 KB (Ampere, some RHEL/Fedora arm64) pages. This is exactly why the `DISABLE_JEMALLOC` escape hatch exists, and the same class of crash is widely reported across projects (Polars, Qdrant, Typesense, KeyDB, Reth, and others). **mimalloc queries the page size at runtime** (`sysconf(_SC_PAGESIZE)` in `_mi_prim_mem_init()`), so it adapts to 4/16/64 KB automatically — no compiled-in assumption, and no such crash reports exist against it. Switching to mimalloc removes the reason `DISABLE_JEMALLOC` was needed.

2. **Memory.** Benchmarking the current image (Python 3.14, musl, GCC/full-LTO/PGO) shows jemalloc retains substantially more memory than either plain musl or mimalloc, for no measurable CPU benefit.

### Benchmark results

CPU measured with the `pyperformance` suite (122 benchmarks — the same tool used in the 2020 blog); peak RSS measured with Core's built-in benchmark workload. All on the qemux86-64 image, CPU-pinned, warmed up.

| Allocator config | CPU (pyperformance geomean) | peak RSS |
|---|---:|---:|
| **jemalloc** (current default) | reference | reference |
| plain musl + pymalloc | ±0% (no measurable difference) | −30% |
| **`PYTHONMALLOC=mimalloc`** (this PR) | **−1.2%** | **−27%** |
| mimalloc process-wide (`LD_PRELOAD`) | −1.1% | +3% to +9% |

Two takeaways: jemalloc shows no measurable CPU advantage over plain musl while using ~40% more peak RSS, and `PYTHONMALLOC=mimalloc` gives the best combined result — mimalloc's full memory benefit (~27% lower peak RSS than jemalloc) at CPU parity-or-better, without `LD_PRELOAD` or an external library. Process-wide mimalloc via `LD_PRELOAD` was tested too and was notably worse on memory, so this PR deliberately uses only the `PYTHONMALLOC` path.

### Supporting references

- CPython bundles mimalloc since 3.13 and selects it with `PYTHONMALLOC=mimalloc` (https://docs.python.org/3/c-api/memory.html); it is the default allocator for free-threaded (no-GIL) builds (https://github.com/python/cpython/issues/90815), so this also aligns Core with CPython's direction.
- mimalloc project and benchmarks: https://github.com/microsoft/mimalloc and https://microsoft.github.io/mimalloc/bench.html.
- jemalloc's build-time page-size limitation: https://github.com/jemalloc/jemalloc/issues/467 and https://github.com/jemalloc/jemalloc/issues/2639.
- Known trade-off, for transparency: mimalloc-for-objects can use slightly more memory than pymalloc for many tiny allocations (https://github.com/python/cpython/issues/135153) — consistent with our data (mimalloc was ~4% above plain musl+pymalloc on peak RSS, but far below jemalloc).

### Caveats / where reviewer input is welcome

- The benchmarks above are largely single-threaded. jemalloc's and mimalloc's signature advantage is multi-threaded allocation (per-thread caches reducing lock contention), which neither `pyperformance` nor the internal benchmarks fully exercise. Core runs a thread-pool executor and many integration threads, so real-world concurrent allocation may differ. This is the main thing worth validating — e.g. on the beta channel, or with a real startup + steady-state RSS profile.
- The jemalloc `MALLOC_CONF` retention tuning (`dirty/muzzy_decay_ms`) is dropped; mimalloc's defaults are used. If needed, mimalloc's `MIMALLOC_PURGE_DELAY` is the analog (higher value = hold freed memory longer, trading RSS for fewer purge syscalls).

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Possible follow-ups, kept out of this PR to stay focused: drop the now-unused jemalloc apk package from the image (size reduction), and add a build/CI assertion that `PYTHONMALLOC=mimalloc python3 -c ''` succeeds so a future base image cannot silently regress to musl.

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
