### PR TITLE
Add Roborock Q10 switch entities

### DIFF
--- a/homeassistant/components/roborock/icons.json
+++ b/homeassistant/components/roborock/icons.json
@@ -123,11 +123,17 @@
       }
     },
     "switch": {
+      "button_light": {
+        "default": "mdi:lightbulb"
+      },
       "child_lock": {
         "default": "mdi:account-lock"
       },
       "dnd_switch": {
         "default": "mdi:bell-cancel"
+      },
+      "dust_collection": {
+        "default": "mdi:delete"
       },
       "off_peak_switch": {
         "default": "mdi:power-plug"

--- a/homeassistant/components/roborock/strings.json
+++ b/homeassistant/components/roborock/strings.json
@@ -604,11 +604,17 @@
       }
     },
     "switch": {
+      "button_light": {
+        "name": "Indicator light"
+      },
       "child_lock": {
         "name": "Child lock"
       },
       "dnd_switch": {
         "name": "Do not disturb"
+      },
+      "dust_collection": {
+        "name": "Dust collection"
       },
       "off_peak_switch": {
         "name": "Off-peak charging"

--- a/homeassistant/components/roborock/switch.py
+++ b/homeassistant/components/roborock/switch.py
@@ -6,18 +6,24 @@ import logging
 from typing import Any, override
 
 from roborock.devices.traits.b01 import Q10PropertiesApi
-from roborock.devices.traits.b01.q10 import DoNotDisturbTrait
+from roborock.devices.traits.b01.q10 import (
+    ButtonLightTrait,
+    ChildLockTrait,
+    DoNotDisturbTrait,
+    DustCollectionTrait,
+)
 from roborock.devices.traits.v1 import PropertiesApi
 from roborock.devices.traits.v1.common import RoborockSwitchBase
 from roborock.exceptions import RoborockException
 from roborock.roborock_message import RoborockDyadDataProtocol, RoborockZeoProtocol
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
-from homeassistant.const import EntityCategory
+from homeassistant.const import STATE_OFF, STATE_ON, EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import DOMAIN
 from .coordinator import (
@@ -86,11 +92,14 @@ class RoborockSwitchDescriptionA01(SwitchEntityDescription):
     data_protocol: RoborockDyadDataProtocol | RoborockZeoProtocol
 
 
+type Q10SwitchTrait = ChildLockTrait | DoNotDisturbTrait | DustCollectionTrait
+
+
 @dataclass(frozen=True, kw_only=True)
 class RoborockSwitchDescriptionQ10(SwitchEntityDescription):
     """Class to describe a Roborock Q10 switch entity."""
 
-    trait: Callable[[Q10PropertiesApi], DoNotDisturbTrait | None]
+    trait: Callable[[Q10PropertiesApi], Q10SwitchTrait | None]
 
 
 A01_SWITCH_DESCRIPTIONS: list[RoborockSwitchDescriptionA01] = [
@@ -109,7 +118,19 @@ Q10_SWITCH_DESCRIPTIONS: list[RoborockSwitchDescriptionQ10] = [
         translation_key="dnd_switch",
         entity_category=EntityCategory.CONFIG,
         trait=lambda traits: traits.do_not_disturb,
-    )
+    ),
+    RoborockSwitchDescriptionQ10(
+        key="child_lock",
+        translation_key="child_lock",
+        entity_category=EntityCategory.CONFIG,
+        trait=lambda traits: traits.child_lock,
+    ),
+    RoborockSwitchDescriptionQ10(
+        key="dust_collection",
+        translation_key="dust_collection",
+        entity_category=EntityCategory.CONFIG,
+        trait=lambda traits: traits.dust_collection,
+    ),
 ]
 
 
@@ -158,6 +179,13 @@ async def async_setup_entry(
                 )
                 for description in Q10_SWITCH_DESCRIPTIONS
                 if (q10_trait := description.trait(coordinator.api)) is not None
+            )
+            entities.append(
+                RoborockSwitchQ10ButtonLight(
+                    f"button_light_{coordinator.duid_slug}",
+                    coordinator,
+                    coordinator.api.button_light,
+                )
             )
         async_add_entities(entities)
 
@@ -290,7 +318,7 @@ class RoborockSwitchQ10(RoborockCoordinatedEntityB01Q10, SwitchEntity):
         unique_id: str,
         coordinator: RoborockB01Q10UpdateCoordinator,
         description: RoborockSwitchDescriptionQ10,
-        trait: DoNotDisturbTrait,
+        trait: Q10SwitchTrait,
     ) -> None:
         """Initialize the entity."""
         self.entity_description = description
@@ -330,3 +358,63 @@ class RoborockSwitchQ10(RoborockCoordinatedEntityB01Q10, SwitchEntity):
     def is_on(self) -> bool | None:
         """Return True if entity is on."""
         return self._trait.is_on
+
+
+class RoborockSwitchQ10ButtonLight(
+    RoborockCoordinatedEntityB01Q10, SwitchEntity, RestoreEntity
+):
+    """A class to toggle the indicator / button light of a Roborock Q10 device.
+
+    The device does not report the light state, so the switch is write-only
+    and assumes the state of the last successful command, restored across
+    restarts.
+    """
+
+    _attr_assumed_state = True
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_translation_key = "button_light"
+
+    def __init__(
+        self,
+        unique_id: str,
+        coordinator: RoborockB01Q10UpdateCoordinator,
+        trait: ButtonLightTrait,
+    ) -> None:
+        """Initialize the entity."""
+        self._trait = trait
+        super().__init__(unique_id, coordinator)
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Restore the last assumed state."""
+        await super().async_added_to_hass()
+        if (last_state := await self.async_get_last_state()) is not None and (
+            last_state.state in (STATE_ON, STATE_OFF)
+        ):
+            self._attr_is_on = last_state.state == STATE_ON
+
+    @override
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off the light."""
+        try:
+            await self._trait.disable()
+        except RoborockException as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="update_options_failed",
+            ) from err
+        self._attr_is_on = False
+        self.async_write_ha_state()
+
+    @override
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on the light."""
+        try:
+            await self._trait.enable()
+        except RoborockException as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="update_options_failed",
+            ) from err
+        self._attr_is_on = True
+        self.async_write_ha_state()

--- a/tests/components/roborock/conftest.py
+++ b/tests/components/roborock/conftest.py
@@ -168,6 +168,46 @@ def create_b01_q7_trait() -> Mock:
     return b01_trait
 
 
+def attach_update_listeners(trait: Mock) -> Callable[[], None]:
+    """Give a mock Q10 trait working add_update_listener support.
+
+    Returns a callback that notifies all currently registered listeners,
+    mimicking a push update from the device.
+    """
+    listeners: list[Callable[[], None]] = []
+
+    def add_update_listener(cb: Callable[[], None]) -> Callable[[], None]:
+        listeners.append(cb)
+        return lambda: listeners.remove(cb)
+
+    trait.add_update_listener = Mock(side_effect=add_update_listener)
+
+    def notify() -> None:
+        for cb in listeners:
+            cb()
+
+    return notify
+
+
+def make_q10_switch_trait(
+    on_change: Callable[[bool], None] | None = None,
+) -> AsyncMock:
+    """Create a mock Q10 switch-like trait (is_on / enable / disable)."""
+    trait = AsyncMock()
+    trait.is_on = True
+    notify = attach_update_listeners(trait)
+
+    def _set(value: bool) -> None:
+        trait.is_on = value
+        if on_change is not None:
+            on_change(value)
+        notify()
+
+    trait.enable = AsyncMock(side_effect=lambda: _set(True))
+    trait.disable = AsyncMock(side_effect=lambda: _set(False))
+    return trait
+
+
 def create_b01_q10_trait() -> Mock:
     """Create B01 Q10 trait for Q10 devices.
 
