### PR TITLE
Use EntityStateAttribute enum in helpers

### DIFF
--- a/homeassistant/helpers/area_registry.py
+++ b/homeassistant/helpers/area_registry.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Literal, TypedDict, override
 
-from homeassistant.const import ATTR_DEVICE_CLASS
+from homeassistant.const import EntityStateAttribute
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.util.dt import utc_from_timestamp, utcnow
 from homeassistant.util.event_type import EventType
@@ -581,7 +581,8 @@ def _validate_temperature_entity(hass: HomeAssistant, entity_id: str) -> None:
 
     if (
         state.domain != "sensor"
-        or state.attributes.get(ATTR_DEVICE_CLASS) != SensorDeviceClass.TEMPERATURE
+        or state.attributes.get(EntityStateAttribute.DEVICE_CLASS)
+        != SensorDeviceClass.TEMPERATURE
     ):
         raise ValueError(f"Entity {entity_id} is not a temperature sensor")
 
@@ -595,6 +596,7 @@ def _validate_humidity_entity(hass: HomeAssistant, entity_id: str) -> None:
 
     if (
         state.domain != "sensor"
-        or state.attributes.get(ATTR_DEVICE_CLASS) != SensorDeviceClass.HUMIDITY
+        or state.attributes.get(EntityStateAttribute.DEVICE_CLASS)
+        != SensorDeviceClass.HUMIDITY
     ):
         raise ValueError(f"Entity {entity_id} is not a humidity sensor")

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -31,8 +31,6 @@ from typing import (
 import voluptuous as vol
 
 from homeassistant.const import (
-    ATTR_DEVICE_CLASS,
-    ATTR_UNIT_OF_MEASUREMENT,
     CONF_ABOVE,
     CONF_AFTER,
     CONF_ATTRIBUTE,
@@ -56,6 +54,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
     WEEKDAYS,
+    EntityStateAttribute,
 )
 from homeassistant.core import HomeAssistant, State, callback, split_entity_id
 from homeassistant.exceptions import (
@@ -989,7 +988,7 @@ class EntityNumericalConditionBase(EntityConditionBase):
             # Entity not found
             return None
         if not self._is_valid_unit(
-            entity_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+            entity_state.attributes.get(EntityStateAttribute.UNIT_OF_MEASUREMENT)
         ):
             # Entity unit does not match the expected unit
             return None
@@ -1007,7 +1006,7 @@ class EntityNumericalConditionBase(EntityConditionBase):
         domain_spec = self._domain_specs[entity_state.domain]
         if domain_spec.value_source is None:
             if not self._is_valid_unit(
-                entity_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+                entity_state.attributes.get(EntityStateAttribute.UNIT_OF_MEASUREMENT)
             ):
                 return None
             return entity_state.state
@@ -1095,7 +1094,7 @@ class EntityNumericalConditionWithUnitBase(EntityNumericalConditionBase):
 
     def _get_entity_unit(self, entity_state: State) -> str | None:
         """Get the unit of an entity from its state."""
-        return entity_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+        return entity_state.attributes.get(EntityStateAttribute.UNIT_OF_MEASUREMENT)
 
     @override
     def _get_threshold_value(self, threshold: ThresholdConfig | None) -> float | None:
@@ -1121,7 +1120,7 @@ class EntityNumericalConditionWithUnitBase(EntityNumericalConditionBase):
         try:
             return self._unit_converter.convert(
                 value,
-                entity_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT),
+                entity_state.attributes.get(EntityStateAttribute.UNIT_OF_MEASUREMENT),
                 self._base_unit,
             )
         except HomeAssistantError:
@@ -1851,7 +1850,7 @@ def time(
         ):
             after = datetime.strptime(after_entity.state, "%H:%M:%S").time()
         elif (
-            after_entity.attributes.get(ATTR_DEVICE_CLASS)
+            after_entity.attributes.get(EntityStateAttribute.DEVICE_CLASS)
             in (SensorDeviceClass.TIMESTAMP, SensorDeviceClass.UPTIME)
         ) and after_entity.state not in (
             STATE_UNAVAILABLE,
@@ -1881,7 +1880,7 @@ def time(
             except ValueError:
                 return False
         elif (
-            before_entity.attributes.get(ATTR_DEVICE_CLASS)
+            before_entity.attributes.get(EntityStateAttribute.DEVICE_CLASS)
             in (SensorDeviceClass.TIMESTAMP, SensorDeviceClass.UPTIME)
         ) and before_entity.state not in (
             STATE_UNAVAILABLE,

--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -14,11 +14,7 @@ from propcache.api import cached_property
 import voluptuous as vol
 
 from homeassistant.components.homeassistant.exposed_entities import async_should_expose
-from homeassistant.const import (
-    ATTR_DEVICE_CLASS,
-    ATTR_ENTITY_ID,
-    ATTR_SUPPORTED_FEATURES,
-)
+from homeassistant.const import ATTR_ENTITY_ID, EntityStateAttribute
 from homeassistant.core import Context, HomeAssistant, State, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util.hass_dict import HassKey
@@ -455,7 +451,9 @@ def _filter_by_features(
             yield candidate
             continue
 
-        supported_features = candidate.state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+        supported_features = candidate.state.attributes.get(
+            EntityStateAttribute.SUPPORTED_FEATURES, 0
+        )
         if (supported_features & features) == features:
             yield candidate
 
@@ -474,7 +472,7 @@ def _filter_by_device_classes(
             yield candidate
             continue
 
-        device_class = candidate.state.attributes.get(ATTR_DEVICE_CLASS)
+        device_class = candidate.state.attributes.get(EntityStateAttribute.DEVICE_CLASS)
         if device_class and (device_class in device_classes):
             yield candidate
 
@@ -811,7 +809,7 @@ def async_match_states(
 @callback
 def async_test_feature(state: State, feature: int, feature_name: str) -> None:
     """Test if state supports a feature."""
-    if state.attributes.get(ATTR_SUPPORTED_FEATURES, 0) & feature == 0:
+    if state.attributes.get(EntityStateAttribute.SUPPORTED_FEATURES, 0) & feature == 0:
         raise IntentHandleError(f"Entity {state.name} does not support {feature_name}")
 
 

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -30,6 +30,7 @@ from homeassistant.const import (
     ATTR_SERVICE,
     EVENT_HOMEASSISTANT_CLOSE,
     EVENT_SERVICE_REMOVED,
+    EntityStateAttribute,
 )
 from homeassistant.core import Context, Event, HomeAssistant, callback, split_entity_id
 from homeassistant.exceptions import HomeAssistantError
@@ -731,7 +732,10 @@ def _get_exposed_entities(
                 info["state"] = async_rounded_state(hass, state.entity_id, state)
 
             # Convert timestamp device_class states from UTC to local time
-            if state.attributes.get("device_class") == "timestamp" and state.state:
+            if (
+                state.attributes.get(EntityStateAttribute.DEVICE_CLASS) == "timestamp"
+                and state.state
+            ):
                 if (parsed_utc := dt_util.parse_datetime(state.state)) is not None:
                     info["state"] = dt_util.as_local(parsed_utc).isoformat()
 

--- a/homeassistant/helpers/template/states.py
+++ b/homeassistant/helpers/template/states.py
@@ -9,7 +9,7 @@ from typing import Any, override
 from lru import LRU
 from propcache.api import under_cached_property
 
-from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, STATE_UNKNOWN
+from homeassistant.const import STATE_UNKNOWN, EntityStateAttribute
 from homeassistant.core import (
     Context,
     HomeAssistant,
@@ -182,7 +182,7 @@ class StateTranslated:
 
         state_value = state.state
         domain = state.domain
-        device_class = state.attributes.get("device_class")
+        device_class = state.attributes.get(EntityStateAttribute.DEVICE_CLASS)
         entry = er.async_get(self._hass).async_get(entity_id)
         platform = None if entry is None else entry.platform
         translation_key = None if entry is None else entry.translation_key
@@ -219,7 +219,7 @@ class StateAttrTranslated:
             return attr_value
 
         domain = state.domain
-        device_class = state.attributes.get("device_class")
+        device_class = state.attributes.get(EntityStateAttribute.DEVICE_CLASS)
         entry = er.async_get(self._hass).async_get(entity_id)
         platform = None if entry is None else entry.platform
         translation_key = None if entry is None else entry.translation_key
@@ -413,7 +413,9 @@ class TemplateStateBase(State):
             state = async_rounded_state(self._hass, self._entity_id, self._state)
         else:
             state = self._state.state
-        if with_unit and (unit := self._state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)):
+        if with_unit and (
+            unit := self._state.attributes.get(EntityStateAttribute.UNIT_OF_MEASUREMENT)
+        ):
             return f"{state} {unit}"
         return state
 

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -26,7 +26,6 @@ import voluptuous as vol
 
 from homeassistant.const import (
     ATTR_ENTITY_ID,
-    ATTR_UNIT_OF_MEASUREMENT,
     CONF_ALIAS,
     CONF_DEVICE_ID,
     CONF_ENABLED,
@@ -42,6 +41,7 @@ from homeassistant.const import (
     CONF_ZONE,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
+    EntityStateAttribute,
 )
 from homeassistant.core import (
     CALLBACK_TYPE,
@@ -856,7 +856,7 @@ class EntityNumericalStateTriggerBase(EntityTriggerBase):
                 entity_id=threshold.entity,
             )
             return None
-        unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+        unit = state.attributes.get(EntityStateAttribute.UNIT_OF_MEASUREMENT)
         if not self._is_valid_unit(unit):
             # Entity unit does not match the expected unit
             report_not_triggered(
@@ -882,7 +882,9 @@ class EntityNumericalStateTriggerBase(EntityTriggerBase):
         domain_spec = self._domain_specs[state.domain]
         raw_value: Any
         if domain_spec.value_source is None:
-            if not self._is_valid_unit(state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)):
+            if not self._is_valid_unit(
+                state.attributes.get(EntityStateAttribute.UNIT_OF_MEASUREMENT)
+            ):
                 return None
             raw_value = state.state
         else:
@@ -907,7 +909,7 @@ class EntityNumericalStateTriggerBase(EntityTriggerBase):
         domain_spec = self._domain_specs[state.domain]
         raw_value: Any
         if domain_spec.value_source is None:
-            unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+            unit = state.attributes.get(EntityStateAttribute.UNIT_OF_MEASUREMENT)
             if not self._is_valid_unit(unit):
                 report_not_triggered(
                     "entity_unit_not_supported",
@@ -984,7 +986,7 @@ class EntityNumericalStateTriggerWithUnitBase(EntityNumericalStateTriggerBase):
 
     def _get_entity_unit(self, state: State) -> str | None:
         """Get the unit of an entity from its state."""
-        return state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+        return state.attributes.get(EntityStateAttribute.UNIT_OF_MEASUREMENT)
 
     @override
     def _report_tracked_value_problem(
@@ -1050,7 +1052,7 @@ class EntityNumericalStateTriggerWithUnitBase(EntityNumericalStateTriggerBase):
             )
             return None
 
-        unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+        unit = state.attributes.get(EntityStateAttribute.UNIT_OF_MEASUREMENT)
         try:
             return self._unit_converter.convert(value, unit, self._base_unit)
         except HomeAssistantError:

--- a/homeassistant/helpers/trigger_template_entity.py
+++ b/homeassistant/helpers/trigger_template_entity.py
@@ -18,14 +18,12 @@ from homeassistant.components.sensor.helpers import (  # pylint: disable=home-as
     async_parse_date_datetime,
 )
 from homeassistant.const import (
-    ATTR_ENTITY_PICTURE,
-    ATTR_FRIENDLY_NAME,
-    ATTR_ICON,
     CONF_DEVICE_CLASS,
     CONF_ICON,
     CONF_NAME,
     CONF_UNIQUE_ID,
     CONF_UNIT_OF_MEASUREMENT,
+    EntityStateAttribute,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import TemplateError
@@ -48,9 +46,9 @@ CONF_ATTRIBUTES = "attributes"
 CONF_PICTURE = "picture"
 
 CONF_TO_ATTRIBUTE = {
-    CONF_ICON: ATTR_ICON,
-    CONF_NAME: ATTR_FRIENDLY_NAME,
-    CONF_PICTURE: ATTR_ENTITY_PICTURE,
+    CONF_ICON: EntityStateAttribute.ICON,
+    CONF_NAME: EntityStateAttribute.FRIENDLY_NAME,
+    CONF_PICTURE: EntityStateAttribute.ENTITY_PICTURE,
 }
 
 TEMPLATE_ENTITY_BASE_SCHEMA = vol.Schema(


### PR DESCRIPTION
## Proposed change

Follow-up to #174633, which introduced the `EntityStateAttribute` enum and
migrated `entity.py` and `entity_registry.py`.

The core constants `ATTR_ASSUMED_STATE`, `ATTR_ATTRIBUTION`, `ATTR_DEVICE_CLASS`,
`ATTR_ENTITY_PICTURE`, `ATTR_FRIENDLY_NAME`, `ATTR_ICON`, `ATTR_SUPPORTED_FEATURES`
and `ATTR_UNIT_OF_MEASUREMENT` lack context and are used interchangeably to access
entity state attributes, configuration, service arguments and even library items.
Using the dedicated `EntityStateAttribute` enum adds context when these constants
are used to read (or write) base state attributes of an entity.

This PR migrates the remaining helper modules to the enum (and replaces a few bare
`"device_class"` string literals along the way):

- `helpers/area_registry.py`
- `helpers/condition.py`
- `helpers/intent.py`
- `helpers/llm.py`
- `helpers/template/states.py`
- `helpers/trigger.py`
- `helpers/trigger_template_entity.py`

No behaviour change: `EntityStateAttribute` is a `StrEnum`, so the resolved
attribute keys/values are identical to the previous constants.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
