### PR TITLE
Added status flags via zeroconf to apple_tv

### DIFF
--- a/homeassistant/components/apple_tv/__init__.py
+++ b/homeassistant/components/apple_tv/__init__.py
@@ -91,7 +91,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: AppleTvConfigEntry) -> bool:
     """Set up a config entry for Apple TV."""
-    _LOGGER.debug("setting up apple tv config entry")
     manager = AppleTVManager(hass, entry)
 
     if manager.is_on:
@@ -124,8 +123,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: AppleTvConfigEntry) -> b
     entry.async_on_unload(
         await _async_register_airplay_status_listener(hass, entry, manager)
     )
-    _LOGGER.debug("Apple TV entry unique id: %s", entry.unique_id)
-
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     await manager.init()
 
@@ -206,27 +203,26 @@ class AppleTVManager(DeviceListener):
     @callback
     def async_add_status_flag_listener(
         self,
-        cllback: Callable[[], None],
+        listener: Callable[[], None],
     ) -> Callable[[], None]:
         """Add a listener for status flag updates."""
-        self._status_flag_callbacks.append(cllback)
+        self._status_flag_callbacks.append(listener)
 
         def remove_listener() -> None:
-            self._status_flag_callbacks.remove(cllback)
+            self._status_flag_callbacks.remove(listener)
 
         return remove_listener
 
     @callback
     def async_set_status_flags(self, status_flags: str | None) -> None:
         """Update status flags."""
-        _LOGGER.debug("status flags changed to %s", status_flags)
         if self.status_flags == status_flags:
             return
 
         self.status_flags = status_flags
 
-        for cllback in self._status_flag_callbacks:
-            cllback()
+        for listener in self._status_flag_callbacks:
+            listener()
 
     @override
     def connection_lost(self, exception: Exception) -> None:

--- a/homeassistant/components/apple_tv/__init__.py
+++ b/homeassistant/components/apple_tv/__init__.py
@@ -143,11 +143,6 @@ async def _async_register_airplay_status_listener(
 
     @callback
     def _async_service_updated(service: AsyncServiceInfo) -> None:
-        _LOGGER.warning(
-            "Zeroconf update received: %s %s",
-            service.type,
-            service.name,
-        )
         if service.type != "_airplay._tcp.local.":
             return
 

--- a/homeassistant/components/apple_tv/__init__.py
+++ b/homeassistant/components/apple_tv/__init__.py
@@ -1,6 +1,7 @@
 """The Apple TV integration."""
 
 import asyncio
+from collections.abc import Callable
 import logging
 from random import randrange
 from typing import Any, cast, override
@@ -9,9 +10,12 @@ from pyatv import connect, exceptions, scan
 from pyatv.conf import AppleTV
 from pyatv.const import DeviceModel, Protocol
 from pyatv.convert import model_str
+from pyatv.helpers import get_unique_id
 from pyatv.interface import AppleTV as AppleTVInterface, DeviceListener
+from zeroconf.asyncio import AsyncServiceInfo
 
 from homeassistant.components import zeroconf
+from homeassistant.components.zeroconf import DATA_DISCOVERY, info_from_service
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_CONNECTIONS,
@@ -87,6 +91,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: AppleTvConfigEntry) -> bool:
     """Set up a config entry for Apple TV."""
+    _LOGGER.debug("setting up apple tv config entry")
     manager = AppleTVManager(hass, entry)
 
     if manager.is_on:
@@ -116,11 +121,60 @@ async def async_setup_entry(hass: HomeAssistant, entry: AppleTvConfigEntry) -> b
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, on_hass_stop)
     )
     entry.async_on_unload(manager.disconnect)
+    entry.async_on_unload(
+        await _async_register_airplay_status_listener(hass, entry, manager)
+    )
+    _LOGGER.debug("Apple TV entry unique id: %s", entry.unique_id)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     await manager.init()
 
     return True
+
+
+async def _async_register_airplay_status_listener(
+    hass: HomeAssistant,
+    entry: AppleTvConfigEntry,
+    manager: AppleTVManager,
+) -> Callable[[], None]:
+    """Register listener for AirPlay TXT record updates."""
+
+    discovery = hass.data[DATA_DISCOVERY]
+
+    @callback
+    def _async_service_updated(service: AsyncServiceInfo) -> None:
+        _LOGGER.warning(
+            "Zeroconf update received: %s %s",
+            service.type,
+            service.name,
+        )
+        if service.type != "_airplay._tcp.local.":
+            return
+
+        info = info_from_service(service)
+        if info is None:
+            return
+
+        service_type = info.type[:-1]
+        name = info.name.replace(f".{service_type}.", "")
+
+        unique_id = get_unique_id(
+            service_type,
+            name,
+            info.properties,
+        )
+
+        if unique_id != entry.unique_id:
+            return
+
+        flags = info.properties.get("flags")
+
+        if flags == manager.status_flags:
+            return
+
+        manager.async_set_status_flags(flags)
+
+    return discovery.async_register_service_update_listener(_async_service_updated)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -146,11 +200,38 @@ class AppleTVManager(DeviceListener):
         self.config_entry = config_entry
         self.hass = hass
         self.is_on = not config_entry.options.get(CONF_START_OFF, False)
+        self.status_flags: str | None = None
+        self._status_flag_callbacks: list[Callable[[], None]] = []
 
     async def init(self) -> None:
         """Initialize power management."""
         if self.is_on:
             await self.connect()
+
+    @callback
+    def async_add_status_flag_listener(
+        self,
+        cllback: Callable[[], None],
+    ) -> Callable[[], None]:
+        """Add a listener for status flag updates."""
+        self._status_flag_callbacks.append(cllback)
+
+        def remove_listener() -> None:
+            self._status_flag_callbacks.remove(cllback)
+
+        return remove_listener
+
+    @callback
+    def async_set_status_flags(self, status_flags: str | None) -> None:
+        """Update status flags."""
+        _LOGGER.debug("status flags changed to %s", status_flags)
+        if self.status_flags == status_flags:
+            return
+
+        self.status_flags = status_flags
+
+        for cllback in self._status_flag_callbacks:
+            cllback()
 
     @override
     def connection_lost(self, exception: Exception) -> None:

--- a/homeassistant/components/apple_tv/media_player.py
+++ b/homeassistant/components/apple_tv/media_player.py
@@ -109,7 +109,6 @@ async def async_setup_entry(
     assert config_entry.unique_id is not None
     manager = config_entry.runtime_data
     async_add_entities([AppleTvMediaPlayer(name, config_entry.unique_id, manager)])
-    _LOGGER.debug("APPLE TV media player entry unique id: %s", config_entry.unique_id)
 
 
 class AppleTvMediaPlayer(
@@ -367,10 +366,6 @@ class AppleTvMediaPlayer(
         attrs = dict(super().extra_state_attributes or {})
         if self.manager.status_flags is not None:
             attrs["status_flags"] = self.manager.status_flags
-            _LOGGER.debug(
-                self.manager.status_flags,
-            )
-
         return attrs
 
     @override

--- a/homeassistant/components/apple_tv/media_player.py
+++ b/homeassistant/components/apple_tv/media_player.py
@@ -1,5 +1,6 @@
 """Support for Apple TV media player."""
 
+from collections.abc import Mapping
 from datetime import datetime
 import logging
 from typing import Any, override
@@ -108,6 +109,7 @@ async def async_setup_entry(
     assert config_entry.unique_id is not None
     manager = config_entry.runtime_data
     async_add_entities([AppleTvMediaPlayer(name, config_entry.unique_id, manager)])
+    _LOGGER.debug("APPLE TV media player entry unique id: %s", config_entry.unique_id)
 
 
 class AppleTvMediaPlayer(
@@ -348,6 +350,28 @@ class AppleTvMediaPlayer(
         if self.state in {MediaPlayerState.PLAYING, MediaPlayerState.PAUSED}:
             return self._playing_last_updated
         return None
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Handle entity being added to Home Assistant."""
+        await super().async_added_to_hass()
+
+        self.async_on_remove(
+            self.manager.async_add_status_flag_listener(self.async_write_ha_state)
+        )
+
+    @property
+    @override
+    def extra_state_attributes(self) -> Mapping[str, Any]:
+        """Return extra state attributes."""
+        attrs = dict(super().extra_state_attributes or {})
+        if self.manager.status_flags is not None:
+            attrs["status_flags"] = self.manager.status_flags
+            _LOGGER.debug(
+                self.manager.status_flags,
+            )
+
+        return attrs
 
     @override
     async def async_play_media(


### PR DESCRIPTION
airport extre doesn't support updating status via protocols, but zeroconf does update certain status flags that allow us to see the state of the airport extreme (see https://github.com/postlund/pyatv/issues/1419#issuecomment-4906875545 )

This pr attempts to add these flags as attributes in HA so they can be used in automations.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In this pr we add listeners for zeroconf status flag updates to apple_tv integration, and add these to the entities state attributes. (Could be expanded to be shown in more places)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

I'm not completely sure of the initial way to handle this, so want some early feedback, if this is the correct way to go more tests and gui integrations will be added (or in seperate pr?)
e.g. a binary sensor `'ON' if (status_flags & 0x800) else 'OFF'`

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
