### PR TITLE
Bump victron-mqtt to 2026.7.0

### DIFF
--- a/homeassistant/components/victron_gx/manifest.json
+++ b/homeassistant/components/victron_gx/manifest.json
@@ -7,7 +7,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "quality_scale": "platinum",
-  "requirements": ["victron-mqtt==2026.6.6"],
+  "requirements": ["victron-mqtt==2026.7.0"],
   "ssdp": [
     {
       "X_MqttOnLan": "1",

--- a/homeassistant/components/victron_gx/strings.json
+++ b/homeassistant/components/victron_gx/strings.json
@@ -94,6 +94,7 @@
     "temperature": "Temperature",
     "terminals_overheated": "Terminals overheated",
     "total_energy": "Total energy",
+    "total_pv_yield_system": "Total PV yield system",
     "total_pv_yield_user": "Total PV yield user",
     "total_yield": "Total yield",
     "unknown": "Unknown",
@@ -325,9 +326,6 @@
       "hub4_ac_grid_setpoint": {
         "name": "AC grid setpoint"
       },
-      "multi_ess_ac_power_setpoint": {
-        "name": "ESS AC power setpoint"
-      },
       "multi_ess_min_soc_limit": {
         "name": "ESS minimum SoC limit"
       },
@@ -491,6 +489,14 @@
           "node_red": "Node-RED",
           "off": "[%key:common::state::off%]",
           "sell": "Sell"
+        }
+      },
+      "system_vrm_portal_mode": {
+        "name": "VRM portal access level",
+        "state": {
+          "full": "[%key:common::state::full%]",
+          "off": "[%key:common::state::off%]",
+          "read_only": "Read-only"
         }
       },
       "vebus_inverter_mode": {
@@ -1317,7 +1323,7 @@
         }
       },
       "inverter_total_pv_yield_system": {
-        "name": "Total PV yield system"
+        "name": "[%key:component::victron_gx::common::total_pv_yield_system%]"
       },
       "inverter_total_pv_yield_user": {
         "name": "[%key:component::victron_gx::common::total_pv_yield_user%]"
@@ -1397,6 +1403,9 @@
       },
       "multi_dc_temperature": {
         "name": "[%key:component::victron_gx::common::dc_temperature%]"
+      },
+      "multi_ess_ac_power_setpoint": {
+        "name": "ESS AC power setpoint"
       },
       "multi_ess_mode": {
         "name": "[%key:component::victron_gx::common::ess_mode%]",
@@ -1628,6 +1637,9 @@
           "sustain_alt": "[%key:component::victron_gx::common::sustain_alt%]"
         }
       },
+      "solarcharger_temperature": {
+        "name": "[%key:component::victron_gx::common::temperature%]"
+      },
       "solarcharger_time_in_absorption_today": {
         "name": "Time in absorption today"
       },
@@ -1636,6 +1648,9 @@
       },
       "solarcharger_time_in_float_today": {
         "name": "Time in float today"
+      },
+      "solarcharger_total_pv_yield_system": {
+        "name": "[%key:component::victron_gx::common::total_pv_yield_system%]"
       },
       "solarcharger_tracker_tracker_current": {
         "name": "PV tracker {tracker} current"
@@ -2254,6 +2269,9 @@
       "system_dvcc": {
         "name": "DVCC"
       },
+      "system_ess_always_peak_shave": {
+        "name": "ESS always peak shave"
+      },
       "system_ess_battery_use": {
         "name": "ESS only critical loads from battery"
       },
@@ -2272,6 +2290,18 @@
       "vebus_device_device_number_power_assist_enabled": {
         "name": "{device_number} PowerAssist enabled"
       },
+      "vebus_hub4_disable_charge": {
+        "name": "Hub4 disable charge"
+      },
+      "vebus_hub4_do_not_feed_in_overvoltage": {
+        "name": "Hub4 do not feed in on overvoltage"
+      },
+      "vebus_hub4_fix_solar_offset_100mv": {
+        "name": "Hub4 fix solar offset to 100mV"
+      },
+      "vebus_hub4_target_power_is_max_feed_in": {
+        "name": "Hub4 target power is max feed-in"
+      },
       "vebus_inverter_ignoreacin1_onoff_control": {
         "name": "Control ignore AC-in-1"
       },
@@ -2280,6 +2310,9 @@
       },
       "vebus_inverter_setting_alarm_grid_lost": {
         "name": "Grid lost alarm setting"
+      },
+      "vebus_pvinverter_disable": {
+        "name": "Vebus PV inverter disable"
       }
     },
     "time": {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3293,7 +3293,7 @@ viaggiatreno_ha==0.2.4
 victron-ble-ha-parser==0.7.0
 
 # homeassistant.components.victron_gx
-victron-mqtt==2026.6.6
+victron-mqtt==2026.7.0
 
 # homeassistant.components.victron_remote_monitoring
 victron-vrm==0.1.12


### PR DESCRIPTION
## Proposed change

Bump `victron-mqtt` library from `2026.6.6` to `2026.7.0` for the `victron_gx` integration.

Changes include:
- Update `victron-mqtt` dependency version in `manifest.json` and requirements files
- Update entity translations (`strings.json`) from latest topic definitions
- Fixing bug #175390

Changelog: https://github.com/tomer-w/victron_mqtt/compare/v2026.6.6...v2026.7.0

## Type of change

- [x] Dependency upgrade

## Additional information

- This PR is related to issue:
- Link to documentation pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40m+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr