### PR TITLE
Remove previously deprecated battery props from xiaomi_miio

### DIFF
--- a/homeassistant/components/xiaomi_miio/vacuum.py
+++ b/homeassistant/components/xiaomi_miio/vacuum.py
@@ -92,7 +92,6 @@ class MiroboVacuum(
         | VacuumEntityFeature.FAN_SPEED
         | VacuumEntityFeature.SEND_COMMAND
         | VacuumEntityFeature.LOCATE
-        | VacuumEntityFeature.BATTERY
         | VacuumEntityFeature.CLEAN_SPOT
         | VacuumEntityFeature.START
     )
@@ -113,12 +112,6 @@ class MiroboVacuum(
             return VacuumActivity.ERROR
 
         return super().activity
-
-    @property
-    @override
-    def battery_level(self) -> int:
-        """Return the battery level of the vacuum cleaner."""
-        return self.coordinator.data.status.battery
 
     @property
     @override

--- a/tests/components/xiaomi_miio/test_vacuum.py
+++ b/tests/components/xiaomi_miio/test_vacuum.py
@@ -9,7 +9,6 @@ from miio import DeviceException
 import pytest
 
 from homeassistant.components.vacuum import (
-    ATTR_BATTERY_ICON,
     ATTR_FAN_SPEED,
     ATTR_FAN_SPEED_LIST,
     DOMAIN as VACUUM_DOMAIN,
@@ -263,9 +262,8 @@ async def test_xiaomi_vacuum_services(
     state = hass.states.get(entity_id)
 
     assert state.state == VacuumActivity.ERROR
-    assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == 14204
+    assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == 14140
     assert state.attributes.get(ATTR_ERROR) == "Error message"
-    assert state.attributes.get(ATTR_BATTERY_ICON) == "mdi:battery-80"
     assert state.attributes.get(ATTR_TIMERS) == [
         {
             "enabled": True,
@@ -449,9 +447,8 @@ async def test_xiaomi_specific_services(
     # Check state attributes
     state = hass.states.get(entity_id)
     assert state.state == VacuumActivity.CLEANING
-    assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == 14204
+    assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == 14140
     assert state.attributes.get(ATTR_ERROR) is None
-    assert state.attributes.get(ATTR_BATTERY_ICON) == "mdi:battery-30"
     assert state.attributes.get(ATTR_TIMERS) == [
         {
             "enabled": True,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
Remove previously deprecated battery props from Xiaomi Home `vacuum` platform

## Proposed change
Linked to: https://github.com/home-assistant/core/pull/175682


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository. 