@@ -188,31 +228,16 @@ def create_b01_q10_trait() -> Mock:
     q10_trait.vacuum = AsyncMock()
     q10_trait.command = AsyncMock()
     q10_trait.refresh = AsyncMock()
-    q10_trait.do_not_disturb = AsyncMock()
-    q10_trait.do_not_disturb.is_on = True
-    _dnd_listeners: list[Callable[[], None]] = []
+    q10_trait.do_not_disturb = make_q10_switch_trait(
+        on_change=lambda value: setattr(q10_trait.status, "not_disturb", value)
+    )
+    q10_trait.child_lock = make_q10_switch_trait()
+    q10_trait.dust_collection = make_q10_switch_trait()
+    # The button light trait is write-only (enable/disable, no is_on)
+    q10_trait.button_light = Mock(spec=["enable", "disable"])
+    q10_trait.button_light.enable = AsyncMock()
+    q10_trait.button_light.disable = AsyncMock()
 
-    def _dnd_add_update_listener(cb: Callable[[], None]) -> Callable[[], None]:
-        _dnd_listeners.append(cb)
-        return lambda: _dnd_listeners.remove(cb)
-
-    q10_trait.do_not_disturb.add_update_listener = Mock(
-        side_effect=_dnd_add_update_listener
-    )
-    q10_trait.do_not_disturb.enable = AsyncMock(
-        side_effect=lambda: (
-            setattr(q10_trait.do_not_disturb, "is_on", True),
-            setattr(q10_trait.status, "not_disturb", True),
-            [cb() for cb in _dnd_listeners],
-        )
-    )
-    q10_trait.do_not_disturb.disable = AsyncMock(
-        side_effect=lambda: (
-            setattr(q10_trait.do_not_disturb, "is_on", False),
-            setattr(q10_trait.status, "not_disturb", False),
-            [cb() for cb in _dnd_listeners],
-        )
-    )
     q10_trait.map = Mock()
     q10_trait.map.rooms = [
         Q10Room(id=9, raw_name="rr_bedroom", pixel_value=36, pixel_count=100),

--- a/tests/components/roborock/snapshots/test_switch.ambr
+++ b/tests/components/roborock/snapshots/test_switch.ambr
@@ -1,4 +1,54 @@
 # serializer version: 1
+# name: test_switches[switch.roborock_q10_s5_child_lock-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.roborock_q10_s5_child_lock',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Child lock',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Child lock',
+    'platform': 'roborock',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'child_lock',
+    'unique_id': 'child_lock_q10_duid',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.roborock_q10_s5_child_lock-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Roborock Q10 S5+ Child lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.roborock_q10_s5_child_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
 # name: test_switches[switch.roborock_q10_s5_do_not_disturb-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -47,6 +97,107 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
+  })
+# ---
+# name: test_switches[switch.roborock_q10_s5_dust_collection-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.roborock_q10_s5_dust_collection',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Dust collection',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Dust collection',
+    'platform': 'roborock',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'dust_collection',
+    'unique_id': 'dust_collection_q10_duid',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.roborock_q10_s5_dust_collection-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Roborock Q10 S5+ Dust collection',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.roborock_q10_s5_dust_collection',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switches[switch.roborock_q10_s5_indicator_light-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.roborock_q10_s5_indicator_light',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Indicator light',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Indicator light',
+    'platform': 'roborock',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'button_light',
+    'unique_id': 'button_light_q10_duid',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.roborock_q10_s5_indicator_light-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ASSUMED_STATE: 'assumed_state'>: True,
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Roborock Q10 S5+ Indicator light',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.roborock_q10_s5_indicator_light',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
   })
 # ---
 # name: test_switches[switch.roborock_s7_2_do_not_disturb-entry]

