### PR TITLE
Bump pyrainbird to 6.5.0

### DIFF
--- a/homeassistant/components/rainbird/manifest.json
+++ b/homeassistant/components/rainbird/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["pyrainbird"],
-  "requirements": ["pyrainbird==6.4.1"]
+  "requirements": ["pyrainbird==6.5.0"]
 }

--- a/homeassistant/components/rainbird/manifest.json
+++ b/homeassistant/components/rainbird/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["pyrainbird"],
-  "requirements": ["pyrainbird==6.3.1"]
+  "requirements": ["pyrainbird==6.4.0"]
 }

--- a/homeassistant/components/rainbird/manifest.json
+++ b/homeassistant/components/rainbird/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["pyrainbird"],
-  "requirements": ["pyrainbird==6.4.0"]
+  "requirements": ["pyrainbird==6.4.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2486,7 +2486,7 @@ pyqwikswitch==0.93
 pyrail==0.4.1
 
 # homeassistant.components.rainbird
-pyrainbird==6.4.0
+pyrainbird==6.4.1
 
 # homeassistant.components.playstation_network
 pyrate-limiter==4.4.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2486,7 +2486,7 @@ pyqwikswitch==0.93
 pyrail==0.4.1
 
 # homeassistant.components.rainbird
-pyrainbird==6.4.1
+pyrainbird==6.5.0
 
 # homeassistant.components.playstation_network
 pyrate-limiter==4.4.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2486,7 +2486,7 @@ pyqwikswitch==0.93
 pyrail==0.4.1
 
 # homeassistant.components.rainbird
-pyrainbird==6.3.1
+pyrainbird==6.4.0
 
 # homeassistant.components.playstation_network
 pyrate-limiter==4.4.0

--- a/tests/components/rainbird/conftest.py
+++ b/tests/components/rainbird/conftest.py
@@ -156,6 +156,13 @@ def setup_platforms(
 
 
 @pytest.fixture(autouse=True)
+def mock_pacing() -> Generator[None]:
+    """Fixture to mock request pacing delay to avoid sleeps in tests."""
+    with patch("pyrainbird.async_client.LOCAL_MIN_DELAY", 0.0):
+        yield
+
+
+@pytest.fixture(autouse=True)
 def aioclient_mock(hass: HomeAssistant) -> Generator[AiohttpClientMocker]:
     """Context manager to mock aiohttp client."""
     mocker = AiohttpClientMocker()

--- a/tests/components/rainbird/conftest.py
+++ b/tests/components/rainbird/conftest.py
@@ -156,13 +156,6 @@ def setup_platforms(
 
 
 @pytest.fixture(autouse=True)
-def mock_pacing() -> Generator[None]:
-    """Fixture to mock request pacing delay to avoid sleeps in tests."""
-    with patch("pyrainbird.async_client.LOCAL_MIN_DELAY", 0.0):
-        yield
-
-
-@pytest.fixture(autouse=True)
 def aioclient_mock(hass: HomeAssistant) -> Generator[AiohttpClientMocker]:
     """Context manager to mock aiohttp client."""
     mocker = AiohttpClientMocker()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump `pyrainbird` dependency version from `6.3.1` to `6.5.0`.

[Diff between 6.3.1 and 6.5.0](https://github.com/allenporter/pyrainbird/compare/6.3.1...6.5.0)

Key changes in `pyrainbird` 6.5.0:
- Fix LNK2 firmware crash by resolving encryption padding issues
- Disable retry behavior by default on local clients (resolving test errors)
- Remove connection pacing delay behavior from local clients

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #169765
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
