### PR TITLE
Use TimerEntityStateAttribute enum in timer

### DIFF
--- a/homeassistant/components/timer/__init__.py
+++ b/homeassistant/components/timer/__init__.py
@@ -292,20 +292,26 @@ class Timer(collection.CollectionEntity, RestoreEntity):
 
         # Begin restoring state
         self._state = state.state
-        self._last_transition = state.attributes.get(ATTR_LAST_TRANSITION)
+        self._last_transition = state.attributes.get(
+            TimerEntityStateAttribute.LAST_TRANSITION
+        )
 
         # Nothing more to do if the timer is idle
         if self._state == STATUS_IDLE:
             return
 
-        self._running_duration = cv.time_period(state.attributes[ATTR_DURATION])
+        self._running_duration = cv.time_period(
+            state.attributes[TimerEntityStateAttribute.DURATION]
+        )
         # If the timer was paused, we restore the remaining time
         if self._state == STATUS_PAUSED:
-            self._remaining = cv.time_period(state.attributes[ATTR_REMAINING])
+            self._remaining = cv.time_period(
+                state.attributes[TimerEntityStateAttribute.REMAINING]
+            )
             return
         # If we get here, the timer must have been active so we need to decide what
         # to do based on end time and the current time
-        end = cv.datetime(state.attributes[ATTR_FINISHES_AT])
+        end = cv.datetime(state.attributes[TimerEntityStateAttribute.FINISHES_AT])
         # If there is time remaining in the timer, restore the remaining time then
         # start the timer
         if (remaining := end - dt_util.utcnow().replace(microsecond=0)) > timedelta(0):

--- a/homeassistant/components/timer/reproduce_state.py
+++ b/homeassistant/components/timer/reproduce_state.py
@@ -17,6 +17,7 @@ from . import (
     STATUS_ACTIVE,
     STATUS_IDLE,
     STATUS_PAUSED,
+    TimerEntityStateAttribute,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -45,15 +46,17 @@ async def _async_reproduce_state(
     # Return if we are already at the right state.
     if cur_state.state == state.state and cur_state.attributes.get(
         ATTR_DURATION
-    ) == state.attributes.get(ATTR_DURATION):
+    ) == state.attributes.get(TimerEntityStateAttribute.DURATION):
         return
 
     service_data = {ATTR_ENTITY_ID: state.entity_id}
 
     if state.state == STATUS_ACTIVE:
         service = SERVICE_START
-        if ATTR_DURATION in state.attributes:
-            service_data[ATTR_DURATION] = state.attributes[ATTR_DURATION]
+        if TimerEntityStateAttribute.DURATION in state.attributes:
+            service_data[ATTR_DURATION] = state.attributes[
+                TimerEntityStateAttribute.DURATION
+            ]
     elif state.state == STATUS_PAUSED:
         service = SERVICE_PAUSE
     elif state.state == STATUS_IDLE:

--- a/homeassistant/components/timer/trigger.py
+++ b/homeassistant/components/timer/trigger.py
@@ -26,7 +26,8 @@ from homeassistant.helpers.trigger import (
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import dt as dt_util
 
-from . import ATTR_FINISHES_AT, ATTR_LAST_TRANSITION, DOMAIN, STATUS_ACTIVE
+from . import DOMAIN, STATUS_ACTIVE
+from .const import TimerEntityStateAttribute
 
 CONF_REMAINING = "remaining"
 
@@ -86,7 +87,9 @@ class TimeRemainingTrigger(Trigger):
             if to_state.state != STATUS_ACTIVE:
                 return
 
-            finishes_at_str = to_state.attributes.get(ATTR_FINISHES_AT)
+            finishes_at_str = to_state.attributes.get(
+                TimerEntityStateAttribute.FINISHES_AT
+            )
             if finishes_at_str is None:
                 return
 
@@ -166,19 +169,24 @@ class TimeRemainingTrigger(Trigger):
 
 TRIGGERS: dict[str, type[Trigger]] = {
     "cancelled": make_entity_target_state_trigger(
-        {DOMAIN: DomainSpec(value_source=ATTR_LAST_TRANSITION)}, "cancelled"
+        {DOMAIN: DomainSpec(value_source=TimerEntityStateAttribute.LAST_TRANSITION)},
+        "cancelled",
     ),
     "finished": make_entity_target_state_trigger(
-        {DOMAIN: DomainSpec(value_source=ATTR_LAST_TRANSITION)}, "finished"
+        {DOMAIN: DomainSpec(value_source=TimerEntityStateAttribute.LAST_TRANSITION)},
+        "finished",
     ),
     "paused": make_entity_target_state_trigger(
-        {DOMAIN: DomainSpec(value_source=ATTR_LAST_TRANSITION)}, "paused"
+        {DOMAIN: DomainSpec(value_source=TimerEntityStateAttribute.LAST_TRANSITION)},
+        "paused",
     ),
     "restarted": make_entity_target_state_trigger(
-        {DOMAIN: DomainSpec(value_source=ATTR_LAST_TRANSITION)}, "restarted"
+        {DOMAIN: DomainSpec(value_source=TimerEntityStateAttribute.LAST_TRANSITION)},
+        "restarted",
     ),
     "started": make_entity_target_state_trigger(
-        {DOMAIN: DomainSpec(value_source=ATTR_LAST_TRANSITION)}, "started"
+        {DOMAIN: DomainSpec(value_source=TimerEntityStateAttribute.LAST_TRANSITION)},
+        "started",
     ),
     "remaining_time_reached": TimeRemainingTrigger,
 }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follow-up to #174633, which introduced the base `EntityStateAttribute` enum. The timer platform exposes `TimerEntityStateAttribute`.

The timer entity restore, trigger and reproduce_state read the timer state attributes through the ambiguous `ATTR_DURATION`, `ATTR_REMAINING`, `ATTR_FINISHES_AT` and `ATTR_LAST_TRANSITION` constants. Reading them through the dedicated enum makes the intent explicit (the entity already writes them through the enum).

This migrates the state-attribute reads:

- `__init__.py`, `trigger.py`, `reproduce_state.py`: `duration`/`remaining`/`finishes_at`/`last_transition` -> `TimerEntityStateAttribute`

The constants used for the service schema and the `start` service call arguments are left unchanged.

No behaviour change: `TimerEntityStateAttribute` is a `StrEnum`, so the resolved keys are identical.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)