### PR TITLE
Fix Teslemetry dead-token retry storm

### DIFF
--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from functools import partial
 from typing import Any, Final, cast
 
-from aiohttp import ClientError, ClientResponseError
+from aiohttp import ClientError
 from tesla_fleet_api.const import Scope
 from tesla_fleet_api.exceptions import (
     Forbidden,
@@ -20,10 +20,15 @@ from homeassistant.components.application_credentials import (
     ClientCredential,
     async_import_client_credential,
 )
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import CONF_ACCESS_TOKEN, Platform
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryNotReady,
+    OAuth2TokenRequestError,
+    OAuth2TokenRequestReauthError,
+)
 from homeassistant.helpers import (
     config_validation as cv,
     device_registry as dr,
@@ -89,18 +94,32 @@ async def _get_access_token(oauth_session: OAuth2Session) -> str:
         oauth_session.valid_token,
         oauth_session.token.get("expires_at"),
     )
+    setup_in_progress = (
+        oauth_session.config_entry.state is ConfigEntryState.SETUP_IN_PROGRESS
+    )
     try:
         await oauth_session.async_ensure_token_valid()
-    except ClientResponseError as err:
-        if err.status == 401:
+    except OAuth2TokenRequestReauthError as err:
+        if setup_in_progress:
             raise ConfigEntryAuthFailed(
                 translation_domain=DOMAIN,
                 translation_key="auth_failed",
             ) from err
