### PR TITLE
SamsungTV refactor `__init__.py` — extract `DebouncedEntryReloader` and SSDP helpers

### DIFF
--- a/homeassistant/components/samsungtv/__init__.py
+++ b/homeassistant/components/samsungtv/__init__.py
@@ -1,13 +1,11 @@
 """The Samsung TV integration."""
 
-from collections.abc import Coroutine, Mapping
+from collections.abc import Mapping
 from functools import partial
 from typing import Any
-from urllib.parse import urlparse
 
 import getmac
 
-from homeassistant.components import ssdp
 from homeassistant.const import (
     CONF_HOST,
     CONF_MAC,
@@ -21,21 +19,12 @@ from homeassistant.const import (
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.helpers.debounce import Debouncer
 
 from .bridge import SamsungTVBridge, mac_from_device_info, model_requires_encryption
-from .const import (
-    CONF_SESSION_ID,
-    CONF_SSDP_MAIN_TV_AGENT_LOCATION,
-    CONF_SSDP_RENDERING_CONTROL_LOCATION,
-    DOMAIN,
-    ENTRY_RELOAD_COOLDOWN,
-    LOGGER,
-    METHOD_ENCRYPTED_WEBSOCKET,
-    UPNP_SVC_MAIN_TV_AGENT,
-    UPNP_SVC_RENDERING_CONTROL,
-)
+from .const import CONF_SESSION_ID, DOMAIN, LOGGER, METHOD_ENCRYPTED_WEBSOCKET
 from .coordinator import SamsungTVConfigEntry, SamsungTVDataUpdateCoordinator
+from .helpers import DebouncedEntryReloader
+from .ssdp_discovery import async_update_ssdp_locations
 
 PLATFORMS = [Platform.MEDIA_PLAYER, Platform.REMOTE]
 
@@ -52,64 +41,6 @@ def _async_get_device_bridge(
         data[CONF_PORT],
         data,
     )
-
-
-class DebouncedEntryReloader:
-    """Reload only after the timer expires."""
-
-    def __init__(self, hass: HomeAssistant, entry: SamsungTVConfigEntry) -> None:
-        """Init the debounced entry reloader."""
-        self.hass = hass
-        self.entry = entry
-        self.token = self.entry.data.get(CONF_TOKEN)
-        self._debounced_reload: Debouncer[Coroutine[Any, Any, None]] = Debouncer(
-            hass,
-            LOGGER,
-            cooldown=ENTRY_RELOAD_COOLDOWN,
-            immediate=False,
-            function=self._async_reload_entry,
-        )
-
-    async def async_call(
-        self, hass: HomeAssistant, entry: SamsungTVConfigEntry
-    ) -> None:
-        """Start the countdown for a reload."""
-        if (new_token := entry.data.get(CONF_TOKEN)) != self.token:
-            LOGGER.debug("Skipping reload as its a token update")
-            self.token = new_token
-            return  # Token updates should not trigger a reload
-        LOGGER.debug("Calling debouncer to get a reload after cooldown")
-        await self._debounced_reload.async_call()
-
-    @callback
-    def async_shutdown(self) -> None:
-        """Cancel any pending reload."""
-        self._debounced_reload.async_shutdown()
-
-    async def _async_reload_entry(self) -> None:
-        """Reload entry."""
-        LOGGER.debug("Reloading entry %s", self.entry.title)
-        await self.hass.config_entries.async_reload(self.entry.entry_id)
-
-
-async def _async_update_ssdp_locations(
-    hass: HomeAssistant, entry: SamsungTVConfigEntry
-) -> None:
-    """Update ssdp locations from discovery cache."""
-    updates = {}
-    for ssdp_st, key in (
-        (UPNP_SVC_RENDERING_CONTROL, CONF_SSDP_RENDERING_CONTROL_LOCATION),
-        (UPNP_SVC_MAIN_TV_AGENT, CONF_SSDP_MAIN_TV_AGENT_LOCATION),
-    ):
-        for discovery_info in await ssdp.async_get_discovery_info_by_st(hass, ssdp_st):
-            location = discovery_info.ssdp_location
-            host = urlparse(location).hostname
-            if host == entry.data[CONF_HOST]:
-                updates[key] = location
-                break
-
-    if updates:
-        hass.config_entries.async_update_entry(entry, data={**entry.data, **updates})
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: SamsungTVConfigEntry) -> bool:
@@ -148,7 +79,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: SamsungTVConfigEntry) ->
     )
     entry.async_on_unload(stop_bridge)
 
-    await _async_update_ssdp_locations(hass, entry)
+    await async_update_ssdp_locations(hass, entry)
 
     # We must not await after we setup the reload or there
     # will be a race where the config flow will see the entry

--- a/homeassistant/components/samsungtv/helpers.py
+++ b/homeassistant/components/samsungtv/helpers.py
@@ -1,12 +1,17 @@
 """Helper functions for Samsung TV."""
 
