### PR TITLE
Remove battery prop from template vacuum

### DIFF
--- a/homeassistant/components/template/strings.json
+++ b/homeassistant/components/template/strings.json
@@ -589,10 +589,6 @@
     "config_format_triggers": {
       "description": "A trigger template configuration needs a trigger and at least one domain when defining an entity. This will be an configuration validation error in Home Assistant Core 2026.5.\n\n Please remove the orphaned trigger from the configuration.\n\n```\n{config}\n```",
       "title": "Incomplete template configuration"
-    },
-    "deprecated_battery_level": {
-      "description": "The template vacuum options `battery_level` and `battery_level_template` are being removed in 2026.8.\n\nPlease remove the `battery_level` or `battery_level_template` option from the YAML configuration for {entity_id} ({entity_name}).",
-      "title": "Deprecated battery level option in {entity_name}"
     }
   },
   "options": {

--- a/homeassistant/components/template/vacuum.py
+++ b/homeassistant/components/template/vacuum.py
@@ -23,12 +23,11 @@ from homeassistant.components.vacuum import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME, CONF_STATE, CONF_UNIQUE_ID
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import config_validation as cv, issue_registry as ir
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_platform import (
     AddConfigEntryEntitiesCallback,
     AddEntitiesCallback,
 )
-from homeassistant.helpers.issue_registry import IssueSeverity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import TriggerUpdateCoordinator, validators as template_validators
@@ -49,7 +48,6 @@ from .trigger_entity import TriggerEntity
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_BATTERY_LEVEL = "battery_level"
 CONF_CLEAN_SEGMENTS = "clean_segments"
 CONF_FAN_SPEED = "fan_speed"
 CONF_FAN_SPEED_LIST = "fan_speeds"
@@ -75,7 +73,6 @@ CLEAN_AREA_GROUP = "clean_area_group"
 
 VACUUM_COMMON_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_BATTERY_LEVEL): cv.template,
         vol.Optional(CONF_FAN_SPEED_LIST, default=[]): cv.ensure_list,
         vol.Optional(CONF_FAN_SPEED): cv.template,
         vol.Optional(CONF_STATE): cv.template,
@@ -164,26 +161,6 @@ def async_create_preview_vacuum(
     )
 
 
-def create_issue(
-    hass: HomeAssistant, supported_features: int, name: str, entity_id: str
-) -> None:
-    """Create the battery_level issue."""
-    if supported_features & VacuumEntityFeature.BATTERY:
-        key = "deprecated_battery_level"
-        ir.async_create_issue(
-            hass,
-            DOMAIN,
-            f"{key}_{entity_id}",
-            is_fixable=False,
-            severity=IssueSeverity.WARNING,
-            translation_key=key,
-            translation_placeholders={
-                "entity_name": name,
-                "entity_id": entity_id,
-            },
-        )
-
-
 def validate_segments(
     entity: AbstractTemplateVacuum,
     option: str,
@@ -266,11 +243,6 @@ class AbstractTemplateVacuum(AbstractTemplateEntity, StateVacuumEntity):
                 self, CONF_FAN_SPEED, self._attr_fan_speed_list
             ),
         )
-        self.setup_template(
-            CONF_BATTERY_LEVEL,
-            "_attr_battery_level",
-            template_validators.number(self, CONF_BATTERY_LEVEL, 0.0, 100.0),
-        )
 
         self.setup_template(
             CONF_SEGMENTS,
@@ -282,9 +254,6 @@ class AbstractTemplateVacuum(AbstractTemplateEntity, StateVacuumEntity):
         self._attr_supported_features = (
             VacuumEntityFeature.START | VacuumEntityFeature.STATE
         )
-
-        if CONF_BATTERY_LEVEL in self._templates:
-            self._attr_supported_features |= VacuumEntityFeature.BATTERY
 
         for action_id, supported_feature in (
             (SERVICE_START, 0),
@@ -419,17 +388,6 @@ class TemplateStateVacuumEntity(TemplateEntity, AbstractTemplateVacuum):
             assert name is not None
         AbstractTemplateVacuum.__init__(self, name, config)
 
-    @override
-    async def async_added_to_hass(self) -> None:
-        """Run when entity about to be added to hass."""
-        await super().async_added_to_hass()
-        create_issue(
-            self.hass,
-            self._attr_supported_features,
-            self._attr_name or DEFAULT_NAME,
-            self.entity_id,
-        )
-
 
 class TriggerVacuumEntity(TriggerEntity, AbstractTemplateVacuum):
     """Vacuum entity based on trigger data."""
@@ -446,14 +404,3 @@ class TriggerVacuumEntity(TriggerEntity, AbstractTemplateVacuum):
         TriggerEntity.__init__(self, hass, coordinator, config)
         self._attr_name = name = self._rendered.get(CONF_NAME, DEFAULT_NAME)
         AbstractTemplateVacuum.__init__(self, name, config)
-
-    @override
-    async def async_added_to_hass(self) -> None:
-        """Run when entity about to be added to hass."""
-        await super().async_added_to_hass()
-        create_issue(
-            self.hass,
-            self._attr_supported_features,
-            self._attr_name or DEFAULT_NAME,
-            self.entity_id,
-        )

--- a/tests/components/template/test_vacuum.py
+++ b/tests/components/template/test_vacuum.py
@@ -9,7 +9,6 @@ from syrupy.assertion import SnapshotAssertion
 from homeassistant.components import template, vacuum
 from homeassistant.components.template.vacuum import CONF_CLEAN_SEGMENTS, CONF_SEGMENTS
 from homeassistant.components.vacuum import (
-    ATTR_BATTERY_LEVEL,
     ATTR_FAN_SPEED,
     Segment,
     VacuumActivity,
@@ -86,14 +85,12 @@ TEMPLATE_VACUUM_ACTIONS = {
 def _verify(
     hass: HomeAssistant,
     expected_state: str,
-    expected_battery_level: int | None = None,
     expected_fan_speed: str | None = None,
 ) -> None:
     """Verify vacuum's state and speed."""
     state = hass.states.get(TEST_VACUUM.entity_id)
     attributes = state.attributes
     assert state.state == expected_state
-    assert attributes.get(ATTR_BATTERY_LEVEL) == expected_battery_level
     assert attributes.get(ATTR_FAN_SPEED) == expected_fan_speed
 
 
@@ -192,88 +189,74 @@ async def setup_attributes_state_vacuum(
 
 @pytest.mark.parametrize("count", [1])
 @pytest.mark.parametrize(
-    ("style", "state_template", "extra_config", "parm1", "parm2"),
+    ("style", "state_template", "extra_config", "parm1"),
     [
         (
             ConfigurationStyle.MODERN,
             None,
             {"start": {"service": "script.vacuum_start"}},
             STATE_UNKNOWN,
-            None,
         ),
         (
             ConfigurationStyle.TRIGGER,
             None,
             {"start": {"service": "script.vacuum_start"}},
             STATE_UNKNOWN,
-            None,
         ),
         (
             ConfigurationStyle.MODERN,
             "{{ 'cleaning' }}",
             {
-                "battery_level": "{{ 100 }}",
                 "start": {"service": "script.vacuum_start"},
             },
             VacuumActivity.CLEANING,
-            100,
         ),
         (
             ConfigurationStyle.TRIGGER,
             "{{ 'cleaning' }}",
             {
-                "battery_level": "{{ 100 }}",
                 "start": {"service": "script.vacuum_start"},
             },
             VacuumActivity.CLEANING,
-            100,
         ),
         (
             ConfigurationStyle.MODERN,
             "{{ 'abc' }}",
             {
-                "battery_level": "{{ 101 }}",
                 "start": {"service": "script.vacuum_start"},
             },
             STATE_UNKNOWN,
-            None,
         ),
         (
             ConfigurationStyle.TRIGGER,
             "{{ 'abc' }}",
             {
-                "battery_level": "{{ 101 }}",
                 "start": {"service": "script.vacuum_start"},
             },
             STATE_UNKNOWN,
-            None,
         ),
         (
             ConfigurationStyle.MODERN,
             "{{ this_function_does_not_exist() }}",
             {
-                "battery_level": "{{ this_function_does_not_exist() }}",
                 "fan_speed": "{{ this_function_does_not_exist() }}",
                 "start": {"service": "script.vacuum_start"},
             },
             STATE_UNAVAILABLE,
-            None,
         ),
         (
             ConfigurationStyle.TRIGGER,
             "{{ this_function_does_not_exist() }}",
             {
-                "battery_level": "{{ this_function_does_not_exist() }}",
                 "fan_speed": "{{ this_function_does_not_exist() }}",
                 "start": {"service": "script.vacuum_start"},
             },
             STATE_UNAVAILABLE,
-            None,
         ),
     ],
 )
 @pytest.mark.usefixtures("setup_base_vacuum")
-async def test_valid_configs(hass: HomeAssistant, count, parm1, parm2) -> None:
+async def test_valid_configs(hass: HomeAssistant, count, parm1) -> None:
     """Test: configs."""
 
     # Ensure trigger entity templates are rendered
@@ -281,7 +264,7 @@ async def test_valid_configs(hass: HomeAssistant, count, parm1, parm2) -> None:
     await hass.async_block_till_done()
 
     assert len(hass.states.async_all("vacuum")) == count
-    _verify(hass, parm1, parm2)
+    _verify(hass, parm1)
 
 
 @pytest.mark.parametrize("count", [0])
@@ -300,68 +283,6 @@ async def test_valid_configs(hass: HomeAssistant, count, parm1, parm2) -> None:
 async def test_invalid_configs(hass: HomeAssistant, count) -> None:
     """Test: configs."""
     assert len(hass.states.async_all("vacuum")) == count
-
-
-@pytest.mark.parametrize(
-    ("count", "state_template", "extra_config"),
-    [(1, "{{ states('sensor.test_state') }}", {})],
-)
-@pytest.mark.parametrize(
-    ("style", "attribute"),
-    [
-        (ConfigurationStyle.MODERN, "battery_level"),
-        (ConfigurationStyle.TRIGGER, "battery_level"),
-    ],
-)
-@pytest.mark.parametrize(
-    ("attribute_template", "expected"),
-    [
-        ("{{ '0' }}", 0),
-        ("{{ 100 }}", 100),
-        ("{{ 101 }}", None),
-        ("{{ -1 }}", None),
-        ("{{ 'foo' }}", None),
-    ],
-)
-@pytest.mark.usefixtures("setup_single_attribute_state_vacuum")
-async def test_battery_level_template(
-    hass: HomeAssistant, expected: int | None
-) -> None:
-    """Test templates with values from other entities."""
-    await async_trigger(hass, TEST_STATE_ENTITY_ID)
-    _verify(hass, STATE_UNKNOWN, expected)
-
-
-@pytest.mark.parametrize(
-    ("count", "state_template", "extra_config", "attribute_template"),
-    [(1, "{{ states('sensor.test_state') }}", {}, "{{ 50 }}")],
-)
-@pytest.mark.parametrize(
-    ("style", "attribute", "issue_count"),
-    [
-        (ConfigurationStyle.MODERN, "battery_level", 1),
-        (ConfigurationStyle.TRIGGER, "battery_level", 1),
-    ],
-)
-@pytest.mark.usefixtures("setup_single_attribute_state_vacuum")
-async def test_battery_level_template_repair(
-    hass: HomeAssistant,
-    issue_count: int,
-    issue_registry: ir.IssueRegistry,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test battery_level template raises issue."""
-    await async_trigger(hass, TEST_STATE_ENTITY_ID, VacuumActivity.DOCKED)
-
-    assert len(issue_registry.issues) == issue_count
-    issue = issue_registry.async_get_issue(
-        "template", f"deprecated_battery_level_{TEST_VACUUM.entity_id}"
-    )
-    assert issue.domain == "template"
-    assert issue.severity == ir.IssueSeverity.WARNING
-    assert issue.translation_placeholders["entity_name"] == TEST_VACUUM.object_id
-    assert issue.translation_placeholders["entity_id"] == TEST_VACUUM.entity_id
-    assert "Detected that integration 'template' is setting the" not in caplog.text
 
 
 @pytest.mark.parametrize(
@@ -396,7 +317,7 @@ async def test_battery_level_template_repair(
 async def test_fan_speed_template(hass: HomeAssistant, expected: str | None) -> None:
     """Test templates with values from other entities."""
     await async_trigger(hass, TEST_STATE_ENTITY_ID)
-    _verify(hass, STATE_UNKNOWN, None, expected)
+    _verify(hass, STATE_UNKNOWN, expected)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
Remove previously deprecated battery property from `template` `vacuum` entities

## Proposed change
Linked to: https://github.com/home-assistant/core/pull/175682

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository. 