### PR TITLE
Add Leviton VRF01 fan controller discovery to zwave_js

### DIFF
--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -256,6 +256,18 @@ DISCOVERY_SCHEMAS = [
             FanValueMapping(speeds=[(1, 25), (26, 50), (51, 75), (76, 99)]),
         ),
     ),
+    # Leviton VRF01 fan controllers using switch multilevel CC
+    ZWaveDiscoverySchema(
+        platform=Platform.FAN,
+        hint="has_fan_value_mapping",
+        manufacturer_id={0x001D},
+        product_id={0x0209, 0x0334},
+        product_type={0x1001},
+        primary_value=SWITCH_MULTILEVEL_CURRENT_VALUE_SCHEMA,
+        data_template=FixedFanValueMappingDataTemplate(
+            FanValueMapping(speeds=[(1, 32), (33, 66), (67, 99)]),
+        ),
+    ),
     # Inovelli LZW36 light / fan controller combo using switch multilevel CC
     # The fan is endpoint 2, the light is endpoint 1.
     ZWaveDiscoverySchema(

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -248,6 +248,12 @@ def leviton_zw4sf_state_fixture() -> dict[str, Any]:
     return load_json_object_fixture("leviton_zw4sf_state.json", DOMAIN)
 
 
+@pytest.fixture(name="leviton_vrf01_state", scope="package")
+def leviton_vrf01_state_fixture() -> dict[str, Any]:
+    """Load the Leviton VRF01 node state fixture data."""
+    return load_json_object_fixture("leviton_vrf01_state.json", DOMAIN)
+
+
 @pytest.fixture(name="fan_honeywell_39358_state", scope="package")
 def fan_honeywell_39358_state_fixture() -> dict[str, Any]:
     """Load the fan node state fixture data."""
@@ -1046,6 +1052,14 @@ def hs_fc200_fixture(client, hs_fc200_state) -> Node:
 def leviton_zw4sf_fixture(client, leviton_zw4sf_state) -> Node:
     """Mock a fan node."""
     node = Node(client, copy.deepcopy(leviton_zw4sf_state))
+    client.driver.controller.nodes[node.node_id] = node
+    return node
+
+
+@pytest.fixture(name="leviton_vrf01")
+def leviton_vrf01_fixture(client, leviton_vrf01_state) -> Node:
+    """Mock a fan node."""
+    node = Node(client, copy.deepcopy(leviton_vrf01_state))
     client.driver.controller.nodes[node.node_id] = node
     return node
 

--- a/tests/components/zwave_js/fixtures/leviton_vrf01_state.json
+++ b/tests/components/zwave_js/fixtures/leviton_vrf01_state.json
@@ -1,0 +1,10969 @@
+{
+  "nodeId": 35,
+  "index": 0,
+  "status": 4,
+  "ready": true,
+  "isListening": true,
+  "isRouting": true,
+  "isSecure": false,
+  "manufacturerId": 29,
+  "productId": 521,
+  "productType": 4097,
+  "firmwareVersion": "0.5",
+  "name": "Fan",
+  "location": "",
+  "deviceConfig": {
+    "filename": "/data/db/devices/0x001d/vrf01.json",
+    "isEmbedded": true,
+    "manufacturer": "Leviton",
+    "manufacturerId": 29,
+    "label": "VRF01",
+    "description": "Scene Capable Quiet Fan Speed Control",
+    "devices": [
+      {
+        "productType": 4097,
+        "productId": 521
+      },
+      {
+        "productType": 4097,
+        "productId": 820
+      }
+    ],
+    "firmwareVersion": {
+      "min": "0.0",
+      "max": "255.255"
+    },
+    "preferred": false,
+    "associations": {
+      "1": {
+        "groupId": 1,
+        "label": "Lifeline",
+        "maxNodes": 5,
+        "isLifeline": true,
+        "multiChannel": "auto"
+      }
+    }
+  },
+  "label": "VRF01",
+  "interviewAttempts": 1,
+  "isFrequentListening": false,
+  "maxDataRate": 40000,
+  "supportedDataRates": [
+    40000
+  ],
+  "protocolVersion": 1,
+  "supportsBeaming": false,
+  "supportsSecurity": false,
+  "nodeType": 1,
+  "deviceClass": {
+    "basic": {
+      "key": 4,
+      "label": "Routing End Node"
+    },
+    "generic": {
+      "key": 17,
+      "label": "Multilevel Switch"
+    },
+    "specific": {
+      "key": 4,
+      "label": "Multilevel Scene Switch"
+    }
+  },
+  "interviewStage": "Complete",
+  "deviceDatabaseUrl": "https://devices.zwave-js.io/?jumpTo=0x001d:0x1001:0x0209:0.5",
+  "statistics": {
+    "commandsTX": 55,
+    "commandsRX": 59,
+    "commandsDroppedRX": 2,
+    "commandsDroppedTX": 0,
+    "timeoutResponse": 23,
+    "lastSeen": "2026-07-04T16:21:27.053Z",
+    "rtt": 41.6,
+    "rssi": -84,
+    "lwr": {
+      "protocolDataRate": 2,
+      "repeaters": [
+        11
+      ],
+      "rssi": -87,
+      "repeaterRSSI": [
+        0
+      ]
+    },
+    "nlwr": {
+      "protocolDataRate": 2,
+      "repeaters": [
+        10
+      ],
+      "rssi": -72,
+      "repeaterRSSI": [
+        0
+      ]
+    }
+  },
+  "highestSecurityClass": -1,
+  "isControllerNode": false,
+  "keepAwake": false,
+  "lastSeen": "2026-07-04T16:21:27.053Z",
+  "protocol": 0,
+  "canSleep": false,
+  "hasSUCReturnRoute": true,
+  "manufacturer": "Leviton",
+  "values": [
+    {
+      "endpoint": 0,
+      "commandClass": 38,
+      "commandClassName": "Multilevel Switch",
+      "property": "Down",
+      "propertyName": "Down",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": false,
+        "writeable": true,
+        "label": "Perform a level change (Down)",
+        "ccSpecific": {
+          "switchType": 2
+        },
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "states": {
+          "true": "Start",
+          "false": "Stop"
+        },
+        "stateful": true,
+        "secret": false
+      },
+      "value": false
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 38,
+      "commandClassName": "Multilevel Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "min": 0,
+        "max": 99,
+        "stateful": true,
+        "secret": false
+      },
+      "value": 73
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 38,
+      "commandClassName": "Multilevel Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 99,
+        "stateful": true,
+        "secret": false
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 38,
+      "commandClassName": "Multilevel Switch",
+      "property": "Up",
+      "propertyName": "Up",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": false,
+        "writeable": true,
+        "label": "Perform a level change (Up)",
+        "ccSpecific": {
+          "switchType": 2
+        },
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "states": {
+          "true": "Start",
+          "false": "Stop"
+        },
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 38,
+      "commandClassName": "Multilevel Switch",
+      "property": "duration",
+      "propertyName": "duration",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": false,
+        "label": "Remaining duration",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 38,
+      "commandClassName": "Multilevel Switch",
+      "property": "restorePrevious",
+      "propertyName": "restorePrevious",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": false,
+        "writeable": true,
+        "label": "Restore previous value",
+        "states": {
+          "true": "Restore"
+        },
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 43,
+      "commandClassName": "Scene Activation",
+      "property": "sceneId",
+      "propertyName": "sceneId",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Scene ID",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 1,
+        "max": 255,
+        "stateful": false,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 43,
+      "commandClassName": "Scene Activation",
+      "property": "dimmingDuration",
+      "propertyName": "dimmingDuration",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 1,
+      "propertyName": "level",
+      "propertyKeyName": "1",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (1)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 1,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "1",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (1)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 2,
+      "propertyName": "level",
+      "propertyKeyName": "2",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (2)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 2,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "2",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (2)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 3,
+      "propertyName": "level",
+      "propertyKeyName": "3",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (3)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 3,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "3",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (3)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 4,
+      "propertyName": "level",
+      "propertyKeyName": "4",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (4)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 4,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "4",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (4)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 5,
+      "propertyName": "level",
+      "propertyKeyName": "5",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (5)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 5,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "5",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (5)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 6,
+      "propertyName": "level",
+      "propertyKeyName": "6",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (6)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 6,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "6",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (6)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 7,
+      "propertyName": "level",
+      "propertyKeyName": "7",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (7)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 7,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "7",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (7)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 8,
+      "propertyName": "level",
+      "propertyKeyName": "8",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (8)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 8,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "8",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (8)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 9,
+      "propertyName": "level",
+      "propertyKeyName": "9",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (9)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 9,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "9",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (9)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 10,
+      "propertyName": "level",
+      "propertyKeyName": "10",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (10)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 10,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "10",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (10)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 11,
+      "propertyName": "level",
+      "propertyKeyName": "11",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (11)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 11,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "11",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (11)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 12,
+      "propertyName": "level",
+      "propertyKeyName": "12",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (12)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 12,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "12",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (12)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 13,
+      "propertyName": "level",
+      "propertyKeyName": "13",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (13)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 13,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "13",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (13)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 14,
+      "propertyName": "level",
+      "propertyKeyName": "14",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (14)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 14,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "14",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (14)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 15,
+      "propertyName": "level",
+      "propertyKeyName": "15",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (15)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 15,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "15",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (15)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 16,
+      "propertyName": "level",
+      "propertyKeyName": "16",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (16)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 16,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "16",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (16)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 17,
+      "propertyName": "level",
+      "propertyKeyName": "17",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (17)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 17,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "17",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (17)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 18,
+      "propertyName": "level",
+      "propertyKeyName": "18",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (18)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 18,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "18",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (18)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 19,
+      "propertyName": "level",
+      "propertyKeyName": "19",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (19)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 19,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "19",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (19)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 20,
+      "propertyName": "level",
+      "propertyKeyName": "20",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (20)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 20,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "20",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (20)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 21,
+      "propertyName": "level",
+      "propertyKeyName": "21",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (21)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 21,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "21",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (21)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 22,
+      "propertyName": "level",
+      "propertyKeyName": "22",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (22)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 22,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "22",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (22)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 23,
+      "propertyName": "level",
+      "propertyKeyName": "23",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (23)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 23,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "23",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (23)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 24,
+      "propertyName": "level",
+      "propertyKeyName": "24",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (24)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 24,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "24",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (24)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 25,
+      "propertyName": "level",
+      "propertyKeyName": "25",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (25)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 25,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "25",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (25)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 26,
+      "propertyName": "level",
+      "propertyKeyName": "26",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (26)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 26,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "26",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (26)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 27,
+      "propertyName": "level",
+      "propertyKeyName": "27",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (27)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 27,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "27",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (27)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 28,
+      "propertyName": "level",
+      "propertyKeyName": "28",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (28)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 28,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "28",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (28)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 29,
+      "propertyName": "level",
+      "propertyKeyName": "29",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (29)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 29,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "29",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (29)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 30,
+      "propertyName": "level",
+      "propertyKeyName": "30",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (30)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 30,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "30",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (30)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 31,
+      "propertyName": "level",
+      "propertyKeyName": "31",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (31)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 31,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "31",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (31)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 32,
+      "propertyName": "level",
+      "propertyKeyName": "32",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (32)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 32,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "32",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (32)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 33,
+      "propertyName": "level",
+      "propertyKeyName": "33",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (33)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 33,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "33",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (33)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 34,
+      "propertyName": "level",
+      "propertyKeyName": "34",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (34)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 34,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "34",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (34)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 35,
+      "propertyName": "level",
+      "propertyKeyName": "35",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (35)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 35,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "35",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (35)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 36,
+      "propertyName": "level",
+      "propertyKeyName": "36",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (36)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 36,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "36",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (36)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 37,
+      "propertyName": "level",
+      "propertyKeyName": "37",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (37)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 37,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "37",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (37)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 38,
+      "propertyName": "level",
+      "propertyKeyName": "38",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (38)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 38,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "38",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (38)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 39,
+      "propertyName": "level",
+      "propertyKeyName": "39",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (39)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 39,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "39",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (39)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 40,
+      "propertyName": "level",
+      "propertyKeyName": "40",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (40)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 40,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "40",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (40)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 41,
+      "propertyName": "level",
+      "propertyKeyName": "41",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (41)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 41,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "41",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (41)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 42,
+      "propertyName": "level",
+      "propertyKeyName": "42",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (42)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 42,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "42",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (42)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 43,
+      "propertyName": "level",
+      "propertyKeyName": "43",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (43)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 43,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "43",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (43)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 44,
+      "propertyName": "level",
+      "propertyKeyName": "44",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (44)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 44,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "44",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (44)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 45,
+      "propertyName": "level",
+      "propertyKeyName": "45",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (45)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 45,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "45",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (45)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 46,
+      "propertyName": "level",
+      "propertyKeyName": "46",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (46)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 46,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "46",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (46)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 47,
+      "propertyName": "level",
+      "propertyKeyName": "47",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (47)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 47,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "47",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (47)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 48,
+      "propertyName": "level",
+      "propertyKeyName": "48",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (48)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 48,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "48",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (48)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 49,
+      "propertyName": "level",
+      "propertyKeyName": "49",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (49)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 49,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "49",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (49)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 50,
+      "propertyName": "level",
+      "propertyKeyName": "50",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (50)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 50,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "50",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (50)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 51,
+      "propertyName": "level",
+      "propertyKeyName": "51",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (51)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 51,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "51",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (51)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 52,
+      "propertyName": "level",
+      "propertyKeyName": "52",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (52)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 52,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "52",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (52)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 53,
+      "propertyName": "level",
+      "propertyKeyName": "53",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (53)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 53,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "53",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (53)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 54,
+      "propertyName": "level",
+      "propertyKeyName": "54",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (54)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 54,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "54",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (54)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 55,
+      "propertyName": "level",
+      "propertyKeyName": "55",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (55)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 55,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "55",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (55)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 56,
+      "propertyName": "level",
+      "propertyKeyName": "56",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (56)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 56,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "56",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (56)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 57,
+      "propertyName": "level",
+      "propertyKeyName": "57",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (57)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 57,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "57",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (57)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 58,
+      "propertyName": "level",
+      "propertyKeyName": "58",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (58)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 58,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "58",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (58)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 59,
+      "propertyName": "level",
+      "propertyKeyName": "59",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (59)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 59,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "59",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (59)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 60,
+      "propertyName": "level",
+      "propertyKeyName": "60",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (60)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 60,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "60",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (60)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 61,
+      "propertyName": "level",
+      "propertyKeyName": "61",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (61)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 61,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "61",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (61)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 62,
+      "propertyName": "level",
+      "propertyKeyName": "62",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (62)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 62,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "62",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (62)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 63,
+      "propertyName": "level",
+      "propertyKeyName": "63",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (63)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 63,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "63",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (63)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 64,
+      "propertyName": "level",
+      "propertyKeyName": "64",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (64)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 64,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "64",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (64)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 65,
+      "propertyName": "level",
+      "propertyKeyName": "65",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (65)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 65,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "65",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (65)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 66,
+      "propertyName": "level",
+      "propertyKeyName": "66",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (66)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 66,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "66",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (66)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 67,
+      "propertyName": "level",
+      "propertyKeyName": "67",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (67)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 67,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "67",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (67)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 68,
+      "propertyName": "level",
+      "propertyKeyName": "68",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (68)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 68,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "68",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (68)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 69,
+      "propertyName": "level",
+      "propertyKeyName": "69",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (69)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 69,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "69",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (69)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 70,
+      "propertyName": "level",
+      "propertyKeyName": "70",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (70)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 70,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "70",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (70)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 71,
+      "propertyName": "level",
+      "propertyKeyName": "71",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (71)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 71,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "71",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (71)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 72,
+      "propertyName": "level",
+      "propertyKeyName": "72",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (72)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 72,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "72",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (72)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 73,
+      "propertyName": "level",
+      "propertyKeyName": "73",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (73)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 73,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "73",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (73)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 74,
+      "propertyName": "level",
+      "propertyKeyName": "74",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (74)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 74,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "74",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (74)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 75,
+      "propertyName": "level",
+      "propertyKeyName": "75",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (75)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 75,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "75",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (75)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 76,
+      "propertyName": "level",
+      "propertyKeyName": "76",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (76)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 76,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "76",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (76)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 77,
+      "propertyName": "level",
+      "propertyKeyName": "77",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (77)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 77,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "77",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (77)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 78,
+      "propertyName": "level",
+      "propertyKeyName": "78",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (78)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 78,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "78",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (78)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 79,
+      "propertyName": "level",
+      "propertyKeyName": "79",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (79)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 79,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "79",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (79)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 80,
+      "propertyName": "level",
+      "propertyKeyName": "80",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (80)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 80,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "80",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (80)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 81,
+      "propertyName": "level",
+      "propertyKeyName": "81",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (81)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 81,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "81",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (81)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 82,
+      "propertyName": "level",
+      "propertyKeyName": "82",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (82)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 82,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "82",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (82)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 83,
+      "propertyName": "level",
+      "propertyKeyName": "83",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (83)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 83,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "83",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (83)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 84,
+      "propertyName": "level",
+      "propertyKeyName": "84",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (84)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 84,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "84",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (84)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 85,
+      "propertyName": "level",
+      "propertyKeyName": "85",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (85)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 85,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "85",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (85)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 86,
+      "propertyName": "level",
+      "propertyKeyName": "86",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (86)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 86,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "86",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (86)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 87,
+      "propertyName": "level",
+      "propertyKeyName": "87",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (87)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 87,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "87",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (87)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 88,
+      "propertyName": "level",
+      "propertyKeyName": "88",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (88)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 88,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "88",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (88)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 89,
+      "propertyName": "level",
+      "propertyKeyName": "89",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (89)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 89,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "89",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (89)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 90,
+      "propertyName": "level",
+      "propertyKeyName": "90",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (90)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 90,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "90",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (90)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 91,
+      "propertyName": "level",
+      "propertyKeyName": "91",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (91)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 91,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "91",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (91)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 92,
+      "propertyName": "level",
+      "propertyKeyName": "92",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (92)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 92,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "92",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (92)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 93,
+      "propertyName": "level",
+      "propertyKeyName": "93",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (93)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 93,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "93",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (93)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 94,
+      "propertyName": "level",
+      "propertyKeyName": "94",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (94)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 94,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "94",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (94)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 95,
+      "propertyName": "level",
+      "propertyKeyName": "95",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (95)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 95,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "95",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (95)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 96,
+      "propertyName": "level",
+      "propertyKeyName": "96",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (96)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 96,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "96",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (96)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 97,
+      "propertyName": "level",
+      "propertyKeyName": "97",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (97)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 97,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "97",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (97)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 98,
+      "propertyName": "level",
+      "propertyKeyName": "98",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (98)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 98,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "98",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (98)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 99,
+      "propertyName": "level",
+      "propertyKeyName": "99",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (99)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 99,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "99",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (99)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 100,
+      "propertyName": "level",
+      "propertyKeyName": "100",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (100)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 100,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "100",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (100)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 101,
+      "propertyName": "level",
+      "propertyKeyName": "101",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (101)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 101,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "101",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (101)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 102,
+      "propertyName": "level",
+      "propertyKeyName": "102",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (102)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 102,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "102",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (102)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 103,
+      "propertyName": "level",
+      "propertyKeyName": "103",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (103)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 103,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "103",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (103)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 104,
+      "propertyName": "level",
+      "propertyKeyName": "104",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (104)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 104,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "104",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (104)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 105,
+      "propertyName": "level",
+      "propertyKeyName": "105",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (105)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 105,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "105",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (105)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 106,
+      "propertyName": "level",
+      "propertyKeyName": "106",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (106)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 106,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "106",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (106)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 107,
+      "propertyName": "level",
+      "propertyKeyName": "107",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (107)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 107,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "107",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (107)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 108,
+      "propertyName": "level",
+      "propertyKeyName": "108",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (108)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 108,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "108",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (108)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 109,
+      "propertyName": "level",
+      "propertyKeyName": "109",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (109)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 109,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "109",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (109)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 110,
+      "propertyName": "level",
+      "propertyKeyName": "110",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (110)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 110,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "110",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (110)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 111,
+      "propertyName": "level",
+      "propertyKeyName": "111",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (111)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 111,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "111",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (111)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 112,
+      "propertyName": "level",
+      "propertyKeyName": "112",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (112)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 112,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "112",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (112)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 113,
+      "propertyName": "level",
+      "propertyKeyName": "113",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (113)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 113,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "113",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (113)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 114,
+      "propertyName": "level",
+      "propertyKeyName": "114",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (114)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 114,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "114",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (114)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 115,
+      "propertyName": "level",
+      "propertyKeyName": "115",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (115)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 115,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "115",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (115)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 116,
+      "propertyName": "level",
+      "propertyKeyName": "116",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (116)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 116,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "116",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (116)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 117,
+      "propertyName": "level",
+      "propertyKeyName": "117",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (117)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 117,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "117",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (117)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 118,
+      "propertyName": "level",
+      "propertyKeyName": "118",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (118)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 118,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "118",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (118)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 119,
+      "propertyName": "level",
+      "propertyKeyName": "119",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (119)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 119,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "119",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (119)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 120,
+      "propertyName": "level",
+      "propertyKeyName": "120",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (120)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 120,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "120",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (120)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 121,
+      "propertyName": "level",
+      "propertyKeyName": "121",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (121)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 121,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "121",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (121)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 122,
+      "propertyName": "level",
+      "propertyKeyName": "122",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (122)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 122,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "122",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (122)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 123,
+      "propertyName": "level",
+      "propertyKeyName": "123",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (123)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 123,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "123",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (123)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 124,
+      "propertyName": "level",
+      "propertyKeyName": "124",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (124)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 124,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "124",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (124)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 125,
+      "propertyName": "level",
+      "propertyKeyName": "125",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (125)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 125,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "125",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (125)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 126,
+      "propertyName": "level",
+      "propertyKeyName": "126",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (126)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 126,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "126",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (126)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 127,
+      "propertyName": "level",
+      "propertyKeyName": "127",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (127)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 127,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "127",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (127)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 128,
+      "propertyName": "level",
+      "propertyKeyName": "128",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (128)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 128,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "128",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (128)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 129,
+      "propertyName": "level",
+      "propertyKeyName": "129",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (129)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 129,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "129",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (129)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 130,
+      "propertyName": "level",
+      "propertyKeyName": "130",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (130)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 130,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "130",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (130)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 131,
+      "propertyName": "level",
+      "propertyKeyName": "131",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (131)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 131,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "131",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (131)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 132,
+      "propertyName": "level",
+      "propertyKeyName": "132",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (132)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 132,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "132",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (132)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 133,
+      "propertyName": "level",
+      "propertyKeyName": "133",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (133)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 133,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "133",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (133)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 134,
+      "propertyName": "level",
+      "propertyKeyName": "134",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (134)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 134,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "134",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (134)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 135,
+      "propertyName": "level",
+      "propertyKeyName": "135",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (135)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 135,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "135",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (135)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 136,
+      "propertyName": "level",
+      "propertyKeyName": "136",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (136)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 136,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "136",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (136)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 137,
+      "propertyName": "level",
+      "propertyKeyName": "137",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (137)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 137,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "137",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (137)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 138,
+      "propertyName": "level",
+      "propertyKeyName": "138",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (138)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 138,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "138",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (138)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 139,
+      "propertyName": "level",
+      "propertyKeyName": "139",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (139)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 139,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "139",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (139)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 140,
+      "propertyName": "level",
+      "propertyKeyName": "140",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (140)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 140,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "140",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (140)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 141,
+      "propertyName": "level",
+      "propertyKeyName": "141",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (141)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 141,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "141",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (141)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 142,
+      "propertyName": "level",
+      "propertyKeyName": "142",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (142)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 142,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "142",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (142)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 143,
+      "propertyName": "level",
+      "propertyKeyName": "143",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (143)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 143,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "143",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (143)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 144,
+      "propertyName": "level",
+      "propertyKeyName": "144",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (144)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 144,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "144",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (144)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 145,
+      "propertyName": "level",
+      "propertyKeyName": "145",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (145)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 145,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "145",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (145)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 146,
+      "propertyName": "level",
+      "propertyKeyName": "146",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (146)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 146,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "146",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (146)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 147,
+      "propertyName": "level",
+      "propertyKeyName": "147",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (147)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 147,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "147",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (147)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 148,
+      "propertyName": "level",
+      "propertyKeyName": "148",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (148)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 148,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "148",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (148)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 149,
+      "propertyName": "level",
+      "propertyKeyName": "149",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (149)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 149,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "149",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (149)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 150,
+      "propertyName": "level",
+      "propertyKeyName": "150",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (150)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 150,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "150",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (150)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 151,
+      "propertyName": "level",
+      "propertyKeyName": "151",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (151)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 151,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "151",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (151)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 152,
+      "propertyName": "level",
+      "propertyKeyName": "152",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (152)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 152,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "152",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (152)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 153,
+      "propertyName": "level",
+      "propertyKeyName": "153",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (153)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 153,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "153",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (153)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 154,
+      "propertyName": "level",
+      "propertyKeyName": "154",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (154)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 154,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "154",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (154)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 155,
+      "propertyName": "level",
+      "propertyKeyName": "155",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (155)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 155,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "155",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (155)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 156,
+      "propertyName": "level",
+      "propertyKeyName": "156",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (156)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 156,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "156",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (156)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 157,
+      "propertyName": "level",
+      "propertyKeyName": "157",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (157)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 157,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "157",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (157)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 158,
+      "propertyName": "level",
+      "propertyKeyName": "158",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (158)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 158,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "158",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (158)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 159,
+      "propertyName": "level",
+      "propertyKeyName": "159",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (159)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 159,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "159",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (159)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 160,
+      "propertyName": "level",
+      "propertyKeyName": "160",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (160)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 160,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "160",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (160)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 161,
+      "propertyName": "level",
+      "propertyKeyName": "161",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (161)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 161,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "161",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (161)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 162,
+      "propertyName": "level",
+      "propertyKeyName": "162",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (162)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 162,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "162",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (162)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 163,
+      "propertyName": "level",
+      "propertyKeyName": "163",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (163)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 163,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "163",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (163)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 164,
+      "propertyName": "level",
+      "propertyKeyName": "164",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (164)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 164,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "164",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (164)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 165,
+      "propertyName": "level",
+      "propertyKeyName": "165",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (165)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 165,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "165",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (165)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 166,
+      "propertyName": "level",
+      "propertyKeyName": "166",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (166)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 166,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "166",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (166)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 167,
+      "propertyName": "level",
+      "propertyKeyName": "167",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (167)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 167,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "167",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (167)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 168,
+      "propertyName": "level",
+      "propertyKeyName": "168",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (168)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 168,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "168",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (168)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 169,
+      "propertyName": "level",
+      "propertyKeyName": "169",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (169)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 169,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "169",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (169)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 170,
+      "propertyName": "level",
+      "propertyKeyName": "170",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (170)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 170,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "170",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (170)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 171,
+      "propertyName": "level",
+      "propertyKeyName": "171",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (171)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 171,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "171",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (171)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 172,
+      "propertyName": "level",
+      "propertyKeyName": "172",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (172)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 172,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "172",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (172)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 173,
+      "propertyName": "level",
+      "propertyKeyName": "173",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (173)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 173,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "173",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (173)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 174,
+      "propertyName": "level",
+      "propertyKeyName": "174",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (174)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 174,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "174",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (174)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 175,
+      "propertyName": "level",
+      "propertyKeyName": "175",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (175)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 175,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "175",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (175)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 176,
+      "propertyName": "level",
+      "propertyKeyName": "176",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (176)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 176,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "176",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (176)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 177,
+      "propertyName": "level",
+      "propertyKeyName": "177",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (177)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 177,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "177",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (177)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 178,
+      "propertyName": "level",
+      "propertyKeyName": "178",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (178)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 178,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "178",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (178)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 179,
+      "propertyName": "level",
+      "propertyKeyName": "179",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (179)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 179,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "179",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (179)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 180,
+      "propertyName": "level",
+      "propertyKeyName": "180",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (180)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 180,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "180",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (180)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 181,
+      "propertyName": "level",
+      "propertyKeyName": "181",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (181)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 181,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "181",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (181)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 182,
+      "propertyName": "level",
+      "propertyKeyName": "182",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (182)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 182,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "182",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (182)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 183,
+      "propertyName": "level",
+      "propertyKeyName": "183",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (183)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 183,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "183",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (183)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 184,
+      "propertyName": "level",
+      "propertyKeyName": "184",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (184)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 184,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "184",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (184)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 185,
+      "propertyName": "level",
+      "propertyKeyName": "185",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (185)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 185,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "185",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (185)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 186,
+      "propertyName": "level",
+      "propertyKeyName": "186",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (186)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 186,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "186",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (186)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 187,
+      "propertyName": "level",
+      "propertyKeyName": "187",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (187)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 187,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "187",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (187)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 188,
+      "propertyName": "level",
+      "propertyKeyName": "188",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (188)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 188,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "188",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (188)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 189,
+      "propertyName": "level",
+      "propertyKeyName": "189",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (189)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 189,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "189",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (189)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 190,
+      "propertyName": "level",
+      "propertyKeyName": "190",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (190)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 190,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "190",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (190)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 191,
+      "propertyName": "level",
+      "propertyKeyName": "191",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (191)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 191,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "191",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (191)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 192,
+      "propertyName": "level",
+      "propertyKeyName": "192",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (192)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 192,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "192",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (192)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 193,
+      "propertyName": "level",
+      "propertyKeyName": "193",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (193)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 193,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "193",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (193)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 194,
+      "propertyName": "level",
+      "propertyKeyName": "194",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (194)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 194,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "194",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (194)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 195,
+      "propertyName": "level",
+      "propertyKeyName": "195",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (195)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 195,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "195",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (195)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 196,
+      "propertyName": "level",
+      "propertyKeyName": "196",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (196)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 196,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "196",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (196)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 197,
+      "propertyName": "level",
+      "propertyKeyName": "197",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (197)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 197,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "197",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (197)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 198,
+      "propertyName": "level",
+      "propertyKeyName": "198",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (198)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 198,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "198",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (198)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 199,
+      "propertyName": "level",
+      "propertyKeyName": "199",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (199)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 199,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "199",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (199)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 200,
+      "propertyName": "level",
+      "propertyKeyName": "200",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (200)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 200,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "200",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (200)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 201,
+      "propertyName": "level",
+      "propertyKeyName": "201",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (201)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 201,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "201",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (201)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 202,
+      "propertyName": "level",
+      "propertyKeyName": "202",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (202)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 202,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "202",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (202)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 203,
+      "propertyName": "level",
+      "propertyKeyName": "203",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (203)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 203,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "203",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (203)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 204,
+      "propertyName": "level",
+      "propertyKeyName": "204",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (204)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 204,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "204",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (204)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 205,
+      "propertyName": "level",
+      "propertyKeyName": "205",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (205)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 205,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "205",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (205)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 206,
+      "propertyName": "level",
+      "propertyKeyName": "206",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (206)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 206,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "206",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (206)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 207,
+      "propertyName": "level",
+      "propertyKeyName": "207",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (207)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 207,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "207",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (207)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 208,
+      "propertyName": "level",
+      "propertyKeyName": "208",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (208)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 208,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "208",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (208)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 209,
+      "propertyName": "level",
+      "propertyKeyName": "209",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (209)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 209,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "209",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (209)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 210,
+      "propertyName": "level",
+      "propertyKeyName": "210",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (210)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 210,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "210",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (210)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 211,
+      "propertyName": "level",
+      "propertyKeyName": "211",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (211)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 211,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "211",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (211)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 212,
+      "propertyName": "level",
+      "propertyKeyName": "212",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (212)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 212,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "212",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (212)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 213,
+      "propertyName": "level",
+      "propertyKeyName": "213",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (213)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 213,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "213",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (213)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 214,
+      "propertyName": "level",
+      "propertyKeyName": "214",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (214)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 214,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "214",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (214)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 215,
+      "propertyName": "level",
+      "propertyKeyName": "215",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (215)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 215,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "215",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (215)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 216,
+      "propertyName": "level",
+      "propertyKeyName": "216",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (216)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 216,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "216",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (216)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 217,
+      "propertyName": "level",
+      "propertyKeyName": "217",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (217)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 217,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "217",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (217)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 218,
+      "propertyName": "level",
+      "propertyKeyName": "218",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (218)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 218,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "218",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (218)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 219,
+      "propertyName": "level",
+      "propertyKeyName": "219",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (219)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 219,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "219",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (219)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 220,
+      "propertyName": "level",
+      "propertyKeyName": "220",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (220)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 220,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "220",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (220)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 221,
+      "propertyName": "level",
+      "propertyKeyName": "221",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (221)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 221,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "221",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (221)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 222,
+      "propertyName": "level",
+      "propertyKeyName": "222",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (222)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 222,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "222",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (222)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 223,
+      "propertyName": "level",
+      "propertyKeyName": "223",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (223)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 223,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "223",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (223)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 224,
+      "propertyName": "level",
+      "propertyKeyName": "224",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (224)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 224,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "224",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (224)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 225,
+      "propertyName": "level",
+      "propertyKeyName": "225",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (225)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 225,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "225",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (225)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 226,
+      "propertyName": "level",
+      "propertyKeyName": "226",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (226)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 226,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "226",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (226)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 227,
+      "propertyName": "level",
+      "propertyKeyName": "227",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (227)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 227,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "227",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (227)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 228,
+      "propertyName": "level",
+      "propertyKeyName": "228",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (228)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 228,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "228",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (228)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 229,
+      "propertyName": "level",
+      "propertyKeyName": "229",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (229)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 229,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "229",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (229)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 230,
+      "propertyName": "level",
+      "propertyKeyName": "230",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (230)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 230,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "230",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (230)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 231,
+      "propertyName": "level",
+      "propertyKeyName": "231",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (231)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 231,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "231",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (231)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 232,
+      "propertyName": "level",
+      "propertyKeyName": "232",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (232)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 232,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "232",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (232)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 233,
+      "propertyName": "level",
+      "propertyKeyName": "233",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (233)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 233,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "233",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (233)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 234,
+      "propertyName": "level",
+      "propertyKeyName": "234",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (234)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 234,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "234",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (234)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 235,
+      "propertyName": "level",
+      "propertyKeyName": "235",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (235)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 235,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "235",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (235)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 236,
+      "propertyName": "level",
+      "propertyKeyName": "236",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (236)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 236,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "236",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (236)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 237,
+      "propertyName": "level",
+      "propertyKeyName": "237",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (237)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 237,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "237",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (237)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 238,
+      "propertyName": "level",
+      "propertyKeyName": "238",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (238)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 238,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "238",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (238)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 239,
+      "propertyName": "level",
+      "propertyKeyName": "239",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (239)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 239,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "239",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (239)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 240,
+      "propertyName": "level",
+      "propertyKeyName": "240",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (240)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 240,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "240",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (240)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 241,
+      "propertyName": "level",
+      "propertyKeyName": "241",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (241)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 241,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "241",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (241)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 242,
+      "propertyName": "level",
+      "propertyKeyName": "242",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (242)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 242,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "242",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (242)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 243,
+      "propertyName": "level",
+      "propertyKeyName": "243",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (243)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 243,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "243",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (243)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 244,
+      "propertyName": "level",
+      "propertyKeyName": "244",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (244)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 244,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "244",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (244)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 245,
+      "propertyName": "level",
+      "propertyKeyName": "245",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (245)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 245,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "245",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (245)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 246,
+      "propertyName": "level",
+      "propertyKeyName": "246",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (246)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 246,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "246",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (246)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 247,
+      "propertyName": "level",
+      "propertyKeyName": "247",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (247)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 247,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "247",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (247)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 248,
+      "propertyName": "level",
+      "propertyKeyName": "248",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (248)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 248,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "248",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (248)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 249,
+      "propertyName": "level",
+      "propertyKeyName": "249",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (249)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 249,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "249",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (249)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 250,
+      "propertyName": "level",
+      "propertyKeyName": "250",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (250)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 250,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "250",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (250)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 251,
+      "propertyName": "level",
+      "propertyKeyName": "251",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (251)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 251,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "251",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (251)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 252,
+      "propertyName": "level",
+      "propertyKeyName": "252",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (252)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 252,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "252",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (252)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 253,
+      "propertyName": "level",
+      "propertyKeyName": "253",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (253)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 253,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "253",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (253)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 254,
+      "propertyName": "level",
+      "propertyKeyName": "254",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (254)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 254,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "254",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (254)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 255,
+      "propertyName": "level",
+      "propertyKeyName": "255",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (255)",
+        "valueChangeOptions": [
+          "transitionDuration"
+        ],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 255,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "255",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (255)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 114,
+      "commandClassName": "Manufacturer Specific",
+      "property": "productId",
+      "propertyName": "productId",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Product ID",
+        "min": 0,
+        "max": 65535,
+        "stateful": true,
+        "secret": false
+      },
+      "value": 521
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 114,
+      "commandClassName": "Manufacturer Specific",
+      "property": "productType",
+      "propertyName": "productType",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Product type",
+        "min": 0,
+        "max": 65535,
+        "stateful": true,
+        "secret": false
+      },
+      "value": 4097
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 114,
+      "commandClassName": "Manufacturer Specific",
+      "property": "manufacturerId",
+      "propertyName": "manufacturerId",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Manufacturer ID",
+        "min": 0,
+        "max": 65535,
+        "stateful": true,
+        "secret": false
+      },
+      "value": 29
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 119,
+      "commandClassName": "Node Naming and Location",
+      "property": "name",
+      "propertyName": "name",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "Node name",
+        "stateful": true,
+        "secret": false
+      },
+      "value": "Fan"
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 119,
+      "commandClassName": "Node Naming and Location",
+      "property": "location",
+      "propertyName": "location",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": true,
+        "label": "Node location",
+        "stateful": true,
+        "secret": false
+      },
+      "value": "Family Room"
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "firmwareVersions",
+      "propertyName": "firmwareVersions",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "string[]",
+        "readable": true,
+        "writeable": false,
+        "label": "Z-Wave chip firmware versions",
+        "stateful": true,
+        "secret": false
+      },
+      "value": [
+        "0.5"
+      ]
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "protocolVersion",
+      "propertyName": "protocolVersion",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": false,
+        "label": "Z-Wave protocol version",
+        "stateful": true,
+        "secret": false
+      },
+      "value": "2.9"
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "libraryType",
+      "propertyName": "libraryType",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Library type",
+        "states": {
+          "0": "Unknown",
+          "1": "Static Controller",
+          "2": "Controller",
+          "3": "Enhanced Slave",
+          "4": "Slave",
+          "5": "Installer",
+          "6": "Routing Slave",
+          "7": "Bridge Controller",
+          "8": "Device under Test",
+          "9": "N/A",
+          "10": "AV Remote",
+          "11": "AV Device"
+        },
+        "stateful": true,
+        "secret": false
+      },
+      "value": 3
+    }
+  ],
+  "endpoints": [
+    {
+      "nodeId": 35,
+      "index": 0,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing End Node"
+        },
+        "generic": {
+          "key": 17,
+          "label": "Multilevel Switch"
+        },
+        "specific": {
+          "key": 4,
+          "label": "Multilevel Scene Switch"
+        }
+      },
+      "commandClasses": [
+        {
+          "id": 38,
+          "name": "Multilevel Switch",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 43,
+          "name": "Scene Activation",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 44,
+          "name": "Scene Actuator Configuration",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 133,
+          "name": "Association",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 114,
+          "name": "Manufacturer Specific",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 134,
+          "name": "Version",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 145,
+          "name": "Manufacturer Proprietary",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 119,
+          "name": "Node Naming and Location",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 115,
+          "name": "Powerlevel",
+          "version": 1,
+          "isSecure": false
+        }
+      ]
+    }
+  ]
+}

