### PR TITLE
Use state attribute enums in Prometheus

### DIFF
--- a/homeassistant/components/prometheus/__init__.py
+++ b/homeassistant/components/prometheus/__init__.py
@@ -15,51 +15,32 @@ import voluptuous as vol
 from homeassistant import core as hacore
 from homeassistant.components.alarm_control_panel import AlarmControlPanelState
 from homeassistant.components.climate import (
-    ATTR_CURRENT_TEMPERATURE,
-    ATTR_FAN_MODE,
-    ATTR_FAN_MODES,
-    ATTR_HVAC_ACTION,
-    ATTR_HVAC_MODES,
-    ATTR_TARGET_TEMP_HIGH,
-    ATTR_TARGET_TEMP_LOW,
+    ClimateEntityCapabilityAttribute,
+    ClimateEntityStateAttribute,
     HVACAction,
 )
-from homeassistant.components.cover import (
-    ATTR_CURRENT_POSITION,
-    ATTR_CURRENT_TILT_POSITION,
-)
+from homeassistant.components.cover import CoverEntityStateAttribute
 from homeassistant.components.fan import (
-    ATTR_DIRECTION,
-    ATTR_OSCILLATING,
-    ATTR_PERCENTAGE,
-    ATTR_PRESET_MODE,
-    ATTR_PRESET_MODES,
     DIRECTION_FORWARD,
     DIRECTION_REVERSE,
+    FanEntityCapabilityAttribute,
+    FanEntityStateAttribute,
 )
 from homeassistant.components.http import KEY_HASS, HomeAssistantView
-from homeassistant.components.humidifier import ATTR_AVAILABLE_MODES, ATTR_HUMIDITY
-from homeassistant.components.light import ATTR_BRIGHTNESS
+from homeassistant.components.humidifier import (
+    HumidifierEntityCapabilityAttribute,
+    HumidifierEntityStateAttribute,
+)
+from homeassistant.components.light import LightEntityStateAttribute
 from homeassistant.components.sensor import SensorDeviceClass
-
-# Alias water_heater constants to avoid name clashes with
-# similarly named climate constants
 from homeassistant.components.water_heater import (
-    ATTR_AWAY_MODE as WATER_HEATER_ATTR_AWAY_MODE,
-    ATTR_CURRENT_TEMPERATURE as WATER_HEATER_ATTR_CURRENT_TEMPERATURE,
-    ATTR_MAX_TEMP as WATER_HEATER_ATTR_MAX_TEMP,
-    ATTR_MIN_TEMP as WATER_HEATER_ATTR_MIN_TEMP,
-    ATTR_OPERATION_LIST as WATER_HEATER_ATTR_OPERATION_LIST,
-    ATTR_OPERATION_MODE as WATER_HEATER_ATTR_OPERATION_MODE,
-    ATTR_TARGET_TEMP_HIGH as WATER_HEATER_ATTR_TARGET_TEMP_HIGH,
-    ATTR_TARGET_TEMP_LOW as WATER_HEATER_ATTR_TARGET_TEMP_LOW,
+    WaterHeaterCapabilityAttribute,
+    WaterHeaterStateAttribute,
 )
 from homeassistant.const import (
     ATTR_BATTERY_LEVEL,
     ATTR_LATITUDE,
     ATTR_LONGITUDE,
-    ATTR_MODE,
-    ATTR_TEMPERATURE,
     CONTENT_TYPE_TEXT_PLAIN,
     EVENT_STATE_CHANGED,
     PERCENTAGE,
@@ -818,13 +799,13 @@ class PrometheusMetrics:
         )
         self._float_metric(
             state,
-            ATTR_CURRENT_POSITION,
+            CoverEntityStateAttribute.CURRENT_POSITION,
             "cover_position",
             "Position of the cover (0-100)",
         )
         self._float_metric(
             state,
-            ATTR_CURRENT_TILT_POSITION,
+            CoverEntityStateAttribute.CURRENT_TILT_POSITION,
             "cover_tilt_position",
             "Tilt Position of the cover (0-100)",
         )
@@ -833,7 +814,7 @@ class PrometheusMetrics:
         if (value := self.state_as_number(state)) is None:
             return
 
-        brightness = state.attributes.get(ATTR_BRIGHTNESS)
+        brightness = state.attributes.get(LightEntityStateAttribute.BRIGHTNESS)
         if state.state == STATE_ON and brightness is not None:
             value = float(brightness) / 255.0
         value = value * 100
