### PR TITLE
Use CoverEntityStateAttribute enum in SwitchBot

### DIFF
--- a/homeassistant/components/switchbot/cover.py
+++ b/homeassistant/components/switchbot/cover.py
@@ -6,13 +6,12 @@ from typing import Any, override
 import switchbot
 
 from homeassistant.components.cover import (
-    ATTR_CURRENT_POSITION,
-    ATTR_CURRENT_TILT_POSITION,
     ATTR_POSITION,
     ATTR_TILT_POSITION,
     CoverDeviceClass,
     CoverEntity,
     CoverEntityFeature,
+    CoverEntityStateAttribute,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -77,11 +76,14 @@ class SwitchBotCurtainEntity(SwitchbotEntity, CoverEntity, RestoreEntity):
         """Run when entity about to be added."""
         await super().async_added_to_hass()
         last_state = await self.async_get_last_state()
-        if not last_state or ATTR_CURRENT_POSITION not in last_state.attributes:
+        if (
+            not last_state
+            or CoverEntityStateAttribute.CURRENT_POSITION not in last_state.attributes
+        ):
             return
 
         self._attr_current_cover_position = last_state.attributes.get(
-            ATTR_CURRENT_POSITION
+            CoverEntityStateAttribute.CURRENT_POSITION
         )
         self._last_run_success = last_state.attributes.get("last_run_success")
         if self._attr_current_cover_position is not None:
@@ -172,11 +174,15 @@ class SwitchBotBlindTiltEntity(SwitchbotEntity, CoverEntity, RestoreEntity):
         """Run when entity about to be added."""
         await super().async_added_to_hass()
         last_state = await self.async_get_last_state()
-        if not last_state or ATTR_CURRENT_TILT_POSITION not in last_state.attributes:
+        if (
+            not last_state
+            or CoverEntityStateAttribute.CURRENT_TILT_POSITION
+            not in last_state.attributes
+        ):
             return
 
         self._attr_current_cover_tilt_position = last_state.attributes.get(
-            ATTR_CURRENT_TILT_POSITION
+            CoverEntityStateAttribute.CURRENT_TILT_POSITION
         )
         self._last_run_success = last_state.attributes.get("last_run_success")
         if (_tilt := self._attr_current_cover_tilt_position) is not None:
@@ -260,11 +266,14 @@ class SwitchBotRollerShadeEntity(SwitchbotEntity, CoverEntity, RestoreEntity):
         """Run when entity about to be added."""
         await super().async_added_to_hass()
         last_state = await self.async_get_last_state()
-        if not last_state or ATTR_CURRENT_POSITION not in last_state.attributes:
+        if (
+            not last_state
+            or CoverEntityStateAttribute.CURRENT_POSITION not in last_state.attributes
+        ):
             return
 
         self._attr_current_cover_position = last_state.attributes.get(
-            ATTR_CURRENT_POSITION
+            CoverEntityStateAttribute.CURRENT_POSITION
         )
         self._last_run_success = last_state.attributes.get("last_run_success")
         if self._attr_current_cover_position is not None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follow-up to #174633, which introduced the base `EntityStateAttribute` enum. The cover platform exposes `CoverEntityStateAttribute`.

The SwitchBot integration restores its cover position and tilt position from the previous state through the ambiguous `ATTR_CURRENT_POSITION` and `ATTR_CURRENT_TILT_POSITION` constants. Reading them through the dedicated enum makes the intent explicit.

This migrates the state-attribute reads in `cover.py`:

- `current_position` / `current_tilt_position` -> `CoverEntityStateAttribute`

The `ATTR_POSITION` / `ATTR_TILT_POSITION` constants used as service call arguments are left unchanged.

No behaviour change: `CoverEntityStateAttribute` is a `StrEnum`, so the resolved keys are identical.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)