### PR TITLE
Add DHCP discovery to stiebel_eltron integration

### DIFF
--- a/homeassistant/components/stiebel_eltron/config_flow.py
+++ b/homeassistant/components/stiebel_eltron/config_flow.py
@@ -8,12 +8,14 @@ import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.selector import (
     NumberSelector,
     NumberSelectorConfig,
     NumberSelectorMode,
     TextSelector,
 )
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from .const import DEFAULT_PORT, DOMAIN
 
@@ -49,6 +51,41 @@ class StiebelEltronConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for STIEBEL ELTRON."""
 
     VERSION = 1
+
+    _discovered_host: str
+
+    @override
+    async def async_step_dhcp(
+        self, discovery_info: DhcpServiceInfo
+    ) -> ConfigFlowResult:
+        """Handle DHCP discovery."""
+        await self.async_set_unique_id(format_mac(discovery_info.macaddress))
+        self._abort_if_unique_id_configured(updates={CONF_HOST: discovery_info.ip})
+        self._async_abort_entries_match({CONF_HOST: discovery_info.ip})
+
+        error = await check_controller_model(discovery_info.ip, DEFAULT_PORT)
+        if error is not None:
+            return self.async_abort(reason=error)
+
+        self._discovered_host = discovery_info.ip
+        self.context["title_placeholders"] = {CONF_HOST: discovery_info.ip}
+        return await self.async_step_discovery_confirm()
+
+    async def async_step_discovery_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Allow the user to confirm adding the discovered device."""
+        if user_input is not None:
+            return self.async_create_entry(
+                title="Stiebel Eltron",
+                data={CONF_HOST: self._discovered_host, CONF_PORT: DEFAULT_PORT},
+            )
+
+        self._set_confirm_only()
+        return self.async_show_form(
+            step_id="discovery_confirm",
+            description_placeholders={CONF_HOST: self._discovered_host},
+        )
 
     @override
     async def async_step_user(

--- a/homeassistant/components/stiebel_eltron/manifest.json
+++ b/homeassistant/components/stiebel_eltron/manifest.json
@@ -3,6 +3,11 @@
   "name": "STIEBEL ELTRON",
   "codeowners": ["@fucm", "@ThyMYthOS"],
   "config_flow": true,
+  "dhcp": [
+    {
+      "hostname": "servicewelt*"
+    }
+  ],
   "documentation": "https://www.home-assistant.io/integrations/stiebel_eltron",
   "integration_type": "device",
   "iot_class": "local_polling",

--- a/homeassistant/components/stiebel_eltron/quality_scale.yaml
+++ b/homeassistant/components/stiebel_eltron/quality_scale.yaml
@@ -48,8 +48,8 @@ rules:
   # Gold
   devices: done
   diagnostics: done
-  discovery-update-info: todo
-  discovery: todo
+  discovery-update-info: done
+  discovery: done
   docs-data-update: todo
   docs-examples: todo
   docs-known-limitations: todo

--- a/homeassistant/components/stiebel_eltron/strings.json
+++ b/homeassistant/components/stiebel_eltron/strings.json
@@ -10,7 +10,11 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
+    "flow_title": "STIEBEL ELTRON ({host})",
     "step": {
+      "discovery_confirm": {
+        "description": "Do you want to set up the STIEBEL ELTRON heat pump at {host}?"
+      },
       "reconfigure": {
         "data": {
           "host": "[%key:common::config_flow::data::host%]",

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -1059,6 +1059,10 @@ DHCP: Final[list[dict[str, str | bool]]] = [
         "macaddress": "001E0C*",
     },
     {
+        "domain": "stiebel_eltron",
+        "hostname": "servicewelt*",
+    },
+    {
         "domain": "sunricher_dali",
         "registered_devices": True,
     },

--- a/tests/components/stiebel_eltron/test_config_flow.py
+++ b/tests/components/stiebel_eltron/test_config_flow.py
@@ -6,15 +6,21 @@ from pystiebeleltron import ControllerModel, StiebelEltronModbusError
 import pytest
 
 from homeassistant.components.stiebel_eltron.const import DOMAIN
-from homeassistant.config_entries import SOURCE_RECONFIGURE, SOURCE_USER
+from homeassistant.config_entries import SOURCE_DHCP, SOURCE_RECONFIGURE, SOURCE_USER
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from tests.common import MockConfigEntry
 
 USER_INPUT = {CONF_HOST: "1.1.1.1", CONF_PORT: 502}
 RECONFIGURE_INPUT = {CONF_HOST: "2.2.2.2", CONF_PORT: 502}
+DHCP_DISCOVERY = DhcpServiceInfo(
+    ip="1.1.1.2",
+    hostname="servicewelt",
+    macaddress="000000000001",
+)
 
 
 async def test_full_flow(hass: HomeAssistant) -> None:
@@ -200,3 +206,82 @@ async def test_already_configured(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+
+
+async def test_dhcp_discovery_flow(hass: HomeAssistant) -> None:
+    """Test the full DHCP discovery flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_DHCP}, data=DHCP_DISCOVERY
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "discovery_confirm"
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Stiebel Eltron"
+    assert result["data"] == {CONF_HOST: "1.1.1.2", CONF_PORT: 502}
+    assert result["result"].unique_id == "00:00:00:00:00:01"
+
+
+async def test_dhcp_discovery_updates_host(hass: HomeAssistant) -> None:
+    """Test DHCP discovery updates the host of an entry with a matching MAC."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Stiebel Eltron",
+        data={CONF_HOST: "1.1.1.1", CONF_PORT: 502},
+        unique_id="00:00:00:00:00:01",
+    )
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_DHCP}, data=DHCP_DISCOVERY
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert config_entry.data[CONF_HOST] == "1.1.1.2"
+
+
+async def test_dhcp_discovery_already_configured(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test DHCP discovery aborts for an already configured host."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_DHCP},
+        data=DhcpServiceInfo(
+            ip="1.1.1.1",
+            hostname="servicewelt",
+            macaddress="000000000001",
+        ),
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "expected_reason"),
+    [
+        pytest.param(StiebelEltronModbusError, "cannot_connect", id="cannot_connect"),
+        pytest.param(Exception, "unknown", id="unknown"),
+    ],
+)
+async def test_dhcp_discovery_errors(
+    hass: HomeAssistant,
+    mock_get_controller_model: MagicMock,
+    side_effect: type[Exception],
+    expected_reason: str,
+) -> None:
+    """Test DHCP discovery aborts when the device cannot be validated."""
+    mock_get_controller_model.side_effect = side_effect
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_DHCP}, data=DHCP_DISCOVERY
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == expected_reason


### PR DESCRIPTION
## Proposed change

The ISG web module registers the hostname "servicewelt" with the DHCP server, so discovery matches on that hostname. The MAC address from the discovery info becomes the config entry unique ID, which also allows updating the stored host when the device receives a new DHCP lease. Entries created before discovery support have no unique ID and are protected against duplicates by the host match.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
