### PR TITLE
Add TP-Link Omada controller entities

### DIFF
--- a/homeassistant/components/tplink_omada/__init__.py
+++ b/homeassistant/components/tplink_omada/__init__.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.typing import ConfigType
 
 from .config_flow import CONF_SITE, create_omada_client
 from .const import DOMAIN
-from .controller import OmadaSiteController
+from .controller import OmadaSiteController, config_entry_controller_unique_id
 from .services import async_setup_services
 
 _LOGGER = logging.getLogger(__name__)
@@ -67,7 +67,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmadaConfigEntry) -> boo
         ) from ex
 
     site_client = await client.get_site_client(OmadaSite("", entry.data[CONF_SITE]))
-    controller = OmadaSiteController(hass, entry, site_client)
+    controller = OmadaSiteController(hass, entry, site_client, client)
     await controller.initialize_first_refresh()
 
     entry.runtime_data = controller
@@ -91,13 +91,15 @@ def _remove_old_devices(
 ) -> None:
     device_registry = dr.async_get(hass)
 
+    controller_unique_id = config_entry_controller_unique_id(entry)
+
     for registered_device in device_registry.devices.get_devices_for_config_entry_id(
         entry.entry_id
     ):
         mac = next(
             (i[1] for i in registered_device.identifiers if i[0] == DOMAIN), None
         )
-        if mac and mac not in omada_devices:
+        if mac and mac not in omada_devices and mac != controller_unique_id:
             device_registry.async_update_device(
                 registered_device.id, remove_config_entry_id=entry.entry_id
             )

--- a/homeassistant/components/tplink_omada/binary_sensor.py
+++ b/homeassistant/components/tplink_omada/binary_sensor.py
@@ -22,13 +22,17 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import OmadaConfigEntry
-from .controller import OmadaGatewayCoordinator
-from .entity import OmadaDeviceEntity
+from .controller import OmadaGatewayCoordinator, config_entry_owns_controller_entities
+from .coordinator import OmadaControllerInfoCoordinator
+from .entity import OmadaDeviceEntity, controller_device_info
 
 PARALLEL_UPDATES = 0
 
@@ -40,6 +44,15 @@ async def async_setup_entry(
 ) -> None:
     """Set up binary sensors."""
     controller = config_entry.runtime_data
+
+    if config_entry_owns_controller_entities(hass, config_entry):
+        async_add_entities(
+            [
+                OmadaControllerConnectivityBinarySensor(
+                    controller.controller_info_coordinator
+                )
+            ]
+        )
 
     async def _create_gateway_port_entities(device: OmadaListDevice) -> None:
         gateway_coordinator = controller.gateway_coordinator
@@ -66,6 +79,34 @@ async def async_setup_entry(
         ),
         _create_gateway_port_entities,
     )
+
+
+class OmadaControllerConnectivityBinarySensor(
+    CoordinatorEntity[OmadaControllerInfoCoordinator], BinarySensorEntity
+):
+    """Connectivity status for an Omada controller."""
+
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_has_entity_name = True
+    _attr_translation_key = "controller_connectivity"
+
+    def __init__(self, coordinator: OmadaControllerInfoCoordinator) -> None:
+        """Initialize the controller connectivity binary sensor."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.data.omadac_id}_controller_connectivity"
+
+    @property
+    @override
+    def device_info(self) -> dr.DeviceInfo:
+        """Return device info for the Omada controller."""
+        return controller_device_info(self.coordinator.data)
+
+    @property
+    @override
+    def is_on(self) -> bool:
+        """Return if the controller is connected."""
+        return self.coordinator.data.configured is not False
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/homeassistant/components/tplink_omada/controller.py
+++ b/homeassistant/components/tplink_omada/controller.py
@@ -3,20 +3,65 @@
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING
 
-from tplink_omada_client import OmadaSiteClient
+from tplink_omada_client import OmadaClient, OmadaSiteClient
 from tplink_omada_client.devices import OmadaListDevice, OmadaSwitch
 
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.core import HomeAssistant, callback
 
 if TYPE_CHECKING:
     from . import OmadaConfigEntry
 
+from .config_flow import CONF_SITE
+from .const import DOMAIN
 from .coordinator import (
     OmadaClientsCoordinator,
+    OmadaControllerInfoCoordinator,
+    OmadaControllerUpdateCoordinator,
     OmadaDevicesCoordinator,
     OmadaGatewayCoordinator,
     OmadaSwitchPortCoordinator,
 )
+
+
+def config_entry_controller_unique_id(config_entry: ConfigEntry) -> str | None:
+    """Return the controller-level unique ID for a site config entry."""
+    if config_entry.unique_id is None:
+        return None
+
+    return config_entry.unique_id.removesuffix(f"_{config_entry.data[CONF_SITE]}")
+
+
+def config_entry_owns_controller_entities(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> bool:
+    """Return if this site entry should add controller-level entities."""
+    controller_unique_id = config_entry_controller_unique_id(config_entry)
+    controller_entries = [
+        entry
+        for entry in hass.config_entries.async_entries(
+            DOMAIN, include_ignore=False, include_disabled=False
+        )
+        if config_entry_controller_unique_id(entry) == controller_unique_id
+    ]
+
+    active_controller_entries = [
+        entry
+        for entry in controller_entries
+        if entry.state
+        in (
+            ConfigEntryState.SETUP_IN_PROGRESS,
+            ConfigEntryState.LOADED,
+        )
+    ]
+    owner_entries = active_controller_entries or controller_entries
+
+    return (
+        config_entry.entry_id
+        == min(
+            owner_entries, key=lambda entry: (entry.created_at, entry.entry_id)
+        ).entry_id
+    )
 
 
 class OmadaSiteController:
@@ -29,11 +74,13 @@ class OmadaSiteController:
         hass: HomeAssistant,
         config_entry: OmadaConfigEntry,
         omada_client: OmadaSiteClient,
+        controller_client: OmadaClient,
     ) -> None:
         """Create the controller."""
         self._hass = hass
         self._config_entry = config_entry
         self._omada_client = omada_client
+        self._controller_client = controller_client
 
         self._switch_port_coordinators: dict[str, OmadaSwitchPortCoordinator] = {}
         self._devices_coordinator = OmadaDevicesCoordinator(
@@ -42,9 +89,16 @@ class OmadaSiteController:
         self._clients_coordinator = OmadaClientsCoordinator(
             hass, config_entry, omada_client
         )
+        self._controller_info_coordinator = OmadaControllerInfoCoordinator(
+            hass, config_entry, controller_client
+        )
+        self._controller_update_coordinator = OmadaControllerUpdateCoordinator(
+            hass, config_entry, controller_client
+        )
 
     async def initialize_first_refresh(self) -> None:
         """Initialize the all coordinators, and perform first refresh."""
+        await self._controller_info_coordinator.async_config_entry_first_refresh()
         await self._devices_coordinator.async_config_entry_first_refresh()
 
         devices = self._devices_coordinator.data.values()
@@ -106,6 +160,11 @@ class OmadaSiteController:
         """Get the connected client API for the site to manage."""
         return self._omada_client
 
+    @property
+    def controller_client(self) -> OmadaClient:
+        """Get the connected client API for controller-level endpoints."""
+        return self._controller_client
+
     def get_switch_port_coordinator(
         self, switch: OmadaSwitch
     ) -> OmadaSwitchPortCoordinator:
@@ -131,3 +190,13 @@ class OmadaSiteController:
     def clients_coordinator(self) -> OmadaClientsCoordinator:
         """Gets the coordinator for site's clients."""
         return self._clients_coordinator
+
+    @property
+    def controller_info_coordinator(self) -> OmadaControllerInfoCoordinator:
+        """Gets the coordinator for controller information."""
+        return self._controller_info_coordinator
+
+    @property
+    def controller_update_coordinator(self) -> OmadaControllerUpdateCoordinator:
+        """Gets the coordinator for controller update information."""
+        return self._controller_update_coordinator

--- a/homeassistant/components/tplink_omada/controller.py
+++ b/homeassistant/components/tplink_omada/controller.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 from tplink_omada_client import OmadaClient, OmadaSiteClient
 from tplink_omada_client.devices import OmadaListDevice, OmadaSwitch
 
-from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 
 if TYPE_CHECKING:
@@ -45,21 +45,10 @@ def config_entry_owns_controller_entities(
         if config_entry_controller_unique_id(entry) == controller_unique_id
     ]
 
-    active_controller_entries = [
-        entry
-        for entry in controller_entries
-        if entry.state
-        in (
-            ConfigEntryState.SETUP_IN_PROGRESS,
-            ConfigEntryState.LOADED,
-        )
-    ]
-    owner_entries = active_controller_entries or controller_entries
-
     return (
         config_entry.entry_id
         == min(
-            owner_entries, key=lambda entry: (entry.created_at, entry.entry_id)
+            controller_entries, key=lambda entry: (entry.created_at, entry.entry_id)
         ).entry_id
     )
 

--- a/homeassistant/components/tplink_omada/coordinator.py
+++ b/homeassistant/components/tplink_omada/coordinator.py
@@ -5,7 +5,13 @@ from datetime import timedelta
 import logging
 from typing import TYPE_CHECKING, NamedTuple, override
 
-from tplink_omada_client import OmadaSiteClient, OmadaSwitchPortDetails
+from tplink_omada_client import (
+    OmadaClient,
+    OmadaControllerInfo,
+    OmadaControllerUpdateInfo,
+    OmadaSiteClient,
+    OmadaSwitchPortDetails,
+)
 from tplink_omada_client.clients import OmadaWirelessClient
 from tplink_omada_client.devices import (
     OmadaFirmwareUpdate,
@@ -28,6 +34,71 @@ POLL_GATEWAY = 300
 POLL_CLIENTS = 300
 POLL_DEVICES = 300
 POLL_UPGRADE = 60
+POLL_CONTROLLER_INFO = 300
+
+
+class OmadaControllerInfoCoordinator(DataUpdateCoordinator[OmadaControllerInfo]):
+    """Coordinator for Omada controller information."""
+
+    config_entry: OmadaConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: OmadaConfigEntry,
+        omada_client: OmadaClient,
+    ) -> None:
+        """Initialize my coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=config_entry,
+            name="Omada API Data - Controller Info",
+            update_interval=timedelta(seconds=POLL_CONTROLLER_INFO),
+        )
+        self.omada_client = omada_client
+
+    @override
+    async def _async_update_data(self) -> OmadaControllerInfo:
+        """Fetch data from API endpoint."""
+        try:
+            async with asyncio.timeout(10):
+                return await self.omada_client.get_controller_info()
+        except OmadaClientException as err:
+            raise UpdateFailed(f"Error communicating with API: {err}") from err
+
+
+class OmadaControllerUpdateCoordinator(
+    DataUpdateCoordinator[OmadaControllerUpdateInfo]
+):
+    """Coordinator for Omada controller update information."""
+
+    config_entry: OmadaConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: OmadaConfigEntry,
+        omada_client: OmadaClient,
+    ) -> None:
+        """Initialize my coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=config_entry,
+            name="Omada API Data - Controller Updates",
+            update_interval=timedelta(seconds=POLL_CONTROLLER_INFO),
+        )
+        self.omada_client = omada_client
+
+    @override
+    async def _async_update_data(self) -> OmadaControllerUpdateInfo:
+        """Fetch data from API endpoint."""
+        try:
+            async with asyncio.timeout(10):
+                return await self.omada_client.check_firmware_updates()
+        except OmadaClientException as err:
+            raise UpdateFailed(f"Error communicating with API: {err}") from err
 
 
 class OmadaCoordinator[_T](DataUpdateCoordinator[dict[str, _T]]):

--- a/homeassistant/components/tplink_omada/entity.py
+++ b/homeassistant/components/tplink_omada/entity.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from tplink_omada_client import OmadaControllerInfo
 from tplink_omada_client.devices import OmadaDevice
 
 from homeassistant.helpers import device_registry as dr
@@ -27,3 +28,14 @@ class OmadaDeviceEntity[_T: OmadaCoordinator[Any]](CoordinatorEntity[_T]):
             model=device.model_display_name,
             name=device.name,
         )
+
+
+def controller_device_info(controller_info: OmadaControllerInfo) -> dr.DeviceInfo:
+    """Return device info for the Omada controller."""
+    return dr.DeviceInfo(
+        identifiers={(DOMAIN, controller_info.omadac_id)},
+        manufacturer="TP-Link",
+        model="Omada Controller",
+        name="Omada Controller",
+        sw_version=controller_info.controller_version,
+    )

--- a/homeassistant/components/tplink_omada/manifest.json
+++ b/homeassistant/components/tplink_omada/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "quality_scale": "bronze",
-  "requirements": ["tplink-omada-client==1.5.8"]
+  "requirements": ["tplink-omada-client==1.5.9"]
 }

--- a/homeassistant/components/tplink_omada/sensor.py
+++ b/homeassistant/components/tplink_omada/sensor.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import override
 
+from tplink_omada_client import OmadaControllerInfo
 from tplink_omada_client.definitions import DeviceStatus, DeviceStatusCategory
 from tplink_omada_client.devices import OmadaListDevice
 
@@ -15,13 +16,16 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import PERCENTAGE, EntityCategory
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import OmadaConfigEntry
 from .const import OmadaDeviceStatus
-from .coordinator import OmadaDevicesCoordinator
-from .entity import OmadaDeviceEntity
+from .controller import config_entry_owns_controller_entities
+from .coordinator import OmadaControllerInfoCoordinator, OmadaDevicesCoordinator
+from .entity import OmadaDeviceEntity, controller_device_info
 
 PARALLEL_UPDATES = 0
 
@@ -55,6 +59,13 @@ def _map_device_status(device: OmadaListDevice) -> str | None:
     return display_status.value if display_status else None
 
 
+def _map_controller_status(controller_info: OmadaControllerInfo) -> str:
+    """Map the controller info response to a device status."""
+    if controller_info.configured is False:
+        return OmadaDeviceStatus.DISCONNECTED.value
+    return OmadaDeviceStatus.CONNECTED.value
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: OmadaConfigEntry,
@@ -63,7 +74,18 @@ async def async_setup_entry(
     """Set up sensors."""
     controller = config_entry.runtime_data
 
+    controller_info_coordinator = controller.controller_info_coordinator
     devices_coordinator = controller.devices_coordinator
+
+    _register_controller_device(hass, config_entry, controller_info_coordinator.data)
+
+    if config_entry_owns_controller_entities(hass, config_entry):
+        async_add_entities(
+            [
+                OmadaControllerSensor(controller_info_coordinator, desc)
+                for desc in OMADA_CONTROLLER_SENSORS
+            ]
+        )
 
     async def _create_device_sensor_entities(
         device: OmadaListDevice,
@@ -89,6 +111,72 @@ class OmadaDeviceSensorEntityDescription(SensorEntityDescription):
 
     exists_func: Callable[[OmadaListDevice], bool] = lambda _: True
     update_func: Callable[[OmadaListDevice], StateType]
+
+
+@dataclass(frozen=True, kw_only=True)
+class OmadaControllerSensorEntityDescription(SensorEntityDescription):
+    """Entity description for status from the Omada controller."""
+
+    update_func: Callable[[OmadaControllerInfo], StateType]
+    extra_attributes_func: Callable[[OmadaControllerInfo], dict[str, StateType]] = (
+        lambda _: {}
+    )
+
+
+def _register_controller_device(
+    hass: HomeAssistant,
+    config_entry: OmadaConfigEntry,
+    controller_info: OmadaControllerInfo,
+) -> None:
+    """Register the controller device with the site config entry."""
+    dr.async_get(hass).async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        **controller_device_info(controller_info),
+    )
+
+
+def _controller_status_attributes(
+    controller_info: OmadaControllerInfo,
+) -> dict[str, StateType]:
+    """Return attributes for the controller status sensor."""
+    return {
+        "configured": controller_info.configured,
+        "type": controller_info.type,
+        "support_app": controller_info.support_app,
+        "registered_root": controller_info.registered_root,
+        "omadac_category": controller_info.omadac_category,
+        "msp_mode": controller_info.msp_mode,
+        "omada_cloud_url": controller_info.omada_cloud_url,
+    }
+
+
+OMADA_CONTROLLER_SENSORS: list[OmadaControllerSensorEntityDescription] = [
+    OmadaControllerSensorEntityDescription(
+        key="device_status",
+        name="Device status",
+        translation_key="device_status",
+        device_class=SensorDeviceClass.ENUM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        update_func=_map_controller_status,
+        extra_attributes_func=_controller_status_attributes,
+        options=[
+            OmadaDeviceStatus.DISCONNECTED.value,
+            OmadaDeviceStatus.CONNECTED.value,
+        ],
+    ),
+    OmadaControllerSensorEntityDescription(
+        key="version",
+        name="Version",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        update_func=lambda controller_info: controller_info.controller_version,
+    ),
+    OmadaControllerSensorEntityDescription(
+        key="api_version",
+        name="API version",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        update_func=lambda controller_info: controller_info.api_version,
+    ),
+]
 
 
 OMADA_DEVICE_SENSORS: list[OmadaDeviceSensorEntityDescription] = [
@@ -117,6 +205,44 @@ OMADA_DEVICE_SENSORS: list[OmadaDeviceSensorEntityDescription] = [
         update_func=lambda device: device.mem_usage,
     ),
 ]
+
+
+class OmadaControllerSensor(
+    CoordinatorEntity[OmadaControllerInfoCoordinator], SensorEntity
+):
+    """Sensor for a property of the Omada controller."""
+
+    _attr_has_entity_name = True
+    entity_description: OmadaControllerSensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: OmadaControllerInfoCoordinator,
+        entity_description: OmadaControllerSensorEntityDescription,
+    ) -> None:
+        """Initialize the controller sensor."""
+        super().__init__(coordinator)
+        self.entity_description = entity_description
+        self._attr_name = (
+            entity_description.name
+            if isinstance(entity_description.name, str)
+            else None
+        )
+        self._attr_unique_id = f"{coordinator.data.omadac_id}_{entity_description.key}"
+        self._attr_suggested_object_id = f"omada_controller_{entity_description.key}"
+        self._attr_device_info = controller_device_info(coordinator.data)
+
+    @property
+    @override
+    def extra_state_attributes(self) -> dict[str, StateType]:
+        """Return extra attributes for the sensor."""
+        return self.entity_description.extra_attributes_func(self.coordinator.data)
+
+    @property
+    @override
+    def native_value(self) -> StateType:
+        """Return the state of the sensor."""
+        return self.entity_description.update_func(self.coordinator.data)
 
 
 class OmadaDeviceSensor(OmadaDeviceEntity[OmadaDevicesCoordinator], SensorEntity):

--- a/homeassistant/components/tplink_omada/strings.json
+++ b/homeassistant/components/tplink_omada/strings.json
@@ -53,6 +53,9 @@
   },
   "entity": {
     "binary_sensor": {
+      "controller_connectivity": {
+        "name": "Connectivity"
+      },
       "lan_status": {
         "name": "Port {port_name} LAN status"
       },
@@ -96,6 +99,11 @@
       },
       "wan_connect_ipv6": {
         "name": "Port {port_name} Internet connected (IPv6)"
+      }
+    },
+    "update": {
+      "firmware": {
+        "name": "Firmware"
       }
     }
   },

--- a/homeassistant/components/tplink_omada/update.py
+++ b/homeassistant/components/tplink_omada/update.py
@@ -109,6 +109,9 @@ class OmadaControllerUpdate(
         self._attr_unique_id = (
             f"{controller_info_coordinator.data.omadac_id}_controller_firmware"
         )
+        self.async_on_remove(
+            controller_info_coordinator.async_add_listener(self._handle_coordinator_update)
+        )
         self._update_attrs()
 
     @property

--- a/homeassistant/components/tplink_omada/update.py
+++ b/homeassistant/components/tplink_omada/update.py
@@ -1,7 +1,9 @@
 """Support for TPLink Omada device firmware updates."""
 
+from dataclasses import dataclass
 from typing import Any, override
 
+from tplink_omada_client import OmadaControllerUpdateInfo
 from tplink_omada_client.devices import OmadaListDevice
 from tplink_omada_client.exceptions import OmadaClientException, RequestFailed
 
@@ -10,13 +12,21 @@ from homeassistant.components.update import (
     UpdateEntity,
     UpdateEntityFeature,
 )
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import OmadaConfigEntry
-from .coordinator import OmadaFirmwareUpdateCoordinator
-from .entity import OmadaDeviceEntity
+from .controller import config_entry_owns_controller_entities
+from .coordinator import (
+    OmadaControllerInfoCoordinator,
+    OmadaControllerUpdateCoordinator,
+    OmadaFirmwareUpdateCoordinator,
+)
+from .entity import OmadaDeviceEntity, controller_device_info
 
 PARALLEL_UPDATES = 0
 
@@ -31,6 +41,17 @@ async def async_setup_entry(
 
     devices = controller.devices_coordinator.data
 
+    if config_entry_owns_controller_entities(hass, config_entry):
+        await controller.controller_update_coordinator.async_request_refresh()
+        async_add_entities(
+            [
+                OmadaControllerUpdate(
+                    controller.controller_update_coordinator,
+                    controller.controller_info_coordinator,
+                )
+            ]
+        )
+
     coordinator = OmadaFirmwareUpdateCoordinator(
         hass, config_entry, controller.omada_client, controller.devices_coordinator
     )
@@ -39,6 +60,96 @@ async def async_setup_entry(
         OmadaDeviceUpdate(coordinator, device) for device in devices.values()
     )
     await coordinator.async_request_refresh()
+
+
+@dataclass(frozen=True, kw_only=True)
+class ControllerUpdateDetails:
+    """Controller update data normalized for the update entity."""
+
+    current_version: str
+    latest_version: str
+    release_notes: str | None
+
+
+def _controller_update_details(
+    update_info: OmadaControllerUpdateInfo,
+) -> ControllerUpdateDetails | None:
+    """Return controller update data, preferring software over hardware updates."""
+    for update in (update_info.software, update_info.hardware):
+        if update:
+            return ControllerUpdateDetails(
+                current_version=update.current_version,
+                latest_version=update.latest_version,
+                release_notes=update.release_notes,
+            )
+
+    return None
+
+
+class OmadaControllerUpdate(
+    CoordinatorEntity[OmadaControllerUpdateCoordinator],
+    UpdateEntity,
+):
+    """Update status for an Omada controller."""
+
+    _attr_device_class = UpdateDeviceClass.FIRMWARE
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_has_entity_name = True
+    _attr_supported_features = UpdateEntityFeature.RELEASE_NOTES
+    _attr_translation_key = "firmware"
+
+    def __init__(
+        self,
+        coordinator: OmadaControllerUpdateCoordinator,
+        controller_info_coordinator: OmadaControllerInfoCoordinator,
+    ) -> None:
+        """Initialize the controller update entity."""
+        super().__init__(coordinator)
+        self._controller_info_coordinator = controller_info_coordinator
+        self._attr_unique_id = (
+            f"{controller_info_coordinator.data.omadac_id}_controller_firmware"
+        )
+        self._update_attrs()
+
+    @property
+    @override
+    def device_info(self) -> dr.DeviceInfo:
+        """Return device info for the Omada controller."""
+        return controller_device_info(self._controller_info_coordinator.data)
+
+    @override
+    def release_notes(self) -> str | None:
+        """Get the release notes for the latest update."""
+        if self.coordinator.data and (
+            update_details := _controller_update_details(self.coordinator.data)
+        ):
+            return update_details.release_notes
+        return None
+
+    @callback
+    def _update_attrs(self) -> None:
+        """Update entity attributes from the coordinator."""
+        update_details = (
+            _controller_update_details(self.coordinator.data)
+            if self.coordinator.data
+            else None
+        )
+        if update_details:
+            self._attr_installed_version = update_details.current_version
+            self._attr_latest_version = update_details.latest_version
+        else:
+            controller_version = (
+                self._controller_info_coordinator.data.controller_version
+            )
+            self._attr_installed_version = controller_version
+            self._attr_latest_version = controller_version
+
+    @callback
+    @override
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._update_attrs()
+        self.async_write_ha_state()
 
 
 class OmadaDeviceUpdate(
@@ -53,6 +164,7 @@ class OmadaDeviceUpdate(
         | UpdateEntityFeature.RELEASE_NOTES
     )
     _attr_device_class = UpdateDeviceClass.FIRMWARE
+    _attr_translation_key = "firmware"
 
     def __init__(
         self,

--- a/homeassistant/components/tplink_omada/update.py
+++ b/homeassistant/components/tplink_omada/update.py
@@ -110,7 +110,9 @@ class OmadaControllerUpdate(
             f"{controller_info_coordinator.data.omadac_id}_controller_firmware"
         )
         self.async_on_remove(
-            controller_info_coordinator.async_add_listener(self._handle_coordinator_update)
+            controller_info_coordinator.async_add_listener(
+                self._handle_coordinator_update
+            )
         )
         self._update_attrs()
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3198,7 +3198,7 @@ toonapi==0.3.0
 total-connect-client==2026.7
 
 # homeassistant.components.tplink_omada
-tplink-omada-client==1.5.8
+tplink-omada-client==1.5.9
 
 # homeassistant.components.transmission
 transmission-rpc==7.0.3

--- a/tests/components/tplink_omada/conftest.py
+++ b/tests/components/tplink_omada/conftest.py
@@ -5,7 +5,11 @@ from functools import partial
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from tplink_omada_client import OmadaSite
+from tplink_omada_client import (
+    OmadaControllerInfo,
+    OmadaControllerUpdateInfo,
+    OmadaSite,
+)
 from tplink_omada_client.clients import (
     OmadaConnectedClient,
     OmadaNetworkClient,
@@ -29,6 +33,7 @@ from tests.common import (
     MockConfigEntry,
     async_load_json_array_fixture,
     async_load_json_object_fixture,
+    load_json_object_fixture,
 )
 
 
@@ -189,6 +194,19 @@ def mock_omada_client(mock_omada_site_client: AsyncMock) -> Generator[MagicMock]
 
         client.get_site_client.return_value = mock_omada_site_client
         client.login.return_value = "12345"
+        client.get_controller_info = AsyncMock(return_value=_get_mock_controller_info())
+        client.check_firmware_updates = AsyncMock(
+            return_value=OmadaControllerUpdateInfo(
+                {
+                    "software": {
+                        "upgrade": True,
+                        "currentVersion": "6.2.10.15",
+                        "latestVersion": "6.2.14.6 Build 20260617091728",
+                        "releaseLog": "Controller software update available.",
+                    }
+                }
+            )
+        )
         client.get_controller_name.return_value = "OC200"
         client.get_sites.return_value = [OmadaSite("Display Name", "SiteId")]
         yield client
@@ -206,6 +224,10 @@ def mock_omada_clients_only_client(
         client = client_mock.return_value
 
         client.get_site_client.return_value = mock_omada_clients_only_site_client
+        client.get_controller_info = AsyncMock(return_value=_get_mock_controller_info())
+        client.check_firmware_updates = AsyncMock(
+            return_value=OmadaControllerUpdateInfo({})
+        )
         yield client
 
 
@@ -222,3 +244,9 @@ async def init_integration(
     await hass.async_block_till_done()
 
     return mock_config_entry
+
+
+def _get_mock_controller_info() -> OmadaControllerInfo:
+    """Return mocked Omada controller information."""
+    controller_info_data = load_json_object_fixture("controller-info.json", DOMAIN)
+    return OmadaControllerInfo(controller_info_data)

--- a/tests/components/tplink_omada/fixtures/controller-info.json
+++ b/tests/components/tplink_omada/fixtures/controller-info.json
@@ -1,0 +1,12 @@
+{
+  "controllerVer": "6.2.10.15",
+  "apiVer": "3",
+  "configured": true,
+  "type": 1,
+  "supportApp": true,
+  "omadacId": "2b8ebfe7af51afa2f58844e1f9ba0c04",
+  "registeredRoot": true,
+  "omadacCategory": "advanced",
+  "mspMode": false,
+  "omadaCloudUrl": "https://omada.tplinkcloud.com"
+}

--- a/tests/components/tplink_omada/snapshots/test_binary_sensor.ambr
+++ b/tests/components/tplink_omada/snapshots/test_binary_sensor.ambr
@@ -1,4 +1,55 @@
 # serializer version: 1
+# name: test_entities[binary_sensor.omada_controller_connectivity-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.omada_controller_connectivity',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Connectivity',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.CONNECTIVITY: 'connectivity'>,
+    'original_icon': None,
+    'original_name': 'Connectivity',
+    'platform': 'tplink_omada',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'controller_connectivity',
+    'unique_id': '2b8ebfe7af51afa2f58844e1f9ba0c04_controller_connectivity',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[binary_sensor.omada_controller_connectivity-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'connectivity',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Omada Controller Connectivity',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.omada_controller_connectivity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
 # name: test_entities[binary_sensor.test_router_port_10_lan_status-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/tplink_omada/snapshots/test_sensor.ambr
+++ b/tests/components/tplink_omada/snapshots/test_sensor.ambr
@@ -1,4 +1,171 @@
 # serializer version: 1
+# name: test_entities[sensor.omada_controller_api_version-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.omada_controller_api_version',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'API version',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'API version',
+    'platform': 'tplink_omada',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '2b8ebfe7af51afa2f58844e1f9ba0c04_api_version',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[sensor.omada_controller_api_version-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Omada Controller API version',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.omada_controller_api_version',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '3',
+  })
+# ---
+# name: test_entities[sensor.omada_controller_device_status-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'disconnected',
+        'connected',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.omada_controller_device_status',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Device status',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Device status',
+    'platform': 'tplink_omada',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'device_status',
+    'unique_id': '2b8ebfe7af51afa2f58844e1f9ba0c04_device_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[sensor.omada_controller_device_status-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'configured': True,
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Omada Controller Device status',
+      'msp_mode': False,
+      'omada_cloud_url': 'https://omada.tplinkcloud.com',
+      'omadac_category': 'advanced',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'disconnected',
+        'connected',
+      ]),
+      'registered_root': True,
+      'support_app': True,
+      'type': 1,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.omada_controller_device_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'connected',
+  })
+# ---
+# name: test_entities[sensor.omada_controller_version-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.omada_controller_version',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Version',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Version',
+    'platform': 'tplink_omada',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '2b8ebfe7af51afa2f58844e1f9ba0c04_version',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[sensor.omada_controller_version-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Omada Controller Version',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.omada_controller_version',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '6.2.10.15',
+  })
+# ---
 # name: test_entities[sensor.test_poe_switch_cpu_usage-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/tplink_omada/snapshots/test_update.ambr
+++ b/tests/components/tplink_omada/snapshots/test_update.ambr
@@ -1,4 +1,67 @@
 # serializer version: 1
+# name: test_entities[update.omada_controller_firmware-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'update',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'update.omada_controller_firmware',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Firmware',
+    'options': dict({
+    }),
+    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
+    'original_icon': None,
+    'original_name': 'Firmware',
+    'platform': 'tplink_omada',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <UpdateEntityFeature: 16>,
+    'translation_key': 'firmware',
+    'unique_id': '2b8ebfe7af51afa2f58844e1f9ba0c04_controller_firmware',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[update.omada_controller_firmware-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <UpdateEntityStateAttribute.AUTO_UPDATE: 'auto_update'>: False,
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'firmware',
+      <UpdateEntityStateAttribute.DISPLAY_PRECISION: 'display_precision'>: 0,
+      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/brands/integration/tplink_omada/icon.png',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Omada Controller Firmware',
+      <UpdateEntityStateAttribute.IN_PROGRESS: 'in_progress'>: False,
+      <UpdateEntityStateAttribute.INSTALLED_VERSION: 'installed_version'>: '6.2.10.15',
+      <UpdateEntityStateAttribute.LATEST_VERSION: 'latest_version'>: '6.2.14.6 Build 20260617091728',
+      <UpdateEntityStateAttribute.RELEASE_SUMMARY: 'release_summary'>: None,
+      <UpdateEntityStateAttribute.RELEASE_URL: 'release_url'>: None,
+      <UpdateEntityStateAttribute.SKIPPED_VERSION: 'skipped_version'>: None,
+      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <UpdateEntityFeature: 16>,
+      <UpdateEntityStateAttribute.TITLE: 'title'>: None,
+      <UpdateEntityStateAttribute.UPDATE_PERCENTAGE: 'update_percentage'>: None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'update.omada_controller_firmware',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
 # name: test_entities[update.test_poe_switch_firmware-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -31,7 +94,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': <UpdateEntityFeature: 21>,
-    'translation_key': None,
+    'translation_key': 'firmware',
     'unique_id': '54-AF-97-00-00-01_firmware',
     'unit_of_measurement': None,
   })
@@ -94,7 +157,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': <UpdateEntityFeature: 21>,
-    'translation_key': None,
+    'translation_key': 'firmware',
     'unique_id': 'AA-BB-CC-DD-EE-FF_firmware',
     'unit_of_measurement': None,
   })

--- a/tests/components/tplink_omada/test_binary_sensor.py
+++ b/tests/components/tplink_omada/test_binary_sensor.py
@@ -6,11 +6,17 @@ from unittest.mock import MagicMock, patch
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from tplink_omada_client import OmadaControllerInfo
 from tplink_omada_client.definitions import DeviceStatus, DeviceStatusCategory
 from tplink_omada_client.devices import OmadaListDevice
+from tplink_omada_client.exceptions import ConnectionFailed
 
 from homeassistant.components.tplink_omada.const import DOMAIN
-from homeassistant.components.tplink_omada.coordinator import POLL_DEVICES
+from homeassistant.components.tplink_omada.coordinator import (
+    POLL_CONTROLLER_INFO,
+    POLL_DEVICES,
+)
+from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -59,6 +65,57 @@ async def test_no_gateway_creates_no_port_sensors(
     await hass.async_block_till_done()
 
     mock_omada_site_client.get_gateway.assert_not_called()
+
+
+async def test_controller_connectivity_sensor_off(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_omada_client: MagicMock,
+) -> None:
+    """Test controller connectivity sensor is off when controller is unconfigured."""
+    mock_omada_client.get_controller_info.return_value = OmadaControllerInfo(
+        {
+            "controllerVer": "6.2.10.17",
+            "configured": False,
+            "omadacId": "12345",
+        }
+    )
+
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.omada_controller_connectivity")
+    assert state is not None
+    assert state.state == STATE_OFF
+
+
+async def test_controller_connectivity_sensor_unavailable(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_omada_client: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test controller connectivity sensor is unavailable after refresh failure."""
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.omada_controller_connectivity")
+    assert state is not None
+    assert state.state == STATE_ON
+
+    mock_omada_client.get_controller_info.side_effect = ConnectionFailed()
+
+    freezer.tick(timedelta(seconds=POLL_CONTROLLER_INFO))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.omada_controller_connectivity")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
 
 
 async def test_disconnected_device_sensor_not_registered(

--- a/tests/components/tplink_omada/test_init.py
+++ b/tests/components/tplink_omada/test_init.py
@@ -1,5 +1,6 @@
 """Tests for TP-Link Omada integration init."""
 
+from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -10,6 +11,9 @@ from tplink_omada_client.exceptions import (
 )
 
 from homeassistant.components.tplink_omada.const import DOMAIN
+from homeassistant.components.tplink_omada.controller import (
+    config_entry_owns_controller_entities,
+)
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -151,6 +155,37 @@ async def test_controller_entities_only_created_once_for_multiple_sites(
             "2b8ebfe7af51afa2f58844e1f9ba0c04_controller_firmware",
         }
     )
+
+
+async def test_controller_entity_owner_ignores_entry_state(
+    hass: HomeAssistant,
+) -> None:
+    """Test controller entity owner is selected independently of entry state."""
+    earlier_entry = MockConfigEntry(
+        title="Test Omada Controller",
+        domain=DOMAIN,
+        data=dict(MOCK_ENTRY_DATA),
+        entry_id="earlier-entry",
+        unique_id="12345_SiteId",
+        version=2,
+        state=ConfigEntryState.NOT_LOADED,
+    )
+    later_entry = MockConfigEntry(
+        title="Test Omada Controller",
+        domain=DOMAIN,
+        data={**MOCK_ENTRY_DATA, "site": "SecondSite"},
+        entry_id="later-entry",
+        unique_id="12345_SecondSite",
+        version=2,
+        state=ConfigEntryState.LOADED,
+    )
+    object.__setattr__(earlier_entry, "created_at", datetime(2026, 1, 1, tzinfo=UTC))
+    object.__setattr__(later_entry, "created_at", datetime(2026, 1, 2, tzinfo=UTC))
+    earlier_entry.add_to_hass(hass)
+    later_entry.add_to_hass(hass)
+
+    assert config_entry_owns_controller_entities(hass, earlier_entry)
+    assert not config_entry_owns_controller_entities(hass, later_entry)
 
 
 async def test_migrate_entry_v1_to_v2(

--- a/tests/components/tplink_omada/test_init.py
+++ b/tests/components/tplink_omada/test_init.py
@@ -1,6 +1,6 @@
 """Tests for TP-Link Omada integration init."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from tplink_omada_client.exceptions import (
@@ -11,8 +11,9 @@ from tplink_omada_client.exceptions import (
 
 from homeassistant.components.tplink_omada.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.common import MockConfigEntry
 
@@ -89,6 +90,67 @@ async def test_missing_devices_removed_at_startup(
     await hass.async_block_till_done()
 
     assert device_registry.async_get(device_entry.id) is None
+
+
+async def test_controller_entities_only_created_once_for_multiple_sites(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_omada_client: MagicMock,
+    mock_omada_site_client: MagicMock,
+) -> None:
+    """Test controller-level entities are only created once for multiple sites."""
+    mock_omada_site_client.get_devices.return_value = []
+
+    first_entry = MockConfigEntry(
+        title="Test Omada Controller",
+        domain=DOMAIN,
+        data=dict(MOCK_ENTRY_DATA),
+        unique_id="12345_SiteId",
+        version=2,
+    )
+    second_entry = MockConfigEntry(
+        title="Test Omada Controller",
+        domain=DOMAIN,
+        data={**MOCK_ENTRY_DATA, "site": "SecondSite"},
+        unique_id="12345_SecondSite",
+        version=2,
+    )
+    first_entry.add_to_hass(hass)
+    second_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.tplink_omada.PLATFORMS",
+        [Platform.BINARY_SENSOR, Platform.UPDATE],
+    ):
+        assert await hass.config_entries.async_setup(first_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert second_entry.state is ConfigEntryState.LOADED
+
+    controller_entities = [
+        entry
+        for entry in er.async_entries_for_config_entry(
+            entity_registry, first_entry.entry_id
+        )
+        if entry.unique_id
+        in {
+            "2b8ebfe7af51afa2f58844e1f9ba0c04_controller_connectivity",
+            "2b8ebfe7af51afa2f58844e1f9ba0c04_controller_firmware",
+        }
+    ]
+
+    assert len(controller_entities) == 2
+    assert {
+        entry.unique_id
+        for entry in er.async_entries_for_config_entry(
+            entity_registry, second_entry.entry_id
+        )
+    }.isdisjoint(
+        {
+            "2b8ebfe7af51afa2f58844e1f9ba0c04_controller_connectivity",
+            "2b8ebfe7af51afa2f58844e1f9ba0c04_controller_firmware",
+        }
+    )
 
 
 async def test_migrate_entry_v1_to_v2(

--- a/tests/components/tplink_omada/test_sensor.py
+++ b/tests/components/tplink_omada/test_sensor.py
@@ -6,18 +6,22 @@ from unittest.mock import MagicMock, patch
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from tplink_omada_client import OmadaControllerInfo
 from tplink_omada_client.definitions import DeviceStatus, DeviceStatusCategory
 from tplink_omada_client.devices import OmadaListDevice
+from tplink_omada_client.exceptions import OmadaClientException
 
 from homeassistant.components.tplink_omada.const import DOMAIN
 from homeassistant.components.tplink_omada.coordinator import POLL_DEVICES
-from homeassistant.core import HomeAssistant
+from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import entity_registry as er
 
 from tests.common import (
     MockConfigEntry,
     async_fire_time_changed,
     async_load_json_array_fixture,
+    async_load_json_object_fixture,
     snapshot_platform,
 )
 
@@ -77,6 +81,73 @@ async def test_device_specific_status(
     assert entity and entity.state == "adopt_failed"
 
 
+async def test_controller_status_connected(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test controller status reports connected."""
+    entity = _get_controller_status_state(hass)
+
+    assert entity.state == "connected"
+    assert entity.attributes["configured"] is True
+    assert entity.attributes["type"] == 1
+    assert entity.attributes["support_app"] is True
+    assert "omadac_id" not in entity.attributes
+    assert entity.attributes["registered_root"] is True
+    assert entity.attributes["omadac_category"] == "advanced"
+    assert entity.attributes["msp_mode"] is False
+    assert entity.attributes["omada_cloud_url"] == "https://omada.tplinkcloud.com"
+
+    version_entity = hass.states.get("sensor.omada_controller_version")
+    assert version_entity is not None
+    assert version_entity.state == "6.2.10.15"
+
+    api_version_entity = hass.states.get("sensor.omada_controller_api_version")
+    assert api_version_entity is not None
+    assert api_version_entity.state == "3"
+
+
+async def test_controller_status_disconnected(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_omada_client: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test controller status reports disconnected when it is not configured."""
+    await _set_controller_configured(hass, mock_omada_client, False)
+
+    freezer.tick(POLL_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    entity = _get_controller_status_state(hass)
+    assert entity.state == "disconnected"
+    assert entity.attributes["configured"] is False
+
+
+async def test_controller_status_unavailable(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_omada_client: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test controller sensors are unavailable when controller info cannot update."""
+    mock_omada_client.get_controller_info.side_effect = OmadaClientException()
+
+    freezer.tick(POLL_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert _get_controller_status_state(hass).state == STATE_UNAVAILABLE
+    version_entity = hass.states.get("sensor.omada_controller_version")
+    assert version_entity is not None
+    assert version_entity.state == STATE_UNAVAILABLE
+
+    api_version_entity = hass.states.get("sensor.omada_controller_api_version")
+    assert api_version_entity is not None
+    assert api_version_entity.state == STATE_UNAVAILABLE
+
+
 async def test_device_category_status(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
@@ -102,6 +173,27 @@ async def test_device_category_status(
 
     entity = hass.states.get(entity_id)
     assert entity and entity.state == "pending"
+
+
+def _get_controller_status_state(hass: HomeAssistant) -> State:
+    entity = hass.states.get("sensor.omada_controller_device_status")
+    assert entity is not None
+    return entity
+
+
+async def _set_controller_configured(
+    hass: HomeAssistant,
+    mock_omada_client: MagicMock,
+    configured: bool,
+) -> None:
+    controller_info_data = await async_load_json_object_fixture(
+        hass, "controller-info.json", DOMAIN
+    )
+    controller_info_data["configured"] = configured
+    mock_omada_client.get_controller_info.reset_mock()
+    mock_omada_client.get_controller_info.return_value = OmadaControllerInfo(
+        controller_info_data
+    )
 
 
 async def _set_test_device_status(

--- a/tests/components/tplink_omada/test_update.py
+++ b/tests/components/tplink_omada/test_update.py
@@ -6,16 +6,19 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from tplink_omada_client import OmadaControllerUpdateInfo
 from tplink_omada_client.devices import OmadaListDevice
 from tplink_omada_client.exceptions import OmadaClientException, RequestFailed
 
 from homeassistant.components.tplink_omada.coordinator import POLL_DEVICES
 from homeassistant.components.update import (
     ATTR_IN_PROGRESS,
+    ATTR_INSTALLED_VERSION,
+    ATTR_LATEST_VERSION,
     DOMAIN as UPDATE_DOMAIN,
     SERVICE_INSTALL,
 )
-from homeassistant.const import ATTR_ENTITY_ID, STATE_ON, Platform
+from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
@@ -102,6 +105,81 @@ async def test_firmware_download_in_progress(
     assert entity.attributes.get(ATTR_IN_PROGRESS) is True
 
 
+@pytest.mark.parametrize(
+    (
+        "controller_update_info",
+        "expected_state",
+        "expected_installed_version",
+        "expected_latest_version",
+    ),
+    [
+        pytest.param(
+            OmadaControllerUpdateInfo(
+                {
+                    "software": {
+                        "upgrade": True,
+                        "currentVersion": "6.2.10.17",
+                        "latestVersion": "6.2.14.6 Build 20260617091728",
+                        "releaseLog": "Controller software update available.",
+                    }
+                }
+            ),
+            STATE_ON,
+            "6.2.10.17",
+            "6.2.14.6 Build 20260617091728",
+            id="software-update",
+        ),
+        pytest.param(
+            OmadaControllerUpdateInfo(
+                {
+                    "hardware": {
+                        "upgrade": True,
+                        "currentVersion": "2.0.1",
+                        "latestVersion": "2.1.0",
+                        "releaseLog": "Hardware controller update available.",
+                    }
+                }
+            ),
+            STATE_ON,
+            "2.0.1",
+            "2.1.0",
+            id="hardware-update",
+        ),
+        pytest.param(
+            OmadaControllerUpdateInfo({}),
+            STATE_OFF,
+            "6.2.10.15",
+            "6.2.10.15",
+            id="no-update",
+        ),
+    ],
+)
+async def test_controller_firmware_update_versions(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_omada_client: MagicMock,
+    controller_update_info: OmadaControllerUpdateInfo,
+    expected_state: str,
+    expected_installed_version: str,
+    expected_latest_version: str,
+) -> None:
+    """Test controller update entity version details."""
+    mock_omada_client.check_firmware_updates = AsyncMock(
+        return_value=controller_update_info
+    )
+
+    mock_config_entry.add_to_hass(hass)
+    with patch("homeassistant.components.tplink_omada.PLATFORMS", [Platform.UPDATE]):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    entity = hass.states.get("update.omada_controller_firmware")
+    assert entity is not None
+    assert entity.state == expected_state
+    assert entity.attributes[ATTR_INSTALLED_VERSION] == expected_installed_version
+    assert entity.attributes[ATTR_LATEST_VERSION] == expected_latest_version
+
+
 async def test_install_firmware_success(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
@@ -174,6 +252,7 @@ async def test_install_firmware_exceptions(
 @pytest.mark.parametrize(
     ("entity_name", "expected_notes"),
     [
+        ("omada_controller", "Controller software update available."),
         ("test_router", None),
         ("test_poe_switch", "Bug fixes and performance improvements"),
     ],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

None.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add TP-Link Omada controller entities backed by controller information and update coordinators:

- Controller connectivity binary sensor
- Controller firmware update entity
- Controller diagnostic sensors for device status, version, and API version

The controller diagnostic sensors reuse the existing `device_status` translation key where applicable. Version and API version use direct entity names instead of adding new translation keys.

This also updates the `tplink-omada-client` dependency to `1.5.9` for the controller information and firmware update API support.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
