### PR TITLE
Proximity: Rename incorrect uses of 'device' to 'tracker'.

### DIFF
--- a/homeassistant/components/proximity/coordinator.py
+++ b/homeassistant/components/proximity/coordinator.py
@@ -143,7 +143,7 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
                 },
             )
 
-    def _tracker_in_zone(self, zone: State, tracker: State) -> bool:
+    def _tracked_entity_in_zone(self, zone: State, tracked_entity_state: State) -> bool:
         """Return whether the tracked entity is currently in the proximity zone."""
 
         # Modern entity-based trackers and person entities always report zone
@@ -160,13 +160,13 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
         # (deprecated, removed in HA Core 2027.7).
 
         # For both, an empty or absent ``in_zones`` does not imply "in no zone", so we
-        # fall back to matching the tracker state against the zone's friendly name
-        # (what a tracker's state is set to for non-home zones), plus an explicit
+        # fall back to matching the tracked entity state against the zone's friendly name
+        # (what a tracked entity's state is set to for non-home zones), plus an explicit
         # home-zone check. Once both deprecations are gone, ``in_zones`` is
-        # authoritative for every tracker and this method should reduce to the
+        # authoritative for every tracked entity and this method should reduce to the
         # membership check alone; the fallback must be removed, as second-guessing an
         # empty list would then be incorrect.
-        if in_zones := tracker.attributes.get(ATTR_IN_ZONES):
+        if in_zones := tracked_entity_state.attributes.get(ATTR_IN_ZONES):
             return zone.entity_id in in_zones
 
         # Remove once legacy device trackers (2027.5) and location_name (2027.7)
@@ -174,21 +174,24 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
         zone_friendly_name = zone.attributes.get(ATTR_FRIENDLY_NAME)
         return (
             zone_friendly_name is not None
-            and tracker.state.lower() == zone_friendly_name.lower()
-        ) or (tracker.state == STATE_HOME and zone.entity_id == ENTITY_ID_HOME)
+            and tracked_entity_state.state.lower() == zone_friendly_name.lower()
+        ) or (
+            tracked_entity_state.state == STATE_HOME
+            and zone.entity_id == ENTITY_ID_HOME
+        )
 
     def _calc_distance_to_zone(
         self,
         zone: State,
-        tracker: State,
+        tracked_entity_state: State,
         latitude: float | None,
         longitude: float | None,
     ) -> int | None:
-        if self._tracker_in_zone(zone, tracker):
+        if self._tracked_entity_in_zone(zone, tracked_entity_state):
             _LOGGER.debug(
                 "%s: %s in zone -> distance=0",
                 self.name,
-                tracker.entity_id,
+                tracked_entity_state.entity_id,
             )
             return 0
 
@@ -196,7 +199,7 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
             _LOGGER.debug(
                 "%s: %s has no coordinates -> distance=None",
                 self.name,
-                tracker.entity_id,
+                tracked_entity_state.entity_id,
             )
             return None
 
@@ -220,17 +223,17 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
     def _calc_direction_of_travel(
         self,
         zone: State,
-        tracker: State,
+        tracked_entity_state: State,
         old_latitude: float | None,
         old_longitude: float | None,
         new_latitude: float | None,
         new_longitude: float | None,
     ) -> str | None:
-        if self._tracker_in_zone(zone, tracker):
+        if self._tracked_entity_in_zone(zone, tracked_entity_state):
             _LOGGER.debug(
                 "%s: %s in zone -> direction_of_travel=arrived",
                 self.name,
-                tracker.entity_id,
+                tracked_entity_state.entity_id,
             )
             return "arrived"
 

--- a/homeassistant/components/proximity/coordinator.py
+++ b/homeassistant/components/proximity/coordinator.py
@@ -143,7 +143,7 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
                 },
             )
 
-    def _device_in_zone(self, zone: State, device: State) -> bool:
+    def _tracker_in_zone(self, zone: State, tracker: State) -> bool:
         """Return whether the tracked entity is currently in the proximity zone."""
 
         # Modern entity-based trackers and person entities always report zone
@@ -160,13 +160,13 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
         # (deprecated, removed in HA Core 2027.7).
 
         # For both, an empty or absent ``in_zones`` does not imply "in no zone", so we
-        # fall back to matching the device state against the zone's friendly name
+        # fall back to matching the tracker state against the zone's friendly name
         # (what a tracker's state is set to for non-home zones), plus an explicit
         # home-zone check. Once both deprecations are gone, ``in_zones`` is
         # authoritative for every tracker and this method should reduce to the
         # membership check alone; the fallback must be removed, as second-guessing an
         # empty list would then be incorrect.
-        if in_zones := device.attributes.get(ATTR_IN_ZONES):
+        if in_zones := tracker.attributes.get(ATTR_IN_ZONES):
             return zone.entity_id in in_zones
 
         # Remove once legacy device trackers (2027.5) and location_name (2027.7)
@@ -174,21 +174,21 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
         zone_friendly_name = zone.attributes.get(ATTR_FRIENDLY_NAME)
         return (
             zone_friendly_name is not None
-            and device.state.lower() == zone_friendly_name.lower()
-        ) or (device.state == STATE_HOME and zone.entity_id == ENTITY_ID_HOME)
+            and tracker.state.lower() == zone_friendly_name.lower()
+        ) or (tracker.state == STATE_HOME and zone.entity_id == ENTITY_ID_HOME)
 
     def _calc_distance_to_zone(
         self,
         zone: State,
-        device: State,
+        tracker: State,
         latitude: float | None,
         longitude: float | None,
     ) -> int | None:
-        if self._device_in_zone(zone, device):
+        if self._tracker_in_zone(zone, tracker):
             _LOGGER.debug(
                 "%s: %s in zone -> distance=0",
                 self.name,
-                device.entity_id,
+                tracker.entity_id,
             )
             return 0
 
@@ -196,7 +196,7 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
             _LOGGER.debug(
                 "%s: %s has no coordinates -> distance=None",
                 self.name,
-                device.entity_id,
+                tracker.entity_id,
             )
             return None
 
@@ -220,17 +220,17 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
     def _calc_direction_of_travel(
         self,
         zone: State,
-        device: State,
+        tracker: State,
         old_latitude: float | None,
         old_longitude: float | None,
         new_latitude: float | None,
         new_longitude: float | None,
     ) -> str | None:
-        if self._device_in_zone(zone, device):
+        if self._tracker_in_zone(zone, tracker):
             _LOGGER.debug(
                 "%s: %s in zone -> direction_of_travel=arrived",
                 self.name,
-                device.entity_id,
+                tracker.entity_id,
             )
             return "arrived"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Proximity integration: Rename variables containing "device" to "tracker" to reduce confusion.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->
Minor change: variable rename as discussed here: https://github.com/home-assistant/core/pull/172602#discussion_r3513795782

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
