### PR TITLE
Migrate timer entity attributes to StrEnum

### DIFF
--- a/homeassistant/components/timer/__init__.py
+++ b/homeassistant/components/timer/__init__.py
@@ -7,7 +7,7 @@ from typing import Any, Self, override
 
 import voluptuous as vol
 
-from homeassistant.const import (
+from homeassistant.const import (  # noqa : F401
     ATTR_EDITABLE,
     ATTR_ENTITY_ID,
     CONF_ICON,
@@ -25,6 +25,8 @@ import homeassistant.helpers.service
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.typing import ConfigType, VolDictType
 from homeassistant.util import dt as dt_util
+
+from .const import TimerEntityStateAttribute
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -256,16 +258,20 @@ class Timer(collection.CollectionEntity, RestoreEntity):
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         attrs: dict[str, Any] = {
-            ATTR_DURATION: _format_timedelta(self._running_duration),
-            ATTR_EDITABLE: self.editable,
-            ATTR_LAST_TRANSITION: self._last_transition,
+            TimerEntityStateAttribute.DURATION: _format_timedelta(
+                self._running_duration
+            ),
+            TimerEntityStateAttribute.EDITABLE: self.editable,
+            TimerEntityStateAttribute.LAST_TRANSITION: self._last_transition,
         }
         if self._end is not None:
-            attrs[ATTR_FINISHES_AT] = self._end.isoformat()
+            attrs[TimerEntityStateAttribute.FINISHES_AT] = self._end.isoformat()
         if self._remaining is not None:
-            attrs[ATTR_REMAINING] = _format_timedelta(self._remaining)
+            attrs[TimerEntityStateAttribute.REMAINING] = _format_timedelta(
+                self._remaining
+            )
         if self._restore:
-            attrs[ATTR_RESTORE] = self._restore
+            attrs[TimerEntityStateAttribute.RESTORE] = self._restore
 
         return attrs
 

--- a/homeassistant/components/timer/__init__.py
+++ b/homeassistant/components/timer/__init__.py
@@ -7,7 +7,7 @@ from typing import Any, Self, override
 
 import voluptuous as vol
 
-from homeassistant.const import (  # noqa : F401
+from homeassistant.const import (  # noqa: F401
     ATTR_EDITABLE,
     ATTR_ENTITY_ID,
     CONF_ICON,

--- a/homeassistant/components/timer/const.py
+++ b/homeassistant/components/timer/const.py
@@ -1,0 +1,14 @@
+"""Constants for the timer integration."""
+
+from enum import StrEnum
+
+
+class TimerEntityStateAttribute(StrEnum):
+    """State attributes for timer entities."""
+
+    DURATION = "duration"
+    EDITABLE = "editable"
+    LAST_TRANSITION = "last_transition"
+    FINISHES_AT = "finishes_at"
+    REMAINING = "remaining"
+    RESTORE = "restore"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add new attribute enum for the capability/state attributes of the timer entity.

Based on https://github.com/home-assistant/architecture/discussions/1406, linked to epic https://github.com/home-assistant/epics/issues/104

A follow-up PR will formally deprecate the corresponding `ATTR_*` constants.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
