### PR TITLE
Remove previously deprecated battery props from tplink

### DIFF
--- a/homeassistant/components/tplink/vacuum.py
+++ b/homeassistant/components/tplink/vacuum.py
@@ -94,7 +94,6 @@ class TPLinkVacuumEntity(CoordinatedTPLinkModuleEntity, StateVacuumEntity):
 
     _attr_supported_features = (
         VacuumEntityFeature.STATE
-        | VacuumEntityFeature.BATTERY
         | VacuumEntityFeature.START
         | VacuumEntityFeature.PAUSE
         | VacuumEntityFeature.RETURN_HOME
@@ -151,12 +150,6 @@ class TPLinkVacuumEntity(CoordinatedTPLinkModuleEntity, StateVacuumEntity):
     async def async_locate(self, **kwargs: Any) -> None:
         """Locate the device."""
         await self._speaker_module.locate()
-
-    @property
-    @override
-    def battery_level(self) -> int | None:
-        """Return battery level."""
-        return self._vacuum_module.battery
 
     @override
     def _async_update_attrs(self) -> bool:

--- a/tests/components/tplink/snapshots/test_vacuum.ambr
+++ b/tests/components/tplink/snapshots/test_vacuum.ambr
@@ -70,7 +70,7 @@
     'platform': 'tplink',
     'previous_unique_id': None,
     'suggested_object_id': None,
-    'supported_features': <VacuumEntityFeature: 12916>,
+    'supported_features': <VacuumEntityFeature: 12852>,
     'translation_key': 'vacuum',
     'unique_id': '123456789ABCDEFGH-vacuum',
     'unit_of_measurement': None,
@@ -79,15 +79,13 @@
 # name: test_states[vacuum.my_vacuum-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'battery_icon': 'mdi:battery-charging-100',
-      'battery_level': 100,
       <VacuumEntityStateAttribute.FAN_SPEED: 'fan_speed'>: 'max',
       <VacuumEntityCapabilityAttribute.FAN_SPEED_LIST: 'fan_speed_list'>: list([
         'quiet',
         'max',
       ]),
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'my_vacuum',
-      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <VacuumEntityFeature: 12916>,
+      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <VacuumEntityFeature: 12852>,
     }),
     'context': <ANY>,
     'entity_id': 'vacuum.my_vacuum',

--- a/tests/components/tplink/test_vacuum.py
+++ b/tests/components/tplink/test_vacuum.py
@@ -5,7 +5,6 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.vacuum import (
-    ATTR_BATTERY_LEVEL,
     ATTR_FAN_SPEED,
     DOMAIN as VACUUM_DOMAIN,
     SERVICE_LOCATE,
@@ -62,7 +61,6 @@ async def test_vacuum(
     assert state.state == VacuumActivity.DOCKED
 
     assert state.attributes[ATTR_FAN_SPEED] == "max"
-    assert state.attributes[ATTR_BATTERY_LEVEL] == 100
     result = translation.async_translate_state(
         hass, "max", "vacuum", "tplink", "vacuum.state_attributes.fan_speed", None
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
Remove previously deprecated battery props from TPlink `vacuum` platform

## Proposed change
Linked to: https://github.com/home-assistant/core/pull/175682


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository. 