### PR TITLE
Reproduce only value in counter reproduce_state

### DIFF
--- a/homeassistant/components/counter/reproduce_state.py
+++ b/homeassistant/components/counter/reproduce_state.py
@@ -8,7 +8,7 @@ from typing import Any
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import Context, HomeAssistant, State
 
-from . import ATTR_MAXIMUM, ATTR_MINIMUM, ATTR_STEP, DOMAIN, SERVICE_SET_VALUE, VALUE
+from . import DOMAIN, SERVICE_SET_VALUE, VALUE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,25 +32,13 @@ async def _async_reproduce_state(
         return
 
     # Return if we are already at the right state.
-    if (
-        cur_state.state == state.state
-        and cur_state.attributes.get(ATTR_MAXIMUM) == state.attributes.get(ATTR_MAXIMUM)
-        and cur_state.attributes.get(ATTR_MINIMUM) == state.attributes.get(ATTR_MINIMUM)
-        and cur_state.attributes.get(ATTR_STEP) == state.attributes.get(ATTR_STEP)
-    ):
+    if cur_state.state == state.state:
         return
 
     service_data = {ATTR_ENTITY_ID: state.entity_id, VALUE: state.state}
-    service = SERVICE_SET_VALUE
-    if ATTR_MAXIMUM in state.attributes:
-        service_data[ATTR_MAXIMUM] = state.attributes[ATTR_MAXIMUM]
-    if ATTR_MINIMUM in state.attributes:
-        service_data[ATTR_MINIMUM] = state.attributes[ATTR_MINIMUM]
-    if ATTR_STEP in state.attributes:
-        service_data[ATTR_STEP] = state.attributes[ATTR_STEP]
 
     await hass.services.async_call(
-        DOMAIN, service, service_data, context=context, blocking=True
+        DOMAIN, SERVICE_SET_VALUE, service_data, context=context, blocking=True
     )
 
 

--- a/tests/components/counter/test_reproduce_state.py
+++ b/tests/components/counter/test_reproduce_state.py
@@ -14,11 +14,13 @@ async def test_reproducing_states(
 ) -> None:
     """Test reproducing Counter states."""
     hass.states.async_set("counter.entity", "5", {})
-    hass.states.async_set("counter.entity_attr", "8", {})
+    hass.states.async_set(
+        "counter.entity_attr", "8", {"minimum": 5, "maximum": 15, "step": 3}
+    )
 
     set_value_calls = async_mock_service(hass, DOMAIN, "set_value")
 
-    # These calls should do nothing as entities already in desired state
+    # These calls should do nothing as entity already in desired state
     await async_reproduce_state(
         hass,
         [
@@ -40,7 +42,7 @@ async def test_reproducing_states(
         hass,
         [
             State("counter.entity", "2"),
-            State("counter.entity_attr", "7"),
+            State("counter.entity_attr", "7", {"minimum": 3, "maximum": 21, "step": 5}),
             # Should not raise
             State("counter.non_existing", "6"),
         ],

--- a/tests/components/counter/test_reproduce_state.py
+++ b/tests/components/counter/test_reproduce_state.py
@@ -14,45 +14,33 @@ async def test_reproducing_states(
 ) -> None:
     """Test reproducing Counter states."""
     hass.states.async_set("counter.entity", "5", {})
-    hass.states.async_set(
-        "counter.entity_attr",
-        "8",
-        {"minimum": 5, "maximum": 15, "step": 3},
-    )
+    hass.states.async_set("counter.entity_attr", "8", {})
 
-    configure_calls = async_mock_service(hass, DOMAIN, "set_value")
+    set_value_calls = async_mock_service(hass, DOMAIN, "set_value")
 
     # These calls should do nothing as entities already in desired state
     await async_reproduce_state(
         hass,
         [
             State("counter.entity", "5"),
-            State(
-                "counter.entity_attr",
-                "8",
-                {"minimum": 5, "maximum": 15, "step": 3},
-            ),
+            State("counter.entity_attr", "8"),
         ],
     )
 
-    assert len(configure_calls) == 0
+    assert len(set_value_calls) == 0
 
     # Test invalid state is handled
     await async_reproduce_state(hass, [State("counter.entity", "not_supported")])
 
     assert "not_supported" in caplog.text
-    assert len(configure_calls) == 0
+    assert len(set_value_calls) == 0
 
     # Make sure correct services are called
     await async_reproduce_state(
         hass,
         [
             State("counter.entity", "2"),
-            State(
-                "counter.entity_attr",
-                "7",
-                {"minimum": 3, "maximum": 21, "step": 5},
-            ),
+            State("counter.entity_attr", "7"),
             # Should not raise
             State("counter.non_existing", "6"),
         ],
@@ -60,16 +48,10 @@ async def test_reproducing_states(
 
     valid_calls = [
         {"entity_id": "counter.entity", "value": "2"},
-        {
-            "entity_id": "counter.entity_attr",
-            "value": "7",
-            "minimum": 3,
-            "maximum": 21,
-            "step": 5,
-        },
+        {"entity_id": "counter.entity_attr", "value": "7"},
     ]
-    assert len(configure_calls) == 2
-    for call in configure_calls:
+    assert len(set_value_calls) == 2
+    for call in set_value_calls:
         assert call.domain == "counter"
         assert call.data in valid_calls
         valid_calls.remove(call.data)


### PR DESCRIPTION
## Breaking change


## Proposed change

The `counter` integration no longer has any service to change `minimum`, `maximum` or `step` at runtime. Those attributes used to be settable via the `counter.configure` service, and `reproduce_state` restored them alongside `value`.

The `configure` service was removed in #103204. That PR mechanically switched `reproduce_state` from `SERVICE_CONFIGURE` to `SERVICE_SET_VALUE`, but left the `minimum`/`maximum`/`step` handling in place — even though `set_value` only accepts `value`. As a result:

- The extra `minimum`/`maximum`/`step` keys added to the service data no longer correspond to anything the `set_value` schema accepts (which validates `{value}` only).
- The only reason this hasn't surfaced as an error is the early-return guard, which short-circuits whenever those attributes already match the current state (the common case, since they rarely change).

This PR strips the dead `minimum`/`maximum`/`step` handling so `reproduce_state` reproduces only the counter value, and simplifies the corresponding test.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
