### PR TITLE
Use LightEntityStateAttribute enum in MQTT light template

### DIFF
--- a/homeassistant/components/mqtt/light/schema_template.py
+++ b/homeassistant/components/mqtt/light/schema_template.py
@@ -19,6 +19,7 @@ from homeassistant.components.light import (
     ColorMode,
     LightEntity,
     LightEntityFeature,
+    LightEntityStateAttribute,
     filter_supported_color_modes,
 )
 from homeassistant.const import (
@@ -361,17 +362,23 @@ class MqttLightTemplate(MqttEntity, LightEntity, RestoreEntity):
         last_state = await self.async_get_last_state()
         if self._optimistic and last_state:
             self._attr_is_on = last_state.state == STATE_ON
-            if last_state.attributes.get(ATTR_BRIGHTNESS):
-                self._attr_brightness = last_state.attributes.get(ATTR_BRIGHTNESS)
-            if last_state.attributes.get(ATTR_HS_COLOR):
-                self._attr_hs_color = last_state.attributes.get(ATTR_HS_COLOR)
-                self._update_color_mode()
-            if last_state.attributes.get(ATTR_COLOR_TEMP_KELVIN):
-                self._attr_color_temp_kelvin = last_state.attributes.get(
-                    ATTR_COLOR_TEMP_KELVIN
+            if last_state.attributes.get(LightEntityStateAttribute.BRIGHTNESS):
+                self._attr_brightness = last_state.attributes.get(
+                    LightEntityStateAttribute.BRIGHTNESS
                 )
-            if last_state.attributes.get(ATTR_EFFECT):
-                self._attr_effect = last_state.attributes.get(ATTR_EFFECT)
+            if last_state.attributes.get(LightEntityStateAttribute.HS_COLOR):
+                self._attr_hs_color = last_state.attributes.get(
+                    LightEntityStateAttribute.HS_COLOR
+                )
+                self._update_color_mode()
+            if last_state.attributes.get(LightEntityStateAttribute.COLOR_TEMP_KELVIN):
+                self._attr_color_temp_kelvin = last_state.attributes.get(
+                    LightEntityStateAttribute.COLOR_TEMP_KELVIN
+                )
+            if last_state.attributes.get(LightEntityStateAttribute.EFFECT):
+                self._attr_effect = last_state.attributes.get(
+                    LightEntityStateAttribute.EFFECT
+                )
 
     @override
     async def async_turn_on(self, **kwargs: Any) -> None:

--- a/homeassistant/components/mqtt/light/schema_template.py
+++ b/homeassistant/components/mqtt/light/schema_template.py
@@ -362,23 +362,21 @@ class MqttLightTemplate(MqttEntity, LightEntity, RestoreEntity):
         last_state = await self.async_get_last_state()
         if self._optimistic and last_state:
             self._attr_is_on = last_state.state == STATE_ON
-            if last_state.attributes.get(LightEntityStateAttribute.BRIGHTNESS):
-                self._attr_brightness = last_state.attributes.get(
-                    LightEntityStateAttribute.BRIGHTNESS
-                )
-            if last_state.attributes.get(LightEntityStateAttribute.HS_COLOR):
-                self._attr_hs_color = last_state.attributes.get(
-                    LightEntityStateAttribute.HS_COLOR
-                )
+            if brightness := last_state.attributes.get(
+                LightEntityStateAttribute.BRIGHTNESS
+            ):
+                self._attr_brightness = brightness
+            if hs_color := last_state.attributes.get(
+                LightEntityStateAttribute.HS_COLOR
+            ):
+                self._attr_hs_color = hs_color
                 self._update_color_mode()
-            if last_state.attributes.get(LightEntityStateAttribute.COLOR_TEMP_KELVIN):
-                self._attr_color_temp_kelvin = last_state.attributes.get(
-                    LightEntityStateAttribute.COLOR_TEMP_KELVIN
-                )
-            if last_state.attributes.get(LightEntityStateAttribute.EFFECT):
-                self._attr_effect = last_state.attributes.get(
-                    LightEntityStateAttribute.EFFECT
-                )
+            if color_temp_kelvin := last_state.attributes.get(
+                LightEntityStateAttribute.COLOR_TEMP_KELVIN
+            ):
+                self._attr_color_temp_kelvin = color_temp_kelvin
+            if effect := last_state.attributes.get(LightEntityStateAttribute.EFFECT):
+                self._attr_effect = effect
 
     @override
     async def async_turn_on(self, **kwargs: Any) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follow-up to #174633, which introduced the base `EntityStateAttribute` enum. The light platform exposes `LightEntityStateAttribute`.

The MQTT template light restores its optimistic state from the previous state through the ambiguous `ATTR_BRIGHTNESS`, `ATTR_HS_COLOR`, `ATTR_COLOR_TEMP_KELVIN` and `ATTR_EFFECT` constants. Reading them through the dedicated enum makes the intent explicit.

This migrates the state-attribute reads in `light/schema_template.py`:

- `brightness` / `hs_color` / `color_temp_kelvin` / `effect` -> `LightEntityStateAttribute`

The same constants used as `turn_on` service call arguments (`kwargs`) are left unchanged.

No behaviour change: `LightEntityStateAttribute` is a `StrEnum`, so the resolved keys are identical.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)