### PR TITLE
Use state attribute enums in August

### DIFF
--- a/homeassistant/components/august/lock.py
+++ b/homeassistant/components/august/lock.py
@@ -8,7 +8,11 @@ from yalexs.activity import ActivityType
 from yalexs.lock import Lock, LockOperation, LockStatus
 from yalexs.util import get_latest_activity, update_lock_detail_from_activity
 
-from homeassistant.components.lock import ATTR_CHANGED_BY, LockEntity, LockEntityFeature
+from homeassistant.components.lock import (
+    LockEntity,
+    LockEntityFeature,
+    LockEntityStateAttribute,
+)
 from homeassistant.const import ATTR_BATTERY_LEVEL
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -134,7 +138,7 @@ class AugustLock(AugustEntity, RestoreEntity, LockEntity):
 
     @override
     async def async_added_to_hass(self) -> None:
-        """Restore ATTR_CHANGED_BY on startup.
+        """Restore changed_by on startup.
 
         It is likely no longer in the activity log.
         """
@@ -143,5 +147,7 @@ class AugustLock(AugustEntity, RestoreEntity, LockEntity):
         if not (last_state := await self.async_get_last_state()):
             return
 
-        if ATTR_CHANGED_BY in last_state.attributes:
-            self._attr_changed_by = last_state.attributes[ATTR_CHANGED_BY]
+        if LockEntityStateAttribute.CHANGED_BY in last_state.attributes:
+            self._attr_changed_by = last_state.attributes[
+                LockEntityStateAttribute.CHANGED_BY
+            ]

--- a/homeassistant/components/august/sensor.py
+++ b/homeassistant/components/august/sensor.py
@@ -170,7 +170,7 @@ class AugustOperatorSensor(AugustEntity, RestoreSensor):
 
     @override
     async def async_added_to_hass(self) -> None:
-        """Restore ATTR_CHANGED_BY on startup.
+        """Restore attributes on startup.
 
         It is likely no longer in the activity log.
         """

--- a/homeassistant/components/august/sensor.py
+++ b/homeassistant/components/august/sensor.py
@@ -17,10 +17,10 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import (
-    ATTR_ENTITY_PICTURE,
     PERCENTAGE,
     STATE_UNAVAILABLE,
     EntityCategory,
+    EntityStateAttribute,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -187,8 +187,8 @@ class AugustOperatorSensor(AugustEntity, RestoreSensor):
 
         self._attr_native_value = last_sensor_state.native_value
         last_attrs = last_state.attributes
-        if ATTR_ENTITY_PICTURE in last_attrs:
-            self._attr_entity_picture = last_attrs[ATTR_ENTITY_PICTURE]
+        if EntityStateAttribute.ENTITY_PICTURE in last_attrs:
+            self._attr_entity_picture = last_attrs[EntityStateAttribute.ENTITY_PICTURE]
         if ATTR_OPERATION_REMOTE in last_attrs:
             self._operated_remote = last_attrs[ATTR_OPERATION_REMOTE]
         if ATTR_OPERATION_KEYPAD in last_attrs:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follow-up to #174633, which introduced the `EntityStateAttribute` enum and migrated `entity.py` and `entity_registry.py`.

The state-attribute constants lack context and are used interchangeably to access state attributes, configuration, service arguments and library items. Reading a state attribute through the dedicated enum makes the intent explicit.

This migrates the state-attribute reads in the August integration, restoring values from the previous state on startup:

- `sensor.py`: `state.attributes[ATTR_ENTITY_PICTURE]` -> `EntityStateAttribute.ENTITY_PICTURE` (base enum)
- `lock.py`: `state.attributes[ATTR_CHANGED_BY]` -> `LockEntityStateAttribute.CHANGED_BY` (lock platform enum)

No behaviour change: both are `StrEnum`s, so the resolved keys are identical.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)