### PR TITLE
Use LightEntityStateAttribute enum in ZHA

### DIFF
--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -12,7 +12,6 @@ from zha.application.platforms.light.const import (
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
-    ATTR_COLOR_MODE,
     ATTR_COLOR_TEMP_KELVIN,
     ATTR_EFFECT,
     ATTR_FLASH,
@@ -21,6 +20,7 @@ from homeassistant.components.light import (
     ColorMode,
     LightEntity,
     LightEntityFeature,
+    LightEntityStateAttribute,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_ON, Platform
@@ -215,20 +215,27 @@ class Light(LightEntity, ZHAEntity):
         """Restore entity state."""
         color_temp = (
             color_util.color_temperature_kelvin_to_mired(color_temp_k)
-            if (color_temp_k := state.attributes.get(ATTR_COLOR_TEMP_KELVIN))
+            if (
+                color_temp_k := state.attributes.get(
+                    LightEntityStateAttribute.COLOR_TEMP_KELVIN
+                )
+            )
             else None
         )
         self.entity_data.entity.restore_external_state_attributes(
             state=(state.state == STATE_ON),
             off_with_transition=state.attributes.get(OFF_WITH_TRANSITION),
             off_brightness=state.attributes.get(OFF_BRIGHTNESS),
-            brightness=state.attributes.get(ATTR_BRIGHTNESS),
+            brightness=state.attributes.get(LightEntityStateAttribute.BRIGHTNESS),
             color_temp=color_temp,
-            xy_color=state.attributes.get(ATTR_XY_COLOR),
+            xy_color=state.attributes.get(LightEntityStateAttribute.XY_COLOR),
             color_mode=(
-                HA_TO_ZHA_COLOR_MODE[ColorMode(state.attributes[ATTR_COLOR_MODE])]
-                if state.attributes.get(ATTR_COLOR_MODE) is not None
+                HA_TO_ZHA_COLOR_MODE[
+                    ColorMode(state.attributes[LightEntityStateAttribute.COLOR_MODE])
+                ]
+                if state.attributes.get(LightEntityStateAttribute.COLOR_MODE)
+                is not None
                 else None
             ),
-            effect=state.attributes.get(ATTR_EFFECT),
+            effect=state.attributes.get(LightEntityStateAttribute.EFFECT),
         )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follow-up to #174633, which introduced the base `EntityStateAttribute` enum. The light platform now exposes `LightEntityStateAttribute`.

`restore_external_state_attributes` reads the restored light state attributes through ambiguous `ATTR_*` constants. Reading them through the dedicated enum makes the intent explicit.

This migrates the state-attribute reads in `light.py`:

- restored `brightness` / `color_temp_kelvin` / `xy_color` / `color_mode` / `effect` -> `LightEntityStateAttribute`

The same constants used as `turn_on` service arguments (read from `kwargs`) are kept for those paths.

No behaviour change: `LightEntityStateAttribute` is a `StrEnum`, so the resolved keys are identical.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)