### PR TITLE
Use CounterEntityStateAttribute enum in counter triggers

### DIFF
--- a/homeassistant/components/counter/trigger.py
+++ b/homeassistant/components/counter/trigger.py
@@ -2,7 +2,6 @@
 
 from typing import override
 
-from homeassistant.const import CONF_MAXIMUM, CONF_MINIMUM
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.automation import DomainSpec
 from homeassistant.helpers.trigger import (
@@ -12,7 +11,8 @@ from homeassistant.helpers.trigger import (
     Trigger,
 )
 
-from . import CONF_INITIAL, DOMAIN
+from . import DOMAIN
+from .const import CounterEntityStateAttribute
 
 
 def _is_integer_state(state: State) -> bool:
@@ -74,7 +74,9 @@ class CounterMaxReachedTrigger(CounterValueBaseTrigger):
         report_not_triggered: NotTriggeredReasonReporter,
     ) -> bool:
         """Check if the new state matches the expected state(s)."""
-        if (max_value := state.attributes.get(CONF_MAXIMUM)) is None:
+        if (
+            max_value := state.attributes.get(CounterEntityStateAttribute.MAXIMUM)
+        ) is None:
             return False
         return state.state == str(max_value)
 
@@ -89,7 +91,9 @@ class CounterMinReachedTrigger(CounterValueBaseTrigger):
         report_not_triggered: NotTriggeredReasonReporter,
     ) -> bool:
         """Check if the new state matches the expected state(s)."""
-        if (min_value := state.attributes.get(CONF_MINIMUM)) is None:
+        if (
+            min_value := state.attributes.get(CounterEntityStateAttribute.MINIMUM)
+        ) is None:
             return False
         return state.state == str(min_value)
 
@@ -104,7 +108,9 @@ class CounterResetTrigger(CounterValueBaseTrigger):
         report_not_triggered: NotTriggeredReasonReporter,
     ) -> bool:
         """Check if the new state matches the expected state(s)."""
-        if (init_state := state.attributes.get(CONF_INITIAL)) is None:
+        if (
+            init_state := state.attributes.get(CounterEntityStateAttribute.INITIAL)
+        ) is None:
             return False
         return state.state == str(init_state)
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follow-up to #174633, which introduced the base `EntityStateAttribute` enum. Platform integrations now expose their own state-attribute enums too (e.g. `CounterEntityStateAttribute`).

The counter triggers read state attributes using the `CONF_MAXIMUM`, `CONF_MINIMUM` and `CONF_INITIAL` configuration constants - a good example of the ambiguity the enum resolves, since those constants describe configuration keys, not state attributes. Reading them through the dedicated `CounterEntityStateAttribute` enum makes the intent explicit.

This migrates the state-attribute reads in the counter triggers:

- `trigger.py`: `state.attributes.get(CONF_MAXIMUM)` -> `CounterEntityStateAttribute.MAXIMUM`
- `trigger.py`: `state.attributes.get(CONF_MINIMUM)` -> `CounterEntityStateAttribute.MINIMUM`
- `trigger.py`: `state.attributes.get(CONF_INITIAL)` -> `CounterEntityStateAttribute.INITIAL`

No behaviour change: `CounterEntityStateAttribute` is a `StrEnum`, so the resolved keys are identical.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)