### PR TITLE
Use state attribute enums in Template

### DIFF
--- a/homeassistant/components/template/entity.py
+++ b/homeassistant/components/template/entity.py
@@ -6,15 +6,13 @@ from dataclasses import dataclass
 from typing import Any, override
 
 from homeassistant.const import (
-    ATTR_ENTITY_PICTURE,
-    ATTR_FRIENDLY_NAME,
-    ATTR_ICON,
     CONF_DEVICE_ID,
     CONF_ICON,
     CONF_NAME,
     CONF_OPTIMISTIC,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
+    EntityStateAttribute,
 )
 from homeassistant.core import Context, HomeAssistant, State, callback
 from homeassistant.helpers import device_registry as dr
@@ -289,9 +287,9 @@ class AbstractTemplateEntity(Entity):
         """Restore attributes from the last state."""
         # Restore built-in attributes from templates
         for conf_key, attr, _attr in (
-            (CONF_ICON, ATTR_ICON, "_attr_icon"),
-            (CONF_NAME, ATTR_FRIENDLY_NAME, "_attr_name"),
-            (CONF_PICTURE, ATTR_ENTITY_PICTURE, "_attr_entity_picture"),
+            (CONF_ICON, EntityStateAttribute.ICON, "_attr_icon"),
+            (CONF_NAME, EntityStateAttribute.FRIENDLY_NAME, "_attr_name"),
+            (CONF_PICTURE, EntityStateAttribute.ENTITY_PICTURE, "_attr_entity_picture"),
         ):
             if conf_key not in self._config or attr not in last_state.attributes:
                 continue

--- a/homeassistant/components/template/update.py
+++ b/homeassistant/components/template/update.py
@@ -6,13 +6,12 @@ from typing import TYPE_CHECKING, Any, override
 import voluptuous as vol
 
 from homeassistant.components.update import (
-    ATTR_INSTALLED_VERSION,
-    ATTR_LATEST_VERSION,
     DEVICE_CLASSES_SCHEMA,
     DOMAIN as UPDATE_DOMAIN,
     ENTITY_ID_FORMAT,
     UpdateEntity,
     UpdateEntityFeature,
+    UpdateEntityStateAttribute,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_DEVICE_CLASS, CONF_NAME
@@ -244,8 +243,12 @@ class AbstractTemplateUpdate(AbstractTemplateEntity, UpdateEntity):
     @override
     def restore_last_state_state(self, last_state: State) -> bool:
         """Restore the state from the last state."""
-        self._attr_installed_version = last_state.attributes[ATTR_INSTALLED_VERSION]
-        self._attr_latest_version = last_state.attributes[ATTR_LATEST_VERSION]
+        self._attr_installed_version = last_state.attributes[
+            UpdateEntityStateAttribute.INSTALLED_VERSION
+        ]
+        self._attr_latest_version = last_state.attributes[
+            UpdateEntityStateAttribute.LATEST_VERSION
+        ]
         return True
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follow-up to #174633, which introduced the base `EntityStateAttribute` enum. The update platform exposes `UpdateEntityStateAttribute`.

The Template integration restores base and update state attributes from the previous state through the ambiguous `ATTR_*` constants. Reading them through the dedicated enums makes the intent explicit.

This migrates the state-attribute reads:

- `entity.py`: `icon` / `friendly_name` / `entity_picture` -> `EntityStateAttribute`
- `update.py`: `installed_version` / `latest_version` -> `UpdateEntityStateAttribute`

No behaviour change: the enums are `StrEnum`s, so the resolved keys are identical.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)