### PR TITLE
Dynamically follow location/DHW renames in evohome reset buttons

### DIFF
--- a/homeassistant/components/evohome/button.py
+++ b/homeassistant/components/evohome/button.py
@@ -30,14 +30,14 @@ async def async_setup_platform(
     coordinator = hass.data[EVOHOME_DATA].coordinator
     tcs = hass.data[EVOHOME_DATA].tcs
 
-    entities: list[EvoResetButtonBase] = [EvoResetSystemButton(coordinator, tcs)]
+    entities: list[EvoResetButtonBase] = [EvoSystemResetButton(coordinator, tcs)]
 
     entities.extend(
-        [EvoResetZoneButton(coordinator, z) for z in tcs.zones if is_valid_zone(z)]
+        EvoZoneResetButton(coordinator, z) for z in tcs.zones if is_valid_zone(z)
     )
 
     if tcs.hotwater:
-        entities.append(EvoResetDhwButton(coordinator, tcs.hotwater))
+        entities.append(EvoDhwResetButton(coordinator, tcs.hotwater))
 
     async_add_entities(entities)
 
@@ -45,6 +45,7 @@ async def async_setup_platform(
 class EvoResetButtonBase(CoordinatorEntity[EvoDataUpdateCoordinator], ButtonEntity):
     """Base for Evohome's Button entities."""
 
+    # for _attr_device_class, ButtonDeviceClass.RESET is not available
     _attr_entity_category = EntityCategory.CONFIG
 
     _evo_device: evo.ControlSystem | evo.HotWater | evo.Zone
@@ -56,7 +57,10 @@ class EvoResetButtonBase(CoordinatorEntity[EvoDataUpdateCoordinator], ButtonEnti
     ) -> None:
         """Initialize an Evohome reset button entity."""
         super().__init__(coordinator, context=evo_device.id)
+
         self._evo_device = evo_device
+
+        self._attr_unique_id = f"{evo_device.id}_reset"
 
     @override
     async def async_press(self) -> None:
@@ -64,7 +68,7 @@ class EvoResetButtonBase(CoordinatorEntity[EvoDataUpdateCoordinator], ButtonEnti
         await self.coordinator.call_client_api(self._evo_device.reset())
 
 
-class EvoResetSystemButton(EvoResetButtonBase):
+class EvoSystemResetButton(EvoResetButtonBase):
     """Button entity for system reset."""
 
     _evo_device: evo.ControlSystem
@@ -77,28 +81,26 @@ class EvoResetSystemButton(EvoResetButtonBase):
         """Initialize the system reset button."""
         super().__init__(coordinator, evo_device)
 
-        self._attr_unique_id = f"{evo_device.id}_reset"
-        self._attr_name = f"Reset {evo_device.location.name}"
+    @property
+    @override
+    def name(self) -> str:
+        """Return the entity name (follows location renames)."""
+        return f"Reset {self._evo_device.location.name}"
 
 
-class EvoResetDhwButton(EvoResetButtonBase):
+class EvoDhwResetButton(EvoResetButtonBase):
     """Button entity for DHW override reset."""
 
     _evo_device: evo.HotWater
 
-    def __init__(
-        self,
-        coordinator: EvoDataUpdateCoordinator,
-        evo_device: evo.HotWater,
-    ) -> None:
-        """Initialize the DHW reset button."""
-        super().__init__(coordinator, evo_device)
-
-        self._attr_unique_id = f"{evo_device.id}_reset"
-        self._attr_name = f"Reset {evo_device.name}"
+    @property
+    @override
+    def name(self) -> str:
+        """Return the entity name (follows location renames)."""
+        return f"Reset {self._evo_device.location.name} DHW"
 
 
-class EvoResetZoneButton(EvoResetButtonBase):
+class EvoZoneResetButton(EvoResetButtonBase):
     """Button entity for zone override reset."""
 
     _evo_device: evo.Zone
@@ -110,10 +112,11 @@ class EvoResetZoneButton(EvoResetButtonBase):
     ) -> None:
         """Initialize the zone reset button."""
         super().__init__(coordinator, evo_device)
+
         self._attr_unique_id = f"{unique_zone_id(evo_device)}_reset"
 
     @property
     @override
     def name(self) -> str:
-        """Return the name, dynamically following any zone rename."""
+        """Return the entity name (follows zone renames)."""
         return f"Reset {self._evo_device.name}"

--- a/tests/components/evohome/snapshots/test_button.ambr
+++ b/tests/components/evohome/snapshots/test_button.ambr
@@ -25,19 +25,6 @@
     'state': 'unknown',
   })
 # ---
-# name: test_setup_platform[botched][button.reset_domestic_hot_water-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Reset Domestic Hot Water',
-    }),
-    'context': <ANY>,
-    'entity_id': 'button.reset_domestic_hot_water',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
 # name: test_setup_platform[botched][button.reset_front_room-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -116,6 +103,19 @@
     'state': 'unknown',
   })
 # ---
+# name: test_setup_platform[botched][button.reset_my_home_dhw-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Reset My Home DHW',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.reset_my_home_dhw',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
 # name: test_setup_platform[default][button.reset_bathroom_dn-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -136,19 +136,6 @@
     }),
     'context': <ANY>,
     'entity_id': 'button.reset_dead_zone',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_setup_platform[default][button.reset_domestic_hot_water-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Reset Domestic Hot Water',
-    }),
-    'context': <ANY>,
-    'entity_id': 'button.reset_domestic_hot_water',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -227,6 +214,19 @@
     }),
     'context': <ANY>,
     'entity_id': 'button.reset_my_home',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_setup_platform[default][button.reset_my_home_dhw-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Reset My Home DHW',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.reset_my_home_dhw',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Aligns the evohome system and DHW reset button entities with the zone reset button's existing behaviour: their name is now a property computed from the live device state, so a rename of the location or hot water device is reflected immediately instead of being frozen at entity creation.

While touching this, the three button classes are renamed for a consistent `Evo{Target}ResetButton` naming pattern, and the duplicated `_attr_unique_id` assignment is consolidated into `EvoResetButtonBase.__init__`.

A minor lint was removed (interator in a list passed in to a `list.extend` method).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
