### PR TITLE
bosch_shc: refactor binary_sensor.py to entity-description pattern

### DIFF
--- a/homeassistant/components/bosch_shc/__init__.py
+++ b/homeassistant/components/bosch_shc/__init__.py
@@ -47,7 +47,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> boo
         raise ConfigEntryNotReady from err
 
     shc_info = session.information
-    if shc_info.updateState.name == "UPDATE_AVAILABLE":
+    # SHCSession is constructed with lazy=False above, so its constructor runs
+    # _enumerate_all() -> authenticate() synchronously: authenticate() either
+    # raises (in which case the SHCSession(...) call above already raised, and
+    # we never reach this line) or unconditionally populates
+    # _shc_information. So `information` is guaranteed non-None here.
+    assert shc_info is not None
+    # get_unique_id() (called from SHCInformation.__init__ above) always sets
+    # _unique_id to a str before returning, on every code path that doesn't
+    # raise SHCConnectionError -- so unique_id is also guaranteed non-None here.
+    assert shc_info.unique_id is not None
+    if (
+        shc_info.updateState is not None
+        and shc_info.updateState.name == "UPDATE_AVAILABLE"
+    ):
         _LOGGER.warning("Please check for software updates in the Bosch Smart Home App")
 
     entry.runtime_data = session

--- a/homeassistant/components/bosch_shc/__init__.py
+++ b/homeassistant/components/bosch_shc/__init__.py
@@ -1,6 +1,7 @@
 """The Bosch Smart Home Controller integration."""
 
 import logging
+from typing import TYPE_CHECKING
 
 from boschshcpy import SHCSession
 from boschshcpy.exceptions import SHCAuthenticationError, SHCConnectionError
@@ -47,9 +48,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> boo
         raise ConfigEntryNotReady from err
 
     shc_info = session.information
-    # Always populated: the synchronous SHCSession construction above already raised otherwise.
-    assert shc_info is not None
-    assert shc_info.unique_id is not None
+    if TYPE_CHECKING:
+        assert shc_info is not None
+        assert shc_info.unique_id is not None
     if (
         shc_info.updateState is not None
         and shc_info.updateState.name == "UPDATE_AVAILABLE"

--- a/homeassistant/components/bosch_shc/__init__.py
+++ b/homeassistant/components/bosch_shc/__init__.py
@@ -1,6 +1,5 @@
 """The Bosch Smart Home Controller integration."""
 
-from dataclasses import dataclass
 import logging
 
 from boschshcpy import SHCSession
@@ -25,15 +24,7 @@ PLATFORMS = [
 _LOGGER = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True, kw_only=True)
-class SHCData:
-    """Runtime data for the Bosch SHC integration."""
-
-    session: SHCSession
-    parent_id: str
-
-
-type BoschConfigEntry = ConfigEntry[SHCData]
+type BoschConfigEntry = ConfigEntry[SHCSession]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> bool:
@@ -56,15 +47,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> boo
         raise ConfigEntryNotReady from err
 
     shc_info = session.information
-    if shc_info is None or shc_info.unique_id is None:
-        raise ConfigEntryNotReady("Bosch SHC did not return controller information")
+    # Always populated: the synchronous SHCSession construction above already raised otherwise.
+    assert shc_info is not None
+    assert shc_info.unique_id is not None
     if (
         shc_info.updateState is not None
         and shc_info.updateState.name == "UPDATE_AVAILABLE"
     ):
         _LOGGER.warning("Please check for software updates in the Bosch Smart Home App")
 
-    entry.runtime_data = SHCData(session=session, parent_id=shc_info.unique_id)
+    entry.runtime_data = session
 
     device_registry = dr.async_get(hass)
     device_registry.async_get_or_create(
@@ -93,6 +85,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> boo
 
 async def async_unload_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> bool:
     """Unload a config entry."""
-    await hass.async_add_executor_job(entry.runtime_data.session.stop_polling)
+    await hass.async_add_executor_job(entry.runtime_data.stop_polling)
 
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/bosch_shc/__init__.py
+++ b/homeassistant/components/bosch_shc/__init__.py
@@ -30,8 +30,7 @@ class SHCData:
     """Runtime data for the Bosch SHC integration."""
 
     session: SHCSession
-    # The SHC controller's own unique_id, used as the parent identifier for
-    # every device entity created by the platforms below.
+    # The SHC controller's unique_id; parent identifier for every device entity.
     parent_id: str
 
 
@@ -58,8 +57,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> boo
         raise ConfigEntryNotReady from err
 
     shc_info = session.information
-    # Always populated by this point: SHCSession's synchronous, non-lazy
-    # construction above already raised if authentication/enumeration failed.
+    # Always populated: the synchronous SHCSession construction above already raised otherwise.
     assert shc_info is not None
     assert shc_info.unique_id is not None
     if (

--- a/homeassistant/components/bosch_shc/__init__.py
+++ b/homeassistant/components/bosch_shc/__init__.py
@@ -49,8 +49,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> boo
 
     shc_info = session.information
     if TYPE_CHECKING:
-        assert shc_info is not None
-        assert shc_info.unique_id is not None
+        assert shc_info is not None and shc_info.unique_id is not None
     if (
         shc_info.updateState is not None
         and shc_info.updateState.name == "UPDATE_AVAILABLE"

--- a/homeassistant/components/bosch_shc/__init__.py
+++ b/homeassistant/components/bosch_shc/__init__.py
@@ -1,5 +1,6 @@
 """The Bosch Smart Home Controller integration."""
 
+from dataclasses import dataclass
 import logging
 
 from boschshcpy import SHCSession
@@ -24,7 +25,17 @@ PLATFORMS = [
 _LOGGER = logging.getLogger(__name__)
 
 
-type BoschConfigEntry = ConfigEntry[SHCSession]
+@dataclass
+class SHCData:
+    """Runtime data for the Bosch SHC integration."""
+
+    session: SHCSession
+    # The SHC controller's own unique_id, used as the parent identifier for
+    # every device entity created by the platforms below.
+    parent_id: str
+
+
+type BoschConfigEntry = ConfigEntry[SHCData]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> bool:
@@ -47,15 +58,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> boo
         raise ConfigEntryNotReady from err
 
     shc_info = session.information
-    # SHCSession is constructed with lazy=False above, so its constructor runs
-    # _enumerate_all() -> authenticate() synchronously: authenticate() either
-    # raises (in which case the SHCSession(...) call above already raised, and
-    # we never reach this line) or unconditionally populates
-    # _shc_information. So `information` is guaranteed non-None here.
+    # Always populated by this point: SHCSession's synchronous, non-lazy
+    # construction above already raised if authentication/enumeration failed.
     assert shc_info is not None
-    # get_unique_id() (called from SHCInformation.__init__ above) always sets
-    # _unique_id to a str before returning, on every code path that doesn't
-    # raise SHCConnectionError -- so unique_id is also guaranteed non-None here.
     assert shc_info.unique_id is not None
     if (
         shc_info.updateState is not None
@@ -63,7 +68,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> boo
     ):
         _LOGGER.warning("Please check for software updates in the Bosch Smart Home App")
 
-    entry.runtime_data = session
+    entry.runtime_data = SHCData(session=session, parent_id=shc_info.unique_id)
 
     device_registry = dr.async_get(hass)
     device_registry.async_get_or_create(
@@ -92,6 +97,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> boo
 
 async def async_unload_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> bool:
     """Unload a config entry."""
-    await hass.async_add_executor_job(entry.runtime_data.stop_polling)
+    await hass.async_add_executor_job(entry.runtime_data.session.stop_polling)
 
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/bosch_shc/__init__.py
+++ b/homeassistant/components/bosch_shc/__init__.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 import logging
+from typing import TYPE_CHECKING
 
 from boschshcpy import SHCSession
 from boschshcpy.exceptions import SHCAuthenticationError, SHCConnectionError
@@ -25,12 +26,11 @@ PLATFORMS = [
 _LOGGER = logging.getLogger(__name__)
 
 
-@dataclass
+@dataclass(frozen=True, kw_only=True)
 class SHCData:
     """Runtime data for the Bosch SHC integration."""
 
     session: SHCSession
-    # The SHC controller's unique_id; parent identifier for every device entity.
     parent_id: str
 
 
@@ -57,9 +57,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> boo
         raise ConfigEntryNotReady from err
 
     shc_info = session.information
-    # Always populated: the synchronous SHCSession construction above already raised otherwise.
-    assert shc_info is not None
-    assert shc_info.unique_id is not None
+    if TYPE_CHECKING:
+        # Always populated: the synchronous SHCSession construction above already raised otherwise.
+        assert shc_info is not None
+        assert shc_info.unique_id is not None
     if (
         shc_info.updateState is not None
         and shc_info.updateState.name == "UPDATE_AVAILABLE"

--- a/homeassistant/components/bosch_shc/__init__.py
+++ b/homeassistant/components/bosch_shc/__init__.py
@@ -2,7 +2,6 @@
 
 from dataclasses import dataclass
 import logging
-from typing import TYPE_CHECKING
 
 from boschshcpy import SHCSession
 from boschshcpy.exceptions import SHCAuthenticationError, SHCConnectionError
@@ -57,10 +56,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> boo
         raise ConfigEntryNotReady from err
 
     shc_info = session.information
-    if TYPE_CHECKING:
-        # Always populated: the synchronous SHCSession construction above already raised otherwise.
-        assert shc_info is not None
-        assert shc_info.unique_id is not None
+    if shc_info is None or shc_info.unique_id is None:
+        raise ConfigEntryNotReady("Bosch SHC did not return controller information")
     if (
         shc_info.updateState is not None
         and shc_info.updateState.name == "UPDATE_AVAILABLE"

--- a/homeassistant/components/bosch_shc/binary_sensor.py
+++ b/homeassistant/components/bosch_shc/binary_sensor.py
@@ -31,12 +31,11 @@ async def async_setup_entry(
     shc_info = session.information
     if TYPE_CHECKING:
         assert shc_info is not None and shc_info.unique_id is not None
-    parent_id = shc_info.unique_id
 
     entities: list[BinarySensorEntity] = [
         ShutterContactSensor(
             device=binary_sensor,
-            parent_id=parent_id,
+            parent_id=shc_info.unique_id,
             entry_id=config_entry.entry_id,
         )
         for binary_sensor in (
@@ -48,7 +47,7 @@ async def async_setup_entry(
     entities.extend(
         BatterySensor(
             device=binary_sensor,
-            parent_id=parent_id,
+            parent_id=shc_info.unique_id,
             entry_id=config_entry.entry_id,
         )
         for binary_sensor in (
@@ -84,7 +83,7 @@ class ShutterContactSensor(SHCEntity[SHCShutterContact], BinarySensorEntity):
             "GENERIC": BinarySensorDeviceClass.WINDOW,
         }
         self._attr_device_class = switcher.get(
-            self._device.device_class or "", BinarySensorDeviceClass.WINDOW
+            self._device.device_class or "GENERIC", BinarySensorDeviceClass.WINDOW
         )
 
     @property

--- a/homeassistant/components/bosch_shc/binary_sensor.py
+++ b/homeassistant/components/bosch_shc/binary_sensor.py
@@ -2,8 +2,12 @@
 
 from typing import override
 
-from boschshcpy import SHCBatteryDevice, SHCShutterContact
-from boschshcpy.device import SHCDevice
+from boschshcpy import (
+    BatteryLevelService,
+    SHCBatteryDevice,
+    SHCShutterContact,
+    ShutterContactService,
+)
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -24,46 +28,55 @@ async def async_setup_entry(
     """Set up the SHC binary sensor platform."""
     session = config_entry.runtime_data
 
+    # See __init__.py's async_setup_entry: session.information (and its
+    # unique_id) are always populated by the time platform setup runs.
+    shc_info = session.information
+    assert shc_info is not None
+    assert shc_info.unique_id is not None
+    parent_id = shc_info.unique_id
+
     entities: list[BinarySensorEntity] = [
         ShutterContactSensor(
             device=binary_sensor,
-            parent_id=session.information.unique_id,
+            parent_id=parent_id,
             entry_id=config_entry.entry_id,
         )
         for binary_sensor in (
-            session.device_helper.shutter_contacts
-            + session.device_helper.shutter_contacts2
+            *session.device_helper.shutter_contacts,
+            *session.device_helper.shutter_contacts2,
         )
     ]
 
     entities.extend(
         BatterySensor(
             device=binary_sensor,
-            parent_id=session.information.unique_id,
+            parent_id=parent_id,
             entry_id=config_entry.entry_id,
         )
         for binary_sensor in (
-            session.device_helper.motion_detectors
-            + session.device_helper.shutter_contacts
-            + session.device_helper.shutter_contacts2
-            + session.device_helper.smoke_detectors
-            + session.device_helper.thermostats
-            + session.device_helper.twinguards
-            + session.device_helper.universal_switches
-            + session.device_helper.wallthermostats
-            + session.device_helper.water_leakage_detectors
+            *session.device_helper.motion_detectors,
+            *session.device_helper.shutter_contacts,
+            *session.device_helper.shutter_contacts2,
+            *session.device_helper.smoke_detectors,
+            *session.device_helper.thermostats,
+            *session.device_helper.twinguards,
+            *session.device_helper.universal_switches,
+            *session.device_helper.wallthermostats,
+            *session.device_helper.water_leakage_detectors,
         )
     )
 
     async_add_entities(entities)
 
 
-class ShutterContactSensor(SHCEntity, BinarySensorEntity):
+class ShutterContactSensor(SHCEntity[SHCShutterContact], BinarySensorEntity):
     """Representation of an SHC shutter contact sensor."""
 
     _attr_name = None
 
-    def __init__(self, device: SHCDevice, parent_id: str, entry_id: str) -> None:
+    def __init__(
+        self, device: SHCShutterContact, parent_id: str, entry_id: str
+    ) -> None:
         """Initialize an SHC shutter contact sensor.."""
         super().__init__(device, parent_id, entry_id)
         switcher = {
@@ -72,23 +85,26 @@ class ShutterContactSensor(SHCEntity, BinarySensorEntity):
             "FRENCH_WINDOW": BinarySensorDeviceClass.DOOR,
             "GENERIC": BinarySensorDeviceClass.WINDOW,
         }
-        self._attr_device_class = switcher.get(
-            self._device.device_class, BinarySensorDeviceClass.WINDOW
+        device_class = self._device.device_class
+        self._attr_device_class = (
+            switcher.get(device_class, BinarySensorDeviceClass.WINDOW)
+            if device_class is not None
+            else BinarySensorDeviceClass.WINDOW
         )
 
     @property
     @override
     def is_on(self) -> bool:
         """Return the state of the sensor."""
-        return self._device.state == SHCShutterContact.ShutterContactService.State.OPEN
+        return self._device.state is ShutterContactService.State.OPEN
 
 
-class BatterySensor(SHCEntity, BinarySensorEntity):
+class BatterySensor(SHCEntity[SHCBatteryDevice], BinarySensorEntity):
     """Representation of an SHC battery reporting sensor."""
 
     _attr_device_class = BinarySensorDeviceClass.BATTERY
 
-    def __init__(self, device: SHCDevice, parent_id: str, entry_id: str) -> None:
+    def __init__(self, device: SHCBatteryDevice, parent_id: str, entry_id: str) -> None:
         """Initialize an SHC battery reporting sensor."""
         super().__init__(device, parent_id, entry_id)
         self._attr_unique_id = f"{device.serial}_battery"
@@ -97,6 +113,4 @@ class BatterySensor(SHCEntity, BinarySensorEntity):
     @override
     def is_on(self) -> bool:
         """Return the state of the sensor."""
-        return (
-            self._device.batterylevel != SHCBatteryDevice.BatteryLevelService.State.OK
-        )
+        return self._device.batterylevel is not BatteryLevelService.State.OK

--- a/homeassistant/components/bosch_shc/binary_sensor.py
+++ b/homeassistant/components/bosch_shc/binary_sensor.py
@@ -1,10 +1,13 @@
 """Platform for binarysensor integration."""
 
+from collections.abc import Callable
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, override
 
 from boschshcpy import (
     BatteryLevelService,
     SHCBatteryDevice,
+    SHCDevice,
     SHCShutterContact,
     ShutterContactService,
 )
@@ -12,12 +15,34 @@ from boschshcpy import (
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
+    BinarySensorEntityDescription,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import BoschConfigEntry
 from .entity import SHCEntity
+
+
+@dataclass(frozen=True, kw_only=True)
+class SHCBinarySensorEntityDescription[_DeviceT: SHCDevice](
+    BinarySensorEntityDescription
+):
+    """Class describing SHC binary sensor entities."""
+
+    is_on_fn: Callable[[_DeviceT], bool]
+
+
+SHUTTER_CONTACT_DESCRIPTION = SHCBinarySensorEntityDescription[SHCShutterContact](
+    key="shutter_contact",
+    is_on_fn=lambda device: device.state is ShutterContactService.State.OPEN,
+)
+
+BATTERY_DESCRIPTION = SHCBinarySensorEntityDescription[SHCBatteryDevice](
+    key="battery",
+    device_class=BinarySensorDeviceClass.BATTERY,
+    is_on_fn=lambda device: device.batterylevel is not BatteryLevelService.State.OK,
+)
 
 
 async def async_setup_entry(
@@ -32,23 +57,25 @@ async def async_setup_entry(
     if TYPE_CHECKING:
         assert shc_info is not None and shc_info.unique_id is not None
 
-    entities: list[BinarySensorEntity] = [
+    async_add_entities(
         ShutterContactSensor(
             device=binary_sensor,
             parent_id=shc_info.unique_id,
             entry_id=config_entry.entry_id,
+            entity_description=SHUTTER_CONTACT_DESCRIPTION,
         )
         for binary_sensor in (
             *session.device_helper.shutter_contacts,
             *session.device_helper.shutter_contacts2,
         )
-    ]
+    )
 
-    entities.extend(
+    async_add_entities(
         BatterySensor(
             device=binary_sensor,
             parent_id=shc_info.unique_id,
             entry_id=config_entry.entry_id,
+            entity_description=BATTERY_DESCRIPTION,
         )
         for binary_sensor in (
             *session.device_helper.motion_detectors,
@@ -63,19 +90,23 @@ async def async_setup_entry(
         )
     )
 
-    async_add_entities(entities)
-
 
 class ShutterContactSensor(SHCEntity[SHCShutterContact], BinarySensorEntity):
     """Representation of an SHC shutter contact sensor."""
 
     _attr_name = None
+    entity_description: SHCBinarySensorEntityDescription[SHCShutterContact]
 
     def __init__(
-        self, device: SHCShutterContact, parent_id: str, entry_id: str
+        self,
+        device: SHCShutterContact,
+        parent_id: str,
+        entry_id: str,
+        entity_description: SHCBinarySensorEntityDescription[SHCShutterContact],
     ) -> None:
         """Initialize an SHC shutter contact sensor."""
         super().__init__(device, parent_id, entry_id)
+        self.entity_description = entity_description
         switcher = {
             "ENTRANCE_DOOR": BinarySensorDeviceClass.DOOR,
             "REGULAR_WINDOW": BinarySensorDeviceClass.WINDOW,
@@ -90,21 +121,28 @@ class ShutterContactSensor(SHCEntity[SHCShutterContact], BinarySensorEntity):
     @override
     def is_on(self) -> bool:
         """Return the state of the sensor."""
-        return self._device.state is ShutterContactService.State.OPEN
+        return self.entity_description.is_on_fn(self._device)
 
 
 class BatterySensor(SHCEntity[SHCBatteryDevice], BinarySensorEntity):
     """Representation of an SHC battery reporting sensor."""
 
-    _attr_device_class = BinarySensorDeviceClass.BATTERY
+    entity_description: SHCBinarySensorEntityDescription[SHCBatteryDevice]
 
-    def __init__(self, device: SHCBatteryDevice, parent_id: str, entry_id: str) -> None:
+    def __init__(
+        self,
+        device: SHCBatteryDevice,
+        parent_id: str,
+        entry_id: str,
+        entity_description: SHCBinarySensorEntityDescription[SHCBatteryDevice],
+    ) -> None:
         """Initialize an SHC battery reporting sensor."""
         super().__init__(device, parent_id, entry_id)
+        self.entity_description = entity_description
         self._attr_unique_id = f"{device.serial}_battery"
 
     @property
     @override
     def is_on(self) -> bool:
         """Return the state of the sensor."""
-        return self._device.batterylevel is not BatteryLevelService.State.OK
+        return self.entity_description.is_on_fn(self._device)

--- a/homeassistant/components/bosch_shc/binary_sensor.py
+++ b/homeassistant/components/bosch_shc/binary_sensor.py
@@ -26,8 +26,14 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the SHC binary sensor platform."""
-    session = config_entry.runtime_data.session
-    parent_id = config_entry.runtime_data.parent_id
+    session = config_entry.runtime_data
+
+    # See __init__.py's async_setup_entry: session.information (and its
+    # unique_id) are always populated by the time platform setup runs.
+    shc_info = session.information
+    assert shc_info is not None
+    assert shc_info.unique_id is not None
+    parent_id = shc_info.unique_id
 
     entities: list[BinarySensorEntity] = [
         ShutterContactSensor(

--- a/homeassistant/components/bosch_shc/binary_sensor.py
+++ b/homeassistant/components/bosch_shc/binary_sensor.py
@@ -30,8 +30,7 @@ async def async_setup_entry(
 
     shc_info = session.information
     if TYPE_CHECKING:
-        assert shc_info is not None
-        assert shc_info.unique_id is not None
+        assert shc_info is not None and shc_info.unique_id is not None
     parent_id = shc_info.unique_id
 
     entities: list[BinarySensorEntity] = [

--- a/homeassistant/components/bosch_shc/binary_sensor.py
+++ b/homeassistant/components/bosch_shc/binary_sensor.py
@@ -26,14 +26,8 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the SHC binary sensor platform."""
-    session = config_entry.runtime_data
-
-    # See __init__.py's async_setup_entry: session.information (and its
-    # unique_id) are always populated by the time platform setup runs.
-    shc_info = session.information
-    assert shc_info is not None
-    assert shc_info.unique_id is not None
-    parent_id = shc_info.unique_id
+    session = config_entry.runtime_data.session
+    parent_id = config_entry.runtime_data.parent_id
 
     entities: list[BinarySensorEntity] = [
         ShutterContactSensor(

--- a/homeassistant/components/bosch_shc/binary_sensor.py
+++ b/homeassistant/components/bosch_shc/binary_sensor.py
@@ -1,6 +1,6 @@
 """Platform for binarysensor integration."""
 
-from typing import override
+from typing import TYPE_CHECKING, override
 
 from boschshcpy import (
     BatteryLevelService,
@@ -28,11 +28,10 @@ async def async_setup_entry(
     """Set up the SHC binary sensor platform."""
     session = config_entry.runtime_data
 
-    # See __init__.py's async_setup_entry: session.information (and its
-    # unique_id) are always populated by the time platform setup runs.
     shc_info = session.information
-    assert shc_info is not None
-    assert shc_info.unique_id is not None
+    if TYPE_CHECKING:
+        assert shc_info is not None
+        assert shc_info.unique_id is not None
     parent_id = shc_info.unique_id
 
     entities: list[BinarySensorEntity] = [
@@ -85,11 +84,8 @@ class ShutterContactSensor(SHCEntity[SHCShutterContact], BinarySensorEntity):
             "FRENCH_WINDOW": BinarySensorDeviceClass.DOOR,
             "GENERIC": BinarySensorDeviceClass.WINDOW,
         }
-        device_class = self._device.device_class
-        self._attr_device_class = (
-            switcher.get(device_class, BinarySensorDeviceClass.WINDOW)
-            if device_class is not None
-            else BinarySensorDeviceClass.WINDOW
+        self._attr_device_class = switcher.get(
+            self._device.device_class or "", BinarySensorDeviceClass.WINDOW
         )
 
     @property

--- a/homeassistant/components/bosch_shc/binary_sensor.py
+++ b/homeassistant/components/bosch_shc/binary_sensor.py
@@ -114,7 +114,7 @@ class ShutterContactSensor(SHCEntity[SHCShutterContact], BinarySensorEntity):
             "GENERIC": BinarySensorDeviceClass.WINDOW,
         }
         self._attr_device_class = switcher.get(
-            self._device.device_class or "GENERIC", BinarySensorDeviceClass.WINDOW
+            self._device.device_class or "", BinarySensorDeviceClass.WINDOW
         )
 
     @property

--- a/homeassistant/components/bosch_shc/binary_sensor.py
+++ b/homeassistant/components/bosch_shc/binary_sensor.py
@@ -71,7 +71,7 @@ class ShutterContactSensor(SHCEntity[SHCShutterContact], BinarySensorEntity):
     def __init__(
         self, device: SHCShutterContact, parent_id: str, entry_id: str
     ) -> None:
-        """Initialize an SHC shutter contact sensor.."""
+        """Initialize an SHC shutter contact sensor."""
         super().__init__(device, parent_id, entry_id)
         switcher = {
             "ENTRANCE_DOOR": BinarySensorDeviceClass.DOOR,

--- a/homeassistant/components/bosch_shc/cover.py
+++ b/homeassistant/components/bosch_shc/cover.py
@@ -23,8 +23,14 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the SHC cover platform."""
-    session = config_entry.runtime_data.session
-    parent_id = config_entry.runtime_data.parent_id
+    session = config_entry.runtime_data
+
+    # See __init__.py's async_setup_entry: session.information (and its
+    # unique_id) are always populated by the time platform setup runs.
+    shc_info = session.information
+    assert shc_info is not None
+    assert shc_info.unique_id is not None
+    parent_id = shc_info.unique_id
 
     async_add_entities(
         ShutterControlCover(

--- a/homeassistant/components/bosch_shc/cover.py
+++ b/homeassistant/components/bosch_shc/cover.py
@@ -2,7 +2,7 @@
 
 from typing import Any, override
 
-from boschshcpy import SHCShutterControl
+from boschshcpy import SHCShutterControl, ShutterControlService
 
 from homeassistant.components.cover import (
     ATTR_POSITION,
@@ -25,17 +25,24 @@ async def async_setup_entry(
     """Set up the SHC cover platform."""
     session = config_entry.runtime_data
 
+    # See __init__.py's async_setup_entry: session.information (and its
+    # unique_id) are always populated by the time platform setup runs.
+    shc_info = session.information
+    assert shc_info is not None
+    assert shc_info.unique_id is not None
+    parent_id = shc_info.unique_id
+
     async_add_entities(
         ShutterControlCover(
             device=cover,
-            parent_id=session.information.unique_id,
+            parent_id=parent_id,
             entry_id=config_entry.entry_id,
         )
         for cover in session.device_helper.shutter_controls
     )
 
 
-class ShutterControlCover(SHCEntity, CoverEntity):
+class ShutterControlCover(SHCEntity[SHCShutterControl], CoverEntity):
     """Representation of a SHC shutter control device."""
 
     _attr_name = None
@@ -68,19 +75,13 @@ class ShutterControlCover(SHCEntity, CoverEntity):
     @override
     def is_opening(self) -> bool:
         """Return if the cover is opening or not."""
-        return (
-            self._device.operation_state
-            == SHCShutterControl.ShutterControlService.State.OPENING
-        )
+        return self._device.operation_state is ShutterControlService.State.OPENING
 
     @property
     @override
     def is_closing(self) -> bool:
         """Return if the cover is closing or not."""
-        return (
-            self._device.operation_state
-            == SHCShutterControl.ShutterControlService.State.CLOSING
-        )
+        return self._device.operation_state is ShutterControlService.State.CLOSING
 
     @override
     def open_cover(self, **kwargs: Any) -> None:

--- a/homeassistant/components/bosch_shc/cover.py
+++ b/homeassistant/components/bosch_shc/cover.py
@@ -27,8 +27,7 @@ async def async_setup_entry(
 
     shc_info = session.information
     if TYPE_CHECKING:
-        assert shc_info is not None
-        assert shc_info.unique_id is not None
+        assert shc_info is not None and shc_info.unique_id is not None
     parent_id = shc_info.unique_id
 
     async_add_entities(

--- a/homeassistant/components/bosch_shc/cover.py
+++ b/homeassistant/components/bosch_shc/cover.py
@@ -28,12 +28,11 @@ async def async_setup_entry(
     shc_info = session.information
     if TYPE_CHECKING:
         assert shc_info is not None and shc_info.unique_id is not None
-    parent_id = shc_info.unique_id
 
     async_add_entities(
         ShutterControlCover(
             device=cover,
-            parent_id=parent_id,
+            parent_id=shc_info.unique_id,
             entry_id=config_entry.entry_id,
         )
         for cover in session.device_helper.shutter_controls

--- a/homeassistant/components/bosch_shc/cover.py
+++ b/homeassistant/components/bosch_shc/cover.py
@@ -1,6 +1,6 @@
 """Platform for cover integration."""
 
-from typing import Any, override
+from typing import TYPE_CHECKING, Any, override
 
 from boschshcpy import SHCShutterControl, ShutterControlService
 
@@ -25,11 +25,10 @@ async def async_setup_entry(
     """Set up the SHC cover platform."""
     session = config_entry.runtime_data
 
-    # See __init__.py's async_setup_entry: session.information (and its
-    # unique_id) are always populated by the time platform setup runs.
     shc_info = session.information
-    assert shc_info is not None
-    assert shc_info.unique_id is not None
+    if TYPE_CHECKING:
+        assert shc_info is not None
+        assert shc_info.unique_id is not None
     parent_id = shc_info.unique_id
 
     async_add_entities(

--- a/homeassistant/components/bosch_shc/cover.py
+++ b/homeassistant/components/bosch_shc/cover.py
@@ -23,14 +23,8 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the SHC cover platform."""
-    session = config_entry.runtime_data
-
-    # See __init__.py's async_setup_entry: session.information (and its
-    # unique_id) are always populated by the time platform setup runs.
-    shc_info = session.information
-    assert shc_info is not None
-    assert shc_info.unique_id is not None
-    parent_id = shc_info.unique_id
+    session = config_entry.runtime_data.session
+    parent_id = config_entry.runtime_data.parent_id
 
     async_add_entities(
         ShutterControlCover(

--- a/homeassistant/components/bosch_shc/entity.py
+++ b/homeassistant/components/bosch_shc/entity.py
@@ -22,12 +22,8 @@ async def async_remove_devices(
         dev_registry.async_update_device(device.id, remove_config_entry_id=entry_id)
 
 
-# SHCBaseEntity is shared by SHCEntity (always backed by a real SHCDevice) and
-# SHCDomainEntity (always backed by the single SHCIntrusionSystem domain
-# service) -- the two are never interchangeable at runtime. Binding each
-# subclass hierarchy to its own concrete type parameter (rather than leaving
-# `_device` typed as the full union on the shared base) lets mypy know which
-# attributes are actually available at each call site.
+# Parameterized so each subclass's _device is statically its real concrete
+# type (SHCEntity's SHCDevice vs. SHCDomainEntity's SHCIntrusionSystem).
 class SHCBaseEntity[_DeviceT: (SHCDevice | SHCIntrusionSystem)](Entity):
     """Base representation of a SHC entity."""
 

--- a/homeassistant/components/bosch_shc/entity.py
+++ b/homeassistant/components/bosch_shc/entity.py
@@ -1,6 +1,6 @@
 """Bosch Smart Home Controller base entity."""
 
-from typing import override
+from typing import Any, override
 
 from boschshcpy import SHCDevice, SHCIntrusionSystem
 
@@ -13,7 +13,7 @@ from .const import DOMAIN
 
 
 async def async_remove_devices(
-    hass: HomeAssistant, entity: SHCBaseEntity, entry_id: str
+    hass: HomeAssistant, entity: SHCBaseEntity[Any], entry_id: str
 ) -> None:
     """Get item that is removed from session."""
     dev_registry = dr.async_get(hass)
@@ -22,17 +22,21 @@ async def async_remove_devices(
         dev_registry.async_update_device(device.id, remove_config_entry_id=entry_id)
 
 
-class SHCBaseEntity(Entity):
+# SHCBaseEntity is shared by SHCEntity (always backed by a real SHCDevice) and
+# SHCDomainEntity (always backed by the single SHCIntrusionSystem domain
+# service) -- the two are never interchangeable at runtime. Binding each
+# subclass hierarchy to its own concrete type parameter (rather than leaving
+# `_device` typed as the full union on the shared base) lets mypy know which
+# attributes are actually available at each call site.
+class SHCBaseEntity[_DeviceT: (SHCDevice | SHCIntrusionSystem)](Entity):
     """Base representation of a SHC entity."""
 
     _attr_should_poll = False
     _attr_has_entity_name = True
 
-    def __init__(
-        self, device: SHCDevice | SHCIntrusionSystem, parent_id: str, entry_id: str
-    ) -> None:
+    def __init__(self, device: _DeviceT, parent_id: str, entry_id: str) -> None:
         """Initialize the generic SHC device."""
-        self._device = device
+        self._device: _DeviceT = device
         self._entry_id = entry_id
 
     @override
@@ -60,10 +64,10 @@ class SHCBaseEntity(Entity):
         return self._device.id
 
 
-class SHCEntity(SHCBaseEntity):
+class SHCEntity[_SHCDeviceT: SHCDevice](SHCBaseEntity[_SHCDeviceT]):
     """Representation of a SHC device entity."""
 
-    def __init__(self, device: SHCDevice, parent_id: str, entry_id: str) -> None:
+    def __init__(self, device: _SHCDeviceT, parent_id: str, entry_id: str) -> None:
         """Initialize generic SHC device."""
         self._attr_unique_id = device.serial
         self._attr_device_info = DeviceInfo(
@@ -100,7 +104,7 @@ class SHCEntity(SHCBaseEntity):
         return self._device.status == "AVAILABLE"
 
 
-class SHCDomainEntity(SHCBaseEntity):
+class SHCDomainEntity(SHCBaseEntity[SHCIntrusionSystem]):
     """Representation of a SHC domain service entity."""
 
     def __init__(

--- a/homeassistant/components/bosch_shc/entity.py
+++ b/homeassistant/components/bosch_shc/entity.py
@@ -1,6 +1,6 @@
 """Bosch Smart Home Controller base entity."""
 
-from typing import Any, override
+from typing import override
 
 from boschshcpy import SHCDevice, SHCIntrusionSystem
 
@@ -13,7 +13,9 @@ from .const import DOMAIN
 
 
 async def async_remove_devices(
-    hass: HomeAssistant, entity: SHCBaseEntity[Any], entry_id: str
+    hass: HomeAssistant,
+    entity: SHCBaseEntity[SHCDevice | SHCIntrusionSystem],
+    entry_id: str,
 ) -> None:
     """Get item that is removed from session."""
     dev_registry = dr.async_get(hass)
@@ -22,8 +24,6 @@ async def async_remove_devices(
         dev_registry.async_update_device(device.id, remove_config_entry_id=entry_id)
 
 
-# Parameterized so each subclass's _device is statically its real concrete
-# type (SHCEntity's SHCDevice vs. SHCDomainEntity's SHCIntrusionSystem).
 class SHCBaseEntity[_DeviceT: (SHCDevice | SHCIntrusionSystem)](Entity):
     """Base representation of a SHC entity."""
 

--- a/homeassistant/components/bosch_shc/manifest.json
+++ b/homeassistant/components/bosch_shc/manifest.json
@@ -8,7 +8,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["boschshcpy"],
-  "requirements": ["boschshcpy==0.3.5"],
+  "requirements": ["boschshcpy==0.4.9"],
   "zeroconf": [
     {
       "name": "bosch shc*",

--- a/homeassistant/components/bosch_shc/sensor.py
+++ b/homeassistant/components/bosch_shc/sensor.py
@@ -144,8 +144,14 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the SHC sensor platform."""
-    session = config_entry.runtime_data.session
-    parent_id = config_entry.runtime_data.parent_id
+    session = config_entry.runtime_data
+
+    # See __init__.py's async_setup_entry: session.information (and its
+    # unique_id) are always populated by the time platform setup runs.
+    shc_info = session.information
+    assert shc_info is not None
+    assert shc_info.unique_id is not None
+    parent_id = shc_info.unique_id
 
     entities: list[SensorEntity] = [
         SHCSensor(

--- a/homeassistant/components/bosch_shc/sensor.py
+++ b/homeassistant/components/bosch_shc/sensor.py
@@ -2,8 +2,16 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, override
+from typing import Any, cast, override
 
+from boschshcpy import (
+    SHCLightSwitchBSM,
+    SHCSmartPlug,
+    SHCSmartPlugCompact,
+    SHCThermostat,
+    SHCTwinguard,
+    SHCWallThermostat,
+)
 from boschshcpy.device import SHCDevice
 
 from homeassistant.components.sensor import (
@@ -34,6 +42,15 @@ class SHCSensorEntityDescription(SensorEntityDescription):
     attributes_fn: Callable[[SHCDevice], dict[str, Any]] | None = None
 
 
+# SHCSensorEntityDescription.value_fn/attributes_fn are declared against the
+# generic SHCDevice (matching self._device's type in SHCSensor below), but
+# each entry here is only ever wired up (in async_setup_entry) to specific
+# device_helper lists whose concrete element type actually has the attribute
+# being accessed. The casts below reflect exactly that per-entry pairing.
+_TemperatureDevice = SHCThermostat | SHCWallThermostat | SHCTwinguard
+_HumidityDevice = SHCWallThermostat | SHCTwinguard
+_PowerMeterDevice = SHCSmartPlug | SHCLightSwitchBSM | SHCSmartPlugCompact
+
 TEMPERATURE_SENSOR = "temperature"
 HUMIDITY_SENSOR = "humidity"
 VALVE_TAPPET_SENSOR = "valvetappet"
@@ -52,69 +69,73 @@ SENSOR_DESCRIPTIONS: dict[str, SHCSensorEntityDescription] = {
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        value_fn=lambda device: device.temperature,
+        value_fn=lambda device: cast(_TemperatureDevice, device).temperature,
     ),
     HUMIDITY_SENSOR: SHCSensorEntityDescription(
         key=HUMIDITY_SENSOR,
         device_class=SensorDeviceClass.HUMIDITY,
         native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
-        value_fn=lambda device: device.humidity,
+        value_fn=lambda device: cast(_HumidityDevice, device).humidity,
     ),
     PURITY_SENSOR: SHCSensorEntityDescription(
         key=PURITY_SENSOR,
         translation_key=PURITY_SENSOR,
         native_unit_of_measurement=UnitOfRatio.PARTS_PER_MILLION,
-        value_fn=lambda device: device.purity,
+        value_fn=lambda device: cast(SHCTwinguard, device).purity,
     ),
     AIR_QUALITY_SENSOR: SHCSensorEntityDescription(
         key=AIR_QUALITY_SENSOR,
         translation_key="air_quality",
-        value_fn=lambda device: device.combined_rating.name,
+        value_fn=lambda device: cast(SHCTwinguard, device).combined_rating.name,
         attributes_fn=lambda device: {
-            "rating_description": device.description,
+            "rating_description": cast(SHCTwinguard, device).description,
         },
     ),
     TEMPERATURE_RATING_SENSOR: SHCSensorEntityDescription(
         key=TEMPERATURE_RATING_SENSOR,
         translation_key=TEMPERATURE_RATING_SENSOR,
-        value_fn=lambda device: device.temperature_rating.name,
+        value_fn=lambda device: cast(SHCTwinguard, device).temperature_rating.name,
     ),
     COMMUNICATION_QUALITY_SENSOR: SHCSensorEntityDescription(
         key=COMMUNICATION_QUALITY_SENSOR,
         translation_key=COMMUNICATION_QUALITY_SENSOR,
-        value_fn=lambda device: device.communicationquality.name,
+        value_fn=lambda device: (
+            cast(SHCSmartPlugCompact, device).communicationquality.name
+        ),
     ),
     HUMIDITY_RATING_SENSOR: SHCSensorEntityDescription(
         key=HUMIDITY_RATING_SENSOR,
         translation_key=HUMIDITY_RATING_SENSOR,
-        value_fn=lambda device: device.humidity_rating.name,
+        value_fn=lambda device: cast(SHCTwinguard, device).humidity_rating.name,
     ),
     PURITY_RATING_SENSOR: SHCSensorEntityDescription(
         key=PURITY_RATING_SENSOR,
         translation_key=PURITY_RATING_SENSOR,
-        value_fn=lambda device: device.purity_rating.name,
+        value_fn=lambda device: cast(SHCTwinguard, device).purity_rating.name,
     ),
     POWER_SENSOR: SHCSensorEntityDescription(
         key=POWER_SENSOR,
         device_class=SensorDeviceClass.POWER,
         native_unit_of_measurement=UnitOfPower.WATT,
-        value_fn=lambda device: device.powerconsumption,
+        value_fn=lambda device: cast(_PowerMeterDevice, device).powerconsumption,
     ),
     ENERGY_SENSOR: SHCSensorEntityDescription(
         key=ENERGY_SENSOR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-        value_fn=lambda device: device.energyconsumption / 1000.0,
+        value_fn=lambda device: (
+            cast(_PowerMeterDevice, device).energyconsumption / 1000.0
+        ),
     ),
     VALVE_TAPPET_SENSOR: SHCSensorEntityDescription(
         key=VALVE_TAPPET_SENSOR,
         translation_key=VALVE_TAPPET_SENSOR,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
-        value_fn=lambda device: device.position,
+        value_fn=lambda device: cast(SHCThermostat, device).position,
         attributes_fn=lambda device: {
-            "valve_tappet_state": device.valvestate.name,
+            "valve_tappet_state": cast(SHCThermostat, device).valvestate.name,
         },
     ),
 }
@@ -128,11 +149,18 @@ async def async_setup_entry(
     """Set up the SHC sensor platform."""
     session = config_entry.runtime_data
 
+    # See __init__.py's async_setup_entry: session.information (and its
+    # unique_id) are always populated by the time platform setup runs.
+    shc_info = session.information
+    assert shc_info is not None
+    assert shc_info.unique_id is not None
+    parent_id = shc_info.unique_id
+
     entities: list[SensorEntity] = [
         SHCSensor(
             device,
             SENSOR_DESCRIPTIONS[sensor_type],
-            session.information.unique_id,
+            parent_id,
             config_entry.entry_id,
         )
         for device in session.device_helper.thermostats
@@ -143,7 +171,7 @@ async def async_setup_entry(
         SHCSensor(
             device,
             SENSOR_DESCRIPTIONS[sensor_type],
-            session.information.unique_id,
+            parent_id,
             config_entry.entry_id,
         )
         for device in session.device_helper.wallthermostats
@@ -154,7 +182,7 @@ async def async_setup_entry(
         SHCSensor(
             device,
             SENSOR_DESCRIPTIONS[sensor_type],
-            session.information.unique_id,
+            parent_id,
             config_entry.entry_id,
         )
         for device in session.device_helper.twinguards
@@ -173,11 +201,12 @@ async def async_setup_entry(
         SHCSensor(
             device,
             SENSOR_DESCRIPTIONS[sensor_type],
-            session.information.unique_id,
+            parent_id,
             config_entry.entry_id,
         )
         for device in (
-            session.device_helper.smart_plugs + session.device_helper.light_switches_bsm
+            *session.device_helper.smart_plugs,
+            *session.device_helper.light_switches_bsm,
         )
         for sensor_type in (POWER_SENSOR, ENERGY_SENSOR)
     )
@@ -186,7 +215,7 @@ async def async_setup_entry(
         SHCSensor(
             device,
             SENSOR_DESCRIPTIONS[sensor_type],
-            session.information.unique_id,
+            parent_id,
             config_entry.entry_id,
         )
         for device in session.device_helper.smart_plugs_compact
@@ -196,7 +225,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class SHCSensor(SHCEntity, SensorEntity):
+class SHCSensor(SHCEntity[SHCDevice], SensorEntity):
     """Representation of a SHC sensor."""
 
     entity_description: SHCSensorEntityDescription

--- a/homeassistant/components/bosch_shc/sensor.py
+++ b/homeassistant/components/bosch_shc/sensor.py
@@ -42,8 +42,7 @@ class SHCSensorEntityDescription(SensorEntityDescription):
     attributes_fn: Callable[[SHCDevice], dict[str, Any]] | None = None
 
 
-# Each entry's value_fn/attributes_fn is only ever wired to a device_helper
-# list whose concrete type actually has the attribute the cast below asserts.
+# Each entry's value_fn is only ever wired to a device_helper list whose concrete type has the cast attribute.
 _TemperatureDevice = SHCThermostat | SHCWallThermostat | SHCTwinguard
 _HumidityDevice = SHCWallThermostat | SHCTwinguard
 _PowerMeterDevice = SHCSmartPlug | SHCLightSwitchBSM | SHCSmartPlugCompact
@@ -148,8 +147,7 @@ async def async_setup_entry(
 
     shc_info = session.information
     if TYPE_CHECKING:
-        assert shc_info is not None
-        assert shc_info.unique_id is not None
+        assert shc_info is not None and shc_info.unique_id is not None
     parent_id = shc_info.unique_id
 
     entities: list[SensorEntity] = [

--- a/homeassistant/components/bosch_shc/sensor.py
+++ b/homeassistant/components/bosch_shc/sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, cast, override
+from typing import TYPE_CHECKING, Any, cast, override
 
 from boschshcpy import (
     SHCLightSwitchBSM,
@@ -146,11 +146,10 @@ async def async_setup_entry(
     """Set up the SHC sensor platform."""
     session = config_entry.runtime_data
 
-    # See __init__.py's async_setup_entry: session.information (and its
-    # unique_id) are always populated by the time platform setup runs.
     shc_info = session.information
-    assert shc_info is not None
-    assert shc_info.unique_id is not None
+    if TYPE_CHECKING:
+        assert shc_info is not None
+        assert shc_info.unique_id is not None
     parent_id = shc_info.unique_id
 
     entities: list[SensorEntity] = [

--- a/homeassistant/components/bosch_shc/sensor.py
+++ b/homeassistant/components/bosch_shc/sensor.py
@@ -147,14 +147,8 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the SHC sensor platform."""
-    session = config_entry.runtime_data
-
-    # See __init__.py's async_setup_entry: session.information (and its
-    # unique_id) are always populated by the time platform setup runs.
-    shc_info = session.information
-    assert shc_info is not None
-    assert shc_info.unique_id is not None
-    parent_id = shc_info.unique_id
+    session = config_entry.runtime_data.session
+    parent_id = config_entry.runtime_data.parent_id
 
     entities: list[SensorEntity] = [
         SHCSensor(

--- a/homeassistant/components/bosch_shc/sensor.py
+++ b/homeassistant/components/bosch_shc/sensor.py
@@ -42,11 +42,8 @@ class SHCSensorEntityDescription(SensorEntityDescription):
     attributes_fn: Callable[[SHCDevice], dict[str, Any]] | None = None
 
 
-# SHCSensorEntityDescription.value_fn/attributes_fn are declared against the
-# generic SHCDevice (matching self._device's type in SHCSensor below), but
-# each entry here is only ever wired up (in async_setup_entry) to specific
-# device_helper lists whose concrete element type actually has the attribute
-# being accessed. The casts below reflect exactly that per-entry pairing.
+# Each entry's value_fn/attributes_fn is only ever wired to a device_helper
+# list whose concrete type actually has the attribute the cast below asserts.
 _TemperatureDevice = SHCThermostat | SHCWallThermostat | SHCTwinguard
 _HumidityDevice = SHCWallThermostat | SHCTwinguard
 _PowerMeterDevice = SHCSmartPlug | SHCLightSwitchBSM | SHCSmartPlugCompact

--- a/homeassistant/components/bosch_shc/sensor.py
+++ b/homeassistant/components/bosch_shc/sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, override
+from typing import Any, cast, override
 
 from boschshcpy import (
     SHCLightSwitchBSM,
@@ -35,13 +35,17 @@ from .entity import SHCEntity
 
 
 @dataclass(frozen=True, kw_only=True)
-class SHCSensorEntityDescription[_DeviceT: SHCDevice](SensorEntityDescription):
+class SHCSensorEntityDescription(SensorEntityDescription):
     """Describes a SHC sensor."""
 
-    value_fn: Callable[[_DeviceT], StateType]
-    attributes_fn: Callable[[_DeviceT], dict[str, Any]] | None = None
+    value_fn: Callable[[SHCDevice], StateType]
+    attributes_fn: Callable[[SHCDevice], dict[str, Any]] | None = None
 
 
+# Each entry's value_fn/attributes_fn is only ever wired to a device_helper
+# list whose concrete type actually has the attribute the cast below asserts.
+_TemperatureDevice = SHCThermostat | SHCWallThermostat | SHCTwinguard
+_HumidityDevice = SHCWallThermostat | SHCTwinguard
 _PowerMeterDevice = SHCSmartPlug | SHCLightSwitchBSM | SHCSmartPlugCompact
 
 TEMPERATURE_SENSOR = "temperature"
@@ -56,114 +60,82 @@ POWER_SENSOR = "power"
 ENERGY_SENSOR = "energy"
 COMMUNICATION_QUALITY_SENSOR = "communication_quality"
 
-THERMOSTAT_SENSOR_TYPES: tuple[SHCSensorEntityDescription[SHCThermostat], ...] = (
-    SHCSensorEntityDescription[SHCThermostat](
+SENSOR_DESCRIPTIONS: dict[str, SHCSensorEntityDescription] = {
+    TEMPERATURE_SENSOR: SHCSensorEntityDescription(
         key=TEMPERATURE_SENSOR,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        value_fn=lambda device: device.temperature,
+        value_fn=lambda device: cast(_TemperatureDevice, device).temperature,
     ),
-    SHCSensorEntityDescription[SHCThermostat](
-        key=VALVE_TAPPET_SENSOR,
-        translation_key=VALVE_TAPPET_SENSOR,
-        state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
-        value_fn=lambda device: device.position,
-        attributes_fn=lambda device: {
-            "valve_tappet_state": device.valvestate.name,
-        },
-    ),
-)
-
-WALLTHERMOSTAT_SENSOR_TYPES: tuple[
-    SHCSensorEntityDescription[SHCWallThermostat], ...
-] = (
-    SHCSensorEntityDescription[SHCWallThermostat](
-        key=TEMPERATURE_SENSOR,
-        device_class=SensorDeviceClass.TEMPERATURE,
-        state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        value_fn=lambda device: device.temperature,
-    ),
-    SHCSensorEntityDescription[SHCWallThermostat](
+    HUMIDITY_SENSOR: SHCSensorEntityDescription(
         key=HUMIDITY_SENSOR,
         device_class=SensorDeviceClass.HUMIDITY,
         native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
-        value_fn=lambda device: device.humidity,
+        value_fn=lambda device: cast(_HumidityDevice, device).humidity,
     ),
-)
-
-TWINGUARD_SENSOR_TYPES: tuple[SHCSensorEntityDescription[SHCTwinguard], ...] = (
-    SHCSensorEntityDescription[SHCTwinguard](
-        key=TEMPERATURE_SENSOR,
-        device_class=SensorDeviceClass.TEMPERATURE,
-        state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        value_fn=lambda device: device.temperature,
-    ),
-    SHCSensorEntityDescription[SHCTwinguard](
-        key=HUMIDITY_SENSOR,
-        device_class=SensorDeviceClass.HUMIDITY,
-        native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
-        value_fn=lambda device: device.humidity,
-    ),
-    SHCSensorEntityDescription[SHCTwinguard](
+    PURITY_SENSOR: SHCSensorEntityDescription(
         key=PURITY_SENSOR,
         translation_key=PURITY_SENSOR,
         native_unit_of_measurement=UnitOfRatio.PARTS_PER_MILLION,
-        value_fn=lambda device: device.purity,
+        value_fn=lambda device: cast(SHCTwinguard, device).purity,
     ),
-    SHCSensorEntityDescription[SHCTwinguard](
+    AIR_QUALITY_SENSOR: SHCSensorEntityDescription(
         key=AIR_QUALITY_SENSOR,
         translation_key="air_quality",
-        value_fn=lambda device: device.combined_rating.name,
+        value_fn=lambda device: cast(SHCTwinguard, device).combined_rating.name,
         attributes_fn=lambda device: {
-            "rating_description": device.description,
+            "rating_description": cast(SHCTwinguard, device).description,
         },
     ),
-    SHCSensorEntityDescription[SHCTwinguard](
+    TEMPERATURE_RATING_SENSOR: SHCSensorEntityDescription(
         key=TEMPERATURE_RATING_SENSOR,
         translation_key=TEMPERATURE_RATING_SENSOR,
-        value_fn=lambda device: device.temperature_rating.name,
+        value_fn=lambda device: cast(SHCTwinguard, device).temperature_rating.name,
     ),
-    SHCSensorEntityDescription[SHCTwinguard](
+    COMMUNICATION_QUALITY_SENSOR: SHCSensorEntityDescription(
+        key=COMMUNICATION_QUALITY_SENSOR,
+        translation_key=COMMUNICATION_QUALITY_SENSOR,
+        value_fn=lambda device: (
+            cast(SHCSmartPlugCompact, device).communicationquality.name
+        ),
+    ),
+    HUMIDITY_RATING_SENSOR: SHCSensorEntityDescription(
         key=HUMIDITY_RATING_SENSOR,
         translation_key=HUMIDITY_RATING_SENSOR,
-        value_fn=lambda device: device.humidity_rating.name,
+        value_fn=lambda device: cast(SHCTwinguard, device).humidity_rating.name,
     ),
-    SHCSensorEntityDescription[SHCTwinguard](
+    PURITY_RATING_SENSOR: SHCSensorEntityDescription(
         key=PURITY_RATING_SENSOR,
         translation_key=PURITY_RATING_SENSOR,
-        value_fn=lambda device: device.purity_rating.name,
+        value_fn=lambda device: cast(SHCTwinguard, device).purity_rating.name,
     ),
-)
-
-POWER_METER_SENSOR_TYPES: tuple[SHCSensorEntityDescription[_PowerMeterDevice], ...] = (
-    SHCSensorEntityDescription[_PowerMeterDevice](
+    POWER_SENSOR: SHCSensorEntityDescription(
         key=POWER_SENSOR,
         device_class=SensorDeviceClass.POWER,
         native_unit_of_measurement=UnitOfPower.WATT,
-        value_fn=lambda device: device.powerconsumption,
+        value_fn=lambda device: cast(_PowerMeterDevice, device).powerconsumption,
     ),
-    SHCSensorEntityDescription[_PowerMeterDevice](
+    ENERGY_SENSOR: SHCSensorEntityDescription(
         key=ENERGY_SENSOR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-        value_fn=lambda device: device.energyconsumption / 1000.0,
+        value_fn=lambda device: (
+            cast(_PowerMeterDevice, device).energyconsumption / 1000.0
+        ),
     ),
-)
-
-PLUG_COMPACT_SENSOR_TYPES: tuple[
-    SHCSensorEntityDescription[SHCSmartPlugCompact], ...
-] = (
-    SHCSensorEntityDescription[SHCSmartPlugCompact](
-        key=COMMUNICATION_QUALITY_SENSOR,
-        translation_key=COMMUNICATION_QUALITY_SENSOR,
-        value_fn=lambda device: device.communicationquality.name,
+    VALVE_TAPPET_SENSOR: SHCSensorEntityDescription(
+        key=VALVE_TAPPET_SENSOR,
+        translation_key=VALVE_TAPPET_SENSOR,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
+        value_fn=lambda device: cast(SHCThermostat, device).position,
+        attributes_fn=lambda device: {
+            "valve_tappet_state": cast(SHCThermostat, device).valvestate.name,
+        },
     ),
-)
+}
 
 
 async def async_setup_entry(
@@ -176,52 +148,83 @@ async def async_setup_entry(
     parent_id = config_entry.runtime_data.parent_id
 
     entities: list[SensorEntity] = [
-        SHCSensor(device, description, parent_id, config_entry.entry_id)
+        SHCSensor(
+            device,
+            SENSOR_DESCRIPTIONS[sensor_type],
+            parent_id,
+            config_entry.entry_id,
+        )
         for device in session.device_helper.thermostats
-        for description in THERMOSTAT_SENSOR_TYPES
+        for sensor_type in (TEMPERATURE_SENSOR, VALVE_TAPPET_SENSOR)
     ]
 
     entities.extend(
-        SHCSensor(device, description, parent_id, config_entry.entry_id)
+        SHCSensor(
+            device,
+            SENSOR_DESCRIPTIONS[sensor_type],
+            parent_id,
+            config_entry.entry_id,
+        )
         for device in session.device_helper.wallthermostats
-        for description in WALLTHERMOSTAT_SENSOR_TYPES
+        for sensor_type in (TEMPERATURE_SENSOR, HUMIDITY_SENSOR)
     )
 
     entities.extend(
-        SHCSensor(device, description, parent_id, config_entry.entry_id)
+        SHCSensor(
+            device,
+            SENSOR_DESCRIPTIONS[sensor_type],
+            parent_id,
+            config_entry.entry_id,
+        )
         for device in session.device_helper.twinguards
-        for description in TWINGUARD_SENSOR_TYPES
-    )
-
-    power_meter_devices: list[_PowerMeterDevice] = [
-        *session.device_helper.smart_plugs,
-        *session.device_helper.light_switches_bsm,
-        *session.device_helper.smart_plugs_compact,
-    ]
-    entities.extend(
-        SHCSensor(device, description, parent_id, config_entry.entry_id)
-        for device in power_meter_devices
-        for description in POWER_METER_SENSOR_TYPES
+        for sensor_type in (
+            TEMPERATURE_SENSOR,
+            HUMIDITY_SENSOR,
+            PURITY_SENSOR,
+            AIR_QUALITY_SENSOR,
+            TEMPERATURE_RATING_SENSOR,
+            HUMIDITY_RATING_SENSOR,
+            PURITY_RATING_SENSOR,
+        )
     )
 
     entities.extend(
-        SHCSensor(device, description, parent_id, config_entry.entry_id)
+        SHCSensor(
+            device,
+            SENSOR_DESCRIPTIONS[sensor_type],
+            parent_id,
+            config_entry.entry_id,
+        )
+        for device in (
+            *session.device_helper.smart_plugs,
+            *session.device_helper.light_switches_bsm,
+        )
+        for sensor_type in (POWER_SENSOR, ENERGY_SENSOR)
+    )
+
+    entities.extend(
+        SHCSensor(
+            device,
+            SENSOR_DESCRIPTIONS[sensor_type],
+            parent_id,
+            config_entry.entry_id,
+        )
         for device in session.device_helper.smart_plugs_compact
-        for description in PLUG_COMPACT_SENSOR_TYPES
+        for sensor_type in (POWER_SENSOR, ENERGY_SENSOR, COMMUNICATION_QUALITY_SENSOR)
     )
 
     async_add_entities(entities)
 
 
-class SHCSensor[_DeviceT: SHCDevice](SHCEntity[_DeviceT], SensorEntity):
+class SHCSensor(SHCEntity[SHCDevice], SensorEntity):
     """Representation of a SHC sensor."""
 
-    entity_description: SHCSensorEntityDescription[_DeviceT]
+    entity_description: SHCSensorEntityDescription
 
     def __init__(
         self,
-        device: _DeviceT,
-        entity_description: SHCSensorEntityDescription[_DeviceT],
+        device: SHCDevice,
+        entity_description: SHCSensorEntityDescription,
         parent_id: str,
         entry_id: str,
     ) -> None:

--- a/homeassistant/components/bosch_shc/sensor.py
+++ b/homeassistant/components/bosch_shc/sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, cast, override
+from typing import Any, override
 
 from boschshcpy import (
     SHCLightSwitchBSM,
@@ -35,17 +35,13 @@ from .entity import SHCEntity
 
 
 @dataclass(frozen=True, kw_only=True)
-class SHCSensorEntityDescription(SensorEntityDescription):
+class SHCSensorEntityDescription[_DeviceT: SHCDevice](SensorEntityDescription):
     """Describes a SHC sensor."""
 
-    value_fn: Callable[[SHCDevice], StateType]
-    attributes_fn: Callable[[SHCDevice], dict[str, Any]] | None = None
+    value_fn: Callable[[_DeviceT], StateType]
+    attributes_fn: Callable[[_DeviceT], dict[str, Any]] | None = None
 
 
-# Each entry's value_fn/attributes_fn is only ever wired to a device_helper
-# list whose concrete type actually has the attribute the cast below asserts.
-_TemperatureDevice = SHCThermostat | SHCWallThermostat | SHCTwinguard
-_HumidityDevice = SHCWallThermostat | SHCTwinguard
 _PowerMeterDevice = SHCSmartPlug | SHCLightSwitchBSM | SHCSmartPlugCompact
 
 TEMPERATURE_SENSOR = "temperature"
@@ -60,82 +56,114 @@ POWER_SENSOR = "power"
 ENERGY_SENSOR = "energy"
 COMMUNICATION_QUALITY_SENSOR = "communication_quality"
 
-SENSOR_DESCRIPTIONS: dict[str, SHCSensorEntityDescription] = {
-    TEMPERATURE_SENSOR: SHCSensorEntityDescription(
+THERMOSTAT_SENSOR_TYPES: tuple[SHCSensorEntityDescription[SHCThermostat], ...] = (
+    SHCSensorEntityDescription[SHCThermostat](
         key=TEMPERATURE_SENSOR,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        value_fn=lambda device: cast(_TemperatureDevice, device).temperature,
+        value_fn=lambda device: device.temperature,
     ),
-    HUMIDITY_SENSOR: SHCSensorEntityDescription(
-        key=HUMIDITY_SENSOR,
-        device_class=SensorDeviceClass.HUMIDITY,
-        native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
-        value_fn=lambda device: cast(_HumidityDevice, device).humidity,
-    ),
-    PURITY_SENSOR: SHCSensorEntityDescription(
-        key=PURITY_SENSOR,
-        translation_key=PURITY_SENSOR,
-        native_unit_of_measurement=UnitOfRatio.PARTS_PER_MILLION,
-        value_fn=lambda device: cast(SHCTwinguard, device).purity,
-    ),
-    AIR_QUALITY_SENSOR: SHCSensorEntityDescription(
-        key=AIR_QUALITY_SENSOR,
-        translation_key="air_quality",
-        value_fn=lambda device: cast(SHCTwinguard, device).combined_rating.name,
-        attributes_fn=lambda device: {
-            "rating_description": cast(SHCTwinguard, device).description,
-        },
-    ),
-    TEMPERATURE_RATING_SENSOR: SHCSensorEntityDescription(
-        key=TEMPERATURE_RATING_SENSOR,
-        translation_key=TEMPERATURE_RATING_SENSOR,
-        value_fn=lambda device: cast(SHCTwinguard, device).temperature_rating.name,
-    ),
-    COMMUNICATION_QUALITY_SENSOR: SHCSensorEntityDescription(
-        key=COMMUNICATION_QUALITY_SENSOR,
-        translation_key=COMMUNICATION_QUALITY_SENSOR,
-        value_fn=lambda device: (
-            cast(SHCSmartPlugCompact, device).communicationquality.name
-        ),
-    ),
-    HUMIDITY_RATING_SENSOR: SHCSensorEntityDescription(
-        key=HUMIDITY_RATING_SENSOR,
-        translation_key=HUMIDITY_RATING_SENSOR,
-        value_fn=lambda device: cast(SHCTwinguard, device).humidity_rating.name,
-    ),
-    PURITY_RATING_SENSOR: SHCSensorEntityDescription(
-        key=PURITY_RATING_SENSOR,
-        translation_key=PURITY_RATING_SENSOR,
-        value_fn=lambda device: cast(SHCTwinguard, device).purity_rating.name,
-    ),
-    POWER_SENSOR: SHCSensorEntityDescription(
-        key=POWER_SENSOR,
-        device_class=SensorDeviceClass.POWER,
-        native_unit_of_measurement=UnitOfPower.WATT,
-        value_fn=lambda device: cast(_PowerMeterDevice, device).powerconsumption,
-    ),
-    ENERGY_SENSOR: SHCSensorEntityDescription(
-        key=ENERGY_SENSOR,
-        device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.TOTAL_INCREASING,
-        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-        value_fn=lambda device: (
-            cast(_PowerMeterDevice, device).energyconsumption / 1000.0
-        ),
-    ),
-    VALVE_TAPPET_SENSOR: SHCSensorEntityDescription(
+    SHCSensorEntityDescription[SHCThermostat](
         key=VALVE_TAPPET_SENSOR,
         translation_key=VALVE_TAPPET_SENSOR,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
-        value_fn=lambda device: cast(SHCThermostat, device).position,
+        value_fn=lambda device: device.position,
         attributes_fn=lambda device: {
-            "valve_tappet_state": cast(SHCThermostat, device).valvestate.name,
+            "valve_tappet_state": device.valvestate.name,
         },
     ),
-}
+)
+
+WALLTHERMOSTAT_SENSOR_TYPES: tuple[
+    SHCSensorEntityDescription[SHCWallThermostat], ...
+] = (
+    SHCSensorEntityDescription[SHCWallThermostat](
+        key=TEMPERATURE_SENSOR,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        value_fn=lambda device: device.temperature,
+    ),
+    SHCSensorEntityDescription[SHCWallThermostat](
+        key=HUMIDITY_SENSOR,
+        device_class=SensorDeviceClass.HUMIDITY,
+        native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
+        value_fn=lambda device: device.humidity,
+    ),
+)
+
+TWINGUARD_SENSOR_TYPES: tuple[SHCSensorEntityDescription[SHCTwinguard], ...] = (
+    SHCSensorEntityDescription[SHCTwinguard](
+        key=TEMPERATURE_SENSOR,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        value_fn=lambda device: device.temperature,
+    ),
+    SHCSensorEntityDescription[SHCTwinguard](
+        key=HUMIDITY_SENSOR,
+        device_class=SensorDeviceClass.HUMIDITY,
+        native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
+        value_fn=lambda device: device.humidity,
+    ),
+    SHCSensorEntityDescription[SHCTwinguard](
+        key=PURITY_SENSOR,
+        translation_key=PURITY_SENSOR,
+        native_unit_of_measurement=UnitOfRatio.PARTS_PER_MILLION,
+        value_fn=lambda device: device.purity,
+    ),
+    SHCSensorEntityDescription[SHCTwinguard](
+        key=AIR_QUALITY_SENSOR,
+        translation_key="air_quality",
+        value_fn=lambda device: device.combined_rating.name,
+        attributes_fn=lambda device: {
+            "rating_description": device.description,
+        },
+    ),
+    SHCSensorEntityDescription[SHCTwinguard](
+        key=TEMPERATURE_RATING_SENSOR,
+        translation_key=TEMPERATURE_RATING_SENSOR,
+        value_fn=lambda device: device.temperature_rating.name,
+    ),
+    SHCSensorEntityDescription[SHCTwinguard](
+        key=HUMIDITY_RATING_SENSOR,
+        translation_key=HUMIDITY_RATING_SENSOR,
+        value_fn=lambda device: device.humidity_rating.name,
+    ),
+    SHCSensorEntityDescription[SHCTwinguard](
+        key=PURITY_RATING_SENSOR,
+        translation_key=PURITY_RATING_SENSOR,
+        value_fn=lambda device: device.purity_rating.name,
+    ),
+)
+
+POWER_METER_SENSOR_TYPES: tuple[SHCSensorEntityDescription[_PowerMeterDevice], ...] = (
+    SHCSensorEntityDescription[_PowerMeterDevice](
+        key=POWER_SENSOR,
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        value_fn=lambda device: device.powerconsumption,
+    ),
+    SHCSensorEntityDescription[_PowerMeterDevice](
+        key=ENERGY_SENSOR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        value_fn=lambda device: device.energyconsumption / 1000.0,
+    ),
+)
+
+PLUG_COMPACT_SENSOR_TYPES: tuple[
+    SHCSensorEntityDescription[SHCSmartPlugCompact], ...
+] = (
+    SHCSensorEntityDescription[SHCSmartPlugCompact](
+        key=COMMUNICATION_QUALITY_SENSOR,
+        translation_key=COMMUNICATION_QUALITY_SENSOR,
+        value_fn=lambda device: device.communicationquality.name,
+    ),
+)
 
 
 async def async_setup_entry(
@@ -148,83 +176,52 @@ async def async_setup_entry(
     parent_id = config_entry.runtime_data.parent_id
 
     entities: list[SensorEntity] = [
-        SHCSensor(
-            device,
-            SENSOR_DESCRIPTIONS[sensor_type],
-            parent_id,
-            config_entry.entry_id,
-        )
+        SHCSensor(device, description, parent_id, config_entry.entry_id)
         for device in session.device_helper.thermostats
-        for sensor_type in (TEMPERATURE_SENSOR, VALVE_TAPPET_SENSOR)
+        for description in THERMOSTAT_SENSOR_TYPES
     ]
 
     entities.extend(
-        SHCSensor(
-            device,
-            SENSOR_DESCRIPTIONS[sensor_type],
-            parent_id,
-            config_entry.entry_id,
-        )
+        SHCSensor(device, description, parent_id, config_entry.entry_id)
         for device in session.device_helper.wallthermostats
-        for sensor_type in (TEMPERATURE_SENSOR, HUMIDITY_SENSOR)
+        for description in WALLTHERMOSTAT_SENSOR_TYPES
     )
 
     entities.extend(
-        SHCSensor(
-            device,
-            SENSOR_DESCRIPTIONS[sensor_type],
-            parent_id,
-            config_entry.entry_id,
-        )
+        SHCSensor(device, description, parent_id, config_entry.entry_id)
         for device in session.device_helper.twinguards
-        for sensor_type in (
-            TEMPERATURE_SENSOR,
-            HUMIDITY_SENSOR,
-            PURITY_SENSOR,
-            AIR_QUALITY_SENSOR,
-            TEMPERATURE_RATING_SENSOR,
-            HUMIDITY_RATING_SENSOR,
-            PURITY_RATING_SENSOR,
-        )
+        for description in TWINGUARD_SENSOR_TYPES
+    )
+
+    power_meter_devices: list[_PowerMeterDevice] = [
+        *session.device_helper.smart_plugs,
+        *session.device_helper.light_switches_bsm,
+        *session.device_helper.smart_plugs_compact,
+    ]
+    entities.extend(
+        SHCSensor(device, description, parent_id, config_entry.entry_id)
+        for device in power_meter_devices
+        for description in POWER_METER_SENSOR_TYPES
     )
 
     entities.extend(
-        SHCSensor(
-            device,
-            SENSOR_DESCRIPTIONS[sensor_type],
-            parent_id,
-            config_entry.entry_id,
-        )
-        for device in (
-            *session.device_helper.smart_plugs,
-            *session.device_helper.light_switches_bsm,
-        )
-        for sensor_type in (POWER_SENSOR, ENERGY_SENSOR)
-    )
-
-    entities.extend(
-        SHCSensor(
-            device,
-            SENSOR_DESCRIPTIONS[sensor_type],
-            parent_id,
-            config_entry.entry_id,
-        )
+        SHCSensor(device, description, parent_id, config_entry.entry_id)
         for device in session.device_helper.smart_plugs_compact
-        for sensor_type in (POWER_SENSOR, ENERGY_SENSOR, COMMUNICATION_QUALITY_SENSOR)
+        for description in PLUG_COMPACT_SENSOR_TYPES
     )
 
     async_add_entities(entities)
 
 
-class SHCSensor(SHCEntity[SHCDevice], SensorEntity):
+class SHCSensor[_DeviceT: SHCDevice](SHCEntity[_DeviceT], SensorEntity):
     """Representation of a SHC sensor."""
 
-    entity_description: SHCSensorEntityDescription
+    entity_description: SHCSensorEntityDescription[_DeviceT]
 
     def __init__(
         self,
-        device: SHCDevice,
-        entity_description: SHCSensorEntityDescription,
+        device: _DeviceT,
+        entity_description: SHCSensorEntityDescription[_DeviceT],
         parent_id: str,
         entry_id: str,
     ) -> None:

--- a/homeassistant/components/bosch_shc/switch.py
+++ b/homeassistant/components/bosch_shc/switch.py
@@ -83,8 +83,7 @@ async def async_setup_entry(
 
     shc_info = session.information
     if TYPE_CHECKING:
-        assert shc_info is not None
-        assert shc_info.unique_id is not None
+        assert shc_info is not None and shc_info.unique_id is not None
     parent_id = shc_info.unique_id
 
     entities: list[SwitchEntity] = [

--- a/homeassistant/components/bosch_shc/switch.py
+++ b/homeassistant/components/bosch_shc/switch.py
@@ -197,7 +197,7 @@ class SHCRoutingSwitch(SHCEntity[SHCSmartPlug], SwitchEntity):
     _attr_entity_category = EntityCategory.CONFIG
 
     def __init__(self, device: SHCSmartPlug, parent_id: str, entry_id: str) -> None:
-        """Initialize an SHC communication quality reporting sensor."""
+        """Initialize an SHC routing switch."""
         super().__init__(device, parent_id, entry_id)
         self._attr_unique_id = f"{device.serial}_routing"
 

--- a/homeassistant/components/bosch_shc/switch.py
+++ b/homeassistant/components/bosch_shc/switch.py
@@ -30,7 +30,6 @@ class SHCSwitchEntityDescription(SwitchEntityDescription):
     """Class describing SHC switch entities."""
 
     on_key: str
-    # Plain Enum members are stored/compared here, not StateType.
     on_value: Enum
     should_poll: bool
 

--- a/homeassistant/components/bosch_shc/switch.py
+++ b/homeassistant/components/bosch_shc/switch.py
@@ -79,8 +79,14 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the SHC switch platform."""
-    session = config_entry.runtime_data.session
-    parent_id = config_entry.runtime_data.parent_id
+    session = config_entry.runtime_data
+
+    # See __init__.py's async_setup_entry: session.information (and its
+    # unique_id) are always populated by the time platform setup runs.
+    shc_info = session.information
+    assert shc_info is not None
+    assert shc_info.unique_id is not None
+    parent_id = shc_info.unique_id
 
     entities: list[SwitchEntity] = [
         SHCSwitch(

--- a/homeassistant/components/bosch_shc/switch.py
+++ b/homeassistant/components/bosch_shc/switch.py
@@ -82,14 +82,8 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the SHC switch platform."""
-    session = config_entry.runtime_data
-
-    # See __init__.py's async_setup_entry: session.information (and its
-    # unique_id) are always populated by the time platform setup runs.
-    shc_info = session.information
-    assert shc_info is not None
-    assert shc_info.unique_id is not None
-    parent_id = shc_info.unique_id
+    session = config_entry.runtime_data.session
+    parent_id = config_entry.runtime_data.parent_id
 
     entities: list[SwitchEntity] = [
         SHCSwitch(

--- a/homeassistant/components/bosch_shc/switch.py
+++ b/homeassistant/components/bosch_shc/switch.py
@@ -30,9 +30,7 @@ class SHCSwitchEntityDescription(SwitchEntityDescription):
     """Class describing SHC switch entities."""
 
     on_key: str
-    # The device-service State enums (PowerSwitchService.State.ON etc.) are
-    # plain Enum subclasses, not str -- StateType (str | int | float | None)
-    # doesn't actually describe what's stored/compared here.
+    # Plain Enum members are stored/compared here, not StateType.
     on_value: Enum
     should_poll: bool
 

--- a/homeassistant/components/bosch_shc/switch.py
+++ b/homeassistant/components/bosch_shc/switch.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, override
+from typing import TYPE_CHECKING, Any, override
 
 from boschshcpy import (
     CameraLightService,
@@ -81,11 +81,10 @@ async def async_setup_entry(
     """Set up the SHC switch platform."""
     session = config_entry.runtime_data
 
-    # See __init__.py's async_setup_entry: session.information (and its
-    # unique_id) are always populated by the time platform setup runs.
     shc_info = session.information
-    assert shc_info is not None
-    assert shc_info.unique_id is not None
+    if TYPE_CHECKING:
+        assert shc_info is not None
+        assert shc_info.unique_id is not None
     parent_id = shc_info.unique_id
 
     entities: list[SwitchEntity] = [

--- a/homeassistant/components/bosch_shc/switch.py
+++ b/homeassistant/components/bosch_shc/switch.py
@@ -172,7 +172,7 @@ class SHCSwitch(SHCEntity[SHCDevice], SwitchEntity):
         """Return the state of the switch."""
         return (
             getattr(self._device, self.entity_description.on_key)
-            == self.entity_description.on_value
+            is self.entity_description.on_value
         )
 
     @override

--- a/homeassistant/components/bosch_shc/switch.py
+++ b/homeassistant/components/bosch_shc/switch.py
@@ -1,14 +1,14 @@
 """Platform for switch integration."""
 
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, override
 
 from boschshcpy import (
-    SHCCamera360,
-    SHCCameraEyes,
-    SHCLightSwitch,
+    CameraLightService,
+    PowerSwitchService,
+    PrivacyModeService,
     SHCSmartPlug,
-    SHCSmartPlugCompact,
 )
 from boschshcpy.device import SHCDevice
 
@@ -20,7 +20,6 @@ from homeassistant.components.switch import (
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.typing import StateType
 
 from . import BoschConfigEntry
 from .entity import SHCEntity
@@ -31,7 +30,10 @@ class SHCSwitchEntityDescription(SwitchEntityDescription):
     """Class describing SHC switch entities."""
 
     on_key: str
-    on_value: StateType
+    # The device-service State enums (PowerSwitchService.State.ON etc.) are
+    # plain Enum subclasses, not str -- StateType (str | int | float | None)
+    # doesn't actually describe what's stored/compared here.
+    on_value: Enum
     should_poll: bool
 
 
@@ -40,35 +42,35 @@ SWITCH_TYPES: dict[str, SHCSwitchEntityDescription] = {
         key="smartplug",
         device_class=SwitchDeviceClass.OUTLET,
         on_key="switchstate",
-        on_value=SHCSmartPlug.PowerSwitchService.State.ON,
+        on_value=PowerSwitchService.State.ON,
         should_poll=False,
     ),
     "smartplugcompact": SHCSwitchEntityDescription(
         key="smartplugcompact",
         device_class=SwitchDeviceClass.OUTLET,
         on_key="switchstate",
-        on_value=SHCSmartPlugCompact.PowerSwitchService.State.ON,
+        on_value=PowerSwitchService.State.ON,
         should_poll=False,
     ),
     "lightswitch": SHCSwitchEntityDescription(
         key="lightswitch",
         device_class=SwitchDeviceClass.SWITCH,
         on_key="switchstate",
-        on_value=SHCLightSwitch.PowerSwitchService.State.ON,
+        on_value=PowerSwitchService.State.ON,
         should_poll=False,
     ),
     "cameraeyes": SHCSwitchEntityDescription(
         key="cameraeyes",
         device_class=SwitchDeviceClass.SWITCH,
         on_key="cameralight",
-        on_value=SHCCameraEyes.CameraLightService.State.ON,
+        on_value=CameraLightService.State.ON,
         should_poll=True,
     ),
     "camera360": SHCSwitchEntityDescription(
         key="camera360",
         device_class=SwitchDeviceClass.SWITCH,
         on_key="privacymode",
-        on_value=SHCCamera360.PrivacyModeService.State.DISABLED,
+        on_value=PrivacyModeService.State.DISABLED,
         should_poll=True,
     ),
 }
@@ -82,10 +84,17 @@ async def async_setup_entry(
     """Set up the SHC switch platform."""
     session = config_entry.runtime_data
 
+    # See __init__.py's async_setup_entry: session.information (and its
+    # unique_id) are always populated by the time platform setup runs.
+    shc_info = session.information
+    assert shc_info is not None
+    assert shc_info.unique_id is not None
+    parent_id = shc_info.unique_id
+
     entities: list[SwitchEntity] = [
         SHCSwitch(
             device=switch,
-            parent_id=session.information.unique_id,
+            parent_id=parent_id,
             entry_id=config_entry.entry_id,
             description=SWITCH_TYPES["smartplug"],
         )
@@ -95,7 +104,7 @@ async def async_setup_entry(
     entities.extend(
         SHCRoutingSwitch(
             device=switch,
-            parent_id=session.information.unique_id,
+            parent_id=parent_id,
             entry_id=config_entry.entry_id,
         )
         for switch in session.device_helper.smart_plugs
@@ -104,7 +113,7 @@ async def async_setup_entry(
     entities.extend(
         SHCSwitch(
             device=switch,
-            parent_id=session.information.unique_id,
+            parent_id=parent_id,
             entry_id=config_entry.entry_id,
             description=SWITCH_TYPES["lightswitch"],
         )
@@ -114,7 +123,7 @@ async def async_setup_entry(
     entities.extend(
         SHCSwitch(
             device=switch,
-            parent_id=session.information.unique_id,
+            parent_id=parent_id,
             entry_id=config_entry.entry_id,
             description=SWITCH_TYPES["smartplugcompact"],
         )
@@ -124,7 +133,7 @@ async def async_setup_entry(
     entities.extend(
         SHCSwitch(
             device=switch,
-            parent_id=session.information.unique_id,
+            parent_id=parent_id,
             entry_id=config_entry.entry_id,
             description=SWITCH_TYPES["cameraeyes"],
         )
@@ -134,7 +143,7 @@ async def async_setup_entry(
     entities.extend(
         SHCSwitch(
             device=switch,
-            parent_id=session.information.unique_id,
+            parent_id=parent_id,
             entry_id=config_entry.entry_id,
             description=SWITCH_TYPES["camera360"],
         )
@@ -144,7 +153,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class SHCSwitch(SHCEntity, SwitchEntity):
+class SHCSwitch(SHCEntity[SHCDevice], SwitchEntity):
     """Representation of a SHC switch."""
 
     entity_description: SHCSwitchEntityDescription
@@ -190,13 +199,13 @@ class SHCSwitch(SHCEntity, SwitchEntity):
         self._device.update()
 
 
-class SHCRoutingSwitch(SHCEntity, SwitchEntity):
+class SHCRoutingSwitch(SHCEntity[SHCSmartPlug], SwitchEntity):
     """Representation of a SHC routing switch."""
 
     _attr_translation_key = "routing"
     _attr_entity_category = EntityCategory.CONFIG
 
-    def __init__(self, device: SHCDevice, parent_id: str, entry_id: str) -> None:
+    def __init__(self, device: SHCSmartPlug, parent_id: str, entry_id: str) -> None:
         """Initialize an SHC communication quality reporting sensor."""
         super().__init__(device, parent_id, entry_id)
         self._attr_unique_id = f"{device.serial}_routing"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -693,7 +693,7 @@ bond-async==0.2.1
 bosch-alarm-mode2==0.4.10
 
 # homeassistant.components.bosch_shc
-boschshcpy==0.3.5
+boschshcpy==0.4.9
 
 # homeassistant.components.amazon_polly
 # homeassistant.components.route53

--- a/tests/components/bosch_shc/__init__.py
+++ b/tests/components/bosch_shc/__init__.py
@@ -1,1 +1,15 @@
 """Tests for the Bosch SHC integration."""
+
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def setup_integration(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Add the config entry and set up the integration."""
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()

--- a/tests/components/bosch_shc/conftest.py
+++ b/tests/components/bosch_shc/conftest.py
@@ -1,10 +1,105 @@
 """bosch_shc session fixtures."""
 
-from unittest.mock import MagicMock
+from collections.abc import Generator
+from unittest.mock import MagicMock, patch
 
 import pytest
+
+from homeassistant.components.bosch_shc.const import (
+    CONF_SSL_CERTIFICATE,
+    CONF_SSL_KEY,
+    DOMAIN,
+)
+from homeassistant.const import CONF_HOST
+
+from tests.common import MockConfigEntry
+
+# Every collection the binary_sensor platform reads off
+# ``session.device_helper`` during setup. Tests inject devices into the
+# relevant list before calling ``setup_integration``; everything else stays
+# empty.
+DEVICE_HELPER_COLLECTIONS = (
+    "motion_detectors",
+    "shutter_contacts",
+    "shutter_contacts2",
+    "smoke_detectors",
+    "thermostats",
+    "twinguards",
+    "universal_switches",
+    "wallthermostats",
+    "water_leakage_detectors",
+)
+
+
+def make_device(
+    device_id: str = "device-1",
+    name: str = "Test device",
+    **attrs: object,
+) -> MagicMock:
+    """Build a mock SHC device with the attributes the entity base needs."""
+    device = MagicMock()
+    device.id = device_id
+    device.name = name
+    device.serial = device_id
+    device.root_device_id = "shc-root"
+    device.device_model = "TEST_MODEL"
+    device.manufacturer = "BOSCH"
+    device.status = "AVAILABLE"
+    device.device_services = []
+    for key, value in attrs.items():
+        setattr(device, key, value)
+    return device
 
 
 @pytest.fixture(autouse=True)
 def bosch_shc_mock_async_zeroconf(mock_async_zeroconf: MagicMock) -> None:
     """Auto mock zeroconf."""
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return a mocked Bosch SHC config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="shc012345",
+        unique_id="test-mac",
+        entry_id="01JE69BM3MA48YE6RH05A4MDKQ",
+        data={
+            CONF_HOST: "1.1.1.1",
+            CONF_SSL_CERTIFICATE: "/etc/bosch_shc/test-cert.pem",
+            CONF_SSL_KEY: "/etc/bosch_shc/test-key.pem",
+        },
+    )
+
+
+@pytest.fixture
+def mock_device_helper() -> MagicMock:
+    """Return a device_helper whose collections are all empty by default."""
+    helper = MagicMock()
+    for collection in DEVICE_HELPER_COLLECTIONS:
+        setattr(helper, collection, [])
+    return helper
+
+
+@pytest.fixture
+def mock_session(mock_device_helper: MagicMock) -> MagicMock:
+    """Return a mocked SHCSession."""
+    session = MagicMock()
+    session.device_helper = mock_device_helper
+    session.information = MagicMock()
+    session.information.unique_id = "test-mac"
+    session.information.updateState = None
+    session.information.version = "10.0.0"
+    session.start_polling = MagicMock()
+    session.stop_polling = MagicMock()
+    return session
+
+
+@pytest.fixture
+def mock_setup_dependencies(mock_session: MagicMock) -> Generator[MagicMock]:
+    """Patch the SHC session constructor used during config entry setup."""
+    with patch(
+        "homeassistant.components.bosch_shc.SHCSession",
+        return_value=mock_session,
+    ):
+        yield mock_session

--- a/tests/components/bosch_shc/snapshots/test_binary_sensor.ambr
+++ b/tests/components/bosch_shc/snapshots/test_binary_sensor.ambr
@@ -1,0 +1,154 @@
+# serializer version: 1
+# name: test_all_entities[binary_sensor.front_door-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.front_door',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.DOOR: 'door'>,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'bosch_shc',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'shutter-1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[binary_sensor.front_door-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'door',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Front Door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.front_door',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_all_entities[binary_sensor.front_door_battery-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.front_door_battery',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Battery',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.BATTERY: 'battery'>,
+    'original_icon': None,
+    'original_name': 'Battery',
+    'platform': 'bosch_shc',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'shutter-1_battery',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[binary_sensor.front_door_battery-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'battery',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Front Door Battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.front_door_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_all_entities[binary_sensor.hallway_motion_battery-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.hallway_motion_battery',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Battery',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.BATTERY: 'battery'>,
+    'original_icon': None,
+    'original_name': 'Battery',
+    'platform': 'bosch_shc',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'motion-1_battery',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[binary_sensor.hallway_motion_battery-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'battery',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Hallway Motion Battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.hallway_motion_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---

--- a/tests/components/bosch_shc/test_binary_sensor.py
+++ b/tests/components/bosch_shc/test_binary_sensor.py
@@ -1,0 +1,50 @@
+"""Tests for the Bosch SHC binary sensor platform."""
+
+from unittest.mock import MagicMock, patch
+
+from boschshcpy import BatteryLevelService, ShutterContactService
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+from .conftest import make_device
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+async def test_all_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    mock_setup_dependencies: MagicMock,
+    mock_device_helper: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test all binary sensor entities."""
+    mock_device_helper.shutter_contacts = [
+        make_device(
+            device_id="shutter-1",
+            name="Front Door",
+            device_class="ENTRANCE_DOOR",
+            state=ShutterContactService.State.OPEN,
+        )
+    ]
+    mock_device_helper.motion_detectors = [
+        make_device(
+            device_id="motion-1",
+            name="Hallway Motion",
+            batterylevel=BatteryLevelService.State.LOW_BATTERY,
+        )
+    ]
+
+    with patch(
+        "homeassistant.components.bosch_shc.PLATFORMS",
+        [Platform.BINARY_SENSOR],
+    ):
+        await setup_integration(hass, mock_config_entry)
+        await snapshot_platform(
+            hass, entity_registry, snapshot, mock_config_entry.entry_id
+        )

--- a/tests/components/bosch_shc/test_binary_sensor.py
+++ b/tests/components/bosch_shc/test_binary_sensor.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock, patch
 
 from boschshcpy import BatteryLevelService, ShutterContactService
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.const import Platform
@@ -15,10 +16,10 @@ from .conftest import make_device
 from tests.common import MockConfigEntry, snapshot_platform
 
 
+@pytest.mark.usefixtures("mock_setup_dependencies")
 async def test_all_entities(
     hass: HomeAssistant,
     snapshot: SnapshotAssertion,
-    mock_setup_dependencies: MagicMock,
     mock_device_helper: MagicMock,
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,


### PR DESCRIPTION
## Proposed change

Refactors `bosch_shc/binary_sensor.py` up to the pattern used by Platinum-tier
integrations (e.g. `portainer`), per discussion with @erwindouna: agreed to
bring bosch_shc platforms up to current best practice one at a time, starting
here.

- Introduces `SHCBinarySensorEntityDescription[_DeviceT]` with an `is_on_fn`
  callable, replacing `ShutterContactSensor`/`BatterySensor`'s duplicated
  `is_on` bodies.
- `async_setup_entry` now feeds `async_add_entities` directly from generator
  expressions instead of building an intermediate `list` + `.extend()`.
- Adds this platform's first test coverage (`test_binary_sensor.py`,
  `snapshot_platform`), plus the minimal sync-`SHCSession` fixture set it
  needed (`mock_config_entry`/`mock_session`/`setup_integration()`).

Built on top of #175902 (boschshcpy 0.4.9 bump) — depends on that PR's
`TYPE_CHECKING`/`shc_info` narrowing pattern already merged into this branch's
history.

No behavior change; no new entities in this PR. Scope is intentionally
limited to the two existing entity types on this platform — additional
bosch_shc entity types that exist in the HACS version (motion detectors,
sirens, Twinguard, etc.) are a separate, later PR, kept out of this one
deliberately to keep it single-purpose.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: (follow-up to #175902, no tracked issue)
- No manifest or dependency changes in this PR (boschshcpy stays pinned at
  0.4.9, confirmed still the latest release on PyPI)

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr