### PR TITLE
Raise ConfigEntryNotReady on connection errors during lg_thinq setup

### DIFF
--- a/homeassistant/components/lg_thinq/__init__.py
+++ b/homeassistant/components/lg_thinq/__init__.py
@@ -4,6 +4,7 @@ import asyncio
 from dataclasses import dataclass, field
 import logging
 
+from aiohttp import ClientError
 from thinqconnect import ThinQApi, ThinQAPIException
 from thinqconnect.integration import async_get_ha_bridge_list
 
@@ -93,6 +94,13 @@ async def async_setup_coordinators(
         bridge_list = await async_get_ha_bridge_list(thinq_api)
     except ThinQAPIException as exc:
         raise ConfigEntryNotReady(exc.message) from exc
+    except (ClientError, TimeoutError) as exc:
+        # A transient network/DNS failure (e.g. Home Assistant starting before
+        # the network is ready after a reboot) surfaces as an aiohttp
+        # ClientError or a timeout rather than a ThinQAPIException. Treat it as
+        # "not ready yet" so Home Assistant retries with backoff instead of
+        # failing setup permanently.
+        raise ConfigEntryNotReady(str(exc)) from exc
 
     if not bridge_list:
         _LOGGER.warning("No devices registered with the correct profile")

--- a/homeassistant/components/lg_thinq/__init__.py
+++ b/homeassistant/components/lg_thinq/__init__.py
@@ -95,12 +95,8 @@ async def async_setup_coordinators(
     except ThinQAPIException as exc:
         raise ConfigEntryNotReady(exc.message) from exc
     except (ClientError, TimeoutError) as exc:
-        # A transient network/DNS failure (e.g. Home Assistant starting before
-        # the network is ready after a reboot) surfaces as an aiohttp
-        # ClientError or a timeout rather than a ThinQAPIException. Treat it as
-        # "not ready yet" so Home Assistant retries with backoff instead of
-        # failing setup permanently.
-        raise ConfigEntryNotReady(str(exc)) from exc
+        # Transient network/DNS errors aren't ThinQAPIException; retry setup.
+        raise ConfigEntryNotReady from exc
 
     if not bridge_list:
         _LOGGER.warning("No devices registered with the correct profile")

--- a/tests/components/lg_thinq/test_init.py
+++ b/tests/components/lg_thinq/test_init.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock, patch
 
+from aiohttp import ClientError
 import pytest
 
 from homeassistant.config_entries import ConfigEntryState
@@ -42,6 +43,28 @@ async def test_config_not_ready(
     """Test for setup failure exception occurred."""
     with patch(
         "homeassistant.components.lg_thinq.ThinQMQTT.async_connect",
+        side_effect=exception,
+    ):
+        await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+@pytest.mark.parametrize("exception", [ClientError(), TimeoutError()])
+async def test_config_not_ready_on_connection_error(
+    hass: HomeAssistant,
+    mock_thinq_api: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    exception: Exception,
+) -> None:
+    """Test setup retries on a transient network/DNS error fetching bridges.
+
+    A connection or DNS failure while fetching the bridge list (e.g. Home
+    Assistant starting before the network is ready) must be treated as
+    "not ready" so setup is retried, not left in a permanent error state.
+    """
+    with patch(
+        "homeassistant.components.lg_thinq.async_get_ha_bridge_list",
         side_effect=exception,
     ):
         await setup_integration(hass, mock_config_entry)

--- a/tests/components/lg_thinq/test_init.py
+++ b/tests/components/lg_thinq/test_init.py
@@ -57,12 +57,7 @@ async def test_config_not_ready_on_connection_error(
     mock_config_entry: MockConfigEntry,
     exception: Exception,
 ) -> None:
-    """Test setup retries on a transient network/DNS error fetching bridges.
-
-    A connection or DNS failure while fetching the bridge list (e.g. Home
-    Assistant starting before the network is ready) must be treated as
-    "not ready" so setup is retried, not left in a permanent error state.
-    """
+    """Test setup retries on a transient connection error fetching bridges."""
     with patch(
         "homeassistant.components.lg_thinq.async_get_ha_bridge_list",
         side_effect=exception,


### PR DESCRIPTION
## Proposed change

The LG ThinQ integration fails to set up permanently (state `SETUP_ERROR`, no
automatic retry) when Home Assistant starts before the network / DNS is ready,
for example right after a power outage. The device list fetch in
`async_setup_coordinators` only catches `ThinQAPIException`:

```python
try:
    bridge_list = await async_get_ha_bridge_list(thinq_api)
except ThinQAPIException as exc:
    raise ConfigEntryNotReady(exc.message) from exc
```

A transient network/DNS failure surfaces as an `aiohttp.ClientError`
(e.g. `ClientConnectorDNSError`) or a `TimeoutError`, neither of which is a
`ThinQAPIException`, so the exception propagates unhandled and Home Assistant
does not retry — the integration stays down until a manual reload or restart.

This change catches `ClientError`/`TimeoutError` in the bridge-list call and
raises `ConfigEntryNotReady`, so Home Assistant retries setup with backoff
(the intended behaviour for transient connectivity issues). This mirrors how the
MQTT setup path in the same module already raises `ConfigEntryNotReady`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #144277
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
