### PR TITLE
Mark ccm15 discovery/exception gold rules exempt

### DIFF
--- a/homeassistant/components/ccm15/climate.py
+++ b/homeassistant/components/ccm15/climate.py
@@ -29,6 +29,8 @@ from .coordinator import CCM15ConfigEntry, CCM15Coordinator
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -146,7 +148,7 @@ class CCM15Climate(CoordinatorEntity[CCM15Coordinator], ClimateEntity):
     @override
     def available(self) -> bool:
         """Return the availability of the entity."""
-        return self.data is not None
+        return super().available and self.data is not None
 
     @property
     @override

--- a/homeassistant/components/ccm15/coordinator.py
+++ b/homeassistant/components/ccm15/coordinator.py
@@ -56,11 +56,11 @@ class CCM15Coordinator(DataUpdateCoordinator[CCM15DeviceState]):
 
     @override
     async def _async_update_data(self) -> CCM15DeviceState:
-        """Fetch data from Rain Bird device."""
+        """Fetch data from the CCM15 device."""
         try:
             return await self._fetch_data()
-        except httpx.RequestError as err:  # pragma: no cover
-            raise UpdateFailed("Error communicating with Device") from err
+        except httpx.RequestError as err:
+            raise UpdateFailed("Error communicating with the CCM15 controller") from err
 
     async def _fetch_data(self) -> CCM15DeviceState:
         """Get the current status of all AC devices."""

--- a/homeassistant/components/ccm15/manifest.json
+++ b/homeassistant/components/ccm15/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://www.home-assistant.io/integrations/ccm15",
   "integration_type": "hub",
   "iot_class": "local_polling",
-  "quality_scale": "bronze",
+  "quality_scale": "silver",
   "requirements": ["py_ccm15==1.1.2"]
 }

--- a/homeassistant/components/ccm15/quality_scale.yaml
+++ b/homeassistant/components/ccm15/quality_scale.yaml
@@ -52,8 +52,14 @@ rules:
   # Gold
   devices: done
   diagnostics: done
-  discovery-update-info: todo
-  discovery: todo
+  discovery-update-info:
+    status: exempt
+    comment: The device is not discoverable, so there is no discovery data to update.
+  discovery:
+    status: exempt
+    comment: >-
+      The CCM15 is a local-polling hub configured by host/IP; it is not
+      discoverable on the network (no mDNS/SSDP/DHCP).
   docs-data-update: todo
   docs-examples: todo
   docs-known-limitations: todo
@@ -74,7 +80,11 @@ rules:
   entity-translations:
     status: exempt
     comment: The climate entity uses the device name; no entity names to translate.
-  exception-translations: todo
+  exception-translations:
+    status: exempt
+    comment: >-
+      The integration raises no user-facing exceptions; the only failure path is
+      an internal UpdateFailed from the coordinator.
   icon-translations:
     status: exempt
     comment: The integration uses default entity icons.

--- a/homeassistant/components/ccm15/quality_scale.yaml
+++ b/homeassistant/components/ccm15/quality_scale.yaml
@@ -39,15 +39,15 @@ rules:
   docs-configuration-parameters:
     status: exempt
     comment: This integration has no options flow.
-  docs-installation-parameters: todo
-  entity-unavailable: todo
+  docs-installation-parameters: done
+  entity-unavailable: done
   integration-owner: done
-  log-when-unavailable: todo
-  parallel-updates: todo
+  log-when-unavailable: done
+  parallel-updates: done
   reauthentication-flow:
     status: exempt
     comment: The device connection is unauthenticated; revisit when optional password (pwd=) support lands.
-  test-coverage: todo
+  test-coverage: done
 
   # Gold
   devices: done

--- a/tests/components/ccm15/conftest.py
+++ b/tests/components/ccm15/conftest.py
@@ -4,6 +4,7 @@ from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 from ccm15 import CCM15DeviceState, CCM15SlaveDevice
+import httpx
 import pytest
 
 
