### PR TITLE
Pin cffi to 2.0.0 in package constraints

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -256,3 +256,7 @@ azure-kusto-data==4.5.1
 azure-kusto-ingest==4.5.1
 coloredlogs==15.0.1
 setuptools==81.0.0
+
+# Pin cffi to 2.0.0 to avoid version mismatch with the pre-baked _cffi_backend in the base image.
+# https://github.com/home-assistant/core/issues/175832
+cffi==2.0.0

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -239,6 +239,10 @@ azure-kusto-data==4.5.1
 azure-kusto-ingest==4.5.1
 coloredlogs==15.0.1
 setuptools==81.0.0
+
+# Pin cffi to 2.0.0 to avoid version mismatch with the pre-baked _cffi_backend in the base image.
+# https://github.com/home-assistant/core/issues/175832
+cffi==2.0.0
 """
 
 GENERATED_MESSAGE = (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Pin `cffi` to version `2.0.0` in `homeassistant/package_constraints.txt` (via `script/gen_requirements_all.py`).

### Reason
The Home Assistant base image contains the compiled `_cffi_backend` module at version `2.0.0`. When `cffi` version `2.1.0` was released on PyPI, dynamic startup dependency installations for integrations (like `google`, `roborock`, `knx`, etc.) began downloading/upgrading the pure-Python package files to `cffi 2.1.0`.

This results in a version mismatch error on startup:
```
Version mismatch: this is the 'cffi' package version 2.1.0, located in '/usr/local/lib/python3.14/site-packages/cffi/api.py'. When we import the top-level '_cffi_backend' extension module, we get version 2.0.0, located in '/usr/local/lib/python3.14/site-packages/_cffi_backend.cpython-314-aarch64-linux-musl.so'.
```

Adding `cffi==2.0.0` to the package constraints prevents startup updates to `cffi 2.1.0`, resolving the issue.

- PyPI release: https://pypi.org/project/cffi/2.0.0/
- Compare link: https://github.com/python-cffi/cffi/compare/v2.0.0...v2.1.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
  - fixes #175832
  - fixes #175878
  - fixes #175882
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
