### PR TITLE
Raise ccm15 to silver quality scale

### DIFF
--- a/homeassistant/components/ccm15/climate.py
+++ b/homeassistant/components/ccm15/climate.py
@@ -29,6 +29,8 @@ from .coordinator import CCM15ConfigEntry, CCM15Coordinator
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -146,7 +148,7 @@ class CCM15Climate(CoordinatorEntity[CCM15Coordinator], ClimateEntity):
     @override
     def available(self) -> bool:
         """Return the availability of the entity."""
-        return self.data is not None
+        return super().available and self.data is not None
 
     @property
     @override

--- a/homeassistant/components/ccm15/coordinator.py
+++ b/homeassistant/components/ccm15/coordinator.py
@@ -56,11 +56,13 @@ class CCM15Coordinator(DataUpdateCoordinator[CCM15DeviceState]):
 
     @override
     async def _async_update_data(self) -> CCM15DeviceState:
-        """Fetch data from Rain Bird device."""
+        """Fetch data from the CCM15 device."""
         try:
             return await self._fetch_data()
-        except httpx.RequestError as err:  # pragma: no cover
-            raise UpdateFailed("Error communicating with Device") from err
+        except httpx.RequestError as err:
+            raise UpdateFailed(
+                f"Error communicating with the CCM15 controller: {err}"
+            ) from err
 
     async def _fetch_data(self) -> CCM15DeviceState:
         """Get the current status of all AC devices."""

--- a/homeassistant/components/ccm15/manifest.json
+++ b/homeassistant/components/ccm15/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://www.home-assistant.io/integrations/ccm15",
   "integration_type": "hub",
   "iot_class": "local_polling",
-  "quality_scale": "bronze",
+  "quality_scale": "silver",
   "requirements": ["py_ccm15==1.1.2"]
 }

--- a/homeassistant/components/ccm15/quality_scale.yaml
+++ b/homeassistant/components/ccm15/quality_scale.yaml
@@ -39,15 +39,15 @@ rules:
   docs-configuration-parameters:
     status: exempt
     comment: This integration has no options flow.
-  docs-installation-parameters: todo
-  entity-unavailable: todo
+  docs-installation-parameters: done
+  entity-unavailable: done
   integration-owner: done
-  log-when-unavailable: todo
-  parallel-updates: todo
+  log-when-unavailable: done
+  parallel-updates: done
   reauthentication-flow:
     status: exempt
     comment: The device connection is unauthenticated; revisit when optional password (pwd=) support lands.
-  test-coverage: todo
+  test-coverage: done
 
   # Gold
   devices: done

--- a/tests/components/ccm15/test_climate.py
+++ b/tests/components/ccm15/test_climate.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from ccm15 import CCM15DeviceState, CCM15SlaveDevice, TriState
 from freezegun.api import FrozenDateTimeFactory
+import httpx
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -31,6 +32,7 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_PORT,
     SERVICE_TURN_OFF,
+    STATE_UNAVAILABLE,
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
@@ -97,7 +99,11 @@ async def test_climate_state(
         await hass.services.async_call(
             CLIMATE_DOMAIN,
             SERVICE_SET_TEMPERATURE,
-            {ATTR_ENTITY_ID: ["climate.midea_0"], ATTR_TEMPERATURE: 25},
+            {
+                ATTR_ENTITY_ID: ["climate.midea_0"],
+                ATTR_TEMPERATURE: 25,
+                ATTR_HVAC_MODE: HVACMode.COOL,
+            },
             blocking=True,
         )
         await hass.async_block_till_done()
@@ -142,6 +148,45 @@ async def test_climate_state(
 
     assert hass.states.get("climate.midea_0") == snapshot
     assert hass.states.get("climate.midea_1") == snapshot
+
+
+@pytest.mark.usefixtures("ccm15_device")
+async def test_climate_unavailable_on_failed_update(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test the entity becomes unavailable when the controller cannot be reached."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="1.1.1.1",
+        data={
+            CONF_HOST: "1.1.1.1",
+            CONF_PORT: 80,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("climate.midea_0")
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+
+    with patch(
+        "homeassistant.components.ccm15.coordinator.CCM15Device.get_status_async",
+        side_effect=httpx.RequestError(
+            "Connection failed",
+            request=httpx.Request("GET", "http://1.1.1.1/status.xml"),
+        ),
+    ):
+        freezer.tick(timedelta(minutes=15))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("climate.midea_0")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
 
 
 async def test_climate_fahrenheit_unit(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Breaking change


## Proposed change

Raise the ccm15 integration to the silver quality scale:

- Set `PARALLEL_UPDATES = 0`.
- Gate entity availability on coordinator success (`super().available and self.data is not None`).
- Mark the `entity-unavailable`, `log-when-unavailable`, `parallel-updates`, `docs-installation-parameters` and `test-coverage` rules done.
- Add a test that the entity becomes unavailable when the controller is unreachable.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: #174945
