### PR TITLE
Remove previously deprecated battery prop from LG thinq

### DIFF
--- a/homeassistant/components/lg_thinq/vacuum.py
+++ b/homeassistant/components/lg_thinq/vacuum.py
@@ -106,7 +106,6 @@ class ThinQStateVacuumEntity(ThinQEntity, StateVacuumEntity):
     _attr_supported_features = (
         VacuumEntityFeature.SEND_COMMAND
         | VacuumEntityFeature.STATE
-        | VacuumEntityFeature.BATTERY
         | VacuumEntityFeature.START
         | VacuumEntityFeature.PAUSE
         | VacuumEntityFeature.RETURN_HOME
@@ -120,19 +119,12 @@ class ThinQStateVacuumEntity(ThinQEntity, StateVacuumEntity):
         # Update state.
         self._attr_activity = ROBOT_STATUS_TO_HA.get(self.data.current_state)
 
-        # Update battery.
-        if (level := self.data.battery) is not None:
-            self._attr_battery_level = (
-                level if isinstance(level, int) else ROBOT_BATT_TO_HA.get(level, 0)
-            )
-
         _LOGGER.debug(
-            "[%s:%s] update status: %s -> %s (battery_level=%s)",
+            "[%s:%s] update status: %s -> %s",
             self.coordinator.device_name,
             self.property_id,
             self.data.current_state,
             self.state,
-            self.battery_level,
         )
 
     @override

--- a/homeassistant/components/lg_thinq/vacuum.py
+++ b/homeassistant/components/lg_thinq/vacuum.py
@@ -65,15 +65,6 @@ ROBOT_STATUS_TO_HA = {
     "clean_select_gozone": VacuumActivity.CLEANING,
     "error": VacuumActivity.ERROR,
 }
-ROBOT_BATT_TO_HA = {
-    "moveless": 5,
-    "dock_level": 5,
-    "low": 30,
-    "mid": 50,
-    "high": 90,
-    "full": 100,
-    "over_charge": 100,
-}
 _LOGGER = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
Remove previously deprecated battery props from LQ ThinQ `vacuum` platform

## Proposed change
Linked to: https://github.com/home-assistant/core/pull/175682

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository. 