### PR TITLE
Allow step_id to be None in all steps for data entry flows

### DIFF
--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 import logging
 from types import MappingProxyType
-from typing import Any, Generic, Required, TypedDict, TypeVar, cast
+from typing import Any, Generic, Required, TypedDict, TypeVar, cast, override
 
 import voluptuous as vol
 
@@ -637,6 +637,15 @@ class FlowHandler(Generic[_FlowContextT, _FlowResultT, _HandlerT]):
     __no_progress_task_reported = False
     deprecated_show_progress = False
 
+    __current_step_id: str | None = None
+
+    @override
+    def __getattribute__(self, name: str) -> Any:
+        """Get attribute."""
+        if name.startswith("async_step_"):
+            self.__current_step_id = name.removeprefix("async_step_")
+        return super().__getattribute__(name)
+
     @property
     def source(self) -> str | None:
         """Source that initialized the flow."""
@@ -714,8 +723,11 @@ class FlowHandler(Generic[_FlowContextT, _FlowResultT, _HandlerT]):
             last_step=last_step,  # Display next or submit button in frontend
             preview=preview,  # Display preview component in frontend
         )
+
         if step_id is not None:
             flow_result["step_id"] = step_id
+        elif self.__current_step_id is not None:
+            flow_result["step_id"] = self.__current_step_id
         return flow_result
 
     @callback
@@ -775,6 +787,8 @@ class FlowHandler(Generic[_FlowContextT, _FlowResultT, _HandlerT]):
         )
         if step_id is not None:
             flow_result["step_id"] = step_id
+        elif self.__current_step_id is not None:
+            flow_result["step_id"] = self.__current_step_id
         return flow_result
 
     @callback
@@ -825,6 +839,8 @@ class FlowHandler(Generic[_FlowContextT, _FlowResultT, _HandlerT]):
         )
         if step_id is not None:
             flow_result["step_id"] = step_id
+        elif self.__current_step_id is not None:
+            flow_result["step_id"] = self.__current_step_id
         return flow_result
 
     @callback
@@ -881,6 +897,8 @@ class FlowHandler(Generic[_FlowContextT, _FlowResultT, _HandlerT]):
             flow_result["sort"] = sort
         if step_id is not None:
             flow_result["step_id"] = step_id
+        elif self.__current_step_id is not None:
+            flow_result["step_id"] = self.__current_step_id
         return flow_result
 
     @callback

--- a/tests/test_data_entry_flow.py
+++ b/tests/test_data_entry_flow.py
@@ -1301,3 +1301,37 @@ async def test_show_advanced_options(
         "removed in HA Core 2027.6. Use a user friendly way to present additional "
         "options in the UI, for example a section instead"
     ) in caplog.text
+
+
+async def test_step_id_is_none(manager: MockFlowManager) -> None:
+    """Test that step_id can always be None."""
+
+    @manager.mock_reg_handler("test")
+    class TestFlow(data_entry_flow.FlowHandler):
+        VERSION = 1
+        data: list[str] | None = None
+
+        async def async_step_first(self, user_input=None):
+            if user_input is not None:
+                self.data = user_input
+                return await self.async_step_second()
+            return self.async_show_form(data_schema=vol.Schema([str]))
+
+        async def async_step_second(self, user_input=None):
+            return await self.async_step_third()
+
+        async def async_step_third(self, user_input=None):
+            if user_input is not None:
+                return self.async_create_entry(
+                    title="Test Entry", data=self.data + user_input
+                )
+            return self.async_show_form(data_schema=vol.Schema([str]))
+
+    form = await manager.async_init("test", context={"init_step": "first"})
+    assert form["step_id"] == "first"
+    form = await manager.async_configure(form["flow_id"], ["FIRST-DATA"])
+    assert form["step_id"] == "third"
+    form = await manager.async_configure(form["flow_id"], ["THIRD-DATA"])
+    assert form["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert form["title"] == "Test Entry"
+    assert form["data"] == ["FIRST-DATA", "THIRD-DATA"]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change


## Proposed change
Always check which step we are in for a data entry flow so we don't need to specify it.
This is a "continuation" of https://github.com/home-assistant/core/pull/107944

Currently it doesn't "know" we have moved from one step to another, with this implementation we check which step it is requesting and set that if a `step_id` isn't provided.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository. 