### PR TITLE
Stop UniFi from piling up thousands of stale client devices

### DIFF
--- a/homeassistant/components/unifi/const.py
+++ b/homeassistant/components/unifi/const.py
@@ -1,5 +1,6 @@
 """Constants for the UniFi Network integration."""
 
+from datetime import timedelta
 import logging
 
 from aiounifi.models.device import DeviceState
@@ -8,6 +9,12 @@ from homeassistant.const import Platform
 
 LOGGER = logging.getLogger(__package__)
 DOMAIN = "unifi"
+
+# The UniFi controller keeps a record of every client it has ever seen. On busy
+# or guest networks that is easily tens of thousands of drive-by devices.
+# Only inactive clients seen within this window are restored on startup, older
+# ones are pruned together with their device so the registry stops growing.
+CLIENT_RESTORE_MAX_AGE = timedelta(days=30)
 
 PLATFORMS = [
     Platform.BUTTON,

--- a/homeassistant/components/unifi/hub/entity_loader.py
+++ b/homeassistant/components/unifi/hub/entity_loader.py
@@ -6,19 +6,21 @@ Make sure expected clients are available for platforms.
 
 import asyncio
 from collections.abc import Callable, Coroutine, Sequence
-from datetime import timedelta
+from datetime import datetime, timedelta
 from functools import partial
 from typing import TYPE_CHECKING, Any
 
 from aiounifi.interfaces.api_handlers import APIHandler, ItemEvent
+from aiounifi.models.client import Client
 
 from homeassistant.const import Platform
 from homeassistant.core import callback
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util import dt as dt_util
 
-from ..const import LOGGER, UNIFI_WIRELESS_CLIENTS
+from ..const import CLIENT_RESTORE_MAX_AGE, LOGGER, UNIFI_WIRELESS_CLIENTS
 from ..coordinator import UnifiDataUpdateCoordinator
 from ..entity import UnifiEntity, UnifiEntityDescription
 
@@ -102,23 +104,72 @@ class UnifiEntityLoader:
 
     @callback
     def _restore_inactive_clients(self) -> None:
-        """Restore inactive clients.
+        """Restore recently seen inactive clients and prune stale ones.
 
-        Provide inactive clients to device tracker and switch platform.
+        The UniFi controller keeps a record of every client it has ever seen.
+        Restoring all of them on every startup is what makes installations pile
+        up thousands of stale client devices. Only clients seen within the
+        retention window, or explicitly selected or blocked, are restored.
+        Trackers falling outside that window are removed together with their
+        device so the registry stops growing unbounded.
         """
         config = self.hub.config
-        entity_registry = er.async_get(self.hub.hass)
-        macs: list[str] = [
-            entry.unique_id.split("-", 1)[1]
-            for entry in er.async_entries_for_config_entry(
-                entity_registry, config.entry.entry_id
-            )
-            if entry.domain == Platform.DEVICE_TRACKER and "-" in entry.unique_id
-        ]
         api = self.hub.api
-        for mac in config.option_supported_clients + config.option_block_clients + macs:
+        entity_registry = er.async_get(self.hub.hass)
+        device_registry = dr.async_get(self.hub.hass)
+
+        now = dt_util.utcnow()
+        always_restore = set(config.option_supported_clients)
+        always_restore.update(config.option_block_clients)
+
+        pruned = 0
+        for entry in er.async_entries_for_config_entry(
+            entity_registry, config.entry.entry_id
+        ):
+            if entry.domain != Platform.DEVICE_TRACKER or "-" not in entry.unique_id:
+                continue
+
+            mac = entry.unique_id.split("-", 1)[1]
+            if mac in api.clients or mac in always_restore:
+                continue
+
+            client = api.clients_all.get(mac)
+            if client is not None and not self._client_is_stale(client, now):
+                api.clients.process_raw([dict(client.raw)])
+                continue
+
+            self._remove_client(entity_registry, device_registry, entry.entity_id, mac)
+            pruned += 1
+
+        if pruned:
+            LOGGER.debug("Pruned %s stale UniFi client device(s)", pruned)
+
+        for mac in always_restore:
             if mac not in api.clients and mac in api.clients_all:
                 api.clients.process_raw([dict(api.clients_all[mac].raw)])
+
+    @callback
+    def _client_is_stale(self, client: Client, now: datetime) -> bool:
+        """Return if a client has not been seen within the retention window."""
+        last_seen = dt_util.utc_from_timestamp(client.last_seen or 0)
+        return now - last_seen > CLIENT_RESTORE_MAX_AGE
+
+    @callback
+    def _remove_client(
+        self,
+        entity_registry: er.EntityRegistry,
+        device_registry: dr.DeviceRegistry,
+        entity_id: str,
+        mac: str,
+    ) -> None:
+        """Remove a stale client's tracker entity and its device."""
+        entity_registry.async_remove(entity_id)
+        if device := device_registry.async_get_device(
+            connections={(dr.CONNECTION_NETWORK_MAC, mac)}
+        ):
+            device_registry.async_update_device(
+                device.id, remove_config_entry_id=self.hub.config.entry.entry_id
+            )
 
     @callback
     def register_platform(

--- a/homeassistant/components/unifi/hub/entity_loader.py
+++ b/homeassistant/components/unifi/hub/entity_loader.py
@@ -133,8 +133,13 @@ class UnifiEntityLoader:
             if mac in api.clients or mac in always_restore:
                 continue
 
-            client = api.clients_all.get(mac)
-            if client is not None and not self._client_is_stale(client, now):
+            # Absent means the controller no longer reports it or the
+            # clients_all fetch failed this cycle. Never prune on that, a failed
+            # fetch would wipe every tracker and its device.
+            if (client := api.clients_all.get(mac)) is None:
+                continue
+
+            if not self._client_is_stale(client, now):
                 api.clients.process_raw([dict(client.raw)])
                 continue
 

--- a/homeassistant/components/unifi/hub/entity_loader.py
+++ b/homeassistant/components/unifi/hub/entity_loader.py
@@ -107,11 +107,10 @@ class UnifiEntityLoader:
         """Restore recently seen inactive clients and prune stale ones.
 
         The UniFi controller keeps a record of every client it has ever seen.
-        Restoring all of them on every startup is what makes installations pile
-        up thousands of stale client devices. Only clients seen within the
-        retention window, or explicitly selected or blocked, are restored.
-        Trackers falling outside that window are removed together with their
-        device so the registry stops growing unbounded.
+        Only clients seen within the retention window, or explicitly selected
+        or blocked, are restored. Trackers falling outside that window are
+        removed together with their device so the registry does not grow
+        unbounded.
         """
         config = self.hub.config
         api = self.hub.api

--- a/homeassistant/components/unifi/sensor.py
+++ b/homeassistant/components/unifi/sensor.py
@@ -50,6 +50,7 @@ from homeassistant.util import dt as dt_util, slugify
 
 from . import UnifiConfigEntry
 from .const import DEVICE_STATES
+from .device_tracker import async_client_allowed_fn
 from .entity import (
     UnifiEntity,
     UnifiEntityDescription,
@@ -106,11 +107,16 @@ def async_client_uptime_value_fn(hub: UnifiHub, client: Client) -> datetime:
 
 @callback
 def async_wired_client_allowed_fn(hub: UnifiHub, obj_id: str) -> bool:
-    """Check if client is wired and allowed."""
+    """Check if client is wired, tracked and reports a link speed.
+
+    Gate on the tracking options so the sensor (and its client device) is only
+    created for clients the user actually tracks, instead of every wired client
+    the controller has ever seen.
+    """
     client = hub.api.clients[obj_id]
     if not client.is_wired or client.wired_rate_mbps <= 0:
         return False
-    return True
+    return async_client_allowed_fn(hub, obj_id)
 
 
 @callback

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -638,26 +638,27 @@ async def test_pruning_stale_restored_clients(
     config_entry_factory: ConfigEntryFactoryType,
     clients_all_payload: list[dict[str, Any]],
 ) -> None:
-    """Restore recently seen inactive clients but prune stale ones and their device.
-
-    The controller keeps every client it has ever seen. Restoring all of them on
-    every startup is what made installations pile up thousands of stale client
-    devices, so clients seen outside the retention window are removed together
-    with their device instead of being resurrected again.
-    """
+    """Restore recently seen inactive clients but prune stale ones and their device."""
     recent, stale = clients_all_payload
+    # Client with a tracker but absent from clients_all, e.g. a failed fetch
+    absent_mac = "00:00:00:00:00:07"
+
     entries: dict[str, er.RegistryEntry] = {}
-    for client in clients_all_payload:
-        entries[client["mac"]] = entity_registry.async_get_or_create(
+    for mac, hostname in (
+        (recent["mac"], "recent"),
+        (stale["mac"], "stale"),
+        (absent_mac, "absent"),
+    ):
+        entries[mac] = entity_registry.async_get_or_create(
             TRACKER_DOMAIN,
             DOMAIN,
-            f"site_id-{client['mac']}",
-            suggested_object_id=client["hostname"],
+            f"site_id-{mac}",
+            suggested_object_id=hostname,
             config_entry=config_entry,
         )
         device_registry.async_get_or_create(
             config_entry_id=config_entry.entry_id,
-            connections={(dr.CONNECTION_NETWORK_MAC, client["mac"])},
+            connections={(dr.CONNECTION_NETWORK_MAC, mac)},
         )
 
     await config_entry_factory()
@@ -677,6 +678,12 @@ async def test_pruning_stale_restored_clients(
             connections={(dr.CONNECTION_NETWORK_MAC, stale["mac"])}
         )
         is None
+    )
+
+    # Client absent from clients_all is left untouched, never pruned on missing data
+    assert entity_registry.async_get(entries[absent_mac].entity_id)
+    assert device_registry.async_get_device(
+        connections={(dr.CONNECTION_NETWORK_MAC, absent_mac)}
     )
 
 

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -25,7 +25,7 @@ from homeassistant.components.unifi.const import (
 )
 from homeassistant.const import STATE_HOME, STATE_NOT_HOME, STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant, State
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util import dt as dt_util
 
 from .conftest import (
@@ -608,6 +608,76 @@ async def test_restoring_client(
     assert hass.states.get("device_tracker.wd_client_1")
     assert hass.states.get("device_tracker.restored")
     assert not hass.states.get("device_tracker.not_restored")
+
+
+@pytest.mark.parametrize("client_payload", [[WIRED_CLIENT_1]])
+@pytest.mark.parametrize(
+    "clients_all_payload",
+    [
+        [
+            {
+                "hostname": "recent",
+                "is_wired": True,
+                "last_seen": dt_util.as_timestamp(dt_util.utcnow()),
+                "mac": "00:00:00:00:00:05",
+            },
+            {
+                "hostname": "stale",
+                "is_wired": True,
+                "last_seen": 1562600145,  # 2019, well beyond the retention window
+                "mac": "00:00:00:00:00:06",
+            },
+        ]
+    ],
+)
+async def test_pruning_stale_restored_clients(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    config_entry: MockConfigEntry,
+    config_entry_factory: ConfigEntryFactoryType,
+    clients_all_payload: list[dict[str, Any]],
+) -> None:
+    """Restore recently seen inactive clients but prune stale ones and their device.
+
+    The controller keeps every client it has ever seen. Restoring all of them on
+    every startup is what made installations pile up thousands of stale client
+    devices, so clients seen outside the retention window are removed together
+    with their device instead of being resurrected again.
+    """
+    recent, stale = clients_all_payload
+    entries: dict[str, er.RegistryEntry] = {}
+    for client in clients_all_payload:
+        entries[client["mac"]] = entity_registry.async_get_or_create(
+            TRACKER_DOMAIN,
+            DOMAIN,
+            f"site_id-{client['mac']}",
+            suggested_object_id=client["hostname"],
+            config_entry=config_entry,
+        )
+        device_registry.async_get_or_create(
+            config_entry_id=config_entry.entry_id,
+            connections={(dr.CONNECTION_NETWORK_MAC, client["mac"])},
+        )
+
+    await config_entry_factory()
+
+    # Recently seen client is restored with its tracker and device intact
+    assert hass.states.get("device_tracker.recent")
+    assert entity_registry.async_get(entries[recent["mac"]].entity_id)
+    assert device_registry.async_get_device(
+        connections={(dr.CONNECTION_NETWORK_MAC, recent["mac"])}
+    )
+
+    # Stale client is pruned together with its device
+    assert not hass.states.get("device_tracker.stale")
+    assert entity_registry.async_get(entries[stale["mac"]].entity_id) is None
+    assert (
+        device_registry.async_get_device(
+            connections={(dr.CONNECTION_NETWORK_MAC, stale["mac"])}
+        )
+        is None
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -23,6 +23,7 @@ from homeassistant.components.unifi.const import (
     CONF_DETECTION_TIME,
     CONF_TRACK_CLIENTS,
     CONF_TRACK_DEVICES,
+    CONF_TRACK_WIRED_CLIENTS,
     DEFAULT_DETECTION_TIME,
     DEVICE_STATES,
 )
@@ -35,7 +36,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryDisabler
 from homeassistant.util import dt as dt_util
 
@@ -577,6 +578,41 @@ async def test_wired_client_speed_sensor(
         await hass.async_block_till_done()
 
     assert hass.states.get("sensor.wired_client_link_speed").state == STATE_UNAVAILABLE
+
+
+@pytest.mark.parametrize(
+    "config_entry_options",
+    [
+        {
+            CONF_TRACK_CLIENTS: False,
+            CONF_TRACK_WIRED_CLIENTS: False,
+            CONF_TRACK_DEVICES: False,
+        }
+    ],
+)
+@pytest.mark.parametrize("client_payload", [[WIRED_CLIENT]])
+@pytest.mark.usefixtures("config_entry_setup")
+async def test_wired_client_speed_sensor_not_created_when_untracked(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    client_payload: list[dict[str, Any]],
+) -> None:
+    """Verify untracked wired clients do not create a link speed sensor or device.
+
+    With client tracking disabled the link speed sensor must not be created for
+    wired clients. The sensor is disabled by default, but the device registry
+    entry is created before that check, so an untracked wired client would
+    otherwise still spawn a client device. This is the root cause of UniFi
+    installs ending up with thousands of phantom client devices.
+    """
+    assert entity_registry.async_get("sensor.wired_client_link_speed") is None
+    assert (
+        device_registry.async_get_device(
+            connections={(dr.CONNECTION_NETWORK_MAC, client_payload[0]["mac"])}
+        )
+        is None
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -598,14 +598,7 @@ async def test_wired_client_speed_sensor_not_created_when_untracked(
     device_registry: dr.DeviceRegistry,
     client_payload: list[dict[str, Any]],
 ) -> None:
-    """Verify untracked wired clients do not create a link speed sensor or device.
-
-    With client tracking disabled the link speed sensor must not be created for
-    wired clients. The sensor is disabled by default, but the device registry
-    entry is created before that check, so an untracked wired client would
-    otherwise still spawn a client device. This is the root cause of UniFi
-    installs ending up with thousands of phantom client devices.
-    """
+    """Verify untracked wired clients create neither a link speed sensor nor a device."""
     assert entity_registry.async_get("sensor.wired_client_link_speed") is None
     assert (
         device_registry.async_get_device(


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Installations end up with thousands, sometimes tens of thousands, of phantom UniFi client devices that reappear right after every restart. The UniFi controller keeps a record of every client it has ever seen (`/rest/user`), including drive-by and guest devices, and two paths turned that history into a flood of devices in Home Assistant.

The wired client link speed sensor created a client device for every wired client, ignoring the tracking options entirely. The sensor is disabled by default, but the device registry entry is created before the disabled-by-default check in the entity platform, so the device was created regardless. This is gated now on the same tracking options as the device tracker, so only clients the user actually tracks get a device.

On top of that, `_restore_inactive_clients` restored every client that ever had a device tracker from the controller's full client list on every startup. The registry only ever grew, and devices deleted by the user came back after a restart. Inactive clients are now only restored when they were seen within a retention window (`CLIENT_RESTORE_MAX_AGE`, 30 days). Trackers falling outside that window are pruned together with their device, so the registry stops growing unbounded and the accumulated pile drains.

Note for reviewers: the 30 day retention is a deliberate behavior change. A client not seen for longer than that stops being restored on startup and its (stale) tracker and device are removed. When it reconnects it is recreated. Happy to adjust the window or make it configurable if preferred. Explicitly selected and blocked clients are always kept regardless of age.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170273
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
