### PR TITLE
Add search feature to Synology DSM media source

### DIFF
--- a/homeassistant/components/synology_dsm/media_source.py
+++ b/homeassistant/components/synology_dsm/media_source.py
@@ -9,7 +9,12 @@ from synology_dsm.api.photos import SynoPhotosAlbum, SynoPhotosItem
 from synology_dsm.exceptions import SynologyDSMException
 
 from homeassistant.components import http
-from homeassistant.components.media_player import BrowseError, MediaClass
+from homeassistant.components.media_player import (
+    BrowseError,
+    MediaClass,
+    SearchMedia,
+    SearchMediaQuery,
+)
 from homeassistant.components.media_source import (
     BrowseMediaSource,
     MediaSource,
@@ -76,6 +81,23 @@ class SynologyPhotosMediaSource(MediaSource):
         self.hass = hass
         self.entries = entries
 
+    def _get_diskstation(
+        self, identifier: SynologyPhotosMediaSourceIdentifier
+    ) -> SynologyDSMData:
+        """Get diskstation object."""
+        entry: SynologyDSMConfigEntry | None = (
+            self.hass.config_entries.async_entry_for_domain_unique_id(
+                DOMAIN, identifier.unique_id
+            )
+        )
+        if TYPE_CHECKING:
+            assert entry
+        diskstation = entry.runtime_data
+        if TYPE_CHECKING:
+            assert diskstation.api.photos is not None
+
+        return diskstation
+
     @override
     async def async_browse_media(
         self,
@@ -84,14 +106,16 @@ class SynologyPhotosMediaSource(MediaSource):
         """Return media."""
         if not self.hass.config_entries.async_loaded_entries(DOMAIN):
             raise BrowseError("Diskstation not initialized")
+
         return BrowseMediaSource(
             domain=DOMAIN,
-            identifier=None,
+            identifier=item.identifier,
             media_class=MediaClass.DIRECTORY,
             media_content_type=MediaClass.IMAGE,
             title="Synology Photos",
             can_play=False,
             can_expand=True,
+            can_search=bool(item.identifier),
             children_media_class=MediaClass.DIRECTORY,
             children=[
                 *await self._async_build_diskstations(item),
@@ -116,14 +140,7 @@ class SynologyPhotosMediaSource(MediaSource):
                 for entry in self.entries
             ]
         identifier = SynologyPhotosMediaSourceIdentifier(item.identifier)
-        entry: SynologyDSMConfigEntry | None = (
-            self.hass.config_entries.async_entry_for_domain_unique_id(
-                DOMAIN, identifier.unique_id
-            )
-        )
-        if TYPE_CHECKING:
-            assert entry
-        diskstation = entry.runtime_data
+        diskstation = self._get_diskstation(identifier)
         if TYPE_CHECKING:
             assert diskstation.api.photos is not None
 
@@ -193,38 +210,34 @@ class SynologyPhotosMediaSource(MediaSource):
                 )
             except SynologyDSMException:
                 return []
-        if TYPE_CHECKING:
-            assert album_items is not None
 
-        ret = []
-        for album_item in album_items:
-            mime_type, _ = mimetypes.guess_type(album_item.file_name)
-            if isinstance(mime_type, str) and mime_type.startswith("image/"):
-                # Force small small thumbnails
-                album_item.thumbnail_size = "sm"
-                suffix = ""
-                if album_item.is_shared:
-                    suffix = SHARED_SUFFIX
-                ret.append(
-                    BrowseMediaSource(
-                        domain=DOMAIN,
-                        identifier=(
-                            f"{identifier.unique_id}/"
-                            f"{identifier.album_id}_{identifier.passphrase}/"
-                            f"{album_item.thumbnail_cache_key}/"
-                            f"{album_item.file_name}{suffix}"
-                        ),
-                        media_class=MediaClass.IMAGE,
-                        media_content_type=mime_type,
-                        title=album_item.file_name,
-                        can_play=True,
-                        can_expand=False,
-                        thumbnail=await self.async_get_thumbnail(
-                            album_item, diskstation
-                        ),
-                    )
+        return await self._async_parse_assets(album_items, identifier, diskstation)
+
+    @override
+    async def async_search_media(
+        self, item: MediaSourceItem, query: SearchMediaQuery
+    ) -> SearchMedia:
+        """Search media."""
+
+        LOGGER.debug("search called with item:%s query:%s", item, query)
+
+        identifier = SynologyPhotosMediaSourceIdentifier(item.identifier)
+        diskstation = self._get_diskstation(identifier)
+        if TYPE_CHECKING:
+            assert diskstation.api.photos is not None
+
+        try:
+            return SearchMedia(
+                result=await self._async_parse_assets(
+                    await diskstation.api.photos.get_items_from_search(
+                        query.search_query, 0, 1000
+                    ),
+                    identifier,
+                    diskstation,
                 )
-        return ret
+            )
+        except SynologyDSMException:
+            return SearchMedia(result=[])
 
     @override
     async def async_resolve_media(self, item: MediaSourceItem) -> PlayMedia:
@@ -262,6 +275,46 @@ class SynologyPhotosMediaSource(MediaSource):
         except SynologyDSMException:
             return None
         return str(thumbnail)
+
+    async def _async_parse_assets(
+        self,
+        album_items: list[SynoPhotosItem] | None,
+        identifier: SynologyPhotosMediaSourceIdentifier,
+        diskstation: SynologyDSMData,
+    ) -> list[BrowseMediaSource]:
+        """Parse list of SynoPhotosItem to list of BrowseMediaSource."""
+        if not album_items:
+            return []
+
+        ret = []
+        for album_item in album_items:
+            mime_type, _ = mimetypes.guess_type(album_item.file_name)
+            if isinstance(mime_type, str) and mime_type.startswith("image/"):
+                # Force small small thumbnails
+                album_item.thumbnail_size = "sm"
+                suffix = ""
+                if album_item.is_shared:
+                    suffix = SHARED_SUFFIX
+                ret.append(
+                    BrowseMediaSource(
+                        domain=DOMAIN,
+                        identifier=(
+                            f"{identifier.unique_id}/"
+                            f"{identifier.album_id}_{identifier.passphrase}/"
+                            f"{album_item.thumbnail_cache_key}/"
+                            f"{album_item.file_name}{suffix}"
+                        ),
+                        media_class=MediaClass.IMAGE,
+                        media_content_type=mime_type,
+                        title=album_item.file_name,
+                        can_play=True,
+                        can_expand=False,
+                        thumbnail=await self.async_get_thumbnail(
+                            album_item, diskstation
+                        ),
+                    )
+                )
+        return ret
 
 
 class SynologyDsmMediaView(http.HomeAssistantView):

--- a/tests/components/synology_dsm/test_media_source.py
+++ b/tests/components/synology_dsm/test_media_source.py
@@ -185,7 +185,7 @@ async def test_browse_media_album_error(
     result = await source.async_browse_media(item)
 
     assert result
-    assert result.identifier is None
+    assert result.identifier == "mocked_syno_dsm_entry"
     assert len(result.children) == 0
 
 
@@ -305,7 +305,7 @@ async def test_browse_media_get_items_error(
     result = await source.async_browse_media(item)
 
     assert result
-    assert result.identifier is None
+    assert result.identifier == "mocked_syno_dsm_entry/1"
     assert len(result.children) == 0
 
     # exception in get_items_from_album()
@@ -316,7 +316,7 @@ async def test_browse_media_get_items_error(
     result = await source.async_browse_media(item)
 
     assert result
-    assert result.identifier is None
+    assert result.identifier == "mocked_syno_dsm_entry/1"
     assert len(result.children) == 0
 
     # exception in get_items_from_shared_space()
@@ -327,7 +327,7 @@ async def test_browse_media_get_items_error(
     result = await source.async_browse_media(item)
 
     assert result
-    assert result.identifier is None
+    assert result.identifier == "mocked_syno_dsm_entry/shared"
     assert len(result.children) == 0
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds the newly added search capabilities to the media source platform of the Synology DSM integration.

should only be merged after https://github.com/home-assistant/frontend/pull/52990 is merged

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
