### PR TITLE
Move service registration to async_setup in Todoist

### DIFF
--- a/homeassistant/components/todoist/__init__.py
+++ b/homeassistant/components/todoist/__init__.py
@@ -7,8 +7,12 @@ from todoist_api_python.api_async import TodoistAPIAsync
 
 from homeassistant.const import CONF_TOKEN, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.typing import ConfigType
 
+from .const import DOMAIN
 from .coordinator import TodoistConfigEntry, TodoistCoordinator
+from .services import async_setup_services
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -16,6 +20,14 @@ SCAN_INTERVAL = datetime.timedelta(minutes=1)
 
 
 PLATFORMS: list[Platform] = [Platform.CALENDAR, Platform.TODO]
+
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the integration."""
+    async_setup_services(hass)
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: TodoistConfigEntry) -> bool:

--- a/homeassistant/components/todoist/calendar.py
+++ b/homeassistant/components/todoist/calendar.py
@@ -33,6 +33,7 @@ from .const import (
     CONF_PROJECT_LABEL_WHITELIST,
     CONF_PROJECT_WHITELIST,
     DESCRIPTION,
+    DOMAIN,
     DUE_TODAY,
     END,
     LABELS,
@@ -109,6 +110,10 @@ async def async_setup_platform(
     api = TodoistAPIAsync(token)
     coordinator = TodoistCoordinator(hass, _LOGGER, None, SCAN_INTERVAL, api, token)
     await coordinator.async_refresh()
+
+    # The YAML platform has no config entry, so expose the coordinator for the
+    # new_task service to reach it.
+    hass.data.setdefault(DOMAIN, []).append(coordinator)
 
     async def _shutdown_coordinator(_: Event) -> None:
         await coordinator.async_shutdown()

--- a/homeassistant/components/todoist/calendar.py
+++ b/homeassistant/components/todoist/calendar.py
@@ -3,7 +3,6 @@
 from datetime import date, datetime, timedelta
 import logging
 from typing import Any, override
-import uuid
 
 from todoist_api_python.api_async import TodoistAPIAsync
 from todoist_api_python.models import Label, Project, Task
@@ -15,10 +14,8 @@ from homeassistant.components.calendar import (
     CalendarEvent,
 )
 from homeassistant.const import CONF_ID, CONF_NAME, CONF_TOKEN, EVENT_HOMEASSISTANT_STOP
-from homeassistant.core import Event, HomeAssistant, ServiceCall, callback
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity_platform import (
     AddConfigEntryEntitiesCallback,
     AddEntitiesCallback,
@@ -30,30 +27,17 @@ from homeassistant.util import dt as dt_util
 from .const import (
     ALL_DAY,
     ALL_TASKS,
-    ASSIGNEE,
     COMPLETED,
     CONF_EXTRA_PROJECTS,
     CONF_PROJECT_DUE_DATE,
     CONF_PROJECT_LABEL_WHITELIST,
     CONF_PROJECT_WHITELIST,
-    CONTENT,
     DESCRIPTION,
-    DOMAIN,
-    DUE_DATE,
-    DUE_DATE_LANG,
-    DUE_DATE_STRING,
-    DUE_DATE_VALID_LANGS,
     DUE_TODAY,
     END,
     LABELS,
     OVERDUE,
     PRIORITY,
-    PROJECT_NAME,
-    REMINDER_DATE,
-    REMINDER_DATE_LANG,
-    REMINDER_DATE_STRING,
-    SECTION_NAME,
-    SERVICE_NEW_TASK,
     START,
     SUMMARY,
 )
@@ -63,25 +47,6 @@ from .util import parse_due_date
 
 _LOGGER = logging.getLogger(__name__)
 
-NEW_TASK_SERVICE_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONTENT): cv.string,
-        vol.Optional(DESCRIPTION): cv.string,
-        vol.Optional(PROJECT_NAME, default="inbox"): vol.All(cv.string, vol.Lower),
-        vol.Optional(SECTION_NAME): vol.All(cv.string, vol.Lower),
-        vol.Optional(LABELS): cv.ensure_list_csv,
-        vol.Optional(ASSIGNEE): cv.string,
-        vol.Optional(PRIORITY): vol.All(vol.Coerce(int), vol.Range(min=1, max=4)),
-        vol.Exclusive(DUE_DATE_STRING, "due_date"): cv.string,
-        vol.Optional(DUE_DATE_LANG): vol.All(cv.string, vol.In(DUE_DATE_VALID_LANGS)),
-        vol.Exclusive(DUE_DATE, "due_date"): cv.string,
-        vol.Exclusive(REMINDER_DATE_STRING, "reminder_date"): cv.string,
-        vol.Optional(REMINDER_DATE_LANG): vol.All(
-            cv.string, vol.In(DUE_DATE_VALID_LANGS)
-        ),
-        vol.Exclusive(REMINDER_DATE, "reminder_date"): cv.string,
-    }
-)
 
 PLATFORM_SCHEMA = CALENDAR_PLATFORM_SCHEMA.extend(
     {
@@ -127,7 +92,6 @@ async def async_setup_entry(
         entities.append(TodoistProjectEntity(coordinator, project_data, labels))
 
     async_add_entities(entities)
-    async_register_services(hass, coordinator)
 
 
 async def async_setup_platform(
@@ -204,157 +168,6 @@ async def async_setup_platform(
         )
 
     async_add_entities(project_devices, update_before_add=True)
-
-    async_register_services(hass, coordinator)
-
-
-def async_register_services(  # noqa: C901
-    hass: HomeAssistant, coordinator: TodoistCoordinator
-) -> None:
-    """Register services."""
-
-    if hass.services.has_service(DOMAIN, SERVICE_NEW_TASK):
-        return
-
-    session = async_get_clientsession(hass)
-
-    async def handle_new_task(call: ServiceCall) -> None:
-        """Call when a user creates a new Todoist Task from Home Assistant."""
-        project_name = call.data[PROJECT_NAME]
-        projects = await coordinator.async_get_projects()
-        project_id: str | None = None
-        for project in projects:
-            if project_name == project.name.lower():
-                project_id = project.id
-                break
-        if project_id is None:
-            raise ServiceValidationError(
-                translation_domain=DOMAIN,
-                translation_key="project_invalid",
-                translation_placeholders={
-                    "project": project_name,
-                },
-            )
-
-        # Optional section within project
-        section_id: str | None = None
-        if SECTION_NAME in call.data:
-            section_name = call.data[SECTION_NAME]
-            sections = await coordinator.async_get_sections(project_id)
-            for section in sections:
-                if section_name == section.name.lower():
-                    section_id = section.id
-                    break
-            if section_id is None:
-                raise ServiceValidationError(
-                    translation_domain=DOMAIN,
-                    translation_key="section_invalid",
-                    translation_placeholders={
-                        "section": section_name,
-                        "project": project_name,
-                    },
-                )
-
-        # Create the task
-        content = call.data[CONTENT]
-        data: dict[str, Any] = {"project_id": project_id}
-
-        if description := call.data.get(DESCRIPTION):
-            data["description"] = description
-
-        if section_id is not None:
-            data["section_id"] = section_id
-
-        if task_labels := call.data.get(LABELS):
-            data["labels"] = task_labels
-
-        if ASSIGNEE in call.data:
-            collaborators_result = await coordinator.api.get_collaborators(project_id)
-            all_collaborators = await flatten_async_pages(collaborators_result)
-            collaborator_id_lookup = {
-                collab.name.lower(): collab.id for collab in all_collaborators
-            }
-            task_assignee = call.data[ASSIGNEE].lower()
-            if task_assignee in collaborator_id_lookup:
-                data["assignee_id"] = collaborator_id_lookup[task_assignee]
-            else:
-                raise ValueError(
-                    f"User is not part of the shared project. user: {task_assignee}"
-                )
-
-        if PRIORITY in call.data:
-            data["priority"] = call.data[PRIORITY]
-
-        if DUE_DATE_STRING in call.data:
-            data["due_string"] = call.data[DUE_DATE_STRING]
-
-        if DUE_DATE_LANG in call.data:
-            data["due_lang"] = call.data[DUE_DATE_LANG]
-
-        if DUE_DATE in call.data:
-            due_date = dt_util.parse_datetime(call.data[DUE_DATE])
-            if due_date is None:
-                due = dt_util.parse_date(call.data[DUE_DATE])
-                if due is None:
-                    raise ValueError(f"Invalid due_date: {call.data[DUE_DATE]}")
-                due_date = datetime(due.year, due.month, due.day)
-            # Pass the datetime object directly - the library handles formatting
-            data["due_datetime"] = dt_util.as_utc(due_date)
-
-        api_task = await coordinator.api.add_task(content, **data)
-
-        # The REST API doesn't support reminders, so we use the Sync API directly
-        # to maintain functional parity with the component.
-        # https://developer.todoist.com/api/v1/#tag/Sync/Reminders/Add-a-reminder
-        _reminder_due: dict = {}
-        if REMINDER_DATE_STRING in call.data:
-            _reminder_due["string"] = call.data[REMINDER_DATE_STRING]
-
-        if REMINDER_DATE_LANG in call.data:
-            _reminder_due["lang"] = call.data[REMINDER_DATE_LANG]
-
-        if REMINDER_DATE in call.data:
-            reminder_date = dt_util.parse_datetime(call.data[REMINDER_DATE])
-            if reminder_date is None:
-                reminder = dt_util.parse_date(call.data[REMINDER_DATE])
-                if reminder is None:
-                    raise ValueError(
-                        f"Invalid reminder_date: {call.data[REMINDER_DATE]}"
-                    )
-                reminder_date = datetime(reminder.year, reminder.month, reminder.day)
-            # Format it in the manner Todoist expects (UTC with Z suffix)
-            reminder_date = dt_util.as_utc(reminder_date)
-            date_format = "%Y-%m-%dT%H:%M:%S.000000Z"
-            _reminder_due["date"] = datetime.strftime(reminder_date, date_format)
-
-        if _reminder_due:
-            sync_url = "https://api.todoist.com/api/v1/sync"
-            reminder_data = {
-                "commands": [
-                    {
-                        "type": "reminder_add",
-                        "temp_id": str(uuid.uuid1()),
-                        "uuid": str(uuid.uuid1()),
-                        "args": {
-                            "item_id": api_task.id,
-                            "type": "absolute",
-                            "due": _reminder_due,
-                        },
-                    }
-                ]
-            }
-            headers = {
-                "Authorization": f"Bearer {coordinator.token}",
-                "Content-Type": "application/json",
-            }
-            await session.post(sync_url, headers=headers, json=reminder_data)
-
-        _LOGGER.debug("Created Todoist task: %s", call.data[CONTENT])
-
-    # pylint: disable-next=home-assistant-service-registered-in-setup-entry
-    hass.services.async_register(
-        DOMAIN, SERVICE_NEW_TASK, handle_new_task, schema=NEW_TASK_SERVICE_SCHEMA
-    )
 
 
 class TodoistProjectEntity(CoordinatorEntity[TodoistCoordinator], CalendarEntity):

--- a/homeassistant/components/todoist/services.py
+++ b/homeassistant/components/todoist/services.py
@@ -31,7 +31,7 @@ from .const import (
     SECTION_NAME,
     SERVICE_NEW_TASK,
 )
-from .coordinator import TodoistConfigEntry, flatten_async_pages
+from .coordinator import TodoistConfigEntry, TodoistCoordinator, flatten_async_pages
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -56,10 +56,22 @@ NEW_TASK_SERVICE_SCHEMA = vol.Schema(
 )
 
 
+def _async_get_coordinator(hass: HomeAssistant) -> TodoistCoordinator:
+    """Return a coordinator to service the request.
+
+    Coordinators created by the legacy YAML calendar platform have no config
+    entry, so they are stored in hass.data and take precedence. Otherwise fall
+    back to the single loaded config entry.
+    """
+    if coordinators := hass.data.get(DOMAIN):
+        return coordinators[0]
+    entry: TodoistConfigEntry = service.async_get_config_entry(hass, DOMAIN, None)
+    return entry.runtime_data
+
+
 async def handle_new_task(call: ServiceCall) -> None:
     """Call when a user creates a new Todoist Task from Home Assistant."""
-    entry: TodoistConfigEntry = service.async_get_config_entry(call.hass, DOMAIN, None)
-    coordinator = entry.runtime_data
+    coordinator = _async_get_coordinator(call.hass)
     project_name = call.data[PROJECT_NAME]
     projects = await coordinator.async_get_projects()
     project_id: str | None = None

--- a/homeassistant/components/todoist/services.py
+++ b/homeassistant/components/todoist/services.py
@@ -1,0 +1,201 @@
+"""Services for Todoist."""
+
+from datetime import datetime
+import logging
+from typing import Any
+import uuid
+
+import voluptuous as vol
+
+from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import config_validation as cv, service
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.util import dt as dt_util
+
+from .const import (
+    ASSIGNEE,
+    CONTENT,
+    DESCRIPTION,
+    DOMAIN,
+    DUE_DATE,
+    DUE_DATE_LANG,
+    DUE_DATE_STRING,
+    DUE_DATE_VALID_LANGS,
+    LABELS,
+    PRIORITY,
+    PROJECT_NAME,
+    REMINDER_DATE,
+    REMINDER_DATE_LANG,
+    REMINDER_DATE_STRING,
+    SECTION_NAME,
+    SERVICE_NEW_TASK,
+)
+from .coordinator import TodoistConfigEntry, flatten_async_pages
+
+_LOGGER = logging.getLogger(__name__)
+
+NEW_TASK_SERVICE_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONTENT): cv.string,
+        vol.Optional(DESCRIPTION): cv.string,
+        vol.Optional(PROJECT_NAME, default="inbox"): vol.All(cv.string, vol.Lower),
+        vol.Optional(SECTION_NAME): vol.All(cv.string, vol.Lower),
+        vol.Optional(LABELS): cv.ensure_list_csv,
+        vol.Optional(ASSIGNEE): cv.string,
+        vol.Optional(PRIORITY): vol.All(vol.Coerce(int), vol.Range(min=1, max=4)),
+        vol.Exclusive(DUE_DATE_STRING, "due_date"): cv.string,
+        vol.Optional(DUE_DATE_LANG): vol.All(cv.string, vol.In(DUE_DATE_VALID_LANGS)),
+        vol.Exclusive(DUE_DATE, "due_date"): cv.string,
+        vol.Exclusive(REMINDER_DATE_STRING, "reminder_date"): cv.string,
+        vol.Optional(REMINDER_DATE_LANG): vol.All(
+            cv.string, vol.In(DUE_DATE_VALID_LANGS)
+        ),
+        vol.Exclusive(REMINDER_DATE, "reminder_date"): cv.string,
+    }
+)
+
+
+async def handle_new_task(call: ServiceCall) -> None:
+    """Call when a user creates a new Todoist Task from Home Assistant."""
+    entry: TodoistConfigEntry = service.async_get_config_entry(call.hass, DOMAIN, None)
+    coordinator = entry.runtime_data
+    project_name = call.data[PROJECT_NAME]
+    projects = await coordinator.async_get_projects()
+    project_id: str | None = None
+    for project in projects:
+        if project_name == project.name.lower():
+            project_id = project.id
+            break
+    if project_id is None:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="project_invalid",
+            translation_placeholders={
+                "project": project_name,
+            },
+        )
+
+    # Optional section within project
+    section_id: str | None = None
+    if SECTION_NAME in call.data:
+        section_name = call.data[SECTION_NAME]
+        sections = await coordinator.async_get_sections(project_id)
+        for section in sections:
+            if section_name == section.name.lower():
+                section_id = section.id
+                break
+        if section_id is None:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="section_invalid",
+                translation_placeholders={
+                    "section": section_name,
+                    "project": project_name,
+                },
+            )
+
+    # Create the task
+    content = call.data[CONTENT]
+    data: dict[str, Any] = {"project_id": project_id}
+
+    if description := call.data.get(DESCRIPTION):
+        data["description"] = description
+
+    if section_id is not None:
+        data["section_id"] = section_id
+
+    if task_labels := call.data.get(LABELS):
+        data["labels"] = task_labels
+
+    if ASSIGNEE in call.data:
+        collaborators_result = await coordinator.api.get_collaborators(project_id)
+        all_collaborators = await flatten_async_pages(collaborators_result)
+        collaborator_id_lookup = {
+            collab.name.lower(): collab.id for collab in all_collaborators
+        }
+        task_assignee = call.data[ASSIGNEE].lower()
+        if task_assignee in collaborator_id_lookup:
+            data["assignee_id"] = collaborator_id_lookup[task_assignee]
+        else:
+            raise ValueError(
+                f"User is not part of the shared project. user: {task_assignee}"
+            )
+
+    if PRIORITY in call.data:
+        data["priority"] = call.data[PRIORITY]
+
+    if DUE_DATE_STRING in call.data:
+        data["due_string"] = call.data[DUE_DATE_STRING]
+
+    if DUE_DATE_LANG in call.data:
+        data["due_lang"] = call.data[DUE_DATE_LANG]
+
+    if DUE_DATE in call.data:
+        due_date = dt_util.parse_datetime(call.data[DUE_DATE])
+        if due_date is None:
+            due = dt_util.parse_date(call.data[DUE_DATE])
+            if due is None:
+                raise ValueError(f"Invalid due_date: {call.data[DUE_DATE]}")
+            due_date = datetime(due.year, due.month, due.day)
+        # Pass the datetime object directly - the library handles formatting
+        data["due_datetime"] = dt_util.as_utc(due_date)
+
+    api_task = await coordinator.api.add_task(content, **data)
+
+    # The REST API doesn't support reminders, so we use the Sync API directly
+    # to maintain functional parity with the component.
+    # https://developer.todoist.com/api/v1/#tag/Sync/Reminders/Add-a-reminder
+    _reminder_due: dict = {}
+    if REMINDER_DATE_STRING in call.data:
+        _reminder_due["string"] = call.data[REMINDER_DATE_STRING]
+
+    if REMINDER_DATE_LANG in call.data:
+        _reminder_due["lang"] = call.data[REMINDER_DATE_LANG]
+
+    if REMINDER_DATE in call.data:
+        reminder_date = dt_util.parse_datetime(call.data[REMINDER_DATE])
+        if reminder_date is None:
+            reminder = dt_util.parse_date(call.data[REMINDER_DATE])
+            if reminder is None:
+                raise ValueError(f"Invalid reminder_date: {call.data[REMINDER_DATE]}")
+            reminder_date = datetime(reminder.year, reminder.month, reminder.day)
+        # Format it in the manner Todoist expects (UTC with Z suffix)
+        reminder_date = dt_util.as_utc(reminder_date)
+        date_format = "%Y-%m-%dT%H:%M:%S.000000Z"
+        _reminder_due["date"] = datetime.strftime(reminder_date, date_format)
+
+    if _reminder_due:
+        sync_url = "https://api.todoist.com/api/v1/sync"
+        reminder_data = {
+            "commands": [
+                {
+                    "type": "reminder_add",
+                    "temp_id": str(uuid.uuid1()),
+                    "uuid": str(uuid.uuid1()),
+                    "args": {
+                        "item_id": api_task.id,
+                        "type": "absolute",
+                        "due": _reminder_due,
+                    },
+                }
+            ]
+        }
+        headers = {
+            "Authorization": f"Bearer {coordinator.token}",
+            "Content-Type": "application/json",
+        }
+        await async_get_clientsession(call.hass).post(
+            sync_url, headers=headers, json=reminder_data
+        )
+
+    _LOGGER.debug("Created Todoist task: %s", call.data[CONTENT])
+
+
+@callback
+def async_setup_services(hass: HomeAssistant) -> None:
+    """Register services."""
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_NEW_TASK, handle_new_task, schema=NEW_TASK_SERVICE_SCHEMA
+    )

--- a/tests/components/todoist/test_calendar.py
+++ b/tests/components/todoist/test_calendar.py
@@ -297,7 +297,7 @@ async def test_create_task_service_call_raises(
 ) -> None:
     """Test adding an item to an invalid project raises an error."""
 
-    with pytest.raises(ServiceValidationError, match="project_invalid"):
+    with pytest.raises(ServiceValidationError) as exc:
         await hass.services.async_call(
             DOMAIN,
             SERVICE_NEW_TASK,
@@ -309,6 +309,7 @@ async def test_create_task_service_call_raises(
             },
             blocking=True,
         )
+    assert exc.value.translation_key == "project_invalid"
 
 
 async def test_create_task_service_call_with_section(

--- a/tests/components/todoist/test_init.py
+++ b/tests/components/todoist/test_init.py
@@ -5,9 +5,18 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from homeassistant.components.todoist.const import DOMAIN
+from homeassistant.components.todoist.const import (
+    ASSIGNEE,
+    CONTENT,
+    DOMAIN,
+    LABELS,
+    PROJECT_NAME,
+    SERVICE_NEW_TASK,
+)
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+
+from .conftest import PROJECT_ID
 
 from tests.common import MockConfigEntry
 
@@ -25,6 +34,24 @@ async def test_load_unload(
 
     assert await hass.config_entries.async_unload(todoist_config_entry.entry_id)
     assert todoist_config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+@pytest.mark.usefixtures("setup_integration")
+async def test_new_task_service_uses_config_entry(
+    hass: HomeAssistant,
+    api: AsyncMock,
+) -> None:
+    """Test the new_task service reaches the config entry coordinator."""
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_NEW_TASK,
+        {ASSIGNEE: "user", CONTENT: "task", LABELS: ["Label1"], PROJECT_NAME: "Name"},
+        blocking=True,
+    )
+
+    api.add_task.assert_called_with(
+        "task", project_id=PROJECT_ID, labels=["Label1"], assignee_id="1"
+    )
 
 
 @pytest.mark.parametrize("todoist_api_status", [HTTPStatus.INTERNAL_SERVER_ERROR])


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Move service registration to async_setup in Todoist.

Todoist still supports the legacy YAML calendar platform (`platform: todoist`), which creates a coordinator without a config entry. Because of that, the `new_task` service cannot rely solely on `async_get_config_entry`. The YAML coordinator is now exposed through `hass.data` and preferred by the service handler, which falls back to the single loaded config entry otherwise. This keeps the service working for both YAML and config-entry setups.

Part of https://github.com/home-assistant/epics/issues/65


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170752 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

