### PR TITLE
Fix remote calendar state after refreshing events

### DIFF
--- a/homeassistant/components/remote_calendar/calendar.py
+++ b/homeassistant/components/remote_calendar/calendar.py
@@ -8,7 +8,7 @@ from ical.event import Event
 from ical.timeline import Timeline, materialize_timeline
 
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
@@ -88,15 +88,13 @@ class RemoteCalendarEntity(
 
         return await self.hass.async_add_executor_job(events_in_range)
 
-    @override
-    async def async_update(self) -> None:
-        """Refresh the timeline.
+    async def _async_update_timeline(self) -> None:
+        """Refresh the timeline and write state.
 
         This is called when the coordinator updates. Creating the timeline may
         require walking through the entire calendar and handling recurring
         events, so it is done as a separate task without blocking the event loop.
         """
-        await super().async_update()
 
         def _get_timeline() -> Timeline | None:
             """Return a materialized timeline with upcoming events."""
@@ -110,6 +108,26 @@ class RemoteCalendarEntity(
             )
 
         self._timeline = await self.hass.async_add_executor_job(_get_timeline)
+
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to hass."""
+        await super().async_added_to_hass()
+        await self._async_update_timeline()
+        self.async_write_ha_state()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self.coordinator.config_entry.async_create_task(
+            self.hass,
+            self._async_handle_coordinator_update(),
+            name="remote calendar timeline update",
+        )
+
+    async def _async_handle_coordinator_update(self) -> None:
+        """Refresh the timeline and write state."""
+        await self._async_update_timeline()
+        self.async_write_ha_state()
 
 
 def _get_calendar_event(event: Event) -> CalendarEvent:

--- a/homeassistant/components/remote_calendar/calendar.py
+++ b/homeassistant/components/remote_calendar/calendar.py
@@ -109,6 +109,7 @@ class RemoteCalendarEntity(
 
         self._timeline = await self.hass.async_add_executor_job(_get_timeline)
 
+    @override
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()
@@ -116,6 +117,7 @@ class RemoteCalendarEntity(
         self.async_write_ha_state()
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self.coordinator.config_entry.async_create_task(

--- a/tests/components/remote_calendar/test_calendar.py
+++ b/tests/components/remote_calendar/test_calendar.py
@@ -1,6 +1,6 @@
 """Tests for calendar platform of Remote Calendar."""
 
-from datetime import datetime
+from datetime import datetime, timedelta
 import pathlib
 import textwrap
 
@@ -12,6 +12,7 @@ from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 
 from . import setup_integration
 from .conftest import (
@@ -530,3 +531,59 @@ async def test_event_edge_during_refresh_interval(
     assert state
     assert state.state == STATE_OFF
     assert state.attributes.get("message") == "Event Two"
+
+
+@respx.mock
+@pytest.mark.freeze_time("2026-05-18 06:00:00+00:00")
+async def test_coordinator_refresh_updates_upcoming_event_state(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test a coordinator refresh updates the materialized upcoming event."""
+    original_calendar = textwrap.dedent(
+        """\
+        BEGIN:VCALENDAR
+        VERSION:2.0
+        BEGIN:VEVENT
+        SUMMARY:Wake up
+        DTSTART:20260518T064000
+        DTEND:20260518T065500
+        END:VEVENT
+        END:VCALENDAR
+        """
+    )
+    updated_calendar = textwrap.dedent(
+        """\
+        BEGIN:VCALENDAR
+        VERSION:2.0
+        BEGIN:VEVENT
+        SUMMARY:Wake up
+        DTSTART:20260519T080000
+        DTEND:20260519T081500
+        END:VEVENT
+        END:VCALENDAR
+        """
+    )
+    route = respx.get(CALENDER_URL).mock(
+        side_effect=[
+            Response(status_code=200, text=original_calendar),
+            # We currently update the calendar twice on startup, tracked
+            # in issue #148315
+            Response(status_code=200, text=original_calendar),
+            Response(status_code=200, text=updated_calendar),
+        ]
+    )
+    await setup_integration(hass, config_entry)
+
+    state = hass.states.get(TEST_ENTITY)
+    assert state
+    assert state.attributes.get("start_time") == "2026-05-18 06:40:00"
+
+    # Advance clock to trigger the next update interval
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(days=1))
+    await hass.async_block_till_done()
+
+    state = hass.states.get(TEST_ENTITY)
+    assert state
+    assert state.attributes.get("start_time") == "2026-05-19 08:00:00"
+    assert route.call_count == 3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix the remote calendar timeline update, by fixing how coordinator updates are handled.
optimize remote calendar timeline updates by moving to dedicated coordinator handle method.

The entity behavior overrides `async_update` to set the timeline which is not correct for updates that come from the coordinator. Now instead we refresh the timeline on startup and coordinator updates.

Other background:
- This change was originally handled in #170972 which has disappeared from github, but wasn't making sufficient progress due to AI coding limitations. This is my patch, with the correct approach and testing.
- This test adds test coverage that illustrates an existing issue being solved in #173190 and tracked in #148315 but this fix will happen in a separate PR.

I am _not_ tagging for a patch release so that this goes through a full beta testing cycle.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: #170791 #148315
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
