### PR TITLE
Add split-phase option to Tesla Wall Connector

### DIFF
--- a/homeassistant/components/tesla_wall_connector/__init__.py
+++ b/homeassistant/components/tesla_wall_connector/__init__.py
@@ -8,6 +8,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
+from .const import CONF_SPLIT_PHASE, DEFAULT_SPLIT_PHASE
 from .coordinator import (
     WallConnectorConfigEntry,
     WallConnectorCoordinator,
@@ -23,7 +24,11 @@ async def async_setup_entry(
     """Set up Tesla Wall Connector from a config entry."""
     hostname = entry.data[CONF_HOST]
 
-    wall_connector = WallConnector(host=hostname, session=async_get_clientsession(hass))
+    wall_connector = WallConnector(
+        host=hostname,
+        session=async_get_clientsession(hass),
+        split_phase=entry.options.get(CONF_SPLIT_PHASE, DEFAULT_SPLIT_PHASE),
+    )
 
     try:
         version_data = await wall_connector.async_get_version()

--- a/homeassistant/components/tesla_wall_connector/config_flow.py
+++ b/homeassistant/components/tesla_wall_connector/config_flow.py
@@ -7,15 +7,55 @@ from tesla_wall_connector import WallConnector
 from tesla_wall_connector.exceptions import WallConnectorError
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import (
+    ConfigFlow,
+    ConfigFlowResult,
+    OptionsFlowWithReload,
+)
 from homeassistant.const import CONF_HOST
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.selector import BooleanSelector
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
-from .const import DOMAIN, WALLCONNECTOR_DEVICE_NAME, WALLCONNECTOR_SERIAL_NUMBER
+from .const import (
+    CONF_SPLIT_PHASE,
+    DEFAULT_SPLIT_PHASE,
+    DOMAIN,
+    WALLCONNECTOR_DEVICE_NAME,
+    WALLCONNECTOR_SERIAL_NUMBER,
+)
+from .coordinator import WallConnectorConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class TeslaWallConnectorOptionsFlow(OptionsFlowWithReload):
+    """Handle Tesla Wall Connector options."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(
+                title="",
+                data={CONF_SPLIT_PHASE: user_input[CONF_SPLIT_PHASE]},
+            )
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_SPLIT_PHASE,
+                        default=self.config_entry.options.get(
+                            CONF_SPLIT_PHASE, DEFAULT_SPLIT_PHASE
+                        ),
+                    ): BooleanSelector(),
+                }
+            ),
+        )
 
 
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
@@ -44,6 +84,15 @@ class TeslaWallConnectorConfigFlow(ConfigFlow, domain=DOMAIN):
         """Initialize config flow."""
         super().__init__()
         self.ip_address: str | None = None
+
+    @staticmethod
+    @callback
+    @override
+    def async_get_options_flow(
+        _config_entry: WallConnectorConfigEntry,
+    ) -> TeslaWallConnectorOptionsFlow:
+        """Get the options flow."""
+        return TeslaWallConnectorOptionsFlow()
 
     @override
     async def async_step_dhcp(
@@ -91,7 +140,12 @@ class TeslaWallConnectorConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle the initial step."""
         data_schema = vol.Schema(
-            {vol.Required(CONF_HOST, default=self.ip_address): str}
+            {
+                vol.Required(CONF_HOST, default=self.ip_address): str,
+                vol.Optional(
+                    CONF_SPLIT_PHASE, default=DEFAULT_SPLIT_PHASE
+                ): BooleanSelector(),
+            }
         )
         if user_input is None:
             return self.async_show_form(step_id="user", data_schema=data_schema)
@@ -110,11 +164,17 @@ class TeslaWallConnectorConfigFlow(ConfigFlow, domain=DOMAIN):
                 unique_id=info[WALLCONNECTOR_SERIAL_NUMBER], raise_on_progress=True
             )
             self._abort_if_unique_id_configured(
-                updates=user_input, reload_on_update=True
+                updates={CONF_HOST: user_input[CONF_HOST]}, reload_on_update=True
             )
 
-            return self.async_create_entry(title=info["title"], data=user_input)
+            return self.async_create_entry(
+                title=info["title"],
+                data={CONF_HOST: user_input[CONF_HOST]},
+                options={CONF_SPLIT_PHASE: user_input[CONF_SPLIT_PHASE]},
+            )
 
         return self.async_show_form(
-            step_id="user", data_schema=data_schema, errors=errors
+            step_id="user",
+            data_schema=self.add_suggested_values_to_schema(data_schema, user_input),
+            errors=errors,
         )

--- a/homeassistant/components/tesla_wall_connector/const.py
+++ b/homeassistant/components/tesla_wall_connector/const.py
@@ -2,6 +2,9 @@
 
 DOMAIN = "tesla_wall_connector"
 DEFAULT_SCAN_INTERVAL = 30
+DEFAULT_SPLIT_PHASE = False
+
+CONF_SPLIT_PHASE = "split_phase"
 
 WALLCONNECTOR_SERIAL_NUMBER = "serial_number"
 

--- a/homeassistant/components/tesla_wall_connector/strings.json
+++ b/homeassistant/components/tesla_wall_connector/strings.json
@@ -1,4 +1,8 @@
 {
+  "common": {
+    "split_phase": "Single-phase / Split-phase electrical service",
+    "split_phase_description": "Enable if your Wall Connector is powered by single-phase / split-phase electrical service. This affects the calculation of the Total power sensor. Leave disabled for three-phase supply (default)."
+  },
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
@@ -11,10 +15,12 @@
     "step": {
       "user": {
         "data": {
-          "host": "[%key:common::config_flow::data::host%]"
+          "host": "[%key:common::config_flow::data::host%]",
+          "split_phase": "[%key:component::tesla_wall_connector::common::split_phase%]"
         },
         "data_description": {
-          "host": "Hostname or IP address of your Tesla Wall Connector."
+          "host": "Hostname or IP address of your Tesla Wall Connector.",
+          "split_phase": "[%key:component::tesla_wall_connector::common::split_phase_description%]"
         },
         "title": "Configure Tesla Wall Connector"
       }
@@ -95,6 +101,18 @@
       },
       "wifi_rssi": {
         "name": "Wi-Fi RSSI"
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "split_phase": "[%key:component::tesla_wall_connector::common::split_phase%]"
+        },
+        "data_description": {
+          "split_phase": "[%key:component::tesla_wall_connector::common::split_phase_description%]"
+        }
       }
     }
   }

--- a/tests/components/tesla_wall_connector/test_config_flow.py
+++ b/tests/components/tesla_wall_connector/test_config_flow.py
@@ -1,17 +1,29 @@
 """Test the Tesla Wall Connector config flow."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from tesla_wall_connector.exceptions import WallConnectorConnectionError
 
 from homeassistant import config_entries
-from homeassistant.components.tesla_wall_connector.const import DOMAIN
+from homeassistant.components.tesla_wall_connector.const import (
+    CONF_SPLIT_PHASE,
+    DEFAULT_SPLIT_PHASE,
+    DOMAIN,
+)
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
-from tests.common import MockConfigEntry
+from .conftest import (
+    get_default_version_data,
+    get_lifetime_mock,
+    get_vitals_mock,
+    get_wifi_status_mock,
+)
+
+from tests.common import MockConfigEntry, get_schema_suggested_value
 
 
 async def test_form(mock_wall_connector_version, hass: HomeAssistant) -> None:
@@ -35,6 +47,7 @@ async def test_form(mock_wall_connector_version, hass: HomeAssistant) -> None:
     assert result2["type"] is FlowResultType.CREATE_ENTRY
     assert result2["title"] == "Tesla Wall Connector"
     assert result2["data"] == {CONF_HOST: "1.1.1.1"}
+    assert result2["options"] == {CONF_SPLIT_PHASE: DEFAULT_SPLIT_PHASE}
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -50,11 +63,19 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {CONF_HOST: "1.1.1.1"},
+            {CONF_HOST: "1.1.1.1", CONF_SPLIT_PHASE: True},
         )
 
     assert result2["type"] is FlowResultType.FORM
     assert result2["errors"] == {"base": "cannot_connect"}
+    assert (
+        get_schema_suggested_value(result2["data_schema"].schema, CONF_HOST)
+        == "1.1.1.1"
+    )
+    assert (
+        get_schema_suggested_value(result2["data_schema"].schema, CONF_SPLIT_PHASE)
+        is True
+    )
 
 
 async def test_form_other_error(
@@ -131,6 +152,79 @@ async def test_dhcp_can_finish(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"] == {CONF_HOST: "1.2.3.4"}
+    assert result["options"] == {CONF_SPLIT_PHASE: DEFAULT_SPLIT_PHASE}
+
+
+async def test_form_with_split_phase(hass: HomeAssistant) -> None:
+    """Test setting single-phase / split-phase during setup."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with (
+        patch(
+            "tesla_wall_connector.WallConnector.async_get_version",
+            return_value=get_default_version_data(),
+        ),
+        patch(
+            "homeassistant.components.tesla_wall_connector.async_setup_entry",
+            return_value=True,
+        ),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: "1.1.1.1",
+                CONF_SPLIT_PHASE: True,
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["data"] == {CONF_HOST: "1.1.1.1"}
+    assert result2["options"] == {CONF_SPLIT_PHASE: True}
+
+
+async def test_options_flow(hass: HomeAssistant) -> None:
+    """Test options flow."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "1.2.3.4"},
+        options={CONF_SPLIT_PHASE: False},
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.tesla_wall_connector.WallConnector"
+    ) as wall_connector:
+        client = wall_connector.return_value
+        client.async_get_version = AsyncMock(return_value=get_default_version_data())
+        client.async_get_vitals = AsyncMock(return_value=get_vitals_mock())
+        client.async_get_lifetime = AsyncMock(return_value=get_lifetime_mock())
+        client.async_get_wifi_status = AsyncMock(return_value=get_wifi_status_mock())
+
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        assert entry.state is ConfigEntryState.LOADED
+        assert wall_connector.call_args.kwargs[CONF_SPLIT_PHASE] is False
+
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "init"
+
+        wall_connector.reset_mock()
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={CONF_SPLIT_PHASE: True},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == {CONF_SPLIT_PHASE: True}
+    assert entry.options == {CONF_SPLIT_PHASE: True}
+    assert entry.state is ConfigEntryState.LOADED
+    assert wall_connector.call_args.kwargs[CONF_SPLIT_PHASE] is True
 
 
 async def test_dhcp_already_exists(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This adds a split-phase electrical service option during setup and in the options flow for Tesla Wall Connector. The option is passed to the Tesla Wall Connector client so the Total power sensor uses the correct calculation for single-phase / split-phase installations, while keeping three-phase as the default behavior for existing entries.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #169343
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/46718
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
