### PR TITLE
Fix stiebel_eltron climate action exceptions to comply with action-exceptions rule

### DIFF
--- a/homeassistant/components/stiebel_eltron/climate.py
+++ b/homeassistant/components/stiebel_eltron/climate.py
@@ -131,8 +131,6 @@ class StiebelEltron(StiebelEltronEntity, ClimateEntity):
     @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new operation mode."""
-        if self.preset_mode:
-            return
         new_mode = HA_TO_LWZ_HVAC[hvac_mode]
         _LOGGER.debug("async_set_hvac_mode: %s -> %s", self._attr_hvac_mode, new_mode)
         try:
@@ -145,8 +143,7 @@ class StiebelEltron(StiebelEltronEntity, ClimateEntity):
     @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
-        if (target_temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
-            raise HomeAssistantError("target temperature must be provided")
+        target_temperature = kwargs[ATTR_TEMPERATURE]
         _LOGGER.debug("async_set_temperature: %s", target_temperature)
         try:
             await self.coordinator.api_client.set_target_temp(target_temperature)

--- a/homeassistant/components/stiebel_eltron/manifest.json
+++ b/homeassistant/components/stiebel_eltron/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["pymodbus", "pystiebeleltron"],
-  "quality_scale": "bronze",
+  "quality_scale": "silver",
   "requirements": ["pystiebeleltron==0.2.5"]
 }

--- a/homeassistant/components/stiebel_eltron/quality_scale.yaml
+++ b/homeassistant/components/stiebel_eltron/quality_scale.yaml
@@ -30,7 +30,7 @@ rules:
   unique-config-entry: done
 
   # Silver
-  action-exceptions: todo
+  action-exceptions: done
   config-entry-unloading: done
   docs-configuration-parameters:
     status: exempt

--- a/tests/components/stiebel_eltron/test_climate.py
+++ b/tests/components/stiebel_eltron/test_climate.py
@@ -22,7 +22,6 @@ from homeassistant.components.stiebel_eltron.climate import (
     PRESET_READY,
     PRESET_WATER_HEATING,
 )
-from homeassistant.const import STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -105,56 +104,25 @@ async def test_climate_entity_operating_modes(
     assert state.attributes[ATTR_PRESET_MODE] == expected_preset
 
 
-async def test_climate_entity_set_hvac_mode_without_preset(
+async def test_climate_entity_set_hvac_mode(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_lwz_api: MagicMock,
 ) -> None:
     """Test setting HVAC mode."""
-
-    # Prepare mock
-    mock_lwz_api.get_operation.return_value = None
-
     await _setup_integration(hass, mock_config_entry)
 
-    # Ensure no preset is active
-    state = hass.states.get(CLIMATE_ENTITY_ID)
-    assert state is not None
-    assert state.state == STATE_UNKNOWN
-    assert state.attributes.get(ATTR_PRESET_MODE) is None
-
-    # Test setting to AUTO
     mock_lwz_api.set_operation.reset_mock()
     await async_set_hvac_mode(hass, HVACMode.AUTO, CLIMATE_ENTITY_ID)
     mock_lwz_api.set_operation.assert_awaited_with(OperatingMode.AUTOMATIC)
 
-    # Test setting to HEAT
     mock_lwz_api.set_operation.reset_mock()
     await async_set_hvac_mode(hass, HVACMode.HEAT, CLIMATE_ENTITY_ID)
     mock_lwz_api.set_operation.assert_awaited_with(OperatingMode.MANUAL_MODE)
 
-    # Test setting to OFF
     mock_lwz_api.set_operation.reset_mock()
     await async_set_hvac_mode(hass, HVACMode.OFF, CLIMATE_ENTITY_ID)
     mock_lwz_api.set_operation.assert_awaited_with(OperatingMode.DHW)
-
-
-async def test_climate_entity_set_hvac_mode_with_preset(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_lwz_api: MagicMock,
-) -> None:
-    """Test that setting HVAC mode does nothing when a preset is active."""
-
-    # Prepare mock
-    mock_lwz_api.get_operation.return_value = OperatingMode.DAY_MODE
-    mock_lwz_api.set_operation.reset_mock()
-
-    await _setup_integration(hass, mock_config_entry)
-
-    # Should not call set_operation when preset is active
-    await async_set_hvac_mode(hass, HVACMode.HEAT, CLIMATE_ENTITY_ID)
-    mock_lwz_api.set_operation.assert_not_called()
 
 
 async def test_climate_entity_set_temperature(
@@ -175,7 +143,6 @@ async def test_climate_entity_set_hvac_mode_handles_api_exception(
     mock_lwz_api: MagicMock,
 ) -> None:
     """Test setting HVAC mode handles API exception."""
-    mock_lwz_api.get_operation.return_value = None
     await _setup_integration(hass, mock_config_entry)
 
     mock_lwz_api.set_operation.side_effect = ModbusException("write failed")


### PR DESCRIPTION
## Proposed change

`async_set_hvac_mode` returned early whenever a preset was active. Since every OperatingMode now maps to a preset, the guard silently blocked every HVAC mode change on a real device with no error and no write to the device; `async_set_preset_mode` already writes the same register unconditionally, so the guard is simply dropped.

`async_set_temperature` raised `HomeAssistantError` for a missing temperature, but that branch is unreachable through the service layer: the entity only declares `ClimateEntityFeature.TARGET_TEMPERATURE`, and the core climate service schema already rejects calls without a usable temperature. Access `kwargs[ATTR_TEMPERATURE]` directly.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
