### PR TITLE
Victron GX: Support for currency symbol for relevant entities

### DIFF
--- a/homeassistant/components/victron_gx/entity.py
+++ b/homeassistant/components/victron_gx/entity.py
@@ -61,7 +61,12 @@ class VictronBaseEntity(Entity):
             metric.generic_short_id not in ENTITIES_DISABLE_BY_DEFAULT
         )
 
-    def _native_unit_of_measurement(self) -> str | None:
+    @property
+    def native_unit_of_measurement(self) -> str | None:
+        """Return the metric unit before entity registration."""
+        if self._metric.metric_type == MetricType.COST:
+            return self.hass.config.currency
+
         unit_of_measurement = self._metric.unit_of_measurement
         # We need to provide a native unit in three cases:
         if (

--- a/homeassistant/components/victron_gx/entity.py
+++ b/homeassistant/components/victron_gx/entity.py
@@ -61,10 +61,9 @@ class VictronBaseEntity(Entity):
             metric.generic_short_id not in ENTITIES_DISABLE_BY_DEFAULT
         )
 
-    @property
-    def native_unit_of_measurement(self) -> str | None:
-        """Return the native unit of measurement."""
-        if self._metric.metric_type == MetricType.COST:
+    def _resolve_native_unit_of_measurement(self) -> str | None:
+        """Resolve native unit of measurement for platforms that support it."""
+        if self._metric.metric_type is MetricType.COST:
             return self.hass.config.currency
 
         unit_of_measurement = self._metric.unit_of_measurement

--- a/homeassistant/components/victron_gx/entity.py
+++ b/homeassistant/components/victron_gx/entity.py
@@ -63,7 +63,7 @@ class VictronBaseEntity(Entity):
 
     @property
     def native_unit_of_measurement(self) -> str | None:
-        """Return the metric unit before entity registration."""
+        """Return the native unit of measurement."""
         if self._metric.metric_type == MetricType.COST:
             return self.hass.config.currency
 

--- a/homeassistant/components/victron_gx/number.py
+++ b/homeassistant/components/victron_gx/number.py
@@ -76,7 +76,6 @@ class VictronNumber(VictronBaseEntity, NumberEntity):
     ) -> None:
         """Initialize the number entity."""
         super().__init__(device, metric, device_info, installation_id)
-        self._attr_native_unit_of_measurement = None
         self._attr_device_class = METRIC_TYPE_TO_DEVICE_CLASS.get(metric.metric_type)
         self._attr_native_value = metric.value
         if metric.min_value is not None:
@@ -92,10 +91,12 @@ class VictronNumber(VictronBaseEntity, NumberEntity):
         self._attr_native_value = value
         self.async_write_ha_state()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
         self._attr_native_unit_of_measurement = self._native_unit_of_measurement()
         await super().async_added_to_hass()
+
     @override
     async def async_set_native_value(self, value: float) -> None:
         """Set a new value."""

--- a/homeassistant/components/victron_gx/number.py
+++ b/homeassistant/components/victron_gx/number.py
@@ -85,6 +85,12 @@ class VictronNumber(VictronBaseEntity, NumberEntity):
         if metric.step is not None:
             self._attr_native_step = metric.step
 
+    @property
+    @override
+    def native_unit_of_measurement(self) -> str | None:
+        """Return the native unit of measurement."""
+        return self._resolve_native_unit_of_measurement()
+
     @callback
     @override
     def _on_update_cb(self, value: Any) -> None:

--- a/homeassistant/components/victron_gx/number.py
+++ b/homeassistant/components/victron_gx/number.py
@@ -76,8 +76,8 @@ class VictronNumber(VictronBaseEntity, NumberEntity):
     ) -> None:
         """Initialize the number entity."""
         super().__init__(device, metric, device_info, installation_id)
+        self._attr_native_unit_of_measurement = None
         self._attr_device_class = METRIC_TYPE_TO_DEVICE_CLASS.get(metric.metric_type)
-        self._attr_native_unit_of_measurement = self._native_unit_of_measurement()
         self._attr_native_value = metric.value
         if metric.min_value is not None:
             self._attr_native_min_value = metric.min_value
@@ -92,6 +92,10 @@ class VictronNumber(VictronBaseEntity, NumberEntity):
         self._attr_native_value = value
         self.async_write_ha_state()
 
+    async def async_added_to_hass(self) -> None:
+        """Run when entity about to be added to hass."""
+        self._attr_native_unit_of_measurement = self._native_unit_of_measurement()
+        await super().async_added_to_hass()
     @override
     async def async_set_native_value(self, value: float) -> None:
         """Set a new value."""

--- a/homeassistant/components/victron_gx/number.py
+++ b/homeassistant/components/victron_gx/number.py
@@ -92,12 +92,6 @@ class VictronNumber(VictronBaseEntity, NumberEntity):
         self.async_write_ha_state()
 
     @override
-    async def async_added_to_hass(self) -> None:
-        """Run when entity about to be added to hass."""
-        self._attr_native_unit_of_measurement = self._native_unit_of_measurement()
-        await super().async_added_to_hass()
-
-    @override
     async def async_set_native_value(self, value: float) -> None:
         """Set a new value."""
         if TYPE_CHECKING:

--- a/homeassistant/components/victron_gx/sensor.py
+++ b/homeassistant/components/victron_gx/sensor.py
@@ -104,6 +104,12 @@ class VictronSensor(VictronBaseEntity, SensorEntity):
             )
         self._attr_native_value = VictronSensor._normalize_value(metric.value)
 
+    @property
+    @override
+    def native_unit_of_measurement(self) -> str | None:
+        """Return the native unit of measurement."""
+        return self._resolve_native_unit_of_measurement()
+
     @callback
     @override
     def _on_update_cb(self, value: Any) -> None:

--- a/homeassistant/components/victron_gx/sensor.py
+++ b/homeassistant/components/victron_gx/sensor.py
@@ -94,7 +94,6 @@ class VictronSensor(VictronBaseEntity, SensorEntity):
     ) -> None:
         """Initialize the sensor."""
         super().__init__(device, metric, device_info, installation_id)
-        self._attr_native_unit_of_measurement = None
         self._attr_device_class = METRIC_TYPE_TO_DEVICE_CLASS.get(metric.metric_type)
         # Enum sensors must not have a state class
         if self._attr_device_class == SensorDeviceClass.ENUM:
@@ -117,8 +116,3 @@ class VictronSensor(VictronBaseEntity, SensorEntity):
         if isinstance(value, VictronEnum):
             return value.id
         return value
-
-    async def async_added_to_hass(self) -> None:
-        """Run when entity about to be added to hass."""
-        self._attr_native_unit_of_measurement = self._native_unit_of_measurement()
-        await super().async_added_to_hass()

--- a/homeassistant/components/victron_gx/sensor.py
+++ b/homeassistant/components/victron_gx/sensor.py
@@ -94,6 +94,7 @@ class VictronSensor(VictronBaseEntity, SensorEntity):
     ) -> None:
         """Initialize the sensor."""
         super().__init__(device, metric, device_info, installation_id)
+        self._attr_native_unit_of_measurement = None
         self._attr_device_class = METRIC_TYPE_TO_DEVICE_CLASS.get(metric.metric_type)
         # Enum sensors must not have a state class
         if self._attr_device_class == SensorDeviceClass.ENUM:
@@ -102,7 +103,6 @@ class VictronSensor(VictronBaseEntity, SensorEntity):
             self._attr_state_class = METRIC_NATURE_TO_STATE_CLASS.get(
                 metric.metric_nature
             )
-        self._attr_native_unit_of_measurement = self._native_unit_of_measurement()
         self._attr_native_value = VictronSensor._normalize_value(metric.value)
 
     @callback
@@ -117,3 +117,8 @@ class VictronSensor(VictronBaseEntity, SensorEntity):
         if isinstance(value, VictronEnum):
             return value.id
         return value
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity about to be added to hass."""
+        self._attr_native_unit_of_measurement = self._native_unit_of_measurement()
+        await super().async_added_to_hass()

--- a/tests/components/victron_gx/test_sensor.py
+++ b/tests/components/victron_gx/test_sensor.py
@@ -1,12 +1,20 @@
 """Tests for Victron GX MQTT sensors."""
 
+from unittest.mock import MagicMock
+
 from victron_mqtt import Hub as VictronVenusHub
 from victron_mqtt.testing import finalize_injection, inject_message
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.components.victron_gx.const import DOMAIN
+from homeassistant.components.victron_gx.sensor import VictronSensor
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers import (
+    device_registry as dr,
+    entity_platform,
+    entity_registry as er,
+)
+from homeassistant.helpers.device_registry import DeviceInfo
 
 from .const import MOCK_INSTALLATION_ID
 
@@ -152,3 +160,149 @@ async def test_victron_main_topic_sensor(
     assert state.state == "mppt_active"
     # Entity uses device name only (no separate entity name)
     assert state.attributes["friendly_name"] == "Multi RS Solar"
+
+
+async def test_native_unit_of_measurement_cost_metric(
+    hass: HomeAssistant,
+    init_integration: tuple[VictronVenusHub, MockConfigEntry],
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test native_unit_of_measurement returns currency for COST metric type."""
+    victron_hub, mock_config_entry = init_integration
+
+    hass.config.currency = "USD"
+
+    await inject_message(
+        victron_hub,
+        f"N/{MOCK_INSTALLATION_ID}/evcharger/0/Session/Cost",
+        '{"value": 12.34}',
+    )
+    await finalize_injection(victron_hub)
+    await hass.async_block_till_done()
+
+    entity = next(
+        e
+        for e in er.async_entries_for_config_entry(
+            entity_registry, mock_config_entry.entry_id
+        )
+        if e.translation_key == "evcharger_session_cost"
+    )
+
+    state = hass.states.get(entity.entity_id)
+    assert state is not None
+    assert state.attributes["unit_of_measurement"] == "USD"
+    assert state.state == "12.34"
+
+
+async def test_native_unit_of_measurement_with_device_class(
+    hass: HomeAssistant,
+    init_integration: tuple[VictronVenusHub, MockConfigEntry],
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test native_unit_of_measurement returns unit for metrics with device class."""
+    victron_hub, mock_config_entry = init_integration
+
+    await inject_message(
+        victron_hub,
+        f"N/{MOCK_INSTALLATION_ID}/battery/0/Dc/0/Current",
+        '{"value": 10.5}',
+    )
+    await finalize_injection(victron_hub)
+    await hass.async_block_till_done()
+
+    entity = next(
+        (
+            e
+            for e in er.async_entries_for_config_entry(
+                entity_registry, mock_config_entry.entry_id
+            )
+            if e.entity_id == "sensor.battery_dc_bus_current"
+        ),
+        None,
+    )
+    assert entity is not None
+
+    platforms = entity_platform.async_get_platforms(hass, DOMAIN)
+    sensor_platform = next(p for p in platforms if p.domain == "sensor")
+    actual_entity = next(
+        (
+            e
+            for e in sensor_platform.entities.values()
+            if e.entity_id == entity.entity_id
+        ),
+        None,
+    )
+
+    assert actual_entity is not None
+    assert actual_entity.native_unit_of_measurement == "A"
+
+
+async def test_native_unit_of_measurement_special_unit(
+    hass: HomeAssistant,
+    init_integration: tuple[VictronVenusHub, MockConfigEntry],
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test native_unit_of_measurement returns special units like %."""
+    victron_hub, mock_config_entry = init_integration
+
+    await inject_message(
+        victron_hub,
+        f"N/{MOCK_INSTALLATION_ID}/battery/0/Soc",
+        '{"value": 85}',
+    )
+    await finalize_injection(victron_hub)
+    await hass.async_block_till_done()
+
+    entity = next(
+        (
+            e
+            for e in er.async_entries_for_config_entry(
+                entity_registry, mock_config_entry.entry_id
+            )
+            if e.unit_of_measurement == "%"
+        ),
+        None,
+    )
+    assert entity is not None
+
+    platforms = entity_platform.async_get_platforms(hass, DOMAIN)
+    sensor_platform = next(p for p in platforms if p.domain == "sensor")
+    actual_entity = next(
+        (
+            e
+            for e in sensor_platform.entities.values()
+            if e.entity_id == entity.entity_id
+        ),
+        None,
+    )
+
+    assert actual_entity is not None
+    assert actual_entity.native_unit_of_measurement == "%"
+
+
+async def test_native_unit_of_measurement_return_none(
+    hass: HomeAssistant,
+) -> None:
+    """Test native_unit_of_measurement returns None when no conditions are met."""
+    mock_device = MagicMock()
+    mock_metric = MagicMock()
+    mock_metric.metric_type = MagicMock()
+    mock_metric.unit_of_measurement = "arbitrary_unit"
+    mock_metric.precision = 0
+    mock_metric.generic_short_id = "test_metric"
+    mock_metric.key_values = {}
+    mock_metric.main_topic = False
+    mock_metric.unique_id = "test_unique_id"
+
+    device_info = DeviceInfo(
+        identifiers={(DOMAIN, "test_device")},
+        manufacturer="Victron Energy",
+        model="Test",
+        name="Test Device",
+    )
+
+    sensor = VictronSensor(mock_device, mock_metric, device_info, "installation_123")
+    sensor.hass = hass
+    sensor._attr_device_class = None
+
+    assert sensor.native_unit_of_measurement is None

--- a/tests/components/victron_gx/test_sensor.py
+++ b/tests/components/victron_gx/test_sensor.py
@@ -1,20 +1,12 @@
 """Tests for Victron GX MQTT sensors."""
 
-from unittest.mock import MagicMock
-
 from victron_mqtt import Hub as VictronVenusHub
 from victron_mqtt.testing import finalize_injection, inject_message
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.components.victron_gx.const import DOMAIN
-from homeassistant.components.victron_gx.sensor import VictronSensor
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import (
-    device_registry as dr,
-    entity_platform,
-    entity_registry as er,
-)
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .const import MOCK_INSTALLATION_ID
 
@@ -165,10 +157,9 @@ async def test_victron_main_topic_sensor(
 async def test_native_unit_of_measurement_cost_metric(
     hass: HomeAssistant,
     init_integration: tuple[VictronVenusHub, MockConfigEntry],
-    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test native_unit_of_measurement returns currency for COST metric type."""
-    victron_hub, mock_config_entry = init_integration
+    victron_hub, _mock_config_entry = init_integration
 
     hass.config.currency = "USD"
 
@@ -180,15 +171,7 @@ async def test_native_unit_of_measurement_cost_metric(
     await finalize_injection(victron_hub)
     await hass.async_block_till_done()
 
-    entity = next(
-        e
-        for e in er.async_entries_for_config_entry(
-            entity_registry, mock_config_entry.entry_id
-        )
-        if e.translation_key == "evcharger_session_cost"
-    )
-
-    state = hass.states.get(entity.entity_id)
+    state = hass.states.get("sensor.ev_charging_station_last_session_cost")
     assert state is not None
     assert state.attributes["unit_of_measurement"] == "USD"
     assert state.state == "12.34"
@@ -197,10 +180,9 @@ async def test_native_unit_of_measurement_cost_metric(
 async def test_native_unit_of_measurement_with_device_class(
     hass: HomeAssistant,
     init_integration: tuple[VictronVenusHub, MockConfigEntry],
-    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test native_unit_of_measurement returns unit for metrics with device class."""
-    victron_hub, mock_config_entry = init_integration
+    victron_hub, _mock_config_entry = init_integration
 
     await inject_message(
         victron_hub,
@@ -210,40 +192,17 @@ async def test_native_unit_of_measurement_with_device_class(
     await finalize_injection(victron_hub)
     await hass.async_block_till_done()
 
-    entity = next(
-        (
-            e
-            for e in er.async_entries_for_config_entry(
-                entity_registry, mock_config_entry.entry_id
-            )
-            if e.entity_id == "sensor.battery_dc_bus_current"
-        ),
-        None,
-    )
-    assert entity is not None
-
-    platforms = entity_platform.async_get_platforms(hass, DOMAIN)
-    sensor_platform = next(p for p in platforms if p.domain == "sensor")
-    actual_entity = next(
-        (
-            e
-            for e in sensor_platform.entities.values()
-            if e.entity_id == entity.entity_id
-        ),
-        None,
-    )
-
-    assert actual_entity is not None
-    assert actual_entity.native_unit_of_measurement == "A"
+    state = hass.states.get("sensor.battery_dc_bus_current")
+    assert state is not None
+    assert state.attributes["unit_of_measurement"] == "A"
 
 
 async def test_native_unit_of_measurement_special_unit(
     hass: HomeAssistant,
     init_integration: tuple[VictronVenusHub, MockConfigEntry],
-    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test native_unit_of_measurement returns special units like %."""
-    victron_hub, mock_config_entry = init_integration
+    victron_hub, _mock_config_entry = init_integration
 
     await inject_message(
         victron_hub,
@@ -253,56 +212,6 @@ async def test_native_unit_of_measurement_special_unit(
     await finalize_injection(victron_hub)
     await hass.async_block_till_done()
 
-    entity = next(
-        (
-            e
-            for e in er.async_entries_for_config_entry(
-                entity_registry, mock_config_entry.entry_id
-            )
-            if e.unit_of_measurement == "%"
-        ),
-        None,
-    )
-    assert entity is not None
-
-    platforms = entity_platform.async_get_platforms(hass, DOMAIN)
-    sensor_platform = next(p for p in platforms if p.domain == "sensor")
-    actual_entity = next(
-        (
-            e
-            for e in sensor_platform.entities.values()
-            if e.entity_id == entity.entity_id
-        ),
-        None,
-    )
-
-    assert actual_entity is not None
-    assert actual_entity.native_unit_of_measurement == "%"
-
-
-async def test_native_unit_of_measurement_return_none(
-    hass: HomeAssistant,
-) -> None:
-    """Test native_unit_of_measurement returns None when no conditions are met."""
-    mock_device = MagicMock()
-    mock_metric = MagicMock()
-    mock_metric.metric_type = MagicMock()
-    mock_metric.unit_of_measurement = "arbitrary_unit"
-    mock_metric.precision = 0
-    mock_metric.generic_short_id = "test_metric"
-    mock_metric.key_values = {}
-    mock_metric.main_topic = False
-    mock_metric.unique_id = "test_unique_id"
-
-    device_info = DeviceInfo(
-        identifiers={(DOMAIN, "test_device")},
-        manufacturer="Victron Energy",
-        model="Test",
-        name="Test Device",
-    )
-
-    sensor = VictronSensor(mock_device, mock_metric, device_info, "installation_123")
-    sensor.hass = hass
-    sensor._attr_device_class = None
-
-    assert sensor.native_unit_of_measurement is None
+    state = hass.states.get("sensor.battery_charge")
+    assert state is not None
+    assert state.attributes["unit_of_measurement"] == "%"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adding the HA default currency symbol to currency related entities

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
