### PR TITLE
Fix RollerShutterUno covers reporting open when closed in Overkiz

### DIFF
--- a/homeassistant/components/overkiz/cover.py
+++ b/homeassistant/components/overkiz/cover.py
@@ -88,6 +88,19 @@ COVER_DESCRIPTIONS: list[OverkizCoverDescription] = [
         invert_position=False,
         is_closed_state=OverkizState.CORE_OPEN_CLOSED,
     ),
+    # Needs override to omit is_closed_state: these devices report a sentinel
+    # ClosureState (124) and an unreliable OpenClosedState that stays "open"
+    # even when closed, so closed state is derived from position instead.
+    # uiClass is RollerShutter
+    OverkizCoverDescription(
+        key=UIWidget.POSITIONABLE_ROLLER_SHUTTER_UNO,
+        device_class=CoverDeviceClass.SHUTTER,
+        current_position_state=OverkizState.CORE_CLOSURE,
+        set_position_command=OverkizCommand.SET_CLOSURE,
+        open_command=OverkizCommand.OPEN,
+        close_command=OverkizCommand.CLOSE,
+        stop_command=OverkizCommand.STOP,
+    ),
     # Needs override to support lower/upper position control
     # uiClass is RollerShutter
     OverkizCoverDescription(

--- a/homeassistant/components/overkiz/cover.py
+++ b/homeassistant/components/overkiz/cover.py
@@ -88,9 +88,7 @@ COVER_DESCRIPTIONS: list[OverkizCoverDescription] = [
         invert_position=False,
         is_closed_state=OverkizState.CORE_OPEN_CLOSED,
     ),
-    # Needs override to omit is_closed_state: these devices report a sentinel
-    # ClosureState (124) and an unreliable OpenClosedState that stays "open"
-    # even when closed, so closed state is derived from position instead.
+    # Needs override to omit is_closed_state, since OpenClosedState is unreliable
     # uiClass is RollerShutter
     OverkizCoverDescription(
         key=UIWidget.POSITIONABLE_ROLLER_SHUTTER_UNO,

--- a/tests/components/overkiz/fixtures/setup/local_somfy_tahoma_switch_europe_2.json
+++ b/tests/components/overkiz/fixtures/setup/local_somfy_tahoma_switch_europe_2.json
@@ -1647,7 +1647,7 @@
         {
           "type": 1,
           "name": "core:TargetClosureState",
-          "value": 0
+          "value": 100
         },
         {
           "type": 6,

--- a/tests/components/overkiz/snapshots/test_cover.ambr
+++ b/tests/components/overkiz/snapshots/test_cover.ambr
@@ -3339,10 +3339,10 @@
 # name: test_cover_entities_snapshot[local_somfy_tahoma_switch_europe_2.json][cover.back_door_shutter-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 100,
+      <CoverEntityStateAttribute.CURRENT_POSITION: 'current_position'>: 0,
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'shutter',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Back Door Shutter',
-      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: True,
       <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
@@ -3350,7 +3350,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'open',
+    'state': 'closed',
   })
 # ---
 # name: test_cover_entities_snapshot[local_somfy_tahoma_switch_europe_2.json][cover.front_door_shutter-entry]

--- a/tests/components/overkiz/test_cover.py
+++ b/tests/components/overkiz/test_cover.py
@@ -102,6 +102,13 @@ POSITIONABLE_ROLLER_SHUTTER_UNO = FixtureDevice(
     "io://1234-5678-1516/3656107",
     "cover.maple_residence_hallway_shutter",
 )
+# Uno device physically closed (TargetClosureState=100) while its
+# unreliable OpenClosedState remains "open"
+CLOSED_ROLLER_SHUTTER_UNO = FixtureDevice(
+    "setup/local_somfy_tahoma_switch_europe_2.json",
+    "io://1234-5678-1516/3897767",
+    "cover.back_door_shutter",
+)
 POSITIONABLE_DUAL_ROLLER_SHUTTER = FixtureDevice(
     "setup/cloud_somfy_tahoma_switch_sc_europe.json",
     "io://1234-5678-5010/12931361",
@@ -751,6 +758,23 @@ async def test_is_closed_falls_back_to_position(
     state = hass.states.get(POSITIONABLE_VENETIAN_BLIND.entity_id)
     assert state.state == CoverState.OPEN
     assert state.attributes[ATTR_CURRENT_POSITION] == 50
+
+
+async def test_is_closed_ignores_unreliable_open_closed_state(
+    hass: HomeAssistant,
+    setup_overkiz_integration: SetupOverkizIntegration,
+) -> None:
+    """Test Uno covers derive closed state from position, not OpenClosedState.
+
+    RollerShutterUnoIO devices report a sentinel ClosureState (124) and an
+    unreliable OpenClosedState that stays "open" even when physically closed.
+    is_closed must fall back to the position derived from TargetClosureState.
+    """
+    await setup_overkiz_integration(fixture=CLOSED_ROLLER_SHUTTER_UNO.fixture)
+
+    state = hass.states.get(CLOSED_ROLLER_SHUTTER_UNO.entity_id)
+    assert state.attributes[ATTR_CURRENT_POSITION] == 0
+    assert state.state == CoverState.CLOSED
 
 
 async def test_cover_tilt_services(

--- a/tests/components/overkiz/test_cover.py
+++ b/tests/components/overkiz/test_cover.py
@@ -102,13 +102,6 @@ POSITIONABLE_ROLLER_SHUTTER_UNO = FixtureDevice(
     "io://1234-5678-1516/3656107",
     "cover.maple_residence_hallway_shutter",
 )
-# Uno device physically closed (TargetClosureState=100) while its
-# unreliable OpenClosedState remains "open"
-CLOSED_ROLLER_SHUTTER_UNO = FixtureDevice(
-    "setup/local_somfy_tahoma_switch_europe_2.json",
-    "io://1234-5678-1516/3897767",
-    "cover.back_door_shutter",
-)
 POSITIONABLE_DUAL_ROLLER_SHUTTER = FixtureDevice(
     "setup/cloud_somfy_tahoma_switch_sc_europe.json",
     "io://1234-5678-5010/12931361",
@@ -758,23 +751,6 @@ async def test_is_closed_falls_back_to_position(
     state = hass.states.get(POSITIONABLE_VENETIAN_BLIND.entity_id)
     assert state.state == CoverState.OPEN
     assert state.attributes[ATTR_CURRENT_POSITION] == 50
-
-
-async def test_is_closed_ignores_unreliable_open_closed_state(
-    hass: HomeAssistant,
-    setup_overkiz_integration: SetupOverkizIntegration,
-) -> None:
-    """Test Uno covers derive closed state from position, not OpenClosedState.
-
-    RollerShutterUnoIO devices report a sentinel ClosureState (124) and an
-    unreliable OpenClosedState that stays "open" even when physically closed.
-    is_closed must fall back to the position derived from TargetClosureState.
-    """
-    await setup_overkiz_integration(fixture=CLOSED_ROLLER_SHUTTER_UNO.fixture)
-
-    state = hass.states.get(CLOSED_ROLLER_SHUTTER_UNO.entity_id)
-    assert state.attributes[ATTR_CURRENT_POSITION] == 0
-    assert state.state == CoverState.CLOSED
 
 
 async def test_cover_tilt_services(


### PR DESCRIPTION
## Proposed change

`io:RollerShutterUnoIOComponent` covers report an unreliable `core:OpenClosedState` that stays `"open"` even when physically closed, so the cover reported position `0` while its state stayed `open`.

This adds a `PositionableRollerShutterUno` override that omits `is_closed_state`, letting `is_closed` fall back to the position (`0` = closed). One of the two identical Uno devices in the existing fixture is set to a closed state to cover this via the snapshot test.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #173349
- This PR is related to issue: #175761

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
