### PR TITLE
samsungtv: Extract UPnP/DMR lifecycle from `media_player.py` into dedicated module

### DIFF
--- a/homeassistant/components/samsungtv/dmr.py
+++ b/homeassistant/components/samsungtv/dmr.py
@@ -1,0 +1,155 @@
+"""Samsung TV DMR/UPnP device handling."""
+
+from collections.abc import Callable, Sequence
+
+from async_upnp_client.aiohttp import AiohttpNotifyServer, AiohttpSessionRequester
+from async_upnp_client.client import UpnpService, UpnpStateVariable
+from async_upnp_client.client_factory import UpnpFactory
+from async_upnp_client.exceptions import (
+    UpnpActionResponseError,
+    UpnpCommunicationError,
+    UpnpConnectionError,
+    UpnpError,
+    UpnpResponseError,
+    UpnpXmlContentError,
+)
+from async_upnp_client.profiles.dlna import DmrDevice
+from async_upnp_client.utils import async_get_local_ip
+
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .const import DOMAIN, LOGGER
+
+
+class SamsungTVDmrDevice:
+    """Wrapper for the UPnP/DMR device lifecycle."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        ssdp_rendering_control_location: str,
+        host: str | None,
+        on_event_callback: Callable[[], None],
+    ) -> None:
+        """Initialize the DMR device wrapper."""
+        self._hass = hass
+        self._ssdp_rendering_control_location = ssdp_rendering_control_location
+        self._host = host
+        self._on_event_callback = on_event_callback
+        self._dmr_device: DmrDevice | None = None
+        self._upnp_server: AiohttpNotifyServer | None = None
+
+    @property
+    def device(self) -> DmrDevice | None:
+        """The DmrDevice instance, if started."""
+        return self._dmr_device
+
+    @property
+    def is_subscribed(self) -> bool:
+        """Whether the DMR device is subscribed to events."""
+        return self._dmr_device is not None and self._dmr_device.is_subscribed
+
+    @property
+    def volume_level(self) -> float | None:
+        """Current volume level from the DMR device."""
+        if self._dmr_device is None:
+            return None
+        return self._dmr_device.volume_level
+
+    @property
+    def is_volume_muted(self) -> bool | None:
+        """Whether volume is muted, from the DMR device."""
+        if self._dmr_device is None:
+            return None
+        return self._dmr_device.is_volume_muted
+
+    async def async_startup(self) -> None:
+        """Create the UPnP device, start the notify server and subscribe to events."""
+        assert self._ssdp_rendering_control_location is not None
+        if self._dmr_device is None:
+            session = async_get_clientsession(self._hass)
+            upnp_requester = AiohttpSessionRequester(session)
+            upnp_factory = UpnpFactory(upnp_requester, non_strict=True)
+            try:
+                upnp_device = await upnp_factory.async_create_device(
+                    self._ssdp_rendering_control_location
+                )
+            except (UpnpConnectionError, UpnpResponseError, UpnpXmlContentError) as err:
+                LOGGER.debug("Unable to create Upnp DMR device: %r", err, exc_info=True)
+                return
+            _, event_ip = await async_get_local_ip(
+                self._ssdp_rendering_control_location, self._hass.loop
+            )
+            source = (event_ip or "0.0.0.0", 0)
+            self._upnp_server = AiohttpNotifyServer(
+                requester=upnp_requester,
+                source=source,
+                callback_url=None,
+                loop=self._hass.loop,
+            )
+            await self._upnp_server.async_start_server()
+            self._dmr_device = DmrDevice(upnp_device, self._upnp_server.event_handler)
+            try:
+                self._dmr_device.on_event = self._on_upnp_event
+                await self._dmr_device.async_subscribe_services(auto_resubscribe=True)
+            except UpnpResponseError as err:
+                LOGGER.debug("Device rejected subscription: %r", err)
+            except UpnpError as err:
+                self._dmr_device.on_event = None
+                self._dmr_device = None
+                await self._upnp_server.async_stop_server()
+                self._upnp_server = None
+                LOGGER.debug("Error while subscribing during device connect: %r", err)
+                raise
+
+    async def async_resubscribe(self) -> None:
+        """Re-subscribe to DMR events."""
+        assert self._dmr_device
+        try:
+            await self._dmr_device.async_subscribe_services(auto_resubscribe=True)
+        except UpnpCommunicationError as err:
+            LOGGER.debug("Device rejected re-subscription: %r", err, exc_info=True)
+
+    async def async_unsubscribe(self) -> None:
+        """Unsubscribe from DMR events (TV turned off)."""
+        if self._dmr_device is not None and self._dmr_device.is_subscribed:
+            await self._dmr_device.async_unsubscribe_services()
+
+    async def async_shutdown(self) -> None:
+        """Shut down the DMR device and stop the UPnP server."""
+        if (dmr_device := self._dmr_device) is not None:
+            self._dmr_device = None
+            dmr_device.on_event = None
+            await dmr_device.async_unsubscribe_services()
+        if (upnp_server := self._upnp_server) is not None:
+            self._upnp_server = None
+            await upnp_server.async_stop_server()
+
+    async def async_set_volume_level(self, volume: float) -> None:
+        """Set volume level via DMR."""
+        if self._dmr_device is None:
+            LOGGER.warning("Upnp services are not available on %s", self._host)
+            return
+        assert self._host
+        try:
+            await self._dmr_device.async_set_volume_level(volume)
+        except UpnpActionResponseError as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="error_set_volume",
+                translation_placeholders={
+                    "error": repr(err),
+                    "host": self._host,
+                },
+            ) from err
+
+    @callback
+    def _on_upnp_event(
+        self,
+        service: UpnpService,
+        state_variables: Sequence[UpnpStateVariable],
+    ) -> None:
+        """State variable(s) changed, notify entity."""
+        self._on_event_callback()

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -1,22 +1,8 @@
 """Support for interface with an Samsung TV."""
 
 import asyncio
-from collections.abc import Sequence
 from typing import Any, override
 
-from async_upnp_client.aiohttp import AiohttpNotifyServer, AiohttpSessionRequester
-from async_upnp_client.client import UpnpDevice, UpnpService, UpnpStateVariable
-from async_upnp_client.client_factory import UpnpFactory
-from async_upnp_client.exceptions import (
-    UpnpActionResponseError,
-    UpnpCommunicationError,
-    UpnpConnectionError,
-    UpnpError,
-    UpnpResponseError,
-    UpnpXmlContentError,
-)
-from async_upnp_client.profiles.dlna import DmrDevice
-from async_upnp_client.utils import async_get_local_ip
 import voluptuous as vol
 
 from homeassistant.components.media_player import (
@@ -29,13 +15,13 @@ from homeassistant.components.media_player import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util.async_ import create_eager_task
 
 from .bridge import SamsungTVWSBridge
 from .const import CONF_SSDP_RENDERING_CONTROL_LOCATION, DOMAIN, LOGGER
 from .coordinator import SamsungTVConfigEntry, SamsungTVDataUpdateCoordinator
+from .dmr import SamsungTVDmrDevice
 from .entity import SamsungTVEntity
 
 SOURCES = {"TV": "KEY_TV", "HDMI": "KEY_HDMI"}
@@ -101,8 +87,7 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         if self._ssdp_rendering_control_location:
             self._attr_supported_features |= MediaPlayerEntityFeature.VOLUME_SET
 
-        self._dmr_device: DmrDevice | None = None
-        self._upnp_server: AiohttpNotifyServer | None = None
+        self._dmr: SamsungTVDmrDevice | None = None
 
     @property
     @override
@@ -144,7 +129,8 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
     async def async_will_remove_from_hass(self) -> None:
         """Handle removal."""
         self.coordinator.async_extra_update = None
-        await self._async_shutdown_dmr()
+        if self._dmr:
+            await self._dmr.async_shutdown()
 
     @callback
     @override
@@ -160,8 +146,8 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
     async def _async_extra_update(self) -> None:
         """Update state of device."""
         if not self.coordinator.is_on:
-            if self._dmr_device and self._dmr_device.is_subscribed:
-                await self._dmr_device.async_unsubscribe_services()
+            if self._dmr and self._dmr.is_subscribed:
+                await self._dmr.async_unsubscribe()
             return
 
         startup_tasks: list[asyncio.Task[Any]] = []
@@ -169,10 +155,18 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         if not self._app_list_event.is_set():
             startup_tasks.append(create_eager_task(self._async_startup_app_list()))
 
-        if self._dmr_device and not self._dmr_device.is_subscribed:
-            startup_tasks.append(create_eager_task(self._async_resubscribe_dmr()))
-        if not self._dmr_device and self._ssdp_rendering_control_location:
-            startup_tasks.append(create_eager_task(self._async_startup_dmr()))
+        if not self._dmr and self._ssdp_rendering_control_location:
+            self._dmr = SamsungTVDmrDevice(
+                hass=self.hass,
+                ssdp_rendering_control_location=self._ssdp_rendering_control_location,
+                host=self._host,
+                on_event_callback=self._on_dmr_event_callback,
+            )
+        if self._dmr:
+            if self._dmr.device and not self._dmr.is_subscribed:
+                startup_tasks.append(create_eager_task(self._dmr.async_resubscribe()))
+            elif not self._dmr.device:
+                startup_tasks.append(create_eager_task(self._dmr.async_startup()))
 
         if startup_tasks:
             await asyncio.gather(*startup_tasks)
@@ -182,19 +176,19 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         # Upnp events can affect other attributes that we currently do not track
         # We want to avoid checking every attribute in 'async_write_ha_state' as we
         # currently only care about two attributes
-        if (dmr_device := self._dmr_device) is None:
+        if self._dmr is None:
             return False
 
         has_updates = False
 
         if (
-            volume_level := dmr_device.volume_level
+            volume_level := self._dmr.volume_level
         ) is not None and self._attr_volume_level != volume_level:
             self._attr_volume_level = volume_level
             has_updates = True
 
         if (
-            is_muted := dmr_device.is_volume_muted
+            is_muted := self._dmr.is_volume_muted
         ) is not None and self._attr_is_volume_muted != is_muted:
             self._attr_is_volume_muted = is_muted
             has_updates = True
@@ -215,75 +209,9 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             self._app_list_event.set()
             LOGGER.debug("Failed to load app list from %s: %r", self._host, err)
 
-    async def _async_startup_dmr(self) -> None:
-        assert self._ssdp_rendering_control_location is not None
-        if self._dmr_device is None:
-            session = async_get_clientsession(self.hass)
-            upnp_requester = AiohttpSessionRequester(session)
-            # Set non_strict to avoid invalid data sent by Samsung TV:
-            # Got invalid value for <UpnpStateVariable(PlaybackStorageMedium, string)>:
-            # NETWORK,NONE
-            upnp_factory = UpnpFactory(upnp_requester, non_strict=True)
-            upnp_device: UpnpDevice | None = None
-            try:
-                upnp_device = await upnp_factory.async_create_device(
-                    self._ssdp_rendering_control_location
-                )
-            except (UpnpConnectionError, UpnpResponseError, UpnpXmlContentError) as err:
-                LOGGER.debug("Unable to create Upnp DMR device: %r", err, exc_info=True)
-                return
-            _, event_ip = await async_get_local_ip(
-                self._ssdp_rendering_control_location, self.hass.loop
-            )
-            source = (event_ip or "0.0.0.0", 0)
-            self._upnp_server = AiohttpNotifyServer(
-                requester=upnp_requester,
-                source=source,
-                callback_url=None,
-                loop=self.hass.loop,
-            )
-            await self._upnp_server.async_start_server()
-            self._dmr_device = DmrDevice(upnp_device, self._upnp_server.event_handler)
-
-            try:
-                self._dmr_device.on_event = self._on_upnp_event
-                await self._dmr_device.async_subscribe_services(auto_resubscribe=True)
-            except UpnpResponseError as err:
-                # Device rejected subscription request. This is OK, variables
-                # will be polled instead.
-                LOGGER.debug("Device rejected subscription: %r", err)
-            except UpnpError as err:
-                # Don't leave the device half-constructed
-                self._dmr_device.on_event = None
-                self._dmr_device = None
-                await self._upnp_server.async_stop_server()
-                self._upnp_server = None
-                LOGGER.debug("Error while subscribing during device connect: %r", err)
-                raise
-
-    async def _async_resubscribe_dmr(self) -> None:
-        assert self._dmr_device
-        try:
-            await self._dmr_device.async_subscribe_services(auto_resubscribe=True)
-        except UpnpCommunicationError as err:
-            LOGGER.debug("Device rejected re-subscription: %r", err, exc_info=True)
-
-    async def _async_shutdown_dmr(self) -> None:
-        """Handle removal."""
-        if (dmr_device := self._dmr_device) is not None:
-            self._dmr_device = None
-            dmr_device.on_event = None
-            await dmr_device.async_unsubscribe_services()
-
-        if (upnp_server := self._upnp_server) is not None:
-            self._upnp_server = None
-            await upnp_server.async_stop_server()
-
-    def _on_upnp_event(
-        self, service: UpnpService, state_variables: Sequence[UpnpStateVariable]
-    ) -> None:
-        """State variable(s) changed, let home-assistant know."""
-        # Ensure the entity has been added to hass to avoid race condition
+    @callback
+    def _on_dmr_event_callback(self) -> None:
+        """Handle UPnP state variable changes from DMR device."""
         if self._update_from_upnp() and self.entity_id:
             self.async_write_ha_state()
 
@@ -306,18 +234,10 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
     @override
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume level on the media player."""
-        if (dmr_device := self._dmr_device) is None:
+        if self._dmr is None:
             LOGGER.warning("Upnp services are not available on %s", self._host)
             return
