### PR TITLE
Enable SSL by default for Splunk

### DIFF
--- a/homeassistant/components/splunk/config_flow.py
+++ b/homeassistant/components/splunk/config_flow.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
 )
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DEFAULT_HOST, DEFAULT_PORT, DOMAIN
+from .const import DEFAULT_HOST, DEFAULT_PORT, DEFAULT_SSL, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -56,7 +56,7 @@ class SplunkConfigFlow(ConfigFlow, domain=DOMAIN):
                     vol.Required(CONF_TOKEN): str,
                     vol.Required(CONF_HOST): str,
                     vol.Optional(CONF_PORT, default=DEFAULT_PORT): int,
-                    vol.Optional(CONF_SSL, default=False): bool,
+                    vol.Optional(CONF_SSL, default=DEFAULT_SSL): bool,
                     vol.Optional(CONF_VERIFY_SSL, default=True): bool,
                     vol.Optional(CONF_NAME): str,
                 }
@@ -109,7 +109,7 @@ class SplunkConfigFlow(ConfigFlow, domain=DOMAIN):
                         vol.Required(CONF_TOKEN): str,
                         vol.Required(CONF_HOST): str,
                         vol.Optional(CONF_PORT, default=DEFAULT_PORT): int,
-                        vol.Optional(CONF_SSL, default=False): bool,
+                        vol.Optional(CONF_SSL, default=DEFAULT_SSL): bool,
                         vol.Optional(CONF_VERIFY_SSL, default=True): bool,
                         vol.Optional(CONF_NAME): str,
                     }
@@ -159,7 +159,7 @@ class SplunkConfigFlow(ConfigFlow, domain=DOMAIN):
             host=user_input.get(CONF_HOST, DEFAULT_HOST),
             port=user_input.get(CONF_PORT, DEFAULT_PORT),
             token=user_input[CONF_TOKEN],
-            use_ssl=user_input.get(CONF_SSL, False),
+            use_ssl=user_input.get(CONF_SSL, DEFAULT_SSL),
             verify_ssl=user_input.get(CONF_VERIFY_SSL, True),
         )
 

--- a/homeassistant/components/splunk/const.py
+++ b/homeassistant/components/splunk/const.py
@@ -6,5 +6,5 @@ CONF_FILTER = "filter"
 
 DEFAULT_HOST = "localhost"
 DEFAULT_PORT = 8088
-DEFAULT_SSL = False
+DEFAULT_SSL = True
 DEFAULT_NAME = "HASS"

--- a/tests/components/splunk/test_config_flow.py
+++ b/tests/components/splunk/test_config_flow.py
@@ -283,11 +283,7 @@ async def test_reconfigure_flow_success(
 async def test_reconfigure_flow_preserves_stored_ssl(
     hass: HomeAssistant, mock_hass_splunk: AsyncMock, mock_config_entry: MockConfigEntry
 ) -> None:
-    """Test reconfigure pre-fills the stored SSL value, not the schema default.
-
-    The stored entry has SSL disabled; flipping the new-entry default to on must
-    not silently enable SSL for an existing user who opens the reconfigure form.
-    """
+    """Test reconfigure pre-fills the stored SSL value, not the schema default."""
     mock_config_entry.add_to_hass(hass)
 
     result = await mock_config_entry.start_reconfigure_flow(hass)

--- a/tests/components/splunk/test_config_flow.py
+++ b/tests/components/splunk/test_config_flow.py
@@ -59,9 +59,8 @@ async def test_user_flow_success(
     assert mock_hass_splunk.check.call_count == 2
 
 
-async def test_user_flow_defaults_ssl_on(
-    hass: HomeAssistant, mock_hass_splunk: AsyncMock
-) -> None:
+@pytest.mark.usefixtures("mock_hass_splunk")
+async def test_user_flow_defaults_ssl_on(hass: HomeAssistant) -> None:
     """Test a new entry defaults to SSL enabled when the field is omitted."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -280,8 +279,9 @@ async def test_reconfigure_flow_success(
     assert mock_config_entry.title == "new-splunk.example.com:9088"
 
 
+@pytest.mark.usefixtures("mock_hass_splunk")
 async def test_reconfigure_flow_preserves_stored_ssl(
-    hass: HomeAssistant, mock_hass_splunk: AsyncMock, mock_config_entry: MockConfigEntry
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:
     """Test reconfigure pre-fills the stored SSL value, not the schema default."""
     mock_config_entry.add_to_hass(hass)

--- a/tests/components/splunk/test_config_flow.py
+++ b/tests/components/splunk/test_config_flow.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, get_schema_suggested_value
 
 pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 
@@ -57,6 +57,28 @@ async def test_user_flow_success(
 
     # Verify that check was called twice (connectivity and token)
     assert mock_hass_splunk.check.call_count == 2
+
+
+async def test_user_flow_defaults_ssl_on(
+    hass: HomeAssistant, mock_hass_splunk: AsyncMock
+) -> None:
+    """Test a new entry defaults to SSL enabled when the field is omitted."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_TOKEN: "test-token-123",
+            CONF_HOST: "splunk.example.com",
+            CONF_PORT: 8088,
+        },
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_SSL] is True
+    assert result["data"][CONF_VERIFY_SSL] is True
 
 
 @pytest.mark.parametrize(
@@ -256,6 +278,23 @@ async def test_reconfigure_flow_success(
     assert mock_config_entry.data[CONF_VERIFY_SSL] is False
     assert mock_config_entry.data[CONF_NAME] == "Updated Splunk"
     assert mock_config_entry.title == "new-splunk.example.com:9088"
+
+
+async def test_reconfigure_flow_preserves_stored_ssl(
+    hass: HomeAssistant, mock_hass_splunk: AsyncMock, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test reconfigure pre-fills the stored SSL value, not the schema default.
+
+    The stored entry has SSL disabled; flipping the new-entry default to on must
+    not silently enable SSL for an existing user who opens the reconfigure form.
+    """
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+    assert get_schema_suggested_value(result["data_schema"].schema, CONF_SSL) is False
 
 
 @pytest.mark.parametrize(

--- a/tests/components/splunk/test_init.py
+++ b/tests/components/splunk/test_init.py
@@ -121,6 +121,29 @@ async def test_yaml_import_without_filter(
 
 
 @pytest.mark.usefixtures("mock_setup_entry")
+async def test_yaml_import_defaults_ssl_on(
+    hass: HomeAssistant, mock_hass_splunk: AsyncMock
+) -> None:
+    """Test YAML import defaults to SSL enabled when the field is omitted."""
+    assert await async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            DOMAIN: {
+                CONF_TOKEN: "test-token",
+                CONF_HOST: "localhost",
+                CONF_PORT: 8088,
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].data[CONF_SSL] is True
+
+
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_yaml_with_filter(
     hass: HomeAssistant, mock_hass_splunk: AsyncMock
 ) -> None:

--- a/tests/components/splunk/test_init.py
+++ b/tests/components/splunk/test_init.py
@@ -120,10 +120,8 @@ async def test_yaml_import_without_filter(
     assert entries[0].source == SOURCE_IMPORT
 
 
-@pytest.mark.usefixtures("mock_setup_entry")
-async def test_yaml_import_defaults_ssl_on(
-    hass: HomeAssistant, mock_hass_splunk: AsyncMock
-) -> None:
+@pytest.mark.usefixtures("mock_setup_entry", "mock_hass_splunk")
+async def test_yaml_import_defaults_ssl_on(hass: HomeAssistant) -> None:
     """Test YAML import defaults to SSL enabled when the field is omitted."""
     assert await async_setup_component(
         hass,


### PR DESCRIPTION
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The Splunk integration defaulted its transport to plaintext **HTTP** (`ssl` off by default). As a result, when a user set up Splunk without explicitly enabling SSL, the Splunk HEC **bearer token** and **all exported entity state data** were sent over the network unencrypted, exposing credentials and state to anyone able to observe the traffic.

This PR flips the default to **SSL/HTTPS on** so new setups are encrypted out of the box. `DEFAULT_SSL` in `const.py` becomes the single source of truth and is referenced by both config-flow schemas (user + reconfigure steps) and the YAML `CONFIG_SCHEMA`, replacing the hard-coded `False` literals.

**Scope — new entries/imports only:**
- Existing config entries store their explicit `CONF_SSL` value in `entry.data` and read it directly in `async_setup_entry`; they are **unaffected** and no migration is required.
- The reconfigure step pre-fills the user's **current stored value** via `add_suggested_values_to_schema(...)` (`suggested_value`), not the schema default, so opening reconfigure does **not** silently enable SSL for an existing user who had it off.
- Only a brand-new config entry or a brand-new YAML import (which aborts as already-configured for existing single-instance setups) picks up the new default.

`CONF_VERIFY_SSL` default remains `True`, unchanged.

Tests were added covering the new default for a new user-flow entry and a new YAML import, plus a test asserting the reconfigure form preserves the stored SSL value.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
