### PR TITLE
Add TP-Link Omada controller entities

### DIFF
--- a/homeassistant/components/tplink_omada/__init__.py
+++ b/homeassistant/components/tplink_omada/__init__.py
@@ -1,6 +1,7 @@
 """The TP-Link Omada integration."""
 
 import logging
+from typing import cast
 
 from tplink_omada_client import OmadaSite
 from tplink_omada_client.devices import OmadaListDevice
@@ -125,7 +126,7 @@ def _config_entry_matches_controller(
     controller_id: str,
 ) -> bool:
     if (runtime_data := getattr(entry, "runtime_data", None)) is not None:
-        return runtime_data.controller_id == controller_id
+        return cast(OmadaSiteController, runtime_data).controller_id == controller_id
     return entry.unique_id is not None and entry.unique_id.startswith(
         f"{controller_id}_"
     )

--- a/homeassistant/components/tplink_omada/__init__.py
+++ b/homeassistant/components/tplink_omada/__init__.py
@@ -11,7 +11,7 @@ from tplink_omada_client.exceptions import (
     UnsupportedControllerVersion,
 )
 
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
@@ -36,6 +36,11 @@ PLATFORMS: list[Platform] = [
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 type OmadaConfigEntry = ConfigEntry[OmadaSiteController]
+
+_CONTROLLER_OWNER_STATES = {
+    ConfigEntryState.LOADED,
+    ConfigEntryState.SETUP_IN_PROGRESS,
+}
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -75,7 +80,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmadaConfigEntry) -> boo
 
     entry.runtime_data = controller
 
-    _register_controller_device(hass, entry)
+    if config_entry_owns_controller_entities(hass, entry):
+        _register_controller_device(hass, entry)
 
     _remove_old_devices(hass, entry, controller.devices_coordinator.data)
 
@@ -87,6 +93,42 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmadaConfigEntry) -> boo
 async def async_unload_entry(hass: HomeAssistant, entry: OmadaConfigEntry) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
+def config_entry_owns_controller_entities(
+    hass: HomeAssistant,
+    entry: OmadaConfigEntry,
+) -> bool:
+    """Return if this entry should own controller-level entities."""
+    controller_id = entry.runtime_data.controller_id
+    entries = [
+        config_entry
+        for config_entry in hass.config_entries.async_entries(DOMAIN)
+        if _config_entry_matches_controller(config_entry, controller_id)
+    ]
+    active_entries = [
+        config_entry
+        for config_entry in entries
+        if config_entry.state in _CONTROLLER_OWNER_STATES
+    ]
+
+    # Omada supports clustering internally, but the public Northbound API does
+    # not document how to determine the current Primary controller.
+    # Until a documented API is available, use a deterministic stable owner.
+    candidate_entries = active_entries or entries
+    owner = min(candidate_entries, key=lambda item: (item.created_at, item.entry_id))
+    return owner.entry_id == entry.entry_id
+
+
+def _config_entry_matches_controller(
+    entry: ConfigEntry,
+    controller_id: str,
+) -> bool:
+    if (runtime_data := getattr(entry, "runtime_data", None)) is not None:
+        return runtime_data.controller_id == controller_id
+    return entry.unique_id is not None and entry.unique_id.startswith(
+        f"{controller_id}_"
+    )
 
 
 def _register_controller_device(

--- a/homeassistant/components/tplink_omada/__init__.py
+++ b/homeassistant/components/tplink_omada/__init__.py
@@ -22,6 +22,7 @@ from homeassistant.helpers.typing import ConfigType
 from .config_flow import CONF_SITE, create_omada_client
 from .const import DOMAIN
 from .controller import OmadaSiteController
+from .entity import controller_model
 from .services import async_setup_services
 
 _LOGGER = logging.getLogger(__name__)
@@ -93,7 +94,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmadaConfigEntry) -> boo
 
 async def async_unload_entry(hass: HomeAssistant, entry: OmadaConfigEntry) -> bool:
     """Unload a config entry."""
-    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    controller_id = entry.runtime_data.controller_id
+    reload_owner = config_entry_owns_controller_entities(hass, entry)
+
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok and reload_owner:
+        _reload_controller_entities_owner(hass, entry, controller_id)
+
+    return unload_ok
 
 
 def config_entry_owns_controller_entities(
@@ -101,24 +109,53 @@ def config_entry_owns_controller_entities(
     entry: OmadaConfigEntry,
 ) -> bool:
     """Return if this entry should own controller-level entities."""
-    controller_id = entry.runtime_data.controller_id
+    owner = _controller_entities_owner(hass, entry.runtime_data.controller_id)
+    return owner is not None and owner.entry_id == entry.entry_id
+
+
+def _controller_entities_owner(
+    hass: HomeAssistant,
+    controller_id: str,
+    exclude_entry: OmadaConfigEntry | None = None,
+    active_only: bool = False,
+) -> ConfigEntry | None:
+    """Return the config entry that should own controller-level entities."""
     entries = [
         config_entry
         for config_entry in hass.config_entries.async_entries(DOMAIN)
         if _config_entry_matches_controller(config_entry, controller_id)
+        and (exclude_entry is None or config_entry.entry_id != exclude_entry.entry_id)
     ]
     active_entries = [
         config_entry
         for config_entry in entries
         if config_entry.state in _CONTROLLER_OWNER_STATES
     ]
+    if active_only:
+        candidate_entries = active_entries
+    else:
+        candidate_entries = active_entries or entries
+    if not candidate_entries:
+        return None
 
     # Omada supports clustering internally, but the public Northbound API does
     # not document how to determine the current Primary controller.
     # Until a documented API is available, use a deterministic stable owner.
-    candidate_entries = active_entries or entries
-    owner = min(candidate_entries, key=lambda item: (item.created_at, item.entry_id))
-    return owner.entry_id == entry.entry_id
+    return min(candidate_entries, key=lambda item: (item.created_at, item.entry_id))
+
+
+def _reload_controller_entities_owner(
+    hass: HomeAssistant,
+    entry: OmadaConfigEntry,
+    controller_id: str,
+) -> None:
+    """Reload the next active owner so controller-level entities are recreated."""
+    if (
+        owner := _controller_entities_owner(
+            hass, controller_id, exclude_entry=entry, active_only=True
+        )
+    ) is not None:
+        hass.async_create_task(hass.config_entries.async_reload(owner.entry_id))
 
 
 def _config_entry_matches_controller(
@@ -144,7 +181,7 @@ def _register_controller_device(
         config_entry_id=entry.entry_id,
         identifiers={(DOMAIN, controller.controller_id)},
         manufacturer="TP-Link",
-        model=controller.controller_name,
+        model=controller_model(controller_info),
         name=controller.controller_name,
         sw_version=controller_info.controller_version,
     )

--- a/homeassistant/components/tplink_omada/__init__.py
+++ b/homeassistant/components/tplink_omada/__init__.py
@@ -50,7 +50,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmadaConfigEntry) -> boo
 
     try:
         client = await create_omada_client(hass, entry.data)
-        await client.login()
+        controller_id = await client.login()
+        controller_name = await client.get_controller_name()
 
     except (LoginFailed, UnsupportedControllerVersion) as ex:
         raise ConfigEntryAuthFailed(
@@ -67,10 +68,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmadaConfigEntry) -> boo
         ) from ex
 
     site_client = await client.get_site_client(OmadaSite("", entry.data[CONF_SITE]))
-    controller = OmadaSiteController(hass, entry, site_client)
+    controller = OmadaSiteController(
+        hass, entry, client, site_client, controller_id, controller_name
+    )
     await controller.initialize_first_refresh()
 
     entry.runtime_data = controller
+
+    _register_controller_device(hass, entry)
 
     _remove_old_devices(hass, entry, controller.devices_coordinator.data)
 
@@ -84,12 +89,31 @@ async def async_unload_entry(hass: HomeAssistant, entry: OmadaConfigEntry) -> bo
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
+def _register_controller_device(
+    hass: HomeAssistant,
+    entry: OmadaConfigEntry,
+) -> None:
+    controller = entry.runtime_data
+    controller_info = controller.controller_coordinator.data.info
+    device_registry = dr.async_get(hass)
+
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, controller.controller_id)},
+        manufacturer="TP-Link",
+        model=controller.controller_name,
+        name=controller.controller_name,
+        sw_version=controller_info.controller_version,
+    )
+
+
 def _remove_old_devices(
     hass: HomeAssistant,
     entry: OmadaConfigEntry,
     omada_devices: dict[str, OmadaListDevice],
 ) -> None:
     device_registry = dr.async_get(hass)
+    controller_id = entry.runtime_data.controller_id
 
     for registered_device in device_registry.devices.get_devices_for_config_entry_id(
         entry.entry_id
@@ -97,8 +121,10 @@ def _remove_old_devices(
         mac = next(
             (i[1] for i in registered_device.identifiers if i[0] == DOMAIN), None
         )
-        if mac and mac not in omada_devices:
-            device_registry.async_remove_device(registered_device.id)
+        if mac and mac != controller_id and mac not in omada_devices:
+            device_registry.async_update_device(
+                registered_device.id, remove_config_entry_id=entry.entry_id
+            )
 
 
 async def async_migrate_entry(hass: HomeAssistant, entry: OmadaConfigEntry) -> bool:

--- a/homeassistant/components/tplink_omada/__init__.py
+++ b/homeassistant/components/tplink_omada/__init__.py
@@ -83,7 +83,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmadaConfigEntry) -> boo
 
     entry.runtime_data = controller
 
-    if config_entry_owns_controller_entities(hass, entry):
+    if config_entry_owns_controller_entities(
+        hass, entry
+    ) or not _controller_device_exists(hass, controller_id):
         _register_controller_device(hass, entry)
 
     _remove_old_devices(hass, entry, controller.devices_coordinator.data)
@@ -194,6 +196,14 @@ def _register_controller_device(
         model=controller_model(controller_info),
         name=controller.controller_name,
         sw_version=controller_info.controller_version,
+    )
+
+
+def _controller_device_exists(hass: HomeAssistant, controller_id: str) -> bool:
+    """Return if the controller device is already registered."""
+    return (
+        dr.async_get(hass).async_get_device(identifiers={(DOMAIN, controller_id)})
+        is not None
     )
 
 

--- a/homeassistant/components/tplink_omada/__init__.py
+++ b/homeassistant/components/tplink_omada/__init__.py
@@ -42,6 +42,7 @@ type OmadaConfigEntry = ConfigEntry[OmadaSiteController]
 _CONTROLLER_OWNER_STATES = {
     ConfigEntryState.LOADED,
     ConfigEntryState.SETUP_IN_PROGRESS,
+    ConfigEntryState.UNLOAD_IN_PROGRESS,
 }
 
 

--- a/homeassistant/components/tplink_omada/__init__.py
+++ b/homeassistant/components/tplink_omada/__init__.py
@@ -177,10 +177,19 @@ def _register_controller_device(
     controller = entry.runtime_data
     controller_info = controller.controller_coordinator.data.info
     device_registry = dr.async_get(hass)
+    identifiers = {(DOMAIN, controller.controller_id)}
+
+    if (
+        device := device_registry.async_get_device(identifiers=identifiers)
+    ) is not None and entry.entry_id not in device.config_entries:
+        device_registry.async_update_device(
+            device.id,
+            new_config_entry_id=entry.entry_id,
+        )
 
     device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
-        identifiers={(DOMAIN, controller.controller_id)},
+        identifiers=identifiers,
         manufacturer="TP-Link",
         model=controller_model(controller_info),
         name=controller.controller_name,

--- a/homeassistant/components/tplink_omada/controller.py
+++ b/homeassistant/components/tplink_omada/controller.py
@@ -3,7 +3,7 @@
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING
 
-from tplink_omada_client import OmadaSiteClient
+from tplink_omada_client import OmadaClient, OmadaSiteClient
 from tplink_omada_client.devices import OmadaListDevice, OmadaSwitch
 
 from homeassistant.core import HomeAssistant, callback
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 
 from .coordinator import (
     OmadaClientsCoordinator,
+    OmadaControllerCoordinator,
     OmadaDevicesCoordinator,
     OmadaGatewayCoordinator,
     OmadaSwitchPortCoordinator,
@@ -28,23 +29,32 @@ class OmadaSiteController:
         self,
         hass: HomeAssistant,
         config_entry: OmadaConfigEntry,
-        omada_client: OmadaSiteClient,
+        omada_client: OmadaClient,
+        site_client: OmadaSiteClient,
+        controller_id: str,
+        controller_name: str,
     ) -> None:
         """Create the controller."""
         self._hass = hass
         self._config_entry = config_entry
-        self._omada_client = omada_client
+        self._omada_client = site_client
+        self._controller_id = controller_id
+        self._controller_name = controller_name
 
         self._switch_port_coordinators: dict[str, OmadaSwitchPortCoordinator] = {}
-        self._devices_coordinator = OmadaDevicesCoordinator(
+        self._controller_coordinator = OmadaControllerCoordinator(
             hass, config_entry, omada_client
         )
+        self._devices_coordinator = OmadaDevicesCoordinator(
+            hass, config_entry, site_client
+        )
         self._clients_coordinator = OmadaClientsCoordinator(
-            hass, config_entry, omada_client
+            hass, config_entry, site_client
         )
 
     async def initialize_first_refresh(self) -> None:
         """Initialize the all coordinators, and perform first refresh."""
+        await self._controller_coordinator.async_config_entry_first_refresh()
         await self._devices_coordinator.async_config_entry_first_refresh()
 
         devices = self._devices_coordinator.data.values()
@@ -105,6 +115,21 @@ class OmadaSiteController:
     def omada_client(self) -> OmadaSiteClient:
         """Get the connected client API for the site to manage."""
         return self._omada_client
+
+    @property
+    def controller_id(self) -> str:
+        """Get the Omada controller device identifier."""
+        return self._controller_id
+
+    @property
+    def controller_name(self) -> str:
+        """Get the Omada controller name."""
+        return self._controller_name
+
+    @property
+    def controller_coordinator(self) -> OmadaControllerCoordinator:
+        """Get the coordinator for Omada controller data."""
+        return self._controller_coordinator
 
     def get_switch_port_coordinator(
         self, switch: OmadaSwitch

--- a/homeassistant/components/tplink_omada/coordinator.py
+++ b/homeassistant/components/tplink_omada/coordinator.py
@@ -5,8 +5,14 @@ from datetime import timedelta
 import logging
 from typing import TYPE_CHECKING, NamedTuple, override
 
-from tplink_omada_client import OmadaSiteClient, OmadaSwitchPortDetails
+from tplink_omada_client import (
+    OmadaClient,
+    OmadaControllerInfo,
+    OmadaSiteClient,
+    OmadaSwitchPortDetails,
+)
 from tplink_omada_client.clients import OmadaWirelessClient
+from tplink_omada_client.definitions import OmadaControllerUpdateInfo
 from tplink_omada_client.devices import (
     OmadaFirmwareUpdate,
     OmadaGateway,
@@ -65,6 +71,47 @@ class OmadaCoordinator[_T](DataUpdateCoordinator[dict[str, _T]]):
     async def poll_update(self) -> dict[str, _T]:
         """Poll the current data from the controller."""
         raise NotImplementedError("Update method not implemented")
+
+
+class ControllerStatus(NamedTuple):
+    """Controller information and update status."""
+
+    info: OmadaControllerInfo
+    updates: OmadaControllerUpdateInfo
+
+
+class OmadaControllerCoordinator(DataUpdateCoordinator[ControllerStatus]):
+    """Coordinator for Omada controller information and update details."""
+
+    config_entry: OmadaConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: OmadaConfigEntry,
+        omada_client: OmadaClient,
+    ) -> None:
+        """Initialize the controller coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=config_entry,
+            name="Omada API Data - Controller",
+            update_interval=timedelta(seconds=POLL_DEVICES),
+        )
+        self.omada_client = omada_client
+
+    @override
+    async def _async_update_data(self) -> ControllerStatus:
+        """Fetch controller data from the API."""
+        try:
+            async with asyncio.timeout(10):
+                info = await self.omada_client.get_controller_info()
+                updates = await self.omada_client.check_firmware_updates()
+        except OmadaClientException as err:
+            raise UpdateFailed(f"Error communicating with API: {err}") from err
+
+        return ControllerStatus(info=info, updates=updates)
 
 
 class OmadaSwitchPortCoordinator(OmadaCoordinator[OmadaSwitchPortDetails]):

--- a/homeassistant/components/tplink_omada/coordinator.py
+++ b/homeassistant/components/tplink_omada/coordinator.py
@@ -77,7 +77,7 @@ class ControllerStatus(NamedTuple):
     """Controller information and update status."""
 
     info: OmadaControllerInfo
-    updates: OmadaControllerUpdateInfo
+    updates: OmadaControllerUpdateInfo | None
 
 
 class OmadaControllerCoordinator(DataUpdateCoordinator[ControllerStatus]):
@@ -107,9 +107,14 @@ class OmadaControllerCoordinator(DataUpdateCoordinator[ControllerStatus]):
         try:
             async with asyncio.timeout(10):
                 info = await self.omada_client.get_controller_info()
-                updates = await self.omada_client.check_firmware_updates()
         except OmadaClientException as err:
             raise UpdateFailed(f"Error communicating with API: {err}") from err
+
+        try:
+            async with asyncio.timeout(10):
+                updates = await self.omada_client.check_firmware_updates()
+        except OmadaClientException:
+            updates = None
 
         return ControllerStatus(info=info, updates=updates)
 

--- a/homeassistant/components/tplink_omada/coordinator.py
+++ b/homeassistant/components/tplink_omada/coordinator.py
@@ -113,7 +113,7 @@ class OmadaControllerCoordinator(DataUpdateCoordinator[ControllerStatus]):
         try:
             async with asyncio.timeout(10):
                 updates = await self.omada_client.check_firmware_updates()
-        except OmadaClientException:
+        except TimeoutError, OmadaClientException:
             updates = None
 
         return ControllerStatus(info=info, updates=updates)

--- a/homeassistant/components/tplink_omada/entity.py
+++ b/homeassistant/components/tplink_omada/entity.py
@@ -8,7 +8,26 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .coordinator import OmadaCoordinator
+from .coordinator import OmadaControllerCoordinator, OmadaCoordinator
+
+
+class OmadaControllerEntity(CoordinatorEntity[OmadaControllerCoordinator]):
+    """Common base class for entities associated with an Omada controller."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: OmadaControllerCoordinator) -> None:
+        """Initialize the controller entity."""
+        super().__init__(coordinator)
+        controller = coordinator.config_entry.runtime_data
+        info = coordinator.data.info
+        self._attr_device_info = dr.DeviceInfo(
+            identifiers={(DOMAIN, controller.controller_id)},
+            manufacturer="TP-Link",
+            model=controller.controller_name,
+            name=controller.controller_name,
+            sw_version=info.controller_version,
+        )
 
 
 class OmadaDeviceEntity[_T: OmadaCoordinator[Any]](CoordinatorEntity[_T]):
@@ -26,4 +45,5 @@ class OmadaDeviceEntity[_T: OmadaCoordinator[Any]](CoordinatorEntity[_T]):
             manufacturer="TP-Link",
             model=device.model_display_name,
             name=device.name,
+            via_device=(DOMAIN, coordinator.config_entry.runtime_data.controller_id),
         )

--- a/homeassistant/components/tplink_omada/entity.py
+++ b/homeassistant/components/tplink_omada/entity.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from tplink_omada_client import OmadaControllerInfo
 from tplink_omada_client.devices import OmadaDevice
 
 from homeassistant.helpers import device_registry as dr
@@ -9,6 +10,18 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import OmadaControllerCoordinator, OmadaCoordinator
+
+
+def controller_model(controller_info: OmadaControllerInfo) -> str | None:
+    """Return the controller model."""
+    match controller_info.omadac_category:
+        case "hardware":
+            # The Omada API does not expose a hardware product model here.
+            return "Hardware"
+        case "software":
+            return "Software"
+        case _:
+            return None
 
 
 class OmadaControllerEntity(CoordinatorEntity[OmadaControllerCoordinator]):
@@ -24,7 +37,7 @@ class OmadaControllerEntity(CoordinatorEntity[OmadaControllerCoordinator]):
         self._attr_device_info = dr.DeviceInfo(
             identifiers={(DOMAIN, controller.controller_id)},
             manufacturer="TP-Link",
-            model=controller.controller_name,
+            model=controller_model(info),
             name=controller.controller_name,
             sw_version=info.controller_version,
         )

--- a/homeassistant/components/tplink_omada/sensor.py
+++ b/homeassistant/components/tplink_omada/sensor.py
@@ -20,8 +20,8 @@ from homeassistant.helpers.typing import StateType
 
 from . import OmadaConfigEntry
 from .const import OmadaDeviceStatus
-from .coordinator import OmadaDevicesCoordinator
-from .entity import OmadaDeviceEntity
+from .coordinator import OmadaControllerCoordinator, OmadaDevicesCoordinator
+from .entity import OmadaControllerEntity, OmadaDeviceEntity
 
 PARALLEL_UPDATES = 0
 
@@ -64,6 +64,10 @@ async def async_setup_entry(
     controller = config_entry.runtime_data
 
     devices_coordinator = controller.devices_coordinator
+
+    async_add_entities(
+        [OmadaControllerDeviceStatusSensor(controller.controller_coordinator)]
+    )
 
     async def _create_device_sensor_entities(
         device: OmadaListDevice,
@@ -117,6 +121,35 @@ OMADA_DEVICE_SENSORS: list[OmadaDeviceSensorEntityDescription] = [
         update_func=lambda device: device.mem_usage,
     ),
 ]
+
+
+class OmadaControllerDeviceStatusSensor(OmadaControllerEntity, SensorEntity):
+    """Sensor for the Omada controller device status."""
+
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_options = [
+        OmadaDeviceStatus.CONNECTED.value,
+        OmadaDeviceStatus.DISCONNECTED.value,
+    ]
+    _attr_translation_key = "device_status"
+
+    def __init__(self, coordinator: OmadaControllerCoordinator) -> None:
+        """Initialize the controller device status sensor."""
+        super().__init__(coordinator)
+        self._attr_unique_id = (
+            f"{coordinator.config_entry.runtime_data.controller_id}_device_status"
+        )
+
+    @property
+    @override
+    def native_value(self) -> StateType:
+        """Return the state of the sensor."""
+        return (
+            OmadaDeviceStatus.CONNECTED.value
+            if self.coordinator.data.info.configured
+            else OmadaDeviceStatus.DISCONNECTED.value
+        )
 
 
 class OmadaDeviceSensor(OmadaDeviceEntity[OmadaDevicesCoordinator], SensorEntity):

--- a/homeassistant/components/tplink_omada/sensor.py
+++ b/homeassistant/components/tplink_omada/sensor.py
@@ -145,11 +145,7 @@ class OmadaControllerDeviceStatusSensor(OmadaControllerEntity, SensorEntity):
     @override
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
-        return (
-            OmadaDeviceStatus.CONNECTED.value
-            if self.coordinator.data.info.configured
-            else OmadaDeviceStatus.DISCONNECTED.value
-        )
+        return OmadaDeviceStatus.CONNECTED.value
 
 
 class OmadaDeviceSensor(OmadaDeviceEntity[OmadaDevicesCoordinator], SensorEntity):

--- a/homeassistant/components/tplink_omada/sensor.py
+++ b/homeassistant/components/tplink_omada/sensor.py
@@ -18,7 +18,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
-from . import OmadaConfigEntry
+from . import OmadaConfigEntry, config_entry_owns_controller_entities
 from .const import OmadaDeviceStatus
 from .coordinator import OmadaControllerCoordinator, OmadaDevicesCoordinator
 from .entity import OmadaControllerEntity, OmadaDeviceEntity
@@ -65,9 +65,10 @@ async def async_setup_entry(
 
     devices_coordinator = controller.devices_coordinator
 
-    async_add_entities(
-        [OmadaControllerDeviceStatusSensor(controller.controller_coordinator)]
-    )
+    if config_entry_owns_controller_entities(hass, config_entry):
+        async_add_entities(
+            [OmadaControllerDeviceStatusSensor(controller.controller_coordinator)]
+        )
 
     async def _create_device_sensor_entities(
         device: OmadaListDevice,

--- a/homeassistant/components/tplink_omada/strings.json
+++ b/homeassistant/components/tplink_omada/strings.json
@@ -97,6 +97,11 @@
       "wan_connect_ipv6": {
         "name": "Port {port_name} Internet connected (IPv6)"
       }
+    },
+    "update": {
+      "firmware": {
+        "name": "Firmware"
+      }
     }
   },
   "services": {

--- a/homeassistant/components/tplink_omada/update.py
+++ b/homeassistant/components/tplink_omada/update.py
@@ -14,7 +14,6 @@ from homeassistant.components.update import (
     UpdateEntity,
     UpdateEntityFeature,
 )
-from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -55,7 +54,6 @@ class OmadaControllerUpdate(OmadaControllerEntity, UpdateEntity):
     """Firmware/software update status for an Omada controller."""
 
     _attr_device_class = UpdateDeviceClass.FIRMWARE
-    _attr_entity_category = EntityCategory.CONFIG
     _attr_translation_key = "firmware"
 
     def __init__(self, coordinator: OmadaControllerCoordinator) -> None:

--- a/homeassistant/components/tplink_omada/update.py
+++ b/homeassistant/components/tplink_omada/update.py
@@ -19,7 +19,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import OmadaConfigEntry
+from . import OmadaConfigEntry, config_entry_owns_controller_entities
 from .coordinator import OmadaControllerCoordinator, OmadaFirmwareUpdateCoordinator
 from .entity import OmadaControllerEntity, OmadaDeviceEntity
 
@@ -40,12 +40,14 @@ async def async_setup_entry(
         hass, config_entry, controller.omada_client, controller.devices_coordinator
     )
 
-    async_add_entities(
-        [
-            OmadaControllerUpdate(controller.controller_coordinator),
-            *(OmadaDeviceUpdate(coordinator, device) for device in devices.values()),
-        ]
+    entities: list[UpdateEntity] = []
+    if config_entry_owns_controller_entities(hass, config_entry):
+        entities.append(OmadaControllerUpdate(controller.controller_coordinator))
+    entities.extend(
+        OmadaDeviceUpdate(coordinator, device) for device in devices.values()
     )
+
+    async_add_entities(entities)
     await coordinator.async_request_refresh()
 
 

--- a/homeassistant/components/tplink_omada/update.py
+++ b/homeassistant/components/tplink_omada/update.py
@@ -2,6 +2,10 @@
 
 from typing import Any, override
 
+from tplink_omada_client.definitions import (
+    OmadaHardwareUpdateInfo,
+    OmadaSoftwareUpdateInfo,
+)
 from tplink_omada_client.devices import OmadaListDevice
 from tplink_omada_client.exceptions import OmadaClientException, RequestFailed
 
@@ -10,13 +14,14 @@ from homeassistant.components.update import (
     UpdateEntity,
     UpdateEntityFeature,
 )
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import OmadaConfigEntry
-from .coordinator import OmadaFirmwareUpdateCoordinator
-from .entity import OmadaDeviceEntity
+from .coordinator import OmadaControllerCoordinator, OmadaFirmwareUpdateCoordinator
+from .entity import OmadaControllerEntity, OmadaDeviceEntity
 
 PARALLEL_UPDATES = 0
 
@@ -26,7 +31,7 @@ async def async_setup_entry(
     config_entry: OmadaConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up switches."""
+    """Set up update entities."""
     controller = config_entry.runtime_data
 
     devices = controller.devices_coordinator.data
@@ -36,9 +41,101 @@ async def async_setup_entry(
     )
 
     async_add_entities(
-        OmadaDeviceUpdate(coordinator, device) for device in devices.values()
+        [
+            OmadaControllerUpdate(controller.controller_coordinator),
+            *(OmadaDeviceUpdate(coordinator, device) for device in devices.values()),
+        ]
     )
     await coordinator.async_request_refresh()
+
+
+class OmadaControllerUpdate(OmadaControllerEntity, UpdateEntity):
+    """Firmware/software update status for an Omada controller."""
+
+    _attr_device_class = UpdateDeviceClass.FIRMWARE
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_name = "Firmware"
+
+    def __init__(self, coordinator: OmadaControllerCoordinator) -> None:
+        """Initialize the controller update entity."""
+        super().__init__(coordinator)
+        self._attr_unique_id = (
+            f"{coordinator.config_entry.runtime_data.controller_id}_firmware"
+        )
+
+    @property
+    def _update_info(self) -> OmadaHardwareUpdateInfo | OmadaSoftwareUpdateInfo | None:
+        """Return the best controller update data to expose."""
+        updates = self.coordinator.data.updates
+        if updates.hardware and updates.hardware.upgrade:
+            return updates.hardware
+        if updates.software and updates.software.upgrade:
+            return updates.software
+        return updates.hardware or updates.software
+
+    @property
+    def _hardware_update(self) -> OmadaHardwareUpdateInfo | None:
+        """Return controller hardware firmware update data."""
+        return (
+            self.coordinator.data.updates.hardware
+            if self._update_info is self.coordinator.data.updates.hardware
+            else None
+        )
+
+    @property
+    @override
+    def supported_features(self) -> UpdateEntityFeature:
+        """Flag supported features."""
+        features = UpdateEntityFeature.RELEASE_NOTES
+        if self._hardware_update:
+            features |= UpdateEntityFeature.INSTALL
+        return features
+
+    @property
+    @override
+    def installed_version(self) -> str | None:
+        """Return the installed controller version."""
+        if self._update_info:
+            return self._update_info.current_version
+        return self.coordinator.data.info.controller_version
+
+    @property
+    @override
+    def latest_version(self) -> str | None:
+        """Return the latest controller version."""
+        if self._update_info:
+            return self._update_info.latest_version
+        return self.coordinator.data.info.controller_version
+
+    @override
+    def release_notes(self) -> str | None:
+        """Get the release notes for the latest controller update."""
+        return self._update_info.release_notes if self._update_info else None
+
+    @override
+    async def async_install(
+        self, version: str | None, backup: bool, **kwargs: Any
+    ) -> None:
+        """Install a controller hardware firmware update."""
+        firmware = self._hardware_update
+        if firmware is None:
+            raise HomeAssistantError("No controller firmware update is available")
+
+        try:
+            await self.coordinator.omada_client.upgrade_controller_firmware(
+                version or firmware.latest_version
+            )
+        except RequestFailed as ex:
+            raise HomeAssistantError(
+                "Controller firmware update request rejected"
+            ) from ex
+        except OmadaClientException as ex:
+            raise HomeAssistantError(
+                "Unable to send controller firmware update request."
+                " Check the controller is online."
+            ) from ex
+        finally:
+            await self.coordinator.async_request_refresh()
 
 
 class OmadaDeviceUpdate(

--- a/homeassistant/components/tplink_omada/update.py
+++ b/homeassistant/components/tplink_omada/update.py
@@ -54,7 +54,7 @@ class OmadaControllerUpdate(OmadaControllerEntity, UpdateEntity):
 
     _attr_device_class = UpdateDeviceClass.FIRMWARE
     _attr_entity_category = EntityCategory.CONFIG
-    _attr_name = "Firmware"
+    _attr_translation_key = "firmware"
 
     def __init__(self, coordinator: OmadaControllerCoordinator) -> None:
         """Initialize the controller update entity."""
@@ -76,11 +76,14 @@ class OmadaControllerUpdate(OmadaControllerEntity, UpdateEntity):
     @property
     def _hardware_update(self) -> OmadaHardwareUpdateInfo | None:
         """Return controller hardware firmware update data."""
-        return (
-            self.coordinator.data.updates.hardware
-            if self._update_info is self.coordinator.data.updates.hardware
-            else None
-        )
+        updates = self.coordinator.data.updates
+        hardware = updates.hardware
+        software = updates.software
+        if hardware and hardware.upgrade:
+            return hardware
+        if software and software.upgrade:
+            return None
+        return hardware
 
     @property
     @override
@@ -150,6 +153,7 @@ class OmadaDeviceUpdate(
         | UpdateEntityFeature.RELEASE_NOTES
     )
     _attr_device_class = UpdateDeviceClass.FIRMWARE
+    _attr_translation_key = "firmware"
 
     def __init__(
         self,

--- a/homeassistant/components/tplink_omada/update.py
+++ b/homeassistant/components/tplink_omada/update.py
@@ -67,6 +67,8 @@ class OmadaControllerUpdate(OmadaControllerEntity, UpdateEntity):
     def _update_info(self) -> OmadaHardwareUpdateInfo | OmadaSoftwareUpdateInfo | None:
         """Return the best controller update data to expose."""
         updates = self.coordinator.data.updates
+        if updates is None:
+            return None
         if updates.hardware and updates.hardware.upgrade:
             return updates.hardware
         if updates.software and updates.software.upgrade:
@@ -77,6 +79,8 @@ class OmadaControllerUpdate(OmadaControllerEntity, UpdateEntity):
     def _hardware_update(self) -> OmadaHardwareUpdateInfo | None:
         """Return controller hardware firmware update data."""
         updates = self.coordinator.data.updates
+        if updates is None:
+            return None
         hardware = updates.hardware
         software = updates.software
         if hardware and hardware.upgrade:
@@ -93,6 +97,12 @@ class OmadaControllerUpdate(OmadaControllerEntity, UpdateEntity):
         if self._hardware_update:
             features |= UpdateEntityFeature.INSTALL
         return features
+
+    @property
+    @override
+    def available(self) -> bool:
+        """Return if update information is available."""
+        return super().available and self.coordinator.data.updates is not None
 
     @property
     @override

--- a/tests/components/tplink_omada/conftest.py
+++ b/tests/components/tplink_omada/conftest.py
@@ -5,13 +5,14 @@ from functools import partial
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from tplink_omada_client import OmadaSite
+from tplink_omada_client import OmadaControllerInfo, OmadaSite
 from tplink_omada_client.clients import (
     OmadaConnectedClient,
     OmadaNetworkClient,
     OmadaWiredClient,
     OmadaWirelessClient,
 )
+from tplink_omada_client.definitions import OmadaControllerUpdateInfo
 from tplink_omada_client.devices import (
     OmadaFirmwareUpdate,
     OmadaGateway,
@@ -30,6 +31,34 @@ from tests.common import (
     async_load_json_array_fixture,
     async_load_json_object_fixture,
 )
+
+
+def _mock_controller_update_info() -> OmadaControllerUpdateInfo:
+    """Return mocked controller update information."""
+    return OmadaControllerUpdateInfo(
+        {
+            "hardware": {
+                "upgrade": False,
+                "currentVersion": "6.2.10.17",
+            },
+            "software": {
+                "upgrade": False,
+                "currentVersion": "6.2.10.17",
+            },
+        }
+    )
+
+
+def _mock_controller_info() -> OmadaControllerInfo:
+    """Return mocked controller information."""
+    return OmadaControllerInfo(
+        {
+            "controllerVer": "6.2.10.17",
+            "configured": True,
+            "omadacId": "12345",
+            "type": "OC200",
+        }
+    )
 
 
 @pytest.fixture
@@ -87,7 +116,6 @@ async def mock_omada_site_client(hass: HomeAssistant) -> AsyncGenerator[AsyncMoc
     switch1_ports = [OmadaSwitchPortDetails(p) for p in switch1_ports_data]
     site_client.get_switch_ports = AsyncMock(return_value=switch1_ports)
 
-    # Mock firmware update API
     async def get_firmware_details(
         device: OmadaListDevice,
     ) -> OmadaFirmwareUpdate | None:
@@ -189,6 +217,10 @@ def mock_omada_client(mock_omada_site_client: AsyncMock) -> Generator[MagicMock]
 
         client.get_site_client.return_value = mock_omada_site_client
         client.login.return_value = "12345"
+        client.get_controller_info = AsyncMock(return_value=_mock_controller_info())
+        client.check_firmware_updates = AsyncMock(
+            return_value=_mock_controller_update_info()
+        )
         client.get_controller_name.return_value = "OC200"
         client.get_sites.return_value = [OmadaSite("Display Name", "SiteId")]
         yield client
@@ -206,6 +238,10 @@ def mock_omada_clients_only_client(
         client = client_mock.return_value
 
         client.get_site_client.return_value = mock_omada_clients_only_site_client
+        client.get_controller_info = AsyncMock(return_value=_mock_controller_info())
+        client.check_firmware_updates = AsyncMock(
+            return_value=_mock_controller_update_info()
+        )
         yield client
 
 

--- a/tests/components/tplink_omada/conftest.py
+++ b/tests/components/tplink_omada/conftest.py
@@ -238,6 +238,8 @@ def mock_omada_clients_only_client(
         client = client_mock.return_value
 
         client.get_site_client.return_value = mock_omada_clients_only_site_client
+        client.login.return_value = "12345"
+        client.get_controller_name.return_value = "OC200"
         client.get_controller_info = AsyncMock(return_value=_mock_controller_info())
         client.check_firmware_updates = AsyncMock(
             return_value=_mock_controller_update_info()

--- a/tests/components/tplink_omada/conftest.py
+++ b/tests/components/tplink_omada/conftest.py
@@ -56,7 +56,7 @@ def _mock_controller_info() -> OmadaControllerInfo:
             "controllerVer": "6.2.10.17",
             "configured": True,
             "omadacId": "12345",
-            "type": "OC200",
+            "omadacCategory": "hardware",
         }
     )
 

--- a/tests/components/tplink_omada/snapshots/test_sensor.ambr
+++ b/tests/components/tplink_omada/snapshots/test_sensor.ambr
@@ -1,4 +1,64 @@
 # serializer version: 1
+# name: test_entities[sensor.oc200_device_status-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'connected',
+        'disconnected',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.oc200_device_status',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Device status',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Device status',
+    'platform': 'tplink_omada',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'device_status',
+    'unique_id': '12345_device_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[sensor.oc200_device_status-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'OC200 Device status',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'connected',
+        'disconnected',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.oc200_device_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'connected',
+  })
+# ---
 # name: test_entities[sensor.test_poe_switch_cpu_usage-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/tplink_omada/snapshots/test_update.ambr
+++ b/tests/components/tplink_omada/snapshots/test_update.ambr
@@ -1,4 +1,67 @@
 # serializer version: 1
+# name: test_entities[update.oc200_firmware-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'update',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'update.oc200_firmware',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Firmware',
+    'options': dict({
+    }),
+    'original_device_class': <UpdateDeviceClass.FIRMWARE: 'firmware'>,
+    'original_icon': None,
+    'original_name': 'Firmware',
+    'platform': 'tplink_omada',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <UpdateEntityFeature: 17>,
+    'translation_key': 'firmware',
+    'unique_id': '12345_firmware',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[update.oc200_firmware-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <UpdateEntityStateAttribute.AUTO_UPDATE: 'auto_update'>: False,
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'firmware',
+      <UpdateEntityStateAttribute.DISPLAY_PRECISION: 'display_precision'>: 0,
+      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/brands/integration/tplink_omada/icon.png',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'OC200 Firmware',
+      <UpdateEntityStateAttribute.IN_PROGRESS: 'in_progress'>: False,
+      <UpdateEntityStateAttribute.INSTALLED_VERSION: 'installed_version'>: '6.2.10.17',
+      <UpdateEntityStateAttribute.LATEST_VERSION: 'latest_version'>: '6.2.10.17',
+      <UpdateEntityStateAttribute.RELEASE_SUMMARY: 'release_summary'>: None,
+      <UpdateEntityStateAttribute.RELEASE_URL: 'release_url'>: None,
+      <UpdateEntityStateAttribute.SKIPPED_VERSION: 'skipped_version'>: None,
+      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <UpdateEntityFeature: 17>,
+      <UpdateEntityStateAttribute.TITLE: 'title'>: None,
+      <UpdateEntityStateAttribute.UPDATE_PERCENTAGE: 'update_percentage'>: None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'update.oc200_firmware',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_entities[update.test_poe_switch_firmware-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -31,7 +94,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': <UpdateEntityFeature: 21>,
-    'translation_key': None,
+    'translation_key': 'firmware',
     'unique_id': '54-AF-97-00-00-01_firmware',
     'unit_of_measurement': None,
   })
@@ -94,7 +157,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': <UpdateEntityFeature: 21>,
-    'translation_key': None,
+    'translation_key': 'firmware',
     'unique_id': 'AA-BB-CC-DD-EE-FF_firmware',
     'unit_of_measurement': None,
   })

--- a/tests/components/tplink_omada/test_init.py
+++ b/tests/components/tplink_omada/test_init.py
@@ -1,5 +1,7 @@
 """Tests for TP-Link Omada integration init."""
 
+from datetime import UTC, datetime
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -9,6 +11,7 @@ from tplink_omada_client.exceptions import (
     UnsupportedControllerVersion,
 )
 
+from homeassistant.components.tplink_omada import config_entry_owns_controller_entities
 from homeassistant.components.tplink_omada.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
@@ -23,6 +26,29 @@ MOCK_ENTRY_DATA = {
     "username": "test-username",
     "password": "test-password",
 }
+
+
+def _mock_controller_entry(
+    hass: HomeAssistant,
+    *,
+    entry_id: str,
+    site_id: str,
+    created_at: datetime,
+    state: ConfigEntryState = ConfigEntryState.NOT_LOADED,
+) -> MockConfigEntry:
+    entry = MockConfigEntry(
+        title="Test Omada Controller",
+        domain=DOMAIN,
+        data={**MOCK_ENTRY_DATA, "site": site_id},
+        entry_id=entry_id,
+        unique_id=f"12345_{site_id}",
+        version=2,
+        state=state,
+    )
+    object.__setattr__(entry, "created_at", created_at)
+    object.__setattr__(entry, "runtime_data", SimpleNamespace(controller_id="12345"))
+    entry.add_to_hass(hass)
+    return entry
 
 
 @pytest.mark.parametrize(
@@ -129,6 +155,79 @@ async def test_omada_devices_link_to_controller_device(
     assert controller_device.config_entries == {init_integration.entry_id}
     assert gateway_device.via_device_id == controller_device.id
     assert switch_device.via_device_id == controller_device.id
+
+
+@pytest.mark.parametrize(
+    "active_state",
+    [ConfigEntryState.LOADED, ConfigEntryState.SETUP_IN_PROGRESS],
+)
+async def test_controller_owner_prefers_active_entry(
+    hass: HomeAssistant,
+    active_state: ConfigEntryState,
+) -> None:
+    """Test controller entities are owned by the first active controller entry."""
+    created_at = datetime(2026, 7, 8, tzinfo=UTC)
+    older_inactive_entry = _mock_controller_entry(
+        hass,
+        entry_id="01",
+        site_id="Default",
+        created_at=created_at,
+    )
+    active_entry = _mock_controller_entry(
+        hass,
+        entry_id="02",
+        site_id="Second",
+        created_at=datetime(2026, 7, 9, tzinfo=UTC),
+        state=active_state,
+    )
+
+    assert config_entry_owns_controller_entities(hass, active_entry)
+    assert not config_entry_owns_controller_entities(hass, older_inactive_entry)
+
+
+async def test_controller_owner_falls_back_to_all_entries(
+    hass: HomeAssistant,
+) -> None:
+    """Test controller ownership falls back to all entries when none are active."""
+    owner_entry = _mock_controller_entry(
+        hass,
+        entry_id="02",
+        site_id="Default",
+        created_at=datetime(2026, 7, 8, tzinfo=UTC),
+    )
+    other_entry = _mock_controller_entry(
+        hass,
+        entry_id="01",
+        site_id="Second",
+        created_at=datetime(2026, 7, 9, tzinfo=UTC),
+    )
+
+    assert config_entry_owns_controller_entities(hass, owner_entry)
+    assert not config_entry_owns_controller_entities(hass, other_entry)
+
+
+async def test_controller_owner_tie_breaks_by_entry_id(
+    hass: HomeAssistant,
+) -> None:
+    """Test controller ownership tie-breaks by entry id."""
+    created_at = datetime(2026, 7, 8, tzinfo=UTC)
+    owner_entry = _mock_controller_entry(
+        hass,
+        entry_id="01",
+        site_id="Default",
+        created_at=created_at,
+        state=ConfigEntryState.LOADED,
+    )
+    other_entry = _mock_controller_entry(
+        hass,
+        entry_id="02",
+        site_id="Second",
+        created_at=created_at,
+        state=ConfigEntryState.LOADED,
+    )
+
+    assert config_entry_owns_controller_entities(hass, owner_entry)
+    assert not config_entry_owns_controller_entities(hass, other_entry)
 
 
 async def test_migrate_entry_v1_to_v2(

--- a/tests/components/tplink_omada/test_init.py
+++ b/tests/components/tplink_omada/test_init.py
@@ -91,6 +91,46 @@ async def test_missing_devices_removed_at_startup(
     assert device_registry.async_get(device_entry.id) is None
 
 
+async def test_controller_device_registered_at_startup(
+    device_registry: dr.DeviceRegistry,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test the controller is registered as a device."""
+    controller_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, "12345")}
+    )
+
+    assert controller_device is not None
+    assert controller_device.config_entries == {init_integration.entry_id}
+    assert controller_device.manufacturer == "TP-Link"
+    assert controller_device.model == "OC200"
+    assert controller_device.name == "OC200"
+    assert controller_device.sw_version == "6.2.10.17"
+
+
+async def test_omada_devices_link_to_controller_device(
+    device_registry: dr.DeviceRegistry,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test Omada devices are linked to the controller device."""
+    controller_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, "12345")}
+    )
+    gateway_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, "AA-BB-CC-DD-EE-FF")}
+    )
+    switch_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, "54-AF-97-00-00-01")}
+    )
+
+    assert controller_device is not None
+    assert gateway_device is not None
+    assert switch_device is not None
+    assert controller_device.config_entries == {init_integration.entry_id}
+    assert gateway_device.via_device_id == controller_device.id
+    assert switch_device.via_device_id == controller_device.id
+
+
 async def test_migrate_entry_v1_to_v2(
     hass: HomeAssistant,
     mock_omada_client: MagicMock,

--- a/tests/components/tplink_omada/test_init.py
+++ b/tests/components/tplink_omada/test_init.py
@@ -2,17 +2,22 @@
 
 from datetime import UTC, datetime
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from tplink_omada_client import OmadaControllerInfo
 from tplink_omada_client.exceptions import (
     ConnectionFailed,
     OmadaClientException,
     UnsupportedControllerVersion,
 )
 
-from homeassistant.components.tplink_omada import config_entry_owns_controller_entities
+from homeassistant.components.tplink_omada import (
+    async_unload_entry,
+    config_entry_owns_controller_entities,
+)
 from homeassistant.components.tplink_omada.const import DOMAIN
+from homeassistant.components.tplink_omada.entity import controller_model
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
@@ -129,9 +134,33 @@ async def test_controller_device_registered_at_startup(
     assert controller_device is not None
     assert controller_device.config_entries == {init_integration.entry_id}
     assert controller_device.manufacturer == "TP-Link"
-    assert controller_device.model == "OC200"
+    assert controller_device.model == "Hardware"
     assert controller_device.name == "OC200"
     assert controller_device.sw_version == "6.2.10.17"
+
+
+@pytest.mark.parametrize(
+    ("omadac_category", "expected_model"),
+    [
+        pytest.param("hardware", "Hardware", id="hardware"),
+        pytest.param("software", "Software", id="software"),
+        pytest.param(None, None, id="unknown"),
+    ],
+)
+def test_controller_model(
+    omadac_category: str | None,
+    expected_model: str | None,
+) -> None:
+    """Test controller model is derived from the controller category."""
+    data = {
+        "controllerVer": "6.2.10.17",
+        "configured": True,
+        "omadacId": "12345",
+    }
+    if omadac_category is not None:
+        data["omadacCategory"] = omadac_category
+
+    assert controller_model(OmadaControllerInfo(data)) == expected_model
 
 
 async def test_omada_devices_link_to_controller_device(
@@ -228,6 +257,43 @@ async def test_controller_owner_tie_breaks_by_entry_id(
 
     assert config_entry_owns_controller_entities(hass, owner_entry)
     assert not config_entry_owns_controller_entities(hass, other_entry)
+
+
+async def test_controller_owner_reload_transfers_to_next_active_entry(
+    hass: HomeAssistant,
+) -> None:
+    """Test unloading the owner reloads the next active controller entry."""
+    owner_entry = _mock_controller_entry(
+        hass,
+        entry_id="01",
+        site_id="Default",
+        created_at=datetime(2026, 7, 8, tzinfo=UTC),
+        state=ConfigEntryState.LOADED,
+    )
+    next_entry = _mock_controller_entry(
+        hass,
+        entry_id="02",
+        site_id="Second",
+        created_at=datetime(2026, 7, 9, tzinfo=UTC),
+        state=ConfigEntryState.LOADED,
+    )
+
+    with (
+        patch.object(
+            hass.config_entries,
+            "async_unload_platforms",
+            AsyncMock(return_value=True),
+        ),
+        patch.object(
+            hass.config_entries,
+            "async_reload",
+            AsyncMock(),
+        ) as mock_reload,
+    ):
+        assert await async_unload_entry(hass, owner_entry)
+        await hass.async_block_till_done()
+
+    mock_reload.assert_awaited_once_with(next_entry.entry_id)
 
 
 async def test_migrate_entry_v1_to_v2(

--- a/tests/components/tplink_omada/test_init.py
+++ b/tests/components/tplink_omada/test_init.py
@@ -12,7 +12,10 @@ from tplink_omada_client.exceptions import (
     UnsupportedControllerVersion,
 )
 
-from homeassistant.components.tplink_omada import config_entry_owns_controller_entities
+from homeassistant.components.tplink_omada import (
+    _register_controller_device,
+    config_entry_owns_controller_entities,
+)
 from homeassistant.components.tplink_omada.const import DOMAIN
 from homeassistant.components.tplink_omada.entity import controller_model
 from homeassistant.config_entries import ConfigEntryState
@@ -181,6 +184,41 @@ async def test_omada_devices_link_to_controller_device(
     assert controller_device.config_entries == {init_integration.entry_id}
     assert gateway_device.via_device_id == controller_device.id
     assert switch_device.via_device_id == controller_device.id
+
+
+async def test_controller_device_moves_to_new_owner(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test the controller device moves to a new controller entity owner."""
+    controller_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, "12345")}
+    )
+    assert controller_device is not None
+    assert controller_device.config_entries == {init_integration.entry_id}
+
+    new_owner_entry = MockConfigEntry(
+        title="Test Omada Controller",
+        domain=DOMAIN,
+        data={**MOCK_ENTRY_DATA, "site": "Second"},
+        unique_id="12345_Second",
+        version=2,
+    )
+    new_owner_entry.add_to_hass(hass)
+    object.__setattr__(new_owner_entry, "runtime_data", init_integration.runtime_data)
+
+    _register_controller_device(hass, new_owner_entry)
+
+    moved_device = device_registry.async_get_device(identifiers={(DOMAIN, "12345")})
+    assert moved_device is not None
+    assert moved_device.id == controller_device.id
+    assert moved_device.config_entries == {new_owner_entry.entry_id}
+    assert [
+        device
+        for device in device_registry.devices.values()
+        if (DOMAIN, "12345") in device.identifiers
+    ] == [moved_device]
 
 
 @pytest.mark.parametrize(

--- a/tests/components/tplink_omada/test_init.py
+++ b/tests/components/tplink_omada/test_init.py
@@ -19,6 +19,7 @@ from homeassistant.components.tplink_omada import (
 from homeassistant.components.tplink_omada.const import DOMAIN
 from homeassistant.components.tplink_omada.entity import controller_model
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
@@ -184,6 +185,39 @@ async def test_omada_devices_link_to_controller_device(
     assert controller_device.config_entries == {init_integration.entry_id}
     assert gateway_device.via_device_id == controller_device.id
     assert switch_device.via_device_id == controller_device.id
+
+
+async def test_controller_device_exists_before_non_owner_devices(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_omada_client: MagicMock,
+) -> None:
+    """Test a non-owner setup still creates the controller device for children."""
+    _mock_controller_entry(
+        hass,
+        entry_id="01",
+        site_id="Second",
+        created_at=datetime(2026, 7, 8, tzinfo=UTC),
+        state=ConfigEntryState.LOADED,
+    )
+    mock_config_entry.add_to_hass(hass)
+
+    with patch("homeassistant.components.tplink_omada.PLATFORMS", [Platform.SENSOR]):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    controller_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, "12345")}
+    )
+    gateway_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, "AA-BB-CC-DD-EE-FF")}
+    )
+
+    assert controller_device is not None
+    assert gateway_device is not None
+    assert controller_device.config_entries == {mock_config_entry.entry_id}
+    assert gateway_device.via_device_id == controller_device.id
 
 
 async def test_controller_device_moves_to_new_owner(

--- a/tests/components/tplink_omada/test_init.py
+++ b/tests/components/tplink_omada/test_init.py
@@ -12,10 +12,7 @@ from tplink_omada_client.exceptions import (
     UnsupportedControllerVersion,
 )
 
-from homeassistant.components.tplink_omada import (
-    async_unload_entry,
-    config_entry_owns_controller_entities,
-)
+from homeassistant.components.tplink_omada import config_entry_owns_controller_entities
 from homeassistant.components.tplink_omada.const import DOMAIN
 from homeassistant.components.tplink_omada.entity import controller_model
 from homeassistant.config_entries import ConfigEntryState
@@ -290,7 +287,7 @@ async def test_controller_owner_reload_transfers_to_next_active_entry(
             AsyncMock(),
         ) as mock_reload,
     ):
-        assert await async_unload_entry(hass, owner_entry)
+        assert await hass.config_entries.async_unload(owner_entry.entry_id)
         await hass.async_block_till_done()
 
     mock_reload.assert_awaited_once_with(next_entry.entry_id)

--- a/tests/components/tplink_omada/test_update.py
+++ b/tests/components/tplink_omada/test_update.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from tplink_omada_client.definitions import OmadaControllerUpdateInfo
 from tplink_omada_client.devices import OmadaListDevice
 from tplink_omada_client.exceptions import OmadaClientException, RequestFailed
 
@@ -14,6 +15,7 @@ from homeassistant.components.update import (
     ATTR_IN_PROGRESS,
     DOMAIN as UPDATE_DOMAIN,
     SERVICE_INSTALL,
+    UpdateEntityFeature,
 )
 from homeassistant.const import ATTR_ENTITY_ID, STATE_ON, Platform
 from homeassistant.core import HomeAssistant
@@ -29,6 +31,42 @@ from tests.common import (
 from tests.typing import WebSocketGenerator
 
 POLL_INTERVAL = timedelta(seconds=POLL_DEVICES)
+
+
+def _controller_update_info(
+    *,
+    hardware_upgrade: bool = False,
+    software_upgrade: bool = False,
+) -> OmadaControllerUpdateInfo:
+    """Return mocked controller update information."""
+    return OmadaControllerUpdateInfo(
+        {
+            "hardware": {
+                "upgrade": hardware_upgrade,
+                "currentVersion": "6.2.10.17",
+                "latestVersion": ("6.2.11.1" if hardware_upgrade else "6.2.10.17"),
+                "releaseNotes": "Controller hardware update",
+            },
+            "software": {
+                "upgrade": software_upgrade,
+                "currentVersion": "6.2.10.17",
+                "latestVersion": ("6.2.12.1" if software_upgrade else "6.2.10.17"),
+                "releaseNotes": "Controller software update",
+            },
+        }
+    )
+
+
+async def _async_setup_update_platform(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Set up only the TP-Link Omada update platform."""
+    mock_config_entry.add_to_hass(hass)
+
+    with patch("homeassistant.components.tplink_omada.PLATFORMS", [Platform.UPDATE]):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
 
 
 async def _rebuild_device_list_with_update(
@@ -202,3 +240,103 @@ async def test_release_notes(
     result = await client.receive_json()
 
     assert expected_notes == result["result"]
+
+
+async def test_controller_hardware_update_install_success(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_omada_client: MagicMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test successful controller hardware firmware installation."""
+    mock_omada_client.check_firmware_updates.return_value = _controller_update_info(
+        hardware_upgrade=True
+    )
+    mock_omada_client.upgrade_controller_firmware = AsyncMock()
+
+    await _async_setup_update_platform(hass, mock_config_entry)
+
+    entity_id = "update.oc200_firmware"
+    entity = hass.states.get(entity_id)
+    assert entity is not None
+    assert entity.state == STATE_ON
+
+    entity_entry = entity_registry.async_get(entity_id)
+    assert entity_entry is not None
+    assert entity_entry.supported_features == (
+        UpdateEntityFeature.INSTALL | UpdateEntityFeature.RELEASE_NOTES
+    )
+
+    await hass.services.async_call(
+        UPDATE_DOMAIN,
+        SERVICE_INSTALL,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    mock_omada_client.upgrade_controller_firmware.assert_awaited_once_with("6.2.11.1")
+
+
+@pytest.mark.parametrize(
+    ("exception_type", "error_message"),
+    [
+        (
+            RequestFailed(500, "Update rejected"),
+            "Controller firmware update request rejected",
+        ),
+        (
+            OmadaClientException("Connection error"),
+            "Unable to send controller firmware update request. Check the controller is online.",
+        ),
+    ],
+)
+async def test_controller_hardware_update_install_exceptions(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_omada_client: MagicMock,
+    exception_type: Exception,
+    error_message: str,
+) -> None:
+    """Test controller hardware firmware installation exception handling."""
+    mock_omada_client.check_firmware_updates.return_value = _controller_update_info(
+        hardware_upgrade=True
+    )
+    mock_omada_client.upgrade_controller_firmware = AsyncMock(
+        side_effect=exception_type
+    )
+
+    await _async_setup_update_platform(hass, mock_config_entry)
+
+    with pytest.raises(HomeAssistantError, match=error_message):
+        await hass.services.async_call(
+            UPDATE_DOMAIN,
+            SERVICE_INSTALL,
+            {ATTR_ENTITY_ID: "update.oc200_firmware"},
+            blocking=True,
+        )
+
+
+async def test_controller_software_update_does_not_support_install(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_omada_client: MagicMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test controller software updates expose version info without install support."""
+    mock_omada_client.check_firmware_updates.return_value = _controller_update_info(
+        software_upgrade=True
+    )
+
+    await _async_setup_update_platform(hass, mock_config_entry)
+
+    entity_id = "update.oc200_firmware"
+    entity = hass.states.get(entity_id)
+    assert entity is not None
+    assert entity.state == STATE_ON
+    assert entity.attributes["installed_version"] == "6.2.10.17"
+    assert entity.attributes["latest_version"] == "6.2.12.1"
+
+    entity_entry = entity_registry.async_get(entity_id)
+    assert entity_entry is not None
+    assert entity_entry.supported_features == UpdateEntityFeature.RELEASE_NOTES

--- a/tests/components/tplink_omada/test_update.py
+++ b/tests/components/tplink_omada/test_update.py
@@ -45,13 +45,13 @@ def _controller_update_info(
                 "upgrade": hardware_upgrade,
                 "currentVersion": "6.2.10.17",
                 "latestVersion": ("6.2.11.1" if hardware_upgrade else "6.2.10.17"),
-                "releaseNotes": "Controller hardware update",
+                "fwReleaseLog": "Controller hardware update",
             },
             "software": {
                 "upgrade": software_upgrade,
                 "currentVersion": "6.2.10.17",
                 "latestVersion": ("6.2.12.1" if software_upgrade else "6.2.10.17"),
-                "releaseNotes": "Controller software update",
+                "releaseLog": "Controller software update",
             },
         }
     )
@@ -322,6 +322,7 @@ async def test_controller_software_update_does_not_support_install(
     mock_config_entry: MockConfigEntry,
     mock_omada_client: MagicMock,
     entity_registry: er.EntityRegistry,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test controller software updates expose version info without install support."""
     mock_omada_client.check_firmware_updates.return_value = _controller_update_info(
@@ -340,3 +341,15 @@ async def test_controller_software_update_does_not_support_install(
     entity_entry = entity_registry.async_get(entity_id)
     assert entity_entry is not None
     assert entity_entry.supported_features == UpdateEntityFeature.RELEASE_NOTES
+
+    client = await hass_ws_client(hass)
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "update/release_notes",
+            "entity_id": entity_id,
+        }
+    )
+    result = await client.receive_json()
+
+    assert result["result"] == "Controller software update"

--- a/tests/components/tplink_omada/test_update.py
+++ b/tests/components/tplink_omada/test_update.py
@@ -14,6 +14,7 @@ from homeassistant.components.tplink_omada.coordinator import (
     POLL_DEVICES,
     OmadaControllerCoordinator,
 )
+from homeassistant.components.tplink_omada.update import OmadaControllerUpdate
 from homeassistant.components.update import (
     ATTR_IN_PROGRESS,
     DOMAIN as UPDATE_DOMAIN,
@@ -403,3 +404,69 @@ async def test_controller_software_update_does_not_support_install(
     result = await client.receive_json()
 
     assert result["result"] == "Controller software update"
+
+
+async def test_controller_update_without_available_upgrade(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_omada_client: MagicMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test controller update entity without an available upgrade."""
+    mock_omada_client.check_firmware_updates.return_value = _controller_update_info()
+
+    await _async_setup_update_platform(hass, mock_config_entry)
+
+    entity_id = "update.oc200_firmware"
+    entity = hass.states.get(entity_id)
+    assert entity is not None
+    assert entity.attributes["installed_version"] == "6.2.10.17"
+    assert entity.attributes["latest_version"] == "6.2.10.17"
+
+    entity_entry = entity_registry.async_get(entity_id)
+    assert entity_entry is not None
+    assert entity_entry.supported_features == (
+        UpdateEntityFeature.INSTALL | UpdateEntityFeature.RELEASE_NOTES
+    )
+
+
+async def test_controller_update_without_update_info(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_omada_client: MagicMock,
+) -> None:
+    """Test controller update entity properties without update information."""
+    mock_omada_client.check_firmware_updates.side_effect = OmadaClientException(
+        "No permission"
+    )
+
+    await _async_setup_update_platform(hass, mock_config_entry)
+
+    coordinator = mock_config_entry.runtime_data.controller_coordinator
+
+    entity = OmadaControllerUpdate(coordinator)
+
+    assert not entity.available
+    assert entity.installed_version == "6.2.10.17"
+    assert entity.latest_version == "6.2.10.17"
+    assert entity.release_notes() is None
+
+
+async def test_controller_software_update_install_raises(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_omada_client: MagicMock,
+) -> None:
+    """Test controller software update install raises without firmware update."""
+    mock_omada_client.check_firmware_updates.return_value = _controller_update_info(
+        software_upgrade=True
+    )
+
+    await _async_setup_update_platform(hass, mock_config_entry)
+
+    entity = OmadaControllerUpdate(mock_config_entry.runtime_data.controller_coordinator)
+
+    with pytest.raises(
+        HomeAssistantError, match="No controller firmware update is available"
+    ):
+        await entity.async_install(None, False)

--- a/tests/components/tplink_omada/test_update.py
+++ b/tests/components/tplink_omada/test_update.py
@@ -464,7 +464,9 @@ async def test_controller_software_update_install_raises(
 
     await _async_setup_update_platform(hass, mock_config_entry)
 
-    entity = OmadaControllerUpdate(mock_config_entry.runtime_data.controller_coordinator)
+    entity = OmadaControllerUpdate(
+        mock_config_entry.runtime_data.controller_coordinator
+    )
 
     with pytest.raises(
         HomeAssistantError, match="No controller firmware update is available"

--- a/tests/components/tplink_omada/test_update.py
+++ b/tests/components/tplink_omada/test_update.py
@@ -130,15 +130,21 @@ async def test_controller_coordinator_fetches_info_and_updates(
     assert data.updates is mock_omada_client.check_firmware_updates.return_value
 
 
+@pytest.mark.parametrize(
+    "side_effect",
+    [
+        pytest.param(OmadaClientException("No permission"), id="client-error"),
+        pytest.param(TimeoutError, id="timeout"),
+    ],
+)
 async def test_controller_update_unavailable_when_update_check_fails(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_omada_client: MagicMock,
+    side_effect: type[Exception] | Exception,
 ) -> None:
     """Test controller update endpoint failure does not block setup."""
-    mock_omada_client.check_firmware_updates.side_effect = OmadaClientException(
-        "No permission"
-    )
+    mock_omada_client.check_firmware_updates.side_effect = side_effect
 
     await _async_setup_update_platform(hass, mock_config_entry)
 

--- a/tests/components/tplink_omada/test_update.py
+++ b/tests/components/tplink_omada/test_update.py
@@ -10,17 +10,21 @@ from tplink_omada_client.definitions import OmadaControllerUpdateInfo
 from tplink_omada_client.devices import OmadaListDevice
 from tplink_omada_client.exceptions import OmadaClientException, RequestFailed
 
-from homeassistant.components.tplink_omada.coordinator import POLL_DEVICES
+from homeassistant.components.tplink_omada.coordinator import (
+    POLL_DEVICES,
+    OmadaControllerCoordinator,
+)
 from homeassistant.components.update import (
     ATTR_IN_PROGRESS,
     DOMAIN as UPDATE_DOMAIN,
     SERVICE_INSTALL,
     UpdateEntityFeature,
 )
-from homeassistant.const import ATTR_ENTITY_ID, STATE_ON, Platform
+from homeassistant.const import ATTR_ENTITY_ID, STATE_ON, STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from tests.common import (
     MockConfigEntry,
@@ -108,6 +112,52 @@ async def test_entities(
 ) -> None:
     """Test the creation of the TP-Link Omada update entities."""
     await snapshot_platform(hass, entity_registry, snapshot, init_integration.entry_id)
+
+
+async def test_controller_coordinator_fetches_info_and_updates(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_omada_client: MagicMock,
+) -> None:
+    """Test the controller coordinator fetches controller info and update status."""
+    mock_config_entry.add_to_hass(hass)
+    coordinator = OmadaControllerCoordinator(hass, mock_config_entry, mock_omada_client)
+
+    data = await coordinator._async_update_data()
+
+    assert data.info is mock_omada_client.get_controller_info.return_value
+    assert data.updates is mock_omada_client.check_firmware_updates.return_value
+
+
+async def test_controller_update_unavailable_when_update_check_fails(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_omada_client: MagicMock,
+) -> None:
+    """Test controller update endpoint failure does not block setup."""
+    mock_omada_client.check_firmware_updates.side_effect = OmadaClientException(
+        "No permission"
+    )
+
+    await _async_setup_update_platform(hass, mock_config_entry)
+
+    entity = hass.states.get("update.oc200_firmware")
+    assert entity is not None
+    assert entity.state == STATE_UNAVAILABLE
+
+
+async def test_controller_coordinator_info_failure_raises_update_failed(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_omada_client: MagicMock,
+) -> None:
+    """Test controller info endpoint failure fails the coordinator."""
+    mock_config_entry.add_to_hass(hass)
+    mock_omada_client.get_controller_info.side_effect = OmadaClientException("Boom")
+    coordinator = OmadaControllerCoordinator(hass, mock_config_entry, mock_omada_client)
+
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
 
 
 async def test_firmware_download_in_progress(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Represent the TP-Link Omada controller as its own Home Assistant device and expose controller-level entities backed by the controller APIs added in tplink-omada-client 1.5.9.

This adds:

- A controller device registered from the Omada controller ID and controller information.
- A controller device status diagnostic sensor, matching the existing device_status sensor convention used for Omada gateways, switches, and access points.
- A controller firmware update entity.

The controller device is also used as the parent device for Omada site devices through via_device, so gateways, switches, access points, and other Omada devices are grouped under the controller in the device hierarchy.

The controller update entity intentionally exposes one firmware update entity. It prefers hardware controller update information when available, otherwise it reports software controller update information so users can still see available release/version information for software controllers. Firmware installation is only sent through the controller firmware update API.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 
- Built on #175881, which bumped `tplink-omada-client` to 1.5.9 for the controller info and controller firmware update APIs.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
