### PR TITLE
Fix teslemetry climate reporting off instead of unknown when coordinator data is missing

### DIFF
--- a/homeassistant/components/teslemetry/climate.py
+++ b/homeassistant/components/teslemetry/climate.py
@@ -212,7 +212,7 @@ class TeslemetryVehiclePollingClimateEntity(
         value = self.get("climate_state_is_climate_on")
         if value is None:
             self._attr_hvac_mode = None
-        if value:
+        elif value:
             self._attr_hvac_mode = HVACMode.HEAT_COOL
         else:
             self._attr_hvac_mode = HVACMode.OFF

--- a/tests/components/teslemetry/test_climate.py
+++ b/tests/components/teslemetry/test_climate.py
@@ -1,5 +1,6 @@
 """Test the Teslemetry climate platform."""
 
+from copy import deepcopy
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -19,7 +20,7 @@ from homeassistant.components.climate import (
     SERVICE_TURN_ON,
     HVACMode,
 )
-from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import entity_registry as er
@@ -28,6 +29,7 @@ from . import assert_entities, reload_platform, setup_platform
 from .const import (
     COMMAND_ERRORS,
     COMMAND_IGNORED_REASON,
+    METADATA,
     METADATA_NOSCOPE,
     VEHICLE_DATA_ALT,
 )
@@ -200,6 +202,26 @@ async def test_climate_alt(
     mock_vehicle_data.return_value = VEHICLE_DATA_ALT
     entry = await setup_platform(hass, [Platform.CLIMATE])
     assert_entities(hass, entry.entry_id, entity_registry, snapshot)
+
+
+async def test_climate_state_unknown(
+    hass: HomeAssistant,
+    mock_metadata: AsyncMock,
+    mock_vehicle_data: AsyncMock,
+) -> None:
+    """Test that a missing climate_state_is_climate_on reports unknown, not off."""
+
+    metadata = deepcopy(METADATA)
+    metadata["vehicles"]["LRW3F7EK4NC700000"]["polling"] = True
+    mock_metadata.return_value = metadata
+
+    data = deepcopy(VEHICLE_DATA_ALT)
+    data["response"]["climate_state"]["is_climate_on"] = None
+    mock_vehicle_data.return_value = data
+
+    await setup_platform(hass, [Platform.CLIMATE])
+
+    assert hass.states.get("climate.test_climate").state == STATE_UNKNOWN
 
 
 async def test_invalid_error(hass: HomeAssistant, snapshot: SnapshotAssertion) -> None:


### PR DESCRIPTION
## Proposed change
In `TeslemetryVehiclePollingClimateEntity._async_update_attrs`, the handling of `climate_state_is_climate_on` had a bug: the `None` case was handled by a standalone `if value is None: ...` followed by a separate `if value: ... else: ...` block, instead of `elif`/`else`. Because the second `if` always ran regardless of the first, whenever the coordinator value was `None` it was immediately overwritten by the on/off branch, and the entity reported HVAC mode OFF rather than unknown.

This matters because automations that key off climate state changes (e.g. transitioning from "unknown" to a real value) can misfire, since the entity spuriously reports "off" whenever coordinator data is temporarily missing, instead of surfacing "unknown" as it should.

The fix is a one-line change: `if value:` becomes `elif value:`.

Added `test_climate_state_unknown`, which forces the vehicle into polling mode and sets `climate_state.is_climate_on` to `null`, then asserts the entity reports `STATE_UNKNOWN`. I manually verified this test fails against the pre-fix code (reports "off") and passes with the fix.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr