### PR TITLE
Fix ZHA device trigger cache not resolving quirks

### DIFF
--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -160,9 +160,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     zha_gateway = await Gateway.async_from_config(zha_lib_data)
 
     # Load and cache device trigger information early. Quirks were registered by
-    # `Gateway.async_from_config` above, so pass the resolver to surface
-    # quirk-defined triggers (e.g. remote button presses); without it the cache
-    # would only hold the built-in triggers of bare, un-quirked devices.
+    # `Gateway.async_from_config` above, so pass the resolver to quirk devices
+    # and surface quirk-defined triggers (e.g. remote button presses).
     device_registry = dr.async_get(hass)
     radio_mgr = ZhaRadioManager.from_config_entry(hass, config_entry)
 

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -9,6 +9,7 @@ from yarl import URL
 from zha.application.const import BAUD_RATES, RadioType
 from zha.application.gateway import Gateway
 from zha.application.helpers import ZHAData
+from zha.quirks import DEVICE_REGISTRY
 from zha.zigbee.device import get_device_automation_triggers
 from zigpy.config import CONF_DATABASE, CONF_DEVICE, CONF_DEVICE_PATH
 from zigpy.exceptions import NetworkSettingsInconsistent, TransientConnectionError
@@ -158,11 +159,16 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     zha_gateway = await Gateway.async_from_config(zha_lib_data)
 
-    # Load and cache device trigger information early
+    # Load and cache device trigger information early. Quirks were registered by
+    # `Gateway.async_from_config` above, so pass the resolver to surface
+    # quirk-defined triggers (e.g. remote button presses); without it the cache
+    # would only hold the built-in triggers of bare, un-quirked devices.
     device_registry = dr.async_get(hass)
     radio_mgr = ZhaRadioManager.from_config_entry(hass, config_entry)
 
-    async with radio_mgr.create_zigpy_app(connect=False) as app:
+    async with radio_mgr.create_zigpy_app(
+        connect=False, device_resolver=DEVICE_REGISTRY.resolve
+    ) as app:
         for dev in app.devices.values():
             dev_entry = device_registry.async_get_device(
                 identifiers={(DOMAIN, str(dev.ieee))},

--- a/homeassistant/components/zha/radio_manager.py
+++ b/homeassistant/components/zha/radio_manager.py
@@ -1,7 +1,7 @@
 """ZHA radio manager."""
 
 import asyncio
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Callable
 import contextlib
 from contextlib import suppress
 import copy
@@ -22,6 +22,7 @@ from zigpy.config import (
     CONF_NWK_BACKUP_ENABLED,
     SCHEMA_DEVICE,
 )
+import zigpy.device
 from zigpy.exceptions import NetworkNotFormed
 
 from homeassistant import config_entries
@@ -174,9 +175,18 @@ class ZhaRadioManager:
 
     @contextlib.asynccontextmanager
     async def create_zigpy_app(
-        self, *, connect: bool = True
+        self,
+        *,
+        connect: bool = True,
+        device_resolver: Callable[[zigpy.device.Device], zigpy.device.Device]
+        | None = None,
     ) -> AsyncGenerator[ControllerApplication]:
-        """Connect to the radio with the current config and then clean up."""
+        """Connect to the radio with the current config and then clean up.
+
+        `device_resolver` is forwarded to zigpy so devices loaded from the
+        database are quirk-resolved; without it they are bare, un-quirked
+        devices (quirk resolution now lives in the ZHA gateway, not zigpy).
+        """
         assert self.radio_type is not None
 
         config = get_zha_data(self.hass).yaml_config
@@ -201,7 +211,10 @@ class ZhaRadioManager:
         app_config[CONF_USE_THREAD] = False
 
         app = await self.radio_type.controller.new(
-            app_config, auto_form=False, start_radio=False
+            app_config,
+            auto_form=False,
+            start_radio=False,
+            device_resolver=device_resolver,
         )
 
         try:

--- a/homeassistant/components/zha/radio_manager.py
+++ b/homeassistant/components/zha/radio_manager.py
@@ -184,8 +184,7 @@ class ZhaRadioManager:
         """Connect to the radio with the current config and then clean up.
 
         `device_resolver` is forwarded to zigpy so devices loaded from the
-        database are quirk-resolved; without it they are bare, un-quirked
-        devices (quirk resolution now lives in the ZHA gateway, not zigpy).
+        database are quirk-resolved to get quirk-defined device triggers.
         """
         assert self.radio_type is not None
 

--- a/tests/components/zha/test_device_trigger.py
+++ b/tests/components/zha/test_device_trigger.py
@@ -1,10 +1,13 @@
 """ZHA device automation trigger tests."""
 
 from collections.abc import Callable, Coroutine
+from contextlib import AbstractAsyncContextManager
+from typing import Any
 from unittest.mock import patch
 
 import pytest
 from zha.application.const import ATTR_ENDPOINT_ID
+from zha.quirks import DEVICE_REGISTRY
 from zigpy.application import ControllerApplication
 from zigpy.device import Device as ZigpyDevice
 import zigpy.profiles.zha
@@ -16,6 +19,7 @@ from homeassistant.components.device_automation import (
     InvalidDeviceAutomationConfig,
 )
 from homeassistant.components.zha.helpers import get_zha_gateway
+from homeassistant.components.zha.radio_manager import ZhaRadioManager
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr
@@ -558,3 +562,34 @@ async def test_validate_trigger_config_unloaded_bad_info(
     )
 
     assert "Unable to find trigger" in caplog.text
+
+
+async def test_device_trigger_cache_built_with_quirk_resolver(
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[None]],
+) -> None:
+    """Test the early device trigger cache is built with quirk resolution.
+
+    Regression test: the cache is populated from a throwaway zigpy app whose
+    database devices must be quirk-resolved, otherwise quirk-defined triggers
+    (e.g. remote button presses) are missing whenever the cache is used as a
+    fallback (i.e. before ZHA has finished loading).
+    """
+    resolvers: list[Callable | None] = []
+    real_create_zigpy_app = ZhaRadioManager.create_zigpy_app
+
+    def spy_create_zigpy_app(
+        self: ZhaRadioManager, **kwargs: Any
+    ) -> AbstractAsyncContextManager[ControllerApplication]:
+        resolvers.append(kwargs.get("device_resolver"))
+        return real_create_zigpy_app(self, **kwargs)
+
+    with patch.object(
+        ZhaRadioManager,
+        "create_zigpy_app",
+        autospec=True,
+        side_effect=spy_create_zigpy_app,
+    ):
+        await setup_zha()
+
+    assert DEVICE_REGISTRY.resolve in resolvers

--- a/tests/components/zha/test_device_trigger.py
+++ b/tests/components/zha/test_device_trigger.py
@@ -1,12 +1,10 @@
 """ZHA device automation trigger tests."""
 
 from collections.abc import Callable, Coroutine
-from contextlib import AbstractAsyncContextManager
-from typing import Any
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
-from zha.application.const import ATTR_ENDPOINT_ID
+from zha.application.const import ATTR_ENDPOINT_ID, RadioType
 from zha.quirks import DEVICE_REGISTRY
 from zigpy.application import ControllerApplication
 from zigpy.device import Device as ZigpyDevice
@@ -19,7 +17,6 @@ from homeassistant.components.device_automation import (
     InvalidDeviceAutomationConfig,
 )
 from homeassistant.components.zha.helpers import get_zha_gateway
-from homeassistant.components.zha.radio_manager import ZhaRadioManager
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr
@@ -566,6 +563,7 @@ async def test_validate_trigger_config_unloaded_bad_info(
 
 async def test_device_trigger_cache_built_with_quirk_resolver(
     hass: HomeAssistant,
+    zigpy_app_controller: ControllerApplication,
     setup_zha: Callable[..., Coroutine[None]],
 ) -> None:
     """Test the early device trigger cache is built with quirk resolution.
@@ -574,21 +572,16 @@ async def test_device_trigger_cache_built_with_quirk_resolver(
     remote button presses) are missing whenever the cache is used as a
     fallback (i.e. before ZHA has finished loading).
     """
-    resolvers: list[Callable | None] = []
-    real_create_zigpy_app = ZhaRadioManager.create_zigpy_app
-
-    def spy_create_zigpy_app(
-        self: ZhaRadioManager, **kwargs: Any
-    ) -> AbstractAsyncContextManager[ControllerApplication]:
-        resolvers.append(kwargs.get("device_resolver"))
-        return real_create_zigpy_app(self, **kwargs)
-
     with patch.object(
-        ZhaRadioManager,
-        "create_zigpy_app",
-        autospec=True,
-        side_effect=spy_create_zigpy_app,
-    ):
+        RadioType.ezsp.controller,
+        "new",
+        AsyncMock(return_value=zigpy_app_controller),
+    ) as mock_new:
         await setup_zha()
 
-    assert DEVICE_REGISTRY.resolve in resolvers
+    # Both the trigger cache app and the gateway app must quirk-resolve devices
+    assert len(mock_new.await_args_list) == 2
+    assert all(
+        call.kwargs.get("device_resolver") == DEVICE_REGISTRY.resolve
+        for call in mock_new.await_args_list
+    )

--- a/tests/components/zha/test_device_trigger.py
+++ b/tests/components/zha/test_device_trigger.py
@@ -562,7 +562,6 @@ async def test_validate_trigger_config_unloaded_bad_info(
 
 
 async def test_device_trigger_cache_built_with_quirk_resolver(
-    hass: HomeAssistant,
     zigpy_app_controller: ControllerApplication,
     setup_zha: Callable[..., Coroutine[None]],
 ) -> None:

--- a/tests/components/zha/test_device_trigger.py
+++ b/tests/components/zha/test_device_trigger.py
@@ -570,9 +570,8 @@ async def test_device_trigger_cache_built_with_quirk_resolver(
 ) -> None:
     """Test the early device trigger cache is built with quirk resolution.
 
-    Regression test: the cache is populated from a throwaway zigpy app whose
-    database devices must be quirk-resolved, otherwise quirk-defined triggers
-    (e.g. remote button presses) are missing whenever the cache is used as a
+    Regression test: without quirk resolution, quirk-defined triggers (e.g.
+    remote button presses) are missing whenever the cache is used as a
     fallback (i.e. before ZHA has finished loading).
     """
     resolvers: list[Callable | None] = []

--- a/tests/components/zha/test_radio_manager.py
+++ b/tests/components/zha/test_radio_manager.py
@@ -510,11 +510,8 @@ async def test_create_zigpy_app_forwards_device_resolver(
 ) -> None:
     """Test that `create_zigpy_app` forwards the device resolver to zigpy.
 
-    Quirk resolution now lives in the ZHA gateway, not zigpy, so zigpy only
-    quirk-resolves devices loaded from the database when a resolver is passed.
-    Regression test: without forwarding the resolver, the early device trigger
-    cache is built from bare, un-quirked devices and quirk-defined triggers
-    (e.g. remote button presses) go missing.
+    zigpy only quirk-resolves devices loaded from the database when a
+    resolver is passed, so quirk-defined triggers would be missing otherwise.
     """
     radio_manager.radio_type = RadioType.ezsp
     radio_manager.device_settings = {CONF_DEVICE_PATH: "/dev/ttyZigbee"}

--- a/tests/components/zha/test_radio_manager.py
+++ b/tests/components/zha/test_radio_manager.py
@@ -8,7 +8,6 @@ from zha.application.const import RadioType
 from zigpy.backups import BackupManager
 import zigpy.config
 from zigpy.config import CONF_DEVICE_PATH
-import zigpy.device
 import zigpy.types
 
 from homeassistant.components.zha import radio_manager
@@ -503,29 +502,3 @@ async def test_create_zigpy_app_connect_oserror(
     with pytest.raises(HomeAssistantError, match="Failed to connect to Zigbee adapter"):
         async with radio_manager.create_zigpy_app():
             pytest.fail("Should not be reached")
-
-
-async def test_create_zigpy_app_forwards_device_resolver(
-    radio_manager: ZhaRadioManager,
-) -> None:
-    """Test that `create_zigpy_app` forwards the device resolver to zigpy.
-
-    zigpy only quirk-resolves devices loaded from the database when a
-    resolver is passed, so quirk-defined triggers would be missing otherwise.
-    """
-    radio_manager.radio_type = RadioType.ezsp
-    radio_manager.device_settings = {CONF_DEVICE_PATH: "/dev/ttyZigbee"}
-
-    def resolver(device: zigpy.device.Device) -> zigpy.device.Device:
-        return device
-
-    with (
-        patch("homeassistant.components.zha.radio_manager.CONNECT_DELAY_S", 0),
-        patch("zigpy.application.ControllerApplication.new", AsyncMock()) as mock_new,
-    ):
-        async with radio_manager.create_zigpy_app(
-            connect=False, device_resolver=resolver
-        ):
-            pass
-
-    assert mock_new.await_args.kwargs["device_resolver"] is resolver

--- a/tests/components/zha/test_radio_manager.py
+++ b/tests/components/zha/test_radio_manager.py
@@ -8,6 +8,7 @@ from zha.application.const import RadioType
 from zigpy.backups import BackupManager
 import zigpy.config
 from zigpy.config import CONF_DEVICE_PATH
+import zigpy.device
 import zigpy.types
 
 from homeassistant.components.zha import radio_manager
@@ -502,3 +503,32 @@ async def test_create_zigpy_app_connect_oserror(
     with pytest.raises(HomeAssistantError, match="Failed to connect to Zigbee adapter"):
         async with radio_manager.create_zigpy_app():
             pytest.fail("Should not be reached")
+
+
+async def test_create_zigpy_app_forwards_device_resolver(
+    radio_manager: ZhaRadioManager,
+) -> None:
+    """Test that `create_zigpy_app` forwards the device resolver to zigpy.
+
+    Quirk resolution now lives in the ZHA gateway, not zigpy, so zigpy only
+    quirk-resolves devices loaded from the database when a resolver is passed.
+    Regression test: without forwarding the resolver, the early device trigger
+    cache is built from bare, un-quirked devices and quirk-defined triggers
+    (e.g. remote button presses) go missing.
+    """
+    radio_manager.radio_type = RadioType.ezsp
+    radio_manager.device_settings = {CONF_DEVICE_PATH: "/dev/ttyZigbee"}
+
+    def resolver(device: zigpy.device.Device) -> zigpy.device.Device:
+        return device
+
+    with (
+        patch("homeassistant.components.zha.radio_manager.CONNECT_DELAY_S", 0),
+        patch("zigpy.application.ControllerApplication.new", AsyncMock()) as mock_new,
+    ):
+        async with radio_manager.create_zigpy_app(
+            connect=False, device_resolver=resolver
+        ):
+            pass
+
+    assert mock_new.await_args.kwargs["device_resolver"] is resolver


### PR DESCRIPTION
## Proposed change

This PR fixes an issue where device triggers may not be available when the ZHA integration is not yet connected to the coordinator whilst HA Core is initially setting up automations.

The fix is to also forward the `device_resolver` (for quirks) when creating the (temporary) zigpy application for caching the device triggers. This was already done by the actual connection happening later.

This bug was a regression introduced in the recent ZHA 2.0.0 refactor:
- https://github.com/home-assistant/core/pull/174586

The fix is a bit awkward to test nicely, so the added test just checks that the `device_resolver` is now correctly passed to the zigpy library (when caching and when actually loading properly).

### AI summary

<details><summary>AI summary (click to expand)</summary>
<p>

Fixes ZHA button/remote **device automation triggers** (e.g. `remote_button_short_press`, `remote_button_double_press`) disappearing after the 2026.7 `zha`/`zigpy`/`zha-quirks` 2.0 bump. Affected automations fail at startup with `Unable to find trigger (...)`, and the device trigger picker only offers entity-based (battery) triggers.

#### Root cause

In the 2.0 refactor, quirk resolution moved out of `zigpy` and into the ZHA gateway, which injects it via `ControllerApplication.new(device_resolver=DEVICE_REGISTRY.resolve)`. `zigpy` now only quirk-resolves devices loaded from the database when that resolver is supplied (`_load_db` → `appdb.load()` → `_resolve_device`, which is a no-op without a resolver).

The early `device_trigger_cache` — built in `async_setup_entry` *before* the gateway connects to the radio, so ZHA device triggers can still be validated/attached while ZHA is starting up or the coordinator is unavailable — is populated from a throwaway `zigpy` app created via `ZhaRadioManager.create_zigpy_app`. That call passed no resolver, so the cache was built from bare, un-quirked devices and only ever contained the built-in `device_offline` trigger. Whenever the cache is used as a fallback (i.e. before ZHA has finished loading, or while it is in a `ConfigEntryNotReady` retry loop), every quirk-defined trigger is missing, so automations referencing them fail to attach.

#### Fix

Forward an optional `device_resolver` through `create_zigpy_app` and pass `DEVICE_REGISTRY.resolve` when building the trigger cache. Quirks are already registered by `Gateway.async_from_config` (via `zhaquirks.setup`) before the cache is built, so the throwaway app now resolves quirks exactly like the live gateway does. Passing the resolver is a harmless no-op when quirks are disabled (the registry is empty and `resolve` returns the device unchanged), and the other `create_zigpy_app` callers (backup / network-settings / migration paths) are unaffected by the new default-`None` parameter.

A regression test is added that patches `ControllerApplication.new` during a full ZHA setup and asserts that both zigpy apps created (the throwaway trigger-cache app and the gateway's own app) receive `DEVICE_REGISTRY.resolve`. It fails on `dev` and passes with this change. (The ZHA test suite mocks `ControllerApplication.new`, so an end-to-end cache-content assertion is not feasible; the test locks in the resolver reaching zigpy instead.)

</p>
</details> 

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #175544, fixes #175890
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
