### PR TITLE
Add decorator for centralized media player command error handling in SamsungTV

### DIFF
--- a/homeassistant/components/samsungtv/decorators.py
+++ b/homeassistant/components/samsungtv/decorators.py
@@ -1,0 +1,48 @@
+"""Decorators for samsungtv media player commands."""
+
+import asyncio
+from collections.abc import Callable, Coroutine
+from functools import wraps
+from typing import Any, TypeVar, cast
+
+from homeassistant.exceptions import HomeAssistantError
+
+from .const import DOMAIN, LOGGER
+
+_CoroT = TypeVar("_CoroT", bound=Callable[..., Coroutine[Any, Any, Any]])
+
+
+def cmd(
+    func: _CoroT,
+) -> _CoroT:
+    """Decorate a media player command with centralized error handling.
+
+    Catches unexpected exceptions raised during command execution, logs them,
+    and raises a HomeAssistantError with a translation key.
+    HomeAssistantError and CancelledError are re-raised unchanged.
+    """
+
+    @wraps(func)
+    async def wrapper(*args: Any, **kwargs: Any) -> Any:
+        try:
+            return await func(*args, **kwargs)
+        except HomeAssistantError, asyncio.CancelledError:
+            raise
+        except Exception as err:
+            entity_id = args[0].entity_id if args else ""
+            LOGGER.exception(
+                "Error executing %s on %s",
+                func.__name__,
+                entity_id,
+            )
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="command_error",
+                translation_placeholders={
+                    "entity": entity_id,
+                    "command": func.__name__,
+                    "error": repr(err),
+                },
+            ) from err
+
+    return cast(_CoroT, wrapper)

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -36,6 +36,7 @@ from homeassistant.util.async_ import create_eager_task
 from .bridge import SamsungTVWSBridge
 from .const import CONF_SSDP_RENDERING_CONTROL_LOCATION, DOMAIN, LOGGER
 from .coordinator import SamsungTVConfigEntry, SamsungTVDataUpdateCoordinator
+from .decorators import cmd
 from .entity import SamsungTVEntity
 
 SOURCES = {"TV": "KEY_TV", "HDMI": "KEY_HDMI"}
@@ -303,6 +304,7 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             return
         await self._bridge.async_send_keys(keys)
 
+    @cmd
     @override
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume level on the media player."""
@@ -319,21 +321,25 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
                 translation_placeholders={"error": repr(err), "host": self._host},
             ) from err
 
+    @cmd
     @override
     async def async_volume_up(self) -> None:
         """Volume up the media player."""
         await self._async_send_keys(["KEY_VOLUP"])
 
+    @cmd
     @override
     async def async_volume_down(self) -> None:
         """Volume down media player."""
         await self._async_send_keys(["KEY_VOLDOWN"])
 
+    @cmd
     @override
     async def async_mute_volume(self, mute: bool) -> None:
         """Send mute command."""
         await self._async_send_keys(["KEY_MUTE"])
 
+    @cmd
     @override
     async def async_media_play_pause(self) -> None:
         """Simulate play pause media player."""
@@ -342,28 +348,33 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
         else:
             await self.async_media_play()
 
+    @cmd
     @override
     async def async_media_play(self) -> None:
         """Send play command."""
         self._playing = True
         await self._async_send_keys(["KEY_PLAY"])
 
+    @cmd
     @override
     async def async_media_pause(self) -> None:
         """Send media pause command to media player."""
         self._playing = False
         await self._async_send_keys(["KEY_PAUSE"])
 
+    @cmd
     @override
     async def async_media_next_track(self) -> None:
         """Send next track command."""
         await self._async_send_keys(["KEY_CHUP"])
 
+    @cmd
     @override
     async def async_media_previous_track(self) -> None:
         """Send the previous track command."""
         await self._async_send_keys(["KEY_CHDOWN"])
 
+    @cmd
     @override
     async def async_play_media(
         self, media_type: MediaType | str, media_id: str, **kwargs: Any
@@ -391,6 +402,7 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
             keys=[f"KEY_{digit}" for digit in media_id] + ["KEY_ENTER"]
         )
 
+    @cmd
     @override
     async def async_select_source(self, source: str) -> None:
         """Select input source."""

--- a/homeassistant/components/samsungtv/strings.json
+++ b/homeassistant/components/samsungtv/strings.json
@@ -72,6 +72,9 @@
     }
   },
   "exceptions": {
+    "command_error": {
+      "message": "Error executing {command} on {entity}: {error}"
+    },
     "encrypted_mode_auth_failed": {
       "message": "Token and session ID are required in encrypted mode."
     },

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -612,6 +612,44 @@ async def test_send_key_unhandled_response(
     assert state.state == STATE_ON
 
 
+@pytest.mark.parametrize(
+    ("side_effect", "expected_translation_key"),
+    [
+        pytest.param(
+            RuntimeError("Unexpected error"),
+            "command_error",
+            id="unexpected_error",
+        ),
+        pytest.param(
+            HomeAssistantError(
+                "Already handled",
+                translation_domain=DOMAIN,
+                translation_key="error_sending_command",
+                translation_placeholders={"error": "test", "host": "127.0.0.1"},
+            ),
+            "error_sending_command",
+            id="passthrough_homeassistant_error",
+        ),
+    ],
+)
+async def test_cmd_decorator_error_handling(
+    hass: HomeAssistant,
+    remote_legacy: Mock,
+    side_effect: RuntimeError | HomeAssistantError,
+    expected_translation_key: str,
+) -> None:
+    """Test @cmd decorator error handling paths."""
+    await setup_samsungtv_entry(hass, ENTRYDATA_LEGACY)
+    remote_legacy.control = Mock(side_effect=side_effect)
+    with pytest.raises(HomeAssistantError) as err:
+        await hass.services.async_call(
+            MP_DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
+        )
+    assert err.value.translation_key == expected_translation_key
+    state = hass.states.get(ENTITY_ID)
+    assert state.state == STATE_ON
+
+
 @pytest.mark.usefixtures("rest_api")
 async def test_send_key_websocketexception(
     hass: HomeAssistant, remote_websocket: Mock


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Introduce a `@cmd` decorator that centralizes error handling for all media player commands in the samsungtv integration. Previously, error handling was inconsistent: `async_set_volume_level` and `async_play_media` had their own `try/except` blocks, while the remaining 9 command methods had no error handling at all, allowing unexpected exceptions to propagate unlogged.

This is point 3 of the refactoring plan tracked in discussion [home-assistant/discussions#4264](https://github.com/orgs/home-assistant/discussions/4264).

### Changes

**New file: `homeassistant/components/samsungtv/decorators.py`**
- `@cmd` decorator that wraps async command methods
- Re-raises `HomeAssistantError` and `CancelledError` unchanged
- Catches any other `Exception` with `LOGGER.exception` and raises `HomeAssistantError` with translation key `"command_error"`

**Modified: `homeassistant/components/samsungtv/media_player.py`**
- Added `from .decorators import cmd`
- Applied `@cmd` to all 11 async command methods:
  `async_set_volume_level`, `async_volume_up`, `async_volume_down`, `async_mute_volume`, `async_media_play_pause`, `async_media_play`,
  `async_media_pause`, `async_media_next_track`, `async_media_previous_track`, `async_play_media`, `async_select_source`

**Modified: `homeassistant/components/samsungtv/strings.json`**
- Added `"command_error"` exception translation key

**Modified: `homeassistant/components/samsungtv/translations/en.json`**
- Regenerated from `strings.json` via `script/translations develop`


### Behaviour preserved

- Existing specific error handling (`error_set_volume`, `media_id_invalid`, `source_unsupported`) is preserved since those raise `HomeAssistantError`, which passes through the decorator unchanged
- Transport-level exceptions (`WebSocketException`, `BrokenPipeError`, `ConnectionClosedError`) are still caught inside the bridge and never reach the decorator


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is part of a series to improve the samsungtv integration towards Platinum quality scale (discussion [home-assistant/discussions#4264](https://github.com/orgs/home-assistant/discussions/4264)).
- This is point 3 of the refactoring plan: centralized error handling in media player commands.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