+from collections.abc import Coroutine
+from typing import Any
+
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_TOKEN
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.device_registry import DeviceEntry
 
 from .bridge import SamsungTVBridge
-from .const import DOMAIN
+from .const import DOMAIN, ENTRY_RELOAD_COOLDOWN, LOGGER
 from .coordinator import SamsungTVConfigEntry
 
 
@@ -61,3 +66,41 @@ def async_get_client_by_device_entry(
     raise ValueError(
         f"Device {device.id} is not from an existing {DOMAIN} config entry"
     )
+
+
+class DebouncedEntryReloader:
+    """Reload only after the timer expires."""
+
+    def __init__(self, hass: HomeAssistant, entry: SamsungTVConfigEntry) -> None:
+        """Init the debounced entry reloader."""
+        self.hass = hass
+        self.entry = entry
+        self.token = self.entry.data.get(CONF_TOKEN)
+        self._debounced_reload: Debouncer[Coroutine[Any, Any, None]] = Debouncer(
+            hass,
+            LOGGER,
+            cooldown=ENTRY_RELOAD_COOLDOWN,
+            immediate=False,
+            function=self._async_reload_entry,
+        )
+
+    async def async_call(
+        self, hass: HomeAssistant, entry: SamsungTVConfigEntry
+    ) -> None:
+        """Start the countdown for a reload."""
+        if (new_token := entry.data.get(CONF_TOKEN)) != self.token:
+            LOGGER.debug("Skipping reload as its a token update")
+            self.token = new_token
+            return  # Token updates should not trigger a reload
+        LOGGER.debug("Calling debouncer to get a reload after cooldown")
+        await self._debounced_reload.async_call()
+
+    @callback
+    def async_shutdown(self) -> None:
+        """Cancel any pending reload."""
+        self._debounced_reload.async_shutdown()
+
+    async def _async_reload_entry(self) -> None:
+        """Reload entry."""
+        LOGGER.debug("Reloading entry %s", self.entry.title)
+        await self.hass.config_entries.async_reload(self.entry.entry_id)

--- a/homeassistant/components/samsungtv/ssdp_discovery.py
+++ b/homeassistant/components/samsungtv/ssdp_discovery.py
@@ -1,0 +1,35 @@
+"""SSDP discovery helpers for Samsung TV."""
+
+from urllib.parse import urlparse
+
+from homeassistant.components.ssdp import async_get_discovery_info_by_st
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+
+from .const import (
+    CONF_SSDP_MAIN_TV_AGENT_LOCATION,
+    CONF_SSDP_RENDERING_CONTROL_LOCATION,
+    UPNP_SVC_MAIN_TV_AGENT,
+    UPNP_SVC_RENDERING_CONTROL,
+)
+from .coordinator import SamsungTVConfigEntry
+
+
+async def async_update_ssdp_locations(
+    hass: HomeAssistant, entry: SamsungTVConfigEntry
+) -> None:
+    """Update ssdp locations from discovery cache."""
+    updates = {}
+    for ssdp_st, key in (
+        (UPNP_SVC_RENDERING_CONTROL, CONF_SSDP_RENDERING_CONTROL_LOCATION),
+        (UPNP_SVC_MAIN_TV_AGENT, CONF_SSDP_MAIN_TV_AGENT_LOCATION),
+    ):
+        for discovery_info in await async_get_discovery_info_by_st(hass, ssdp_st):
+            location = discovery_info.ssdp_location
+            host = urlparse(location).hostname
+            if host == entry.data[CONF_HOST]:
+                updates[key] = location
+                break
+
+    if updates:
+        hass.config_entries.async_update_entry(entry, data={**entry.data, **updates})

--- a/tests/components/samsungtv/test_init.py
+++ b/tests/components/samsungtv/test_init.py
@@ -96,7 +96,7 @@ async def test_setup_updates_from_ssdp(hass: HomeAssistant) -> None:
         raise ValueError(f"Unknown st {mock_st}")
 
     with patch(
-        "homeassistant.components.samsungtv.ssdp.async_get_discovery_info_by_st",
+        "homeassistant.components.samsungtv.ssdp_discovery.async_get_discovery_info_by_st",
         _mock_async_get_discovery_info_by_st,
     ):
         await hass.config_entries.async_setup(entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The SamsungTV integration's `__init__.py` currently mixes setup logic with helpers and SSDP location management. This PR moves `DebouncedEntryReloader` to `helpers.py` and `_async_update_ssdp_locations` to a new `ssdp_discovery.py` module, keeping `__init__.py` focused on entry setup, migration, and bridge creation.
 
This is step 1 of the refactoring plan discussed in [home-assistant/discussions#4264](https://github.com/orgs/home-assistant/discussions/4264) (SamsungTV integration refactoring — Gold to Platinum).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
