### PR TITLE
Add MIT-0 to OSI approved SPDX licenses

### DIFF
--- a/script/licenses.py
+++ b/script/licenses.py
@@ -83,6 +83,7 @@ OSI_APPROVED_LICENSES_SPDX = {
     "LGPL-3.0-only",
     "LGPL-3.0-or-later",
     "MIT",
+    "MIT-0",
     "MIT-CMU",
     "MPL-1.1",
     "MPL-2.0",


### PR DESCRIPTION
## Proposed change

`MIT-0` ("MIT No Attribution", https://opensource.org/license/mit-0/) is an
OSI-approved license that was missing from `OSI_APPROVED_LICENSES_SPDX` in
`script/licenses.py`.

`cffi` 2.1.0 declares its license via the PEP 639 `License-Expression`
metadata field as `MIT-0`. Because that identifier wasn't in our allow-list,
the `Audit licenses` CI job fails with:

```
We could not detect an OSI-approved license for cffi@2.1.0: MIT-0
```

on any PR whose dependency set resolves to `cffi` 2.1.0.

This adds the single missing entry, alphabetically positioned between `MIT`
and `MIT-CMU`. No other files are touched.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

<details><summary>Full narrative / original brief</summary>

Add `MIT-0` to Home Assistant's approved SPDX license allow-list. This is a
single-purpose infra PR: one line added to `script/licenses.py`, adding
`"MIT-0"` to the `OSI_APPROVED_LICENSES_SPDX` set in alphabetical position
(right after `"MIT"`, before `"MIT-CMU"`).

`MIT-0` (SPDX "MIT No Attribution") is an OSI-approved license that is
missing from HA's SPDX allow-list. `cffi` 2.1.0 declares its license via the
PEP 639 `License-Expression` metadata field as `MIT-0`, so the `Audit
licenses` CI job fails with `We could not detect an OSI-approved license for
cffi@2.1.0: MIT-0` on any PR whose dependency set re-resolves to cffi 2.1.0.
Adding MIT-0 to the approved set is the correct, general fix (it is
genuinely OSI-approved), and unblocks that audit for every consumer.

Validated locally: `check_license_expression("MIT-0")` now returns `True`,
and `uv run python -m script.licenses extract` + `check` both pass with no
regressions.

</details>