-        try:
-            await dmr_device.async_set_volume_level(volume)
-        except UpnpActionResponseError as err:
-            assert self._host
-            raise HomeAssistantError(
-                translation_domain=DOMAIN,
-                translation_key="error_set_volume",
-                translation_placeholders={"error": repr(err), "host": self._host},
-            ) from err
+        await self._dmr.async_set_volume_level(volume)
 
     @override
     async def async_volume_up(self) -> None:

--- a/tests/components/samsungtv/conftest.py
+++ b/tests/components/samsungtv/conftest.py
@@ -55,7 +55,7 @@ def silent_ssdp_scanner() -> Generator[None]:
 def samsungtv_mock_async_get_local_ip() -> Generator[None]:
     """Mock upnp util's async_get_local_ip."""
     with patch(
-        "homeassistant.components.samsungtv.media_player.async_get_local_ip",
+        "homeassistant.components.samsungtv.dmr.async_get_local_ip",
         return_value=(AddressFamily.AF_INET, "10.10.10.10"),
     ):
         yield
@@ -82,7 +82,7 @@ def app_list_delay_fixture() -> Generator[None]:
 def upnp_factory_fixture() -> Generator[Mock]:
     """Patch UpnpFactory."""
     with patch(
-        "homeassistant.components.samsungtv.media_player.UpnpFactory",
+        "homeassistant.components.samsungtv.dmr.UpnpFactory",
         autospec=True,
     ) as upnp_factory_class:
         upnp_factory: Mock = upnp_factory_class.return_value
