### PR TITLE
Add MIT-0 to OSI approved SPDX licenses

### DIFF
--- a/script/licenses.py
+++ b/script/licenses.py
@@ -83,6 +83,7 @@ OSI_APPROVED_LICENSES_SPDX = {
     "LGPL-3.0-only",
     "LGPL-3.0-or-later",
     "MIT",
+    "MIT-0",
     "MIT-CMU",
     "MPL-1.1",
     "MPL-2.0",


### PR DESCRIPTION
## Proposed change

cffi 2.1.0 relicensed from MIT to MIT No Attribution (MIT-0) and declares it via the SPDX `License-Expression` field, causing the CI license check to fail:

```
We could not detect an OSI-approved license for cffi@2.1.0: MIT-0 -- None -- []
```

MIT-0 is [OSI-approved](https://opensource.org/license/mit-0). It's the MIT license with the attribution clause removed, and carries the SPDX identifier [`MIT-0`](https://spdx.org/licenses/MIT-0.html). The script already recognizes it on the classifier path (`OSI_APPROVED_LICENSES`), but it was missing from `OSI_APPROVED_LICENSES_SPDX`, which validates packages using the SPDX `License-Expression` field. This adds it to that allow-list.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
