### PR TITLE
Use entity state attribute enums in universal

### DIFF
--- a/homeassistant/components/universal/media_player.py
+++ b/homeassistant/components/universal/media_player.py
@@ -6,28 +6,13 @@ from typing import Any, override
 import voluptuous as vol
 
 from homeassistant.components.media_player import (
-    ATTR_APP_ID,
-    ATTR_APP_NAME,
     ATTR_INPUT_SOURCE,
     ATTR_INPUT_SOURCE_LIST,
-    ATTR_MEDIA_ALBUM_ARTIST,
-    ATTR_MEDIA_ALBUM_NAME,
-    ATTR_MEDIA_ARTIST,
-    ATTR_MEDIA_CHANNEL,
     ATTR_MEDIA_CONTENT_ID,
     ATTR_MEDIA_CONTENT_TYPE,
-    ATTR_MEDIA_DURATION,
-    ATTR_MEDIA_EPISODE,
-    ATTR_MEDIA_PLAYLIST,
-    ATTR_MEDIA_POSITION,
-    ATTR_MEDIA_POSITION_UPDATED_AT,
     ATTR_MEDIA_REPEAT,
-    ATTR_MEDIA_SEASON,
     ATTR_MEDIA_SEEK_POSITION,
-    ATTR_MEDIA_SERIES_TITLE,
     ATTR_MEDIA_SHUFFLE,
-    ATTR_MEDIA_TITLE,
-    ATTR_MEDIA_TRACK,
     ATTR_MEDIA_VOLUME_LEVEL,
     ATTR_MEDIA_VOLUME_MUTED,
     ATTR_SOUND_MODE,
@@ -41,16 +26,15 @@ from homeassistant.components.media_player import (
     SERVICE_SELECT_SOURCE,
     BrowseMedia,
     MediaPlayerEntity,
+    MediaPlayerEntityCapabilityAttribute,
     MediaPlayerEntityFeature,
+    MediaPlayerEntityStateAttribute,
     MediaPlayerState,
     MediaType,
     RepeatMode,
 )
 from homeassistant.const import (
-    ATTR_ASSUMED_STATE,
     ATTR_ENTITY_ID,
-    ATTR_ENTITY_PICTURE,
-    ATTR_SUPPORTED_FEATURES,
     CONF_DEVICE_CLASS,
     CONF_NAME,
     CONF_STATE,
@@ -76,6 +60,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
+    EntityStateAttribute,
     Platform,
 )
 from homeassistant.core import Event, EventStateChangedData, HomeAssistant, callback
@@ -318,7 +303,7 @@ class UniversalMediaPlayer(MediaPlayerEntity):
     @override
     def assumed_state(self) -> bool:
         """Return True if unable to access real state of the entity."""
-        return self._child_attr(ATTR_ASSUMED_STATE)
+        return self._child_attr(EntityStateAttribute.ASSUMED_STATE)
 
     @property
     @override
@@ -343,7 +328,11 @@ class UniversalMediaPlayer(MediaPlayerEntity):
     def volume_level(self):
         """Volume level of entity specified in attributes or active child."""
         try:
-            return float(self._override_or_child_attr(ATTR_MEDIA_VOLUME_LEVEL))
+            return float(
+                self._override_or_child_attr(
+                    MediaPlayerEntityStateAttribute.MEDIA_VOLUME_LEVEL
+                )
+            )
         except TypeError, ValueError:
             return None
 
@@ -351,31 +340,33 @@ class UniversalMediaPlayer(MediaPlayerEntity):
     @override
     def is_volume_muted(self):
         """Boolean if volume is muted."""
-        return self._override_or_child_attr(ATTR_MEDIA_VOLUME_MUTED) in [True, STATE_ON]
+        return self._override_or_child_attr(
+            MediaPlayerEntityStateAttribute.MEDIA_VOLUME_MUTED
+        ) in [True, STATE_ON]
 
     @property
     @override
     def media_content_id(self):
         """Return the content ID of current playing media."""
-        return self._child_attr(ATTR_MEDIA_CONTENT_ID)
+        return self._child_attr(MediaPlayerEntityStateAttribute.MEDIA_CONTENT_ID)
 
     @property
     @override
     def media_content_type(self):
         """Return the content type of current playing media."""
-        return self._child_attr(ATTR_MEDIA_CONTENT_TYPE)
+        return self._child_attr(MediaPlayerEntityStateAttribute.MEDIA_CONTENT_TYPE)
 
     @property
     @override
     def media_duration(self):
         """Return the duration of current playing media in seconds."""
-        return self._child_attr(ATTR_MEDIA_DURATION)
+        return self._child_attr(MediaPlayerEntityStateAttribute.MEDIA_DURATION)
 
     @property
     @override
     def media_image_url(self):
         """Image url of current playing media."""
-        return self._override_or_child_attr(ATTR_ENTITY_PICTURE)
+        return self._override_or_child_attr(EntityStateAttribute.ENTITY_PICTURE)
 
     @property
     @override
@@ -392,116 +383,126 @@ class UniversalMediaPlayer(MediaPlayerEntity):
     @override
     def media_title(self):
         """Title of current playing media."""
-        return self._child_attr(ATTR_MEDIA_TITLE)
+        return self._child_attr(MediaPlayerEntityStateAttribute.MEDIA_TITLE)
 
     @property
     @override
     def media_artist(self):
         """Artist of current playing media (Music track only)."""
-        return self._child_attr(ATTR_MEDIA_ARTIST)
+        return self._child_attr(MediaPlayerEntityStateAttribute.MEDIA_ARTIST)
 
     @property
     @override
     def media_album_name(self):
         """Album name of current playing media (Music track only)."""
-        return self._child_attr(ATTR_MEDIA_ALBUM_NAME)
+        return self._child_attr(MediaPlayerEntityStateAttribute.MEDIA_ALBUM_NAME)
 
     @property
     @override
     def media_album_artist(self):
         """Album artist of current playing media (Music track only)."""
-        return self._child_attr(ATTR_MEDIA_ALBUM_ARTIST)
+        return self._child_attr(MediaPlayerEntityStateAttribute.MEDIA_ALBUM_ARTIST)
 
     @property
     @override
     def media_track(self):
         """Track number of current playing media (Music track only)."""
-        return self._child_attr(ATTR_MEDIA_TRACK)
+        return self._child_attr(MediaPlayerEntityStateAttribute.MEDIA_TRACK)
 
     @property
     @override
     def media_series_title(self):
         """Return the title of the series of current playing media (TV)."""
-        return self._child_attr(ATTR_MEDIA_SERIES_TITLE)
+        return self._child_attr(MediaPlayerEntityStateAttribute.MEDIA_SERIES_TITLE)
 
     @property
     @override
     def media_season(self):
         """Season of current playing media (TV Show only)."""
-        return self._child_attr(ATTR_MEDIA_SEASON)
+        return self._child_attr(MediaPlayerEntityStateAttribute.MEDIA_SEASON)
 
     @property
     @override
     def media_episode(self):
         """Episode of current playing media (TV Show only)."""
-        return self._child_attr(ATTR_MEDIA_EPISODE)
+        return self._child_attr(MediaPlayerEntityStateAttribute.MEDIA_EPISODE)
 
     @property
     @override
     def media_channel(self):
         """Channel currently playing."""
-        return self._child_attr(ATTR_MEDIA_CHANNEL)
+        return self._child_attr(MediaPlayerEntityStateAttribute.MEDIA_CHANNEL)
 
     @property
     @override
     def media_playlist(self):
         """Title of Playlist currently playing."""
-        return self._child_attr(ATTR_MEDIA_PLAYLIST)
+        return self._child_attr(MediaPlayerEntityStateAttribute.MEDIA_PLAYLIST)
 
     @property
     @override
     def app_id(self):
         """ID of the current running app."""
-        return self._child_attr(ATTR_APP_ID)
+        return self._child_attr(MediaPlayerEntityStateAttribute.APP_ID)
 
     @property
     @override
     def app_name(self):
         """Name of the current running app."""
-        return self._child_attr(ATTR_APP_NAME)
+        return self._child_attr(MediaPlayerEntityStateAttribute.APP_NAME)
 
     @property
     @override
     def sound_mode(self):
         """Return the current sound mode of the device."""
-        return self._override_or_child_attr(ATTR_SOUND_MODE)
+        return self._override_or_child_attr(MediaPlayerEntityStateAttribute.SOUND_MODE)
 
     @property
     @override
     def sound_mode_list(self):
         """List of available sound modes."""
-        return self._override_or_child_attr(ATTR_SOUND_MODE_LIST)
+        return self._override_or_child_attr(
+            MediaPlayerEntityCapabilityAttribute.SOUND_MODE_LIST
+        )
 
     @property
     @override
     def source(self):
         """Return the current input source of the device."""
-        return self._override_or_child_attr(ATTR_INPUT_SOURCE)
+        return self._override_or_child_attr(
+            MediaPlayerEntityStateAttribute.INPUT_SOURCE
+        )
 
     @property
     @override
     def source_list(self):
         """List of available input sources."""
-        return self._override_or_child_attr(ATTR_INPUT_SOURCE_LIST)
+        return self._override_or_child_attr(
+            MediaPlayerEntityCapabilityAttribute.INPUT_SOURCE_LIST
+        )
 
     @property
     @override
     def repeat(self):
         """Boolean if repeating is enabled."""
-        return self._override_or_child_attr(ATTR_MEDIA_REPEAT)
+        return self._override_or_child_attr(
+            MediaPlayerEntityStateAttribute.MEDIA_REPEAT
+        )
 
     @property
     @override
     def shuffle(self):
         """Boolean if shuffling is enabled."""
-        return self._override_or_child_attr(ATTR_MEDIA_SHUFFLE)
+        return self._override_or_child_attr(
+            MediaPlayerEntityStateAttribute.MEDIA_SHUFFLE
+        )
 
     @property
     @override
     def supported_features(self) -> MediaPlayerEntityFeature:
         """Flag media player features that are supported."""
         flags: MediaPlayerEntityFeature = self._child_attr(
-            ATTR_SUPPORTED_FEATURES
+            EntityStateAttribute.SUPPORTED_FEATURES
         ) or MediaPlayerEntityFeature(0)
 
         if SERVICE_TURN_ON in self._cmds:
@@ -573,13 +574,15 @@ class UniversalMediaPlayer(MediaPlayerEntity):
     @override
     def media_position(self):
         """Position of current playing media in seconds."""
-        return self._child_attr(ATTR_MEDIA_POSITION)
+        return self._child_attr(MediaPlayerEntityStateAttribute.MEDIA_POSITION)
 
     @property
     @override
     def media_position_updated_at(self):
         """When was the position of the current playing media valid."""
-        return self._child_attr(ATTR_MEDIA_POSITION_UPDATED_AT)
+        return self._child_attr(
+            MediaPlayerEntityStateAttribute.MEDIA_POSITION_UPDATED_AT
+        )
 
     @override
     async def async_turn_on(self) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follow-up to #174633, which introduced the base `EntityStateAttribute` enum. The media_player platform now exposes `MediaPlayerEntityStateAttribute` / `MediaPlayerEntityCapabilityAttribute`.

The universal media player reads a large set of state attributes from its child media_player entities through ambiguous `ATTR_*` constants. Reading them through the dedicated enums makes the intent explicit.

This migrates the child state-attribute reads in `media_player.py`:

- media / app / source / sound_mode / shuffle / repeat / position attributes -> `MediaPlayerEntityStateAttribute`
- `source_list` / `sound_mode_list` -> `MediaPlayerEntityCapabilityAttribute`
- `assumed_state` / `entity_picture` / `supported_features` -> base `EntityStateAttribute`

Constants that are also used as service-call data keys (writes) or config-attribute membership checks are kept for those paths.

No behaviour change: these enums are `StrEnum`s, so the resolved keys are identical.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)