### PR TITLE
Add face detection event entity to UniFi Protect

### DIFF
--- a/homeassistant/components/unifiprotect/const.py
+++ b/homeassistant/components/unifiprotect/const.py
@@ -88,9 +88,11 @@ EVENT_TYPE_FINGERPRINT_NOT_IDENTIFIED: Final = "not_identified"
 EVENT_TYPE_NFC_SCANNED: Final = "scanned"
 EVENT_TYPE_VEHICLE_DETECTED: Final = "detected"
 EVENT_TYPE_PACKAGE_DETECTED: Final = "detected"
+EVENT_TYPE_FACE_DETECTED: Final = "detected"
 
-# Delay in seconds before firing vehicle event after last thumbnail
-VEHICLE_EVENT_DELAY_SECONDS: Final = 3
+# Delay in seconds before firing a thumbnail-enriched smart detect event
+# (vehicle/face) after the last thumbnail, so recognition data can arrive.
+SMART_DETECT_EVENT_DELAY_SECONDS: Final = 3
 
 KEYRINGS_ULP_ID: Final = "ulp_id"
 KEYRINGS_USER_STATUS: Final = "user_status"

--- a/homeassistant/components/unifiprotect/event.py
+++ b/homeassistant/components/unifiprotect/event.py
@@ -20,6 +20,7 @@ from homeassistant.helpers.event import async_call_at
 from . import Bootstrap
 from .const import (
     ATTR_EVENT_ID,
+    EVENT_TYPE_FACE_DETECTED,
     EVENT_TYPE_FINGERPRINT_IDENTIFIED,
     EVENT_TYPE_FINGERPRINT_NOT_IDENTIFIED,
     EVENT_TYPE_NFC_SCANNED,
@@ -29,7 +30,7 @@ from .const import (
     KEYRINGS_ULP_ID,
     KEYRINGS_USER_FULL_NAME,
     KEYRINGS_USER_STATUS,
-    VEHICLE_EVENT_DELAY_SECONDS,
+    SMART_DETECT_EVENT_DELAY_SECONDS,
 )
 from .data import (
     EventType,
@@ -184,19 +185,31 @@ class ProtectDeviceFingerprintEventEntity(
             self.async_write_ha_state()
 
 
-class ProtectDeviceVehicleEventEntity(
+class ProtectDeviceThumbnailEventEntity(
     EventEntityMixin, ProtectDeviceEntity, EventEntity
 ):
-    """A UniFi Protect vehicle detection event entity.
+    """Base entity for smart detect events enriched by detected thumbnails.
 
-    Vehicle detection events use a delayed firing mechanism to allow time for
-    the best thumbnail (with license plate recognition data) to arrive. The
-    timer is extended each time new thumbnails arrive for the same event. If
-    a new event arrives while a timer is pending, the old event fires immediately
-    with its stored thumbnails, then a new timer starts for the new event.
+    Some smart detect object types carry recognition data on their detected
+    thumbnails that only arrives near the *end* of the event: license plate
+    recognition for vehicles and face recognition for faces, both exposed via
+    ``thumbnail.group.matched_name``. To capture it these events use a delayed
+    firing mechanism: the timer is extended each time new thumbnails arrive for
+    the same event. If a new event arrives while a timer is pending, the old
+    event fires immediately with its stored thumbnails, then a new timer starts
+    for the new event.
+
+    Subclasses set ``_thumbnail_type`` (the detected-thumbnail type to select)
+    and ``_matched_name_attr`` (the event-data attribute used to expose
+    ``group.matched_name``).
     """
 
     entity_description: ProtectEventEntityDescription
+
+    _thumbnail_type: str
+    _matched_name_attr: str
+    _event_type: str
+
     _thumbnail_timer_cancel: CALLBACK_TYPE | None = None
     _latest_event_id: str | None = None
     _latest_thumbnails: list[EventDetectedThumbnail] | None = None
@@ -231,20 +244,20 @@ class ProtectDeviceVehicleEventEntity(
             return
 
         if self._latest_event_id:
-            self._fire_vehicle_event(self._latest_event_id, self._latest_thumbnails)
+            self._fire_event(self._latest_event_id, self._latest_thumbnails)
 
-    @staticmethod
-    def _get_vehicle_thumbnails(event: Event) -> list[EventDetectedThumbnail]:
-        """Get vehicle thumbnails from event."""
+    def _get_thumbnails(self, event: Event) -> list[EventDetectedThumbnail]:
+        """Get thumbnails of this entity's object type from the event."""
         if event.metadata and event.metadata.detected_thumbnails:
             return [
-                t for t in event.metadata.detected_thumbnails if t.type == "vehicle"
+                t
+                for t in event.metadata.detected_thumbnails
+                if t.type == self._thumbnail_type
             ]
         return []
 
-    @staticmethod
     def _build_event_data(
-        event_id: str, thumbnails: list[EventDetectedThumbnail]
+        self, event_id: str, thumbnails: list[EventDetectedThumbnail]
     ) -> dict[str, Any]:
         """Build event data dictionary from thumbnails."""
         event_data: dict[str, Any] = {
@@ -262,11 +275,12 @@ class ProtectDeviceVehicleEventEntity(
         if thumbnail.clock_best_wall is not None:
             event_data["clock_best_wall"] = thumbnail.clock_best_wall.isoformat()
 
-        # License plate from group.matched_name (UFP 6.0+) or name field (older)
+        # Recognition result from group.matched_name (UFP 6.0+) or name field
+        # (older): license plate for vehicles, matched name for faces.
         if thumbnail.group and thumbnail.group.matched_name:
-            event_data["license_plate"] = thumbnail.group.matched_name
+            event_data[self._matched_name_attr] = thumbnail.group.matched_name
         elif thumbnail.name:
-            event_data["license_plate"] = thumbnail.name
+            event_data[self._matched_name_attr] = thumbnail.name
 
         # Add all thumbnail attributes as dict
         if thumbnail.attributes:
@@ -275,10 +289,10 @@ class ProtectDeviceVehicleEventEntity(
         return event_data
 
     @callback
-    def _fire_vehicle_event(
+    def _fire_event(
         self, event_id: str, thumbnails: list[EventDetectedThumbnail] | None = None
     ) -> None:
-        """Fire the vehicle detection event with best available thumbnail.
+        """Fire the detection event with the best available thumbnail.
 
         Args:
             event_id: The event ID to include in the fired event data.
@@ -290,7 +304,7 @@ class ProtectDeviceVehicleEventEntity(
             event = self.entity_description.get_event_obj(self.device)
             if not event or event.id != event_id:
                 return
-            thumbnails = self._get_vehicle_thumbnails(event)
+            thumbnails = self._get_thumbnails(event)
 
         if not thumbnails:
             return
@@ -305,7 +319,7 @@ class ProtectDeviceVehicleEventEntity(
         self._fired_event_id = event_id
         self._fired_event_data = event_data
 
-        self._trigger_event(EVENT_TYPE_VEHICLE_DETECTED, event_data)
+        self._trigger_event(self._event_type, event_data)
         self.async_write_ha_state()
 
     @callback
@@ -327,11 +341,11 @@ class ProtectDeviceVehicleEventEntity(
             self._event = event
             self._event_end = event.end if event else None
 
-        # Process vehicle detection events with thumbnails
+        # Process detection events with thumbnails of our object type
         if (
             event
             and event.type is EventType.SMART_DETECT
-            and (thumbnails := self._get_vehicle_thumbnails(event))
+            and (thumbnails := self._get_thumbnails(event))
         ):
             # Skip if same event with same data (no changes)
             if (
@@ -345,19 +359,42 @@ class ProtectDeviceVehicleEventEntity(
             # Fire the old event immediately since it has completed
             if self._latest_event_id and self._latest_event_id != event.id:
                 # Only fire if we haven't already (shouldn't happen, but defensive)
-                self._fire_vehicle_event(self._latest_event_id, self._latest_thumbnails)
+                self._fire_event(self._latest_event_id, self._latest_thumbnails)
                 self._cancel_thumbnail_timer()
 
             # Store event data and extend/start the timer
-            # Timer extension allows better thumbnails (with LPR) to arrive
+            # Timer extension allows better thumbnails (with recognition) to arrive
             self._latest_event_id = event.id
             self._latest_thumbnails = thumbnails
             self._thumbnail_timer_due = (
-                self.hass.loop.time() + VEHICLE_EVENT_DELAY_SECONDS
+                self.hass.loop.time() + SMART_DETECT_EVENT_DELAY_SECONDS
             )
             # Only schedule if no timer running; existing timer will re-arm
             if self._thumbnail_timer_cancel is None:
                 self._async_set_thumbnail_timer()
+
+
+class ProtectDeviceVehicleEventEntity(ProtectDeviceThumbnailEventEntity):
+    """A UniFi Protect vehicle detection event entity.
+
+    Exposes the recognized license plate (when available) as ``license_plate``.
+    """
+
+    _thumbnail_type = "vehicle"
+    _matched_name_attr = "license_plate"
+    _event_type = EVENT_TYPE_VEHICLE_DETECTED
+
+
+class ProtectDeviceFaceEventEntity(ProtectDeviceThumbnailEventEntity):
+    """A UniFi Protect face detection event entity.
+
+    Exposes the recognized person (when Protect face recognition matches a
+    known face) as ``detected_name``.
+    """
+
+    _thumbnail_type = "face"
+    _matched_name_attr = "detected_name"
+    _event_type = EVENT_TYPE_FACE_DETECTED
 
 
 class ProtectDeviceSmartDetectEventEntity(
@@ -438,6 +475,14 @@ EVENT_DESCRIPTIONS: tuple[ProtectEventEntityDescription, ...] = (
         ufp_obj_type=SmartDetectObjectType.PACKAGE,
         event_types=[EVENT_TYPE_PACKAGE_DETECTED],
         entity_class=ProtectDeviceSmartDetectEventEntity,
+    ),
+    ProtectEventEntityDescription(
+        key="face",
+        translation_key="face",
+        ufp_required_field="can_detect_face",
+        ufp_event_obj="last_smart_detect_event",
+        event_types=[EVENT_TYPE_FACE_DETECTED],
+        entity_class=ProtectDeviceFaceEventEntity,
     ),
 )
 

--- a/homeassistant/components/unifiprotect/icons.json
+++ b/homeassistant/components/unifiprotect/icons.json
@@ -178,6 +178,9 @@
       "doorbell": {
         "default": "mdi:doorbell-video"
       },
+      "face": {
+        "default": "mdi:face-recognition"
+      },
       "fingerprint": {
         "default": "mdi:fingerprint"
       },

--- a/homeassistant/components/unifiprotect/strings.json
+++ b/homeassistant/components/unifiprotect/strings.json
@@ -278,6 +278,16 @@
           }
         }
       },
+      "face": {
+        "name": "Face",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "detected": "Detected"
+            }
+          }
+        }
+      },
       "fingerprint": {
         "name": "Fingerprint",
         "state_attributes": {

--- a/tests/components/unifiprotect/test_event.py
+++ b/tests/components/unifiprotect/test_event.py
@@ -41,9 +41,9 @@ TEST_VEHICLE_EVENT_DELAY = 0.05
 
 @pytest.fixture(autouse=True)
 def short_vehicle_delay():
-    """Use a short delay for vehicle event tests."""
+    """Use a short delay for thumbnail-enriched smart detect event tests."""
     with patch(
-        "homeassistant.components.unifiprotect.event.VEHICLE_EVENT_DELAY_SECONDS",
+        "homeassistant.components.unifiprotect.event.SMART_DETECT_EVENT_DELAY_SECONDS",
         TEST_VEHICLE_EVENT_DELAY,
     ):
         yield
@@ -1738,3 +1738,163 @@ async def test_aiport_no_event_entities(
     # AI Port should not create any camera-specific event entities
     # (doorbell, motion, etc.)
     assert_entity_counts(hass, Platform.EVENT, 0, 0)
+
+
+async def test_face_detection_recognized(
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+    doorbell: Camera,
+    unadopted_camera: Camera,
+    fixed_now: datetime,
+) -> None:
+    """Test face detection event exposes the recognized (matched) name."""
+
+    doorbell.feature_flags.smart_detect_types.append(SmartDetectObjectType.FACE)
+    await init_entry(hass, ufp, [doorbell, unadopted_camera])
+    # Face capability adds one more event entity to the doorbell.
+    assert_entity_counts(hass, Platform.EVENT, 6, 6)
+    events: list[HAEvent] = []
+
+    @callback
+    def _capture_event(event: HAEvent) -> None:
+        events.append(event)
+
+    _, entity_id = await ids_from_device_description(
+        hass, Platform.EVENT, doorbell, EVENT_DESCRIPTIONS[5]
+    )
+
+    unsub = async_track_state_change_event(hass, entity_id, _capture_event)
+
+    # Create event with a face thumbnail carrying a matched name (UFP 6.0+),
+    # plus a person thumbnail that must be ignored.
+    event = Event(
+        model=ModelType.EVENT,
+        id="test_face_event_id",
+        type=EventType.SMART_DETECT,
+        start=fixed_now - timedelta(seconds=1),
+        end=None,
+        score=100,
+        smart_detect_types=[],
+        smart_detect_event_ids=[],
+        camera_id=doorbell.id,
+        api=ufp.api,
+        metadata={
+            "detected_thumbnails": [
+                {
+                    "type": "face",
+                    "confidence": 87,
+                    "clock_best_wall": fixed_now,
+                    "cropped_id": "test_thumb_id",
+                    "group": {
+                        "id": "face_group_1",
+                        "matched_name": "John Doe",
+                        "confidence": 87,
+                    },
+                },
+                {
+                    "type": "person",  # Should be ignored
+                    "confidence": 100,
+                    "clock_best_wall": fixed_now,
+                    "cropped_id": "test_thumb_id_person",
+                },
+            ]
+        },
+    )
+
+    new_camera = doorbell.model_copy()
+    new_camera.last_smart_detect_event_id = "test_face_event_id"
+    ufp.api.bootstrap.cameras = {new_camera.id: new_camera}
+    ufp.api.bootstrap.events = {event.id: event}
+
+    mock_msg = Mock()
+    mock_msg.changed_data = {}
+    mock_msg.new_obj = event
+    ufp.ws_msg(mock_msg)
+
+    # Wait for the timer
+    await asyncio.sleep(TEST_VEHICLE_EVENT_DELAY * 2)
+    await hass.async_block_till_done()
+
+    # Should have received a face detection event with the matched name
+    assert len(events) == 1
+    state = events[0].data["new_state"]
+    assert state
+    assert state.attributes[ATTR_ATTRIBUTION] == DEFAULT_ATTRIBUTION
+    assert state.attributes[ATTR_EVENT_ID] == "test_face_event_id"
+    assert state.attributes["confidence"] == 87
+    assert state.attributes["detected_name"] == "John Doe"
+
+    unsub()
+
+
+async def test_face_detection_unrecognized(
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+    doorbell: Camera,
+    unadopted_camera: Camera,
+    fixed_now: datetime,
+) -> None:
+    """Test face detection event without a match omits the detected name."""
+
+    doorbell.feature_flags.smart_detect_types.append(SmartDetectObjectType.FACE)
+    await init_entry(hass, ufp, [doorbell, unadopted_camera])
+    assert_entity_counts(hass, Platform.EVENT, 6, 6)
+    events: list[HAEvent] = []
+
+    @callback
+    def _capture_event(event: HAEvent) -> None:
+        events.append(event)
+
+    _, entity_id = await ids_from_device_description(
+        hass, Platform.EVENT, doorbell, EVENT_DESCRIPTIONS[5]
+    )
+
+    unsub = async_track_state_change_event(hass, entity_id, _capture_event)
+
+    # Face thumbnail with no group and no name: an unrecognized face.
+    event = Event(
+        model=ModelType.EVENT,
+        id="test_face_unknown_id",
+        type=EventType.SMART_DETECT,
+        start=fixed_now - timedelta(seconds=1),
+        end=None,
+        score=100,
+        smart_detect_types=[],
+        smart_detect_event_ids=[],
+        camera_id=doorbell.id,
+        api=ufp.api,
+        metadata={
+            "detected_thumbnails": [
+                {
+                    "type": "face",
+                    "confidence": 60,
+                    "clock_best_wall": fixed_now,
+                    "cropped_id": "test_thumb_id",
+                }
+            ]
+        },
+    )
+
+    new_camera = doorbell.model_copy()
+    new_camera.last_smart_detect_event_id = "test_face_unknown_id"
+    ufp.api.bootstrap.cameras = {new_camera.id: new_camera}
+    ufp.api.bootstrap.events = {event.id: event}
+
+    mock_msg = Mock()
+    mock_msg.changed_data = {}
+    mock_msg.new_obj = event
+    ufp.ws_msg(mock_msg)
+
+    # Wait for the timer
+    await asyncio.sleep(TEST_VEHICLE_EVENT_DELAY * 2)
+    await hass.async_block_till_done()
+
+    # Event fires (a face was detected) but carries no recognized name.
+    assert len(events) == 1
+    state = events[0].data["new_state"]
+    assert state
+    assert state.attributes[ATTR_EVENT_ID] == "test_face_unknown_id"
+    assert state.attributes["confidence"] == 60
+    assert "detected_name" not in state.attributes
+
+    unsub()


### PR DESCRIPTION
## Proposed change

UniFi Protect surfaces face-recognition results on smart detect events the same
way it does license-plate recognition for vehicles: the matched name is carried
on a detected thumbnail's `group.matched_name` (UFP 6.0+). The integration
already consumes this for vehicles (`event.<camera>_vehicle` → `license_plate`),
but never exposed it for faces.

This adds a **face** event entity (`event.<camera>_face`) that fires on face
smart detections and exposes the recognized person via a `detected_name`
attribute (present only when Protect matches a known face).

To avoid duplicating the vehicle entity's delayed-firing / best-thumbnail logic,
the existing `ProtectDeviceVehicleEventEntity` is generalized into a
`ProtectDeviceThumbnailEventEntity` base, parameterized by the detected-thumbnail
type and the event-data attribute used to expose `group.matched_name`. Vehicle
keeps exposing `license_plate`; the new face entity exposes `detected_name`.

The entity is created only for cameras with face-detection capability
(`can_detect_face`), so setups without it are unaffected.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- Face recognition must be enabled in UniFi Protect (UFP 6.0+) with labeled
  faces for `detected_name` to be populated; otherwise the event still fires on
  a detected face with no name (mirroring how vehicle events fire without a
  `license_plate` when there is no LPR match).
- The delayed-fire timer is reused because recognition data (matched name)
  arrives near the end of the smart detect event, same as license plates.

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`).
- [x] Tests have been added to verify that the new code works.
- [x] Documentation added/updated is not required (attributes documented via strings/icons).
