### PR TITLE
Add renew authentication token in additional coordinators for solarlog

### DIFF
--- a/homeassistant/components/solarlog/coordinator.py
+++ b/homeassistant/components/solarlog/coordinator.py
@@ -154,6 +154,13 @@ class SolarLogDeviceDataCoordinator(DataUpdateCoordinator[dict[int, InverterData
             await self.solarlog.update_device_list()
             inverter_data = await self.solarlog.update_inverter_data()
         except SolarLogAuthenticationError as ex:
+            # check, if only access token has expired, try to renew it and retry data update
+            if await self.config_entry.runtime_data.basic_data_coordinator.renew_authentication():
+                # login was successful, retry data update
+                raise UpdateFailed(
+                    translation_domain=DOMAIN,
+                    translation_key="update_failed",
+                ) from ex
             raise ConfigEntryAuthFailed(
                 translation_domain=DOMAIN,
                 translation_key="auth_failed",
@@ -286,6 +293,13 @@ class SolarLogLongtimeDataCoordinator(DataUpdateCoordinator[EnergyData]):
                 timeout=self.connection_timeout
             )
         except SolarLogAuthenticationError as ex:
+            # check, if only access token has expired, try to renew it and retry data update
+            if await self.config_entry.runtime_data.basic_data_coordinator.renew_authentication():
+                # login was successful, retry data update
+                raise UpdateFailed(
+                    translation_domain=DOMAIN,
+                    translation_key="update_failed",
+                ) from ex
             raise ConfigEntryAuthFailed(
                 translation_domain=DOMAIN,
                 translation_key="auth_failed",

--- a/tests/components/solarlog/test_init.py
+++ b/tests/components/solarlog/test_init.py
@@ -15,9 +15,9 @@ from solarlog_cli.solarlog_models import EnergyData
 
 from homeassistant.components.solarlog.const import CONF_HAS_PWD, DOMAIN
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import CONF_HOST, CONF_TIMEOUT, Platform
+from homeassistant.const import CONF_HOST, CONF_TIMEOUT, STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.device_registry import DeviceRegistry
 from homeassistant.helpers.entity_registry import EntityRegistry
 
@@ -123,6 +123,77 @@ async def test_other_exceptions_during_first_refresh(
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
 
     assert len(hass.config_entries.flow.async_progress()) == 0
+
+
+async def test_devicedatacoordinator_exceptions_during_refresh(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_solarlog_connector: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test the correct exceptions are thrown during first refresh of SolarLogDeviceDataCoordinator."""
+
+    await setup_platform(hass, mock_config_entry, [Platform.SENSOR])
+    await hass.async_block_till_done()
+
+    mock_solarlog_connector.update_inverter_data.side_effect = (
+        SolarLogAuthenticationError
+    )
+
+    freezer.tick(delta=timedelta(minutes=2))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("sensor.inverter_1_power").state == STATE_UNAVAILABLE
+
+    mock_solarlog_connector.login.return_value = False
+    mock_solarlog_connector.login.side_effect = None
+
+    freezer.tick(delta=timedelta(minutes=2))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    config_entry = hass.config_entries.async_get_entry(mock_config_entry.entry_id)
+    assert isinstance(
+        config_entry.runtime_data.device_data_coordinator.last_exception,
+        ConfigEntryAuthFailed,
+    )
+
+
+async def test_longtimedatacoordinator_exceptions_during_refresh(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_solarlog_connector: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test the correct exceptions are thrown during first refresh of SolarLogLongtimeDataCoordinator."""
+
+    await setup_platform(hass, mock_config_entry, [Platform.SENSOR])
+    await hass.async_block_till_done()
+
+    mock_solarlog_connector.update_energy_data.side_effect = SolarLogAuthenticationError
+
+    freezer.tick(delta=timedelta(minutes=2))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert (
+        hass.states.get("sensor.solarlog_self_consumption_year").state
+        == STATE_UNAVAILABLE
+    )
+
+    mock_solarlog_connector.login.return_value = False
+    mock_solarlog_connector.login.side_effect = None
+
+    freezer.tick(delta=timedelta(minutes=2))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    config_entry = hass.config_entries.async_get_entry(mock_config_entry.entry_id)
+    assert isinstance(
+        config_entry.runtime_data.longtime_data_coordinator.last_exception,
+        ConfigEntryAuthFailed,
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently only in the basic data update coordinator a renewal of the authentication token is made. This fix adds a renewal also for the other coordinators, as apparently there are users experiencing problems when the token expires and is not renewed automatically.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #169718
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