--- a/tests/components/zwave_js/fixtures/leviton_vrf01_state.json
+++ b/tests/components/zwave_js/fixtures/leviton_vrf01_state.json
@@ -48,9 +48,7 @@
   "interviewAttempts": 1,
   "isFrequentListening": false,
   "maxDataRate": 40000,
-  "supportedDataRates": [
-    40000
-  ],
+  "supportedDataRates": [40000],
   "protocolVersion": 1,
   "supportsBeaming": false,
   "supportsSecurity": false,
@@ -82,23 +80,15 @@
     "rssi": -84,
     "lwr": {
       "protocolDataRate": 2,
-      "repeaters": [
-        11
-      ],
+      "repeaters": [11],
       "rssi": -87,
-      "repeaterRSSI": [
-        0
-      ]
+      "repeaterRSSI": [0]
     },
     "nlwr": {
       "protocolDataRate": 2,
-      "repeaters": [
-        10
-      ],
+      "repeaters": [10],
       "rssi": -72,
-      "repeaterRSSI": [
-        0
-      ]
+      "repeaterRSSI": [0]
     }
   },
   "highestSecurityClass": -1,
@@ -125,9 +115,7 @@
         "ccSpecific": {
           "switchType": 2
         },
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "states": {
           "true": "Start",
           "false": "Stop"
@@ -168,9 +156,7 @@
         "readable": true,
         "writeable": true,
         "label": "Target value",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 99,
         "stateful": true,
@@ -193,9 +179,7 @@
         "ccSpecific": {
           "switchType": 2
         },
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "states": {
           "true": "Start",
           "false": "Stop"
@@ -251,9 +235,7 @@
         "readable": true,
         "writeable": true,
         "label": "Scene ID",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 1,
         "max": 255,
         "stateful": false,
@@ -290,9 +272,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (1)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -331,9 +311,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (2)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -372,9 +350,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (3)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -413,9 +389,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (4)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -454,9 +428,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (5)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -495,9 +467,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (6)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -536,9 +506,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (7)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -577,9 +545,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (8)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -618,9 +584,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (9)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -659,9 +623,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (10)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -700,9 +662,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (11)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -741,9 +701,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (12)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -782,9 +740,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (13)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -823,9 +779,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (14)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -864,9 +818,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (15)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -905,9 +857,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (16)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -946,9 +896,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (17)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -987,9 +935,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (18)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -1028,9 +974,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (19)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -1069,9 +1013,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (20)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -1110,9 +1052,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (21)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -1151,9 +1091,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (22)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -1192,9 +1130,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (23)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -1233,9 +1169,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (24)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -1274,9 +1208,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (25)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -1315,9 +1247,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (26)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -1356,9 +1286,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (27)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -1397,9 +1325,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (28)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -1438,9 +1364,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (29)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -1479,9 +1403,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (30)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -1520,9 +1442,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (31)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -1561,9 +1481,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (32)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -1602,9 +1520,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (33)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -1643,9 +1559,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (34)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -1684,9 +1598,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (35)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -1725,9 +1637,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (36)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -1766,9 +1676,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (37)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -1807,9 +1715,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (38)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -1848,9 +1754,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (39)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -1889,9 +1793,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (40)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -1930,9 +1832,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (41)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -1971,9 +1871,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (42)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -2012,9 +1910,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (43)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -2053,9 +1949,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (44)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -2094,9 +1988,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (45)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -2135,9 +2027,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (46)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -2176,9 +2066,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (47)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -2217,9 +2105,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (48)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -2258,9 +2144,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (49)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -2299,9 +2183,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (50)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -2340,9 +2222,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (51)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -2381,9 +2261,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (52)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -2422,9 +2300,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (53)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -2463,9 +2339,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (54)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -2504,9 +2378,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (55)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -2545,9 +2417,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (56)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -2586,9 +2456,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (57)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -2627,9 +2495,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (58)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -2668,9 +2534,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (59)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -2709,9 +2573,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (60)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -2750,9 +2612,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (61)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -2791,9 +2651,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (62)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -2832,9 +2690,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (63)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -2873,9 +2729,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (64)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -2914,9 +2768,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (65)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -2955,9 +2807,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (66)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -2996,9 +2846,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (67)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -3037,9 +2885,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (68)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -3078,9 +2924,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (69)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -3119,9 +2963,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (70)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -3160,9 +3002,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (71)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -3201,9 +3041,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (72)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -3242,9 +3080,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (73)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -3283,9 +3119,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (74)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -3324,9 +3158,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (75)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -3365,9 +3197,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (76)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -3406,9 +3236,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (77)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -3447,9 +3275,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (78)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -3488,9 +3314,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (79)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -3529,9 +3353,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (80)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -3570,9 +3392,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (81)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -3611,9 +3431,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (82)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -3652,9 +3470,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (83)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -3693,9 +3509,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (84)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -3734,9 +3548,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (85)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -3775,9 +3587,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (86)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -3816,9 +3626,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (87)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -3857,9 +3665,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (88)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -3898,9 +3704,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (89)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -3939,9 +3743,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (90)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -3980,9 +3782,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (91)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -4021,9 +3821,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (92)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -4062,9 +3860,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (93)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -4103,9 +3899,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (94)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -4144,9 +3938,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (95)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -4185,9 +3977,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (96)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -4226,9 +4016,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (97)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -4267,9 +4055,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (98)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -4308,9 +4094,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (99)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -4349,9 +4133,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (100)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -4390,9 +4172,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (101)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -4431,9 +4211,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (102)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -4472,9 +4250,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (103)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -4513,9 +4289,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (104)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -4554,9 +4328,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (105)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -4595,9 +4367,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (106)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -4636,9 +4406,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (107)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -4677,9 +4445,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (108)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -4718,9 +4484,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (109)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -4759,9 +4523,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (110)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -4800,9 +4562,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (111)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -4841,9 +4601,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (112)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -4882,9 +4640,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (113)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -4923,9 +4679,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (114)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -4964,9 +4718,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (115)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -5005,9 +4757,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (116)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -5046,9 +4796,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (117)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -5087,9 +4835,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (118)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -5128,9 +4874,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (119)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -5169,9 +4913,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (120)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -5210,9 +4952,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (121)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -5251,9 +4991,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (122)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -5292,9 +5030,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (123)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -5333,9 +5069,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (124)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -5374,9 +5108,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (125)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -5415,9 +5147,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (126)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -5456,9 +5186,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (127)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -5497,9 +5225,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (128)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -5538,9 +5264,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (129)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -5579,9 +5303,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (130)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -5620,9 +5342,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (131)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -5661,9 +5381,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (132)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -5702,9 +5420,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (133)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -5743,9 +5459,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (134)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -5784,9 +5498,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (135)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -5825,9 +5537,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (136)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -5866,9 +5576,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (137)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -5907,9 +5615,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (138)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -5948,9 +5654,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (139)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -5989,9 +5693,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (140)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -6030,9 +5732,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (141)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -6071,9 +5771,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (142)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -6112,9 +5810,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (143)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -6153,9 +5849,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (144)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -6194,9 +5888,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (145)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -6235,9 +5927,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (146)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -6276,9 +5966,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (147)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -6317,9 +6005,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (148)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -6358,9 +6044,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (149)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -6399,9 +6083,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (150)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -6440,9 +6122,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (151)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -6481,9 +6161,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (152)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -6522,9 +6200,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (153)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -6563,9 +6239,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (154)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -6604,9 +6278,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (155)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -6645,9 +6317,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (156)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -6686,9 +6356,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (157)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -6727,9 +6395,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (158)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -6768,9 +6434,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (159)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -6809,9 +6473,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (160)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -6850,9 +6512,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (161)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -6891,9 +6551,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (162)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -6932,9 +6590,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (163)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -6973,9 +6629,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (164)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -7014,9 +6668,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (165)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -7055,9 +6707,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (166)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -7096,9 +6746,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (167)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -7137,9 +6785,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (168)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -7178,9 +6824,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (169)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -7219,9 +6863,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (170)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -7260,9 +6902,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (171)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -7301,9 +6941,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (172)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -7342,9 +6980,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (173)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -7383,9 +7019,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (174)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -7424,9 +7058,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (175)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -7465,9 +7097,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (176)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -7506,9 +7136,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (177)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -7547,9 +7175,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (178)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -7588,9 +7214,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (179)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -7629,9 +7253,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (180)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -7670,9 +7292,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (181)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -7711,9 +7331,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (182)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -7752,9 +7370,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (183)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -7793,9 +7409,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (184)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -7834,9 +7448,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (185)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -7875,9 +7487,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (186)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -7916,9 +7526,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (187)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -7957,9 +7565,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (188)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -7998,9 +7604,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (189)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -8039,9 +7643,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (190)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -8080,9 +7682,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (191)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -8121,9 +7721,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (192)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -8162,9 +7760,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (193)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -8203,9 +7799,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (194)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -8244,9 +7838,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (195)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -8285,9 +7877,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (196)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -8326,9 +7916,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (197)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -8367,9 +7955,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (198)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -8408,9 +7994,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (199)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -8449,9 +8033,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (200)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -8490,9 +8072,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (201)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -8531,9 +8111,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (202)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -8572,9 +8150,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (203)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -8613,9 +8189,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (204)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -8654,9 +8228,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (205)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -8695,9 +8267,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (206)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -8736,9 +8306,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (207)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -8777,9 +8345,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (208)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -8818,9 +8384,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (209)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -8859,9 +8423,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (210)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -8900,9 +8462,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (211)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -8941,9 +8501,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (212)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -8982,9 +8540,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (213)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -9023,9 +8579,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (214)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -9064,9 +8618,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (215)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -9105,9 +8657,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (216)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -9146,9 +8696,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (217)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -9187,9 +8735,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (218)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -9228,9 +8774,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (219)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -9269,9 +8813,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (220)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -9310,9 +8852,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (221)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -9351,9 +8891,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (222)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -9392,9 +8930,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (223)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -9433,9 +8969,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (224)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -9474,9 +9008,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (225)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -9515,9 +9047,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (226)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -9556,9 +9086,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (227)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -9597,9 +9125,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (228)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -9638,9 +9164,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (229)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -9679,9 +9203,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (230)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -9720,9 +9242,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (231)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -9761,9 +9281,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (232)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -9802,9 +9320,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (233)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -9843,9 +9359,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (234)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -9884,9 +9398,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (235)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -9925,9 +9437,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (236)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -9966,9 +9476,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (237)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -10007,9 +9515,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (238)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -10048,9 +9554,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (239)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -10089,9 +9593,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (240)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -10130,9 +9632,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (241)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -10171,9 +9671,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (242)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -10212,9 +9710,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (243)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -10253,9 +9749,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (244)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -10294,9 +9788,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (245)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -10335,9 +9827,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (246)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -10376,9 +9866,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (247)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -10417,9 +9905,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (248)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -10458,9 +9944,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (249)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -10499,9 +9983,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (250)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -10540,9 +10022,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (251)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -10581,9 +10061,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (252)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -10622,9 +10100,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (253)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -10663,9 +10139,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (254)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -10704,9 +10178,7 @@
         "readable": true,
         "writeable": true,
         "label": "Level (255)",
-        "valueChangeOptions": [
-          "transitionDuration"
-        ],
+        "valueChangeOptions": ["transitionDuration"],
         "min": 0,
         "max": 255,
         "stateful": true,
@@ -10837,9 +10309,7 @@
         "stateful": true,
         "secret": false
       },
-      "value": [
-        "0.5"
-      ]
+      "value": ["0.5"]
     },
     {
       "endpoint": 0,

--- a/tests/components/zwave_js/test_discovery.py
+++ b/tests/components/zwave_js/test_discovery.py
@@ -139,6 +139,17 @@ async def test_inovelli_lzw36(
     assert state
 
 
+async def test_leviton_vrf01(
+    hass: HomeAssistant, client, leviton_vrf01, integration
+) -> None:
+    """Test Leviton VRF01 multilevel switch is discovered as a fan, not a light."""
+    node = leviton_vrf01
+    assert node.device_class.specific.label == "Multilevel Scene Switch"
+
+    assert hass.states.get("fan.fan")
+    assert not hass.states.get("light.fan")
+
+
 async def test_vision_security_zl7432(
     hass: HomeAssistant, client, vision_security_zl7432, integration
 ) -> None:

--- a/tests/components/zwave_js/test_fan.py
+++ b/tests/components/zwave_js/test_fan.py
@@ -719,6 +719,76 @@ async def test_leviton_zw4sf_fan(
     assert state.attributes[ATTR_PRESET_MODES] == []
 
 
+async def test_leviton_vrf01_fan(
+    hass: HomeAssistant, client, leviton_vrf01, integration
+) -> None:
+    """Test a Leviton VRF01 fan with 3 fixed speeds."""
+    node = leviton_vrf01
+    node_id = node.node_id
+    entity_id = "fan.fan"
+
+    async def get_zwave_speed_from_percentage(percentage):
+        """Set the fan to a particular percentage and get the resulting Zwave speed."""
+        client.async_send_command.reset_mock()
+
+        await hass.services.async_call(
+            "fan",
+            "turn_on",
+            {"entity_id": entity_id, "percentage": percentage},
+            blocking=True,
+        )
+
+        assert len(client.async_send_command.call_args_list) == 1
+        args = client.async_send_command.call_args[0][0]
+        assert args["command"] == "node.set_value"
+        assert args["nodeId"] == node_id
+        return args["value"]
+
+    async def get_percentage_from_zwave_speed(zwave_speed):
+        """Set the underlying device speed and get the resulting percentage."""
+        event = Event(
+            type="value updated",
+            data={
+                "source": "node",
+                "event": "value updated",
+                "nodeId": node_id,
+                "args": {
+                    "commandClassName": "Multilevel Switch",
+                    "commandClass": 38,
+                    "endpoint": 0,
+                    "property": "currentValue",
+                    "newValue": zwave_speed,
+                    "prevValue": 0,
+                    "propertyName": "currentValue",
+                },
+            },
+        )
+        node.receive_event(event)
+        state = hass.states.get(entity_id)
+        return state.attributes[ATTR_PERCENTAGE]
+
+    # This device has the speeds:
+    # 1 = 1-32, 2 = 33-66, 3 = 67-99
+    percentages_to_zwave_speeds = [
+        [[0], [0]],
+        [range(1, 34), range(1, 33)],
+        [range(34, 67), range(33, 67)],
+        [range(67, 101), range(67, 100)],
+    ]
+
+    for percentages, zwave_speeds in percentages_to_zwave_speeds:
+        for percentage in percentages:
+            actual_zwave_speed = await get_zwave_speed_from_percentage(percentage)
+            assert actual_zwave_speed in zwave_speeds
+        for zwave_speed in zwave_speeds:
+            actual_percentage = await get_percentage_from_zwave_speed(zwave_speed)
+            assert actual_percentage in percentages
+
+    state = hass.states.get(entity_id)
+    assert state.attributes[ATTR_PERCENTAGE_STEP] == pytest.approx(100 / 3, rel=1e-3)
+    assert state.attributes[ATTR_PRESET_MODES] == []
+
+
 async def test_enbrighten_55258_zw4002_fan(
     hass: HomeAssistant, client, enbrighten_55258_zw4002, integration
 ) -> None:


### PR DESCRIPTION
## Proposed change

The Leviton VRF01 ("Scene Capable Quiet Fan Speed Control") reports a
Z-Wave generic device class of Multilevel Switch, which the `zwave_js`
integration discovers as a light entity by default. This adds a
device-specific discovery schema (following the pattern already used
for the Leviton ZW4SF fan controller) so the VRF01 is correctly
discovered as a `fan` entity with its 3 fixed speeds instead of a
`light` entity.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)