### PR TITLE
Fix for Roborock uninitialized coordinator data

### DIFF
--- a/homeassistant/components/roborock/__init__.py
+++ b/homeassistant/components/roborock/__init__.py
@@ -277,16 +277,21 @@ async def async_setup_device(
             _LOGGER.warning("Failed to close device %s: %s", device.duid, err)
         return
 
+    try:
+        await coordinator.async_refresh()
+    except RoborockException as err:
+        _LOGGER.error(
+            "Failed initial attempt to connect to device %s (%s): %s",
+            device.name,
+            device.duid,
+            err,
+        )
+
     entry.runtime_data.add(coordinator)
     async_dispatcher_send(
         hass,
         f"roborock_coordinator_added_{entry.entry_id}",
         coordinator,
-    )
-    entry.async_create_background_task(
-        hass,
-        coordinator.async_refresh(),
-        name=f"roborock_coordinator_refresh_{coordinator.duid}",
     )
 
 

--- a/homeassistant/components/roborock/sensor.py
+++ b/homeassistant/components/roborock/sensor.py
@@ -570,7 +570,6 @@ async def async_setup_entry(
             entities.extend(
                 RoborockSensorEntityB01Q7(coordinator, description)
                 for description in Q7_B01_SENSOR_DESCRIPTIONS
-                if description.value_fn(coordinator.data) is not None
             )
         elif isinstance(coordinator, RoborockB01Q10UpdateCoordinator):
             entities.extend(

--- a/tests/components/roborock/test_binary_sensor.py
+++ b/tests/components/roborock/test_binary_sensor.py
@@ -1,11 +1,16 @@
 """Test Roborock Binary Sensor."""
 
+from typing import Any
+
 import pytest
+from roborock.exceptions import RoborockException
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.const import Platform
+from homeassistant.const import STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+
+from .conftest import FakeDevice
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -24,3 +29,50 @@ async def test_binary_sensors(
 ) -> None:
     """Test binary sensors and check test values are correctly set."""
     await snapshot_platform(hass, entity_registry, snapshot, setup_entry.entry_id)
+
+
+def setup_coordinator_side_effect(
+    fake_devices: list[FakeDevice], side_effect: Any
+) -> None:
+    """Set the query/refresh side effect on all fake devices to simulate failure or delay."""
+    for device in fake_devices:
+        if device.v1_properties is not None:
+            device.v1_properties.status.refresh.side_effect = side_effect
+        if device.dyad is not None:
+            device.dyad.query_values.side_effect = side_effect
+        if device.zeo is not None:
+            device.zeo.query_values.side_effect = side_effect
+        if device.b01_q10_properties is not None:
+            device.b01_q10_properties.refresh.side_effect = side_effect
+        if device.b01_q7_properties is not None:
+            device.b01_q7_properties.query_values.side_effect = side_effect
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "expected_state"),
+    [
+        (RoborockException("Simulated failure"), STATE_UNAVAILABLE),
+    ],
+)
+async def test_binary_sensors_coordinator_state(
+    hass: HomeAssistant,
+    mock_roborock_entry: MockConfigEntry,
+    fake_devices: list[FakeDevice],
+    side_effect: Any,
+    expected_state: str,
+) -> None:
+    """Test binary sensors state based on coordinator update success or delay."""
+    setup_coordinator_side_effect(fake_devices, side_effect)
+
+    await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # V1 binary sensors
+    state = hass.states.get("binary_sensor.roborock_s7_maxv_mop_attached")
+    assert state is not None
+    assert state.state == expected_state
+
+    # A01 (Dyad/Zeo) binary sensors
+    state = hass.states.get("binary_sensor.zeo_one_detergent")
+    assert state is not None
+    assert state.state == expected_state

--- a/tests/components/roborock/test_sensor.py
+++ b/tests/components/roborock/test_sensor.py
@@ -1,11 +1,16 @@
 """Test Roborock Sensors."""
 
+from typing import Any
+
 import pytest
+from roborock.exceptions import RoborockException
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.const import Platform
+from homeassistant.const import STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+
+from .conftest import FakeDevice
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -24,3 +29,64 @@ async def test_sensors(
 ) -> None:
     """Test sensors and check test values are correctly set."""
     await snapshot_platform(hass, entity_registry, snapshot, setup_entry.entry_id)
+
+
+def setup_coordinator_side_effect(
+    fake_devices: list[FakeDevice], side_effect: Any
+) -> None:
+    """Set the query/refresh side effect on all fake devices to simulate failure or delay."""
+    for device in fake_devices:
+        if device.v1_properties is not None:
+            device.v1_properties.status.refresh.side_effect = side_effect
+        if device.dyad is not None:
+            device.dyad.query_values.side_effect = side_effect
+        if device.zeo is not None:
+            device.zeo.query_values.side_effect = side_effect
+        if device.b01_q10_properties is not None:
+            device.b01_q10_properties.refresh.side_effect = side_effect
+        if device.b01_q7_properties is not None:
+            device.b01_q7_properties.query_values.side_effect = side_effect
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "expected_state"),
+    [
+        (RoborockException("Simulated failure"), STATE_UNAVAILABLE),
+    ],
+)
+async def test_sensors_coordinator_state(
+    hass: HomeAssistant,
+    mock_roborock_entry: MockConfigEntry,
+    fake_devices: list[FakeDevice],
+    side_effect: Any,
+    expected_state: str,
+) -> None:
+    """Test sensors state based on coordinator update success or delay."""
+    setup_coordinator_side_effect(fake_devices, side_effect)
+
+    await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # V1 sensors
+    state = hass.states.get("sensor.roborock_s7_maxv_battery")
+    assert state is not None
+    assert state.state == expected_state
+
+    # A01 (Dyad/Zeo) sensors
+    state = hass.states.get("sensor.dyad_pro_battery")
+    assert state is not None
+    assert state.state == expected_state
+
+    state = hass.states.get("sensor.zeo_one_washing_left")
+    assert state is not None
+    assert state.state == expected_state
+
+    # B01 Q7 sensors
+    state = hass.states.get("sensor.roborock_q7_battery")
+    assert state is not None
+    assert state.state == expected_state
+
+    # B01 Q10 sensors
+    state = hass.states.get("sensor.roborock_q10_s5_battery")
+    assert state is not None
+    assert state.state == expected_state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix for Roborock uninitialized coordinator data

This adds a defensive check for `None` since the entity may be created without initial data if we fail to connect to the device. Also, as discussed in #175387 we'll change behavior to always block on attempting to connect to the device at least once. Previously, we optimized for showing the device as fast as possible, but now we'll at least attempt to have data to avoid entering an unknown state initially.

This is intentionally smaller scoped than #175387 and avoiding touching as many files to avoid merge conflicts. As a result, it has some test duplication we can simplify in a future PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: #175353
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
