### PR TITLE
Raise ccm15 to silver quality scale

### DIFF
--- a/homeassistant/components/ccm15/climate.py
+++ b/homeassistant/components/ccm15/climate.py
@@ -29,6 +29,8 @@ from .coordinator import CCM15ConfigEntry, CCM15Coordinator
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -146,7 +148,7 @@ class CCM15Climate(CoordinatorEntity[CCM15Coordinator], ClimateEntity):
     @override
     def available(self) -> bool:
         """Return the availability of the entity."""
-        return self.data is not None
+        return super().available and self.data is not None
 
     @property
     @override

--- a/homeassistant/components/ccm15/coordinator.py
+++ b/homeassistant/components/ccm15/coordinator.py
@@ -56,11 +56,11 @@ class CCM15Coordinator(DataUpdateCoordinator[CCM15DeviceState]):
 
     @override
     async def _async_update_data(self) -> CCM15DeviceState:
-        """Fetch data from Rain Bird device."""
+        """Fetch data from the CCM15 device."""
         try:
             return await self._fetch_data()
-        except httpx.RequestError as err:  # pragma: no cover
-            raise UpdateFailed("Error communicating with Device") from err
+        except httpx.RequestError as err:
+            raise UpdateFailed("Error communicating with the CCM15 controller") from err
 
     async def _fetch_data(self) -> CCM15DeviceState:
         """Get the current status of all AC devices."""

--- a/homeassistant/components/ccm15/manifest.json
+++ b/homeassistant/components/ccm15/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://www.home-assistant.io/integrations/ccm15",
   "integration_type": "hub",
   "iot_class": "local_polling",
-  "quality_scale": "bronze",
+  "quality_scale": "silver",
   "requirements": ["py_ccm15==1.1.2"]
 }

--- a/homeassistant/components/ccm15/quality_scale.yaml
+++ b/homeassistant/components/ccm15/quality_scale.yaml
@@ -39,15 +39,15 @@ rules:
   docs-configuration-parameters:
     status: exempt
     comment: This integration has no options flow.
-  docs-installation-parameters: todo
-  entity-unavailable: todo
+  docs-installation-parameters: done
+  entity-unavailable: done
   integration-owner: done
-  log-when-unavailable: todo
-  parallel-updates: todo
+  log-when-unavailable: done
+  parallel-updates: done
   reauthentication-flow:
     status: exempt
     comment: The device connection is unauthenticated; revisit when optional password (pwd=) support lands.
-  test-coverage: todo
+  test-coverage: done
 
   # Gold
   devices: done

--- a/tests/components/ccm15/conftest.py
+++ b/tests/components/ccm15/conftest.py
@@ -4,8 +4,22 @@ from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 from ccm15 import CCM15DeviceState, CCM15SlaveDevice
-import httpx
 import pytest
+
+from homeassistant.components.ccm15.const import DOMAIN
+from homeassistant.const import CONF_HOST, CONF_PORT
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return a mock ccm15 config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="1.1.1.1",
+        data={CONF_HOST: "1.1.1.1", CONF_PORT: 80},
+    )
 
 
 @pytest.fixture
@@ -18,36 +32,20 @@ def mock_setup_entry() -> Generator[AsyncMock]:
 
 
 @pytest.fixture
-def ccm15_device() -> Generator[None]:
-    """Mock ccm15 device."""
-    ccm15_devices = {
-        0: CCM15SlaveDevice(bytes.fromhex("000000b0b8001b")),
-        1: CCM15SlaveDevice(bytes.fromhex("00000041c0001a")),
-    }
-    device_state = CCM15DeviceState(devices=ccm15_devices)
+def ccm15_device() -> Generator[AsyncMock]:
+    """Mock the ccm15 device status.
+
+    Returns two devices by default. Reconfigure per test via the yielded mock's
+    ``return_value`` (e.g. an empty ``CCM15DeviceState``) or ``side_effect``
+    (e.g. ``httpx.RequestError`` for an unreachable controller).
+    """
     with patch(
         "homeassistant.components.ccm15.coordinator.CCM15Device.get_status_async",
-        return_value=device_state,
-    ):
-        yield
-
-
-@pytest.fixture
-def network_failure_ccm15_device() -> Generator[None]:
-    """Mock empty set of ccm15 device."""
-    device_state = CCM15DeviceState(devices={})
-    with patch(
-        "homeassistant.components.ccm15.coordinator.CCM15Device.get_status_async",
-        return_value=device_state,
-    ):
-        yield
-
-
-@pytest.fixture
-def network_error_ccm15_device() -> Generator[None]:
-    """Mock a ccm15 device that cannot be reached."""
-    with patch(
-        "homeassistant.components.ccm15.coordinator.CCM15Device.get_status_async",
-        side_effect=httpx.RequestError("Connection failed"),
-    ):
-        yield
+    ) as mock_get_status:
+        mock_get_status.return_value = CCM15DeviceState(
+            devices={
+                0: CCM15SlaveDevice(bytes.fromhex("000000b0b8001b")),
+                1: CCM15SlaveDevice(bytes.fromhex("00000041c0001a")),
+            }
+        )
+        yield mock_get_status

--- a/tests/components/ccm15/conftest.py
+++ b/tests/components/ccm15/conftest.py
@@ -4,6 +4,7 @@ from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 from ccm15 import CCM15DeviceState, CCM15SlaveDevice
+import httpx
 import pytest
 
 
@@ -38,5 +39,15 @@ def network_failure_ccm15_device() -> Generator[None]:
     with patch(
         "homeassistant.components.ccm15.coordinator.CCM15Device.get_status_async",
         return_value=device_state,
+    ):
+        yield
+
+
+@pytest.fixture
+def network_error_ccm15_device() -> Generator[None]:
+    """Mock a ccm15 device that cannot be reached."""
+    with patch(
+        "homeassistant.components.ccm15.coordinator.CCM15Device.get_status_async",
+        side_effect=httpx.RequestError("Connection failed"),
     ):
         yield

