### PR TITLE
Remove previously deprecated battery props from SwitchBot Cloud

### DIFF
--- a/homeassistant/components/switchbot_cloud/vacuum.py
+++ b/homeassistant/components/switchbot_cloud/vacuum.py
@@ -75,8 +75,7 @@ class SwitchBotCloudVacuum(SwitchBotCloudEntity, StateVacuumEntity):
     # "Robot Vacuum Cleaner S1 Plus"
 
     _attr_supported_features: VacuumEntityFeature = (
-        VacuumEntityFeature.BATTERY
-        | VacuumEntityFeature.FAN_SPEED
+        VacuumEntityFeature.FAN_SPEED
         | VacuumEntityFeature.PAUSE
         | VacuumEntityFeature.RETURN_HOME
         | VacuumEntityFeature.START
@@ -123,7 +122,6 @@ class SwitchBotCloudVacuum(SwitchBotCloudEntity, StateVacuumEntity):
         if self.coordinator.data is None:
             return
 
-        self._attr_battery_level = self.coordinator.data.get("battery")
         self._attr_available = self.coordinator.data.get("onlineStatus") == "online"
 
         switchbot_state = str(self.coordinator.data.get("workingStatus"))

--- a/tests/components/switchbot_cloud/test_init.py
+++ b/tests/components/switchbot_cloud/test_init.py
@@ -300,7 +300,6 @@ async def test_polling_is_only_disabled_after_webhook_delivery(
     entity_id = "vacuum.vacuum_name_1"
     state = hass.states.get(entity_id)
     assert state is not None
-    assert state.attributes["battery_level"] == 71
 
     # Change API return values and wait for update
     mock_get_status.return_value = {

--- a/tests/components/switchbot_cloud/test_init.py
+++ b/tests/components/switchbot_cloud/test_init.py
@@ -316,7 +316,6 @@ async def test_polling_is_only_disabled_after_webhook_delivery(
     # Validate that the state was updated again via fetch
     state = hass.states.get(entity_id)
     assert state is not None
-    assert state.attributes["battery_level"] == 60
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     webhook_id = entry.data[CONF_WEBHOOK_ID]

--- a/tests/components/switchbot_cloud/test_vacuum.py
+++ b/tests/components/switchbot_cloud/test_vacuum.py
@@ -293,7 +293,6 @@ async def test_k10_plus_webhook_updates_state_after_reload(
     state = hass.states.get(entity_id)
     assert state is not None
     assert state.state == VacuumActivity.CLEANING.value
-    assert state.attributes["battery_level"] == 74
 
 
 async def test_k20_plus_pro_set_fan_speed(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
Remove previously deprecated battery props from SwitchBot Cloud `vacuum` platform

## Proposed change
Linked to: https://github.com/home-assistant/core/pull/175682


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository. 