### PR TITLE
Add get_positions service to sun

### DIFF
--- a/homeassistant/components/sun/__init__.py
+++ b/homeassistant/components/sun/__init__.py
@@ -19,11 +19,13 @@ from . import (
     sensor as sensor_pre_import,  # noqa: F401
 )
 from .const import (  # noqa: F401  # noqa: F401
+    DATA_COMPONENT,
     DOMAIN,
     STATE_ABOVE_HORIZON,
     STATE_BELOW_HORIZON,
 )
 from .entity import Sun, SunConfigEntry
+from .services import async_setup_services
 
 PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR]
 
@@ -34,6 +36,8 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Track the state of the sun."""
+    hass.data[DATA_COMPONENT] = EntityComponent[Sun](_LOGGER, DOMAIN, hass)
+    async_setup_services(hass)
     if not hass.config_entries.async_entries(DOMAIN):
         # We avoid creating an import flow if its already
         # setup since it will have to import the config_flow
@@ -58,8 +62,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: SunConfigEntry) -> bool:
         ent_reg.async_remove(entity_id)
 
     sun = Sun(hass)
-    component = EntityComponent[Sun](_LOGGER, DOMAIN, hass)
-    await component.async_add_entities([sun])
+    await hass.data[DATA_COMPONENT].async_add_entities([sun])
     entry.runtime_data = sun
     entry.async_on_unload(sun.remove_listeners)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/homeassistant/components/sun/const.py
+++ b/homeassistant/components/sun/const.py
@@ -1,10 +1,18 @@
 """Constants for the Sun integration."""
 
-from typing import Final
+from typing import TYPE_CHECKING, Final
 
 import astral
 
+from homeassistant.util.hass_dict import HassKey
+
+if TYPE_CHECKING:
+    from homeassistant.helpers.entity_component import EntityComponent
+
+    from .entity import Sun
+
 DOMAIN: Final = "sun"
+DATA_COMPONENT: HassKey[EntityComponent[Sun]] = HassKey(DOMAIN)
 
 DEFAULT_NAME: Final = "Sun"
 

--- a/homeassistant/components/sun/icons.json
+++ b/homeassistant/components/sun/icons.json
@@ -62,6 +62,11 @@
       }
     }
   },
+  "services": {
+    "get_positions": {
+      "service": "mdi:sun-angle"
+    }
+  },
   "triggers": {
     "dawn": {
       "trigger": "mdi:weather-sunset-up"

--- a/homeassistant/components/sun/services.py
+++ b/homeassistant/components/sun/services.py
@@ -1,0 +1,120 @@
+"""Services for the Sun integration."""
+
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, Final
+
+from astral import Observer
+import astral.sun
+import voluptuous as vol
+
+from homeassistant.core import (
+    HomeAssistant,
+    ServiceCall,
+    ServiceResponse,
+    SupportsResponse,
+    callback,
+)
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import config_validation as cv
+from homeassistant.util import dt as dt_util
+from homeassistant.util.json import JsonValueType
+
+from .const import DATA_COMPONENT, DOMAIN, STATE_ATTR_AZIMUTH, STATE_ATTR_ELEVATION
+
+if TYPE_CHECKING:
+    from .entity import Sun
+
+SERVICE_GET_POSITIONS: Final = "get_positions"
+
+ATTR_START_DATE_TIME: Final = "start_date_time"
+ATTR_END_DATE_TIME: Final = "end_date_time"
+ATTR_DURATION: Final = "duration"
+ATTR_INTERVAL: Final = "interval"
+ATTR_POSITIONS: Final = "positions"
+ATTR_DATETIME: Final = "datetime"
+
+DEFAULT_DURATION: Final = timedelta(days=1)
+DEFAULT_INTERVAL: Final = timedelta(minutes=5)
+MIN_INTERVAL: Final = timedelta(seconds=1)
+
+# Highest number of samples a single call may return (14 days at the default
+# 5-minute interval), bounding the computation a call can request.
+MAX_POSITIONS: Final = 4032
+
+SERVICE_GET_POSITIONS_SCHEMA: Final = vol.All(
+    cv.has_at_most_one_key(ATTR_END_DATE_TIME, ATTR_DURATION),
+    cv.make_entity_service_schema(
+        {
+            vol.Optional(ATTR_START_DATE_TIME): cv.datetime,
+            vol.Optional(ATTR_END_DATE_TIME): cv.datetime,
+            vol.Optional(ATTR_DURATION): vol.All(cv.time_period, cv.positive_timedelta),
+            # positive_timedelta allows zero; the explicit floor also keeps a
+            # single call from requesting sub-second sampling.
+            vol.Optional(ATTR_INTERVAL, default=DEFAULT_INTERVAL): vol.All(
+                cv.time_period, vol.Range(min=MIN_INTERVAL)
+            ),
+        }
+    ),
+)
+
+
+def _compute_positions(
+    observer: Observer, start: datetime, end: datetime, interval: timedelta
+) -> list[JsonValueType]:
+    """Sample the solar trajectory over the requested time range."""
+    positions: list[JsonValueType] = []
+    sample = start
+    while sample <= end:
+        positions.append(
+            {
+                ATTR_DATETIME: sample.isoformat(),
+                STATE_ATTR_AZIMUTH: round(astral.sun.azimuth(observer, sample), 2),
+                STATE_ATTR_ELEVATION: round(astral.sun.elevation(observer, sample), 2),
+            }
+        )
+        sample += interval
+    return positions
+
+
+async def _async_get_positions(sun: Sun, call: ServiceCall) -> ServiceResponse:
+    """Return the solar azimuth and elevation over the requested time range."""
+    start = dt_util.as_utc(call.data.get(ATTR_START_DATE_TIME, dt_util.now()))
+    if (duration := call.data.get(ATTR_DURATION)) is not None:
+        end = start + duration
+    elif (end_date_time := call.data.get(ATTR_END_DATE_TIME)) is not None:
+        end = dt_util.as_utc(end_date_time)
+    else:
+        end = start + DEFAULT_DURATION
+    if end <= start:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="end_before_start",
+        )
+    interval: timedelta = call.data[ATTR_INTERVAL]
+    count = int((end - start) / interval) + 1
+    if count > MAX_POSITIONS:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="too_many_positions",
+            translation_placeholders={
+                "requested": str(count),
+                "limit": str(MAX_POSITIONS),
+            },
+        )
+    # The astral calls are pure CPU-bound math; a wide range at a small
+    # interval is thousands of them, so compute off the event loop.
+    positions = await sun.hass.async_add_executor_job(
+        _compute_positions, sun.observer, start, end, interval
+    )
+    return {ATTR_POSITIONS: positions}
+
+
+@callback
+def async_setup_services(hass: HomeAssistant) -> None:
+    """Register the Sun services."""
+    hass.data[DATA_COMPONENT].async_register_entity_service(
+        SERVICE_GET_POSITIONS,
+        SERVICE_GET_POSITIONS_SCHEMA,
+        _async_get_positions,
+        supports_response=SupportsResponse.ONLY,
+    )

--- a/homeassistant/components/sun/services.yaml
+++ b/homeassistant/components/sun/services.yaml
@@ -1,0 +1,19 @@
+get_positions:
+  target:
+    entity:
+      domain: sun
+  fields:
+    start_date_time:
+      example: "2026-07-04 06:00:00"
+      selector:
+        datetime:
+    end_date_time:
+      example: "2026-07-05 06:00:00"
+      selector:
+        datetime:
+    duration:
+      selector:
+        duration:
+    interval:
+      selector:
+        duration:

--- a/homeassistant/components/sun/strings.json
+++ b/homeassistant/components/sun/strings.json
@@ -94,6 +94,14 @@
       }
     }
   },
+  "exceptions": {
+    "end_before_start": {
+      "message": "The end of the requested time range must be after its start."
+    },
+    "too_many_positions": {
+      "message": "The requested time range and interval would return {requested} positions; the maximum is {limit}. Use a shorter range or a larger interval."
+    }
+  },
   "selector": {
     "twilight_type": {
       "options": {
@@ -102,6 +110,30 @@
         "civil": "Civil",
         "nautical": "Nautical"
       }
+    }
+  },
+  "services": {
+    "get_positions": {
+      "description": "Retrieves the solar azimuth and elevation over a time range.",
+      "fields": {
+        "duration": {
+          "description": "Length of the time range from the start. Cannot be used together with 'End time'.",
+          "name": "Duration"
+        },
+        "end_date_time": {
+          "description": "End of the time range. Cannot be used together with 'Duration'. Defaults to 24 hours after the start.",
+          "name": "End time"
+        },
+        "interval": {
+          "description": "Time between two returned positions. Defaults to 5 minutes.",
+          "name": "Interval"
+        },
+        "start_date_time": {
+          "description": "Start of the time range. Defaults to now.",
+          "name": "Start time"
+        }
+      },
+      "name": "Get positions"
     }
   },
   "title": "Sun",

--- a/tests/components/sun/snapshots/test_services.ambr
+++ b/tests/components/sun/snapshots/test_services.ambr
@@ -1,0 +1,34 @@
+# serializer version: 1
+# name: test_get_positions
+  dict({
+    'sun.sun': dict({
+      'positions': list([
+        dict({
+          'azimuth': 330.3,
+          'datetime': '2026-07-04T06:00:00+00:00',
+          'elevation': -28.04,
+        }),
+        dict({
+          'azimuth': 337.57,
+          'datetime': '2026-07-04T06:30:00+00:00',
+          'elevation': -30.81,
+        }),
+        dict({
+          'azimuth': 345.35,
+          'datetime': '2026-07-04T07:00:00+00:00',
+          'elevation': -32.82,
+        }),
+        dict({
+          'azimuth': 353.51,
+          'datetime': '2026-07-04T07:30:00+00:00',
+          'elevation': -33.98,
+        }),
+        dict({
+          'azimuth': 1.86,
+          'datetime': '2026-07-04T08:00:00+00:00',
+          'elevation': -34.23,
+        }),
+      ]),
+    }),
+  })
+# ---

--- a/tests/components/sun/test_services.py
+++ b/tests/components/sun/test_services.py
@@ -1,0 +1,136 @@
+"""The tests for the Sun services."""
+
+from datetime import datetime, timedelta
+
+from freezegun import freeze_time
+import pytest
+from syrupy.assertion import SnapshotAssertion
+import voluptuous as vol
+
+from homeassistant.components import sun
+from homeassistant.components.sun.entity import ENTITY_ID
+from homeassistant.components.sun.services import (
+    ATTR_DURATION,
+    ATTR_END_DATE_TIME,
+    ATTR_INTERVAL,
+    ATTR_POSITIONS,
+    ATTR_START_DATE_TIME,
+    SERVICE_GET_POSITIONS,
+)
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
+
+UTC_NOW = datetime(2026, 7, 4, 12, 0, 0, tzinfo=dt_util.UTC)
+
+
+async def setup_sun(hass: HomeAssistant) -> None:
+    """Set up the sun integration."""
+    await async_setup_component(hass, sun.DOMAIN, {sun.DOMAIN: {}})
+    await hass.async_block_till_done()
+
+
+async def get_positions(hass: HomeAssistant, data: dict) -> dict:
+    """Call the get_positions service and return its response."""
+    return await hass.services.async_call(
+        sun.DOMAIN,
+        SERVICE_GET_POSITIONS,
+        {ATTR_ENTITY_ID: ENTITY_ID, **data},
+        blocking=True,
+        return_response=True,
+    )
+
+
+async def test_get_positions(hass: HomeAssistant, snapshot: SnapshotAssertion) -> None:
+    """Test retrieving the solar trajectory over an explicit time range."""
+    with freeze_time(UTC_NOW):
+        await setup_sun(hass)
+        response = await get_positions(
+            hass,
+            {
+                ATTR_START_DATE_TIME: datetime(2026, 7, 4, 6, 0, 0, tzinfo=dt_util.UTC),
+                ATTR_END_DATE_TIME: datetime(2026, 7, 4, 8, 0, 0, tzinfo=dt_util.UTC),
+                ATTR_INTERVAL: {"minutes": 30},
+            },
+        )
+    assert response == snapshot
+
+
+async def test_get_positions_defaults(hass: HomeAssistant) -> None:
+    """Test the default range: 24 hours from now, sampled every 5 minutes."""
+    with freeze_time(UTC_NOW):
+        await setup_sun(hass)
+        response = await get_positions(hass, {})
+    positions = response[ENTITY_ID][ATTR_POSITIONS]
+    assert len(positions) == 24 * 12 + 1
+    assert positions[0]["datetime"] == UTC_NOW.isoformat()
+    assert positions[-1]["datetime"] == (UTC_NOW + timedelta(days=1)).isoformat()
+    for position in (positions[0], positions[-1]):
+        assert isinstance(position["azimuth"], float)
+        assert isinstance(position["elevation"], float)
+
+
+async def test_get_positions_duration(hass: HomeAssistant) -> None:
+    """Test the duration alternative to an explicit end time."""
+    with freeze_time(UTC_NOW):
+        await setup_sun(hass)
+        response = await get_positions(
+            hass,
+            {ATTR_DURATION: {"hours": 1}, ATTR_INTERVAL: {"minutes": 15}},
+        )
+    positions = response[ENTITY_ID][ATTR_POSITIONS]
+    assert len(positions) == 5
+
+
+async def test_get_positions_end_before_start(hass: HomeAssistant) -> None:
+    """Test that an inverted time range is rejected."""
+    with freeze_time(UTC_NOW):
+        await setup_sun(hass)
+        with pytest.raises(
+            ServiceValidationError,
+            match="The end of the requested time range must be after its start",
+        ):
+            await get_positions(
+                hass,
+                {ATTR_END_DATE_TIME: UTC_NOW - timedelta(hours=1)},
+            )
+
+
+async def test_get_positions_too_many_positions(hass: HomeAssistant) -> None:
+    """Test that an excessive range and interval combination is rejected."""
+    with freeze_time(UTC_NOW):
+        await setup_sun(hass)
+        with pytest.raises(
+            ServiceValidationError,
+            match="Use a shorter range or a larger interval",
+        ):
+            await get_positions(
+                hass,
+                {ATTR_DURATION: {"days": 14}, ATTR_INTERVAL: {"minutes": 1}},
+            )
+
+
+async def test_get_positions_end_and_duration_exclusive(
+    hass: HomeAssistant,
+) -> None:
+    """Test that an end time and a duration cannot be combined."""
+    with freeze_time(UTC_NOW):
+        await setup_sun(hass)
+        with pytest.raises(vol.Invalid):
+            await get_positions(
+                hass,
+                {
+                    ATTR_END_DATE_TIME: UTC_NOW + timedelta(hours=1),
+                    ATTR_DURATION: {"hours": 1},
+                },
+            )
+
+
+async def test_get_positions_zero_interval(hass: HomeAssistant) -> None:
+    """Test that a zero interval is rejected."""
+    with freeze_time(UTC_NOW):
+        await setup_sun(hass)
+        with pytest.raises(vol.Invalid):
+            await get_positions(hass, {ATTR_INTERVAL: {"seconds": 0}})


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
-->

## Proposed change

Adds a `sun.get_positions` entity service returning the solar azimuth and elevation sampled over a requested time range, following the response-service pattern of `weather.get_forecasts` and `calendar.get_events`.

**Motivation.** Today the sun integration only exposes the position at the current instant. Any consumer that wants the sun's path (a dashboard drawing the solar arc, an automation anticipating the sun's elevation, shading/blind logic) has to recompute the astronomy on its own. This came out of the Solar dashboard MVP discussions: solar data should come from core integrations rather than be recomputed by frontend cards. Choosing a service (rather than a websocket command) also makes the data directly usable from automations and templates; if another API shape seems preferable, that is open for discussion, which is what this draft is for.

### API

```yaml
action: sun.get_positions
target:
  entity_id: sun.sun
data:
  start_date_time: "2026-07-04 06:00:00"  # optional, defaults to now
  end_date_time: "2026-07-05 06:00:00"    # optional, exclusive with duration
  duration: "24:00:00"                     # optional, exclusive with end_date_time
  interval: "00:05:00"                     # optional, defaults to 5 minutes
```

Response, keyed by entity id like `weather.get_forecasts`:

```json
{
  "sun.sun": {
    "positions": [
      {"datetime": "2026-07-04T06:00:00+00:00", "azimuth": 62.4, "elevation": -3.1}
    ]
  }
}
```

### Implementation notes

- The service is registered in `async_setup` (not `async_setup_entry`), per the `action-setup` quality scale rule as I understand it; the `EntityComponent` therefore moves from the config entry setup into `async_setup` and `hass.data`, mirroring weather/calendar. This is the only refactor in the PR, and the point where feedback is most welcome.
- The schema mirrors `calendar.get_events` (`start_date_time` plus `end_date_time` XOR `duration`); the sampling `interval` has an explicit floor since `cv.positive_timedelta` accepts zero.
- The sample count is bounded (`MAX_POSITIONS`, 14 days at the default interval) with translated `ServiceValidationError`s; the threshold values are open to debate.
- The astral loop is pure CPU-bound math and runs in the executor.
- Legacy inverted wirings are honoured through the existing canonical-sign convention.

### Tests

7 dedicated tests (snapshotted trajectory, defaults, duration variant, and the four validation rejections); the full sun suite passes.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: N/A
- This PR is related to: the Solar dashboard MVP discussions (solar path data should come from core)
- Link to documentation pull request: to follow once the API shape is agreed

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
