### PR TITLE
Add stale device support to Vistapool

### DIFF
--- a/homeassistant/components/vistapool/__init__.py
+++ b/homeassistant/components/vistapool/__init__.py
@@ -20,6 +20,7 @@ from homeassistant.exceptions import (
     ConfigEntryError,
     ConfigEntryNotReady,
 )
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
@@ -96,6 +97,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: VistapoolConfigEntry) ->
             await coordinator.async_shutdown()
         raise
 
+    # Catch pools removed from the account while Home Assistant was offline; the
+    # first live snapshot is a no-op so it wouldn't clean these up.
+    _async_remove_stale_devices(hass, entry, set(pools))
+
     def _on_user_pools_snapshot(pool_ids: list[str]) -> None:
         """Bridge the Firestore snapshot from the watch thread to the HA loop."""
         hass.loop.call_soon_threadsafe(_schedule_reconcile, pool_ids)
@@ -134,6 +139,18 @@ async def async_unload_entry(hass: HomeAssistant, entry: VistapoolConfigEntry) -
             for coordinator in entry.runtime_data.coordinators.values():
                 await coordinator.async_shutdown()
     return unload_ok
+
+
+@callback
+def _async_remove_stale_devices(
+    hass: HomeAssistant, entry: VistapoolConfigEntry, valid_pool_ids: set[str]
+) -> None:
+    """Remove registry devices for pools no longer present on the account."""
+    device_registry = dr.async_get(hass)
+    for device in dr.async_entries_for_config_entry(device_registry, entry.entry_id):
+        pool_id = next((i[1] for i in device.identifiers if i[0] == DOMAIN), None)
+        if pool_id is not None and pool_id not in valid_pool_ids:
+            device_registry.async_remove_device(device.id)
 
 
 async def _async_initial_refresh(
@@ -210,3 +227,8 @@ async def _async_reconcile_pools(
             async_dispatcher_send(
                 hass, f"{SIGNAL_NEW_POOL}_{entry.entry_id}", coordinator
             )
+
+        if stale := current - fetched:
+            for pool_id in stale:
+                await entry.runtime_data.coordinators.pop(pool_id).async_shutdown()
+            _async_remove_stale_devices(hass, entry, fetched)

--- a/homeassistant/components/vistapool/__init__.py
+++ b/homeassistant/components/vistapool/__init__.py
@@ -150,7 +150,9 @@ def _async_remove_stale_devices(
     for device in dr.async_entries_for_config_entry(device_registry, entry.entry_id):
         pool_id = next((i[1] for i in device.identifiers if i[0] == DOMAIN), None)
         if pool_id is not None and pool_id not in valid_pool_ids:
-            device_registry.async_remove_device(device.id)
+            device_registry.async_update_device(
+                device.id, remove_config_entry_id=entry.entry_id
+            )
 
 
 async def _async_initial_refresh(

--- a/tests/components/vistapool/test_init.py
+++ b/tests/components/vistapool/test_init.py
@@ -17,6 +17,7 @@ from tests.common import MockConfigEntry
 
 _SECOND_POOL_ID = "ZYXWVU9876543210"
 _SECOND_POOL_NAME = "Spa"
+_THIRD_POOL_ID = "QQQQQQ1111111111"
 
 
 async def test_setup_entry(
@@ -198,6 +199,86 @@ async def test_user_pools_snapshot_no_change_is_noop(
     await hass.async_block_till_done()
 
     mock_vistapool_client.get_pools.assert_not_called()
+
+
+async def test_user_pools_snapshot_removes_stale_pool(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_vistapool_client: AsyncMock,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test a user-pools snapshot missing a pool removes its entities and device."""
+    mock_vistapool_client.get_pools.return_value = {
+        MOCK_POOL_ID: MOCK_POOL_NAME,
+        _SECOND_POOL_ID: _SECOND_POOL_NAME,
+    }
+    mock_config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("sensor.spa_temperature") is not None
+
+    snapshot_cb = mock_vistapool_client.subscribe_user_pools_resilient.call_args.args[0]
+    snapshot_cb([MOCK_POOL_ID])
+    await hass.async_block_till_done()
+
+    assert hass.states.get("sensor.spa_temperature") is None
+    assert (
+        device_registry.async_get_device(identifiers={(DOMAIN, _SECOND_POOL_ID)})
+        is None
+    )
+
+
+async def test_user_pools_snapshot_drops_stale_even_if_get_pools_fails(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_vistapool_client: AsyncMock,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test stale pool removal still runs when get_pools() raises during reconcile."""
+    mock_vistapool_client.get_pools.return_value = {
+        MOCK_POOL_ID: MOCK_POOL_NAME,
+        _SECOND_POOL_ID: _SECOND_POOL_NAME,
+    }
+    mock_config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert hass.states.get("sensor.spa_temperature") is not None
+
+    mock_vistapool_client.get_pools.side_effect = AquariteError("name lookup down")
+    snapshot_cb = mock_vistapool_client.subscribe_user_pools_resilient.call_args.args[0]
+    snapshot_cb([MOCK_POOL_ID, _THIRD_POOL_ID])
+    await hass.async_block_till_done()
+
+    # New pool skipped (no name available), stale pool removed regardless.
+    assert hass.states.get("sensor.spa_temperature") is None
+    assert (
+        device_registry.async_get_device(identifiers={(DOMAIN, _THIRD_POOL_ID)}) is None
+    )
+
+
+async def test_setup_prunes_devices_removed_while_offline(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_vistapool_client: AsyncMock,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test setup removes a leftover device for a pool no longer on the account."""
+    mock_config_entry.add_to_hass(hass)
+    stale_device = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={(DOMAIN, _SECOND_POOL_ID)},
+    )
+    assert stale_device is not None
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert device_registry.async_get_device(identifiers={(DOMAIN, MOCK_POOL_ID)})
+    assert (
+        device_registry.async_get_device(identifiers={(DOMAIN, _SECOND_POOL_ID)})
+        is None
+    )
 
 
 async def test_apply_optimistic_creates_missing_intermediate_dicts(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds automatic stale-device removal for Vistapool, following the dynamic-devices support in #172912.

A Vistapool account can hold multiple pools, and the set changes over time — most notably for pool-service professionals and installers who manage their customers' controllers under a single account. When a pool disappears from the user-pools Firestore snapshot (a controller is unlinked from the account), its coordinator is shut down and its device is detached from the config entry (and removed once no entries remain) automatically.

A setup-time prune (`_async_remove_stale_devices`) also removes leftover devices for pools that were removed while Home Assistant was offline — the case the first (no-op) live snapshot can't catch. Because removal is fully automatic across both paths, no manual `async_remove_config_entry_device` hook is needed.

The `stale-devices` quality scale rule is intentionally left unchanged here; the rule flip and manifest tier bump will come in a separate quality-scale PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr