### PR TITLE
Narrow CCM15 slot state before climate writes

### DIFF
--- a/homeassistant/components/ccm15/climate.py
+++ b/homeassistant/components/ccm15/climate.py
@@ -160,26 +160,32 @@ class CCM15Climate(CoordinatorEntity[CCM15Coordinator], ClimateEntity):
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set the target temperature."""
         if (temperature := kwargs.get(ATTR_TEMPERATURE)) is not None:
+            data = self.data
+            assert data is not None
             await self.coordinator.async_set_temperature(
-                self._ac_index, self.data, temperature, kwargs.get(ATTR_HVAC_MODE)
+                self._ac_index, data, temperature, kwargs.get(ATTR_HVAC_MODE)
             )
 
     @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set the hvac mode."""
-        await self.coordinator.async_set_hvac_mode(self._ac_index, self.data, hvac_mode)
+        data = self.data
+        assert data is not None
+        await self.coordinator.async_set_hvac_mode(self._ac_index, data, hvac_mode)
 
     @override
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set the fan mode."""
-        await self.coordinator.async_set_fan_mode(self._ac_index, self.data, fan_mode)
+        data = self.data
+        assert data is not None
+        await self.coordinator.async_set_fan_mode(self._ac_index, data, fan_mode)
 
     @override
     async def async_set_swing_mode(self, swing_mode: str) -> None:
         """Set the swing mode."""
-        await self.coordinator.async_set_swing_mode(
-            self._ac_index, self.data, swing_mode
-        )
+        data = self.data
+        assert data is not None
+        await self.coordinator.async_set_swing_mode(self._ac_index, data, swing_mode)
 
     @override
     async def async_turn_off(self) -> None:


### PR DESCRIPTION
## Breaking change


## Proposed change

Narrow the per-slot device state to non-`None` before the climate write helpers
(`async_set_temperature` / `async_set_hvac_mode` / `async_set_fan_mode` /
`async_set_swing_mode`) hand it to the coordinator.

`CCM15Climate.data` is `CCM15SlaveDevice | None`; it is `None` only when the slot
has no current data, in which case the entity is unavailable and HA already
filters it out of service dispatch. So reaching a write helper with `None` is an
invariant violation, not a runtime case to handle gracefully: an `assert` fails
loudly if it is ever violated (surfacing the upstream bug) instead of silently
swallowing the call, and narrows the type for the write.

Split out of the `py_ccm15` 1.1.1 bump (#175203): the 1.1.x line ships
`py.typed`, which turns `mypy --strict` on against the library and makes this
narrowing required. Landing it on its own keeps that bump to just the version
change.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: #175203

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] The [manifest file][manifest-docs] has all fields filled out correctly.

[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
