### PR TITLE
Use EntityStateAttribute enum in configurator

### DIFF
--- a/homeassistant/components/configurator/__init__.py
+++ b/homeassistant/components/configurator/__init__.py
@@ -14,7 +14,7 @@ from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.const import ATTR_ENTITY_PICTURE, ATTR_FRIENDLY_NAME
+from homeassistant.const import EntityStateAttribute
 from homeassistant.core import (
     HassJob,
     HomeAssistant,
@@ -181,8 +181,8 @@ class Configurator:
         data = {
             ATTR_CONFIGURE_ID: request_id,
             ATTR_FIELDS: fields,
-            ATTR_FRIENDLY_NAME: name,
-            ATTR_ENTITY_PICTURE: entity_picture,
+            EntityStateAttribute.FRIENDLY_NAME: name,
+            EntityStateAttribute.ENTITY_PICTURE: entity_picture,
         }
 
         data.update(

--- a/tests/components/configurator/test_init.py
+++ b/tests/components/configurator/test_init.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 import pytest
 
 from homeassistant.components import configurator
-from homeassistant.const import ATTR_FRIENDLY_NAME
+from homeassistant.const import EntityStateAttribute
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.exceptions import Unauthorized
 from homeassistant.util import dt as dt_util
@@ -40,7 +40,7 @@ async def test_request_least_info(hass: HomeAssistant) -> None:
 async def test_request_all_info(hass: HomeAssistant) -> None:
     """Test request config with all possible info."""
     exp_attr = {
-        ATTR_FRIENDLY_NAME: "Test Request",
+        EntityStateAttribute.FRIENDLY_NAME: "Test Request",
         configurator.ATTR_DESCRIPTION: """config description
 
 [link name](link url)
@@ -48,7 +48,7 @@ async def test_request_all_info(hass: HomeAssistant) -> None:
 ![Description image](config image url)""",
         configurator.ATTR_SUBMIT_CAPTION: "config submit caption",
         configurator.ATTR_FIELDS: [],
-        configurator.ATTR_ENTITY_PICTURE: "config entity picture",
+        EntityStateAttribute.ENTITY_PICTURE: "config entity picture",
         configurator.ATTR_CONFIGURE_ID: configurator.async_request_config(
             hass,
             name="Test Request",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follow-up to #174633, which introduced the `EntityStateAttribute` enum and migrated `entity.py` and `entity_registry.py`.

The base state-attribute constants lack context and are used interchangeably to access state attributes, configuration, service arguments and library items. Writing a state attribute through the dedicated `EntityStateAttribute` enum makes the intent explicit.

This migrates the base state attributes set on the configurator entity state:

- `__init__.py`: the attributes dict passed to `states.async_set` now uses `EntityStateAttribute.FRIENDLY_NAME` / `EntityStateAttribute.ENTITY_PICTURE`

The test previously reached `ATTR_ENTITY_PICTURE` through the configurator module (a leaked import of the const); it now references the enum directly.

No behaviour change: `EntityStateAttribute` is a `StrEnum`, so the resolved keys are identical.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)