--- a/tests/components/roborock/test_switch.py
+++ b/tests/components/roborock/test_switch.py
@@ -10,15 +10,20 @@ from roborock.roborock_message import RoborockZeoProtocol
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.switch import SERVICE_TURN_OFF, SERVICE_TURN_ON
-from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.const import ATTR_ASSUMED_STATE, STATE_ON, STATE_UNKNOWN, Platform
+from homeassistant.core import HomeAssistant, State
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
 
 from .conftest import FakeDevice
 
-from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
+from tests.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+    mock_restore_cache,
+    snapshot_platform,
+)
 
 
 @pytest.fixture
@@ -257,14 +262,22 @@ async def test_a01_switch_unknown_state(
     assert state.state == "unknown"
 
 
-async def test_q10_do_not_disturb_switch_success(
+@pytest.mark.parametrize(
+    ("entity_id", "trait_name"),
+    [
+        ("switch.roborock_q10_s5_do_not_disturb", "do_not_disturb"),
+        ("switch.roborock_q10_s5_child_lock", "child_lock"),
+        ("switch.roborock_q10_s5_dust_collection", "dust_collection"),
+    ],
+)
+async def test_q10_switch_success(
     hass: HomeAssistant,
     setup_entry: MockConfigEntry,
     fake_q10_vacuum: FakeDevice,
+    entity_id: str,
+    trait_name: str,
 ) -> None:
-    """Test turning Q10 Do Not Disturb on and off."""
-    entity_id = "switch.roborock_q10_s5_do_not_disturb"
-
+    """Test turning Q10 switch entities on and off."""
     assert hass.states.get(entity_id) is not None
 
     await hass.services.async_call(
@@ -290,25 +303,34 @@ async def test_q10_do_not_disturb_switch_success(
     assert state.state == "on"
 
     assert fake_q10_vacuum.b01_q10_properties is not None
-    assert fake_q10_vacuum.b01_q10_properties.do_not_disturb.enable.call_count == 1
-    assert fake_q10_vacuum.b01_q10_properties.do_not_disturb.disable.call_count == 1
+    trait = getattr(fake_q10_vacuum.b01_q10_properties, trait_name)
+    trait.enable.assert_awaited_once()
+    trait.disable.assert_awaited_once()
 
 
-async def test_q10_do_not_disturb_switch_failure(
+@pytest.mark.parametrize(
+    ("entity_id", "trait_name"),
+    [
+        ("switch.roborock_q10_s5_do_not_disturb", "do_not_disturb"),
+        ("switch.roborock_q10_s5_child_lock", "child_lock"),
+        ("switch.roborock_q10_s5_dust_collection", "dust_collection"),
+    ],
+)
+async def test_q10_switch_failure(
     hass: HomeAssistant,
     setup_entry: MockConfigEntry,
     fake_q10_vacuum: FakeDevice,
+    entity_id: str,
+    trait_name: str,
 ) -> None:
-    """Test a failure while updating Q10 Do Not Disturb."""
-    entity_id = "switch.roborock_q10_s5_do_not_disturb"
+    """Test a failure while updating a Q10 switch."""
     assert fake_q10_vacuum.b01_q10_properties is not None
-    fake_q10_vacuum.b01_q10_properties.do_not_disturb.enable.side_effect = (
-        roborock.exceptions.RoborockTimeout
-    )
+    trait = getattr(fake_q10_vacuum.b01_q10_properties, trait_name)
+    trait.enable.side_effect = roborock.exceptions.RoborockTimeout
 
     assert hass.states.get(entity_id) is not None
 
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(HomeAssistantError, match="Failed to update Roborock options"):
         await hass.services.async_call(
             "switch",
             SERVICE_TURN_ON,
@@ -316,3 +338,89 @@ async def test_q10_do_not_disturb_switch_failure(
             blocking=True,
             target={"entity_id": entity_id},
         )
+
+
+async def test_q10_button_light_switch(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    fake_q10_vacuum: FakeDevice,
+) -> None:
+    """Test the Q10 write-only indicator light switch assumes its state."""
+    entity_id = "switch.roborock_q10_s5_indicator_light"
+
+    # The device never reports the light state, so it starts unknown
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+    assert state.attributes.get(ATTR_ASSUMED_STATE) is True
+
+    await hass.services.async_call(
+        "switch",
+        SERVICE_TURN_ON,
+        service_data=None,
+        blocking=True,
+        target={"entity_id": entity_id},
+    )
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "on"
+
+    await hass.services.async_call(
+        "switch",
+        SERVICE_TURN_OFF,
+        service_data=None,
+        blocking=True,
+        target={"entity_id": entity_id},
+    )
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "off"
+
+    assert fake_q10_vacuum.b01_q10_properties is not None
+    fake_q10_vacuum.b01_q10_properties.button_light.enable.assert_awaited_once()
+    fake_q10_vacuum.b01_q10_properties.button_light.disable.assert_awaited_once()
+
+
+async def test_q10_button_light_switch_restore_state(
+    hass: HomeAssistant,
+    mock_roborock_entry: MockConfigEntry,
+) -> None:
+    """Test the Q10 indicator light restores its assumed state after a restart."""
+    entity_id = "switch.roborock_q10_s5_indicator_light"
+    mock_restore_cache(hass, (State(entity_id, STATE_ON),))
+
+    await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == STATE_ON
+
+
+async def test_q10_button_light_switch_failure(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    fake_q10_vacuum: FakeDevice,
+) -> None:
+    """Test the Q10 indicator light keeps its state on a failed command."""
+    entity_id = "switch.roborock_q10_s5_indicator_light"
+    assert fake_q10_vacuum.b01_q10_properties is not None
+    fake_q10_vacuum.b01_q10_properties.button_light.enable.side_effect = (
+        roborock.exceptions.RoborockTimeout
+    )
+
+    assert hass.states.get(entity_id) is not None
+
+    with pytest.raises(HomeAssistantError, match="Failed to update Roborock options"):
+        await hass.services.async_call(
+            "switch",
+            SERVICE_TURN_ON,
+            service_data=None,
+            blocking=True,
+            target={"entity_id": entity_id},
+        )
+
+    # The failed command must not flip the assumed state
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == STATE_UNKNOWN


### PR DESCRIPTION
## Proposed change

Adds the remaining **switch entities** for the Roborock **Q10** (B01/ss07), following the merged Q10 DND switch pattern. Split out to one platform per PR as requested in home-assistant/core#173883; number and image are separate PRs.

- **Child lock** and **dust collection** (dock auto-empty) extend the existing `RoborockSwitchDescriptionQ10` list — the description's trait type widens from `DoNotDisturbTrait` to a `Q10SwitchTrait` union, everything else follows the merged DND pattern (push updates via `add_update_listener`).
- **Indicator / button light**: the device never reports the light state, so this switch is write-only — `_attr_assumed_state`, state only flips after a successful command, and `RestoreEntity` keeps the assumed state across restarts.

No dependency bump: targets `python-roborock==5.25.0`, which `dev` already pins.

## Type of change

- [x] New feature (which adds functionality to an existing integration)

## Testing

- The Q10 switch tests are parametrized across DND / child lock / dust collection (on/off round-trip through the trait listener, and failure paths asserting the translated error).
- Dedicated button-light tests: starts `unknown` with `assumed_state`, on/off round-trip, a failed command not flipping the assumed state, and state restore after a restart.
- The Q10 mock trait in `conftest.py` gained small reusable helpers (`attach_update_listeners`, `make_q10_switch_trait`); the existing DND mock was ported onto them (behavior unchanged).
- `test_switch` snapshot regenerated (additions only). Full `tests/components/roborock` suite passes locally (Python 3.14, python-roborock 5.25.0). Ruff, mypy (strict) and hassfest clean.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] There is no commented out code in this PR.
- [x] I have followed the development checklist.
- [x] I have followed the perfect PR recommendations.
- [x] The code has been formatted using Ruff.
- [x] Tests have been added to verify that the new code works.
