### PR TITLE
Core integrations not explicitly setting config entry parameter for coordinator now raises

### DIFF
--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -103,7 +103,6 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
                 core_behavior=frame.ReportBehavior.ERROR,
                 core_integration_behavior=frame.ReportBehavior.ERROR,
                 custom_integration_behavior=frame.ReportBehavior.IGNORE,
-                breaks_in_ha_version="2026.8",
             )
 
             self.config_entry = config_entries.current_entry.get()

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -101,6 +101,7 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
             frame.report_usage(
                 "relies on ContextVar, but should pass the config entry explicitly.",
                 core_behavior=frame.ReportBehavior.ERROR,
+                core_integration_behavior=frame.ReportBehavior.ERROR,
                 custom_integration_behavior=frame.ReportBehavior.IGNORE,
                 breaks_in_ha_version="2026.8",
             )

--- a/tests/helpers/test_update_coordinator.py
+++ b/tests/helpers/test_update_coordinator.py
@@ -1099,7 +1099,7 @@ async def test_config_entry(
 
     # Default without context should raise
     caplog.clear()
-    core_crd = None
+    crd = None
     with pytest.raises(
         RuntimeError,
         match=(
@@ -1107,10 +1107,8 @@ async def test_config_entry(
             "but should pass the config entry explicitly."
         ),
     ):
-        core_crd = update_coordinator.DataUpdateCoordinator[int](
-            hass, _LOGGER, name="test"
-        )
-    assert not core_crd
+        crd = update_coordinator.DataUpdateCoordinator[int](hass, _LOGGER, name="test")
+    assert crd is None
 
     # Default with context should raise
     caplog.clear()
@@ -1123,10 +1121,8 @@ async def test_config_entry(
             "but should pass the config entry explicitly."
         ),
     ):
-        core_crd = update_coordinator.DataUpdateCoordinator[int](
-            hass, _LOGGER, name="test"
-        )
-    assert not core_crd
+        crd = update_coordinator.DataUpdateCoordinator[int](hass, _LOGGER, name="test")
+    assert crd is None
 
 
 @pytest.mark.parametrize("integration_frame_path", ["custom_components/my_integration"])

--- a/tests/helpers/test_update_coordinator.py
+++ b/tests/helpers/test_update_coordinator.py
@@ -1097,25 +1097,36 @@ async def test_config_entry(
         not in caplog.text
     )
 
-    # Default without context should log a warning
+    # Default without context should raise
     caplog.clear()
-    crd = update_coordinator.DataUpdateCoordinator[int](hass, _LOGGER, name="test")
-    assert crd.config_entry is None
-    assert (
-        "Detected that integration 'my_integration' relies on ContextVar, "
-        "but should pass the config entry explicitly."
-    ) in caplog.text
+    core_crd = None
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "Detected that integration 'my_integration' relies on ContextVar, "
+            "but should pass the config entry explicitly."
+        ),
+    ):
+        core_crd = update_coordinator.DataUpdateCoordinator[int](
+            hass, _LOGGER, name="test"
+        )
+    assert not core_crd
 
-    # Default with context should log a warning
+    # Default with context should raise
     caplog.clear()
     frame._REPORTED_INTEGRATIONS.clear()
     config_entries.current_entry.set(entry)
-    crd = update_coordinator.DataUpdateCoordinator[int](hass, _LOGGER, name="test")
-    assert (
-        "Detected that integration 'my_integration' relies on ContextVar, "
-        "but should pass the config entry explicitly."
-    ) in caplog.text
-    assert crd.config_entry is entry
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "Detected that integration 'my_integration' relies on ContextVar, "
+            "but should pass the config entry explicitly."
+        ),
+    ):
+        core_crd = update_coordinator.DataUpdateCoordinator[int](
+            hass, _LOGGER, name="test"
+        )
+    assert not core_crd
 
 
 @pytest.mark.parametrize("integration_frame_path", ["custom_components/my_integration"])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
Core integration using update coordinator needs to explicitly set the config entry parameter.
Custom components are not affected by this

## Proposed change
Changes from logging to raises.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository. 