### PR TITLE
Fix lexicographic firmware version comparison in Teslemetry entity selection

### DIFF
--- a/homeassistant/components/teslemetry/binary_sensor.py
+++ b/homeassistant/components/teslemetry/binary_sensor.py
@@ -25,6 +25,7 @@ from .entity import (
     TeslemetryVehiclePollingEntity,
     TeslemetryVehicleStreamEntity,
 )
+from .helpers import firmware_at_least
 from .models import TeslemetryEnergyData, TeslemetryVehicleData
 
 PARALLEL_UPDATES = 0
@@ -557,7 +558,7 @@ async def async_setup_entry(
             if (
                 not vehicle.poll
                 and description.streaming_listener
-                and vehicle.firmware >= description.streaming_firmware
+                and firmware_at_least(vehicle.firmware, description.streaming_firmware)
             ):
                 entities.append(
                     TeslemetryVehicleStreamingBinarySensorEntity(vehicle, description)

--- a/homeassistant/components/teslemetry/climate.py
+++ b/homeassistant/components/teslemetry/climate.py
@@ -31,7 +31,7 @@ from .entity import (
     TeslemetryVehiclePollingEntity,
     TeslemetryVehicleStreamEntity,
 )
-from .helpers import handle_vehicle_command
+from .helpers import firmware_at_least, handle_vehicle_command
 from .models import TeslemetryVehicleData
 
 DEFAULT_MIN_TEMP = 15
@@ -65,7 +65,7 @@ async def async_setup_entry(
                 TeslemetryVehiclePollingClimateEntity(
                     vehicle, TeslemetryClimateSide.DRIVER, entry.runtime_data.scopes
                 )
-                if vehicle.poll or vehicle.firmware < "2024.44.25"
+                if vehicle.poll or not firmware_at_least(vehicle.firmware, "2024.44.25")
                 else TeslemetryStreamingClimateEntity(
                     vehicle, TeslemetryClimateSide.DRIVER, entry.runtime_data.scopes
                 )
@@ -75,7 +75,7 @@ async def async_setup_entry(
                 TeslemetryVehiclePollingCabinOverheatProtectionEntity(
                     vehicle, entry.runtime_data.scopes
                 )
-                if vehicle.poll or vehicle.firmware < "2024.44.25"
+                if vehicle.poll or not firmware_at_least(vehicle.firmware, "2024.44.25")
                 else TeslemetryStreamingCabinOverheatProtectionEntity(
                     vehicle, entry.runtime_data.scopes
                 )

--- a/homeassistant/components/teslemetry/cover.py
+++ b/homeassistant/components/teslemetry/cover.py
@@ -23,7 +23,7 @@ from .entity import (
     TeslemetryVehiclePollingEntity,
     TeslemetryVehicleStreamEntity,
 )
-from .helpers import handle_vehicle_command
+from .helpers import firmware_at_least, handle_vehicle_command
 from .models import TeslemetryVehicleData
 
 OPEN = 1
@@ -43,7 +43,7 @@ async def async_setup_entry(
         chain(
             (
                 TeslemetryVehiclePollingWindowEntity(vehicle, entry.runtime_data.scopes)
-                if vehicle.poll or vehicle.firmware < "2024.26"
+                if vehicle.poll or not firmware_at_least(vehicle.firmware, "2024.26")
                 else TeslemetryStreamingWindowEntity(vehicle, entry.runtime_data.scopes)
                 for vehicle in entry.runtime_data.vehicles
             ),
@@ -51,7 +51,7 @@ async def async_setup_entry(
                 TeslemetryVehiclePollingChargePortEntity(
                     vehicle, entry.runtime_data.scopes
                 )
-                if vehicle.poll or vehicle.firmware < "2024.44.25"
+                if vehicle.poll or not firmware_at_least(vehicle.firmware, "2024.44.25")
                 else TeslemetryStreamingChargePortEntity(
                     vehicle, entry.runtime_data.scopes
                 )
@@ -61,7 +61,7 @@ async def async_setup_entry(
                 TeslemetryVehiclePollingFrontTrunkEntity(
                     vehicle, entry.runtime_data.scopes
                 )
-                if vehicle.poll or vehicle.firmware < "2024.26"
+                if vehicle.poll or not firmware_at_least(vehicle.firmware, "2024.26")
                 else TeslemetryStreamingFrontTrunkEntity(
                     vehicle, entry.runtime_data.scopes
                 )
@@ -71,7 +71,7 @@ async def async_setup_entry(
                 TeslemetryVehiclePollingRearTrunkEntity(
                     vehicle, entry.runtime_data.scopes
                 )
-                if vehicle.poll or vehicle.firmware < "2024.26"
+                if vehicle.poll or not firmware_at_least(vehicle.firmware, "2024.26")
                 else TeslemetryStreamingRearTrunkEntity(
                     vehicle, entry.runtime_data.scopes
                 )

--- a/homeassistant/components/teslemetry/device_tracker.py
+++ b/homeassistant/components/teslemetry/device_tracker.py
@@ -18,6 +18,7 @@ from homeassistant.helpers.restore_state import RestoreEntity
 
 from . import TeslemetryConfigEntry
 from .entity import TeslemetryVehiclePollingEntity, TeslemetryVehicleStreamEntity
+from .helpers import firmware_at_least
 from .models import TeslemetryVehicleData
 
 PARALLEL_UPDATES = 0
@@ -78,7 +79,9 @@ async def async_setup_entry(
 
     for vehicle in entry.runtime_data.vehicles:
         for description in DESCRIPTIONS:
-            if vehicle.poll or vehicle.firmware < description.streaming_firmware:
+            if vehicle.poll or not firmware_at_least(
+                vehicle.firmware, description.streaming_firmware
+            ):
                 if description.polling_prefix:
                     entities.append(
                         TeslemetryVehiclePollingDeviceTrackerEntity(

--- a/homeassistant/components/teslemetry/helpers.py
+++ b/homeassistant/components/teslemetry/helpers.py
@@ -3,6 +3,7 @@
 from collections.abc import Awaitable
 from typing import Any
 
+from awesomeversion import AwesomeVersion, AwesomeVersionException
 from tesla_fleet_api.exceptions import TeslaFleetError
 
 from homeassistant.core import HomeAssistant, callback
@@ -10,6 +11,19 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 
 from .const import DOMAIN, LOGGER
+
+
+def firmware_at_least(firmware: str, minimum: str) -> bool:
+    """Return True if the vehicle firmware is at least the given version.
+
+    Tesla firmware versions are week-based (e.g. 2025.14.3), so a plain
+    string comparison misorders them; an unresolved "Unknown" firmware is
+    treated as not meeting the minimum.
+    """
+    try:
+        return AwesomeVersion(firmware) >= AwesomeVersion(minimum)
+    except AwesomeVersionException:
+        return False
 
 
 def flatten(

--- a/homeassistant/components/teslemetry/lock.py
+++ b/homeassistant/components/teslemetry/lock.py
@@ -19,7 +19,7 @@ from .entity import (
     TeslemetryVehiclePollingEntity,
     TeslemetryVehicleStreamEntity,
 )
-from .helpers import handle_vehicle_command
+from .helpers import firmware_at_least, handle_vehicle_command
 from .models import TeslemetryVehicleData
 
 ENGAGED = "Engaged"
@@ -40,7 +40,7 @@ async def async_setup_entry(
                 TeslemetryVehiclePollingVehicleLockEntity(
                     vehicle, Scope.VEHICLE_CMDS in entry.runtime_data.scopes
                 )
-                if vehicle.poll or vehicle.firmware < "2024.26"
+                if vehicle.poll or not firmware_at_least(vehicle.firmware, "2024.26")
                 else TeslemetryStreamingVehicleLockEntity(
                     vehicle, Scope.VEHICLE_CMDS in entry.runtime_data.scopes
                 )
@@ -50,7 +50,7 @@ async def async_setup_entry(
                 TeslemetryVehiclePollingCableLockEntity(
                     vehicle, Scope.VEHICLE_CMDS in entry.runtime_data.scopes
                 )
-                if vehicle.poll or vehicle.firmware < "2024.26"
+                if vehicle.poll or not firmware_at_least(vehicle.firmware, "2024.26")
                 else TeslemetryStreamingCableLockEntity(
                     vehicle, Scope.VEHICLE_CMDS in entry.runtime_data.scopes
                 )

--- a/homeassistant/components/teslemetry/media_player.py
+++ b/homeassistant/components/teslemetry/media_player.py
@@ -21,7 +21,7 @@ from .entity import (
     TeslemetryVehiclePollingEntity,
     TeslemetryVehicleStreamEntity,
 )
-from .helpers import handle_vehicle_command
+from .helpers import firmware_at_least, handle_vehicle_command
 from .models import TeslemetryVehicleData
 
 STATES = {
@@ -53,7 +53,7 @@ async def async_setup_entry(
 
     async_add_entities(
         TeslemetryVehiclePollingMediaEntity(vehicle, entry.runtime_data.scopes)
-        if vehicle.poll or vehicle.firmware < "2025.2.6"
+        if vehicle.poll or not firmware_at_least(vehicle.firmware, "2025.2.6")
         else TeslemetryStreamingMediaEntity(vehicle, entry.runtime_data.scopes)
         for vehicle in entry.runtime_data.vehicles
     )

--- a/homeassistant/components/teslemetry/number.py
+++ b/homeassistant/components/teslemetry/number.py
@@ -33,7 +33,7 @@ from .entity import (
     TeslemetryVehiclePollingEntity,
     TeslemetryVehicleStreamEntity,
 )
-from .helpers import handle_command, handle_vehicle_command
+from .helpers import firmware_at_least, handle_command, handle_vehicle_command
 from .models import TeslemetryEnergyData, TeslemetryVehicleData
 
 PARALLEL_UPDATES = 0
@@ -142,7 +142,7 @@ async def async_setup_entry(
                     description,
                     entry.runtime_data.scopes,
                 )
-                if vehicle.poll or vehicle.firmware < "2024.26"
+                if vehicle.poll or not firmware_at_least(vehicle.firmware, "2024.26")
                 else TeslemetryStreamingNumberEntity(
                     vehicle,
                     description,

--- a/homeassistant/components/teslemetry/select.py
+++ b/homeassistant/components/teslemetry/select.py
@@ -21,7 +21,7 @@ from .entity import (
     TeslemetryVehiclePollingEntity,
     TeslemetryVehicleStreamEntity,
 )
-from .helpers import handle_command, handle_vehicle_command
+from .helpers import firmware_at_least, handle_command, handle_vehicle_command
 from .models import TeslemetryEnergyData, TeslemetryVehicleData
 
 OFF = "off"
@@ -220,7 +220,7 @@ async def async_setup_entry(
                     vehicle, description, entry.runtime_data.scopes
                 )
                 if vehicle.poll
-                or vehicle.firmware < "2024.26"
+                or not firmware_at_least(vehicle.firmware, "2024.26")
                 or description.streaming_listener is None
                 else TeslemetryStreamingSelectEntity(
                     vehicle, description, entry.runtime_data.scopes

--- a/homeassistant/components/teslemetry/sensor.py
+++ b/homeassistant/components/teslemetry/sensor.py
@@ -44,6 +44,7 @@ from .entity import (
     TeslemetryVehicleStreamEntity,
     TeslemetryWallConnectorEntity,
 )
+from .helpers import firmware_at_least
 from .models import TeslemetryEnergyData, TeslemetryVehicleData
 
 PARALLEL_UPDATES = 0
@@ -1605,16 +1606,15 @@ async def async_setup_entry(
             if (
                 not vehicle.poll
                 and description.streaming_listener
-                and vehicle.firmware >= description.streaming_firmware
+                and firmware_at_least(vehicle.firmware, description.streaming_firmware)
             ):
                 entities.append(TeslemetryStreamSensorEntity(vehicle, description))
             elif description.polling:
                 entities.append(TeslemetryVehicleSensorEntity(vehicle, description))
 
         for time_description in VEHICLE_TIME_DESCRIPTIONS:
-            if (
-                not vehicle.poll
-                and vehicle.firmware >= time_description.streaming_firmware
+            if not vehicle.poll and firmware_at_least(
+                vehicle.firmware, time_description.streaming_firmware
             ):
                 entities.append(
                     TeslemetryStreamTimeSensorEntity(vehicle, time_description)

--- a/homeassistant/components/teslemetry/switch.py
+++ b/homeassistant/components/teslemetry/switch.py
@@ -25,7 +25,7 @@ from .entity import (
     TeslemetryVehiclePollingEntity,
     TeslemetryVehicleStreamEntity,
 )
-from .helpers import handle_command, handle_vehicle_command
+from .helpers import firmware_at_least, handle_command, handle_vehicle_command
 from .models import TeslemetryEnergyData, TeslemetryVehicleData
 
 PARALLEL_UPDATES = 0
@@ -162,7 +162,9 @@ async def async_setup_entry(
 
     for vehicle in entry.runtime_data.vehicles:
         for description in VEHICLE_DESCRIPTIONS:
-            if vehicle.poll or vehicle.firmware < description.streaming_firmware:
+            if vehicle.poll or not firmware_at_least(
+                vehicle.firmware, description.streaming_firmware
+            ):
                 if description.polling:
                     entities.append(
                         TeslemetryVehiclePollingVehicleSwitchEntity(

--- a/homeassistant/components/teslemetry/update.py
+++ b/homeassistant/components/teslemetry/update.py
@@ -16,7 +16,7 @@ from .entity import (
     TeslemetryVehiclePollingEntity,
     TeslemetryVehicleStreamEntity,
 )
-from .helpers import handle_vehicle_command
+from .helpers import firmware_at_least, handle_vehicle_command
 from .models import TeslemetryVehicleData
 
 AVAILABLE = "available"
@@ -37,7 +37,7 @@ async def async_setup_entry(
 
     async_add_entities(
         TeslemetryVehiclePollingUpdateEntity(vehicle, entry.runtime_data.scopes)
-        if vehicle.poll or vehicle.firmware < "2024.44.25"
+        if vehicle.poll or not firmware_at_least(vehicle.firmware, "2024.44.25")
         else TeslemetryStreamingUpdateEntity(vehicle, entry.runtime_data.scopes)
         for vehicle in entry.runtime_data.vehicles
     )

--- a/tests/components/teslemetry/test_helpers.py
+++ b/tests/components/teslemetry/test_helpers.py
@@ -1,0 +1,23 @@
+"""Test the Teslemetry helpers."""
+
+import pytest
+
+from homeassistant.components.teslemetry.helpers import firmware_at_least
+
+
+@pytest.mark.parametrize(
+    ("firmware", "minimum", "expected"),
+    [
+        ("2024.8", "2024.8", True),
+        ("2024.8", "2024.44.25", False),
+        ("2024.44.25", "2024.8", True),
+        ("2024.44.25", "2024.44.25", True),
+        ("2025.14", "2025.2.6", True),
+        ("2025.2.6", "2025.14", False),
+        ("Unknown", "2024.8", False),
+        ("Unknown", "2025.14", False),
+    ],
+)
+def test_firmware_at_least(firmware: str, minimum: str, expected: bool) -> None:
+    """Test firmware_at_least correctly compares week-based firmware versions."""
+    assert firmware_at_least(firmware, minimum) is expected


### PR DESCRIPTION
## Breaking change


## Proposed change

Tesla firmware versions are week-based (e.g. `2025.14.3`), but the Teslemetry integration was comparing them as plain strings to decide whether a vehicle gets streaming or polling entities. String comparison misorders these versions: `"2025.14.3" < "2025.2.6"` is `True`, so vehicles on `2025.10`-`2025.19` firmware were denied streaming entities at every gate above `2025.2.6`, while some old firmware wrongly passed higher gates. A firmware value of `"Unknown"` (the default when firmware isn't reported) passed every gate as well, which could hand streaming entities to vehicles that may never actually emit that data.

This adds a small `firmware_at_least()` helper (`helpers.py`) built on `AwesomeVersion`, which already understands this CalVer-style versioning, and replaces every lexicographic firmware comparison across the platform modules with it. `"Unknown"`/unparseable firmware is treated as not meeting the minimum, so those vehicles fall back to the safer polling entity classes instead of streaming ones that may never populate.

This is purely an entity-selection correctness fix; it does not change any entity's behavior once selected.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #170998
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