@@ -848,25 +829,25 @@ class PrometheusMetrics:
     def _handle_climate(self, state: State) -> None:
         self._temperature_metric(
             state,
-            ATTR_TEMPERATURE,
+            ClimateEntityStateAttribute.TEMPERATURE,
             "climate_target_temperature_celsius",
             "Target temperature in degrees Celsius",
         )
         self._temperature_metric(
             state,
-            ATTR_TARGET_TEMP_HIGH,
+            ClimateEntityStateAttribute.TARGET_TEMP_HIGH,
             "climate_target_temperature_high_celsius",
             "Target high temperature in degrees Celsius",
         )
         self._temperature_metric(
             state,
-            ATTR_TARGET_TEMP_LOW,
+            ClimateEntityStateAttribute.TARGET_TEMP_LOW,
             "climate_target_temperature_low_celsius",
             "Target low temperature in degrees Celsius",
         )
         self._temperature_metric(
             state,
-            ATTR_CURRENT_TEMPERATURE,
+            ClimateEntityStateAttribute.CURRENT_TEMPERATURE,
             "climate_current_temperature_celsius",
             "Current temperature in degrees Celsius",
         )
@@ -874,7 +855,7 @@ class PrometheusMetrics:
         self._enum_metric(
             state,
             (
-                (attr := state.attributes.get(ATTR_HVAC_ACTION))
+                (attr := state.attributes.get(ClimateEntityStateAttribute.HVAC_ACTION))
                 and getattr(attr, "value", attr)
             ),
             [action.value for action in HVACAction],
@@ -885,23 +866,23 @@ class PrometheusMetrics:
         self._enum_metric(
             state,
             state.state,
-            state.attributes.get(ATTR_HVAC_MODES),
+            state.attributes.get(ClimateEntityCapabilityAttribute.HVAC_MODES),
             "climate_mode",
             "HVAC mode",
             "mode",
         )
         self._enum_metric(
             state,
-            state.attributes.get(ATTR_PRESET_MODE),
-            state.attributes.get(ATTR_PRESET_MODES),
+            state.attributes.get(ClimateEntityStateAttribute.PRESET_MODE),
+            state.attributes.get(ClimateEntityCapabilityAttribute.PRESET_MODES),
             "climate_preset_mode",
             "Preset mode enum",
             "mode",
         )
         self._enum_metric(
             state,
-            state.attributes.get(ATTR_FAN_MODE),
-            state.attributes.get(ATTR_FAN_MODES),
+            state.attributes.get(ClimateEntityStateAttribute.FAN_MODE),
+            state.attributes.get(ClimateEntityCapabilityAttribute.FAN_MODES),
             "climate_fan_mode",
             "Fan mode enum",
             "mode",
@@ -912,15 +893,15 @@ class PrometheusMetrics:
 
         self._float_metric(
             state,
-            ATTR_HUMIDITY,
+            HumidifierEntityStateAttribute.HUMIDITY,
             "humidifier_target_humidity_percent",
             "Target Relative Humidity",
         )
 
         self._enum_metric(
             state,
-            state.attributes.get(ATTR_MODE),
-            state.attributes.get(ATTR_AVAILABLE_MODES),
+            state.attributes.get(HumidifierEntityStateAttribute.MODE),
+            state.attributes.get(HumidifierEntityCapabilityAttribute.AVAILABLE_MODES),
             "humidifier_mode",
             "Humidifier Mode",
             "mode",
@@ -930,44 +911,45 @@ class PrometheusMetrics:
         # Temperatures
         self._temperature_metric(
             state,
-            ATTR_TEMPERATURE,
+            WaterHeaterStateAttribute.TEMPERATURE,
             "water_heater_temperature_celsius",
             "Target temperature in degrees Celsius",
         )
         self._temperature_metric(
             state,
-            WATER_HEATER_ATTR_CURRENT_TEMPERATURE,
+            WaterHeaterStateAttribute.CURRENT_TEMPERATURE,
             "water_heater_current_temperature_celsius",
             "Current temperature in degrees Celsius",
         )
         self._temperature_metric(
             state,
-            WATER_HEATER_ATTR_TARGET_TEMP_HIGH,
+            WaterHeaterStateAttribute.TARGET_TEMP_HIGH,
             "water_heater_target_temperature_high_celsius",
             "Target high temperature in degrees Celsius",
         )
         self._temperature_metric(
             state,
-            WATER_HEATER_ATTR_TARGET_TEMP_LOW,
+            WaterHeaterStateAttribute.TARGET_TEMP_LOW,
             "water_heater_target_temperature_low_celsius",
             "Target low temperature in degrees Celsius",
         )
         self._temperature_metric(
             state,
-            WATER_HEATER_ATTR_MIN_TEMP,
+            WaterHeaterCapabilityAttribute.MIN_TEMP,
             "water_heater_min_temperature_celsius",
             "Minimum allowed temperature in degrees Celsius",
         )
         self._temperature_metric(
             state,
-            WATER_HEATER_ATTR_MAX_TEMP,
+            WaterHeaterCapabilityAttribute.MAX_TEMP,
             "water_heater_max_temperature_celsius",
             "Maximum allowed temperature in degrees Celsius",
         )
         self._enum_metric(
             state,
-            state.attributes.get(WATER_HEATER_ATTR_OPERATION_MODE) or state.state,
-            state.attributes.get(WATER_HEATER_ATTR_OPERATION_LIST),
+            state.attributes.get(WaterHeaterStateAttribute.OPERATION_MODE)
+            or state.state,
+            state.attributes.get(WaterHeaterCapabilityAttribute.OPERATION_LIST),
             "water_heater_operation_mode",
             "Water heater operation mode",
             "mode",
@@ -976,7 +958,7 @@ class PrometheusMetrics:
         # Away mode bool
         self._bool_metric(
             state,
-            WATER_HEATER_ATTR_AWAY_MODE,
+            WaterHeaterStateAttribute.AWAY_MODE,
             "water_heater_away_mode",
             "Whether away mode is on (0/1)",
             {STATE_ON},
@@ -989,29 +971,32 @@ class PrometheusMetrics:
     def _handle_fan(self, state: State) -> None:
         self._numeric_metric(state, "fan", "fan")
         self._float_metric(
-            state, ATTR_PERCENTAGE, "fan_speed_percent", "Fan speed percent (0-100)"
+            state,
+            FanEntityStateAttribute.PERCENTAGE,
+            "fan_speed_percent",
+            "Fan speed percent (0-100)",
         )
         self._bool_metric(
             state,
-            ATTR_OSCILLATING,
+            FanEntityStateAttribute.OSCILLATING,
             "fan_is_oscillating",
             "Whether the fan is oscillating (0/1)",
         )
 
         self._enum_metric(
             state,
-            state.attributes.get(ATTR_PRESET_MODE),
-            state.attributes.get(ATTR_PRESET_MODES),
+            state.attributes.get(FanEntityStateAttribute.PRESET_MODE),
+            state.attributes.get(FanEntityCapabilityAttribute.PRESET_MODES),
             "fan_preset_mode",
             "Fan preset mode enum",
             "mode",
         )
 
-        fan_direction = state.attributes.get(ATTR_DIRECTION)
+        fan_direction = state.attributes.get(FanEntityStateAttribute.DIRECTION)
         if fan_direction in {DIRECTION_FORWARD, DIRECTION_REVERSE}:
             self._bool_metric(
                 state,
-                ATTR_DIRECTION,
+                FanEntityStateAttribute.DIRECTION,
                 "fan_direction_reversed",
                 "Fan direction reversed (bool)",
                 {DIRECTION_REVERSE},

--- a/homeassistant/components/prometheus/__init__.py
+++ b/homeassistant/components/prometheus/__init__.py
@@ -56,13 +56,10 @@ from homeassistant.components.water_heater import (
 )
 from homeassistant.const import (
     ATTR_BATTERY_LEVEL,
-    ATTR_DEVICE_CLASS,
-    ATTR_FRIENDLY_NAME,
     ATTR_LATITUDE,
     ATTR_LONGITUDE,
     ATTR_MODE,
     ATTR_TEMPERATURE,
-    ATTR_UNIT_OF_MEASUREMENT,
     CONTENT_TYPE_TEXT_PLAIN,
     EVENT_STATE_CHANGED,
     PERCENTAGE,
@@ -73,6 +70,7 @@ from homeassistant.const import (
     STATE_OPENING,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
+    EntityStateAttribute,
     UnitOfLength,
     UnitOfTemperature,
 )
@@ -293,8 +291,8 @@ class PrometheusMetrics:
         if (
             old_state := event.data.get("old_state")
         ) is not None and old_state.attributes.get(
-            ATTR_FRIENDLY_NAME
-        ) != state.attributes.get(ATTR_FRIENDLY_NAME):
+            EntityStateAttribute.FRIENDLY_NAME
+        ) != state.attributes.get(EntityStateAttribute.FRIENDLY_NAME):
             self._remove_labelsets(old_state.entity_id)
 
         self.handle_state(state)
@@ -569,7 +567,10 @@ class PrometheusMetrics:
     def state_as_number(state: State) -> float | None:
         """Return state as a float, or None if state cannot be converted."""
         try:
-            if state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.TIMESTAMP:
+            if (
+                state.attributes.get(EntityStateAttribute.DEVICE_CLASS)
+                == SensorDeviceClass.TIMESTAMP
+            ):
                 value = as_timestamp(state.state)
             else:
                 value = state_helper.state_as_number(state)
@@ -588,7 +589,7 @@ class PrometheusMetrics:
         labels = {
             "entity": state.entity_id,
             "domain": state.domain,
-            "friendly_name": state.attributes.get(ATTR_FRIENDLY_NAME),
+            "friendly_name": state.attributes.get(EntityStateAttribute.FRIENDLY_NAME),
         }
         if not labels.keys().isdisjoint(extra_labels.keys()):
             conflicting_keys = labels.keys() & extra_labels.keys()
@@ -731,7 +732,9 @@ class PrometheusMetrics:
         if (value := self.state_as_number(state)) is None:
             return
 
-        if unit := self._unit_string(state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)):
+        if unit := self._unit_string(
+            state.attributes.get(EntityStateAttribute.UNIT_OF_MEASUREMENT)
+        ):
             metric = self._metric(
                 f"{domain}_state_{unit}",
                 prometheus_client.Gauge,
@@ -747,7 +750,7 @@ class PrometheusMetrics:
             )
 
         if (
-            state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+            state.attributes.get(EntityStateAttribute.UNIT_OF_MEASUREMENT)
             == UnitOfTemperature.FAHRENHEIT
         ):
             value = TemperatureConverter.convert(
@@ -777,7 +780,7 @@ class PrometheusMetrics:
     def _handle_geo_location(self, state: State) -> None:
         labels = self._labels(state, {"source": state.attributes.get("source", "")})
         if (value := self.state_as_number(state)) is not None:
-            unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+            unit = state.attributes.get(EntityStateAttribute.UNIT_OF_MEASUREMENT)
             if unit is not None:
                 value = DistanceConverter.convert(value, unit, UnitOfLength.METERS)
             self._metric(
@@ -1050,7 +1053,9 @@ class PrometheusMetrics:
         )
 
     def _handle_sensor(self, state: State) -> None:
-        unit = self._unit_string(state.attributes.get(ATTR_UNIT_OF_MEASUREMENT))
+        unit = self._unit_string(
+            state.attributes.get(EntityStateAttribute.UNIT_OF_MEASUREMENT)
+        )
 
         for metric_handler in self._sensor_metric_handlers:
             metric = metric_handler(state, unit)
@@ -1063,7 +1068,7 @@ class PrometheusMetrics:
                 documentation = f"Sensor data measured in {unit}"
 
             if (
-                state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+                state.attributes.get(EntityStateAttribute.UNIT_OF_MEASUREMENT)
                 == UnitOfTemperature.FAHRENHEIT
             ):
                 value = TemperatureConverter.convert(
@@ -1085,7 +1090,7 @@ class PrometheusMetrics:
     @staticmethod
     def _sensor_attribute_metric(state: State, unit: str | None) -> str | None:
         """Get metric based on device class attribute."""
-        metric = state.attributes.get(ATTR_DEVICE_CLASS)
+        metric = state.attributes.get(EntityStateAttribute.DEVICE_CLASS)
         if metric is not None:
             return f"sensor_{metric}_{unit}"
         return None
@@ -1096,7 +1101,7 @@ class PrometheusMetrics:
 
         These have no unit of measurement attribute.
         """
-        metric = state.attributes.get(ATTR_DEVICE_CLASS)
+        metric = state.attributes.get(EntityStateAttribute.DEVICE_CLASS)
         if metric == SensorDeviceClass.TIMESTAMP:
             return f"sensor_{metric}_seconds"
         return None


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follow-up to #174633, which introduced the base `EntityStateAttribute` enum. Platform integrations now expose their own state/capability attribute enums too.

The base and platform state-attribute constants lack context and are used interchangeably to access state attributes, configuration, service arguments and library items. Reading them through the dedicated enums makes the intent explicit.

This migrates the state/capability-attribute reads in the Prometheus integration:

- base: `device_class`, `friendly_name`, `unit_of_measurement` -> `EntityStateAttribute`
- climate: `temperature`, `current_temperature`, `target_temp_high/low`, `hvac_action`, `preset_mode`, `fan_mode` -> `ClimateEntityStateAttribute`; `hvac_modes`, `preset_modes`, `fan_modes` -> `ClimateEntityCapabilityAttribute`
- cover: `current_position`, `current_tilt_position` -> `CoverEntityStateAttribute`
- fan: `percentage`, `oscillating`, `preset_mode`, `direction` -> `FanEntityStateAttribute`; `preset_modes` -> `FanEntityCapabilityAttribute`
- humidifier: `humidity`, `mode` -> `HumidifierEntityStateAttribute`; `available_modes` -> `HumidifierEntityCapabilityAttribute`
- light: `brightness` -> `LightEntityStateAttribute`
- water_heater: `temperature`, `current_temperature`, `target_temp_high/low`, `operation_mode`, `away_mode` -> `WaterHeaterStateAttribute`; `min_temp`, `max_temp`, `operation_list` -> `WaterHeaterCapabilityAttribute`

`ATTR_BATTERY_LEVEL`, `ATTR_LATITUDE` and `ATTR_LONGITUDE` are left unchanged, as no dedicated enum covers them (read generically across entity types).

No behaviour change: the enums are `StrEnum`s, so the resolved keys are identical (verified by the unchanged metric-output tests).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)