### PR TITLE
Fix tesla_fleet media player volume step calculation

### DIFF
--- a/homeassistant/components/tesla_fleet/media_player.py
+++ b/homeassistant/components/tesla_fleet/media_player.py
@@ -76,14 +76,11 @@ class TeslaFleetMediaEntity(TeslaFleetVehicleEntity, MediaPlayerEntity):
         self._attr_state = STATES.get(
             self.get("vehicle_state_media_info_media_playback_status") or "Off",
         )
+        # volume_level is audio_volume / audio_volume_max, so one notch as a
+        # fraction of range is the per-notch increment divided by the max.
         self._attr_volume_step = (
-            1.0
-            / self._volume_max
-            / (
-                self.get("vehicle_state_media_info_audio_volume_increment")
-                or VOLUME_STEP
-            )
-        )
+            self.get("vehicle_state_media_info_audio_volume_increment") or VOLUME_STEP
+        ) / self._volume_max
 
         if volume := self.get("vehicle_state_media_info_audio_volume"):
             self._attr_volume_level = volume / self._volume_max

--- a/tests/components/tesla_fleet/test_media_player.py
+++ b/tests/components/tesla_fleet/test_media_player.py
@@ -61,8 +61,7 @@ async def test_media_player_volume_step(
         )
 
     # One notch up from the vehicle_data fixture's audio_volume of 1.6667 in a
-    # 10.333333 range: (1.6667 + 0.333333) / 10.333333. The old inverted formula
-    # would land at ~0.4516, roughly nine times too large a jump.
+    # 10.333333 range: (1.6667 + 0.333333) / 10.333333.
     state = hass.states.get(entity_id)
     assert state.attributes[ATTR_MEDIA_VOLUME_LEVEL] == pytest.approx(
         0.1935516, abs=1e-4

--- a/tests/components/tesla_fleet/test_media_player.py
+++ b/tests/components/tesla_fleet/test_media_player.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from syrupy.assertion import SnapshotAssertion
 from tesla_fleet_api.exceptions import VehicleOffline
 
@@ -35,6 +36,19 @@ async def test_media_player(
 
     await setup_platform(hass, normal_config_entry, [Platform.MEDIA_PLAYER])
     assert_entities(hass, normal_config_entry.entry_id, entity_registry, snapshot)
+
+
+async def test_media_player_volume_step(
+    hass: HomeAssistant,
+    normal_config_entry: MockConfigEntry,
+) -> None:
+    """Test volume_step is one Tesla notch as a fraction of the volume range."""
+
+    await setup_platform(hass, normal_config_entry, [Platform.MEDIA_PLAYER])
+
+    entity = hass.data[MEDIA_PLAYER_DOMAIN].get_entity("media_player.test_media_player")
+    # audio_volume_increment / audio_volume_max from the vehicle_data fixture.
+    assert entity.volume_step == pytest.approx(0.333333 / 10.333333)
 
 
 async def test_media_player_alt(

--- a/tests/components/tesla_fleet/test_media_player.py
+++ b/tests/components/tesla_fleet/test_media_player.py
@@ -14,6 +14,7 @@ from homeassistant.components.media_player import (
     SERVICE_MEDIA_PLAY,
     SERVICE_MEDIA_PREVIOUS_TRACK,
     SERVICE_VOLUME_SET,
+    SERVICE_VOLUME_UP,
     MediaPlayerState,
 )
 from homeassistant.const import ATTR_ENTITY_ID, Platform
@@ -42,13 +43,30 @@ async def test_media_player_volume_step(
     hass: HomeAssistant,
     normal_config_entry: MockConfigEntry,
 ) -> None:
-    """Test volume_step is one Tesla notch as a fraction of the volume range."""
+    """Test volume_up raises the level by exactly one Tesla notch."""
 
     await setup_platform(hass, normal_config_entry, [Platform.MEDIA_PLAYER])
 
-    entity = hass.data[MEDIA_PLAYER_DOMAIN].get_entity("media_player.test_media_player")
-    # audio_volume_increment / audio_volume_max from the vehicle_data fixture.
-    assert entity.volume_step == pytest.approx(0.333333 / 10.333333)
+    entity_id = "media_player.test_media_player"
+
+    with patch(
+        "tesla_fleet_api.tesla.VehicleFleet.adjust_volume",
+        return_value=COMMAND_OK,
+    ):
+        await hass.services.async_call(
+            MEDIA_PLAYER_DOMAIN,
+            SERVICE_VOLUME_UP,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
+
+    # One notch up from the vehicle_data fixture's audio_volume of 1.6667 in a
+    # 10.333333 range: (1.6667 + 0.333333) / 10.333333. The old inverted formula
+    # would land at ~0.4516, roughly nine times too large a jump.
+    state = hass.states.get(entity_id)
+    assert state.attributes[ATTR_MEDIA_VOLUME_LEVEL] == pytest.approx(
+        0.1935516, abs=1e-4
+    )
 
 
 async def test_media_player_alt(


### PR DESCRIPTION
## Proposed change

The media player `volume_step` for `tesla_fleet` was computed as
`1 / (audio_volume_max * audio_volume_increment)`, which is dimensionally wrong
and works out to roughly 9x too large. Bumping the volume once would jump the
slider by a large chunk of the range instead of a single Tesla notch.

Since `volume_level` is exposed as `audio_volume / audio_volume_max`, one Tesla
volume notch expressed as a fraction of the range is simply
`audio_volume_increment / audio_volume_max` (≈0.032, i.e. ~31 notches across the
full scale). Production NATS telemetry (2026-07-06) confirms
`audio_volume_increment` is consistently `0.333` and `audio_volume_max` is
consistently `10.333` in the same units, which lines up with the corrected
formula.

A regression test was added asserting `volume_step == increment / max`.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr