### PR TITLE
Re-import Rexel client credential in Overkiz config flow

### DIFF
--- a/homeassistant/components/overkiz/config_flow.py
+++ b/homeassistant/components/overkiz/config_flow.py
@@ -191,12 +191,9 @@ class OverkizConfigFlow(
     async def async_step_pick_implementation(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Start the Rexel OAuth2 flow, ensuring its client credential exists.
-
-        Rexel's public OAuth2 client is auto-imported at startup, but a user can
-        remove it from the Application credentials menu. Re-importing here means a
-        fresh setup always has it available, without requiring a restart.
-        """
+        """Start the Rexel OAuth2 flow, re-importing the credential if removed."""
+        # Re-import here so a fresh setup works even after the user removed the
+        # auto-imported credential, without requiring a restart.
         await async_import_client_credential(
             self.hass,
             DOMAIN,

--- a/homeassistant/components/overkiz/config_flow.py
+++ b/homeassistant/components/overkiz/config_flow.py
@@ -192,8 +192,6 @@ class OverkizConfigFlow(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Start the Rexel OAuth2 flow, re-importing the credential if removed."""
-        # Re-import here so a fresh setup works even after the user removed the
-        # auto-imported credential, without requiring a restart.
         await async_import_client_credential(
             self.hass,
             DOMAIN,

--- a/homeassistant/components/overkiz/config_flow.py
+++ b/homeassistant/components/overkiz/config_flow.py
@@ -11,7 +11,11 @@ from pyoverkiz.auth.credentials import (
     UsernamePasswordCredentials,
 )
 from pyoverkiz.client import GatewayCandidate, OverkizClient
-from pyoverkiz.const import SERVERS_WITH_LOCAL_API, SUPPORTED_SERVERS
+from pyoverkiz.const import (
+    REXEL_OAUTH_CLIENT_ID,
+    SERVERS_WITH_LOCAL_API,
+    SUPPORTED_SERVERS,
+)
 from pyoverkiz.enums import APIType, Server
 from pyoverkiz.exceptions import (
     ApplicationNotAllowedError,
@@ -28,6 +32,10 @@ from pyoverkiz.obfuscate import obfuscate_id
 from pyoverkiz.utils import create_local_server_config, is_overkiz_gateway
 import voluptuous as vol
 
+from homeassistant.components.application_credentials import (
+    ClientCredential,
+    async_import_client_credential,
+)
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlowResult
 from homeassistant.const import (
     CONF_HOST,
@@ -133,7 +141,7 @@ class OverkizConfigFlow(
 
             # Rexel authenticates via OAuth2 (Azure AD B2C with PKCE).
             if self._server == Server.REXEL:
-                return await self.async_step_pick_implementation()
+                return await self._async_step_rexel_oauth()
 
             return await self.async_step_cloud()
 
@@ -160,7 +168,7 @@ class OverkizConfigFlow(
 
             # Rexel authenticates via OAuth2 (Azure AD B2C with PKCE).
             if self._server == Server.REXEL:
-                return await self.async_step_pick_implementation()
+                return await self._async_step_rexel_oauth()
 
             return await self.async_step_cloud()
 
@@ -178,6 +186,20 @@ class OverkizConfigFlow(
             ),
             description_placeholders={"local_api_docs": LOCAL_API_DOCS_URL},
         )
+
+    async def _async_step_rexel_oauth(self) -> ConfigFlowResult:
+        """Start the Rexel OAuth2 flow, ensuring its client credential exists.
+
+        Rexel's public OAuth2 client is auto-imported at startup, but a user can
+        remove it from the Application credentials menu. Re-importing here means a
+        fresh setup always has it available, without requiring a restart.
+        """
+        await async_import_client_credential(
+            self.hass,
+            DOMAIN,
+            ClientCredential(REXEL_OAUTH_CLIENT_ID, "", name="Rexel"),
+        )
+        return await self.async_step_pick_implementation()
 
     async def async_step_cloud(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/overkiz/config_flow.py
+++ b/homeassistant/components/overkiz/config_flow.py
@@ -141,7 +141,7 @@ class OverkizConfigFlow(
 
             # Rexel authenticates via OAuth2 (Azure AD B2C with PKCE).
             if self._server == Server.REXEL:
-                return await self._async_step_rexel_oauth()
+                return await self.async_step_pick_implementation()
 
             return await self.async_step_cloud()
 
@@ -168,7 +168,7 @@ class OverkizConfigFlow(
 
             # Rexel authenticates via OAuth2 (Azure AD B2C with PKCE).
             if self._server == Server.REXEL:
-                return await self._async_step_rexel_oauth()
+                return await self.async_step_pick_implementation()
 
             return await self.async_step_cloud()
 
@@ -187,7 +187,10 @@ class OverkizConfigFlow(
             description_placeholders={"local_api_docs": LOCAL_API_DOCS_URL},
         )
 
-    async def _async_step_rexel_oauth(self) -> ConfigFlowResult:
+    @override
+    async def async_step_pick_implementation(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Start the Rexel OAuth2 flow, ensuring its client credential exists.
 
         Rexel's public OAuth2 client is auto-imported at startup, but a user can
@@ -199,7 +202,7 @@ class OverkizConfigFlow(
             DOMAIN,
             ClientCredential(REXEL_OAUTH_CLIENT_ID, "", name="Rexel"),
         )
-        return await self.async_step_pick_implementation()
+        return await super().async_step_pick_implementation(user_input)
 
     async def async_step_cloud(
         self, user_input: dict[str, Any] | None = None

--- a/tests/components/overkiz/test_config_flow.py
+++ b/tests/components/overkiz/test_config_flow.py
@@ -1136,6 +1136,29 @@ async def test_rexel_full_flow_single_gateway(
     assert len(mock_setup_entry.mock_calls) == 1
 
 
+@pytest.mark.usefixtures("current_request_with_host")
+async def test_rexel_flow_reimports_removed_credential(
+    hass: HomeAssistant,
+) -> None:
+    """The Rexel flow re-imports its client credential if the user removed it."""
+    assert await async_setup_component(hass, "application_credentials", {})
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"hub": "rexel"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"api_type": "cloud"}
+    )
+
+    # Reaching the OAuth2 external step proves an implementation was available,
+    # i.e. the credential was re-imported despite not being present beforehand.
+    assert result["type"] is FlowResultType.EXTERNAL_STEP
+    assert REXEL_OAUTH_AUTHORIZE_URL in result["url"]
+
+
 @pytest.mark.usefixtures("current_request_with_host", "setup_rexel_credentials")
 async def test_rexel_full_flow_multiple_gateways(
     hass: HomeAssistant,


### PR DESCRIPTION
## Proposed change

Rexel's public OAuth2 client is auto-imported at startup, but a user can delete it from the Application credentials menu (e.g. via the prompt shown when removing a config entry). Since startup import only runs once, setting Rexel up again without a restart would then abort with `missing_credentials`.

Re-importing the credential at the start of the Rexel OAuth2 flow ensures a fresh setup always has it available. The import is idempotent, so it is a no-op when the credential already exists.

(this step can't be disabled at the moment unfortunately)
<img width="505" height="229" alt="image" src="https://github.com/user-attachments/assets/0711ddef-23b5-4f61-a695-b111cf12d2c9" />


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr