### PR TITLE
Fix teslemetry streaming enum sensors swallowing None updates

### DIFF
--- a/homeassistant/components/teslemetry/sensor.py
+++ b/homeassistant/components/teslemetry/sensor.py
@@ -833,8 +833,8 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetryVehicleSensorEntityDescription, ...] = (
     TeslemetryVehicleSensorEntityDescription(
         key="di_state_f",
         streaming_listener=lambda vehicle, callback: vehicle.listen_DiStateF(
-            lambda value: (
-                None if value is None else callback(DRIVE_INVERTER_STATES.get(value))
+            lambda value: callback(
+                None if value is None else DRIVE_INVERTER_STATES.get(value)
             )
         ),
         device_class=SensorDeviceClass.ENUM,
@@ -845,8 +845,8 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetryVehicleSensorEntityDescription, ...] = (
     TeslemetryVehicleSensorEntityDescription(
         key="di_state_r",
         streaming_listener=lambda vehicle, callback: vehicle.listen_DiStateR(
-            lambda value: (
-                None if value is None else callback(DRIVE_INVERTER_STATES.get(value))
+            lambda value: callback(
+                None if value is None else DRIVE_INVERTER_STATES.get(value)
             )
         ),
         device_class=SensorDeviceClass.ENUM,
@@ -857,8 +857,8 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetryVehicleSensorEntityDescription, ...] = (
     TeslemetryVehicleSensorEntityDescription(
         key="di_state_rel",
         streaming_listener=lambda vehicle, callback: vehicle.listen_DiStateREL(
-            lambda value: (
-                None if value is None else callback(DRIVE_INVERTER_STATES.get(value))
+            lambda value: callback(
+                None if value is None else DRIVE_INVERTER_STATES.get(value)
             )
         ),
         device_class=SensorDeviceClass.ENUM,
@@ -869,8 +869,8 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetryVehicleSensorEntityDescription, ...] = (
     TeslemetryVehicleSensorEntityDescription(
         key="di_state_rer",
         streaming_listener=lambda vehicle, callback: vehicle.listen_DiStateRER(
-            lambda value: (
-                None if value is None else callback(DRIVE_INVERTER_STATES.get(value))
+            lambda value: callback(
+                None if value is None else DRIVE_INVERTER_STATES.get(value)
             )
         ),
         device_class=SensorDeviceClass.ENUM,
@@ -1011,8 +1011,8 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetryVehicleSensorEntityDescription, ...] = (
     TeslemetryVehicleSensorEntityDescription(
         key="sentry_mode",
         streaming_listener=lambda vehicle, callback: vehicle.listen_SentryMode(
-            lambda value: (
-                None if value is None else callback(SENTRY_MODE_STATES.get(value))
+            lambda value: callback(
+                None if value is None else SENTRY_MODE_STATES.get(value)
             )
         ),
         options=list(SENTRY_MODE_STATES.values()),
@@ -1044,10 +1044,10 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetryVehicleSensorEntityDescription, ...] = (
         key="forward_collision_warning",
         streaming_listener=lambda vehicle, callback: (
             vehicle.listen_ForwardCollisionWarning(
-                lambda value: (
+                lambda value: callback(
                     None
                     if value is None
-                    else callback(FORWARD_COLLISION_SENSITIVITIES.get(value))
+                    else FORWARD_COLLISION_SENSITIVITIES.get(value)
                 )
             )
         ),
@@ -1069,10 +1069,10 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetryVehicleSensorEntityDescription, ...] = (
         key="guest_mode_mobile_access_state",
         streaming_listener=lambda vehicle, callback: (
             vehicle.listen_GuestModeMobileAccessState(
-                lambda value: (
+                lambda value: callback(
                     None
                     if value is None
-                    else callback(GUEST_MODE_MOBILE_ACCESS_STATES.get(value))
+                    else GUEST_MODE_MOBILE_ACCESS_STATES.get(value)
                 )
             )
         ),
@@ -1122,8 +1122,8 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetryVehicleSensorEntityDescription, ...] = (
         key="lane_departure_avoidance",
         streaming_listener=lambda vehicle, callback: (
             vehicle.listen_LaneDepartureAvoidance(
-                lambda value: (
-                    None if value is None else callback(LANE_ASSIST_LEVELS.get(value))
+                lambda value: callback(
+                    None if value is None else LANE_ASSIST_LEVELS.get(value)
                 )
             )
         ),
@@ -1249,8 +1249,8 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetryVehicleSensorEntityDescription, ...] = (
     TeslemetryVehicleSensorEntityDescription(
         key="powershare_status",
         streaming_listener=lambda vehicle, callback: vehicle.listen_PowershareStatus(
-            lambda value: (
-                None if value is None else callback(POWER_SHARE_STATES.get(value))
+            lambda value: callback(
+                None if value is None else POWER_SHARE_STATES.get(value)
             )
         ),
         device_class=SensorDeviceClass.ENUM,
@@ -1262,10 +1262,8 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetryVehicleSensorEntityDescription, ...] = (
         key="powershare_stop_reason",
         streaming_listener=lambda vehicle, callback: (
             vehicle.listen_PowershareStopReason(
-                lambda value: (
-                    None
-                    if value is None
-                    else callback(POWER_SHARE_STOP_REASONS.get(value))
+                lambda value: callback(
+                    None if value is None else POWER_SHARE_STOP_REASONS.get(value)
                 )
             )
         ),
@@ -1277,8 +1275,8 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetryVehicleSensorEntityDescription, ...] = (
     TeslemetryVehicleSensorEntityDescription(
         key="powershare_type",
         streaming_listener=lambda vehicle, callback: vehicle.listen_PowershareType(
-            lambda value: (
-                None if value is None else callback(POWER_SHARE_TYPES.get(value))
+            lambda value: callback(
+                None if value is None else POWER_SHARE_TYPES.get(value)
             )
         ),
         device_class=SensorDeviceClass.ENUM,
@@ -1301,10 +1299,8 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetryVehicleSensorEntityDescription, ...] = (
         key="scheduled_charging_mode",
         streaming_listener=lambda vehicle, callback: (
             vehicle.listen_ScheduledChargingMode(
-                lambda value: (
-                    None
-                    if value is None
-                    else callback(SCHEDULED_CHARGING_MODES.get(value))
+                lambda value: callback(
+                    None if value is None else SCHEDULED_CHARGING_MODES.get(value)
                 )
             )
         ),
@@ -1327,8 +1323,8 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetryVehicleSensorEntityDescription, ...] = (
     TeslemetryVehicleSensorEntityDescription(
         key="speed_limit_warning",
         streaming_listener=lambda vehicle, callback: vehicle.listen_SpeedLimitWarning(
-            lambda value: (
-                None if value is None else callback(SPEED_ASSIST_LEVELS.get(value))
+            lambda value: callback(
+                None if value is None else SPEED_ASSIST_LEVELS.get(value)
             )
         ),
         device_class=SensorDeviceClass.ENUM,
@@ -1339,8 +1335,8 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetryVehicleSensorEntityDescription, ...] = (
     TeslemetryVehicleSensorEntityDescription(
         key="tonneau_tent_mode",
         streaming_listener=lambda vehicle, callback: vehicle.listen_TonneauTentMode(
-            lambda value: (
-                None if value is None else callback(TONNEAU_TENT_MODE_STATES.get(value))
+            lambda value: callback(
+                None if value is None else TONNEAU_TENT_MODE_STATES.get(value)
             )
         ),
         device_class=SensorDeviceClass.ENUM,
@@ -1367,8 +1363,8 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetryVehicleSensorEntityDescription, ...] = (
     TeslemetryVehicleSensorEntityDescription(
         key="lights_turn_signal",
         streaming_listener=lambda vehicle, callback: vehicle.listen_LightsTurnSignal(
-            lambda value: (
-                None if value is None else callback(TURN_SIGNAL_STATES.get(value))
+            lambda value: callback(
+                None if value is None else TURN_SIGNAL_STATES.get(value)
             )
         ),
         device_class=SensorDeviceClass.ENUM,
@@ -1390,8 +1386,8 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetryVehicleSensorEntityDescription, ...] = (
     TeslemetryVehicleSensorEntityDescription(
         key="hvac_power_state",
         streaming_listener=lambda vehicle, callback: vehicle.listen_HvacPower(
-            lambda value: (
-                None if value is None else callback(HVAC_POWER_STATES.get(value))
+            lambda value: callback(
+                None if value is None else HVAC_POWER_STATES.get(value)
             )
         ),
         device_class=SensorDeviceClass.ENUM,

--- a/tests/components/teslemetry/test_sensor.py
+++ b/tests/components/teslemetry/test_sensor.py
@@ -7,6 +7,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 from teslemetry_stream import Signal
 
+from homeassistant.components.teslemetry.const import DOMAIN
 from homeassistant.components.teslemetry.coordinator import VEHICLE_INTERVAL
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, Platform
@@ -114,6 +115,85 @@ async def test_sensors_streaming(
     assert hass.states.get("sensor.teslemetry_command_credits").state == "1980"
     assert (quota_state := hass.states.get("sensor.teslemetry_command_quota_used"))
     assert quota_state.state == "21.2"
+
+
+@pytest.mark.parametrize(
+    ("key", "signal", "raw_value", "state"),
+    [
+        ("di_state_f", Signal.DI_STATE_F, "Standby", "standby"),
+        ("di_state_r", Signal.DI_STATE_R, "Standby", "standby"),
+        ("di_state_rel", Signal.DI_STATE_REL, "Standby", "standby"),
+        ("di_state_rer", Signal.DI_STATE_RER, "Standby", "standby"),
+        ("sentry_mode", Signal.SENTRY_MODE, "Armed", "armed"),
+        (
+            "forward_collision_warning",
+            Signal.FORWARD_COLLISION_WARNING,
+            "Average",
+            "average",
+        ),
+        (
+            "guest_mode_mobile_access_state",
+            Signal.GUEST_MODE_MOBILE_ACCESS_STATE,
+            "Authenticated",
+            "authenticated",
+        ),
+        (
+            "lane_departure_avoidance",
+            Signal.LANE_DEPARTURE_AVOIDANCE,
+            "Warning",
+            "warning",
+        ),
+        ("powershare_status", Signal.POWERSHARE_STATUS, "Enabled", "enabled"),
+        ("powershare_stop_reason", Signal.POWERSHARE_STOP_REASON, "Fault", "fault"),
+        ("powershare_type", Signal.POWERSHARE_TYPE, "Home", "home"),
+        (
+            "scheduled_charging_mode",
+            Signal.SCHEDULED_CHARGING_MODE,
+            "StartAt",
+            "start_at",
+        ),
+        ("speed_limit_warning", Signal.SPEED_LIMIT_WARNING, "Chime", "chime"),
+        ("tonneau_tent_mode", Signal.TONNEAU_TENT_MODE, "Active", "active"),
+        ("lights_turn_signal", Signal.LIGHTS_TURN_SIGNAL, "Left", "left"),
+        ("hvac_power_state", Signal.HVAC_POWER, "On", "on"),
+    ],
+)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_streaming_enum_none_clears_state(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_vehicle_data: AsyncMock,
+    mock_add_listener: AsyncMock,
+    key: str,
+    signal: Signal,
+    raw_value: str,
+    state: str,
+) -> None:
+    """A None streamed value must clear the entity, not leave it stale."""
+    await setup_platform(hass, [Platform.SENSOR])
+    vin = VEHICLE_DATA_ALT["response"]["vin"]
+    entity_id = entity_registry.async_get_entity_id("sensor", DOMAIN, f"{vin}-{key}")
+    assert entity_id is not None
+
+    mock_add_listener.send(
+        {
+            "vin": vin,
+            "data": {signal: raw_value},
+            "createdAt": "2024-10-04T10:45:17.537Z",
+        }
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(entity_id).state == state
+
+    mock_add_listener.send(
+        {
+            "vin": vin,
+            "data": {signal: None},
+            "createdAt": "2024-10-04T10:45:18.537Z",
+        }
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(entity_id).state == STATE_UNKNOWN
 
 
 async def test_energy_history_no_time_series(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

16 streaming enum sensor listeners in `sensor.py` used a lambda of the shape `lambda value: (None if value is None else callback(MAP.get(value)))`.

When the vehicle's streaming telemetry sent a `None` value for one of these signals, that ternary expression evaluates to `None` as a no-op - it never actually calls `callback`. As a result, `_async_value_from_stream` was never invoked for these sensors on a `None` update, and the entity kept showing its last (possibly hours-stale, restored-from-disk) value as if it were still live.

The fix rewrites all 16 call sites to `lambda value: callback(None if value is None else MAP.get(value))`, matching the already-correct idiom used elsewhere in the same file (the `charge_state_charging_state` sensor).

Please do not include in a patch release, as this may have unexpected consequences.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr