### PR TITLE
Improve time handling in Nord Pool

### DIFF
--- a/homeassistant/components/nordpool/coordinator.py
+++ b/homeassistant/components/nordpool/coordinator.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, override
 
 import aiohttp
+from aiozoneinfo import get_time_zone
 from pynordpool import (
     Currency,
     DeliveryPeriodData,
@@ -27,6 +28,13 @@ from .const import CONF_AREAS, DOMAIN, LOGGER
 if TYPE_CHECKING:
     from . import NordPoolConfigEntry
 
+NORDPOOL_TIMEZONE = get_time_zone("Europe/Oslo")
+
+
+def get_nordpool_current_time() -> datetime:
+    """Return the Nord Pool current time."""
+    return dt_util.utcnow().astimezone(NORDPOOL_TIMEZONE)
+
 
 class NordPoolDataUpdateCoordinator(DataUpdateCoordinator[DeliveryPeriodsData]):
     """A Nord Pool Data Update Coordinator."""
@@ -47,26 +55,20 @@ class NordPoolDataUpdateCoordinator(DataUpdateCoordinator[DeliveryPeriodsData]):
 
     def get_next_data_interval(self, now: datetime) -> datetime:
         """Compute next time an update should occur."""
-        next_hour = dt_util.utcnow() + timedelta(hours=1)
-        next_run = datetime(
-            next_hour.year,
-            next_hour.month,
-            next_hour.day,
-            next_hour.hour,
-            tzinfo=dt_util.UTC,
-        )
-        LOGGER.debug("Next data update at %s", next_run)
+        next_data_run = now + timedelta(hours=1)
+        next_run = next_data_run.replace(minute=0, second=0, microsecond=0)
+        LOGGER.debug("Next data update at %s", next_run.astimezone(NORDPOOL_TIMEZONE))
         return next_run
 
     def get_next_15_interval(self, now: datetime) -> datetime:
         """Compute next time we need to notify listeners."""
-        next_run = dt_util.utcnow() + timedelta(minutes=15)
+        next_run = now + timedelta(minutes=15)
         next_minute = next_run.minute // 15 * 15
-        next_run = next_run.replace(
-            minute=next_minute, second=0, microsecond=0, tzinfo=dt_util.UTC
-        )
+        next_run = next_run.replace(minute=next_minute, second=0, microsecond=0)
 
-        LOGGER.debug("Next listener update at %s", next_run)
+        LOGGER.debug(
+            "Next listener update at %s", next_run.astimezone(NORDPOOL_TIMEZONE)
+        )
         return next_run
 
     @override
@@ -85,14 +87,14 @@ class NordPoolDataUpdateCoordinator(DataUpdateCoordinator[DeliveryPeriodsData]):
         self.listener_unsub = async_track_point_in_utc_time(
             self.hass,
             self.update_listeners,
-            self.get_next_15_interval(dt_util.utcnow()),
+            self.get_next_15_interval(now),
         )
         self.async_update_listeners()
 
     async def fetch_data(self, now: datetime, initial: bool = False) -> None:
         """Fetch data from Nord Pool."""
         self.data_unsub = async_track_point_in_utc_time(
-            self.hass, self.fetch_data, self.get_next_data_interval(dt_util.utcnow())
+            self.hass, self.fetch_data, self.get_next_data_interval(now)
         )
         if self.config_entry.pref_disable_polling and not initial:
             return
@@ -107,7 +109,7 @@ class NordPoolDataUpdateCoordinator(DataUpdateCoordinator[DeliveryPeriodsData]):
         """Fetch data from Nord Pool."""
         data = await self.api_call()
         if data and data.entries:
-            current_day = dt_util.now().date()
+            current_day = get_nordpool_current_time().date()
             if current_day in data.entries:
                 LOGGER.debug("Data for current day found")
                 return data
@@ -129,9 +131,9 @@ class NordPoolDataUpdateCoordinator(DataUpdateCoordinator[DeliveryPeriodsData]):
         try:
             data = await self.client.async_get_delivery_periods(
                 [
-                    dt_util.now() - timedelta(days=1),
-                    dt_util.now(),
-                    dt_util.now() + timedelta(days=1),
+                    get_nordpool_current_time() - timedelta(days=1),
+                    get_nordpool_current_time(),
+                    get_nordpool_current_time() + timedelta(days=1),
                 ],
                 Currency(self.config_entry.data[CONF_CURRENCY]),
                 self.config_entry.data[CONF_AREAS],
@@ -164,10 +166,10 @@ class NordPoolDataUpdateCoordinator(DataUpdateCoordinator[DeliveryPeriodsData]):
 
     def get_data_current_day(self) -> DeliveryPeriodData:
         """Return the current day data."""
-        current_day = dt_util.now().date()
+        current_day = get_nordpool_current_time().date()
         return self.data.entries[current_day]
 
     def get_data_tomorrow(self) -> DeliveryPeriodData | None:
         """Return tomorrow's day data if available."""
-        tomorrow = dt_util.now().date() + timedelta(days=1)
+        tomorrow = get_nordpool_current_time().date() + timedelta(days=1)
         return self.data.entries.get(tomorrow)

--- a/tests/components/nordpool/conftest.py
+++ b/tests/components/nordpool/conftest.py
@@ -1,6 +1,7 @@
 """Fixtures for the Nord Pool integration."""
 
 from collections.abc import AsyncGenerator
+from http import HTTPStatus
 import json
 from typing import Any
 
@@ -107,6 +108,28 @@ async def get_data_from_library(
             "currency": "SEK",
         },
         json=load_json[2],
+    )
+    aioclient_mock.request(
+        "GET",
+        url=API + "/DayAheadPrices",
+        params={
+            "date": "2025-10-03",
+            "market": "DayAhead",
+            "deliveryArea": "SE3,SE4",
+            "currency": "SEK",
+        },
+        status=HTTPStatus.NO_CONTENT,
+    )
+    aioclient_mock.request(
+        "GET",
+        url=API + "/DayAheadPrices",
+        params={
+            "date": "2025-10-04",
+            "market": "DayAhead",
+            "deliveryArea": "SE3,SE4",
+            "currency": "SEK",
+        },
+        status=HTTPStatus.NO_CONTENT,
     )
     client = NordPoolClient(aioclient_mock.create_session(hass.loop))
     yield client

--- a/tests/components/nordpool/test_coordinator.py
+++ b/tests/components/nordpool/test_coordinator.py
@@ -29,7 +29,7 @@ from . import ENTRY_CONFIG
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
-@pytest.mark.freeze_time("2025-10-01T10:00:00+00:00")
+@pytest.mark.freeze_time("2025-10-01T10:00:00+02:00")
 async def test_coordinator(
     hass: HomeAssistant,
     get_client: NordPoolClient,
@@ -48,11 +48,12 @@ async def test_coordinator(
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
     state = hass.states.get("sensor.nord_pool_se3_current_price")
-    assert state.state == "0.67405"
+    assert state.state == "1.03744"
 
-    assert "Next data update at 2025-10-01 11:00:00+00:00" in caplog.text
-    assert "Next listener update at 2025-10-01 10:15:00+00:00" in caplog.text
+    assert "Next data update at 2025-10-01 11:00:00+02:00" in caplog.text
+    assert "Next listener update at 2025-10-01 10:15:00+02:00" in caplog.text
 
+    caplog.clear()
     with (
         patch(
             "homeassistant.components.nordpool.coordinator.NordPoolClient.async_get_delivery_period",
@@ -64,10 +65,10 @@ async def test_coordinator(
         await hass.async_block_till_done(wait_background_tasks=True)
         assert mock_data.call_count == 0
         state = hass.states.get("sensor.nord_pool_se3_current_price")
-        assert state.state == "0.63858"
+        assert state.state == "0.95013"
 
-    assert "Next data update at 2025-10-01 11:00:00+00:00" in caplog.text
-    assert "Next listener update at 2025-10-01 10:30:00+00:00" in caplog.text
+    assert "Next data update at 2025-10-01 11:00:00+02:00" not in caplog.text
+    assert "Next listener update at 2025-10-01 10:30:00+02:00" in caplog.text
 
     with (
         patch(
@@ -80,7 +81,7 @@ async def test_coordinator(
         await hass.async_block_till_done(wait_background_tasks=True)
         assert mock_data.call_count == 1
         state = hass.states.get("sensor.nord_pool_se3_current_price")
-        assert state.state == "0.66068"
+        assert state.state == "0.72279"
 
     with (
         patch(
@@ -94,9 +95,10 @@ async def test_coordinator(
         await hass.async_block_till_done(wait_background_tasks=True)
         assert mock_data.call_count == 1
         state = hass.states.get("sensor.nord_pool_se3_current_price")
-        assert state.state == "0.68544"
+        assert state.state == "0.63858"
         assert "Authentication error" in caplog.text
 
+    caplog.clear()
     with (
         patch(
             "homeassistant.components.nordpool.coordinator.NordPoolClient.async_get_delivery_period",
@@ -110,7 +112,7 @@ async def test_coordinator(
         # Empty responses does not raise
         assert mock_data.call_count == 3
         state = hass.states.get("sensor.nord_pool_se3_current_price")
-        assert state.state == "0.72953"
+        assert state.state == "0.66068"
         assert "Empty response" in caplog.text
 
     with (
@@ -125,7 +127,7 @@ async def test_coordinator(
         await hass.async_block_till_done(wait_background_tasks=True)
         assert mock_data.call_count == 1
         state = hass.states.get("sensor.nord_pool_se3_current_price")
-        assert state.state == "0.90294"
+        assert state.state == "0.68544"
         assert "error" in caplog.text
 
     with (
@@ -140,7 +142,7 @@ async def test_coordinator(
         await hass.async_block_till_done(wait_background_tasks=True)
         assert mock_data.call_count == 1
         state = hass.states.get("sensor.nord_pool_se3_current_price")
-        assert state.state == "1.16266"
+        assert state.state == "0.72953"
         assert "error" in caplog.text
 
     with (
@@ -155,14 +157,14 @@ async def test_coordinator(
         await hass.async_block_till_done(wait_background_tasks=True)
         assert mock_data.call_count == 1
         state = hass.states.get("sensor.nord_pool_se3_current_price")
-        assert state.state == "1.90004"
+        assert state.state == "0.90294"
         assert "Response error" in caplog.text
 
     freezer.tick(timedelta(hours=1))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
     state = hass.states.get("sensor.nord_pool_se3_current_price")
-    assert state.state == "3.42983"
+    assert state.state == "1.16266"
 
     # Test manual polling
     hass.config_entries.async_update_entry(
@@ -173,14 +175,14 @@ async def test_coordinator(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
     state = hass.states.get("sensor.nord_pool_se3_current_price")
-    assert state.state == "1.42403"
+    assert state.state == "1.90004"
 
     # Prices should update without any polling made (read from cache)
     freezer.tick(timedelta(hours=1))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
     state = hass.states.get("sensor.nord_pool_se3_current_price")
-    assert state.state == "1.1358"
+    assert state.state == "3.42983"
 
     # Test manually updating the data
     with (
@@ -201,7 +203,7 @@ async def test_coordinator(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
     state = hass.states.get("sensor.nord_pool_se3_current_price")
-    assert state.state == "0.933"
+    assert state.state == "1.42403"
 
     hass.config_entries.async_update_entry(
         entry=config_entry, pref_disable_polling=False


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change


## Proposed change
Improve time handling in Nord Pool, ensure we use Nord Pool timezone for which day we're at.
All logging done in Nord Pool timezone

Related to: https://github.com/home-assistant/core/pull/175715

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository. 