--- a/tests/components/ccm15/test_climate.py
+++ b/tests/components/ccm15/test_climate.py
@@ -141,7 +141,7 @@ async def test_entity_unavailable_without_data(
     ccm15_device: AsyncMock,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """When a slot stops reporting, the entity is unavailable and its attrs are None."""
+    """A slot that stops reporting becomes unavailable."""
     mock_config_entry.add_to_hass(hass)
 
     assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
@@ -155,16 +155,6 @@ async def test_entity_unavailable_without_data(
     await hass.async_block_till_done()
 
     assert hass.states.get("climate.midea_0").state == STATE_UNAVAILABLE
-
-    entity = hass.data[CLIMATE_DOMAIN].get_entity("climate.midea_0")
-    assert entity is not None
-    assert entity.available is False
-    assert entity.current_temperature is None
-    assert entity.target_temperature is None
-    assert entity.hvac_mode is None
-    assert entity.fan_mode is None
-    assert entity.swing_mode is None
-    assert entity.extra_state_attributes == {}
 
 
 async def test_climate_fahrenheit_unit(

--- a/tests/components/ccm15/test_climate.py
+++ b/tests/components/ccm15/test_climate.py
@@ -1,14 +1,13 @@
 """Unit test for CCM15 coordinator component."""
 
 from datetime import timedelta
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from ccm15 import CCM15DeviceState, CCM15SlaveDevice, TriState
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.ccm15.const import DOMAIN
 from homeassistant.components.climate import (
     ATTR_CURRENT_TEMPERATURE,
     ATTR_FAN_MODE,
@@ -28,8 +27,6 @@ from homeassistant.components.climate import (
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
-    CONF_HOST,
-    CONF_PORT,
     SERVICE_TURN_OFF,
     STATE_UNAVAILABLE,
     UnitOfTemperature,
@@ -41,25 +38,18 @@ from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
-@pytest.mark.usefixtures("ccm15_device")
 async def test_climate_state(
     hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    ccm15_device: AsyncMock,
     snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test the coordinator."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        unique_id="1.1.1.1",
-        data={
-            CONF_HOST: "1.1.1.1",
-            CONF_PORT: 80,
-        },
-    )
-    entry.add_to_hass(hass)
+    mock_config_entry.add_to_hass(hass)
 
-    assert await hass.config_entries.async_setup(entry.entry_id)
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
     assert entity_registry.async_get("climate.midea_0") == snapshot
@@ -132,15 +122,11 @@ async def test_climate_state(
         await hass.async_block_till_done()
         mock_set_state.assert_called_once()
 
-    # Create an instance of the CCM15DeviceState class
-    device_state = CCM15DeviceState(devices={})
-    with patch(
-        "ccm15.CCM15Device.CCM15Device.get_status_async",
-        return_value=device_state,
-    ):
-        freezer.tick(timedelta(minutes=15))
-        async_fire_time_changed(hass)
-        await hass.async_block_till_done()
+    # The next poll returns no devices.
+    ccm15_device.return_value = CCM15DeviceState(devices={})
+    freezer.tick(timedelta(minutes=15))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
 
     assert entity_registry.async_get("climate.midea_0") == snapshot
     assert entity_registry.async_get("climate.midea_1") == snapshot
@@ -149,25 +135,23 @@ async def test_climate_state(
     assert hass.states.get("climate.midea_1") == snapshot
 
 
-@pytest.mark.usefixtures("ccm15_device")
-async def test_entity_unavailable_without_data(hass: HomeAssistant) -> None:
+async def test_entity_unavailable_without_data(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    ccm15_device: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
     """When a slot stops reporting, the entity is unavailable and its attrs are None."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        unique_id="1.1.1.1",
-        data={
-            CONF_HOST: "1.1.1.1",
-            CONF_PORT: 80,
-        },
-    )
-    entry.add_to_hass(hass)
+    mock_config_entry.add_to_hass(hass)
 
-    assert await hass.config_entries.async_setup(entry.entry_id)
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
     assert hass.states.get("climate.midea_0").state != STATE_UNAVAILABLE
 
-    # The slot stops reporting: push empty data through the coordinator.
-    entry.runtime_data.async_set_updated_data(CCM15DeviceState(devices={}))
+    # The slot stops reporting: the next poll returns no devices.
+    ccm15_device.return_value = CCM15DeviceState(devices={})
+    freezer.tick(timedelta(minutes=15))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
     assert hass.states.get("climate.midea_0").state == STATE_UNAVAILABLE
@@ -183,25 +167,20 @@ async def test_entity_unavailable_without_data(hass: HomeAssistant) -> None:
     assert entity.extra_state_attributes == {}
 
 
-async def test_climate_fahrenheit_unit(hass: HomeAssistant) -> None:
+async def test_climate_fahrenheit_unit(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    ccm15_device: AsyncMock,
+) -> None:
     """A controller set to Fahrenheit is reported in Fahrenheit."""
     hass.config.units = US_CUSTOMARY_SYSTEM
-    device_state = CCM15DeviceState(
+    ccm15_device.return_value = CCM15DeviceState(
         devices={0: CCM15SlaveDevice(bytes.fromhex("01000041c0004b"))}
     )
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        unique_id="1.1.1.1",
-        data={CONF_HOST: "1.1.1.1", CONF_PORT: 80},
-    )
-    entry.add_to_hass(hass)
+    mock_config_entry.add_to_hass(hass)
 
-    with patch(
-        "homeassistant.components.ccm15.coordinator.CCM15Device.get_status_async",
-        return_value=device_state,
-    ):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
 
     # The entity must report the device's Fahrenheit unit, not hardcoded Celsius.
     climate_component = hass.data[CLIMATE_DOMAIN]
@@ -224,17 +203,15 @@ async def test_climate_fahrenheit_unit(hass: HomeAssistant) -> None:
     [(SWING_ON, TriState.ON), (SWING_OFF, TriState.OFF)],
 )
 async def test_climate_set_swing_mode(
-    hass: HomeAssistant, swing_mode: str, expected: TriState
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    swing_mode: str,
+    expected: TriState,
 ) -> None:
     """Setting the swing mode sends the desired swing to the device."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        unique_id="1.1.1.1",
-        data={CONF_HOST: "1.1.1.1", CONF_PORT: 80},
-    )
-    entry.add_to_hass(hass)
+    mock_config_entry.add_to_hass(hass)
 
-    assert await hass.config_entries.async_setup(entry.entry_id)
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
     with patch(

--- a/tests/components/ccm15/test_climate.py
+++ b/tests/components/ccm15/test_climate.py
@@ -31,6 +31,7 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_PORT,
     SERVICE_TURN_OFF,
+    STATE_UNAVAILABLE,
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
@@ -97,7 +98,11 @@ async def test_climate_state(
         await hass.services.async_call(
             CLIMATE_DOMAIN,
             SERVICE_SET_TEMPERATURE,
-            {ATTR_ENTITY_ID: ["climate.midea_0"], ATTR_TEMPERATURE: 25},
+            {
+                ATTR_ENTITY_ID: ["climate.midea_0"],
+                ATTR_TEMPERATURE: 25,
+                ATTR_HVAC_MODE: HVACMode.COOL,
+            },
             blocking=True,
         )
         await hass.async_block_till_done()
@@ -142,6 +147,40 @@ async def test_climate_state(
 
     assert hass.states.get("climate.midea_0") == snapshot
     assert hass.states.get("climate.midea_1") == snapshot
+
+
+@pytest.mark.usefixtures("ccm15_device")
+async def test_entity_unavailable_without_data(hass: HomeAssistant) -> None:
+    """When a slot stops reporting, the entity is unavailable and its attrs are None."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="1.1.1.1",
+        data={
+            CONF_HOST: "1.1.1.1",
+            CONF_PORT: 80,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    assert hass.states.get("climate.midea_0").state != STATE_UNAVAILABLE
+
+    # The slot stops reporting: push empty data through the coordinator.
+    entry.runtime_data.async_set_updated_data(CCM15DeviceState(devices={}))
+    await hass.async_block_till_done()
+
+    assert hass.states.get("climate.midea_0").state == STATE_UNAVAILABLE
+
+    entity = hass.data[CLIMATE_DOMAIN].get_entity("climate.midea_0")
+    assert entity is not None
+    assert entity.available is False
+    assert entity.current_temperature is None
+    assert entity.target_temperature is None
+    assert entity.hvac_mode is None
+    assert entity.fan_mode is None
+    assert entity.swing_mode is None
+    assert entity.extra_state_attributes == {}
 
 
 async def test_climate_fahrenheit_unit(hass: HomeAssistant) -> None:

--- a/tests/components/ccm15/test_diagnostics.py
+++ b/tests/components/ccm15/test_diagnostics.py
@@ -3,8 +3,6 @@
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.ccm15.const import DOMAIN
-from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
@@ -16,22 +14,17 @@ from tests.typing import ClientSessionGenerator
 async def test_entry_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
+    mock_config_entry: MockConfigEntry,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test config entry diagnostics."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        unique_id="1.1.1.1",
-        data={
-            CONF_HOST: "1.1.1.1",
-            CONF_PORT: 80,
-        },
-    )
-    entry.add_to_hass(hass)
+    mock_config_entry.add_to_hass(hass)
 
-    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    result = await get_diagnostics_for_config_entry(hass, hass_client, entry)
+    result = await get_diagnostics_for_config_entry(
+        hass, hass_client, mock_config_entry
+    )
 
     assert result == snapshot

--- a/tests/components/ccm15/test_init.py
+++ b/tests/components/ccm15/test_init.py
@@ -70,3 +70,19 @@ async def test_non_contiguous_slots(hass: HomeAssistant) -> None:
         state = hass.states.get(entity_id)
         assert state is not None
         assert state.state != "unavailable"
+
+
+@pytest.mark.usefixtures("network_error_ccm15_device")
+async def test_setup_retry_on_connection_error(hass: HomeAssistant) -> None:
+    """Setup is retried when the controller cannot be reached."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="1.1.1.1",
+        data={CONF_HOST: "1.1.1.1", CONF_PORT: 80},
+    )
+    entry.add_to_hass(hass)
+
+    assert not await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/ccm15/test_init.py
+++ b/tests/components/ccm15/test_init.py
@@ -1,70 +1,58 @@
 """Tests for the ccm15 component."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock
 
 from ccm15 import CCM15DeviceState, CCM15SlaveDevice
+import httpx
 import pytest
 
-from homeassistant.components.ccm15.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
 
 @pytest.mark.usefixtures("ccm15_device")
-async def test_load_unload(hass: HomeAssistant) -> None:
-    """Test options flow."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        unique_id="1.1.1.1",
-        data={
-            CONF_HOST: "1.1.1.1",
-            CONF_PORT: 80,
-        },
-    )
-    entry.add_to_hass(hass)
+async def test_load_unload(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test the config entry loads and unloads."""
+    mock_config_entry.add_to_hass(hass)
 
-    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert entry.state is ConfigEntryState.LOADED
+    assert mock_config_entry.state is ConfigEntryState.LOADED
 
-    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.config_entries.async_unload(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert entry.state is ConfigEntryState.NOT_LOADED
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
 
 
-async def test_non_contiguous_slots(hass: HomeAssistant) -> None:
+async def test_non_contiguous_slots(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    ccm15_device: AsyncMock,
+) -> None:
     """Entities for sparse slot indices, including >= 32, are available.
 
     ``devices`` is keyed by the true slot index, which can be sparse and reach
     >= 32. The coordinator must look devices up by key, not assume a contiguous
     0..N-1 range, or any entity past a gap stays permanently unavailable.
     """
-    device_state = CCM15DeviceState(
+    ccm15_device.return_value = CCM15DeviceState(
         devices={
             4: CCM15SlaveDevice(bytes.fromhex("000000b0b8001b")),
             33: CCM15SlaveDevice(bytes.fromhex("00000041c0001a")),
         }
     )
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        unique_id="1.1.1.1",
-        data={CONF_HOST: "1.1.1.1", CONF_PORT: 80},
-    )
-    entry.add_to_hass(hass)
+    mock_config_entry.add_to_hass(hass)
 
-    with patch(
-        "homeassistant.components.ccm15.coordinator.CCM15Device.get_status_async",
-        return_value=device_state,
-    ):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
 
-    assert entry.state is ConfigEntryState.LOADED
+    assert mock_config_entry.state is ConfigEntryState.LOADED
 
     for entity_id in ("climate.midea_4", "climate.midea_33"):
         state = hass.states.get(entity_id)
@@ -72,17 +60,16 @@ async def test_non_contiguous_slots(hass: HomeAssistant) -> None:
         assert state.state != "unavailable"
 
 
-@pytest.mark.usefixtures("network_error_ccm15_device")
-async def test_setup_retry_on_connection_error(hass: HomeAssistant) -> None:
+async def test_setup_retry_on_connection_error(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    ccm15_device: AsyncMock,
+) -> None:
     """Setup is retried when the controller cannot be reached."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        unique_id="1.1.1.1",
-        data={CONF_HOST: "1.1.1.1", CONF_PORT: 80},
-    )
-    entry.add_to_hass(hass)
+    ccm15_device.side_effect = httpx.RequestError("Connection failed")
+    mock_config_entry.add_to_hass(hass)
 
-    assert not await hass.config_entries.async_setup(entry.entry_id)
+    assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert entry.state is ConfigEntryState.SETUP_RETRY
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY


### PR DESCRIPTION
## Breaking change


## Proposed change

Raise the ccm15 integration to the silver quality scale: set `PARALLEL_UPDATES = 1` (serialize control writes on this simple embedded controller), gate entity availability on coordinator success (`super().available and self.data is not None`), mark the `entity-unavailable` / `log-when-unavailable` / `parallel-updates` / `docs-installation-parameters` / `test-coverage` rules done, and add tests for the unavailable/attrs-None path and setup-retry on connection error.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #174945
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
