### PR TITLE
Fix temperature bound resolution for BSBLAN climate devices

### DIFF
--- a/homeassistant/components/bsblan/climate.py
+++ b/homeassistant/components/bsblan/climate.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Final, override
 
-from bsblan import BSBLANError, State, get_hvac_action_category
+from bsblan import BSBLANError, EntityInfo, State, get_hvac_action_category
 
 from homeassistant.components.climate import (
     ATTR_HVAC_MODE,
@@ -54,6 +54,14 @@ BSBLAN_TO_HA_HVAC_MODE: Final[dict[int, HVACMode]] = {
 }
 
 
+def _resolve_temperature_bound(*sources: EntityInfo[float] | None) -> float | None:
+    """Return the first usable temperature bound from the given sources."""
+    for source in sources:
+        if source is not None and source.value is not None:
+            return source.value
+    return None
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: BSBLanConfigEntry,
@@ -97,12 +105,23 @@ class BSBLANClimate(BSBLanCircuitEntity, ClimateEntity):
         else:
             self._attr_unique_id = f"{mac}-climate-{circuit}"  # pylint: disable=home-assistant-entity-unique-id-redundant-platform
 
-        # Set temperature range from per-circuit static data
+        # Set temperature range from per-circuit static data. Standard BSB/LPB
+        # circuits expose the bounds via heating_protective_setpoint (714) and
+        # comfort_setpoint_max (716); min_temp/max_temp (15006/15007) exist
+        # only on PPS devices. Inactive parameters ("---") have value None.
         if (static := data.static.get(circuit)) is not None:
-            if (min_temp := static.min_temp) is not None and min_temp.value is not None:
-                self._attr_min_temp = min_temp.value
-            if (max_temp := static.max_temp) is not None and max_temp.value is not None:
-                self._attr_max_temp = max_temp.value
+            if (
+                min_temp := _resolve_temperature_bound(
+                    static.heating_protective_setpoint, static.min_temp
+                )
+            ) is not None:
+                self._attr_min_temp = min_temp
+            if (
+                max_temp := _resolve_temperature_bound(
+                    static.comfort_setpoint_max, static.max_temp
+                )
+            ) is not None:
+                self._attr_max_temp = max_temp
         self._attr_temperature_unit = data.fast_coordinator.client.get_temperature_unit
 
     @property

--- a/tests/components/bsblan/test_climate.py
+++ b/tests/components/bsblan/test_climate.py
@@ -1,9 +1,10 @@
 """Tests for the BSB-LAN climate platform."""
 
 from datetime import timedelta
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
-from bsblan import BSBLANError, HeatingCircuitStatus
+from bsblan import BSBLANError, HeatingCircuitStatus, StaticState
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -12,6 +13,8 @@ from homeassistant.components.bsblan.const import DOMAIN
 from homeassistant.components.climate import (
     ATTR_HVAC_MODE,
     ATTR_PRESET_MODE,
+    DEFAULT_MAX_TEMP,
+    DEFAULT_MIN_TEMP,
     DOMAIN as CLIMATE_DOMAIN,
     PRESET_ECO,
     PRESET_NONE,
@@ -31,6 +34,81 @@ from . import setup_with_selected_platforms
 from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
 
 ENTITY_ID = "climate.heating_circuit_1"
+
+
+def _temp_param(value: str) -> dict[str, Any]:
+    """Build a raw BSB-LAN temperature parameter payload."""
+    return {
+        "name": "",
+        "value": value,
+        "unit": "&deg;C",
+        "desc": "",
+        "dataType": 0,
+        "readonly": 0,
+        "error": 0,
+    }
+
+
+@pytest.mark.parametrize(
+    ("static_data", "expected_min", "expected_max"),
+    [
+        pytest.param(
+            {
+                "heating_protective_setpoint": _temp_param("10.0"),
+                "comfort_setpoint_max": _temp_param("26.0"),
+            },
+            10.0,
+            26.0,
+            id="standard_device",
+        ),
+        pytest.param(
+            {
+                "min_temp": _temp_param("8.0"),
+                "max_temp": _temp_param("20.0"),
+            },
+            8.0,
+            20.0,
+            id="pps_device",
+        ),
+        pytest.param(
+            {
+                "heating_protective_setpoint": _temp_param("---"),
+                "comfort_setpoint_max": _temp_param("---"),
+                "min_temp": _temp_param("8.0"),
+                "max_temp": _temp_param("20.0"),
+            },
+            8.0,
+            20.0,
+            id="inactive_preferred_source",
+        ),
+        pytest.param(
+            {
+                "heating_protective_setpoint": _temp_param("---"),
+                "comfort_setpoint_max": _temp_param("---"),
+            },
+            DEFAULT_MIN_TEMP,
+            DEFAULT_MAX_TEMP,
+            id="all_sources_inactive",
+        ),
+    ],
+)
+async def test_climate_min_max_temperature(
+    hass: HomeAssistant,
+    mock_bsblan: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    static_data: dict[str, Any],
+    expected_min: float,
+    expected_max: float,
+) -> None:
+    """Test min/max temperature bounds resolved from per-circuit static values."""
+    mock_bsblan.static_values.return_value = StaticState.model_validate(static_data)
+
+    await setup_with_selected_platforms(hass, mock_config_entry, [Platform.CLIMATE])
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.attributes["min_temp"] == expected_min
+    assert state.attributes["max_temp"] == expected_max
 
 
 async def test_celsius_fahrenheit(


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The inclusion of pps systems caused a regression for bsb systems reading min and max temp. The is a bug fix that checks both parameters. The bsb has other names by design and it was my choice to leave it this name to have clearer naming when cooling support is added that bsb systems support. 

- Introduced a helper function to resolve temperature bounds from multiple sources.
- Updated the BSBLANClimate class to utilize the new function for setting min/max temperature attributes.
- Enhanced test coverage for min/max temperature bounds based on various static data scenarios.

ps it was not yet reported as an bug by the community


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
