### PR TITLE
Use state attribute enums in legacy device_tracker

### DIFF
--- a/homeassistant/components/device_tracker/legacy.py
+++ b/homeassistant/components/device_tracker/legacy.py
@@ -77,7 +77,9 @@ from .const import (
     LOGGER,
     PLATFORM_TYPE_LEGACY,
     SCAN_INTERVAL,
+    DeviceTrackerEntityStateAttribute,
     SourceType,
+    TrackerEntityStateAttribute,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -840,12 +842,14 @@ class Device(RestoreEntity):
     @override
     def state_attributes(self) -> dict[str, StateType]:
         """Return the device state attributes."""
-        attributes: dict[str, StateType] = {ATTR_SOURCE_TYPE: self.source_type}
+        attributes: dict[str, StateType] = {
+            DeviceTrackerEntityStateAttribute.SOURCE_TYPE: self.source_type
+        }
 
         if self.gps is not None:
-            attributes[ATTR_LATITUDE] = self.gps[0]
-            attributes[ATTR_LONGITUDE] = self.gps[1]
-            attributes[ATTR_GPS_ACCURACY] = self.gps_accuracy
+            attributes[TrackerEntityStateAttribute.LATITUDE] = self.gps[0]
+            attributes[TrackerEntityStateAttribute.LONGITUDE] = self.gps[1]
+            attributes[TrackerEntityStateAttribute.GPS_ACCURACY] = self.gps_accuracy
 
         if self.battery is not None:
             attributes[ATTR_BATTERY] = self.battery
@@ -952,17 +956,17 @@ class Device(RestoreEntity):
         self.last_seen = dt_util.utcnow()
 
         for attribute, var in (
-            (ATTR_SOURCE_TYPE, "source_type"),
-            (ATTR_GPS_ACCURACY, "gps_accuracy"),
+            (DeviceTrackerEntityStateAttribute.SOURCE_TYPE, "source_type"),
+            (TrackerEntityStateAttribute.GPS_ACCURACY, "gps_accuracy"),
             (ATTR_BATTERY, "battery"),
         ):
             if attribute in state.attributes:
                 setattr(self, var, state.attributes[attribute])
 
-        if ATTR_LONGITUDE in state.attributes:
+        if TrackerEntityStateAttribute.LONGITUDE in state.attributes:
             self.gps = (
-                state.attributes[ATTR_LATITUDE],
-                state.attributes[ATTR_LONGITUDE],
+                state.attributes[TrackerEntityStateAttribute.LATITUDE],
+                state.attributes[TrackerEntityStateAttribute.LONGITUDE],
             )
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follow-up to #174633, which introduced the base `EntityStateAttribute` enum. Platform integrations now expose their own state-attribute enums too (e.g. `DeviceTrackerEntityStateAttribute`, `TrackerEntityStateAttribute`).

The legacy device tracker `Device` entity reads and writes its state attributes through the ambiguous `ATTR_SOURCE_TYPE`, `ATTR_LATITUDE`, `ATTR_LONGITUDE` and `ATTR_GPS_ACCURACY` constants, which are also used for configuration schemas and the `see` service data. Accessing the state attributes through the dedicated enums makes the intent explicit.

This migrates the state-attribute access in `legacy.py`:

- `state_attributes`: `source_type` -> `DeviceTrackerEntityStateAttribute.SOURCE_TYPE`; `latitude` / `longitude` / `gps_accuracy` -> `TrackerEntityStateAttribute`
- restore from previous state: the same reads use the enums

Only the entity state-attribute access is migrated. The voluptuous config schema, the `see` service data, the `EVENT_NEW_DEVICE` event data, the `known_devices.yaml` writer and the zone attribute reads keep the original constants, and `ATTR_BATTERY` is left unchanged as no enum member exists for it.

No behaviour change: the enums are `StrEnum`s, so the resolved keys are identical.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)