### PR TITLE
Bump boschshcpy to 0.6.4

### DIFF
--- a/homeassistant/components/bosch_shc/__init__.py
+++ b/homeassistant/components/bosch_shc/__init__.py
@@ -47,7 +47,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> boo
         raise ConfigEntryNotReady from err
 
     shc_info = session.information
-    if shc_info.updateState.name == "UPDATE_AVAILABLE":
+    # SHCSession is constructed with lazy=False above, so its constructor runs
+    # _enumerate_all() -> authenticate() synchronously: authenticate() either
+    # raises (in which case the SHCSession(...) call above already raised, and
+    # we never reach this line) or unconditionally populates
+    # _shc_information. So `information` is guaranteed non-None here.
+    assert shc_info is not None
+    # get_unique_id() (called from SHCInformation.__init__ above) always sets
+    # _unique_id to a str before returning, on every code path that doesn't
+    # raise SHCConnectionError -- so unique_id is also guaranteed non-None here.
+    assert shc_info.unique_id is not None
+    if (
+        shc_info.updateState is not None
+        and shc_info.updateState.name == "UPDATE_AVAILABLE"
+    ):
         _LOGGER.warning("Please check for software updates in the Bosch Smart Home App")
 
     entry.runtime_data = session

--- a/homeassistant/components/bosch_shc/__init__.py
+++ b/homeassistant/components/bosch_shc/__init__.py
@@ -1,6 +1,7 @@
 """The Bosch Smart Home Controller integration."""
 
 import logging
+from typing import TYPE_CHECKING
 
 from boschshcpy import SHCSession
 from boschshcpy.exceptions import SHCAuthenticationError, SHCConnectionError
@@ -47,9 +48,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> boo
         raise ConfigEntryNotReady from err
 
     shc_info = session.information
-    # Always populated: the synchronous SHCSession construction above already raised otherwise.
-    assert shc_info is not None
-    assert shc_info.unique_id is not None
+    if TYPE_CHECKING:
+        assert shc_info is not None
+        assert shc_info.unique_id is not None
     if (
         shc_info.updateState is not None
         and shc_info.updateState.name == "UPDATE_AVAILABLE"

--- a/homeassistant/components/bosch_shc/__init__.py
+++ b/homeassistant/components/bosch_shc/__init__.py
@@ -1,6 +1,5 @@
 """The Bosch Smart Home Controller integration."""
 
-from dataclasses import dataclass
 import logging
 
 from boschshcpy import SHCSession
@@ -25,15 +24,7 @@ PLATFORMS = [
 _LOGGER = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True, kw_only=True)
-class SHCData:
-    """Runtime data for the Bosch SHC integration."""
-
-    session: SHCSession
-    parent_id: str
-
-
-type BoschConfigEntry = ConfigEntry[SHCData]
+type BoschConfigEntry = ConfigEntry[SHCSession]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> bool:
@@ -56,15 +47,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> boo
         raise ConfigEntryNotReady from err
 
     shc_info = session.information
-    if shc_info is None or shc_info.unique_id is None:
-        raise ConfigEntryNotReady("Bosch SHC did not return controller information")
+    # Always populated: the synchronous SHCSession construction above already raised otherwise.
+    assert shc_info is not None
+    assert shc_info.unique_id is not None
     if (
         shc_info.updateState is not None
         and shc_info.updateState.name == "UPDATE_AVAILABLE"
     ):
         _LOGGER.warning("Please check for software updates in the Bosch Smart Home App")
 
-    entry.runtime_data = SHCData(session=session, parent_id=shc_info.unique_id)
+    entry.runtime_data = session
 
     device_registry = dr.async_get(hass)
     device_registry.async_get_or_create(
@@ -93,6 +85,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> boo
 
 async def async_unload_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> bool:
     """Unload a config entry."""
-    await hass.async_add_executor_job(entry.runtime_data.session.stop_polling)
+    await hass.async_add_executor_job(entry.runtime_data.stop_polling)
 
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/bosch_shc/__init__.py
+++ b/homeassistant/components/bosch_shc/__init__.py
@@ -30,8 +30,7 @@ class SHCData:
     """Runtime data for the Bosch SHC integration."""
 
     session: SHCSession
-    # The SHC controller's own unique_id, used as the parent identifier for
-    # every device entity created by the platforms below.
+    # The SHC controller's unique_id; parent identifier for every device entity.
     parent_id: str
 
 
@@ -58,8 +57,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> boo
         raise ConfigEntryNotReady from err
 
     shc_info = session.information
-    # Always populated by this point: SHCSession's synchronous, non-lazy
-    # construction above already raised if authentication/enumeration failed.
+    # Always populated: the synchronous SHCSession construction above already raised otherwise.
     assert shc_info is not None
     assert shc_info.unique_id is not None
     if (

--- a/homeassistant/components/bosch_shc/__init__.py
+++ b/homeassistant/components/bosch_shc/__init__.py
@@ -49,8 +49,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> boo
 
     shc_info = session.information
     if TYPE_CHECKING:
-        assert shc_info is not None
-        assert shc_info.unique_id is not None
+        assert shc_info is not None and shc_info.unique_id is not None
     if (
         shc_info.updateState is not None
         and shc_info.updateState.name == "UPDATE_AVAILABLE"

--- a/homeassistant/components/bosch_shc/__init__.py
+++ b/homeassistant/components/bosch_shc/__init__.py
@@ -1,5 +1,6 @@
 """The Bosch Smart Home Controller integration."""
 
+from dataclasses import dataclass
 import logging
 
 from boschshcpy import SHCSession
@@ -24,7 +25,17 @@ PLATFORMS = [
 _LOGGER = logging.getLogger(__name__)
 
 
-type BoschConfigEntry = ConfigEntry[SHCSession]
+@dataclass
+class SHCData:
+    """Runtime data for the Bosch SHC integration."""
+
+    session: SHCSession
+    # The SHC controller's own unique_id, used as the parent identifier for
+    # every device entity created by the platforms below.
+    parent_id: str
+
+
+type BoschConfigEntry = ConfigEntry[SHCData]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> bool:
@@ -47,15 +58,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> boo
         raise ConfigEntryNotReady from err
 
     shc_info = session.information
-    # SHCSession is constructed with lazy=False above, so its constructor runs
-    # _enumerate_all() -> authenticate() synchronously: authenticate() either
-    # raises (in which case the SHCSession(...) call above already raised, and
-    # we never reach this line) or unconditionally populates
-    # _shc_information. So `information` is guaranteed non-None here.
+    # Always populated by this point: SHCSession's synchronous, non-lazy
+    # construction above already raised if authentication/enumeration failed.
     assert shc_info is not None
-    # get_unique_id() (called from SHCInformation.__init__ above) always sets
-    # _unique_id to a str before returning, on every code path that doesn't
-    # raise SHCConnectionError -- so unique_id is also guaranteed non-None here.
     assert shc_info.unique_id is not None
     if (
         shc_info.updateState is not None
@@ -63,7 +68,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> boo
     ):
         _LOGGER.warning("Please check for software updates in the Bosch Smart Home App")
 
-    entry.runtime_data = session
+    entry.runtime_data = SHCData(session=session, parent_id=shc_info.unique_id)
 
     device_registry = dr.async_get(hass)
     device_registry.async_get_or_create(
@@ -92,6 +97,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> boo
 
 async def async_unload_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> bool:
     """Unload a config entry."""
-    await hass.async_add_executor_job(entry.runtime_data.stop_polling)
+    await hass.async_add_executor_job(entry.runtime_data.session.stop_polling)
 
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/bosch_shc/__init__.py
+++ b/homeassistant/components/bosch_shc/__init__.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 import logging
+from typing import TYPE_CHECKING
 
 from boschshcpy import SHCSession
 from boschshcpy.exceptions import SHCAuthenticationError, SHCConnectionError
@@ -25,12 +26,11 @@ PLATFORMS = [
 _LOGGER = logging.getLogger(__name__)
 
 
-@dataclass
+@dataclass(frozen=True, kw_only=True)
 class SHCData:
     """Runtime data for the Bosch SHC integration."""
 
     session: SHCSession
-    # The SHC controller's unique_id; parent identifier for every device entity.
     parent_id: str
 
 
@@ -57,9 +57,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> boo
         raise ConfigEntryNotReady from err
 
     shc_info = session.information
-    # Always populated: the synchronous SHCSession construction above already raised otherwise.
-    assert shc_info is not None
-    assert shc_info.unique_id is not None
+    if TYPE_CHECKING:
+        # Always populated: the synchronous SHCSession construction above already raised otherwise.
+        assert shc_info is not None
+        assert shc_info.unique_id is not None
     if (
         shc_info.updateState is not None
         and shc_info.updateState.name == "UPDATE_AVAILABLE"

--- a/homeassistant/components/bosch_shc/__init__.py
+++ b/homeassistant/components/bosch_shc/__init__.py
@@ -2,7 +2,6 @@
 
 from dataclasses import dataclass
 import logging
-from typing import TYPE_CHECKING
 
 from boschshcpy import SHCSession
 from boschshcpy.exceptions import SHCAuthenticationError, SHCConnectionError
@@ -57,10 +56,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> boo
         raise ConfigEntryNotReady from err
 
     shc_info = session.information
-    if TYPE_CHECKING:
-        # Always populated: the synchronous SHCSession construction above already raised otherwise.
-        assert shc_info is not None
-        assert shc_info.unique_id is not None
+    if shc_info is None or shc_info.unique_id is None:
+        raise ConfigEntryNotReady("Bosch SHC did not return controller information")
     if (
         shc_info.updateState is not None
         and shc_info.updateState.name == "UPDATE_AVAILABLE"

--- a/homeassistant/components/bosch_shc/__init__.py
+++ b/homeassistant/components/bosch_shc/__init__.py
@@ -50,10 +50,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> boo
     shc_info = session.information
     if TYPE_CHECKING:
         assert shc_info is not None and shc_info.unique_id is not None
-    if (
-        shc_info.updateState is not None
-        and shc_info.updateState.name == "UPDATE_AVAILABLE"
-    ):
+    if shc_info.updateState.name == "UPDATE_AVAILABLE":
         _LOGGER.warning("Please check for software updates in the Bosch Smart Home App")
 
     entry.runtime_data = session

--- a/homeassistant/components/bosch_shc/binary_sensor.py
+++ b/homeassistant/components/bosch_shc/binary_sensor.py
@@ -31,12 +31,11 @@ async def async_setup_entry(
     shc_info = session.information
     if TYPE_CHECKING:
         assert shc_info is not None and shc_info.unique_id is not None
-    parent_id = shc_info.unique_id
 
     entities: list[BinarySensorEntity] = [
         ShutterContactSensor(
             device=binary_sensor,
-            parent_id=parent_id,
+            parent_id=shc_info.unique_id,
             entry_id=config_entry.entry_id,
         )
         for binary_sensor in (
@@ -48,7 +47,7 @@ async def async_setup_entry(
     entities.extend(
         BatterySensor(
             device=binary_sensor,
-            parent_id=parent_id,
+            parent_id=shc_info.unique_id,
             entry_id=config_entry.entry_id,
         )
         for binary_sensor in (
@@ -84,7 +83,7 @@ class ShutterContactSensor(SHCEntity[SHCShutterContact], BinarySensorEntity):
             "GENERIC": BinarySensorDeviceClass.WINDOW,
         }
         self._attr_device_class = switcher.get(
-            self._device.device_class or "", BinarySensorDeviceClass.WINDOW
+            self._device.device_class or "GENERIC", BinarySensorDeviceClass.WINDOW
         )
 
     @property

--- a/homeassistant/components/bosch_shc/binary_sensor.py
+++ b/homeassistant/components/bosch_shc/binary_sensor.py
@@ -2,8 +2,12 @@
 
 from typing import override
 
-from boschshcpy import SHCBatteryDevice, SHCShutterContact
-from boschshcpy.device import SHCDevice
+from boschshcpy import (
+    BatteryLevelService,
+    SHCBatteryDevice,
+    SHCShutterContact,
+    ShutterContactService,
+)
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -24,46 +28,55 @@ async def async_setup_entry(
     """Set up the SHC binary sensor platform."""
     session = config_entry.runtime_data
 
+    # See __init__.py's async_setup_entry: session.information (and its
+    # unique_id) are always populated by the time platform setup runs.
+    shc_info = session.information
+    assert shc_info is not None
+    assert shc_info.unique_id is not None
+    parent_id = shc_info.unique_id
+
     entities: list[BinarySensorEntity] = [
         ShutterContactSensor(
             device=binary_sensor,
-            parent_id=session.information.unique_id,
+            parent_id=parent_id,
             entry_id=config_entry.entry_id,
         )
         for binary_sensor in (
-            session.device_helper.shutter_contacts
-            + session.device_helper.shutter_contacts2
+            *session.device_helper.shutter_contacts,
+            *session.device_helper.shutter_contacts2,
         )
     ]
 
     entities.extend(
         BatterySensor(
             device=binary_sensor,
-            parent_id=session.information.unique_id,
+            parent_id=parent_id,
             entry_id=config_entry.entry_id,
         )
         for binary_sensor in (
-            session.device_helper.motion_detectors
-            + session.device_helper.shutter_contacts
-            + session.device_helper.shutter_contacts2
-            + session.device_helper.smoke_detectors
-            + session.device_helper.thermostats
-            + session.device_helper.twinguards
-            + session.device_helper.universal_switches
-            + session.device_helper.wallthermostats
-            + session.device_helper.water_leakage_detectors
+            *session.device_helper.motion_detectors,
+            *session.device_helper.shutter_contacts,
+            *session.device_helper.shutter_contacts2,
+            *session.device_helper.smoke_detectors,
+            *session.device_helper.thermostats,
+            *session.device_helper.twinguards,
+            *session.device_helper.universal_switches,
+            *session.device_helper.wallthermostats,
+            *session.device_helper.water_leakage_detectors,
         )
     )
 
     async_add_entities(entities)
 
 
-class ShutterContactSensor(SHCEntity, BinarySensorEntity):
+class ShutterContactSensor(SHCEntity[SHCShutterContact], BinarySensorEntity):
     """Representation of an SHC shutter contact sensor."""
 
     _attr_name = None
 
-    def __init__(self, device: SHCDevice, parent_id: str, entry_id: str) -> None:
+    def __init__(
+        self, device: SHCShutterContact, parent_id: str, entry_id: str
+    ) -> None:
         """Initialize an SHC shutter contact sensor.."""
         super().__init__(device, parent_id, entry_id)
         switcher = {
@@ -72,23 +85,26 @@ class ShutterContactSensor(SHCEntity, BinarySensorEntity):
             "FRENCH_WINDOW": BinarySensorDeviceClass.DOOR,
             "GENERIC": BinarySensorDeviceClass.WINDOW,
         }
-        self._attr_device_class = switcher.get(
-            self._device.device_class, BinarySensorDeviceClass.WINDOW
+        device_class = self._device.device_class
+        self._attr_device_class = (
+            switcher.get(device_class, BinarySensorDeviceClass.WINDOW)
+            if device_class is not None
+            else BinarySensorDeviceClass.WINDOW
         )
 
     @property
     @override
     def is_on(self) -> bool:
         """Return the state of the sensor."""
-        return self._device.state == SHCShutterContact.ShutterContactService.State.OPEN
+        return self._device.state is ShutterContactService.State.OPEN
 
 
-class BatterySensor(SHCEntity, BinarySensorEntity):
+class BatterySensor(SHCEntity[SHCBatteryDevice], BinarySensorEntity):
     """Representation of an SHC battery reporting sensor."""
 
     _attr_device_class = BinarySensorDeviceClass.BATTERY
 
-    def __init__(self, device: SHCDevice, parent_id: str, entry_id: str) -> None:
+    def __init__(self, device: SHCBatteryDevice, parent_id: str, entry_id: str) -> None:
         """Initialize an SHC battery reporting sensor."""
         super().__init__(device, parent_id, entry_id)
         self._attr_unique_id = f"{device.serial}_battery"
@@ -97,6 +113,4 @@ class BatterySensor(SHCEntity, BinarySensorEntity):
     @override
     def is_on(self) -> bool:
         """Return the state of the sensor."""
-        return (
-            self._device.batterylevel != SHCBatteryDevice.BatteryLevelService.State.OK
-        )
+        return self._device.batterylevel is not BatteryLevelService.State.OK

--- a/homeassistant/components/bosch_shc/binary_sensor.py
+++ b/homeassistant/components/bosch_shc/binary_sensor.py
@@ -26,8 +26,14 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the SHC binary sensor platform."""
-    session = config_entry.runtime_data.session
-    parent_id = config_entry.runtime_data.parent_id
+    session = config_entry.runtime_data
+
+    # See __init__.py's async_setup_entry: session.information (and its
+    # unique_id) are always populated by the time platform setup runs.
+    shc_info = session.information
+    assert shc_info is not None
+    assert shc_info.unique_id is not None
+    parent_id = shc_info.unique_id
 
     entities: list[BinarySensorEntity] = [
         ShutterContactSensor(

--- a/homeassistant/components/bosch_shc/binary_sensor.py
+++ b/homeassistant/components/bosch_shc/binary_sensor.py
@@ -83,7 +83,7 @@ class ShutterContactSensor(SHCEntity[SHCShutterContact], BinarySensorEntity):
             "GENERIC": BinarySensorDeviceClass.WINDOW,
         }
         self._attr_device_class = switcher.get(
-            self._device.device_class or "GENERIC", BinarySensorDeviceClass.WINDOW
+            self._device.device_class or "", BinarySensorDeviceClass.WINDOW
         )
 
     @property

--- a/homeassistant/components/bosch_shc/binary_sensor.py
+++ b/homeassistant/components/bosch_shc/binary_sensor.py
@@ -66,10 +66,11 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class ShutterContactSensor(SHCEntity[SHCShutterContact], BinarySensorEntity):
+class ShutterContactSensor(SHCEntity, BinarySensorEntity):
     """Representation of an SHC shutter contact sensor."""
 
     _attr_name = None
+    _device: SHCShutterContact
 
     def __init__(
         self, device: SHCShutterContact, parent_id: str, entry_id: str
@@ -93,10 +94,11 @@ class ShutterContactSensor(SHCEntity[SHCShutterContact], BinarySensorEntity):
         return self._device.state is ShutterContactService.State.OPEN
 
 
-class BatterySensor(SHCEntity[SHCBatteryDevice], BinarySensorEntity):
+class BatterySensor(SHCEntity, BinarySensorEntity):
     """Representation of an SHC battery reporting sensor."""
 
     _attr_device_class = BinarySensorDeviceClass.BATTERY
+    _device: SHCBatteryDevice
 
     def __init__(self, device: SHCBatteryDevice, parent_id: str, entry_id: str) -> None:
         """Initialize an SHC battery reporting sensor."""

--- a/homeassistant/components/bosch_shc/binary_sensor.py
+++ b/homeassistant/components/bosch_shc/binary_sensor.py
@@ -30,8 +30,7 @@ async def async_setup_entry(
 
     shc_info = session.information
     if TYPE_CHECKING:
-        assert shc_info is not None
-        assert shc_info.unique_id is not None
+        assert shc_info is not None and shc_info.unique_id is not None
     parent_id = shc_info.unique_id
 
     entities: list[BinarySensorEntity] = [

--- a/homeassistant/components/bosch_shc/binary_sensor.py
+++ b/homeassistant/components/bosch_shc/binary_sensor.py
@@ -74,7 +74,7 @@ class ShutterContactSensor(SHCEntity, BinarySensorEntity):
     _device: SHCShutterContact
 
     def __init__(self, device: SHCDevice, parent_id: str, entry_id: str) -> None:
-        """Initialize an SHC shutter contact sensor."""
+        """Initialize an SHC shutter contact sensor.."""
         super().__init__(device, parent_id, entry_id)
         switcher = {
             "ENTRANCE_DOOR": BinarySensorDeviceClass.DOOR,

--- a/homeassistant/components/bosch_shc/binary_sensor.py
+++ b/homeassistant/components/bosch_shc/binary_sensor.py
@@ -26,14 +26,8 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the SHC binary sensor platform."""
-    session = config_entry.runtime_data
-
-    # See __init__.py's async_setup_entry: session.information (and its
-    # unique_id) are always populated by the time platform setup runs.
-    shc_info = session.information
-    assert shc_info is not None
-    assert shc_info.unique_id is not None
-    parent_id = shc_info.unique_id
+    session = config_entry.runtime_data.session
+    parent_id = config_entry.runtime_data.parent_id
 
     entities: list[BinarySensorEntity] = [
         ShutterContactSensor(

--- a/homeassistant/components/bosch_shc/binary_sensor.py
+++ b/homeassistant/components/bosch_shc/binary_sensor.py
@@ -1,6 +1,6 @@
 """Platform for binarysensor integration."""
 
-from typing import override
+from typing import TYPE_CHECKING, override
 
 from boschshcpy import (
     BatteryLevelService,
@@ -28,11 +28,10 @@ async def async_setup_entry(
     """Set up the SHC binary sensor platform."""
     session = config_entry.runtime_data
 
-    # See __init__.py's async_setup_entry: session.information (and its
-    # unique_id) are always populated by the time platform setup runs.
     shc_info = session.information
-    assert shc_info is not None
-    assert shc_info.unique_id is not None
+    if TYPE_CHECKING:
+        assert shc_info is not None
+        assert shc_info.unique_id is not None
     parent_id = shc_info.unique_id
 
     entities: list[BinarySensorEntity] = [
@@ -85,11 +84,8 @@ class ShutterContactSensor(SHCEntity[SHCShutterContact], BinarySensorEntity):
             "FRENCH_WINDOW": BinarySensorDeviceClass.DOOR,
             "GENERIC": BinarySensorDeviceClass.WINDOW,
         }
-        device_class = self._device.device_class
-        self._attr_device_class = (
-            switcher.get(device_class, BinarySensorDeviceClass.WINDOW)
-            if device_class is not None
-            else BinarySensorDeviceClass.WINDOW
+        self._attr_device_class = switcher.get(
+            self._device.device_class or "", BinarySensorDeviceClass.WINDOW
         )
 
     @property

--- a/homeassistant/components/bosch_shc/binary_sensor.py
+++ b/homeassistant/components/bosch_shc/binary_sensor.py
@@ -8,6 +8,7 @@ from boschshcpy import (
     SHCShutterContact,
     ShutterContactService,
 )
+from boschshcpy.device import SHCDevice
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -72,9 +73,7 @@ class ShutterContactSensor(SHCEntity, BinarySensorEntity):
     _attr_name = None
     _device: SHCShutterContact
 
-    def __init__(
-        self, device: SHCShutterContact, parent_id: str, entry_id: str
-    ) -> None:
+    def __init__(self, device: SHCDevice, parent_id: str, entry_id: str) -> None:
         """Initialize an SHC shutter contact sensor."""
         super().__init__(device, parent_id, entry_id)
         switcher = {
@@ -100,7 +99,7 @@ class BatterySensor(SHCEntity, BinarySensorEntity):
     _attr_device_class = BinarySensorDeviceClass.BATTERY
     _device: SHCBatteryDevice
 
-    def __init__(self, device: SHCBatteryDevice, parent_id: str, entry_id: str) -> None:
+    def __init__(self, device: SHCDevice, parent_id: str, entry_id: str) -> None:
         """Initialize an SHC battery reporting sensor."""
         super().__init__(device, parent_id, entry_id)
         self._attr_unique_id = f"{device.serial}_battery"

--- a/homeassistant/components/bosch_shc/binary_sensor.py
+++ b/homeassistant/components/bosch_shc/binary_sensor.py
@@ -71,7 +71,7 @@ class ShutterContactSensor(SHCEntity[SHCShutterContact], BinarySensorEntity):
     def __init__(
         self, device: SHCShutterContact, parent_id: str, entry_id: str
     ) -> None:
-        """Initialize an SHC shutter contact sensor.."""
+        """Initialize an SHC shutter contact sensor."""
         super().__init__(device, parent_id, entry_id)
         switcher = {
             "ENTRANCE_DOOR": BinarySensorDeviceClass.DOOR,

--- a/homeassistant/components/bosch_shc/binary_sensor.py
+++ b/homeassistant/components/bosch_shc/binary_sensor.py
@@ -76,14 +76,14 @@ class ShutterContactSensor(SHCEntity, BinarySensorEntity):
     def __init__(self, device: SHCDevice, parent_id: str, entry_id: str) -> None:
         """Initialize an SHC shutter contact sensor.."""
         super().__init__(device, parent_id, entry_id)
-        switcher = {
+        switcher: dict[str | None, BinarySensorDeviceClass] = {
             "ENTRANCE_DOOR": BinarySensorDeviceClass.DOOR,
             "REGULAR_WINDOW": BinarySensorDeviceClass.WINDOW,
             "FRENCH_WINDOW": BinarySensorDeviceClass.DOOR,
             "GENERIC": BinarySensorDeviceClass.WINDOW,
         }
         self._attr_device_class = switcher.get(
-            self._device.device_class or "", BinarySensorDeviceClass.WINDOW
+            self._device.device_class, BinarySensorDeviceClass.WINDOW
         )
 
     @property

--- a/homeassistant/components/bosch_shc/binary_sensor.py
+++ b/homeassistant/components/bosch_shc/binary_sensor.py
@@ -74,7 +74,7 @@ class ShutterContactSensor(SHCEntity, BinarySensorEntity):
     _device: SHCShutterContact
 
     def __init__(self, device: SHCDevice, parent_id: str, entry_id: str) -> None:
-        """Initialize an SHC shutter contact sensor.."""
+        """Initialize an SHC shutter contact sensor."""
         super().__init__(device, parent_id, entry_id)
         switcher: dict[str | None, BinarySensorDeviceClass] = {
             "ENTRANCE_DOOR": BinarySensorDeviceClass.DOOR,

--- a/homeassistant/components/bosch_shc/cover.py
+++ b/homeassistant/components/bosch_shc/cover.py
@@ -23,8 +23,14 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the SHC cover platform."""
-    session = config_entry.runtime_data.session
-    parent_id = config_entry.runtime_data.parent_id
+    session = config_entry.runtime_data
+
+    # See __init__.py's async_setup_entry: session.information (and its
+    # unique_id) are always populated by the time platform setup runs.
+    shc_info = session.information
+    assert shc_info is not None
+    assert shc_info.unique_id is not None
+    parent_id = shc_info.unique_id
 
     async_add_entities(
         ShutterControlCover(

--- a/homeassistant/components/bosch_shc/cover.py
+++ b/homeassistant/components/bosch_shc/cover.py
@@ -2,7 +2,7 @@
 
 from typing import Any, override
 
-from boschshcpy import SHCShutterControl
+from boschshcpy import SHCShutterControl, ShutterControlService
 
 from homeassistant.components.cover import (
     ATTR_POSITION,
@@ -25,17 +25,24 @@ async def async_setup_entry(
     """Set up the SHC cover platform."""
     session = config_entry.runtime_data
 
+    # See __init__.py's async_setup_entry: session.information (and its
+    # unique_id) are always populated by the time platform setup runs.
+    shc_info = session.information
+    assert shc_info is not None
+    assert shc_info.unique_id is not None
+    parent_id = shc_info.unique_id
+
     async_add_entities(
         ShutterControlCover(
             device=cover,
-            parent_id=session.information.unique_id,
+            parent_id=parent_id,
             entry_id=config_entry.entry_id,
         )
         for cover in session.device_helper.shutter_controls
     )
 
 
-class ShutterControlCover(SHCEntity, CoverEntity):
+class ShutterControlCover(SHCEntity[SHCShutterControl], CoverEntity):
     """Representation of a SHC shutter control device."""
 
     _attr_name = None
@@ -68,19 +75,13 @@ class ShutterControlCover(SHCEntity, CoverEntity):
     @override
     def is_opening(self) -> bool:
         """Return if the cover is opening or not."""
-        return (
-            self._device.operation_state
-            == SHCShutterControl.ShutterControlService.State.OPENING
-        )
+        return self._device.operation_state is ShutterControlService.State.OPENING
 
     @property
     @override
     def is_closing(self) -> bool:
         """Return if the cover is closing or not."""
-        return (
-            self._device.operation_state
-            == SHCShutterControl.ShutterControlService.State.CLOSING
-        )
+        return self._device.operation_state is ShutterControlService.State.CLOSING
 
     @override
     def open_cover(self, **kwargs: Any) -> None:

--- a/homeassistant/components/bosch_shc/cover.py
+++ b/homeassistant/components/bosch_shc/cover.py
@@ -27,8 +27,7 @@ async def async_setup_entry(
 
     shc_info = session.information
     if TYPE_CHECKING:
-        assert shc_info is not None
-        assert shc_info.unique_id is not None
+        assert shc_info is not None and shc_info.unique_id is not None
     parent_id = shc_info.unique_id
 
     async_add_entities(

--- a/homeassistant/components/bosch_shc/cover.py
+++ b/homeassistant/components/bosch_shc/cover.py
@@ -28,12 +28,11 @@ async def async_setup_entry(
     shc_info = session.information
     if TYPE_CHECKING:
         assert shc_info is not None and shc_info.unique_id is not None
-    parent_id = shc_info.unique_id
 
     async_add_entities(
         ShutterControlCover(
             device=cover,
-            parent_id=parent_id,
+            parent_id=shc_info.unique_id,
             entry_id=config_entry.entry_id,
         )
         for cover in session.device_helper.shutter_controls

--- a/homeassistant/components/bosch_shc/cover.py
+++ b/homeassistant/components/bosch_shc/cover.py
@@ -39,11 +39,12 @@ async def async_setup_entry(
     )
 
 
-class ShutterControlCover(SHCEntity[SHCShutterControl], CoverEntity):
+class ShutterControlCover(SHCEntity, CoverEntity):
     """Representation of a SHC shutter control device."""
 
     _attr_name = None
     _attr_device_class = CoverDeviceClass.SHUTTER
+    _device: SHCShutterControl
     _attr_supported_features = (
         CoverEntityFeature.OPEN
         | CoverEntityFeature.CLOSE

--- a/homeassistant/components/bosch_shc/cover.py
+++ b/homeassistant/components/bosch_shc/cover.py
@@ -1,6 +1,6 @@
 """Platform for cover integration."""
 
-from typing import Any, override
+from typing import TYPE_CHECKING, Any, override
 
 from boschshcpy import SHCShutterControl, ShutterControlService
 
@@ -25,11 +25,10 @@ async def async_setup_entry(
     """Set up the SHC cover platform."""
     session = config_entry.runtime_data
 
-    # See __init__.py's async_setup_entry: session.information (and its
-    # unique_id) are always populated by the time platform setup runs.
     shc_info = session.information
-    assert shc_info is not None
-    assert shc_info.unique_id is not None
+    if TYPE_CHECKING:
+        assert shc_info is not None
+        assert shc_info.unique_id is not None
     parent_id = shc_info.unique_id
 
     async_add_entities(

--- a/homeassistant/components/bosch_shc/cover.py
+++ b/homeassistant/components/bosch_shc/cover.py
@@ -23,14 +23,8 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the SHC cover platform."""
-    session = config_entry.runtime_data
-
-    # See __init__.py's async_setup_entry: session.information (and its
-    # unique_id) are always populated by the time platform setup runs.
-    shc_info = session.information
-    assert shc_info is not None
-    assert shc_info.unique_id is not None
-    parent_id = shc_info.unique_id
+    session = config_entry.runtime_data.session
+    parent_id = config_entry.runtime_data.parent_id
 
     async_add_entities(
         ShutterControlCover(

--- a/homeassistant/components/bosch_shc/entity.py
+++ b/homeassistant/components/bosch_shc/entity.py
@@ -13,9 +13,7 @@ from .const import DOMAIN
 
 
 async def async_remove_devices(
-    hass: HomeAssistant,
-    entity: SHCBaseEntity[SHCDevice | SHCIntrusionSystem],
-    entry_id: str,
+    hass: HomeAssistant, entity: SHCBaseEntity, entry_id: str
 ) -> None:
     """Get item that is removed from session."""
     dev_registry = dr.async_get(hass)
@@ -24,15 +22,17 @@ async def async_remove_devices(
         dev_registry.async_update_device(device.id, remove_config_entry_id=entry_id)
 
 
-class SHCBaseEntity[_DeviceT: (SHCDevice | SHCIntrusionSystem)](Entity):
+class SHCBaseEntity(Entity):
     """Base representation of a SHC entity."""
 
     _attr_should_poll = False
     _attr_has_entity_name = True
 
-    def __init__(self, device: _DeviceT, parent_id: str, entry_id: str) -> None:
+    def __init__(
+        self, device: SHCDevice | SHCIntrusionSystem, parent_id: str, entry_id: str
+    ) -> None:
         """Initialize the generic SHC device."""
-        self._device: _DeviceT = device
+        self._device = device
         self._entry_id = entry_id
 
     @override
@@ -60,10 +60,12 @@ class SHCBaseEntity[_DeviceT: (SHCDevice | SHCIntrusionSystem)](Entity):
         return self._device.id
 
 
-class SHCEntity[_SHCDeviceT: SHCDevice](SHCBaseEntity[_SHCDeviceT]):
+class SHCEntity(SHCBaseEntity):
     """Representation of a SHC device entity."""
 
-    def __init__(self, device: _SHCDeviceT, parent_id: str, entry_id: str) -> None:
+    _device: SHCDevice
+
+    def __init__(self, device: SHCDevice, parent_id: str, entry_id: str) -> None:
         """Initialize generic SHC device."""
         self._attr_unique_id = device.serial
         self._attr_device_info = DeviceInfo(
@@ -100,8 +102,10 @@ class SHCEntity[_SHCDeviceT: SHCDevice](SHCBaseEntity[_SHCDeviceT]):
         return self._device.status == "AVAILABLE"
 
 
-class SHCDomainEntity(SHCBaseEntity[SHCIntrusionSystem]):
+class SHCDomainEntity(SHCBaseEntity):
     """Representation of a SHC domain service entity."""
+
+    _device: SHCIntrusionSystem
 
     def __init__(
         self, domain: SHCIntrusionSystem, parent_id: str, entry_id: str

--- a/homeassistant/components/bosch_shc/entity.py
+++ b/homeassistant/components/bosch_shc/entity.py
@@ -22,12 +22,8 @@ async def async_remove_devices(
         dev_registry.async_update_device(device.id, remove_config_entry_id=entry_id)
 
 
-# SHCBaseEntity is shared by SHCEntity (always backed by a real SHCDevice) and
-# SHCDomainEntity (always backed by the single SHCIntrusionSystem domain
-# service) -- the two are never interchangeable at runtime. Binding each
-# subclass hierarchy to its own concrete type parameter (rather than leaving
-# `_device` typed as the full union on the shared base) lets mypy know which
-# attributes are actually available at each call site.
+# Parameterized so each subclass's _device is statically its real concrete
+# type (SHCEntity's SHCDevice vs. SHCDomainEntity's SHCIntrusionSystem).
 class SHCBaseEntity[_DeviceT: (SHCDevice | SHCIntrusionSystem)](Entity):
     """Base representation of a SHC entity."""
 

--- a/homeassistant/components/bosch_shc/entity.py
+++ b/homeassistant/components/bosch_shc/entity.py
@@ -1,6 +1,6 @@
 """Bosch Smart Home Controller base entity."""
 
-from typing import override
+from typing import Any, override
 
 from boschshcpy import SHCDevice, SHCIntrusionSystem
 
@@ -13,7 +13,7 @@ from .const import DOMAIN
 
 
 async def async_remove_devices(
-    hass: HomeAssistant, entity: SHCBaseEntity, entry_id: str
+    hass: HomeAssistant, entity: SHCBaseEntity[Any], entry_id: str
 ) -> None:
     """Get item that is removed from session."""
     dev_registry = dr.async_get(hass)
@@ -22,17 +22,21 @@ async def async_remove_devices(
         dev_registry.async_update_device(device.id, remove_config_entry_id=entry_id)
 
 
-class SHCBaseEntity(Entity):
+# SHCBaseEntity is shared by SHCEntity (always backed by a real SHCDevice) and
+# SHCDomainEntity (always backed by the single SHCIntrusionSystem domain
+# service) -- the two are never interchangeable at runtime. Binding each
+# subclass hierarchy to its own concrete type parameter (rather than leaving
+# `_device` typed as the full union on the shared base) lets mypy know which
+# attributes are actually available at each call site.
+class SHCBaseEntity[_DeviceT: (SHCDevice | SHCIntrusionSystem)](Entity):
     """Base representation of a SHC entity."""
 
     _attr_should_poll = False
     _attr_has_entity_name = True
 
-    def __init__(
-        self, device: SHCDevice | SHCIntrusionSystem, parent_id: str, entry_id: str
-    ) -> None:
+    def __init__(self, device: _DeviceT, parent_id: str, entry_id: str) -> None:
         """Initialize the generic SHC device."""
-        self._device = device
+        self._device: _DeviceT = device
         self._entry_id = entry_id
 
     @override
@@ -60,10 +64,10 @@ class SHCBaseEntity(Entity):
         return self._device.id
 
 
-class SHCEntity(SHCBaseEntity):
+class SHCEntity[_SHCDeviceT: SHCDevice](SHCBaseEntity[_SHCDeviceT]):
     """Representation of a SHC device entity."""
 
-    def __init__(self, device: SHCDevice, parent_id: str, entry_id: str) -> None:
+    def __init__(self, device: _SHCDeviceT, parent_id: str, entry_id: str) -> None:
         """Initialize generic SHC device."""
         self._attr_unique_id = device.serial
         self._attr_device_info = DeviceInfo(
@@ -100,7 +104,7 @@ class SHCEntity(SHCBaseEntity):
         return self._device.status == "AVAILABLE"
 
 
-class SHCDomainEntity(SHCBaseEntity):
+class SHCDomainEntity(SHCBaseEntity[SHCIntrusionSystem]):
     """Representation of a SHC domain service entity."""
 
     def __init__(

--- a/homeassistant/components/bosch_shc/entity.py
+++ b/homeassistant/components/bosch_shc/entity.py
@@ -1,6 +1,6 @@
 """Bosch Smart Home Controller base entity."""
 
-from typing import Any, override
+from typing import override
 
 from boschshcpy import SHCDevice, SHCIntrusionSystem
 
@@ -13,7 +13,9 @@ from .const import DOMAIN
 
 
 async def async_remove_devices(
-    hass: HomeAssistant, entity: SHCBaseEntity[Any], entry_id: str
+    hass: HomeAssistant,
+    entity: SHCBaseEntity[SHCDevice | SHCIntrusionSystem],
+    entry_id: str,
 ) -> None:
     """Get item that is removed from session."""
     dev_registry = dr.async_get(hass)
@@ -22,8 +24,6 @@ async def async_remove_devices(
         dev_registry.async_update_device(device.id, remove_config_entry_id=entry_id)
 
 
-# Parameterized so each subclass's _device is statically its real concrete
-# type (SHCEntity's SHCDevice vs. SHCDomainEntity's SHCIntrusionSystem).
 class SHCBaseEntity[_DeviceT: (SHCDevice | SHCIntrusionSystem)](Entity):
     """Base representation of a SHC entity."""
 

--- a/homeassistant/components/bosch_shc/manifest.json
+++ b/homeassistant/components/bosch_shc/manifest.json
@@ -8,7 +8,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["boschshcpy"],
-  "requirements": ["boschshcpy==0.4.9"],
+  "requirements": ["boschshcpy==0.4.10"],
   "zeroconf": [
     {
       "name": "bosch shc*",

--- a/homeassistant/components/bosch_shc/manifest.json
+++ b/homeassistant/components/bosch_shc/manifest.json
@@ -8,7 +8,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["boschshcpy"],
-  "requirements": ["boschshcpy==0.4.10"],
+  "requirements": ["boschshcpy==0.4.12"],
   "zeroconf": [
     {
       "name": "bosch shc*",

--- a/homeassistant/components/bosch_shc/manifest.json
+++ b/homeassistant/components/bosch_shc/manifest.json
@@ -8,7 +8,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["boschshcpy"],
-  "requirements": ["boschshcpy==0.3.5"],
+  "requirements": ["boschshcpy==0.4.9"],
   "zeroconf": [
     {
       "name": "bosch shc*",

--- a/homeassistant/components/bosch_shc/manifest.json
+++ b/homeassistant/components/bosch_shc/manifest.json
@@ -8,7 +8,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["boschshcpy"],
-  "requirements": ["boschshcpy==0.4.12"],
+  "requirements": ["boschshcpy==0.4.13"],
   "zeroconf": [
     {
       "name": "bosch shc*",

--- a/homeassistant/components/bosch_shc/manifest.json
+++ b/homeassistant/components/bosch_shc/manifest.json
@@ -8,7 +8,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["boschshcpy"],
-  "requirements": ["boschshcpy==0.6.2"],
+  "requirements": ["boschshcpy==0.6.3"],
   "zeroconf": [
     {
       "name": "bosch shc*",

--- a/homeassistant/components/bosch_shc/manifest.json
+++ b/homeassistant/components/bosch_shc/manifest.json
@@ -8,7 +8,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["boschshcpy"],
-  "requirements": ["boschshcpy==0.5.0"],
+  "requirements": ["boschshcpy==0.6.1"],
   "zeroconf": [
     {
       "name": "bosch shc*",

--- a/homeassistant/components/bosch_shc/manifest.json
+++ b/homeassistant/components/bosch_shc/manifest.json
@@ -8,7 +8,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["boschshcpy"],
-  "requirements": ["boschshcpy==0.4.14"],
+  "requirements": ["boschshcpy==0.5.0"],
   "zeroconf": [
     {
       "name": "bosch shc*",

--- a/homeassistant/components/bosch_shc/manifest.json
+++ b/homeassistant/components/bosch_shc/manifest.json
@@ -8,7 +8,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["boschshcpy"],
-  "requirements": ["boschshcpy==0.4.13"],
+  "requirements": ["boschshcpy==0.4.14"],
   "zeroconf": [
     {
       "name": "bosch shc*",

--- a/homeassistant/components/bosch_shc/manifest.json
+++ b/homeassistant/components/bosch_shc/manifest.json
@@ -8,7 +8,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["boschshcpy"],
-  "requirements": ["boschshcpy==0.6.3"],
+  "requirements": ["boschshcpy==0.6.4"],
   "zeroconf": [
     {
       "name": "bosch shc*",

--- a/homeassistant/components/bosch_shc/manifest.json
+++ b/homeassistant/components/bosch_shc/manifest.json
@@ -8,7 +8,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["boschshcpy"],
-  "requirements": ["boschshcpy==0.6.1"],
+  "requirements": ["boschshcpy==0.6.2"],
   "zeroconf": [
     {
       "name": "bosch shc*",

--- a/homeassistant/components/bosch_shc/sensor.py
+++ b/homeassistant/components/bosch_shc/sensor.py
@@ -144,8 +144,14 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the SHC sensor platform."""
-    session = config_entry.runtime_data.session
-    parent_id = config_entry.runtime_data.parent_id
+    session = config_entry.runtime_data
+
+    # See __init__.py's async_setup_entry: session.information (and its
+    # unique_id) are always populated by the time platform setup runs.
+    shc_info = session.information
+    assert shc_info is not None
+    assert shc_info.unique_id is not None
+    parent_id = shc_info.unique_id
 
     entities: list[SensorEntity] = [
         SHCSensor(

--- a/homeassistant/components/bosch_shc/sensor.py
+++ b/homeassistant/components/bosch_shc/sensor.py
@@ -2,8 +2,16 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, override
+from typing import Any, cast, override
 
+from boschshcpy import (
+    SHCLightSwitchBSM,
+    SHCSmartPlug,
+    SHCSmartPlugCompact,
+    SHCThermostat,
+    SHCTwinguard,
+    SHCWallThermostat,
+)
 from boschshcpy.device import SHCDevice
 
 from homeassistant.components.sensor import (
@@ -34,6 +42,15 @@ class SHCSensorEntityDescription(SensorEntityDescription):
     attributes_fn: Callable[[SHCDevice], dict[str, Any]] | None = None
 
 
+# SHCSensorEntityDescription.value_fn/attributes_fn are declared against the
+# generic SHCDevice (matching self._device's type in SHCSensor below), but
+# each entry here is only ever wired up (in async_setup_entry) to specific
+# device_helper lists whose concrete element type actually has the attribute
+# being accessed. The casts below reflect exactly that per-entry pairing.
+_TemperatureDevice = SHCThermostat | SHCWallThermostat | SHCTwinguard
+_HumidityDevice = SHCWallThermostat | SHCTwinguard
+_PowerMeterDevice = SHCSmartPlug | SHCLightSwitchBSM | SHCSmartPlugCompact
+
 TEMPERATURE_SENSOR = "temperature"
 HUMIDITY_SENSOR = "humidity"
 VALVE_TAPPET_SENSOR = "valvetappet"
@@ -52,69 +69,73 @@ SENSOR_DESCRIPTIONS: dict[str, SHCSensorEntityDescription] = {
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        value_fn=lambda device: device.temperature,
+        value_fn=lambda device: cast(_TemperatureDevice, device).temperature,
     ),
     HUMIDITY_SENSOR: SHCSensorEntityDescription(
         key=HUMIDITY_SENSOR,
         device_class=SensorDeviceClass.HUMIDITY,
         native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
-        value_fn=lambda device: device.humidity,
+        value_fn=lambda device: cast(_HumidityDevice, device).humidity,
     ),
     PURITY_SENSOR: SHCSensorEntityDescription(
         key=PURITY_SENSOR,
         translation_key=PURITY_SENSOR,
         native_unit_of_measurement=UnitOfRatio.PARTS_PER_MILLION,
-        value_fn=lambda device: device.purity,
+        value_fn=lambda device: cast(SHCTwinguard, device).purity,
     ),
     AIR_QUALITY_SENSOR: SHCSensorEntityDescription(
         key=AIR_QUALITY_SENSOR,
         translation_key="air_quality",
-        value_fn=lambda device: device.combined_rating.name,
+        value_fn=lambda device: cast(SHCTwinguard, device).combined_rating.name,
         attributes_fn=lambda device: {
-            "rating_description": device.description,
+            "rating_description": cast(SHCTwinguard, device).description,
         },
     ),
     TEMPERATURE_RATING_SENSOR: SHCSensorEntityDescription(
         key=TEMPERATURE_RATING_SENSOR,
         translation_key=TEMPERATURE_RATING_SENSOR,
-        value_fn=lambda device: device.temperature_rating.name,
+        value_fn=lambda device: cast(SHCTwinguard, device).temperature_rating.name,
     ),
     COMMUNICATION_QUALITY_SENSOR: SHCSensorEntityDescription(
         key=COMMUNICATION_QUALITY_SENSOR,
         translation_key=COMMUNICATION_QUALITY_SENSOR,
-        value_fn=lambda device: device.communicationquality.name,
+        value_fn=lambda device: (
+            cast(SHCSmartPlugCompact, device).communicationquality.name
+        ),
     ),
     HUMIDITY_RATING_SENSOR: SHCSensorEntityDescription(
         key=HUMIDITY_RATING_SENSOR,
         translation_key=HUMIDITY_RATING_SENSOR,
-        value_fn=lambda device: device.humidity_rating.name,
+        value_fn=lambda device: cast(SHCTwinguard, device).humidity_rating.name,
     ),
     PURITY_RATING_SENSOR: SHCSensorEntityDescription(
         key=PURITY_RATING_SENSOR,
         translation_key=PURITY_RATING_SENSOR,
-        value_fn=lambda device: device.purity_rating.name,
+        value_fn=lambda device: cast(SHCTwinguard, device).purity_rating.name,
     ),
     POWER_SENSOR: SHCSensorEntityDescription(
         key=POWER_SENSOR,
         device_class=SensorDeviceClass.POWER,
         native_unit_of_measurement=UnitOfPower.WATT,
-        value_fn=lambda device: device.powerconsumption,
+        value_fn=lambda device: cast(_PowerMeterDevice, device).powerconsumption,
     ),
     ENERGY_SENSOR: SHCSensorEntityDescription(
         key=ENERGY_SENSOR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-        value_fn=lambda device: device.energyconsumption / 1000.0,
+        value_fn=lambda device: (
+            cast(_PowerMeterDevice, device).energyconsumption / 1000.0
+        ),
     ),
     VALVE_TAPPET_SENSOR: SHCSensorEntityDescription(
         key=VALVE_TAPPET_SENSOR,
         translation_key=VALVE_TAPPET_SENSOR,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
-        value_fn=lambda device: device.position,
+        value_fn=lambda device: cast(SHCThermostat, device).position,
         attributes_fn=lambda device: {
-            "valve_tappet_state": device.valvestate.name,
+            "valve_tappet_state": cast(SHCThermostat, device).valvestate.name,
         },
     ),
 }
@@ -128,11 +149,18 @@ async def async_setup_entry(
     """Set up the SHC sensor platform."""
     session = config_entry.runtime_data
 
+    # See __init__.py's async_setup_entry: session.information (and its
+    # unique_id) are always populated by the time platform setup runs.
+    shc_info = session.information
+    assert shc_info is not None
+    assert shc_info.unique_id is not None
+    parent_id = shc_info.unique_id
+
     entities: list[SensorEntity] = [
         SHCSensor(
             device,
             SENSOR_DESCRIPTIONS[sensor_type],
-            session.information.unique_id,
+            parent_id,
             config_entry.entry_id,
         )
         for device in session.device_helper.thermostats
@@ -143,7 +171,7 @@ async def async_setup_entry(
         SHCSensor(
             device,
             SENSOR_DESCRIPTIONS[sensor_type],
-            session.information.unique_id,
+            parent_id,
             config_entry.entry_id,
         )
         for device in session.device_helper.wallthermostats
@@ -154,7 +182,7 @@ async def async_setup_entry(
         SHCSensor(
             device,
             SENSOR_DESCRIPTIONS[sensor_type],
-            session.information.unique_id,
+            parent_id,
             config_entry.entry_id,
         )
         for device in session.device_helper.twinguards
@@ -173,11 +201,12 @@ async def async_setup_entry(
         SHCSensor(
             device,
             SENSOR_DESCRIPTIONS[sensor_type],
-            session.information.unique_id,
+            parent_id,
             config_entry.entry_id,
         )
         for device in (
-            session.device_helper.smart_plugs + session.device_helper.light_switches_bsm
+            *session.device_helper.smart_plugs,
+            *session.device_helper.light_switches_bsm,
         )
         for sensor_type in (POWER_SENSOR, ENERGY_SENSOR)
     )
@@ -186,7 +215,7 @@ async def async_setup_entry(
         SHCSensor(
             device,
             SENSOR_DESCRIPTIONS[sensor_type],
-            session.information.unique_id,
+            parent_id,
             config_entry.entry_id,
         )
         for device in session.device_helper.smart_plugs_compact
@@ -196,7 +225,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class SHCSensor(SHCEntity, SensorEntity):
+class SHCSensor(SHCEntity[SHCDevice], SensorEntity):
     """Representation of a SHC sensor."""
 
     entity_description: SHCSensorEntityDescription

--- a/homeassistant/components/bosch_shc/sensor.py
+++ b/homeassistant/components/bosch_shc/sensor.py
@@ -148,13 +148,12 @@ async def async_setup_entry(
     shc_info = session.information
     if TYPE_CHECKING:
         assert shc_info is not None and shc_info.unique_id is not None
-    parent_id = shc_info.unique_id
 
     entities: list[SensorEntity] = [
         SHCSensor(
             device,
             SENSOR_DESCRIPTIONS[sensor_type],
-            parent_id,
+            shc_info.unique_id,
             config_entry.entry_id,
         )
         for device in session.device_helper.thermostats
@@ -165,7 +164,7 @@ async def async_setup_entry(
         SHCSensor(
             device,
             SENSOR_DESCRIPTIONS[sensor_type],
-            parent_id,
+            shc_info.unique_id,
             config_entry.entry_id,
         )
         for device in session.device_helper.wallthermostats
@@ -176,7 +175,7 @@ async def async_setup_entry(
         SHCSensor(
             device,
             SENSOR_DESCRIPTIONS[sensor_type],
-            parent_id,
+            shc_info.unique_id,
             config_entry.entry_id,
         )
         for device in session.device_helper.twinguards
@@ -195,7 +194,7 @@ async def async_setup_entry(
         SHCSensor(
             device,
             SENSOR_DESCRIPTIONS[sensor_type],
-            parent_id,
+            shc_info.unique_id,
             config_entry.entry_id,
         )
         for device in (
@@ -209,7 +208,7 @@ async def async_setup_entry(
         SHCSensor(
             device,
             SENSOR_DESCRIPTIONS[sensor_type],
-            parent_id,
+            shc_info.unique_id,
             config_entry.entry_id,
         )
         for device in session.device_helper.smart_plugs_compact
@@ -219,7 +218,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class SHCSensor(SHCEntity[SHCDevice], SensorEntity):
+class SHCSensor(SHCEntity, SensorEntity):
     """Representation of a SHC sensor."""
 
     entity_description: SHCSensorEntityDescription

--- a/homeassistant/components/bosch_shc/sensor.py
+++ b/homeassistant/components/bosch_shc/sensor.py
@@ -42,8 +42,7 @@ class SHCSensorEntityDescription(SensorEntityDescription):
     attributes_fn: Callable[[SHCDevice], dict[str, Any]] | None = None
 
 
-# Each entry's value_fn/attributes_fn is only ever wired to a device_helper
-# list whose concrete type actually has the attribute the cast below asserts.
+# Each entry's value_fn is only ever wired to a device_helper list whose concrete type has the cast attribute.
 _TemperatureDevice = SHCThermostat | SHCWallThermostat | SHCTwinguard
 _HumidityDevice = SHCWallThermostat | SHCTwinguard
 _PowerMeterDevice = SHCSmartPlug | SHCLightSwitchBSM | SHCSmartPlugCompact
@@ -148,8 +147,7 @@ async def async_setup_entry(
 
     shc_info = session.information
     if TYPE_CHECKING:
-        assert shc_info is not None
-        assert shc_info.unique_id is not None
+        assert shc_info is not None and shc_info.unique_id is not None
     parent_id = shc_info.unique_id
 
     entities: list[SensorEntity] = [

--- a/homeassistant/components/bosch_shc/sensor.py
+++ b/homeassistant/components/bosch_shc/sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, cast, override
+from typing import TYPE_CHECKING, Any, cast, override
 
 from boschshcpy import (
     SHCLightSwitchBSM,
@@ -146,11 +146,10 @@ async def async_setup_entry(
     """Set up the SHC sensor platform."""
     session = config_entry.runtime_data
 
-    # See __init__.py's async_setup_entry: session.information (and its
-    # unique_id) are always populated by the time platform setup runs.
     shc_info = session.information
-    assert shc_info is not None
-    assert shc_info.unique_id is not None
+    if TYPE_CHECKING:
+        assert shc_info is not None
+        assert shc_info.unique_id is not None
     parent_id = shc_info.unique_id
 
     entities: list[SensorEntity] = [

--- a/homeassistant/components/bosch_shc/sensor.py
+++ b/homeassistant/components/bosch_shc/sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, cast, override
+from typing import TYPE_CHECKING, Any, override
 
 from boschshcpy import (
     SHCLightSwitchBSM,
@@ -35,17 +35,24 @@ from .entity import SHCEntity
 
 
 @dataclass(frozen=True, kw_only=True)
-class SHCSensorEntityDescription(SensorEntityDescription):
-    """Describes a SHC sensor."""
+class SHCSensorEntityDescription[_DeviceT: SHCDevice](SensorEntityDescription):
+    """Describes a SHC sensor.
 
-    value_fn: Callable[[SHCDevice], StateType]
-    attributes_fn: Callable[[SHCDevice], dict[str, Any]] | None = None
+    Each description is parametrized on the exact device type(s) it is wired
+    to in async_setup_entry below, so value_fn/attributes_fn never need a
+    cast to access device-specific attributes. Descriptions reused across
+    device_helper buckets that carry different device classes (e.g.
+    temperature on thermostats vs. wallthermostats) get one instance per
+    concrete device type rather than a single instance typed to a union --
+    mixing differently-parametrized descriptions in one list would make the
+    _DeviceT of SHCSensor.__init__ unresolvable for type checkers.
+    """
+
+    value_fn: Callable[[_DeviceT], StateType]
+    attributes_fn: Callable[[_DeviceT], dict[str, Any]] | None = None
 
 
-# Each entry's value_fn is only ever wired to a device_helper list whose concrete type has the accessed attribute.
-_TemperatureDevice = SHCThermostat | SHCWallThermostat | SHCTwinguard
-_HumidityDevice = SHCWallThermostat | SHCTwinguard
-_PowerMeterDevice = SHCSmartPlug | SHCLightSwitchBSM | SHCSmartPlugCompact
+_PowerMeterDevice = SHCSmartPlug | SHCLightSwitchBSM
 
 TEMPERATURE_SENSOR = "temperature"
 HUMIDITY_SENSOR = "humidity"
@@ -59,82 +66,141 @@ POWER_SENSOR = "power"
 ENERGY_SENSOR = "energy"
 COMMUNICATION_QUALITY_SENSOR = "communication_quality"
 
-SENSOR_DESCRIPTIONS: dict[str, SHCSensorEntityDescription] = {
-    TEMPERATURE_SENSOR: SHCSensorEntityDescription(
+_THERMOSTAT_TEMPERATURE_DESCRIPTION: SHCSensorEntityDescription[SHCThermostat] = (
+    SHCSensorEntityDescription(
         key=TEMPERATURE_SENSOR,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        value_fn=lambda device: cast(_TemperatureDevice, device).temperature,
-    ),
-    HUMIDITY_SENSOR: SHCSensorEntityDescription(
-        key=HUMIDITY_SENSOR,
-        device_class=SensorDeviceClass.HUMIDITY,
-        native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
-        value_fn=lambda device: cast(_HumidityDevice, device).humidity,
-    ),
-    PURITY_SENSOR: SHCSensorEntityDescription(
-        key=PURITY_SENSOR,
-        translation_key=PURITY_SENSOR,
-        native_unit_of_measurement=UnitOfRatio.PARTS_PER_MILLION,
-        value_fn=lambda device: cast(SHCTwinguard, device).purity,
-    ),
-    AIR_QUALITY_SENSOR: SHCSensorEntityDescription(
-        key=AIR_QUALITY_SENSOR,
-        translation_key="air_quality",
-        value_fn=lambda device: cast(SHCTwinguard, device).combined_rating.name,
-        attributes_fn=lambda device: {
-            "rating_description": cast(SHCTwinguard, device).description,
-        },
-    ),
-    TEMPERATURE_RATING_SENSOR: SHCSensorEntityDescription(
-        key=TEMPERATURE_RATING_SENSOR,
-        translation_key=TEMPERATURE_RATING_SENSOR,
-        value_fn=lambda device: cast(SHCTwinguard, device).temperature_rating.name,
-    ),
-    COMMUNICATION_QUALITY_SENSOR: SHCSensorEntityDescription(
-        key=COMMUNICATION_QUALITY_SENSOR,
-        translation_key=COMMUNICATION_QUALITY_SENSOR,
-        value_fn=lambda device: (
-            cast(SHCSmartPlugCompact, device).communicationquality.name
-        ),
-    ),
-    HUMIDITY_RATING_SENSOR: SHCSensorEntityDescription(
-        key=HUMIDITY_RATING_SENSOR,
-        translation_key=HUMIDITY_RATING_SENSOR,
-        value_fn=lambda device: cast(SHCTwinguard, device).humidity_rating.name,
-    ),
-    PURITY_RATING_SENSOR: SHCSensorEntityDescription(
-        key=PURITY_RATING_SENSOR,
-        translation_key=PURITY_RATING_SENSOR,
-        value_fn=lambda device: cast(SHCTwinguard, device).purity_rating.name,
-    ),
-    POWER_SENSOR: SHCSensorEntityDescription(
-        key=POWER_SENSOR,
-        device_class=SensorDeviceClass.POWER,
-        native_unit_of_measurement=UnitOfPower.WATT,
-        value_fn=lambda device: cast(_PowerMeterDevice, device).powerconsumption,
-    ),
-    ENERGY_SENSOR: SHCSensorEntityDescription(
-        key=ENERGY_SENSOR,
-        device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.TOTAL_INCREASING,
-        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-        value_fn=lambda device: (
-            cast(_PowerMeterDevice, device).energyconsumption / 1000.0
-        ),
-    ),
-    VALVE_TAPPET_SENSOR: SHCSensorEntityDescription(
+        value_fn=lambda device: device.temperature,
+    )
+)
+_VALVE_TAPPET_DESCRIPTION: SHCSensorEntityDescription[SHCThermostat] = (
+    SHCSensorEntityDescription(
         key=VALVE_TAPPET_SENSOR,
         translation_key=VALVE_TAPPET_SENSOR,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
-        value_fn=lambda device: cast(SHCThermostat, device).position,
+        value_fn=lambda device: device.position,
         attributes_fn=lambda device: {
-            "valve_tappet_state": cast(SHCThermostat, device).valvestate.name,
+            "valve_tappet_state": device.valvestate.name,
         },
-    ),
-}
+    )
+)
+_WALLTHERMOSTAT_TEMPERATURE_DESCRIPTION: SHCSensorEntityDescription[
+    SHCWallThermostat
+] = SHCSensorEntityDescription(
+    key=TEMPERATURE_SENSOR,
+    device_class=SensorDeviceClass.TEMPERATURE,
+    state_class=SensorStateClass.MEASUREMENT,
+    native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+    value_fn=lambda device: device.temperature,
+)
+_WALLTHERMOSTAT_HUMIDITY_DESCRIPTION: SHCSensorEntityDescription[SHCWallThermostat] = (
+    SHCSensorEntityDescription(
+        key=HUMIDITY_SENSOR,
+        device_class=SensorDeviceClass.HUMIDITY,
+        native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
+        value_fn=lambda device: device.humidity,
+    )
+)
+_TWINGUARD_TEMPERATURE_DESCRIPTION: SHCSensorEntityDescription[SHCTwinguard] = (
+    SHCSensorEntityDescription(
+        key=TEMPERATURE_SENSOR,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        value_fn=lambda device: device.temperature,
+    )
+)
+_TWINGUARD_HUMIDITY_DESCRIPTION: SHCSensorEntityDescription[SHCTwinguard] = (
+    SHCSensorEntityDescription(
+        key=HUMIDITY_SENSOR,
+        device_class=SensorDeviceClass.HUMIDITY,
+        native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
+        value_fn=lambda device: device.humidity,
+    )
+)
+_PURITY_DESCRIPTION: SHCSensorEntityDescription[SHCTwinguard] = (
+    SHCSensorEntityDescription(
+        key=PURITY_SENSOR,
+        translation_key=PURITY_SENSOR,
+        native_unit_of_measurement=UnitOfRatio.PARTS_PER_MILLION,
+        value_fn=lambda device: device.purity,
+    )
+)
+_AIR_QUALITY_DESCRIPTION: SHCSensorEntityDescription[SHCTwinguard] = (
+    SHCSensorEntityDescription(
+        key=AIR_QUALITY_SENSOR,
+        translation_key="air_quality",
+        value_fn=lambda device: device.combined_rating.name,
+        attributes_fn=lambda device: {
+            "rating_description": device.description,
+        },
+    )
+)
+_TEMPERATURE_RATING_DESCRIPTION: SHCSensorEntityDescription[SHCTwinguard] = (
+    SHCSensorEntityDescription(
+        key=TEMPERATURE_RATING_SENSOR,
+        translation_key=TEMPERATURE_RATING_SENSOR,
+        value_fn=lambda device: device.temperature_rating.name,
+    )
+)
+_HUMIDITY_RATING_DESCRIPTION: SHCSensorEntityDescription[SHCTwinguard] = (
+    SHCSensorEntityDescription(
+        key=HUMIDITY_RATING_SENSOR,
+        translation_key=HUMIDITY_RATING_SENSOR,
+        value_fn=lambda device: device.humidity_rating.name,
+    )
+)
+_PURITY_RATING_DESCRIPTION: SHCSensorEntityDescription[SHCTwinguard] = (
+    SHCSensorEntityDescription(
+        key=PURITY_RATING_SENSOR,
+        translation_key=PURITY_RATING_SENSOR,
+        value_fn=lambda device: device.purity_rating.name,
+    )
+)
+_POWER_DESCRIPTION: SHCSensorEntityDescription[_PowerMeterDevice] = (
+    SHCSensorEntityDescription(
+        key=POWER_SENSOR,
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        value_fn=lambda device: device.powerconsumption,
+    )
+)
+_ENERGY_DESCRIPTION: SHCSensorEntityDescription[_PowerMeterDevice] = (
+    SHCSensorEntityDescription(
+        key=ENERGY_SENSOR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        value_fn=lambda device: device.energyconsumption / 1000.0,
+    )
+)
+_COMPACT_POWER_DESCRIPTION: SHCSensorEntityDescription[SHCSmartPlugCompact] = (
+    SHCSensorEntityDescription(
+        key=POWER_SENSOR,
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        value_fn=lambda device: device.powerconsumption,
+    )
+)
+_COMPACT_ENERGY_DESCRIPTION: SHCSensorEntityDescription[SHCSmartPlugCompact] = (
+    SHCSensorEntityDescription(
+        key=ENERGY_SENSOR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        value_fn=lambda device: device.energyconsumption / 1000.0,
+    )
+)
+_COMMUNICATION_QUALITY_DESCRIPTION: SHCSensorEntityDescription[SHCSmartPlugCompact] = (
+    SHCSensorEntityDescription(
+        key=COMMUNICATION_QUALITY_SENSOR,
+        translation_key=COMMUNICATION_QUALITY_SENSOR,
+        value_fn=lambda device: device.communicationquality.name,
+    )
+)
 
 
 async def async_setup_entry(
@@ -152,86 +218,98 @@ async def async_setup_entry(
     entities: list[SensorEntity] = [
         SHCSensor(
             device,
-            SENSOR_DESCRIPTIONS[sensor_type],
+            description,
             shc_info.unique_id,
             config_entry.entry_id,
         )
         for device in session.device_helper.thermostats
-        for sensor_type in (TEMPERATURE_SENSOR, VALVE_TAPPET_SENSOR)
+        for description in (
+            _THERMOSTAT_TEMPERATURE_DESCRIPTION,
+            _VALVE_TAPPET_DESCRIPTION,
+        )
     ]
 
     entities.extend(
         SHCSensor(
             device,
-            SENSOR_DESCRIPTIONS[sensor_type],
+            description,
             shc_info.unique_id,
             config_entry.entry_id,
         )
         for device in session.device_helper.wallthermostats
-        for sensor_type in (TEMPERATURE_SENSOR, HUMIDITY_SENSOR)
+        for description in (
+            _WALLTHERMOSTAT_TEMPERATURE_DESCRIPTION,
+            _WALLTHERMOSTAT_HUMIDITY_DESCRIPTION,
+        )
     )
 
     entities.extend(
         SHCSensor(
             device,
-            SENSOR_DESCRIPTIONS[sensor_type],
+            description,
             shc_info.unique_id,
             config_entry.entry_id,
         )
         for device in session.device_helper.twinguards
-        for sensor_type in (
-            TEMPERATURE_SENSOR,
-            HUMIDITY_SENSOR,
-            PURITY_SENSOR,
-            AIR_QUALITY_SENSOR,
-            TEMPERATURE_RATING_SENSOR,
-            HUMIDITY_RATING_SENSOR,
-            PURITY_RATING_SENSOR,
+        for description in (
+            _TWINGUARD_TEMPERATURE_DESCRIPTION,
+            _TWINGUARD_HUMIDITY_DESCRIPTION,
+            _PURITY_DESCRIPTION,
+            _AIR_QUALITY_DESCRIPTION,
+            _TEMPERATURE_RATING_DESCRIPTION,
+            _HUMIDITY_RATING_DESCRIPTION,
+            _PURITY_RATING_DESCRIPTION,
         )
     )
 
+    power_meter_devices: list[_PowerMeterDevice] = [
+        *session.device_helper.smart_plugs,
+        *session.device_helper.light_switches_bsm,
+    ]
     entities.extend(
         SHCSensor(
             device,
-            SENSOR_DESCRIPTIONS[sensor_type],
+            description,
             shc_info.unique_id,
             config_entry.entry_id,
         )
-        for device in (
-            *session.device_helper.smart_plugs,
-            *session.device_helper.light_switches_bsm,
-        )
-        for sensor_type in (POWER_SENSOR, ENERGY_SENSOR)
+        for device in power_meter_devices
+        for description in (_POWER_DESCRIPTION, _ENERGY_DESCRIPTION)
     )
 
     entities.extend(
         SHCSensor(
             device,
-            SENSOR_DESCRIPTIONS[sensor_type],
+            description,
             shc_info.unique_id,
             config_entry.entry_id,
         )
         for device in session.device_helper.smart_plugs_compact
-        for sensor_type in (POWER_SENSOR, ENERGY_SENSOR, COMMUNICATION_QUALITY_SENSOR)
+        for description in (
+            _COMPACT_POWER_DESCRIPTION,
+            _COMPACT_ENERGY_DESCRIPTION,
+            _COMMUNICATION_QUALITY_DESCRIPTION,
+        )
     )
 
     async_add_entities(entities)
 
 
-class SHCSensor(SHCEntity, SensorEntity):
+class SHCSensor[_DeviceT: SHCDevice](SHCEntity, SensorEntity):
     """Representation of a SHC sensor."""
 
-    entity_description: SHCSensorEntityDescription
+    entity_description: SHCSensorEntityDescription[_DeviceT]
 
     def __init__(
         self,
-        device: SHCDevice,
-        entity_description: SHCSensorEntityDescription,
+        device: _DeviceT,
+        entity_description: SHCSensorEntityDescription[_DeviceT],
         parent_id: str,
         entry_id: str,
     ) -> None:
         """Initialize sensor."""
         super().__init__(device, parent_id, entry_id)
+        self._device: _DeviceT = device
         self.entity_description = entity_description
         self._attr_unique_id = f"{device.serial}_{entity_description.key}"
 

--- a/homeassistant/components/bosch_shc/sensor.py
+++ b/homeassistant/components/bosch_shc/sensor.py
@@ -147,14 +147,8 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the SHC sensor platform."""
-    session = config_entry.runtime_data
-
-    # See __init__.py's async_setup_entry: session.information (and its
-    # unique_id) are always populated by the time platform setup runs.
-    shc_info = session.information
-    assert shc_info is not None
-    assert shc_info.unique_id is not None
-    parent_id = shc_info.unique_id
+    session = config_entry.runtime_data.session
+    parent_id = config_entry.runtime_data.parent_id
 
     entities: list[SensorEntity] = [
         SHCSensor(

--- a/homeassistant/components/bosch_shc/sensor.py
+++ b/homeassistant/components/bosch_shc/sensor.py
@@ -38,14 +38,7 @@ from .entity import SHCEntity
 class SHCSensorEntityDescription[_DeviceT: SHCDevice](SensorEntityDescription):
     """Describes a SHC sensor.
 
-    Each description is parametrized on the exact device type(s) it is wired
-    to in async_setup_entry below, so value_fn/attributes_fn never need a
-    cast to access device-specific attributes. Descriptions reused across
-    device_helper buckets that carry different device classes (e.g.
-    temperature on thermostats vs. wallthermostats) get one instance per
-    concrete device type rather than a single instance typed to a union --
-    mixing differently-parametrized descriptions in one list would make the
-    _DeviceT of SHCSensor.__init__ unresolvable for type checkers.
+    Never share one instance across descriptions for different device types.
     """
 
     value_fn: Callable[[_DeviceT], StateType]

--- a/homeassistant/components/bosch_shc/sensor.py
+++ b/homeassistant/components/bosch_shc/sensor.py
@@ -42,11 +42,8 @@ class SHCSensorEntityDescription(SensorEntityDescription):
     attributes_fn: Callable[[SHCDevice], dict[str, Any]] | None = None
 
 
-# SHCSensorEntityDescription.value_fn/attributes_fn are declared against the
-# generic SHCDevice (matching self._device's type in SHCSensor below), but
-# each entry here is only ever wired up (in async_setup_entry) to specific
-# device_helper lists whose concrete element type actually has the attribute
-# being accessed. The casts below reflect exactly that per-entry pairing.
+# Each entry's value_fn/attributes_fn is only ever wired to a device_helper
+# list whose concrete type actually has the attribute the cast below asserts.
 _TemperatureDevice = SHCThermostat | SHCWallThermostat | SHCTwinguard
 _HumidityDevice = SHCWallThermostat | SHCTwinguard
 _PowerMeterDevice = SHCSmartPlug | SHCLightSwitchBSM | SHCSmartPlugCompact

--- a/homeassistant/components/bosch_shc/sensor.py
+++ b/homeassistant/components/bosch_shc/sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, override
+from typing import Any, cast, override
 
 from boschshcpy import (
     SHCLightSwitchBSM,
@@ -35,13 +35,17 @@ from .entity import SHCEntity
 
 
 @dataclass(frozen=True, kw_only=True)
-class SHCSensorEntityDescription[_DeviceT: SHCDevice](SensorEntityDescription):
+class SHCSensorEntityDescription(SensorEntityDescription):
     """Describes a SHC sensor."""
 
-    value_fn: Callable[[_DeviceT], StateType]
-    attributes_fn: Callable[[_DeviceT], dict[str, Any]] | None = None
+    value_fn: Callable[[SHCDevice], StateType]
+    attributes_fn: Callable[[SHCDevice], dict[str, Any]] | None = None
 
 
+# Each entry's value_fn/attributes_fn is only ever wired to a device_helper
+# list whose concrete type actually has the attribute the cast below asserts.
+_TemperatureDevice = SHCThermostat | SHCWallThermostat | SHCTwinguard
+_HumidityDevice = SHCWallThermostat | SHCTwinguard
 _PowerMeterDevice = SHCSmartPlug | SHCLightSwitchBSM | SHCSmartPlugCompact
 
 TEMPERATURE_SENSOR = "temperature"
@@ -56,114 +60,82 @@ POWER_SENSOR = "power"
 ENERGY_SENSOR = "energy"
 COMMUNICATION_QUALITY_SENSOR = "communication_quality"
 
-THERMOSTAT_SENSOR_TYPES: tuple[SHCSensorEntityDescription[SHCThermostat], ...] = (
-    SHCSensorEntityDescription[SHCThermostat](
+SENSOR_DESCRIPTIONS: dict[str, SHCSensorEntityDescription] = {
+    TEMPERATURE_SENSOR: SHCSensorEntityDescription(
         key=TEMPERATURE_SENSOR,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        value_fn=lambda device: device.temperature,
+        value_fn=lambda device: cast(_TemperatureDevice, device).temperature,
     ),
-    SHCSensorEntityDescription[SHCThermostat](
-        key=VALVE_TAPPET_SENSOR,
-        translation_key=VALVE_TAPPET_SENSOR,
-        state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
-        value_fn=lambda device: device.position,
-        attributes_fn=lambda device: {
-            "valve_tappet_state": device.valvestate.name,
-        },
-    ),
-)
-
-WALLTHERMOSTAT_SENSOR_TYPES: tuple[
-    SHCSensorEntityDescription[SHCWallThermostat], ...
-] = (
-    SHCSensorEntityDescription[SHCWallThermostat](
-        key=TEMPERATURE_SENSOR,
-        device_class=SensorDeviceClass.TEMPERATURE,
-        state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        value_fn=lambda device: device.temperature,
-    ),
-    SHCSensorEntityDescription[SHCWallThermostat](
+    HUMIDITY_SENSOR: SHCSensorEntityDescription(
         key=HUMIDITY_SENSOR,
         device_class=SensorDeviceClass.HUMIDITY,
         native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
-        value_fn=lambda device: device.humidity,
+        value_fn=lambda device: cast(_HumidityDevice, device).humidity,
     ),
-)
-
-TWINGUARD_SENSOR_TYPES: tuple[SHCSensorEntityDescription[SHCTwinguard], ...] = (
-    SHCSensorEntityDescription[SHCTwinguard](
-        key=TEMPERATURE_SENSOR,
-        device_class=SensorDeviceClass.TEMPERATURE,
-        state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        value_fn=lambda device: device.temperature,
-    ),
-    SHCSensorEntityDescription[SHCTwinguard](
-        key=HUMIDITY_SENSOR,
-        device_class=SensorDeviceClass.HUMIDITY,
-        native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
-        value_fn=lambda device: device.humidity,
-    ),
-    SHCSensorEntityDescription[SHCTwinguard](
+    PURITY_SENSOR: SHCSensorEntityDescription(
         key=PURITY_SENSOR,
         translation_key=PURITY_SENSOR,
         native_unit_of_measurement=UnitOfRatio.PARTS_PER_MILLION,
-        value_fn=lambda device: device.purity,
+        value_fn=lambda device: cast(SHCTwinguard, device).purity,
     ),
-    SHCSensorEntityDescription[SHCTwinguard](
+    AIR_QUALITY_SENSOR: SHCSensorEntityDescription(
         key=AIR_QUALITY_SENSOR,
         translation_key="air_quality",
-        value_fn=lambda device: device.combined_rating.name,
+        value_fn=lambda device: cast(SHCTwinguard, device).combined_rating.name,
         attributes_fn=lambda device: {
-            "rating_description": device.description,
+            "rating_description": cast(SHCTwinguard, device).description,
         },
     ),
-    SHCSensorEntityDescription[SHCTwinguard](
+    TEMPERATURE_RATING_SENSOR: SHCSensorEntityDescription(
         key=TEMPERATURE_RATING_SENSOR,
         translation_key=TEMPERATURE_RATING_SENSOR,
-        value_fn=lambda device: device.temperature_rating.name,
+        value_fn=lambda device: cast(SHCTwinguard, device).temperature_rating.name,
     ),
-    SHCSensorEntityDescription[SHCTwinguard](
+    COMMUNICATION_QUALITY_SENSOR: SHCSensorEntityDescription(
+        key=COMMUNICATION_QUALITY_SENSOR,
+        translation_key=COMMUNICATION_QUALITY_SENSOR,
+        value_fn=lambda device: (
+            cast(SHCSmartPlugCompact, device).communicationquality.name
+        ),
+    ),
+    HUMIDITY_RATING_SENSOR: SHCSensorEntityDescription(
         key=HUMIDITY_RATING_SENSOR,
         translation_key=HUMIDITY_RATING_SENSOR,
-        value_fn=lambda device: device.humidity_rating.name,
+        value_fn=lambda device: cast(SHCTwinguard, device).humidity_rating.name,
     ),
-    SHCSensorEntityDescription[SHCTwinguard](
+    PURITY_RATING_SENSOR: SHCSensorEntityDescription(
         key=PURITY_RATING_SENSOR,
         translation_key=PURITY_RATING_SENSOR,
-        value_fn=lambda device: device.purity_rating.name,
+        value_fn=lambda device: cast(SHCTwinguard, device).purity_rating.name,
     ),
-)
-
-POWER_METER_SENSOR_TYPES: tuple[SHCSensorEntityDescription[_PowerMeterDevice], ...] = (
-    SHCSensorEntityDescription[_PowerMeterDevice](
+    POWER_SENSOR: SHCSensorEntityDescription(
         key=POWER_SENSOR,
         device_class=SensorDeviceClass.POWER,
         native_unit_of_measurement=UnitOfPower.WATT,
-        value_fn=lambda device: device.powerconsumption,
+        value_fn=lambda device: cast(_PowerMeterDevice, device).powerconsumption,
     ),
-    SHCSensorEntityDescription[_PowerMeterDevice](
+    ENERGY_SENSOR: SHCSensorEntityDescription(
         key=ENERGY_SENSOR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-        value_fn=lambda device: device.energyconsumption / 1000.0,
+        value_fn=lambda device: (
+            cast(_PowerMeterDevice, device).energyconsumption / 1000.0
+        ),
     ),
-)
-
-PLUG_COMPACT_SENSOR_TYPES: tuple[
-    SHCSensorEntityDescription[SHCSmartPlugCompact], ...
-] = (
-    SHCSensorEntityDescription[SHCSmartPlugCompact](
-        key=COMMUNICATION_QUALITY_SENSOR,
-        translation_key=COMMUNICATION_QUALITY_SENSOR,
-        value_fn=lambda device: device.communicationquality.name,
+    VALVE_TAPPET_SENSOR: SHCSensorEntityDescription(
+        key=VALVE_TAPPET_SENSOR,
+        translation_key=VALVE_TAPPET_SENSOR,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
+        value_fn=lambda device: cast(SHCThermostat, device).position,
+        attributes_fn=lambda device: {
+            "valve_tappet_state": cast(SHCThermostat, device).valvestate.name,
+        },
     ),
-)
+}
 
 
 async def async_setup_entry(
@@ -176,52 +148,83 @@ async def async_setup_entry(
     parent_id = config_entry.runtime_data.parent_id
 
     entities: list[SensorEntity] = [
-        SHCSensor(device, description, parent_id, config_entry.entry_id)
+        SHCSensor(
+            device,
+            SENSOR_DESCRIPTIONS[sensor_type],
+            parent_id,
+            config_entry.entry_id,
+        )
         for device in session.device_helper.thermostats
-        for description in THERMOSTAT_SENSOR_TYPES
+        for sensor_type in (TEMPERATURE_SENSOR, VALVE_TAPPET_SENSOR)
     ]
 
     entities.extend(
-        SHCSensor(device, description, parent_id, config_entry.entry_id)
+        SHCSensor(
+            device,
+            SENSOR_DESCRIPTIONS[sensor_type],
+            parent_id,
+            config_entry.entry_id,
+        )
         for device in session.device_helper.wallthermostats
-        for description in WALLTHERMOSTAT_SENSOR_TYPES
+        for sensor_type in (TEMPERATURE_SENSOR, HUMIDITY_SENSOR)
     )
 
     entities.extend(
-        SHCSensor(device, description, parent_id, config_entry.entry_id)
+        SHCSensor(
+            device,
+            SENSOR_DESCRIPTIONS[sensor_type],
+            parent_id,
+            config_entry.entry_id,
+        )
         for device in session.device_helper.twinguards
-        for description in TWINGUARD_SENSOR_TYPES
-    )
-
-    power_meter_devices: list[_PowerMeterDevice] = [
-        *session.device_helper.smart_plugs,
-        *session.device_helper.light_switches_bsm,
-        *session.device_helper.smart_plugs_compact,
-    ]
-    entities.extend(
-        SHCSensor(device, description, parent_id, config_entry.entry_id)
-        for device in power_meter_devices
-        for description in POWER_METER_SENSOR_TYPES
+        for sensor_type in (
+            TEMPERATURE_SENSOR,
+            HUMIDITY_SENSOR,
+            PURITY_SENSOR,
+            AIR_QUALITY_SENSOR,
+            TEMPERATURE_RATING_SENSOR,
+            HUMIDITY_RATING_SENSOR,
+            PURITY_RATING_SENSOR,
+        )
     )
 
     entities.extend(
-        SHCSensor(device, description, parent_id, config_entry.entry_id)
+        SHCSensor(
+            device,
+            SENSOR_DESCRIPTIONS[sensor_type],
+            parent_id,
+            config_entry.entry_id,
+        )
+        for device in (
+            *session.device_helper.smart_plugs,
+            *session.device_helper.light_switches_bsm,
+        )
+        for sensor_type in (POWER_SENSOR, ENERGY_SENSOR)
+    )
+
+    entities.extend(
+        SHCSensor(
+            device,
+            SENSOR_DESCRIPTIONS[sensor_type],
+            parent_id,
+            config_entry.entry_id,
+        )
         for device in session.device_helper.smart_plugs_compact
-        for description in PLUG_COMPACT_SENSOR_TYPES
+        for sensor_type in (POWER_SENSOR, ENERGY_SENSOR, COMMUNICATION_QUALITY_SENSOR)
     )
 
     async_add_entities(entities)
 
 
-class SHCSensor[_DeviceT: SHCDevice](SHCEntity[_DeviceT], SensorEntity):
+class SHCSensor(SHCEntity[SHCDevice], SensorEntity):
     """Representation of a SHC sensor."""
 
-    entity_description: SHCSensorEntityDescription[_DeviceT]
+    entity_description: SHCSensorEntityDescription
 
     def __init__(
         self,
-        device: _DeviceT,
-        entity_description: SHCSensorEntityDescription[_DeviceT],
+        device: SHCDevice,
+        entity_description: SHCSensorEntityDescription,
         parent_id: str,
         entry_id: str,
     ) -> None:

--- a/homeassistant/components/bosch_shc/sensor.py
+++ b/homeassistant/components/bosch_shc/sensor.py
@@ -42,7 +42,7 @@ class SHCSensorEntityDescription(SensorEntityDescription):
     attributes_fn: Callable[[SHCDevice], dict[str, Any]] | None = None
 
 
-# Each entry's value_fn is only ever wired to a device_helper list whose concrete type has the cast attribute.
+# Each entry's value_fn is only ever wired to a device_helper list whose concrete type has the accessed attribute.
 _TemperatureDevice = SHCThermostat | SHCWallThermostat | SHCTwinguard
 _HumidityDevice = SHCWallThermostat | SHCTwinguard
 _PowerMeterDevice = SHCSmartPlug | SHCLightSwitchBSM | SHCSmartPlugCompact

--- a/homeassistant/components/bosch_shc/sensor.py
+++ b/homeassistant/components/bosch_shc/sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, cast, override
+from typing import Any, override
 
 from boschshcpy import (
     SHCLightSwitchBSM,
@@ -35,17 +35,13 @@ from .entity import SHCEntity
 
 
 @dataclass(frozen=True, kw_only=True)
-class SHCSensorEntityDescription(SensorEntityDescription):
+class SHCSensorEntityDescription[_DeviceT: SHCDevice](SensorEntityDescription):
     """Describes a SHC sensor."""
 
-    value_fn: Callable[[SHCDevice], StateType]
-    attributes_fn: Callable[[SHCDevice], dict[str, Any]] | None = None
+    value_fn: Callable[[_DeviceT], StateType]
+    attributes_fn: Callable[[_DeviceT], dict[str, Any]] | None = None
 
 
-# Each entry's value_fn/attributes_fn is only ever wired to a device_helper
-# list whose concrete type actually has the attribute the cast below asserts.
-_TemperatureDevice = SHCThermostat | SHCWallThermostat | SHCTwinguard
-_HumidityDevice = SHCWallThermostat | SHCTwinguard
 _PowerMeterDevice = SHCSmartPlug | SHCLightSwitchBSM | SHCSmartPlugCompact
 
 TEMPERATURE_SENSOR = "temperature"
@@ -60,82 +56,114 @@ POWER_SENSOR = "power"
 ENERGY_SENSOR = "energy"
 COMMUNICATION_QUALITY_SENSOR = "communication_quality"
 
-SENSOR_DESCRIPTIONS: dict[str, SHCSensorEntityDescription] = {
-    TEMPERATURE_SENSOR: SHCSensorEntityDescription(
+THERMOSTAT_SENSOR_TYPES: tuple[SHCSensorEntityDescription[SHCThermostat], ...] = (
+    SHCSensorEntityDescription[SHCThermostat](
         key=TEMPERATURE_SENSOR,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        value_fn=lambda device: cast(_TemperatureDevice, device).temperature,
+        value_fn=lambda device: device.temperature,
     ),
-    HUMIDITY_SENSOR: SHCSensorEntityDescription(
-        key=HUMIDITY_SENSOR,
-        device_class=SensorDeviceClass.HUMIDITY,
-        native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
-        value_fn=lambda device: cast(_HumidityDevice, device).humidity,
-    ),
-    PURITY_SENSOR: SHCSensorEntityDescription(
-        key=PURITY_SENSOR,
-        translation_key=PURITY_SENSOR,
-        native_unit_of_measurement=UnitOfRatio.PARTS_PER_MILLION,
-        value_fn=lambda device: cast(SHCTwinguard, device).purity,
-    ),
-    AIR_QUALITY_SENSOR: SHCSensorEntityDescription(
-        key=AIR_QUALITY_SENSOR,
-        translation_key="air_quality",
-        value_fn=lambda device: cast(SHCTwinguard, device).combined_rating.name,
-        attributes_fn=lambda device: {
-            "rating_description": cast(SHCTwinguard, device).description,
-        },
-    ),
-    TEMPERATURE_RATING_SENSOR: SHCSensorEntityDescription(
-        key=TEMPERATURE_RATING_SENSOR,
-        translation_key=TEMPERATURE_RATING_SENSOR,
-        value_fn=lambda device: cast(SHCTwinguard, device).temperature_rating.name,
-    ),
-    COMMUNICATION_QUALITY_SENSOR: SHCSensorEntityDescription(
-        key=COMMUNICATION_QUALITY_SENSOR,
-        translation_key=COMMUNICATION_QUALITY_SENSOR,
-        value_fn=lambda device: (
-            cast(SHCSmartPlugCompact, device).communicationquality.name
-        ),
-    ),
-    HUMIDITY_RATING_SENSOR: SHCSensorEntityDescription(
-        key=HUMIDITY_RATING_SENSOR,
-        translation_key=HUMIDITY_RATING_SENSOR,
-        value_fn=lambda device: cast(SHCTwinguard, device).humidity_rating.name,
-    ),
-    PURITY_RATING_SENSOR: SHCSensorEntityDescription(
-        key=PURITY_RATING_SENSOR,
-        translation_key=PURITY_RATING_SENSOR,
-        value_fn=lambda device: cast(SHCTwinguard, device).purity_rating.name,
-    ),
-    POWER_SENSOR: SHCSensorEntityDescription(
-        key=POWER_SENSOR,
-        device_class=SensorDeviceClass.POWER,
-        native_unit_of_measurement=UnitOfPower.WATT,
-        value_fn=lambda device: cast(_PowerMeterDevice, device).powerconsumption,
-    ),
-    ENERGY_SENSOR: SHCSensorEntityDescription(
-        key=ENERGY_SENSOR,
-        device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.TOTAL_INCREASING,
-        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-        value_fn=lambda device: (
-            cast(_PowerMeterDevice, device).energyconsumption / 1000.0
-        ),
-    ),
-    VALVE_TAPPET_SENSOR: SHCSensorEntityDescription(
+    SHCSensorEntityDescription[SHCThermostat](
         key=VALVE_TAPPET_SENSOR,
         translation_key=VALVE_TAPPET_SENSOR,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
-        value_fn=lambda device: cast(SHCThermostat, device).position,
+        value_fn=lambda device: device.position,
         attributes_fn=lambda device: {
-            "valve_tappet_state": cast(SHCThermostat, device).valvestate.name,
+            "valve_tappet_state": device.valvestate.name,
         },
     ),
-}
+)
+
+WALLTHERMOSTAT_SENSOR_TYPES: tuple[
+    SHCSensorEntityDescription[SHCWallThermostat], ...
+] = (
+    SHCSensorEntityDescription[SHCWallThermostat](
+        key=TEMPERATURE_SENSOR,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        value_fn=lambda device: device.temperature,
+    ),
+    SHCSensorEntityDescription[SHCWallThermostat](
+        key=HUMIDITY_SENSOR,
+        device_class=SensorDeviceClass.HUMIDITY,
+        native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
+        value_fn=lambda device: device.humidity,
+    ),
+)
+
+TWINGUARD_SENSOR_TYPES: tuple[SHCSensorEntityDescription[SHCTwinguard], ...] = (
+    SHCSensorEntityDescription[SHCTwinguard](
+        key=TEMPERATURE_SENSOR,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        value_fn=lambda device: device.temperature,
+    ),
+    SHCSensorEntityDescription[SHCTwinguard](
+        key=HUMIDITY_SENSOR,
+        device_class=SensorDeviceClass.HUMIDITY,
+        native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
+        value_fn=lambda device: device.humidity,
+    ),
+    SHCSensorEntityDescription[SHCTwinguard](
+        key=PURITY_SENSOR,
+        translation_key=PURITY_SENSOR,
+        native_unit_of_measurement=UnitOfRatio.PARTS_PER_MILLION,
+        value_fn=lambda device: device.purity,
+    ),
+    SHCSensorEntityDescription[SHCTwinguard](
+        key=AIR_QUALITY_SENSOR,
+        translation_key="air_quality",
+        value_fn=lambda device: device.combined_rating.name,
+        attributes_fn=lambda device: {
+            "rating_description": device.description,
+        },
+    ),
+    SHCSensorEntityDescription[SHCTwinguard](
+        key=TEMPERATURE_RATING_SENSOR,
+        translation_key=TEMPERATURE_RATING_SENSOR,
+        value_fn=lambda device: device.temperature_rating.name,
+    ),
+    SHCSensorEntityDescription[SHCTwinguard](
+        key=HUMIDITY_RATING_SENSOR,
+        translation_key=HUMIDITY_RATING_SENSOR,
+        value_fn=lambda device: device.humidity_rating.name,
+    ),
+    SHCSensorEntityDescription[SHCTwinguard](
+        key=PURITY_RATING_SENSOR,
+        translation_key=PURITY_RATING_SENSOR,
+        value_fn=lambda device: device.purity_rating.name,
+    ),
+)
+
+POWER_METER_SENSOR_TYPES: tuple[SHCSensorEntityDescription[_PowerMeterDevice], ...] = (
+    SHCSensorEntityDescription[_PowerMeterDevice](
+        key=POWER_SENSOR,
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        value_fn=lambda device: device.powerconsumption,
+    ),
+    SHCSensorEntityDescription[_PowerMeterDevice](
+        key=ENERGY_SENSOR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        value_fn=lambda device: device.energyconsumption / 1000.0,
+    ),
+)
+
+PLUG_COMPACT_SENSOR_TYPES: tuple[
+    SHCSensorEntityDescription[SHCSmartPlugCompact], ...
+] = (
+    SHCSensorEntityDescription[SHCSmartPlugCompact](
+        key=COMMUNICATION_QUALITY_SENSOR,
+        translation_key=COMMUNICATION_QUALITY_SENSOR,
+        value_fn=lambda device: device.communicationquality.name,
+    ),
+)
 
 
 async def async_setup_entry(
@@ -148,83 +176,52 @@ async def async_setup_entry(
     parent_id = config_entry.runtime_data.parent_id
 
     entities: list[SensorEntity] = [
-        SHCSensor(
-            device,
-            SENSOR_DESCRIPTIONS[sensor_type],
-            parent_id,
-            config_entry.entry_id,
-        )
+        SHCSensor(device, description, parent_id, config_entry.entry_id)
         for device in session.device_helper.thermostats
-        for sensor_type in (TEMPERATURE_SENSOR, VALVE_TAPPET_SENSOR)
+        for description in THERMOSTAT_SENSOR_TYPES
     ]
 
     entities.extend(
-        SHCSensor(
-            device,
-            SENSOR_DESCRIPTIONS[sensor_type],
-            parent_id,
-            config_entry.entry_id,
-        )
+        SHCSensor(device, description, parent_id, config_entry.entry_id)
         for device in session.device_helper.wallthermostats
-        for sensor_type in (TEMPERATURE_SENSOR, HUMIDITY_SENSOR)
+        for description in WALLTHERMOSTAT_SENSOR_TYPES
     )
 
     entities.extend(
-        SHCSensor(
-            device,
-            SENSOR_DESCRIPTIONS[sensor_type],
-            parent_id,
-            config_entry.entry_id,
-        )
+        SHCSensor(device, description, parent_id, config_entry.entry_id)
         for device in session.device_helper.twinguards
-        for sensor_type in (
-            TEMPERATURE_SENSOR,
-            HUMIDITY_SENSOR,
-            PURITY_SENSOR,
-            AIR_QUALITY_SENSOR,
-            TEMPERATURE_RATING_SENSOR,
-            HUMIDITY_RATING_SENSOR,
-            PURITY_RATING_SENSOR,
-        )
+        for description in TWINGUARD_SENSOR_TYPES
+    )
+
+    power_meter_devices: list[_PowerMeterDevice] = [
+        *session.device_helper.smart_plugs,
+        *session.device_helper.light_switches_bsm,
+        *session.device_helper.smart_plugs_compact,
+    ]
+    entities.extend(
+        SHCSensor(device, description, parent_id, config_entry.entry_id)
+        for device in power_meter_devices
+        for description in POWER_METER_SENSOR_TYPES
     )
 
     entities.extend(
-        SHCSensor(
-            device,
-            SENSOR_DESCRIPTIONS[sensor_type],
-            parent_id,
-            config_entry.entry_id,
-        )
-        for device in (
-            *session.device_helper.smart_plugs,
-            *session.device_helper.light_switches_bsm,
-        )
-        for sensor_type in (POWER_SENSOR, ENERGY_SENSOR)
-    )
-
-    entities.extend(
-        SHCSensor(
-            device,
-            SENSOR_DESCRIPTIONS[sensor_type],
-            parent_id,
-            config_entry.entry_id,
-        )
+        SHCSensor(device, description, parent_id, config_entry.entry_id)
         for device in session.device_helper.smart_plugs_compact
-        for sensor_type in (POWER_SENSOR, ENERGY_SENSOR, COMMUNICATION_QUALITY_SENSOR)
+        for description in PLUG_COMPACT_SENSOR_TYPES
     )
 
     async_add_entities(entities)
 
 
-class SHCSensor(SHCEntity[SHCDevice], SensorEntity):
+class SHCSensor[_DeviceT: SHCDevice](SHCEntity[_DeviceT], SensorEntity):
     """Representation of a SHC sensor."""
 
-    entity_description: SHCSensorEntityDescription
+    entity_description: SHCSensorEntityDescription[_DeviceT]
 
     def __init__(
         self,
-        device: SHCDevice,
-        entity_description: SHCSensorEntityDescription,
+        device: _DeviceT,
+        entity_description: SHCSensorEntityDescription[_DeviceT],
         parent_id: str,
         entry_id: str,
     ) -> None:

--- a/homeassistant/components/bosch_shc/switch.py
+++ b/homeassistant/components/bosch_shc/switch.py
@@ -83,8 +83,7 @@ async def async_setup_entry(
 
     shc_info = session.information
     if TYPE_CHECKING:
-        assert shc_info is not None
-        assert shc_info.unique_id is not None
+        assert shc_info is not None and shc_info.unique_id is not None
     parent_id = shc_info.unique_id
 
     entities: list[SwitchEntity] = [

--- a/homeassistant/components/bosch_shc/switch.py
+++ b/homeassistant/components/bosch_shc/switch.py
@@ -197,7 +197,7 @@ class SHCRoutingSwitch(SHCEntity[SHCSmartPlug], SwitchEntity):
     _attr_entity_category = EntityCategory.CONFIG
 
     def __init__(self, device: SHCSmartPlug, parent_id: str, entry_id: str) -> None:
-        """Initialize an SHC communication quality reporting sensor."""
+        """Initialize an SHC routing switch."""
         super().__init__(device, parent_id, entry_id)
         self._attr_unique_id = f"{device.serial}_routing"
 

--- a/homeassistant/components/bosch_shc/switch.py
+++ b/homeassistant/components/bosch_shc/switch.py
@@ -30,7 +30,6 @@ class SHCSwitchEntityDescription(SwitchEntityDescription):
     """Class describing SHC switch entities."""
 
     on_key: str
-    # Plain Enum members are stored/compared here, not StateType.
     on_value: Enum
     should_poll: bool
 

--- a/homeassistant/components/bosch_shc/switch.py
+++ b/homeassistant/components/bosch_shc/switch.py
@@ -79,8 +79,14 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the SHC switch platform."""
-    session = config_entry.runtime_data.session
-    parent_id = config_entry.runtime_data.parent_id
+    session = config_entry.runtime_data
+
+    # See __init__.py's async_setup_entry: session.information (and its
+    # unique_id) are always populated by the time platform setup runs.
+    shc_info = session.information
+    assert shc_info is not None
+    assert shc_info.unique_id is not None
+    parent_id = shc_info.unique_id
 
     entities: list[SwitchEntity] = [
         SHCSwitch(

--- a/homeassistant/components/bosch_shc/switch.py
+++ b/homeassistant/components/bosch_shc/switch.py
@@ -82,14 +82,8 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the SHC switch platform."""
-    session = config_entry.runtime_data
-
-    # See __init__.py's async_setup_entry: session.information (and its
-    # unique_id) are always populated by the time platform setup runs.
-    shc_info = session.information
-    assert shc_info is not None
-    assert shc_info.unique_id is not None
-    parent_id = shc_info.unique_id
+    session = config_entry.runtime_data.session
+    parent_id = config_entry.runtime_data.parent_id
 
     entities: list[SwitchEntity] = [
         SHCSwitch(

--- a/homeassistant/components/bosch_shc/switch.py
+++ b/homeassistant/components/bosch_shc/switch.py
@@ -30,9 +30,7 @@ class SHCSwitchEntityDescription(SwitchEntityDescription):
     """Class describing SHC switch entities."""
 
     on_key: str
-    # The device-service State enums (PowerSwitchService.State.ON etc.) are
-    # plain Enum subclasses, not str -- StateType (str | int | float | None)
-    # doesn't actually describe what's stored/compared here.
+    # Plain Enum members are stored/compared here, not StateType.
     on_value: Enum
     should_poll: bool
 

--- a/homeassistant/components/bosch_shc/switch.py
+++ b/homeassistant/components/bosch_shc/switch.py
@@ -201,7 +201,7 @@ class SHCRoutingSwitch(SHCEntity, SwitchEntity):
     _device: SHCSmartPlug
 
     def __init__(self, device: SHCDevice, parent_id: str, entry_id: str) -> None:
-        """Initialize an SHC routing switch."""
+        """Initialize an SHC communication quality reporting sensor."""
         super().__init__(device, parent_id, entry_id)
         self._attr_unique_id = f"{device.serial}_routing"
 

--- a/homeassistant/components/bosch_shc/switch.py
+++ b/homeassistant/components/bosch_shc/switch.py
@@ -200,7 +200,7 @@ class SHCRoutingSwitch(SHCEntity, SwitchEntity):
     _attr_entity_category = EntityCategory.CONFIG
     _device: SHCSmartPlug
 
-    def __init__(self, device: SHCSmartPlug, parent_id: str, entry_id: str) -> None:
+    def __init__(self, device: SHCDevice, parent_id: str, entry_id: str) -> None:
         """Initialize an SHC routing switch."""
         super().__init__(device, parent_id, entry_id)
         self._attr_unique_id = f"{device.serial}_routing"

--- a/homeassistant/components/bosch_shc/switch.py
+++ b/homeassistant/components/bosch_shc/switch.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, override
+from typing import TYPE_CHECKING, Any, override
 
 from boschshcpy import (
     CameraLightService,
@@ -81,11 +81,10 @@ async def async_setup_entry(
     """Set up the SHC switch platform."""
     session = config_entry.runtime_data
 
-    # See __init__.py's async_setup_entry: session.information (and its
-    # unique_id) are always populated by the time platform setup runs.
     shc_info = session.information
-    assert shc_info is not None
-    assert shc_info.unique_id is not None
+    if TYPE_CHECKING:
+        assert shc_info is not None
+        assert shc_info.unique_id is not None
     parent_id = shc_info.unique_id
 
     entities: list[SwitchEntity] = [

--- a/homeassistant/components/bosch_shc/switch.py
+++ b/homeassistant/components/bosch_shc/switch.py
@@ -172,7 +172,7 @@ class SHCSwitch(SHCEntity[SHCDevice], SwitchEntity):
         """Return the state of the switch."""
         return (
             getattr(self._device, self.entity_description.on_key)
-            == self.entity_description.on_value
+            is self.entity_description.on_value
         )
 
     @override

--- a/homeassistant/components/bosch_shc/switch.py
+++ b/homeassistant/components/bosch_shc/switch.py
@@ -1,14 +1,14 @@
 """Platform for switch integration."""
 
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, override
 
 from boschshcpy import (
-    SHCCamera360,
-    SHCCameraEyes,
-    SHCLightSwitch,
+    CameraLightService,
+    PowerSwitchService,
+    PrivacyModeService,
     SHCSmartPlug,
-    SHCSmartPlugCompact,
 )
 from boschshcpy.device import SHCDevice
 
@@ -20,7 +20,6 @@ from homeassistant.components.switch import (
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.typing import StateType
 
 from . import BoschConfigEntry
 from .entity import SHCEntity
@@ -31,7 +30,10 @@ class SHCSwitchEntityDescription(SwitchEntityDescription):
     """Class describing SHC switch entities."""
 
     on_key: str
-    on_value: StateType
+    # The device-service State enums (PowerSwitchService.State.ON etc.) are
+    # plain Enum subclasses, not str -- StateType (str | int | float | None)
+    # doesn't actually describe what's stored/compared here.
+    on_value: Enum
     should_poll: bool
 
 
@@ -40,35 +42,35 @@ SWITCH_TYPES: dict[str, SHCSwitchEntityDescription] = {
         key="smartplug",
         device_class=SwitchDeviceClass.OUTLET,
         on_key="switchstate",
-        on_value=SHCSmartPlug.PowerSwitchService.State.ON,
+        on_value=PowerSwitchService.State.ON,
         should_poll=False,
     ),
     "smartplugcompact": SHCSwitchEntityDescription(
         key="smartplugcompact",
         device_class=SwitchDeviceClass.OUTLET,
         on_key="switchstate",
-        on_value=SHCSmartPlugCompact.PowerSwitchService.State.ON,
+        on_value=PowerSwitchService.State.ON,
         should_poll=False,
     ),
     "lightswitch": SHCSwitchEntityDescription(
         key="lightswitch",
         device_class=SwitchDeviceClass.SWITCH,
         on_key="switchstate",
-        on_value=SHCLightSwitch.PowerSwitchService.State.ON,
+        on_value=PowerSwitchService.State.ON,
         should_poll=False,
     ),
     "cameraeyes": SHCSwitchEntityDescription(
         key="cameraeyes",
         device_class=SwitchDeviceClass.SWITCH,
         on_key="cameralight",
-        on_value=SHCCameraEyes.CameraLightService.State.ON,
+        on_value=CameraLightService.State.ON,
         should_poll=True,
     ),
     "camera360": SHCSwitchEntityDescription(
         key="camera360",
         device_class=SwitchDeviceClass.SWITCH,
         on_key="privacymode",
-        on_value=SHCCamera360.PrivacyModeService.State.DISABLED,
+        on_value=PrivacyModeService.State.DISABLED,
         should_poll=True,
     ),
 }
@@ -82,10 +84,17 @@ async def async_setup_entry(
     """Set up the SHC switch platform."""
     session = config_entry.runtime_data
 
+    # See __init__.py's async_setup_entry: session.information (and its
+    # unique_id) are always populated by the time platform setup runs.
+    shc_info = session.information
+    assert shc_info is not None
+    assert shc_info.unique_id is not None
+    parent_id = shc_info.unique_id
+
     entities: list[SwitchEntity] = [
         SHCSwitch(
             device=switch,
-            parent_id=session.information.unique_id,
+            parent_id=parent_id,
             entry_id=config_entry.entry_id,
             description=SWITCH_TYPES["smartplug"],
         )
@@ -95,7 +104,7 @@ async def async_setup_entry(
     entities.extend(
         SHCRoutingSwitch(
             device=switch,
-            parent_id=session.information.unique_id,
+            parent_id=parent_id,
             entry_id=config_entry.entry_id,
         )
         for switch in session.device_helper.smart_plugs
@@ -104,7 +113,7 @@ async def async_setup_entry(
     entities.extend(
         SHCSwitch(
             device=switch,
-            parent_id=session.information.unique_id,
+            parent_id=parent_id,
             entry_id=config_entry.entry_id,
             description=SWITCH_TYPES["lightswitch"],
         )
@@ -114,7 +123,7 @@ async def async_setup_entry(
     entities.extend(
         SHCSwitch(
             device=switch,
-            parent_id=session.information.unique_id,
+            parent_id=parent_id,
             entry_id=config_entry.entry_id,
             description=SWITCH_TYPES["smartplugcompact"],
         )
@@ -124,7 +133,7 @@ async def async_setup_entry(
     entities.extend(
         SHCSwitch(
             device=switch,
-            parent_id=session.information.unique_id,
+            parent_id=parent_id,
             entry_id=config_entry.entry_id,
             description=SWITCH_TYPES["cameraeyes"],
         )
@@ -134,7 +143,7 @@ async def async_setup_entry(
     entities.extend(
         SHCSwitch(
             device=switch,
-            parent_id=session.information.unique_id,
+            parent_id=parent_id,
             entry_id=config_entry.entry_id,
             description=SWITCH_TYPES["camera360"],
         )
@@ -144,7 +153,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class SHCSwitch(SHCEntity, SwitchEntity):
+class SHCSwitch(SHCEntity[SHCDevice], SwitchEntity):
     """Representation of a SHC switch."""
 
     entity_description: SHCSwitchEntityDescription
@@ -190,13 +199,13 @@ class SHCSwitch(SHCEntity, SwitchEntity):
         self._device.update()
 
 
-class SHCRoutingSwitch(SHCEntity, SwitchEntity):
+class SHCRoutingSwitch(SHCEntity[SHCSmartPlug], SwitchEntity):
     """Representation of a SHC routing switch."""
 
     _attr_translation_key = "routing"
     _attr_entity_category = EntityCategory.CONFIG
 
-    def __init__(self, device: SHCDevice, parent_id: str, entry_id: str) -> None:
+    def __init__(self, device: SHCSmartPlug, parent_id: str, entry_id: str) -> None:
         """Initialize an SHC communication quality reporting sensor."""
         super().__init__(device, parent_id, entry_id)
         self._attr_unique_id = f"{device.serial}_routing"

--- a/homeassistant/components/bosch_shc/switch.py
+++ b/homeassistant/components/bosch_shc/switch.py
@@ -84,12 +84,11 @@ async def async_setup_entry(
     shc_info = session.information
     if TYPE_CHECKING:
         assert shc_info is not None and shc_info.unique_id is not None
-    parent_id = shc_info.unique_id
 
     entities: list[SwitchEntity] = [
         SHCSwitch(
             device=switch,
-            parent_id=parent_id,
+            parent_id=shc_info.unique_id,
             entry_id=config_entry.entry_id,
             description=SWITCH_TYPES["smartplug"],
         )
@@ -99,7 +98,7 @@ async def async_setup_entry(
     entities.extend(
         SHCRoutingSwitch(
             device=switch,
-            parent_id=parent_id,
+            parent_id=shc_info.unique_id,
             entry_id=config_entry.entry_id,
         )
         for switch in session.device_helper.smart_plugs
@@ -108,7 +107,7 @@ async def async_setup_entry(
     entities.extend(
         SHCSwitch(
             device=switch,
-            parent_id=parent_id,
+            parent_id=shc_info.unique_id,
             entry_id=config_entry.entry_id,
             description=SWITCH_TYPES["lightswitch"],
         )
@@ -118,7 +117,7 @@ async def async_setup_entry(
     entities.extend(
         SHCSwitch(
             device=switch,
-            parent_id=parent_id,
+            parent_id=shc_info.unique_id,
             entry_id=config_entry.entry_id,
             description=SWITCH_TYPES["smartplugcompact"],
         )
@@ -128,7 +127,7 @@ async def async_setup_entry(
     entities.extend(
         SHCSwitch(
             device=switch,
-            parent_id=parent_id,
+            parent_id=shc_info.unique_id,
             entry_id=config_entry.entry_id,
             description=SWITCH_TYPES["cameraeyes"],
         )
@@ -138,7 +137,7 @@ async def async_setup_entry(
     entities.extend(
         SHCSwitch(
             device=switch,
-            parent_id=parent_id,
+            parent_id=shc_info.unique_id,
             entry_id=config_entry.entry_id,
             description=SWITCH_TYPES["camera360"],
         )
@@ -148,7 +147,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class SHCSwitch(SHCEntity[SHCDevice], SwitchEntity):
+class SHCSwitch(SHCEntity, SwitchEntity):
     """Representation of a SHC switch."""
 
     entity_description: SHCSwitchEntityDescription
@@ -194,11 +193,12 @@ class SHCSwitch(SHCEntity[SHCDevice], SwitchEntity):
         self._device.update()
 
 
-class SHCRoutingSwitch(SHCEntity[SHCSmartPlug], SwitchEntity):
+class SHCRoutingSwitch(SHCEntity, SwitchEntity):
     """Representation of a SHC routing switch."""
 
     _attr_translation_key = "routing"
     _attr_entity_category = EntityCategory.CONFIG
+    _device: SHCSmartPlug
 
     def __init__(self, device: SHCSmartPlug, parent_id: str, entry_id: str) -> None:
         """Initialize an SHC routing switch."""

--- a/homeassistant/components/bosch_shc/switch.py
+++ b/homeassistant/components/bosch_shc/switch.py
@@ -201,7 +201,7 @@ class SHCRoutingSwitch(SHCEntity, SwitchEntity):
     _device: SHCSmartPlug
 
     def __init__(self, device: SHCDevice, parent_id: str, entry_id: str) -> None:
-        """Initialize an SHC communication quality reporting sensor."""
+        """Initialize an SHC routing switch."""
         super().__init__(device, parent_id, entry_id)
         self._attr_unique_id = f"{device.serial}_routing"
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -693,7 +693,7 @@ bond-async==0.2.1
 bosch-alarm-mode2==0.4.10
 
 # homeassistant.components.bosch_shc
-boschshcpy==0.3.5
+boschshcpy==0.4.9
 
 # homeassistant.components.amazon_polly
 # homeassistant.components.route53

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -693,7 +693,7 @@ bond-async==0.2.1
 bosch-alarm-mode2==0.4.10
 
 # homeassistant.components.bosch_shc
-boschshcpy==0.4.9
+boschshcpy==0.4.10
 
 # homeassistant.components.amazon_polly
 # homeassistant.components.route53

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -693,7 +693,7 @@ bond-async==0.2.1
 bosch-alarm-mode2==0.4.10
 
 # homeassistant.components.bosch_shc
-boschshcpy==0.4.10
+boschshcpy==0.4.12
 
 # homeassistant.components.amazon_polly
 # homeassistant.components.route53

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -693,7 +693,7 @@ bond-async==0.2.1
 bosch-alarm-mode2==0.4.10
 
 # homeassistant.components.bosch_shc
-boschshcpy==0.6.2
+boschshcpy==0.6.3
 
 # homeassistant.components.amazon_polly
 # homeassistant.components.route53

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -693,7 +693,7 @@ bond-async==0.2.1
 bosch-alarm-mode2==0.4.10
 
 # homeassistant.components.bosch_shc
-boschshcpy==0.6.3
+boschshcpy==0.6.4
 
 # homeassistant.components.amazon_polly
 # homeassistant.components.route53

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -693,7 +693,7 @@ bond-async==0.2.1
 bosch-alarm-mode2==0.4.10
 
 # homeassistant.components.bosch_shc
-boschshcpy==0.4.14
+boschshcpy==0.5.0
 
 # homeassistant.components.amazon_polly
 # homeassistant.components.route53

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -693,7 +693,7 @@ bond-async==0.2.1
 bosch-alarm-mode2==0.4.10
 
 # homeassistant.components.bosch_shc
-boschshcpy==0.4.12
+boschshcpy==0.4.13
 
 # homeassistant.components.amazon_polly
 # homeassistant.components.route53

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -693,7 +693,7 @@ bond-async==0.2.1
 bosch-alarm-mode2==0.4.10
 
 # homeassistant.components.bosch_shc
-boschshcpy==0.6.1
+boschshcpy==0.6.2
 
 # homeassistant.components.amazon_polly
 # homeassistant.components.route53

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -693,7 +693,7 @@ bond-async==0.2.1
 bosch-alarm-mode2==0.4.10
 
 # homeassistant.components.bosch_shc
-boschshcpy==0.5.0
+boschshcpy==0.6.1
 
 # homeassistant.components.amazon_polly
 # homeassistant.components.route53

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -693,7 +693,7 @@ bond-async==0.2.1
 bosch-alarm-mode2==0.4.10
 
 # homeassistant.components.bosch_shc
-boschshcpy==0.4.13
+boschshcpy==0.4.14
 
 # homeassistant.components.amazon_polly
 # homeassistant.components.route53


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

<!-- Not a breaking change. -->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bumps the `bosch_shc` integration's `boschshcpy` pin from `0.3.5` to `0.6.4` (the latest release).

This is split out from #174613 (adding a `button` platform to `bosch_shc`), where review feedback (Copilot) pointed out that `button.py` has to catch `requests.exceptions.RequestException` directly alongside `boschshcpy`'s own `SHCException`, because the library didn't consistently wrap transport errors. That's fixed in `boschshcpy` 0.4.9 (`SHCConnectionError` now subclasses `SHCException`, and all of `SHCAPI`'s `_get/_put/_post_api_or_fail` wrap transport errors into it), but bumping the pin inside #174613 itself would have been out of scope for that PR — see the discussion there for why.

The library moved 15+ releases since `0.3.5`, including breaking changes to type surfaces this component relies on (mostly from `boschshcpy` 0.3.22's full `mypy --strict` pass — service classes became module-level exports instead of nested class attributes, several `SHCInformation`/`device_class` fields became `Optional`, and comparable service states became real `Enum` members). Bumping the pin reintroduced ~105 mypy errors across `cover.py`, `switch.py`, `sensor.py`, `binary_sensor.py`, `button.py`, `__init__.py` and `entity.py`.

Those have been fixed across this PR's commits — verified against `boschshcpy` 0.4.9's actual source, no functional behavior changes, mypy/ruff/pylint/hassfest all clean, all existing tests pass. An early review round trimmed the diff back down to only what the version bump actually forces: dropped a PEP-695 generic *base-entity* hierarchy (`SHCBaseEntity[_DeviceT]`, shared across every platform) and per-subclass constructor type-narrowing that turned out not to be required for the bump itself (confirmed by reverting each and rerunning mypy against 0.4.9 — both stayed clean without them).

A later review round asked to eliminate `sensor.py`'s remaining `cast()` calls (used because its old single `SENSOR_DESCRIPTIONS` dict was typed against the common `SHCDevice` base, forcing an unsafe cast inside every `value_fn`/`attributes_fn` lambda to access device-specific attributes). Fixed by making `SHCSensorEntityDescription` generic over device type (PEP-695) and splitting the old shared dict into per-device-type description constants, each wired to exactly the `device_helper` bucket it's used with — this makes `SHCSensor` itself generic too (`class SHCSensor[_DeviceT: SHCDevice]`), but scoped only to `sensor.py`'s own leaf entity class, not the shared base-entity hierarchy dropped above. Zero casts left in `sensor.py`, mypy/ruff/pylint clean, all tests pass.

`boschshcpy` 0.4.10 was released during this PR's review (purely additive — a new Zigbee routing-info API surface, no changes to existing types this component uses). Bumped the pin to keep up; mypy/ruff/pylint/hassfest/pytest all pass unchanged, zero further fixes required.

Two more patch releases landed since (`0.4.11`: hardens `ChildProtectionService.childLockActive` against a partial poll snapshot, wraps async request timeouts into `SHCConnectionError`; `0.4.12`: fixes a thread-safety race between the polling thread and cross-thread reads of the device list). Both are internal implementation fixes with no type-surface changes. Bumped the pin to `0.4.12`; mypy/ruff/pylint/hassfest/pytest all pass unchanged, zero further fixes required.

`boschshcpy` 0.4.13 (found via a chaos-engineering test round, no live incident) hardens the long-poll message-processing path in `session.py`/`device_service.py` against a malformed/adversarial message shape (missing `@type`, non-dict `arguments`/`state`) that previously raised an uncaught exception and stalled the poll thread for 15s. Purely internal, no type-surface change. Bumped the pin to `0.4.13`; mypy/ruff/pylint/hassfest/pytest all pass unchanged (the same 5 pre-existing, unrelated `sensor.py` mypy findings persist identically against both 0.4.12 and 0.4.13 — confirmed via a stash/diff, not introduced by this bump), zero further fixes required.

`boschshcpy` 0.4.14 fixes a real bug reported against the integration (tschamm/boschshc-hass#370): after a long-poll poll-id resubscribe (a ~24h cycle, or any connection gap long enough to invalidate the poll id — e.g. an SHC firmware update), the existing per-device refresh only short-polled each device's *services*, never re-fetching the device's own top-level `status` field. A device that went `UNDEFINED` during the gap and later reconnected could keep reporting stale availability indefinitely. Purely internal, no type-surface change. Bumped the pin to `0.4.14`; mypy/ruff/pylint/hassfest/pytest all pass unchanged (same 5 pre-existing, unrelated `sensor.py` mypy findings, confirmed via a stash/diff, not introduced by this bump), zero further fixes required.

`boschshcpy` 0.5.0 is a larger release adding several new capability surfaces (automation-rule engine read/enable/trigger, a whole-home water-leak alarm domain, intrusion-system read-only discovery, per-device thermostat regulation algorithm, per-room temperature-drop service, plus provisional hydraulic-balancing/comfort-zone-template API methods) — none of which this component consumes yet, so there is no type-surface impact from those additions. Bumped the pin to `0.5.0`; mypy/ruff/hassfest/pytest all pass unchanged (same 5 pre-existing, unrelated `sensor.py` mypy findings, confirmed via a stash/diff, not introduced by this bump), zero further fixes required.

`boschshcpy` 0.5.1 fixed two real bugs in the just-released water-leak alarm domain, found by cross-checking it against Bosch's own official OpenAPI spec (github.com/BoschSmartHome/bosch-shc-api-docs): the `AlarmState` enum used `ALARM_ON` where the spec says `WATER_ALARM`, and `mute()` used HTTP PUT where the spec says POST. Neither bug is reachable from this component (it doesn't consume the water-alarm domain yet), so no type-surface impact.

`boschshcpy` 0.6.0/0.6.1 is a further, larger release from a systematic audit of this library's implementation against all 24 of Bosch's official spec files: a new Multiroom Boiler Control device family (spec-only, not live-tested — no owned hardware), a whole-home open-doors/open-windows summary, a handful of additional read-only fields (`SHCInformation.shcGeneration`/`api_versions`, water-alarm incident detail, two Shutter-II/PowerMeter fields), and (0.6.1) a same-day fix for a missing `SHCBoiler` top-level export. None of this is consumed by this component yet either, so again no type-surface impact.

`boschshcpy` 0.6.2 exports its existing capability mixins (`TemperatureLevelMixin`/`HumidityLevelMixin`/`PowerMeterMixin`/`CommunicationQualityMixin`) from the package top-level, and makes `session.information`/`session.unique_id` non-optional (raises instead of returning `None` pre-authentication). Neither is consumed by this component.

`boschshcpy` 0.6.3 fixes a long-poll robustness bug: a poll error other than `-32001` ("unknown poll id") never invalidated the internal poll id, so the poll loop kept retrying with the same broken id and repeating the identical error indefinitely instead of recovering via resubscribe. Internal to the library's polling thread/task, not consumed by this component's own code. Bumped the pin to `0.6.3`; mypy/ruff/hassfest/pytest all pass unchanged (same 5 pre-existing, unrelated `sensor.py` mypy findings, confirmed via a stash/diff, not introduced by this bump), zero further fixes required.

`boschshcpy` 0.6.4 fixes a crash reported via a community-forum traceback: a corrupted or missing client certificate/key made `SHCAPIAsync`'s constructor raise a raw `ssl.SSLError`/`OSError` on its fallback path instead of a catchable error. This component uses the synchronous `SHCSession` with cert/key file paths (not `SHCAPIAsync`), written via its own `config_flow.write_tls_asset` — a different code path from the one 0.6.4 patches, so bumping the pin doesn't change this component's own behavior. Bumped the pin to `0.6.4`; mypy/ruff/hassfest/pytest all pass unchanged (same 5 pre-existing, unrelated `sensor.py` mypy findings, confirmed via a stash/diff, not introduced by this bump), zero further fixes required.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #174613 (button platform — the RequestException/SHCException discussion that motivated this)
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:
- Diff between library versions: https://github.com/tschamm/boschshcpy/compare/v0.3.5...v0.6.4 (changelog: https://github.com/tschamm/boschshcpy/blob/master/CHANGELOG.md)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr









