### PR TITLE
bump weatherflow4py to 1.5.7

### DIFF
--- a/homeassistant/components/weatherflow_cloud/manifest.json
+++ b/homeassistant/components/weatherflow_cloud/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "loggers": ["weatherflow4py"],
-  "requirements": ["weatherflow4py==1.5.4"]
+  "requirements": ["weatherflow4py==1.5.7"]
 }


### PR DESCRIPTION
## Summary

- Bump `weatherflow4py` from `1.5.4` → `1.5.7` in `homeassistant/components/weatherflow_cloud/manifest.json`

## Changes

- `weatherflow4py` 1.5.7 includes:
  - Fix: decode observations that omit solar_radiation and other sensor fields
  - Fix: cover websocket shutdown regression and update dev deps
  - Version bumps to 1.5.5 and 1.5.6

## Test Plan

- [ ] CI passes
- [ ] Integration tests pass