### PR TITLE
Add pylint rule enforcing usb dependency for SerialPortSelector

### DIFF
--- a/homeassistant/components/edl21/manifest.json
+++ b/homeassistant/components/edl21/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "edl21",
   "name": "EDL21",
+  "after_dependencies": ["usb"],
   "codeowners": [],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/edl21",

--- a/homeassistant/components/edl21/manifest.json
+++ b/homeassistant/components/edl21/manifest.json
@@ -1,9 +1,9 @@
 {
   "domain": "edl21",
   "name": "EDL21",
-  "after_dependencies": ["usb"],
   "codeowners": [],
   "config_flow": true,
+  "dependencies": ["usb"],
   "documentation": "https://www.home-assistant.io/integrations/edl21",
   "integration_type": "device",
   "iot_class": "local_push",

--- a/homeassistant/components/modbus_connection/manifest.json
+++ b/homeassistant/components/modbus_connection/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "modbus_connection",
   "name": "Modbus Connection",
+  "after_dependencies": ["usb"],
   "codeowners": ["@home-assistant/core"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/modbus_connection",

--- a/homeassistant/components/modbus_connection/manifest.json
+++ b/homeassistant/components/modbus_connection/manifest.json
@@ -1,9 +1,9 @@
 {
   "domain": "modbus_connection",
   "name": "Modbus Connection",
-  "after_dependencies": ["usb"],
   "codeowners": ["@home-assistant/core"],
   "config_flow": true,
+  "dependencies": ["usb"],
   "documentation": "https://www.home-assistant.io/integrations/modbus_connection",
   "integration_type": "hub",
   "iot_class": "local_polling",

--- a/homeassistant/components/russound_rio/manifest.json
+++ b/homeassistant/components/russound_rio/manifest.json
@@ -1,9 +1,9 @@
 {
   "domain": "russound_rio",
   "name": "Russound RIO",
-  "after_dependencies": ["usb"],
   "codeowners": ["@noahhusby"],
   "config_flow": true,
+  "dependencies": ["usb"],
   "documentation": "https://www.home-assistant.io/integrations/russound_rio",
   "integration_type": "hub",
   "iot_class": "local_push",

--- a/homeassistant/components/upb/manifest.json
+++ b/homeassistant/components/upb/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "upb",
   "name": "Universal Powerline Bus (UPB)",
+  "after_dependencies": ["usb"],
   "codeowners": ["@gwww"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/upb",

--- a/homeassistant/components/upb/manifest.json
+++ b/homeassistant/components/upb/manifest.json
@@ -1,9 +1,9 @@
 {
   "domain": "upb",
   "name": "Universal Powerline Bus (UPB)",
-  "after_dependencies": ["usb"],
   "codeowners": ["@gwww"],
   "config_flow": true,
+  "dependencies": ["usb"],
   "documentation": "https://www.home-assistant.io/integrations/upb",
   "iot_class": "local_push",
   "loggers": ["upb_lib"],

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -1,10 +1,10 @@
 {
   "domain": "zha",
   "name": "Zigbee Home Automation",
-  "after_dependencies": ["hassio", "onboarding", "usb"],
+  "after_dependencies": ["hassio", "onboarding"],
   "codeowners": ["@dmulcahey", "@adminiuga", "@puddly", "@TheJulianJES"],
   "config_flow": true,
-  "dependencies": ["file_upload", "homeassistant_hardware"],
+  "dependencies": ["file_upload", "homeassistant_hardware", "usb"],
   "documentation": "https://www.home-assistant.io/integrations/zha",
   "integration_type": "hub",
   "iot_class": "local_polling",

--- a/pylint/plugins/README.md
+++ b/pylint/plugins/README.md
@@ -132,6 +132,7 @@ Every check has a code following the
 | `W7415` | [`home-assistant-sequential-executor-jobs`](#w7415-home-assistant-sequential-executor-jobs) | Sequential `async_add_executor_job` calls should be grouped |
 | `W7416` | [`home-assistant-missing-has-entity-name`](#w7416-home-assistant-missing-has-entity-name) | Entity class should set `_attr_has_entity_name = True` |
 | `W7429` | [`home-assistant-unnecessary-format-mac`](#w7429-home-assistant-unnecessary-format-mac) | `format_mac()` is unnecessary with `CONNECTION_NETWORK_MAC` |
+| `W7430` | [`home-assistant-serial-port-selector-usb-dependency`](#w7430-home-assistant-serial-port-selector-usb-dependency) | Config flow using `SerialPortSelector` must declare `usb` in `dependencies` |
 
 
 ## `home_assistant_logger` checker
@@ -849,3 +850,17 @@ Tuples used for direct comparison against `device.connections` (e.g.
 the `in` operator, set intersection) are not flagged because those
 comparisons bypass the device registry normalization and genuinely
 need `format_mac()` to match the stored normalized format.
+
+
+## `home_assistant_serial_port_selector_usb_dependency` checker
+
+Detects config flows using `SerialPortSelector` whose `manifest.json` does
+not declare `usb` as a hard dependency.
+
+### `W7430`: `home-assistant-serial-port-selector-usb-dependency`
+
+`SerialPortSelector` populates its port list via the `usb/list_serial_ports`
+websocket command, which is only registered when the `usb` integration is set
+up. The selector therefore requires `usb` as a hard dependency
+(`"dependencies": ["usb"]`); `after_dependencies` is not sufficient because it
+does not force `usb` to be set up.

--- a/pylint/plugins/pylint_home_assistant/checkers/config_flow/serial_port_usb_dependency.py
+++ b/pylint/plugins/pylint_home_assistant/checkers/config_flow/serial_port_usb_dependency.py
@@ -1,0 +1,83 @@
+"""Checker for the usb dependency when a config flow uses SerialPortSelector.
+
+``SerialPortSelector`` populates its port list via the
+``usb/list_serial_ports`` websocket command, which is only registered when the
+``usb`` integration is set up. Integrations using the selector must therefore
+declare ``usb`` in ``dependencies`` or ``after_dependencies`` in
+``manifest.json``, otherwise the dropdown may not populate on installations
+that do not load ``usb`` via ``default_config``.
+"""
+
+from astroid import nodes
+from pylint.checkers import BaseChecker
+from pylint.lint import PyLinter
+
+from pylint_home_assistant.const import Module
+from pylint_home_assistant.helpers.integration import read_manifest
+from pylint_home_assistant.helpers.module_info import parse_module
+
+
+class HassEnforceSerialPortSelectorUsbChecker(BaseChecker):
+    """Checker for the usb dependency when using SerialPortSelector."""
+
+    name = "home_assistant_serial_port_selector_usb_dependency"
+    priority = -1
+    msgs = {
+        "W7430": (
+            "Config flow uses SerialPortSelector but the integration does not "
+            "depend on the 'usb' integration -- add 'usb' to 'dependencies' or "
+            "'after_dependencies' in manifest.json",
+            "home-assistant-serial-port-selector-usb-dependency",
+            "SerialPortSelector populates its port list via the "
+            "'usb/list_serial_ports' websocket command, which is only "
+            "registered when the 'usb' integration is set up. Without a "
+            "dependency on 'usb', the dropdown may not populate on "
+            "installations that do not load 'usb' via 'default_config'.",
+        ),
+    }
+    options = ()
+
+    def __init__(self, linter: PyLinter) -> None:
+        """Initialize the checker."""
+        super().__init__(linter)
+        self._reported_modules: set[str] = set()
+
+    def visit_call(self, node: nodes.Call) -> None:
+        """Check that SerialPortSelector usage declares the usb dependency."""
+        func = node.func
+        if isinstance(func, nodes.Attribute):
+            name = func.attrname
+        elif isinstance(func, nodes.Name):
+            name = func.name
+        else:
+            return
+        if name != "SerialPortSelector":
+            return
+
+        parsed = parse_module(node.root().name)
+        if parsed is None or parsed.module != Module.CONFIG_FLOW:
+            return
+
+        module_name = node.root().name
+        if module_name in self._reported_modules:
+            return
+
+        manifest = read_manifest(node.root())
+        if manifest is None:
+            return
+
+        if "usb" in manifest.get("dependencies", []) or "usb" in manifest.get(
+            "after_dependencies", []
+        ):
+            return
+
+        self._reported_modules.add(module_name)
+        self.add_message(
+            "home-assistant-serial-port-selector-usb-dependency",
+            node=node,
+        )
+
+
+def register(linter: PyLinter) -> None:
+    """Register the checker."""
+    linter.register_checker(HassEnforceSerialPortSelectorUsbChecker(linter))

--- a/pylint/plugins/pylint_home_assistant/checkers/config_flow/serial_port_usb_dependency.py
+++ b/pylint/plugins/pylint_home_assistant/checkers/config_flow/serial_port_usb_dependency.py
@@ -3,9 +3,9 @@
 ``SerialPortSelector`` populates its port list via the
 ``usb/list_serial_ports`` websocket command, which is only registered when the
 ``usb`` integration is set up. Integrations using the selector must therefore
-declare ``usb`` in ``dependencies`` or ``after_dependencies`` in
-``manifest.json``, otherwise the dropdown may not populate on installations
-that do not load ``usb`` via ``default_config``.
+declare ``usb`` as a hard dependency in ``manifest.json`` so it is guaranteed
+to be set up; ``after_dependencies`` is not sufficient because it does not
+force ``usb`` to be set up.
 """
 
 from astroid import nodes
@@ -25,14 +25,14 @@ class HassEnforceSerialPortSelectorUsbChecker(BaseChecker):
     msgs = {
         "W7430": (
             "Config flow uses SerialPortSelector but the integration does not "
-            "depend on the 'usb' integration -- add 'usb' to 'dependencies' or "
-            "'after_dependencies' in manifest.json",
+            "declare 'usb' in 'dependencies' in manifest.json",
             "home-assistant-serial-port-selector-usb-dependency",
             "SerialPortSelector populates its port list via the "
             "'usb/list_serial_ports' websocket command, which is only "
-            "registered when the 'usb' integration is set up. Without a "
-            "dependency on 'usb', the dropdown may not populate on "
-            "installations that do not load 'usb' via 'default_config'.",
+            "registered when the 'usb' integration is set up. The selector "
+            "therefore requires 'usb' as a hard dependency; "
+            "'after_dependencies' is not sufficient because it does not force "
+            "'usb' to be set up.",
         ),
     }
     options = ()
@@ -66,9 +66,7 @@ class HassEnforceSerialPortSelectorUsbChecker(BaseChecker):
         if manifest is None:
             return
 
-        if "usb" in manifest.get("dependencies", []) or "usb" in manifest.get(
-            "after_dependencies", []
-        ):
+        if "usb" in manifest.get("dependencies", []):
             return
 
         self._reported_modules.add(module_name)

--- a/tests/pylint/config_flow/test_serial_port_usb_dependency.py
+++ b/tests/pylint/config_flow/test_serial_port_usb_dependency.py
@@ -1,0 +1,113 @@
+"""Tests for the serial_port_selector usb dependency pylint plugin."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import astroid
+from pylint.checkers import BaseChecker
+from pylint.testutils.unittest_linter import UnittestLinter
+import pytest
+
+from tests.pylint import assert_no_messages, walk_checker
+
+
+def _write_integration(tmp_path: Path, domain: str, manifest: dict) -> Path:
+    """Create an integration directory with a manifest and config_flow."""
+    integration_dir = tmp_path / "homeassistant" / "components" / domain
+    integration_dir.mkdir(parents=True)
+    (integration_dir / "config_flow.py").touch()
+    (integration_dir / "manifest.json").write_text(json.dumps(manifest))
+    return integration_dir
+
+
+@pytest.mark.parametrize(
+    "manifest",
+    [
+        pytest.param(
+            {"domain": "my_device", "dependencies": ["usb"]},
+            id="dependencies",
+        ),
+        pytest.param(
+            {"domain": "my_device", "after_dependencies": ["usb"]},
+            id="after_dependencies",
+        ),
+    ],
+)
+def test_serial_port_selector_with_usb_dependency(
+    linter: UnittestLinter,
+    enforce_serial_port_selector_usb_checker: BaseChecker,
+    tmp_path: Path,
+    manifest: dict,
+) -> None:
+    """A config flow declaring the usb dependency is not flagged."""
+    integration_dir = _write_integration(tmp_path, "my_device", manifest)
+
+    code = """
+    vol.Schema({vol.Required(CONF_PORT): SerialPortSelector()})
+    """
+    root_node = astroid.parse(code, "homeassistant.components.my_device.config_flow")
+    root_node.file = str(integration_dir / "config_flow.py")
+
+    with assert_no_messages(linter):
+        walk_checker(linter, enforce_serial_port_selector_usb_checker, root_node)
+
+
+@pytest.mark.parametrize(
+    ("code", "module_name"),
+    [
+        pytest.param(
+            """
+        vol.Schema({vol.Required(CONF_HOST): TextSelector()})
+        """,
+            "homeassistant.components.my_device.config_flow",
+            id="other_selector",
+        ),
+        pytest.param(
+            """
+        SerialPortSelector()
+        """,
+            "homeassistant.components.my_device.sensor",
+            id="not_config_flow",
+        ),
+    ],
+)
+def test_serial_port_selector_not_flagged(
+    linter: UnittestLinter,
+    enforce_serial_port_selector_usb_checker: BaseChecker,
+    tmp_path: Path,
+    code: str,
+    module_name: str,
+) -> None:
+    """Cases that must not be flagged even without a usb dependency."""
+    integration_dir = _write_integration(tmp_path, "my_device", {"domain": "my_device"})
+
+    root_node = astroid.parse(code, module_name)
+    root_node.file = str(integration_dir / f"{module_name.rsplit('.', 1)[1]}.py")
+
+    with assert_no_messages(linter):
+        walk_checker(linter, enforce_serial_port_selector_usb_checker, root_node)
+
+
+def test_serial_port_selector_without_usb_dependency(
+    linter: UnittestLinter,
+    enforce_serial_port_selector_usb_checker: BaseChecker,
+    tmp_path: Path,
+) -> None:
+    """A config flow missing the usb dependency is flagged once."""
+    integration_dir = _write_integration(tmp_path, "my_device", {"domain": "my_device"})
+
+    code = """
+    vol.Schema({
+        vol.Required(CONF_PORT): SerialPortSelector(),
+        vol.Optional(CONF_OTHER): SerialPortSelector(),
+    })
+    """
+    root_node = astroid.parse(code, "homeassistant.components.my_device.config_flow")
+    root_node.file = str(integration_dir / "config_flow.py")
+
+    walk_checker(linter, enforce_serial_port_selector_usb_checker, root_node)
+    messages = linter.release_messages()
+    assert len(messages) == 1
+    assert messages[0].msg_id == "home-assistant-serial-port-selector-usb-dependency"

--- a/tests/pylint/config_flow/test_serial_port_usb_dependency.py
+++ b/tests/pylint/config_flow/test_serial_port_usb_dependency.py
@@ -22,27 +22,15 @@ def _write_integration(tmp_path: Path, domain: str, manifest: dict) -> Path:
     return integration_dir
 
 
-@pytest.mark.parametrize(
-    "manifest",
-    [
-        pytest.param(
-            {"domain": "my_device", "dependencies": ["usb"]},
-            id="dependencies",
-        ),
-        pytest.param(
-            {"domain": "my_device", "after_dependencies": ["usb"]},
-            id="after_dependencies",
-        ),
-    ],
-)
 def test_serial_port_selector_with_usb_dependency(
     linter: UnittestLinter,
     enforce_serial_port_selector_usb_checker: BaseChecker,
     tmp_path: Path,
-    manifest: dict,
 ) -> None:
-    """A config flow declaring the usb dependency is not flagged."""
-    integration_dir = _write_integration(tmp_path, "my_device", manifest)
+    """A config flow declaring usb as a hard dependency is not flagged."""
+    integration_dir = _write_integration(
+        tmp_path, "my_device", {"domain": "my_device", "dependencies": ["usb"]}
+    )
 
     code = """
     vol.Schema({vol.Required(CONF_PORT): SerialPortSelector()})
@@ -90,13 +78,24 @@ def test_serial_port_selector_not_flagged(
         walk_checker(linter, enforce_serial_port_selector_usb_checker, root_node)
 
 
+@pytest.mark.parametrize(
+    "manifest",
+    [
+        pytest.param({"domain": "my_device"}, id="no_dependency"),
+        pytest.param(
+            {"domain": "my_device", "after_dependencies": ["usb"]},
+            id="after_dependencies_only",
+        ),
+    ],
+)
 def test_serial_port_selector_without_usb_dependency(
     linter: UnittestLinter,
     enforce_serial_port_selector_usb_checker: BaseChecker,
     tmp_path: Path,
+    manifest: dict,
 ) -> None:
-    """A config flow missing the usb dependency is flagged once."""
-    integration_dir = _write_integration(tmp_path, "my_device", {"domain": "my_device"})
+    """A config flow without usb as a hard dependency is flagged once."""
+    integration_dir = _write_integration(tmp_path, "my_device", manifest)
 
     code = """
     vol.Schema({

--- a/tests/pylint/conftest.py
+++ b/tests/pylint/conftest.py
@@ -9,6 +9,9 @@ from pylint_home_assistant.checkers.config_flow.no_name import (
 from pylint_home_assistant.checkers.config_flow.no_polling import (
     HassEnforceConfigFlowNoPollingChecker,
 )
+from pylint_home_assistant.checkers.config_flow.serial_port_usb_dependency import (
+    HassEnforceSerialPortSelectorUsbChecker,
+)
 from pylint_home_assistant.checkers.config_flow.unique_id_no_ip import (
     HassEnforceConfigEntryUniqueIdNoIpChecker,
 )
@@ -91,6 +94,17 @@ def enforce_config_entry_unique_id_no_ip_checker_fixture(
     """Fixture to provide a unique_id_no_ip checker."""
     clear_caches()
     checker = HassEnforceConfigEntryUniqueIdNoIpChecker(linter)
+    checker.module = "homeassistant.components.pylint_test"
+    return checker
+
+
+@pytest.fixture(name="enforce_serial_port_selector_usb_checker")
+def enforce_serial_port_selector_usb_checker_fixture(
+    linter: UnittestLinter,
+) -> BaseChecker:
+    """Fixture to provide a serial_port_selector usb dependency checker."""
+    clear_caches()
+    checker = HassEnforceSerialPortSelectorUsbChecker(linter)
     checker.module = "homeassistant.components.pylint_test"
     return checker
 


### PR DESCRIPTION
## Breaking change


## Proposed change

Turns a PR review comment ([#175707 discussion](https://github.com/home-assistant/core/pull/175707#discussion_r3525335262)) into an enforceable pylint rule.

`SerialPortSelector` populates its port dropdown via the `usb` integration's `usb/list_serial_ports` websocket command, which is only registered once `usb` is set up. `after_dependencies` does not force `usb` to be set up, so the selector requires `usb` as a hard `dependencies` entry to guarantee the command exists.

This adds a checker (`home-assistant-serial-port-selector-usb-dependency`, `W7430`) under `pylint/plugins/pylint_home_assistant/checkers/config_flow/` that flags any `config_flow.py` using `SerialPortSelector` whose `manifest.json` does not declare `usb` in `dependencies`. It reads the manifest via the existing `read_manifest` helper (cross-file analysis, which is why this is a pylint rule and not a Ruff rule) and reports once per module.

Running the new rule surfaced five integrations that did not satisfy it, now fixed by declaring `usb` as a hard dependency:

- `edl21`, `modbus_connection`, `upb` — had no `usb` dependency at all
- `russound_rio`, `zha` — used `after_dependencies`, which is insufficient (moved to `dependencies`)

All ten integrations using `SerialPortSelector` now declare `usb` as a hard dependency. Unit tests cover the pass case, the missing-dependency case, and the `after_dependencies`-only case, plus negatives (other selectors, non-config-flow modules).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0131ZPwrXUCYRLS3aZw4ab4Z

---
_Generated by [Claude Code](https://claude.ai/code/session_0131ZPwrXUCYRLS3aZw4ab4Z)_