### PR TITLE
[http] Use ip_network for trusted_proxies instead of string in middleware

### DIFF
--- a/homeassistant/components/http/forwarded.py
+++ b/homeassistant/components/http/forwarded.py
@@ -1,7 +1,7 @@
 """Middleware to handle forwarded data by a reverse proxy."""
 
 from collections.abc import Awaitable, Callable
-from ipaddress import IPv4Network, IPv6Network, ip_address
+from ipaddress import IPv4Network, IPv6Network, ip_address, ip_network
 import logging
 
 from aiohttp.hdrs import X_FORWARDED_FOR, X_FORWARDED_HOST, X_FORWARDED_PROTO
@@ -95,6 +95,8 @@ def async_setup_forwarded(
 
         connected_ip = ip_address(request.transport.get_extra_info("peername")[0])
 
+        trusted_networks = [ip_network(p) for p in trusted_proxies]
+
         # We have X-Forwarded-For, but config does not agree
         if not use_x_forwarded_for:
             _LOGGER.error(
@@ -107,7 +109,7 @@ def async_setup_forwarded(
             raise HTTPBadRequest
 
         # Ensure the IP of the connected peer is trusted
-        if not any(connected_ip in ip_network(trusted_proxy) for trusted_proxy in trusted_proxies):
+        if not any(connected_ip in trusted_network for trusted_network in trusted_networks):
             _LOGGER.error(
                 "Received X-Forwarded-For header from an untrusted proxy %s",
                 connected_ip,
@@ -133,7 +135,7 @@ def async_setup_forwarded(
         # Find the last trusted index in the X-Forwarded-For list
         forwarded_for_index = 0
         for forwarded_ip in forwarded_for:
-            if any(forwarded_ip in ip_network(trusted_proxy) for trusted_proxy in trusted_proxies):
+            if any(forwarded_ip in trusted_network for trusted_network in trusted_networks):
                 forwarded_for_index += 1
                 continue
             overrides["remote"] = str(forwarded_ip)

--- a/homeassistant/components/http/forwarded.py
+++ b/homeassistant/components/http/forwarded.py
@@ -107,7 +107,7 @@ def async_setup_forwarded(
             raise HTTPBadRequest
 
         # Ensure the IP of the connected peer is trusted
-        if not any(connected_ip in trusted_proxy for trusted_proxy in trusted_proxies):
+        if not any(connected_ip in ip_network(trusted_proxy) for trusted_proxy in trusted_proxies):
             _LOGGER.error(
                 "Received X-Forwarded-For header from an untrusted proxy %s",
                 connected_ip,
@@ -133,7 +133,7 @@ def async_setup_forwarded(
         # Find the last trusted index in the X-Forwarded-For list
         forwarded_for_index = 0
         for forwarded_ip in forwarded_for:
-            if any(forwarded_ip in trusted_proxy for trusted_proxy in trusted_proxies):
+            if any(forwarded_ip in ip_network(trusted_proxy) for trusted_proxy in trusted_proxies):
                 forwarded_for_index += 1
                 continue
             overrides["remote"] = str(forwarded_ip)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #175894 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
