### PR TITLE
Fix Teslemetry insufficient-credits polling storm

### DIFF
--- a/homeassistant/components/teslemetry/coordinator.py
+++ b/homeassistant/components/teslemetry/coordinator.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, override
 from tesla_fleet_api.const import TeslaEnergyPeriod, VehicleDataEndpoint
 from tesla_fleet_api.exceptions import (
     GatewayTimeout,
+    InsufficientCredits,
     InvalidResponse,
     InvalidToken,
     LoginRequired,
@@ -49,6 +50,10 @@ ENERGY_INFO_INTERVAL = timedelta(seconds=30)
 ENERGY_HISTORY_INTERVAL = timedelta(seconds=60)
 METADATA_INTERVAL = timedelta(hours=1)
 
+# Insufficient credits will not resolve itself quickly, so back off polling
+# instead of hammering the API at the coordinator's normal interval.
+INSUFFICIENT_CREDITS_RETRY_AFTER = timedelta(hours=1).total_seconds()
+
 ENDPOINTS = [
     VehicleDataEndpoint.CHARGE_STATE,
     VehicleDataEndpoint.CLIMATE_STATE,
@@ -87,6 +92,12 @@ class TeslemetryMetadataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             data = await self.teslemetry.metadata()
         except (InvalidToken, SubscriptionRequired, LoginRequired) as e:
             raise ConfigEntryAuthFailed from e
+        except InsufficientCredits as e:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="update_failed_insufficient_credits",
+                retry_after=INSUFFICIENT_CREDITS_RETRY_AFTER,
+            ) from e
         except RETRY_EXCEPTIONS as e:
             raise UpdateFailed(
                 translation_domain=DOMAIN,
@@ -139,6 +150,12 @@ class TeslemetryVehicleDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             data = (await self.api.vehicle_data(endpoints=ENDPOINTS))["response"]
         except (InvalidToken, SubscriptionRequired, LoginRequired) as e:
             raise ConfigEntryAuthFailed from e
+        except InsufficientCredits as e:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="update_failed_insufficient_credits",
+                retry_after=INSUFFICIENT_CREDITS_RETRY_AFTER,
+            ) from e
         except RETRY_EXCEPTIONS as e:
             raise UpdateFailed(
                 translation_domain=DOMAIN,
@@ -192,6 +209,12 @@ class TeslemetryEnergySiteLiveCoordinator(DataUpdateCoordinator[dict[str, Any]])
             data: dict[str, Any] = (await self.api.live_status())["response"]
         except (InvalidToken, SubscriptionRequired, LoginRequired) as e:
             raise ConfigEntryAuthFailed from e
+        except InsufficientCredits as e:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="update_failed_insufficient_credits",
+                retry_after=INSUFFICIENT_CREDITS_RETRY_AFTER,
+            ) from e
         except RETRY_EXCEPTIONS as e:
             raise UpdateFailed(
                 translation_domain=DOMAIN,
@@ -242,6 +265,12 @@ class TeslemetryEnergySiteInfoCoordinator(DataUpdateCoordinator[dict[str, Any]])
             data = (await self.api.site_info())["response"]
         except (InvalidToken, SubscriptionRequired, LoginRequired) as e:
             raise ConfigEntryAuthFailed from e
+        except InsufficientCredits as e:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="update_failed_insufficient_credits",
+                retry_after=INSUFFICIENT_CREDITS_RETRY_AFTER,
+            ) from e
         except RETRY_EXCEPTIONS as e:
             raise UpdateFailed(
                 translation_domain=DOMAIN,
@@ -291,6 +320,12 @@ class TeslemetryEnergyHistoryCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             data = (await self.api.energy_history(TeslaEnergyPeriod.DAY))["response"]
         except (InvalidToken, SubscriptionRequired, LoginRequired) as e:
             raise ConfigEntryAuthFailed from e
+        except InsufficientCredits as e:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="update_failed_insufficient_credits",
+                retry_after=INSUFFICIENT_CREDITS_RETRY_AFTER,
+            ) from e
         except RETRY_EXCEPTIONS as e:
             raise UpdateFailed(
                 translation_domain=DOMAIN,

--- a/homeassistant/components/teslemetry/coordinator.py
+++ b/homeassistant/components/teslemetry/coordinator.py
@@ -92,12 +92,6 @@ class TeslemetryMetadataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             data = await self.teslemetry.metadata()
         except (InvalidToken, SubscriptionRequired, LoginRequired) as e:
             raise ConfigEntryAuthFailed from e
-        except InsufficientCredits as e:
-            raise UpdateFailed(
-                translation_domain=DOMAIN,
-                translation_key="update_failed_insufficient_credits",
-                retry_after=INSUFFICIENT_CREDITS_RETRY_AFTER,
-            ) from e
         except RETRY_EXCEPTIONS as e:
             raise UpdateFailed(
                 translation_domain=DOMAIN,
@@ -209,12 +203,6 @@ class TeslemetryEnergySiteLiveCoordinator(DataUpdateCoordinator[dict[str, Any]])
             data: dict[str, Any] = (await self.api.live_status())["response"]
         except (InvalidToken, SubscriptionRequired, LoginRequired) as e:
             raise ConfigEntryAuthFailed from e
-        except InsufficientCredits as e:
-            raise UpdateFailed(
-                translation_domain=DOMAIN,
-                translation_key="update_failed_insufficient_credits",
-                retry_after=INSUFFICIENT_CREDITS_RETRY_AFTER,
-            ) from e
         except RETRY_EXCEPTIONS as e:
             raise UpdateFailed(
                 translation_domain=DOMAIN,
@@ -265,12 +253,6 @@ class TeslemetryEnergySiteInfoCoordinator(DataUpdateCoordinator[dict[str, Any]])
             data = (await self.api.site_info())["response"]
         except (InvalidToken, SubscriptionRequired, LoginRequired) as e:
             raise ConfigEntryAuthFailed from e
-        except InsufficientCredits as e:
-            raise UpdateFailed(
-                translation_domain=DOMAIN,
-                translation_key="update_failed_insufficient_credits",
-                retry_after=INSUFFICIENT_CREDITS_RETRY_AFTER,
-            ) from e
         except RETRY_EXCEPTIONS as e:
             raise UpdateFailed(
                 translation_domain=DOMAIN,
@@ -320,12 +302,6 @@ class TeslemetryEnergyHistoryCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             data = (await self.api.energy_history(TeslaEnergyPeriod.DAY))["response"]
         except (InvalidToken, SubscriptionRequired, LoginRequired) as e:
             raise ConfigEntryAuthFailed from e
-        except InsufficientCredits as e:
-            raise UpdateFailed(
-                translation_domain=DOMAIN,
-                translation_key="update_failed_insufficient_credits",
-                retry_after=INSUFFICIENT_CREDITS_RETRY_AFTER,
-            ) from e
         except RETRY_EXCEPTIONS as e:
             raise UpdateFailed(
                 translation_domain=DOMAIN,

--- a/homeassistant/components/teslemetry/coordinator.py
+++ b/homeassistant/components/teslemetry/coordinator.py
@@ -50,7 +50,7 @@ ENERGY_INFO_INTERVAL = timedelta(seconds=30)
 ENERGY_HISTORY_INTERVAL = timedelta(seconds=60)
 METADATA_INTERVAL = timedelta(hours=1)
 
-# Insufficient credits will not resolve itself quickly, so back off polling
+# Insufficient credits will not resolve themselves quickly, so back off polling
 # instead of hammering the API at the coordinator's normal interval.
 INSUFFICIENT_CREDITS_RETRY_AFTER = timedelta(hours=1).total_seconds()
 

--- a/homeassistant/components/teslemetry/strings.json
+++ b/homeassistant/components/teslemetry/strings.json
@@ -1197,6 +1197,9 @@
     "update_failed": {
       "message": "Error fetching data from Teslemetry API: {message}"
     },
+    "update_failed_insufficient_credits": {
+      "message": "Teslemetry account has insufficient command credits, pausing updates until credits are added"
+    },
     "update_failed_invalid_data": {
       "message": "Received invalid data from API"
     },

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -62,8 +62,12 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 ERRORS = [
     (InvalidToken, ConfigEntryState.SETUP_ERROR),
     (SubscriptionRequired, ConfigEntryState.SETUP_ERROR),
-    (InsufficientCredits, ConfigEntryState.SETUP_RETRY),
     (TeslaFleetError, ConfigEntryState.SETUP_RETRY),
+]
+
+VEHICLE_ERRORS = [
+    *ERRORS,
+    (InsufficientCredits, ConfigEntryState.SETUP_RETRY),
 ]
 
 
@@ -105,7 +109,7 @@ async def test_devices(
         assert device == snapshot(name=f"{device.identifiers}")
 
 
-@pytest.mark.parametrize(("side_effect", "state"), ERRORS)
+@pytest.mark.parametrize(("side_effect", "state"), VEHICLE_ERRORS)
 async def test_vehicle_refresh_error(
     hass: HomeAssistant,
     mock_vehicle_data: AsyncMock,
@@ -143,20 +147,6 @@ async def test_energy_site_refresh_error(
 ) -> None:
     """Test coordinator refresh with an error."""
     mock_site_info.side_effect = side_effect
-    entry = await setup_platform(hass)
-    assert entry.state is state
-
-
-# Test Metadata Coordinator
-@pytest.mark.parametrize(("side_effect", "state"), ERRORS)
-async def test_metadata_refresh_error(
-    hass: HomeAssistant,
-    mock_metadata: AsyncMock,
-    side_effect: TeslaFleetError,
-    state: ConfigEntryState,
-) -> None:
-    """Test coordinator refresh with an error."""
-    mock_metadata.side_effect = side_effect
     entry = await setup_platform(hass)
     assert entry.state is state
 
@@ -913,7 +903,6 @@ async def test_live_status_coordinator_refresh_error(
     "side_effect",
     [
         [InvalidToken],
-        [InsufficientCredits],
         [TeslaFleetError],
         [ENERGY_HISTORY, {"response": {}}],
     ],
@@ -1020,33 +1009,32 @@ async def test_dynamic_device_discovery_no_reload_without_changes(
 async def test_insufficient_credits_backs_off_polling(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
-    mock_live_status: AsyncMock,
+    mock_vehicle_data: AsyncMock,
+    mock_legacy: AsyncMock,
 ) -> None:
-    """Running out of credits should back off, not hammer the API every poll."""
+    """Running out of command credits should back off, not hammer the API every poll."""
     call_count = 0
 
-    def live_status_side_effect():
+    def vehicle_data_side_effect(**kwargs):
         nonlocal call_count
         call_count += 1
         if call_count == 1:
-            return deepcopy(LIVE_STATUS)
+            return deepcopy(VEHICLE_DATA)
         raise InsufficientCredits
 
-    mock_live_status.side_effect = live_status_side_effect
+    mock_vehicle_data.side_effect = vehicle_data_side_effect
 
     entry = await setup_platform(hass)
     assert entry.state is ConfigEntryState.LOADED
     assert call_count == 1
 
-    freezer.tick(ENERGY_LIVE_INTERVAL)
+    freezer.tick(VEHICLE_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
     assert call_count == 2
     assert entry.state is ConfigEntryState.LOADED
 
-    live_coordinator = entry.runtime_data.energysites[0].live_coordinator
-    assert isinstance(live_coordinator.last_exception, UpdateFailed)
-    assert (
-        live_coordinator.last_exception.retry_after == INSUFFICIENT_CREDITS_RETRY_AFTER
-    )
+    coordinator = entry.runtime_data.vehicles[0].coordinator
+    assert isinstance(coordinator.last_exception, UpdateFailed)
+    assert coordinator.last_exception.retry_after == INSUFFICIENT_CREDITS_RETRY_AFTER

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -10,6 +10,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 from tesla_fleet_api.exceptions import (
     Forbidden,
+    InsufficientCredits,
     InvalidResponse,
     InvalidToken,
     RateLimited,
@@ -24,6 +25,7 @@ from homeassistant.components.teslemetry.coordinator import (
     ENERGY_HISTORY_INTERVAL,
     ENERGY_INFO_INTERVAL,
     ENERGY_LIVE_INTERVAL,
+    INSUFFICIENT_CREDITS_RETRY_AFTER,
     METADATA_INTERVAL,
     VEHICLE_INTERVAL,
 )
@@ -38,6 +40,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from . import setup_platform
 from .const import (
@@ -59,6 +62,7 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 ERRORS = [
     (InvalidToken, ConfigEntryState.SETUP_ERROR),
     (SubscriptionRequired, ConfigEntryState.SETUP_ERROR),
+    (InsufficientCredits, ConfigEntryState.SETUP_RETRY),
     (TeslaFleetError, ConfigEntryState.SETUP_RETRY),
 ]
 
@@ -139,6 +143,20 @@ async def test_energy_site_refresh_error(
 ) -> None:
     """Test coordinator refresh with an error."""
     mock_site_info.side_effect = side_effect
+    entry = await setup_platform(hass)
+    assert entry.state is state
+
+
+# Test Metadata Coordinator
+@pytest.mark.parametrize(("side_effect", "state"), ERRORS)
+async def test_metadata_refresh_error(
+    hass: HomeAssistant,
+    mock_metadata: AsyncMock,
+    side_effect: TeslaFleetError,
+    state: ConfigEntryState,
+) -> None:
+    """Test coordinator refresh with an error."""
+    mock_metadata.side_effect = side_effect
     entry = await setup_platform(hass)
     assert entry.state is state
 
@@ -895,6 +913,7 @@ async def test_live_status_coordinator_refresh_error(
     "side_effect",
     [
         [InvalidToken],
+        [InsufficientCredits],
         [TeslaFleetError],
         [ENERGY_HISTORY, {"response": {}}],
     ],
@@ -996,3 +1015,38 @@ async def test_dynamic_device_discovery_no_reload_without_changes(
 
     # Verify reload was NOT triggered since no subscription changes
     mock_reload.assert_not_called()
+
+
+async def test_insufficient_credits_backs_off_polling(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_live_status: AsyncMock,
+) -> None:
+    """Running out of credits should back off, not hammer the API every poll."""
+    call_count = 0
+
+    def live_status_side_effect():
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return deepcopy(LIVE_STATUS)
+        raise InsufficientCredits
+
+    mock_live_status.side_effect = live_status_side_effect
+
+    entry = await setup_platform(hass)
+    assert entry.state is ConfigEntryState.LOADED
+    assert call_count == 1
+
+    freezer.tick(ENERGY_LIVE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert call_count == 2
+    assert entry.state is ConfigEntryState.LOADED
+
+    live_coordinator = entry.runtime_data.energysites[0].live_coordinator
+    assert isinstance(live_coordinator.last_exception, UpdateFailed)
+    assert (
+        live_coordinator.last_exception.retry_after == INSUFFICIENT_CREDITS_RETRY_AFTER
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Teslemetry API only returns `InsufficientCredits` (a 402 response) on the vehicle_data refresh for customers who have intentionally enabled a polling-only entity. This change prevents the coordinator from hammering the API when the users account isn't able to service the request due to the lack of paid credits. Downgraded from breakfix to code quality as it only really impacts the Teslemetry upstream.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
