### PR TITLE
Bump `ha-iotawattpy` from 0.1.2 to 0.2.1

### DIFF
--- a/homeassistant/components/iotawatt/coordinator.py
+++ b/homeassistant/components/iotawatt/coordinator.py
@@ -78,6 +78,9 @@ class IotawattUpdater(DataUpdateCoordinator):
 
             self.api = api
 
-        await self.api.update(lastUpdate=self._last_run)
+        try:
+            await self.api.update(lastUpdate=self._last_run)
+        except CONNECTION_ERRORS as err:
+            raise UpdateFailed("Connection failed") from err
         self._last_run = None
         return self.api.getSensors()

--- a/homeassistant/components/iotawatt/manifest.json
+++ b/homeassistant/components/iotawatt/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["iotawattpy"],
-  "requirements": ["ha-iotawattpy==0.1.2"]
+  "requirements": ["ha-iotawattpy==0.2.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1201,7 +1201,7 @@ h2==4.3.0
 ha-ffmpeg==3.2.2
 
 # homeassistant.components.iotawatt
-ha-iotawattpy==0.1.2
+ha-iotawattpy==0.2.1
 
 # homeassistant.components.philips_js
 ha-philipsjs==3.2.4

--- a/tests/components/iotawatt/test_init.py
+++ b/tests/components/iotawatt/test_init.py
@@ -42,3 +42,15 @@ async def test_setup_auth_failed(
     assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
     assert entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_setup_update_failed(
+    hass: HomeAssistant, mock_iotawatt: MagicMock, entry: MockConfigEntry
+) -> None:
+    """Test error while fetching sensor data during startup."""
+    mock_iotawatt.update.side_effect = httpx.HTTPStatusError(
+        "", request=MagicMock(), response=MagicMock()
+    )
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+    assert entry.state is ConfigEntryState.SETUP_RETRY


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bump `ha-iotawattpy` from 0.1.2 to 0.2.1.

The new release fixes an `IndexError` raised when the IoTaWatt device returns an empty query result for the day-total energy sensors. This happens when the device is polled within the first seconds after device-local midnight, where the queried interval (`begin=d&end=s`) is zero-length.

The library now performs `raise_for_status()` on all device requests and raises `httpx` errors from `update()` (0.1.2 silently returned `None`/`False` on some errors). The coordinator therefore wraps the update call in the existing `CONNECTION_ERRORS` handling, raising `UpdateFailed` instead of logging an unexpected error, with a test covering the new path.

- **PyPI release**: https://pypi.org/project/ha-iotawattpy/0.2.1/
- **Changelog**: https://github.com/home-assistant-libs/iotawattpy/releases/tag/v0.2.1
- **Version diff**: https://github.com/home-assistant-libs/iotawattpy/compare/v0.1.2...v0.2.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #125038
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
