### PR TITLE
Use state attribute enums in temperature

### DIFF
--- a/homeassistant/components/temperature/condition.py
+++ b/homeassistant/components/temperature/condition.py
@@ -3,20 +3,19 @@
 from typing import override
 
 from homeassistant.components.climate import (
-    ATTR_CURRENT_TEMPERATURE as CLIMATE_ATTR_CURRENT_TEMPERATURE,
     DOMAIN as CLIMATE_DOMAIN,
+    ClimateEntityStateAttribute,
 )
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN, SensorDeviceClass
 from homeassistant.components.water_heater import (
-    ATTR_CURRENT_TEMPERATURE as WATER_HEATER_ATTR_CURRENT_TEMPERATURE,
     DOMAIN as WATER_HEATER_DOMAIN,
+    WaterHeaterStateAttribute,
 )
 from homeassistant.components.weather import (
-    ATTR_WEATHER_TEMPERATURE,
-    ATTR_WEATHER_TEMPERATURE_UNIT,
     DOMAIN as WEATHER_DOMAIN,
+    WeatherEntityStateAttribute,
 )
-from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, UnitOfTemperature
+from homeassistant.const import EntityStateAttribute, UnitOfTemperature
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.automation import DomainSpec
 from homeassistant.helpers.condition import (
@@ -27,16 +26,16 @@ from homeassistant.util.unit_conversion import TemperatureConverter
 
 TEMPERATURE_DOMAIN_SPECS: dict[str, DomainSpec] = {
     CLIMATE_DOMAIN: DomainSpec(
-        value_source=CLIMATE_ATTR_CURRENT_TEMPERATURE,
+        value_source=ClimateEntityStateAttribute.CURRENT_TEMPERATURE,
     ),
     SENSOR_DOMAIN: DomainSpec(
         device_class=SensorDeviceClass.TEMPERATURE,
     ),
     WATER_HEATER_DOMAIN: DomainSpec(
-        value_source=WATER_HEATER_ATTR_CURRENT_TEMPERATURE,
+        value_source=WaterHeaterStateAttribute.CURRENT_TEMPERATURE,
     ),
     WEATHER_DOMAIN: DomainSpec(
-        value_source=ATTR_WEATHER_TEMPERATURE,
+        value_source=WeatherEntityStateAttribute.TEMPERATURE,
     ),
 }
 
@@ -68,9 +67,11 @@ class TemperatureCondition(EntityNumericalConditionWithUnitBase):
     def _get_entity_unit(self, entity_state: State) -> str | None:
         """Get the temperature unit of an entity from its state."""
         if entity_state.domain == SENSOR_DOMAIN:
-            return entity_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+            return entity_state.attributes.get(EntityStateAttribute.UNIT_OF_MEASUREMENT)
         if entity_state.domain == WEATHER_DOMAIN:
-            return entity_state.attributes.get(ATTR_WEATHER_TEMPERATURE_UNIT)
+            return entity_state.attributes.get(
+                WeatherEntityStateAttribute.TEMPERATURE_UNIT
+            )
         # Climate and water_heater: show_temp converts to system unit
         return self._hass.config.units.temperature_unit
 

--- a/homeassistant/components/temperature/trigger.py
+++ b/homeassistant/components/temperature/trigger.py
@@ -3,20 +3,19 @@
 from typing import override
 
 from homeassistant.components.climate import (
-    ATTR_CURRENT_TEMPERATURE as CLIMATE_ATTR_CURRENT_TEMPERATURE,
     DOMAIN as CLIMATE_DOMAIN,
+    ClimateEntityStateAttribute,
 )
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN, SensorDeviceClass
 from homeassistant.components.water_heater import (
-    ATTR_CURRENT_TEMPERATURE as WATER_HEATER_ATTR_CURRENT_TEMPERATURE,
     DOMAIN as WATER_HEATER_DOMAIN,
+    WaterHeaterStateAttribute,
 )
 from homeassistant.components.weather import (
-    ATTR_WEATHER_TEMPERATURE,
-    ATTR_WEATHER_TEMPERATURE_UNIT,
     DOMAIN as WEATHER_DOMAIN,
+    WeatherEntityStateAttribute,
 )
-from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, UnitOfTemperature
+from homeassistant.const import EntityStateAttribute, UnitOfTemperature
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.automation import DomainSpec
 from homeassistant.helpers.trigger import (
@@ -29,14 +28,16 @@ from homeassistant.util.unit_conversion import TemperatureConverter
 
 TEMPERATURE_DOMAIN_SPECS: dict[str, DomainSpec] = {
     CLIMATE_DOMAIN: DomainSpec(
-        value_source=CLIMATE_ATTR_CURRENT_TEMPERATURE,
+        value_source=ClimateEntityStateAttribute.CURRENT_TEMPERATURE,
     ),
     SENSOR_DOMAIN: DomainSpec(
         device_class=SensorDeviceClass.TEMPERATURE,
     ),
-    WATER_HEATER_DOMAIN: DomainSpec(value_source=WATER_HEATER_ATTR_CURRENT_TEMPERATURE),
+    WATER_HEATER_DOMAIN: DomainSpec(
+        value_source=WaterHeaterStateAttribute.CURRENT_TEMPERATURE
+    ),
     WEATHER_DOMAIN: DomainSpec(
-        value_source=ATTR_WEATHER_TEMPERATURE,
+        value_source=WeatherEntityStateAttribute.TEMPERATURE,
     ),
 }
 
@@ -70,9 +71,9 @@ class _TemperatureTriggerMixin(EntityNumericalStateTriggerWithUnitBase):
     def _get_entity_unit(self, state: State) -> str | None:
         """Get the temperature unit of an entity from its state."""
         if state.domain == SENSOR_DOMAIN:
-            return state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+            return state.attributes.get(EntityStateAttribute.UNIT_OF_MEASUREMENT)
         if state.domain == WEATHER_DOMAIN:
-            return state.attributes.get(ATTR_WEATHER_TEMPERATURE_UNIT)
+            return state.attributes.get(WeatherEntityStateAttribute.TEMPERATURE_UNIT)
         # Climate and water_heater: show_temp converts to system unit
         return self._hass.config.units.temperature_unit
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follow-up to #174633, which introduced the base `EntityStateAttribute` enum. Platform integrations expose their own state-attribute enums too.

The temperature condition and trigger read the source entity unit and temperature attributes (per source domain) through the ambiguous `ATTR_UNIT_OF_MEASUREMENT`, `ATTR_CURRENT_TEMPERATURE`, `ATTR_WEATHER_TEMPERATURE` and `ATTR_WEATHER_TEMPERATURE_UNIT` constants. Reading them through the dedicated enums makes the intent explicit.

This migrates the attribute references in `condition.py` and `trigger.py`:

- `unit_of_measurement` -> `EntityStateAttribute.UNIT_OF_MEASUREMENT`
- climate `current_temperature` -> `ClimateEntityStateAttribute.CURRENT_TEMPERATURE`
- water_heater `current_temperature` -> `WaterHeaterStateAttribute.CURRENT_TEMPERATURE`
- weather `temperature` / `temperature_unit` -> `WeatherEntityStateAttribute`

No behaviour change: the enums are `StrEnum`s, so the resolved keys are identical.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)