-        raise ConfigEntryNotReady(
-            translation_domain=DOMAIN,
-            translation_key="not_ready_connection_error",
-        ) from err
+        # Not in setup: let the coordinator's own OAuth2TokenRequestError
+        # handling stop polling and (re)start reauth without tearing
+        # down the already-loaded entry.
+        oauth_session.config_entry.async_start_reauth(oauth_session.hass)
+        raise
+    except OAuth2TokenRequestError as err:
+        # Recoverable (e.g. 429/5xx). During setup this backs off via the
+        # normal ConfigEntryNotReady retry; once loaded, let it propagate so
+        # the coordinator treats it as a transient failed update instead.
+        if setup_in_progress:
+            raise ConfigEntryNotReady(
+                translation_domain=DOMAIN,
+                translation_key="not_ready_connection_error",
+            ) from err
+        raise
     except (KeyError, TypeError) as err:
         raise ConfigEntryAuthFailed(
             translation_domain=DOMAIN,

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -18,6 +18,7 @@ from tesla_fleet_api.exceptions import (
     TeslaFleetError,
 )
 
+from homeassistant.components.teslemetry import _get_access_token
 from homeassistant.components.teslemetry.const import CLIENT_ID, DOMAIN
 
 # Coordinator constants
@@ -30,6 +31,7 @@ from homeassistant.components.teslemetry.coordinator import (
     VEHICLE_INTERVAL,
 )
 from homeassistant.components.teslemetry.models import TeslemetryData
+from homeassistant.components.teslemetry.oauth import TeslemetryImplementation
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
     STATE_OFF,
@@ -39,10 +41,17 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryNotReady,
+    OAuth2TokenRequestReauthError,
+    OAuth2TokenRequestTransientError,
+)
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.config_entry_oauth2_flow import OAuth2Session
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
-from . import setup_platform
+from . import mock_config_entry, setup_platform
 from .const import (
     CONFIG_V1,
     ENERGY_HISTORY,
@@ -1038,3 +1047,115 @@ async def test_insufficient_credits_backs_off_polling(
     coordinator = entry.runtime_data.vehicles[0].coordinator
     assert isinstance(coordinator.last_exception, UpdateFailed)
     assert coordinator.last_exception.retry_after == INSUFFICIENT_CREDITS_RETRY_AFTER
+
+
+def _oauth_session(hass: HomeAssistant, entry: MockConfigEntry) -> OAuth2Session:
+    """Build an OAuth2Session for directly exercising _get_access_token."""
+    return OAuth2Session(hass, entry, TeslemetryImplementation(hass, DOMAIN, CLIENT_ID))
+
+
+async def test_get_access_token_dead_token_during_setup_triggers_auth_failed(
+    hass: HomeAssistant,
+) -> None:
+    """A dead/revoked refresh token during setup must raise ConfigEntryAuthFailed.
+
+    OAuth servers commonly report a dead refresh token with a non-401 status
+    (e.g. 400 invalid_grant). Only recognizing status 401 let this fall
+    through to ConfigEntryNotReady, which retries setup indefinitely without
+    ever prompting the user to reauthenticate.
+    """
+    mock_entry = mock_config_entry()
+    mock_entry.add_to_hass(hass)
+    mock_entry.mock_state(hass, ConfigEntryState.SETUP_IN_PROGRESS)
+    session = _oauth_session(hass, mock_entry)
+
+    with (
+        patch.object(
+            OAuth2Session,
+            "async_ensure_token_valid",
+            side_effect=OAuth2TokenRequestReauthError(
+                request_info=MagicMock(), status=400, domain=DOMAIN
+            ),
+        ),
+        pytest.raises(ConfigEntryAuthFailed),
+    ):
+        await _get_access_token(session)
+
+
+async def test_get_access_token_rate_limited_during_setup_is_not_fatal(
+    hass: HomeAssistant,
+) -> None:
+    """A 429 from the token endpoint during setup should back off, not be fatal."""
+    mock_entry = mock_config_entry()
+    mock_entry.add_to_hass(hass)
+    mock_entry.mock_state(hass, ConfigEntryState.SETUP_IN_PROGRESS)
+    session = _oauth_session(hass, mock_entry)
+
+    with (
+        patch.object(
+            OAuth2Session,
+            "async_ensure_token_valid",
+            side_effect=OAuth2TokenRequestTransientError(
+                request_info=MagicMock(), status=429, domain=DOMAIN
+            ),
+        ),
+        pytest.raises(ConfigEntryNotReady),
+    ):
+        await _get_access_token(session)
+
+
+async def test_get_access_token_dead_token_after_setup_starts_reauth(
+    hass: HomeAssistant,
+) -> None:
+    """Test a token dying after setup (re)starts reauth without tearing down.
+
+    The coordinator handles the rest once the exception is re-raised.
+    """
+    mock_entry = mock_config_entry()
+    mock_entry.add_to_hass(hass)
+    mock_entry.mock_state(hass, ConfigEntryState.LOADED)
+    session = _oauth_session(hass, mock_entry)
+
+    with (
+        patch.object(
+            OAuth2Session,
+            "async_ensure_token_valid",
+            side_effect=OAuth2TokenRequestReauthError(
+                request_info=MagicMock(), status=400, domain=DOMAIN
+            ),
+        ),
+        pytest.raises(OAuth2TokenRequestReauthError),
+    ):
+        await _get_access_token(session)
+    await hass.async_block_till_done()
+
+    flows = hass.config_entries.flow.async_progress()
+    assert any(
+        flow["handler"] == DOMAIN and flow["context"].get("source") == "reauth"
+        for flow in flows
+    )
+
+
+async def test_get_access_token_rate_limited_after_setup_is_not_fatal(
+    hass: HomeAssistant,
+) -> None:
+    """A transient token-refresh error after setup must not force reauth."""
+    mock_entry = mock_config_entry()
+    mock_entry.add_to_hass(hass)
+    mock_entry.mock_state(hass, ConfigEntryState.LOADED)
+    session = _oauth_session(hass, mock_entry)
+
+    with (
+        patch.object(
+            OAuth2Session,
+            "async_ensure_token_valid",
+            side_effect=OAuth2TokenRequestTransientError(
+                request_info=MagicMock(), status=429, domain=DOMAIN
+            ),
+        ),
+        pytest.raises(OAuth2TokenRequestTransientError),
+    ):
+        await _get_access_token(session)
+    await hass.async_block_till_done()
+
+    assert not hass.config_entries.flow.async_progress()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Not a breaking change.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Instances holding a dead/expired refresh token were hammering `/oauth/token` indefinitely, silently broken for the user the whole time (observed at ~40k 401s/day per affected instance). `_get_access_token` only classified a token refresh failure as fatal when the OAuth server responded with status 401. OAuth servers commonly report a dead/revoked refresh token with a different 4xx status (e.g. `400 invalid_grant`), which fell through to `ConfigEntryNotReady` and retried forever without ever prompting the user to reauthenticate.

This switches `_get_access_token` to use Home Assistant's `OAuth2TokenRequestError` / `OAuth2TokenRequestReauthError` / `OAuth2TokenRequestTransientError` hierarchy (the same helper that already classifies the response for us), following the pattern used by other OAuth integrations such as `google_mail`. During initial setup, a non-recoverable failure now raises `ConfigEntryAuthFailed` regardless of the exact status code, while a recoverable one (429/5xx) raises `ConfigEntryNotReady` as before. Once the entry is already loaded, a non-recoverable failure explicitly (re)starts the reauth flow and re-raises, and a recoverable failure is simply re-raised so the coordinator's own native `OAuth2TokenRequestError` handling treats it as a transient failed update (poll again next interval) instead of an unhandled/fatal error that also happened to never stop rescheduling. 429s from the token endpoint are treated the same as other transient errors (5xx) rather than as fatal, since the API now rate-limits repeated auth failures.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