@@ -104,7 +104,7 @@ def upnp_device_fixture(upnp_factory: Mock) -> Mock:
 def dmr_device_fixture(upnp_device: Mock) -> Generator[Mock]:
     """Patch async_upnp_client."""
     with patch(
-        "homeassistant.components.samsungtv.media_player.DmrDevice",
+        "homeassistant.components.samsungtv.dmr.DmrDevice",
         autospec=True,
     ) as dmr_device_class:
         dmr_device: Mock = dmr_device_class.return_value
@@ -139,7 +139,7 @@ def dmr_device_fixture(upnp_device: Mock) -> Generator[Mock]:
 def upnp_notify_server_fixture(upnp_factory: Mock) -> Generator[Mock]:
     """Patch async_upnp_client."""
     with patch(
-        "homeassistant.components.samsungtv.media_player.AiohttpNotifyServer",
+        "homeassistant.components.samsungtv.dmr.AiohttpNotifyServer",
         autospec=True,
     ) as notify_server_class:
         notify_server: Mock = notify_server_class.return_value


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Extract the UPnP/DMR lifecycle (startup, subscribe, resubscribe, unsubscribe, shutdown, event handling, and volume setting) from `media_player.py` into a new `dmr.py` module with a dedicated `SamsungTVDmrDevice` class.
 
