### PR TITLE
samsungtv: Restore supported features from cache when TV is off during startup

### DIFF
--- a/homeassistant/components/samsungtv/entity.py
+++ b/homeassistant/components/samsungtv/entity.py
@@ -15,6 +15,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, issue_registry as ir
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.trigger import PluggableAction
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -25,7 +26,9 @@ from .triggers.turn_on import async_get_turn_on_trigger
 DEPRECATED_IMPLICIT_WAKE_ON_LAN = "deprecated_implicit_wake_on_lan_{}"
 
 
-class SamsungTVEntity(CoordinatorEntity[SamsungTVDataUpdateCoordinator], Entity):
+class SamsungTVEntity(
+    CoordinatorEntity[SamsungTVDataUpdateCoordinator], RestoreEntity, Entity
+):
     """Defines a base SamsungTV entity."""
 
     _attr_has_entity_name = True

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -26,6 +26,7 @@ from homeassistant.components.media_player import (
     MediaPlayerState,
     MediaType,
 )
+from homeassistant.const import ATTR_SUPPORTED_FEATURES
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
@@ -139,6 +140,13 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             self._update_from_upnp()
         else:
             self._attr_state = MediaPlayerState.OFF
+            if (state := await self.async_get_last_state()) is not None:
+                self._attr_supported_features |= (
+                    state.attributes.get(
+                        ATTR_SUPPORTED_FEATURES, MediaPlayerEntityFeature(0)
+                    )
+                    & ~MediaPlayerEntityFeature.TURN_ON
+                )
 
     @override
     async def async_will_remove_from_hass(self) -> None:

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -35,6 +35,7 @@ from homeassistant.components.media_player import (
     SERVICE_PLAY_MEDIA,
     SERVICE_SELECT_SOURCE,
     MediaPlayerDeviceClass,
+    MediaPlayerEntityFeature,
     MediaType,
 )
 from homeassistant.components.samsungtv.const import (
@@ -75,7 +76,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, State
 from homeassistant.exceptions import HomeAssistantError, ServiceNotSupported
 from homeassistant.setup import async_setup_component
 
@@ -91,6 +92,7 @@ from tests.common import (
     MockConfigEntry,
     async_fire_time_changed,
     async_load_json_object_fixture,
+    mock_restore_cache,
 )
 
 ENTITY_ID = f"{MP_DOMAIN}.mock_title"
@@ -1501,3 +1503,38 @@ async def test_upnp_failed_re_subscribe_events(
     state = hass.states.get(ENTITY_ID)
     assert state.state == STATE_ON
     assert "Device rejected re-subscription" in caplog.text
+
+
+@pytest.mark.usefixtures("remote_websocket", "rest_api")
+async def test_restore_supported_features_cached(
+    hass: HomeAssistant,
+    remote_websocket: Mock,
+) -> None:
+    """Test supported_features is restored from cache on cold start.
+
+    When the TV is off during startup, the entity should restore any
+    previously-known features (except TURN_ON) from the last state.
+    """
+    remote_websocket.is_alive.return_value = False
+
+    mock_restore_cache(
+        hass,
+        [
+            State(
+                ENTITY_ID,
+                STATE_OFF,
+                attributes={
+                    ATTR_SUPPORTED_FEATURES: (
+                        SUPPORT_SAMSUNGTV | MediaPlayerEntityFeature.VOLUME_SET
+                    ),
+                },
+            )
+        ],
+    )
+    await setup_samsungtv_entry(hass, MOCK_CONFIGWS)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state
+    assert state.state == STATE_OFF
+    supported = state.attributes[ATTR_SUPPORTED_FEATURES]
+    assert supported & MediaPlayerEntityFeature.VOLUME_SET


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When the Samsung TV is off during a Home Assistant restart, the media_player entity cannot reach the TV to discover dynamic supported features such as `VOLUME_SET` (from DMR/UPnP). This causes the entity to lose those features until the TV is turned on again.
 
This PR adds `RestoreEntity` as a mixin to `SamsungTVEntity` and restores cached `supported_features` (excluding `TURN_ON`) when the TV is offline during startup. `TURN_ON` is excluded because it depends on runtime state (configured triggers / WOL MAC) that is re-evaluated by the `supported_features` property.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is part of a series to improve the samsungtv integration towards Platinum quality scale ([home-assistant/discussions#4264](https://github.com/orgs/home-assistant/discussions/4264)).


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