@@ -38,5 +39,15 @@ def network_failure_ccm15_device() -> Generator[None]:
     with patch(
         "homeassistant.components.ccm15.coordinator.CCM15Device.get_status_async",
         return_value=device_state,
+    ):
+        yield
+
+
+@pytest.fixture
+def network_error_ccm15_device() -> Generator[None]:
+    """Mock a ccm15 device that cannot be reached."""
+    with patch(
+        "homeassistant.components.ccm15.coordinator.CCM15Device.get_status_async",
+        side_effect=httpx.RequestError("Connection failed"),
     ):
         yield

--- a/tests/components/ccm15/test_climate.py
+++ b/tests/components/ccm15/test_climate.py
@@ -31,6 +31,7 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_PORT,
     SERVICE_TURN_OFF,
+    STATE_UNAVAILABLE,
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
@@ -97,7 +98,11 @@ async def test_climate_state(
         await hass.services.async_call(
             CLIMATE_DOMAIN,
             SERVICE_SET_TEMPERATURE,
-            {ATTR_ENTITY_ID: ["climate.midea_0"], ATTR_TEMPERATURE: 25},
+            {
+                ATTR_ENTITY_ID: ["climate.midea_0"],
+                ATTR_TEMPERATURE: 25,
+                ATTR_HVAC_MODE: HVACMode.COOL,
+            },
             blocking=True,
         )
         await hass.async_block_till_done()
@@ -142,6 +147,40 @@ async def test_climate_state(
 
     assert hass.states.get("climate.midea_0") == snapshot
     assert hass.states.get("climate.midea_1") == snapshot
+
+
+@pytest.mark.usefixtures("ccm15_device")
+async def test_entity_unavailable_without_data(hass: HomeAssistant) -> None:
+    """When a slot stops reporting, the entity is unavailable and its attrs are None."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="1.1.1.1",
+        data={
+            CONF_HOST: "1.1.1.1",
+            CONF_PORT: 80,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    assert hass.states.get("climate.midea_0").state != STATE_UNAVAILABLE
+
+    # The slot stops reporting: push empty data through the coordinator.
+    entry.runtime_data.async_set_updated_data(CCM15DeviceState(devices={}))
+    await hass.async_block_till_done()
+
+    assert hass.states.get("climate.midea_0").state == STATE_UNAVAILABLE
+
+    entity = hass.data[CLIMATE_DOMAIN].get_entity("climate.midea_0")
+    assert entity is not None
+    assert entity.available is False
+    assert entity.current_temperature is None
+    assert entity.target_temperature is None
+    assert entity.hvac_mode is None
+    assert entity.fan_mode is None
+    assert entity.swing_mode is None
+    assert entity.extra_state_attributes == {}
 
 
 async def test_climate_fahrenheit_unit(hass: HomeAssistant) -> None:

--- a/tests/components/ccm15/test_init.py
+++ b/tests/components/ccm15/test_init.py
@@ -70,3 +70,19 @@ async def test_non_contiguous_slots(hass: HomeAssistant) -> None:
         state = hass.states.get(entity_id)
         assert state is not None
         assert state.state != "unavailable"
+
+
+@pytest.mark.usefixtures("network_error_ccm15_device")
+async def test_setup_retry_on_connection_error(hass: HomeAssistant) -> None:
+    """Setup is retried when the controller cannot be reached."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="1.1.1.1",
+        data={CONF_HOST: "1.1.1.1", CONF_PORT: 80},
+    )
+    entry.add_to_hass(hass)
+
+    assert not await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY


### PR DESCRIPTION
## Breaking change


## Proposed change

Mark the ccm15 `discovery`, `discovery-update-info` and `exception-translations` gold rules exempt: the CCM15 is a local-polling hub configured by host/IP (no mDNS/SSDP/DHCP), and the integration raises no user-facing exceptions. No code change.

Depends on #175669 (silver); its changes show in this diff until it merges.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
