### PR TITLE
Fix for Atlantic heaters missing regulation mode in Overkiz

### DIFF
--- a/homeassistant/components/overkiz/climate/atlantic_electrical_heater_with_adjustable_temperature_setpoint.py
+++ b/homeassistant/components/overkiz/climate/atlantic_electrical_heater_with_adjustable_temperature_setpoint.py
@@ -105,9 +105,11 @@ class AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint(
     def hvac_mode(self) -> HVACMode:
         """Return hvac operation ie. heat, cool mode."""
         states = self.device.states
-        if (state := states[OverkizState.CORE_OPERATING_MODE]) and state.value_as_str:
+        if (
+            state := states.get(OverkizState.CORE_OPERATING_MODE)
+        ) and state.value_as_str:
             return OVERKIZ_TO_HVAC_MODE[state.value_as_str]
-        if (state := states[OverkizState.CORE_ON_OFF]) and state.value_as_str:
+        if (state := states.get(OverkizState.CORE_ON_OFF)) and state.value_as_str:
             return OVERKIZ_TO_HVAC_MODE[state.value_as_str]
         return HVACMode.OFF
 
@@ -123,7 +125,9 @@ class AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint(
     def hvac_action(self) -> HVACAction:
         """Return the current running hvac operation ie. heating, idle, off."""
         states = self.device.states
-        if (state := states[OverkizState.CORE_REGULATION_MODE]) and state.value_as_str:
+        if (
+            state := states.get(OverkizState.CORE_REGULATION_MODE)
+        ) and state.value_as_str:
             return OVERKIZ_TO_HVAC_ACTION[state.value_as_str]
         return HVACAction.OFF
 
@@ -135,12 +139,12 @@ class AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint(
         states = self.device.states
 
         if (
-            state := states[OverkizState.IO_TARGET_HEATING_LEVEL]
+            state := states.get(OverkizState.IO_TARGET_HEATING_LEVEL)
         ) and state.value_as_str:
             return OVERKIZ_TO_PRESET_MODE[state.value_as_str]
 
         if (
-            operating_mode := states[OverkizState.CORE_OPERATING_MODE]
+            operating_mode := states.get(OverkizState.CORE_OPERATING_MODE)
         ) and operating_mode.value_as_str == OverkizCommandParam.EXTERNAL:
             return PRESET_EXTERNAL
         return None

--- a/tests/components/overkiz/fixtures/setup/cloud_atlantic_cozytouch.json
+++ b/tests/components/overkiz/fixtures/setup/cloud_atlantic_cozytouch.json
@@ -1598,6 +1598,650 @@
       "type": 5,
       "uiClass": "ProtocolGateway",
       "widget": "IOStack"
+    },
+    {
+      "creationTime": 1673778881000,
+      "lastUpdateTime": 1673778881000,
+      "label": "Living room heater",
+      "deviceURL": "modbuslink://1234-5678-5643/1#1",
+      "shortcut": false,
+      "controllableName": "modbuslink:AtlanticElectricalHeaterWithAdjustableTemperatureSetpointMBLComponent",
+      "definition": {
+        "commands": [
+          {
+            "commandName": "off",
+            "nparams": 0
+          },
+          {
+            "commandName": "on",
+            "nparams": 0
+          },
+          {
+            "commandName": "refreshAbsenceEndDate",
+            "nparams": 0
+          },
+          {
+            "commandName": "refreshAbsenceMode",
+            "nparams": 0
+          },
+          {
+            "commandName": "refreshAbsenceStartDate",
+            "nparams": 0
+          },
+          {
+            "commandName": "refreshBoostActivation",
+            "nparams": 0
+          },
+          {
+            "commandName": "refreshDateTime",
+            "nparams": 0
+          },
+          {
+            "commandName": "refreshErrorCode",
+            "nparams": 0
+          },
+          {
+            "commandName": "refreshFridayTimeProgram",
+            "nparams": 0
+          },
+          {
+            "commandName": "refreshHeatingLevel",
+            "nparams": 0
+          },
+          {
+            "commandName": "refreshIdentifier",
+            "nparams": 0
+          },
+          {
+            "commandName": "refreshLanguage",
+            "nparams": 0
+          },
+          {
+            "commandName": "refreshMaximumHeatingTargetTemperature",
+            "nparams": 0
+          },
+          {
+            "commandName": "refreshMondayTimeProgram",
+            "nparams": 0
+          },
+          {
+            "commandName": "refreshOccupancyActivation",
+            "nparams": 0
+          },
+          {
+            "commandName": "refreshOnOffState",
+            "nparams": 0
+          },
+          {
+            "commandName": "refreshOperatingMode",
+            "nparams": 0
+          },
+          {
+            "commandName": "refreshSaturdayTimeProgram",
+            "nparams": 0
+          },
+          {
+            "commandName": "refreshSundayTimeProgram",
+            "nparams": 0
+          },
+          {
+            "commandName": "refreshTargetTemperature",
+            "nparams": 0
+          },
+          {
+            "commandName": "refreshThursdayTimeProgram",
+            "nparams": 0
+          },
+          {
+            "commandName": "refreshTuesdayTimeProgram",
+            "nparams": 0
+          },
+          {
+            "commandName": "refreshWednesdayTimeProgram",
+            "nparams": 0
+          },
+          {
+            "commandName": "setAbsenceEndDate",
+            "nparams": 1
+          },
+          {
+            "commandName": "setAbsenceMode",
+            "nparams": 1
+          },
+          {
+            "commandName": "setAbsenceStartDate",
+            "nparams": 1
+          },
+          {
+            "commandName": "setBoostActivation",
+            "nparams": 1
+          },
+          {
+            "commandName": "setDateTime",
+            "nparams": 1
+          },
+          {
+            "commandName": "setHeatingLevel",
+            "nparams": 1
+          },
+          {
+            "commandName": "setLanguage",
+            "nparams": 1
+          },
+          {
+            "commandName": "setMaximumHeatingTargetTemperature",
+            "nparams": 1
+          },
+          {
+            "commandName": "setMondayTimeProgram",
+            "nparams": 1
+          },
+          {
+            "commandName": "setOccupancyActivation",
+            "nparams": 1
+          },
+          {
+            "commandName": "setOnOff",
+            "nparams": 1
+          },
+          {
+            "commandName": "setOperatingMode",
+            "nparams": 1
+          },
+          {
+            "commandName": "setSaturdayTimeProgram",
+            "nparams": 1
+          },
+          {
+            "commandName": "setSundayTimeProgram",
+            "nparams": 1
+          },
+          {
+            "commandName": "setTargetTemperature",
+            "nparams": 1
+          },
+          {
+            "commandName": "setWednesdayTimeProgram",
+            "nparams": 1
+          },
+          {
+            "commandName": "startIdentify",
+            "nparams": 0
+          },
+          {
+            "commandName": "stopIdentify",
+            "nparams": 0
+          },
+          {
+            "commandName": "setFridayTimeProgram",
+            "nparams": 1
+          },
+          {
+            "commandName": "setThursdayTimeProgram",
+            "nparams": 1
+          },
+          {
+            "commandName": "setTuesdayTimeProgram",
+            "nparams": 1
+          },
+          {
+            "commandName": "refreshDiagnostic",
+            "nparams": 0
+          },
+          {
+            "commandName": "refreshSetpointLoweringTemperatureInProgMode",
+            "nparams": 0
+          },
+          {
+            "commandName": "refreshStaticStates1",
+            "nparams": 0
+          },
+          {
+            "commandName": "refreshStaticStates2",
+            "nparams": 0
+          },
+          {
+            "commandName": "setSetpointLoweringTemperatureInProgMode",
+            "nparams": 1
+          }
+        ],
+        "states": [
+          {
+            "type": "DataState",
+            "qualifiedName": "core:AbsenceEndDateState"
+          },
+          {
+            "type": "DataState",
+            "qualifiedName": "core:AbsenceStartDateState"
+          },
+          {
+            "type": "DiscreteState",
+            "values": ["active", "inactive"],
+            "qualifiedName": "core:BoostActivationState"
+          },
+          {
+            "type": "DataState",
+            "qualifiedName": "core:DateTimeState"
+          },
+          {
+            "type": "DataState",
+            "qualifiedName": "core:ErrorCodeState"
+          },
+          {
+            "type": "DataState",
+            "qualifiedName": "core:FridayTimeProgramState"
+          },
+          {
+            "type": "DataState",
+            "qualifiedName": "core:IdentifierState"
+          },
+          {
+            "type": "ContinuousState",
+            "qualifiedName": "core:LanguageState"
+          },
+          {
+            "type": "ContinuousState",
+            "qualifiedName": "core:MaximumHeatingTargetTemperatureState"
+          },
+          {
+            "type": "DataState",
+            "qualifiedName": "core:MondayTimeProgramState"
+          },
+          {
+            "type": "DataState",
+            "qualifiedName": "core:NameState"
+          },
+          {
+            "type": "DiscreteState",
+            "values": ["active", "inactive"],
+            "qualifiedName": "core:OccupancyActivationState"
+          },
+          {
+            "type": "DiscreteState",
+            "values": ["available", "unavailable"],
+            "qualifiedName": "core:OccupancySensorStatusState"
+          },
+          {
+            "type": "DiscreteState",
+            "values": ["off", "on"],
+            "qualifiedName": "core:OnOffState"
+          },
+          {
+            "type": "DiscreteState",
+            "values": [
+              "antifreeze",
+              "auto",
+              "away",
+              "eco",
+              "frostprotection",
+              "manual",
+              "max",
+              "normal",
+              "off",
+              "on",
+              "prog",
+              "program",
+              "boost"
+            ],
+            "qualifiedName": "core:OperatingModeState"
+          },
+          {
+            "type": "DataState",
+            "qualifiedName": "core:SaturdayTimeProgramState"
+          },
+          {
+            "type": "DataState",
+            "qualifiedName": "core:SundayTimeProgramState"
+          },
+          {
+            "type": "DiscreteState",
+            "values": [
+              "boost",
+              "comfort",
+              "comfort-1",
+              "comfort-2",
+              "eco",
+              "frostprotection",
+              "off",
+              "secured"
+            ],
+            "qualifiedName": "core:TargetHeatingLevelState"
+          },
+          {
+            "type": "ContinuousState",
+            "qualifiedName": "core:TargetTemperatureState"
+          },
+          {
+            "type": "DataState",
+            "qualifiedName": "core:ThursdayTimeProgramState"
+          },
+          {
+            "type": "DataState",
+            "qualifiedName": "core:TuesdayTimeProgramState"
+          },
+          {
+            "type": "ContinuousState",
+            "qualifiedName": "core:VersionState"
+          },
+          {
+            "type": "DataState",
+            "qualifiedName": "core:WednesdayTimeProgramState"
+          },
+          {
+            "type": "DiscreteState",
+            "values": ["off", "on", "prog"],
+            "qualifiedName": "modbuslink:AbsenceModeState"
+          },
+          {
+            "type": "ContinuousState",
+            "qualifiedName": "modbuslink:SetpointLoweringTemperatureInProgModeState"
+          },
+          {
+            "type": "DiscreteState",
+            "values": ["boost", "comfort", "eco"],
+            "qualifiedName": "modbuslink:TargetHeatingLevelState"
+          }
+        ],
+        "dataProperties": [],
+        "widgetName": "AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint",
+        "uiProfiles": [
+          "StatefulHeatingLevel",
+          "HeatingLevel",
+          "StatefulThermostat",
+          "Thermostat",
+          "StatefulSwitchable",
+          "Switchable"
+        ],
+        "uiClass": "HeatingSystem",
+        "uiClassifiers": ["emitter"],
+        "qualifiedName": "modbuslink:AtlanticElectricalHeaterWithAdjustableTemperatureSetpointMBLComponent",
+        "type": "ACTUATOR"
+      },
+      "states": [
+        {
+          "name": "modbuslink:AbsenceModeState",
+          "type": 3,
+          "value": "off"
+        },
+        {
+          "name": "core:MaximumHeatingTargetTemperatureState",
+          "type": 2,
+          "value": 30.0
+        },
+        {
+          "name": "core:IdentifierState",
+          "type": 3,
+          "value": "off"
+        },
+        {
+          "name": "core:MondayTimeProgramState",
+          "type": 11,
+          "value": {
+            "monday": [
+              {
+                "start": "06:00",
+                "end": "08:00"
+              },
+              {
+                "start": "18:00",
+                "end": "22:00"
+              },
+              {
+                "start": "00:00",
+                "end": "00:00"
+              }
+            ]
+          }
+        },
+        {
+          "name": "core:TuesdayTimeProgramState",
+          "type": 11,
+          "value": {
+            "tuesday": [
+              {
+                "start": "06:00",
+                "end": "08:00"
+              },
+              {
+                "start": "18:00",
+                "end": "22:00"
+              },
+              {
+                "start": "00:00",
+                "end": "00:00"
+              }
+            ]
+          }
+        },
+        {
+          "name": "core:WednesdayTimeProgramState",
+          "type": 11,
+          "value": {
+            "wednesday": [
+              {
+                "start": "06:00",
+                "end": "08:00"
+              },
+              {
+                "start": "12:00",
+                "end": "14:00"
+              },
+              {
+                "start": "18:00",
+                "end": "22:00"
+              }
+            ]
+          }
+        },
+        {
+          "name": "core:ThursdayTimeProgramState",
+          "type": 11,
+          "value": {
+            "thursday": [
+              {
+                "start": "06:00",
+                "end": "08:00"
+              },
+              {
+                "start": "18:00",
+                "end": "22:00"
+              },
+              {
+                "start": "00:00",
+                "end": "00:00"
+              }
+            ]
+          }
+        },
+        {
+          "name": "core:FridayTimeProgramState",
+          "type": 11,
+          "value": {
+            "friday": [
+              {
+                "start": "06:00",
+                "end": "08:00"
+              },
+              {
+                "start": "18:00",
+                "end": "22:00"
+              },
+              {
+                "start": "00:00",
+                "end": "00:00"
+              }
+            ]
+          }
+        },
+        {
+          "name": "core:SaturdayTimeProgramState",
+          "type": 11,
+          "value": {
+            "saturday": [
+              {
+                "start": "08:00",
+                "end": "22:00"
+              },
+              {
+                "start": "00:00",
+                "end": "00:00"
+              },
+              {
+                "start": "00:00",
+                "end": "00:00"
+              }
+            ]
+          }
+        },
+        {
+          "name": "core:SundayTimeProgramState",
+          "type": 11,
+          "value": {
+            "sunday": [
+              {
+                "start": "08:00",
+                "end": "22:00"
+              },
+              {
+                "start": "00:00",
+                "end": "00:00"
+              },
+              {
+                "start": "00:00",
+                "end": "00:00"
+              }
+            ]
+          }
+        },
+        {
+          "name": "core:TargetTemperatureState",
+          "type": 2,
+          "value": 7.0
+        },
+        {
+          "name": "modbuslink:SetpointLoweringTemperatureInProgModeState",
+          "type": 1,
+          "value": 15
+        },
+        {
+          "name": "core:OperatingModeState",
+          "type": 3,
+          "value": "manual"
+        },
+        {
+          "name": "core:BoostActivationState",
+          "type": 3,
+          "value": "active"
+        },
+        {
+          "name": "core:OccupancyActivationState",
+          "type": 3,
+          "value": "active"
+        },
+        {
+          "name": "modbuslink:TargetHeatingLevelState",
+          "type": 3,
+          "value": "comfort"
+        },
+        {
+          "name": "core:TargetHeatingLevelState",
+          "type": 3,
+          "value": "comfort"
+        },
+        {
+          "name": "core:OnOffState",
+          "type": 3,
+          "value": "off"
+        },
+        {
+          "name": "core:OccupancySensorStatusState",
+          "type": 3,
+          "value": "active"
+        },
+        {
+          "name": "core:VersionState",
+          "type": 1,
+          "value": 67
+        },
+        {
+          "name": "core:AbsenceEndDateState",
+          "type": 11,
+          "value": {
+            "month": 12,
+            "hour": 18,
+            "year": 2023,
+            "weekday": 4,
+            "day": 22,
+            "minute": 32,
+            "second": 39
+          }
+        },
+        {
+          "name": "core:AbsenceStartDateState",
+          "type": 11,
+          "value": {
+            "month": 12,
+            "hour": 20,
+            "year": 2023,
+            "weekday": 6,
+            "day": 17,
+            "minute": 22,
+            "second": 57
+          }
+        }
+      ],
+      "available": true,
+      "enabled": true,
+      "widget": "AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint",
+      "type": 1,
+      "uiClass": "HeatingSystem"
+    },
+    {
+      "creationTime": 1673778881000,
+      "lastUpdateTime": 1673778881000,
+      "label": "Living room temperature",
+      "deviceURL": "modbuslink://1234-5678-5643/1#2",
+      "shortcut": false,
+      "controllableName": "modbuslink:TemperatureInCelciusMBLSystemDeviceSensor",
+      "definition": {
+        "commands": [],
+        "states": [
+          {
+            "type": "ContinuousState",
+            "qualifiedName": "core:TemperatureState"
+          }
+        ],
+        "dataProperties": [],
+        "widgetName": "TemperatureSensor",
+        "uiProfiles": ["Temperature"],
+        "uiClass": "TemperatureSensor",
+        "qualifiedName": "modbuslink:TemperatureInCelciusMBLSystemDeviceSensor",
+        "type": "SENSOR"
+      },
+      "states": [
+        {
+          "name": "core:TemperatureState",
+          "type": 2,
+          "value": 21.1
+        }
+      ],
+      "attributes": [
+        {
+          "name": "core:MeasuredValueType",
+          "type": 3,
+          "value": "core:TemperatureInCelcius"
+        },
+        {
+          "name": "core:PowerSourceType",
+          "type": 3,
+          "value": "mainSupply"
+        }
+      ],
+      "available": true,
+      "enabled": true,
+      "widget": "TemperatureSensor",
+      "type": 2,
+      "uiClass": "TemperatureSensor"
     }
   ],
   "features": [],

--- a/tests/components/overkiz/snapshots/test_climate.ambr
+++ b/tests/components/overkiz/snapshots/test_climate.ambr
@@ -1,0 +1,423 @@
+# serializer version: 1
+# name: test_climate_entities_snapshot[cloud_atlantic_cozytouch.json][climate.living_room_heater-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <ClimateEntityCapabilityAttribute.HVAC_MODES: 'hvac_modes'>: list([
+        <HVACMode.HEAT: 'heat'>,
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.AUTO: 'auto'>,
+      ]),
+      <ClimateEntityCapabilityAttribute.MAX_TEMP: 'max_temp'>: 35,
+      <ClimateEntityCapabilityAttribute.MIN_TEMP: 'min_temp'>: 7,
+      <ClimateEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
+        'none',
+        'frost_protection',
+        'eco',
+        'comfort',
+        'comfort-1',
+        'comfort-2',
+        'auto',
+        'boost',
+        'external',
+        'prog',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.living_room_heater',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 401>,
+    'translation_key': 'overkiz',
+    'unique_id': 'modbuslink://1234-5678-5643/1#1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_climate_entities_snapshot[cloud_atlantic_cozytouch.json][climate.living_room_heater-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <ClimateEntityStateAttribute.CURRENT_TEMPERATURE: 'current_temperature'>: 21.1,
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Living room heater',
+      <ClimateEntityStateAttribute.HVAC_ACTION: 'hvac_action'>: <HVACAction.OFF: 'off'>,
+      <ClimateEntityCapabilityAttribute.HVAC_MODES: 'hvac_modes'>: list([
+        <HVACMode.HEAT: 'heat'>,
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.AUTO: 'auto'>,
+      ]),
+      <ClimateEntityCapabilityAttribute.MAX_TEMP: 'max_temp'>: 35,
+      <ClimateEntityCapabilityAttribute.MIN_TEMP: 'min_temp'>: 7,
+      <ClimateEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <ClimateEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
+        'none',
+        'frost_protection',
+        'eco',
+        'comfort',
+        'comfort-1',
+        'comfort-2',
+        'auto',
+        'boost',
+        'external',
+        'prog',
+      ]),
+      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <ClimateEntityFeature: 401>,
+      <ClimateEntityStateAttribute.TEMPERATURE: 'temperature'>: 7.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.living_room_heater',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat',
+  })
+# ---
+# name: test_climate_entities_snapshot[cloud_nexity_rail_din_europe.json][climate.maple_residence_garden_radiator-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <ClimateEntityCapabilityAttribute.HVAC_MODES: 'hvac_modes'>: list([
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      <ClimateEntityCapabilityAttribute.MAX_TEMP: 'max_temp'>: 26.0,
+      <ClimateEntityCapabilityAttribute.MIN_TEMP: 'min_temp'>: 5.0,
+      <ClimateEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
+        'none',
+        'away',
+        'comfort',
+        'eco',
+        'frost_protection',
+        'manual',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.maple_residence_garden_radiator',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 17>,
+    'translation_key': 'overkiz',
+    'unique_id': 'io://1234-5678-1698/15702199#1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_climate_entities_snapshot[cloud_nexity_rail_din_europe.json][climate.maple_residence_garden_radiator-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <ClimateEntityStateAttribute.CURRENT_TEMPERATURE: 'current_temperature'>: 24.4,
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Garden Radiator',
+      <ClimateEntityStateAttribute.HVAC_ACTION: 'hvac_action'>: <HVACAction.IDLE: 'idle'>,
+      <ClimateEntityCapabilityAttribute.HVAC_MODES: 'hvac_modes'>: list([
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      <ClimateEntityCapabilityAttribute.MAX_TEMP: 'max_temp'>: 26.0,
+      <ClimateEntityCapabilityAttribute.MIN_TEMP: 'min_temp'>: 5.0,
+      <ClimateEntityStateAttribute.PRESET_MODE: 'preset_mode'>: 'comfort',
+      <ClimateEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
+        'none',
+        'away',
+        'comfort',
+        'eco',
+        'frost_protection',
+        'manual',
+      ]),
+      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <ClimateEntityFeature: 17>,
+      <ClimateEntityStateAttribute.TEMPERATURE: 'temperature'>: 21.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.maple_residence_garden_radiator',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat',
+  })
+# ---
+# name: test_climate_entities_snapshot[cloud_nexity_rail_din_europe.json][climate.maple_residence_living_room_radiator-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <ClimateEntityCapabilityAttribute.HVAC_MODES: 'hvac_modes'>: list([
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      <ClimateEntityCapabilityAttribute.MAX_TEMP: 'max_temp'>: 26.0,
+      <ClimateEntityCapabilityAttribute.MIN_TEMP: 'min_temp'>: 5.0,
+      <ClimateEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
+        'none',
+        'away',
+        'comfort',
+        'eco',
+        'frost_protection',
+        'manual',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.maple_residence_living_room_radiator',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 17>,
+    'translation_key': 'overkiz',
+    'unique_id': 'io://1234-5678-1698/9253412#1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_climate_entities_snapshot[cloud_nexity_rail_din_europe.json][climate.maple_residence_living_room_radiator-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <ClimateEntityStateAttribute.CURRENT_TEMPERATURE: 'current_temperature'>: 21.5,
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Living Room Radiator',
+      <ClimateEntityStateAttribute.HVAC_ACTION: 'hvac_action'>: <HVACAction.IDLE: 'idle'>,
+      <ClimateEntityCapabilityAttribute.HVAC_MODES: 'hvac_modes'>: list([
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      <ClimateEntityCapabilityAttribute.MAX_TEMP: 'max_temp'>: 26.0,
+      <ClimateEntityCapabilityAttribute.MIN_TEMP: 'min_temp'>: 5.0,
+      <ClimateEntityStateAttribute.PRESET_MODE: 'preset_mode'>: 'comfort',
+      <ClimateEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
+        'none',
+        'away',
+        'comfort',
+        'eco',
+        'frost_protection',
+        'manual',
+      ]),
+      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <ClimateEntityFeature: 17>,
+      <ClimateEntityStateAttribute.TEMPERATURE: 'temperature'>: 21.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.maple_residence_living_room_radiator',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat',
+  })
+# ---
+# name: test_climate_entities_snapshot[cloud_nexity_rail_din_europe.json][climate.maple_residence_study_radiator-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <ClimateEntityCapabilityAttribute.HVAC_MODES: 'hvac_modes'>: list([
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      <ClimateEntityCapabilityAttribute.MAX_TEMP: 'max_temp'>: 26.0,
+      <ClimateEntityCapabilityAttribute.MIN_TEMP: 'min_temp'>: 5.0,
+      <ClimateEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
+        'none',
+        'away',
+        'comfort',
+        'eco',
+        'frost_protection',
+        'manual',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.maple_residence_study_radiator',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 17>,
+    'translation_key': 'overkiz',
+    'unique_id': 'io://1234-5678-1698/9187218#1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_climate_entities_snapshot[cloud_nexity_rail_din_europe.json][climate.maple_residence_study_radiator-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <ClimateEntityStateAttribute.CURRENT_TEMPERATURE: 'current_temperature'>: 20.6,
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Study Radiator',
+      <ClimateEntityStateAttribute.HVAC_ACTION: 'hvac_action'>: <HVACAction.HEATING: 'heating'>,
+      <ClimateEntityCapabilityAttribute.HVAC_MODES: 'hvac_modes'>: list([
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      <ClimateEntityCapabilityAttribute.MAX_TEMP: 'max_temp'>: 26.0,
+      <ClimateEntityCapabilityAttribute.MIN_TEMP: 'min_temp'>: 5.0,
+      <ClimateEntityStateAttribute.PRESET_MODE: 'preset_mode'>: 'comfort',
+      <ClimateEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
+        'none',
+        'away',
+        'comfort',
+        'eco',
+        'frost_protection',
+        'manual',
+      ]),
+      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <ClimateEntityFeature: 17>,
+      <ClimateEntityStateAttribute.TEMPERATURE: 'temperature'>: 21.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.maple_residence_study_radiator',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat',
+  })
+# ---
+# name: test_climate_entities_snapshot[cloud_nexity_rail_din_europe.json][climate.maple_residence_terrace_radiator-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <ClimateEntityCapabilityAttribute.HVAC_MODES: 'hvac_modes'>: list([
+        <HVACMode.AUTO: 'auto'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+        <HVACMode.OFF: 'off'>,
+      ]),
+      <ClimateEntityCapabilityAttribute.MAX_TEMP: 'max_temp'>: 26.0,
+      <ClimateEntityCapabilityAttribute.MIN_TEMP: 'min_temp'>: 15.0,
+      <ClimateEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
+        'away',
+        'eco',
+        'comfort',
+        'none',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.maple_residence_terrace_radiator',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 401>,
+    'translation_key': None,
+    'unique_id': 'ovp://1234-5678-1698/374762#1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_climate_entities_snapshot[cloud_nexity_rail_din_europe.json][climate.maple_residence_terrace_radiator-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <ClimateEntityStateAttribute.CURRENT_TEMPERATURE: 'current_temperature'>: 23.3,
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Terrace Radiator',
+      <ClimateEntityStateAttribute.HVAC_ACTION: 'hvac_action'>: <HVACAction.HEATING: 'heating'>,
+      <ClimateEntityCapabilityAttribute.HVAC_MODES: 'hvac_modes'>: list([
+        <HVACMode.AUTO: 'auto'>,
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+        <HVACMode.OFF: 'off'>,
+      ]),
+      <ClimateEntityCapabilityAttribute.MAX_TEMP: 'max_temp'>: 26.0,
+      <ClimateEntityCapabilityAttribute.MIN_TEMP: 'min_temp'>: 15.0,
+      <ClimateEntityStateAttribute.PRESET_MODE: 'preset_mode'>: 'comfort',
+      <ClimateEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
+        'away',
+        'eco',
+        'comfort',
+        'none',
+      ]),
+      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <ClimateEntityFeature: 401>,
+      <ClimateEntityStateAttribute.TEMPERATURE: 'temperature'>: 23.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.maple_residence_terrace_radiator',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat_cool',
+  })
+# ---

--- a/tests/components/overkiz/snapshots/test_sensor.ambr
+++ b/tests/components/overkiz/snapshots/test_sensor.ambr
@@ -1,4 +1,62 @@
 # serializer version: 1
+# name: test_sensor_entities_snapshot[cloud_atlantic_cozytouch.json][sensor.living_room_temperature_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.living_room_temperature_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Living room temperature Temperature',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Living room temperature Temperature',
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'modbuslink://1234-5678-5643/1#2-core:TemperatureState',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensor_entities_snapshot[cloud_atlantic_cozytouch.json][sensor.living_room_temperature_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'temperature',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Living room temperature Temperature',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.living_room_temperature_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '21.1',
+  })
+# ---
 # name: test_sensor_entities_snapshot[cloud_atlantic_cozytouch.json][sensor.my_home_patio_water_heating_bottom_tank_water_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/overkiz/test_climate.py
+++ b/tests/components/overkiz/test_climate.py
@@ -1,21 +1,19 @@
 """Tests for the Overkiz climate platform."""
 
 from collections.abc import Generator
+from pathlib import Path
 from unittest.mock import patch
 
 from freezegun.api import FrozenDateTimeFactory
 from pyoverkiz.enums import OverkizState
 from pyoverkiz.models import Event
 import pytest
+from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.climate import (
-    ATTR_HVAC_ACTION,
-    ATTR_PRESET_MODE,
-    HVACAction,
-    HVACMode,
-)
+from homeassistant.components.climate import ATTR_HVAC_ACTION, HVACAction
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 from .conftest import FixtureDevice, MockOverkizClient, SetupOverkizIntegration
 from .helpers import (
@@ -26,19 +24,25 @@ from .helpers import (
     device_unavailable_event,
 )
 
+from tests.common import snapshot_platform
+
 VALVE = FixtureDevice(
     "setup/cloud_nexity_rail_din_europe.json",
     "io://1234-5678-1698/15702199#1",
     "climate.maple_residence_garden_radiator",
 )
-
-# Atlantic MODBUSLINK heater that does not expose core:RegulationModeState,
-# io:TargetHeatingLevelState. See https://github.com/home-assistant/core/issues/175812.
-MODBUSLINK_HEATER = FixtureDevice(
+# Atlantic MODBUSLINK heater without core:RegulationModeState and
+# io:TargetHeatingLevelState states.
+COZYTOUCH = FixtureDevice(
     "setup/cloud_atlantic_cozytouch.json",
     "modbuslink://1234-5678-5643/1#1",
     "climate.living_room_heater",
 )
+
+SNAPSHOT_FIXTURES = [
+    VALVE,
+    COZYTOUCH,
+]
 
 
 @pytest.fixture(autouse=True)
@@ -46,6 +50,25 @@ def fixture_platforms() -> Generator[None]:
     """Limit platforms to climate only."""
     with patch("homeassistant.components.overkiz.PLATFORMS", [Platform.CLIMATE]):
         yield
+
+
+@pytest.mark.parametrize(
+    "device",
+    SNAPSHOT_FIXTURES,
+    ids=[Path(device.fixture).name for device in SNAPSHOT_FIXTURES],
+)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_climate_entities_snapshot(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+    device: FixtureDevice,
+) -> None:
+    """Test representative real setups via snapshot."""
+    config_entry = await setup_overkiz_integration(fixture=device.fixture)
+
+    await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
 
 
 async def test_valve_hvac_action_none_state(
@@ -84,20 +107,6 @@ async def test_valve_hvac_action_none_state(
     state = hass.states.get(VALVE.entity_id)
     assert state is not None
     assert state.attributes.get(ATTR_HVAC_ACTION) is None
-
-
-async def test_modbuslink_heater_loads_without_regulation_mode(
-    hass: HomeAssistant,
-    setup_overkiz_integration: SetupOverkizIntegration,
-) -> None:
-    """Test Atlantic MODBUSLINK heater loads when optional states are missing."""
-    await setup_overkiz_integration(fixture=MODBUSLINK_HEATER.fixture)
-
-    state = hass.states.get(MODBUSLINK_HEATER.entity_id)
-    assert state is not None
-    assert state.state == HVACMode.HEAT
-    assert state.attributes.get(ATTR_HVAC_ACTION) == HVACAction.OFF
-    assert state.attributes.get(ATTR_PRESET_MODE) is None
 
 
 UNKNOWN_DEVICE_URL = "zigbee://1234-5678-1698/65535"

--- a/tests/components/overkiz/test_climate.py
+++ b/tests/components/overkiz/test_climate.py
@@ -26,6 +26,7 @@ from .helpers import (
 
 from tests.common import snapshot_platform
 
+# io:HeatingValveIOComponent
 VALVE = FixtureDevice(
     "setup/cloud_nexity_rail_din_europe.json",
     "io://1234-5678-1698/15702199#1",

--- a/tests/components/overkiz/test_climate.py
+++ b/tests/components/overkiz/test_climate.py
@@ -8,7 +8,12 @@ from pyoverkiz.enums import OverkizState
 from pyoverkiz.models import Event
 import pytest
 
-from homeassistant.components.climate import ATTR_HVAC_ACTION, HVACAction
+from homeassistant.components.climate import (
+    ATTR_HVAC_ACTION,
+    ATTR_PRESET_MODE,
+    HVACAction,
+    HVACMode,
+)
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
@@ -25,6 +30,14 @@ VALVE = FixtureDevice(
     "setup/cloud_nexity_rail_din_europe.json",
     "io://1234-5678-1698/15702199#1",
     "climate.maple_residence_garden_radiator",
+)
+
+# Atlantic MODBUSLINK heater that does not expose core:RegulationModeState,
+# io:TargetHeatingLevelState. See https://github.com/home-assistant/core/issues/175812.
+MODBUSLINK_HEATER = FixtureDevice(
+    "setup/cloud_atlantic_cozytouch.json",
+    "modbuslink://1234-5678-5643/1#1",
+    "climate.living_room_heater",
 )
 
 
@@ -71,6 +84,20 @@ async def test_valve_hvac_action_none_state(
     state = hass.states.get(VALVE.entity_id)
     assert state is not None
     assert state.attributes.get(ATTR_HVAC_ACTION) is None
+
+
+async def test_modbuslink_heater_loads_without_regulation_mode(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+) -> None:
+    """Test Atlantic MODBUSLINK heater loads when optional states are missing."""
+    await setup_overkiz_integration(fixture=MODBUSLINK_HEATER.fixture)
+
+    state = hass.states.get(MODBUSLINK_HEATER.entity_id)
+    assert state is not None
+    assert state.state == HVACMode.HEAT
+    assert state.attributes.get(ATTR_HVAC_ACTION) == HVACAction.OFF
+    assert state.attributes.get(ATTR_PRESET_MODE) is None
 
 
 UNKNOWN_DEVICE_URL = "zigbee://1234-5678-1698/65535"

--- a/tests/components/overkiz/test_climate.py
+++ b/tests/components/overkiz/test_climate.py
@@ -31,8 +31,7 @@ VALVE = FixtureDevice(
     "io://1234-5678-1698/15702199#1",
     "climate.maple_residence_garden_radiator",
 )
-# Atlantic MODBUSLINK heater without core:RegulationModeState and
-# io:TargetHeatingLevelState states.
+# modbuslink:AtlanticElectricalHeaterWithAdjustableTemperatureSetpointMBLComponent
 COZYTOUCH = FixtureDevice(
     "setup/cloud_atlantic_cozytouch.json",
     "modbuslink://1234-5678-5643/1#1",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Atlantic MODBUSLINK electrical heaters (`modbuslink:AtlanticElectricalHeaterWithAdjustableTemperatureSetpointMBLComponent`) do not expose states such as `core:RegulationModeState` or `io:TargetHeatingLevelState`. Since the pyOverkiz 2.0 bump (#173212), `States.__getitem__` raises `KeyError` for a missing state instead of returning `None`, so `hvac_mode`, `hvac_action` and `preset_mode` crashed and the climate entities failed to load.

This uses `States.get()` for these optional lookups, matching the change already made for `target_temperature` and `current_temperature`. Climate entities are now also covered by snapshot tests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'"'"'ll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #175812
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you'"'"'re unsure about any of them, don'"'"'t hesitate to ask.
  We'"'"'re here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn'"'"'t yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr