### PR TITLE
Add diagnostics support for stiebel_eltron integration

### DIFF
--- a/homeassistant/components/stiebel_eltron/diagnostics.py
+++ b/homeassistant/components/stiebel_eltron/diagnostics.py
@@ -1,0 +1,35 @@
+"""Diagnostics support for STIEBEL ELTRON."""
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+
+from . import StiebelEltronConfigEntry
+
+TO_REDACT = {CONF_HOST}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: StiebelEltronConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator = entry.runtime_data
+
+    return {
+        "entry_data": async_redact_data(entry.data, TO_REDACT),
+        "model": coordinator.device_info["model"],
+        "modbus": {
+            "is_connected": coordinator.api_client.is_connected,
+        },
+        "data": {
+            "current_temp": coordinator.api_client.get_current_temp(),
+            "target_temp": coordinator.api_client.get_target_temp(),
+            "current_humidity": coordinator.api_client.get_current_humidity(),
+            "operating_mode": coordinator.api_client.get_operation().name,
+            "heating_status": coordinator.api_client.get_heating_status(),
+            "cooling_status": coordinator.api_client.get_cooling_status(),
+            "filter_alarm": coordinator.api_client.get_filter_alarm_status(),
+        },
+    }

--- a/homeassistant/components/stiebel_eltron/quality_scale.yaml
+++ b/homeassistant/components/stiebel_eltron/quality_scale.yaml
@@ -47,7 +47,7 @@ rules:
 
   # Gold
   devices: done
-  diagnostics: todo
+  diagnostics: done
   discovery-update-info: todo
   discovery: todo
   docs-data-update: todo

--- a/tests/components/stiebel_eltron/conftest.py
+++ b/tests/components/stiebel_eltron/conftest.py
@@ -44,9 +44,14 @@ def mock_lwz_api() -> Generator[MagicMock]:
         api_client.get_current_temp = MagicMock(return_value=21.0)
         api_client.get_current_humidity = MagicMock(return_value=45.0)
         api_client.get_operation = MagicMock(return_value=OperatingMode.AUTOMATIC)
+        api_client.get_heating_status = MagicMock(return_value=True)
+        api_client.get_cooling_status = MagicMock(return_value=False)
         api_client.get_filter_alarm_status = MagicMock(return_value=False)
 
-        api_client.connect = AsyncMock()
+        def _connect() -> None:
+            api_client.is_connected = True
+
+        api_client.connect = AsyncMock(side_effect=_connect)
         api_client.close = AsyncMock()
         api_client.async_update = AsyncMock()
         api_client.set_operation = AsyncMock()

--- a/tests/components/stiebel_eltron/snapshots/test_diagnostics.ambr
+++ b/tests/components/stiebel_eltron/snapshots/test_diagnostics.ambr
@@ -1,0 +1,22 @@
+# serializer version: 1
+# name: test_diagnostics
+  dict({
+    'data': dict({
+      'cooling_status': False,
+      'current_humidity': 45.0,
+      'current_temp': 21.0,
+      'filter_alarm': False,
+      'heating_status': True,
+      'operating_mode': 'AUTOMATIC',
+      'target_temp': 22.5,
+    }),
+    'entry_data': dict({
+      'host': '**REDACTED**',
+      'port': 502,
+    }),
+    'modbus': dict({
+      'is_connected': True,
+    }),
+    'model': 'LWZ',
+  })
+# ---

--- a/tests/components/stiebel_eltron/test_diagnostics.py
+++ b/tests/components/stiebel_eltron/test_diagnostics.py
@@ -1,0 +1,26 @@
+"""Tests for STIEBEL ELTRON diagnostics."""
+
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
+
+
+async def test_diagnostics(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_config_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test config entry diagnostics."""
+    mock_config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        await get_diagnostics_for_config_entry(hass, hass_client, mock_config_entry)
+        == snapshot
+    )


### PR DESCRIPTION
## Proposed change

Dump the redacted config entry data, the controller model, the Modbus connection state, and every value the integration reads from the device (temperatures, humidity, operating mode, heating/cooling status, filter alarm). The host is redacted as it identifies the user's network.

The mocked API client now flips is_connected on connect() so the diagnostics snapshot documents the realistic post-setup state.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
