### PR TITLE
Bump py_ccm15 to 1.1.2

### DIFF
--- a/homeassistant/components/ccm15/manifest.json
+++ b/homeassistant/components/ccm15/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "quality_scale": "bronze",
-  "requirements": ["py_ccm15==1.1.1"]
+  "requirements": ["py_ccm15==1.1.2"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1988,7 +1988,7 @@ pyW215==0.8.0
 pyW800rf32==0.4
 
 # homeassistant.components.ccm15
-py_ccm15==1.1.1
+py_ccm15==1.1.2
 
 # homeassistant.components.html5
 py_vapid==1.9.4


### PR DESCRIPTION
## Breaking change


## Proposed change

Bump `py_ccm15` from `1.1.1` to `1.1.2`.

1.1.2 is a `perf` release (HomeOps/py-ccm15#65): each slot's `CCM15SlaveDevice`
is created once and then updated in place on later polls, instead of being
reallocated every poll — stable object identity across polls and no allocation
churn. No public API or behaviour change, so no integration code change is
needed.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

py_ccm15 1.1.2 release: https://github.com/HomeOps/py-ccm15/releases/tag/v1.1.2
Delta 1.1.1...1.1.2: https://github.com/HomeOps/py-ccm15/compare/v1.1.1...v1.1.2
(one `perf` change — reuse slave-device instances across polls; no runtime
behaviour change.)

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and a link to
      the changelog/release notes is added to the PR description.

[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