This is point 2 of the refactoring plan tracked in discussion [home-assistant/discussions#4264](https://github.com/orgs/home-assistant/discussions/4264) (SamsungTV integration refactoring — Gold to Platinum).

### Changes
 
**New file: `homeassistant/components/samsungtv/dmr.py`**
- `SamsungTVDmrDevice` class that wraps `DmrDevice`, `UpnpFactory`, and `AiohttpNotifyServer`
- Properties: `device`, `is_subscribed`, `volume_level`, `is_volume_muted`
- Methods: `async_startup`, `async_resubscribe`, `async_unsubscribe`, `async_shutdown`, `async_set_volume_level`

**Modified: `homeassistant/components/samsungtv/media_player.py`**
- Removed all `async_upnp_client` imports (moved to `dmr.py`)
- Removed `async_get_clientsession` import (moved to `dmr.py`)
- Removed methods: `_async_startup_dmr`, `_async_resubscribe_dmr`, `_async_shutdown_dmr`, `_on_upnp_event`
- Added `from .dmr import SamsungTVDmrDevice`
- Replaced `self._dmr_device` / `self._upnp_server` with `self._dmr`
- Delegates DMR operations to `self._dmr.*`
- Added `_on_dmr_event_callback` method

**Modified: `tests/components/samsungtv/conftest.py`**
- Updated 4 patch paths from `media_player.UpnpFactory`, `media_player.DmrDevice`, `media_player.AiohttpNotifyServer`, `media_player.async_get_local_ip` to the `dmr.` prefix

### Behaviour preserved

- The DMR device is still created lazily on first `_async_extra_update` call (not in `__init__`)
- All subscription/unsubscription lifecycle events remain identical
- Volume setting still delegates to the mock DMR device


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is part of a series to improve the samsungtv integration towards Platinum quality scale (discussion [home-assistant/discussions#4264](https://github.com/orgs/home-assistant/discussions/4264)).
- This is point 2 of the refactoring plan: extract UPnP/DMR lifecycle from `media_player.py` into a dedicated module.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
