### PR TITLE
Use state attribute enums in derivative

### DIFF
--- a/homeassistant/components/derivative/config_flow.py
+++ b/homeassistant/components/derivative/config_flow.py
@@ -8,12 +8,7 @@ import voluptuous as vol
 from homeassistant.components.counter import DOMAIN as COUNTER_DOMAIN
 from homeassistant.components.input_number import DOMAIN as INPUT_NUMBER_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
-from homeassistant.const import (
-    ATTR_UNIT_OF_MEASUREMENT,
-    CONF_NAME,
-    CONF_SOURCE,
-    UnitOfTime,
-)
+from homeassistant.const import CONF_NAME, CONF_SOURCE, EntityStateAttribute, UnitOfTime
 from homeassistant.core import callback
 from homeassistant.helpers import selector
 from homeassistant.helpers.schema_config_entry_flow import (
@@ -59,13 +54,16 @@ def entity_selector_compatible(
     """Return an entity selector which compatible entities."""
     current = handler.hass.states.get(handler.options[CONF_SOURCE])
     unit_of_measurement = (
-        current.attributes.get(ATTR_UNIT_OF_MEASUREMENT) if current else None
+        current.attributes.get(EntityStateAttribute.UNIT_OF_MEASUREMENT)
+        if current
+        else None
     )
 
     entities = [
         ent.entity_id
         for ent in handler.hass.states.async_all(ALLOWED_DOMAINS)
-        if ent.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == unit_of_measurement
+        if ent.attributes.get(EntityStateAttribute.UNIT_OF_MEASUREMENT)
+        == unit_of_measurement
         and ent.domain in ALLOWED_DOMAINS
     ]
 

--- a/homeassistant/components/derivative/sensor.py
+++ b/homeassistant/components/derivative/sensor.py
@@ -8,23 +8,22 @@ from typing import override
 import voluptuous as vol
 
 from homeassistant.components.sensor import (
-    ATTR_STATE_CLASS,
     DEVICE_CLASS_UNITS,
     PLATFORM_SCHEMA as SENSOR_PLATFORM_SCHEMA,
     RestoreSensor,
     SensorDeviceClass,
     SensorEntity,
+    SensorEntityCapabilityAttribute,
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    ATTR_DEVICE_CLASS,
-    ATTR_UNIT_OF_MEASUREMENT,
     CONF_NAME,
     CONF_SOURCE,
     CONF_UNIQUE_ID,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
+    EntityStateAttribute,
     Platform,
     UnitOfTime,
 )
@@ -243,7 +242,9 @@ class DerivativeSensor(RestoreSensor, SensorEntity):
         if not source_state:
             return
 
-        source_class_raw = source_state.attributes.get(ATTR_DEVICE_CLASS)
+        source_class_raw = source_state.attributes.get(
+            EntityStateAttribute.DEVICE_CLASS
+        )
         source_class: SensorDeviceClass | None = None
         if isinstance(source_class_raw, str):
             try:
@@ -252,7 +253,9 @@ class DerivativeSensor(RestoreSensor, SensorEntity):
                 source_class = None
         if self._string_unit_prefix is not None and self._string_unit_time is not None:
             original_unit = self._attr_native_unit_of_measurement
-            source_unit = source_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+            source_unit = source_state.attributes.get(
+                EntityStateAttribute.UNIT_OF_MEASUREMENT
+            )
             if (
                 (
                     source_class
@@ -366,7 +369,9 @@ class DerivativeSensor(RestoreSensor, SensorEntity):
 
         last_state = await self.async_get_last_state()
         if last_state:
-            self._attr_device_class = last_state.attributes.get(ATTR_DEVICE_CLASS)
+            self._attr_device_class = last_state.attributes.get(
+                EntityStateAttribute.DEVICE_CLASS
+            )
 
     @override
     async def async_added_to_hass(self) -> None:
@@ -540,7 +545,7 @@ class DerivativeSensor(RestoreSensor, SensorEntity):
             # A negative derivative for a total increasing sensor likely indicates the
             # sensor has been reset. To prevent inaccurate data, discard this sample.
             if (
-                new_state.attributes.get(ATTR_STATE_CLASS)
+                new_state.attributes.get(SensorEntityCapabilityAttribute.STATE_CLASS)
                 == SensorStateClass.TOTAL_INCREASING
                 and new_derivative < 0
             ):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follow-up to #174633, which introduced the `EntityStateAttribute` enum and migrated `entity.py` and `entity_registry.py`.

The base state-attribute constants lack context and are used interchangeably to access state attributes, configuration, service arguments and library items. Reading a state (or capability) attribute through the dedicated enum makes the intent explicit.

This migrates the attribute reads in the derivative integration:

- `config_flow.py`: `state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)` -> `EntityStateAttribute.UNIT_OF_MEASUREMENT`
- `sensor.py`: `state.attributes.get(ATTR_DEVICE_CLASS)` -> `EntityStateAttribute.DEVICE_CLASS`
- `sensor.py`: `state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)` -> `EntityStateAttribute.UNIT_OF_MEASUREMENT`
- `sensor.py`: `state.attributes.get(ATTR_STATE_CLASS)` -> `SensorEntityCapabilityAttribute.STATE_CLASS` (state_class is exposed as a capability attribute)

No behaviour change: the enums are `StrEnum`s, so the resolved keys are identical.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)