### PR TITLE
Clean up Evohome's storage tests

### DIFF
--- a/tests/components/evohome/test_storage.py
+++ b/tests/components/evohome/test_storage.py
@@ -1,8 +1,9 @@
 """The tests for evohome storage load & save."""
 
 from datetime import datetime, timedelta
-from typing import Any, Final, NotRequired, TypedDict
+from typing import Any, Final, TypedDict
 
+from evohomeasync.auth import SZ_SESSION_ID, SZ_SESSION_ID_EXPIRES
 from evohomeasync2.auth import (
     SZ_ACCESS_TOKEN,
     SZ_ACCESS_TOKEN_EXPIRES,
@@ -11,6 +12,7 @@ from evohomeasync2.auth import (
 import pytest
 
 from homeassistant.components.evohome.const import DOMAIN, STORAGE_KEY, STORAGE_VER
+from homeassistant.components.evohome.storage import _TokenStoreT
 from homeassistant.const import CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
@@ -19,24 +21,8 @@ from .conftest import setup_evohome
 from .const import ACCESS_TOKEN, REFRESH_TOKEN, SESSION_ID, USERNAME
 
 
-class _SessionDataT(TypedDict):
-    session_id: str
-    session_id_expires: NotRequired[str]  # 2024-07-27T23:57:30+01:00
-
-
-class _TokenStoreT(TypedDict):
-    username: str
-    refresh_token: str
-    access_token: str
-    access_token_expires: str  # 2024-07-27T23:57:30+01:00
-    user_data: NotRequired[_SessionDataT]
-
-
 class _EmptyStoreT(TypedDict):
     pass
-
-
-SZ_USER_DATA: Final = "user_data"
 
 
 def dt_pair(dt_dtm: datetime) -> tuple[datetime, str]:
@@ -46,12 +32,10 @@ def dt_pair(dt_dtm: datetime) -> tuple[datetime, str]:
 
 
 ACCESS_TOKEN_EXP_DTM, ACCESS_TOKEN_EXP_STR = dt_pair(dt_util.now() + timedelta(hours=1))
-
-USERNAME_DIFF: Final = f"not_{USERNAME}"
-USERNAME_SAME: Final = USERNAME
+_, SESSION_ID_EXP_STR = dt_pair(dt_util.now() + timedelta(minutes=15))
 
 _TEST_STORAGE_BASE: Final[_TokenStoreT] = {
-    CONF_USERNAME: USERNAME_SAME,
+    CONF_USERNAME: USERNAME,
     SZ_REFRESH_TOKEN: REFRESH_TOKEN,
     SZ_ACCESS_TOKEN: ACCESS_TOKEN,
     SZ_ACCESS_TOKEN_EXPIRES: ACCESS_TOKEN_EXP_STR,
@@ -59,8 +43,11 @@ _TEST_STORAGE_BASE: Final[_TokenStoreT] = {
 
 TEST_STORAGE_DATA: Final[dict[str, _TokenStoreT]] = {
     "sans_session_id": _TEST_STORAGE_BASE,
-    "null_session_id": _TEST_STORAGE_BASE | {SZ_USER_DATA: None},  # type: ignore[dict-item]
-    "with_session_id": _TEST_STORAGE_BASE | {SZ_USER_DATA: {"session_id": SESSION_ID}},
+    "with_session_id": _TEST_STORAGE_BASE
+    | {
+        SZ_SESSION_ID: SESSION_ID,
+        SZ_SESSION_ID_EXPIRES: SESSION_ID_EXP_STR,
+    },  # pyright: ignore[reportAssignmentType]
 }
 
 TEST_STORAGE_NULL: Final[dict[str, _EmptyStoreT | None]] = {
@@ -68,7 +55,7 @@ TEST_STORAGE_NULL: Final[dict[str, _EmptyStoreT | None]] = {
     "store_was_reset": {},
 }
 
-DOMAIN_STORAGE_BASE: Final = {
+DOMAIN_STORAGE_ROOT: Final = {
     "version": STORAGE_VER,
     "minor_version": 1,
     "key": STORAGE_KEY,
@@ -86,21 +73,20 @@ async def test_auth_tokens_null(
 ) -> None:
     """Test credentials manager when cache is empty."""
 
-    hass_storage[DOMAIN] = DOMAIN_STORAGE_BASE | {"data": TEST_STORAGE_NULL[idx]}
+    hass_storage[DOMAIN] = DOMAIN_STORAGE_ROOT | {"data": TEST_STORAGE_NULL[idx]}
 
     async for _ in setup_evohome(hass, config, install=install):
         pass
 
-    # Confirm the expected tokens were cached to storage...
     data: _TokenStoreT = hass_storage[DOMAIN]["data"]
 
-    assert data[CONF_USERNAME] == USERNAME_SAME
+    # Confirm the expected tokens were cached to storage...
+    assert data[CONF_USERNAME] == USERNAME
     assert data[SZ_REFRESH_TOKEN] == f"new_{REFRESH_TOKEN}"
     assert data[SZ_ACCESS_TOKEN] == f"new_{ACCESS_TOKEN}"
-    assert (
-        dt_util.parse_datetime(data[SZ_ACCESS_TOKEN_EXPIRES], raise_on_error=True)
-        > dt_util.now()
-    )
+
+    assert (expires := data.get(SZ_ACCESS_TOKEN_EXPIRES)) is not None
+    assert dt_util.parse_datetime(expires, raise_on_error=True) > dt_util.now()
 
 
 @pytest.mark.parametrize("install", ["minimal"])
@@ -114,18 +100,20 @@ async def test_auth_tokens_same(
 ) -> None:
     """Test credentials manager when cache contains valid data for this user."""
 
-    hass_storage[DOMAIN] = DOMAIN_STORAGE_BASE | {"data": TEST_STORAGE_DATA[idx]}
+    hass_storage[DOMAIN] = DOMAIN_STORAGE_ROOT | {"data": TEST_STORAGE_DATA[idx]}
 
     async for _ in setup_evohome(hass, config, install=install):
         pass
 
-    # Confirm the expected tokens were cached to storage...
     data: _TokenStoreT = hass_storage[DOMAIN]["data"]
 
-    assert data[CONF_USERNAME] == USERNAME_SAME
+    # Confirm the expected tokens were cached to storage...
+    assert data[CONF_USERNAME] == USERNAME
     assert data[SZ_REFRESH_TOKEN] == REFRESH_TOKEN
     assert data[SZ_ACCESS_TOKEN] == ACCESS_TOKEN
-    assert dt_util.parse_datetime(data[SZ_ACCESS_TOKEN_EXPIRES]) == ACCESS_TOKEN_EXP_DTM
+
+    assert (expires := data[SZ_ACCESS_TOKEN_EXPIRES]) is not None
+    assert dt_util.parse_datetime(expires, raise_on_error=True) == ACCESS_TOKEN_EXP_DTM
 
 
 @pytest.mark.parametrize("install", ["minimal"])
@@ -139,27 +127,26 @@ async def test_auth_tokens_past(
 ) -> None:
     """Test credentials manager when cache contains expired data for this user."""
 
-    _dt_dtm, dt_str = dt_pair(dt_util.now() - timedelta(hours=1))
+    # make this access token to have expired in the past...
+    _, dt_str = dt_pair(dt_util.now() - timedelta(hours=1))
 
-    # make this access token have expired in the past...
     test_data = TEST_STORAGE_DATA[idx].copy()  # shallow copy is OK here
     test_data[SZ_ACCESS_TOKEN_EXPIRES] = dt_str
 
-    hass_storage[DOMAIN] = DOMAIN_STORAGE_BASE | {"data": test_data}
+    hass_storage[DOMAIN] = DOMAIN_STORAGE_ROOT | {"data": test_data}
 
     async for _ in setup_evohome(hass, config, install=install):
         pass
 
-    # Confirm the expected tokens were cached to storage...
     data: _TokenStoreT = hass_storage[DOMAIN]["data"]
 
-    assert data[CONF_USERNAME] == USERNAME_SAME
+    # Confirm the expected tokens were cached to storage...
+    assert data[CONF_USERNAME] == USERNAME
     assert data[SZ_REFRESH_TOKEN] == f"new_{REFRESH_TOKEN}"
     assert data[SZ_ACCESS_TOKEN] == f"new_{ACCESS_TOKEN}"
-    assert (
-        dt_util.parse_datetime(data[SZ_ACCESS_TOKEN_EXPIRES], raise_on_error=True)
-        > dt_util.now()
-    )
+
+    assert (expires := data[SZ_ACCESS_TOKEN_EXPIRES]) is not None
+    assert dt_util.parse_datetime(expires, raise_on_error=True) > dt_util.now()
 
 
 @pytest.mark.parametrize("install", ["minimal"])
@@ -173,19 +160,19 @@ async def test_auth_tokens_diff(
 ) -> None:
     """Test credentials manager when cache contains data for a different user."""
 
-    hass_storage[DOMAIN] = DOMAIN_STORAGE_BASE | {"data": TEST_STORAGE_DATA[idx]}
-    config["username"] = USERNAME_DIFF
+    # make this access token to be for a different user...
+    hass_storage[DOMAIN] = DOMAIN_STORAGE_ROOT | {"data": TEST_STORAGE_DATA[idx]}
+    config[CONF_USERNAME] = f"new_{USERNAME}"
 
     async for _ in setup_evohome(hass, config, install=install):
         pass
 
-    # Confirm the expected tokens were cached to storage...
     data: _TokenStoreT = hass_storage[DOMAIN]["data"]
 
-    assert data[CONF_USERNAME] == USERNAME_DIFF
+    # Confirm the expected tokens were cached to storage...
+    assert data[CONF_USERNAME] == f"new_{USERNAME}"
     assert data[SZ_REFRESH_TOKEN] == f"new_{REFRESH_TOKEN}"
     assert data[SZ_ACCESS_TOKEN] == f"new_{ACCESS_TOKEN}"
-    assert (
-        dt_util.parse_datetime(data[SZ_ACCESS_TOKEN_EXPIRES], raise_on_error=True)
-        > dt_util.now()
-    )
+
+    assert (expires := data[SZ_ACCESS_TOKEN_EXPIRES]) is not None
+    assert dt_util.parse_datetime(expires, raise_on_error=True) > dt_util.now()

--- a/tests/components/evohome/test_storage.py
+++ b/tests/components/evohome/test_storage.py
@@ -127,7 +127,7 @@ async def test_auth_tokens_past(
 ) -> None:
     """Test credentials manager when cache contains expired data for this user."""
 
-    # make this access token to have expired in the past...
+    # Make this access token have expired in the past...
     _, dt_str = dt_pair(dt_util.now() - timedelta(hours=1))
 
     test_data = TEST_STORAGE_DATA[idx].copy()  # shallow copy is OK here
@@ -160,7 +160,7 @@ async def test_auth_tokens_diff(
 ) -> None:
     """Test credentials manager when cache contains data for a different user."""
 
-    # make this access token to be for a different user...
+    # Make this access token be for a different user...
     hass_storage[DOMAIN] = DOMAIN_STORAGE_ROOT | {"data": TEST_STORAGE_DATA[idx]}
     config[CONF_USERNAME] = f"new_{USERNAME}"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR makes code-quality improvements to Evohome's storage tests:

- imports rather than re-creates the `_TokenStoreT` TypedDict, thus correcting the storage schema 
- imports constants instead of using string literals (`SZ_SESSION_ID`, `SZ_SESSION_ID_EXPIRES`)
- remove a duplicate test, when `SZ_SESSION_ID` is not in the dict or `.get(SZ_SESSION_ID) == None`
- renames some symbols, moves some comments (improves code clarity)

The existing test should not be passing as it expects a hierarchial structure for the storage, where the actual structure is flat - this is because session ids are not validated in this test.

A subsequent PR will correct this deficiency, and this PR prepares the code for that fix.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
