### PR TITLE
Refresh hassio coordinator after OS update install

### DIFF
--- a/homeassistant/components/hassio/update.py
+++ b/homeassistant/components/hassio/update.py
@@ -278,6 +278,7 @@ class SupervisorOSUpdateEntity(HassioOSEntity, UpdateEntity):
     ) -> None:
         """Install an update."""
         await update_os(self.hass, version, backup)
+        await self.coordinator.async_refresh()
 
     @override
     async def async_release_notes(self) -> str | None:

--- a/tests/components/hassio/test_update.py
+++ b/tests/components/hassio/test_update.py
@@ -523,7 +523,9 @@ async def test_update_addon_with_backup_removes_old_backups(
     update_addon.assert_called_once_with("test", StoreAddonUpdate(backup=False))
 
 
-async def test_update_os(hass: HomeAssistant, supervisor_client: AsyncMock) -> None:
+async def test_update_os(
+    hass: HomeAssistant, supervisor_client: AsyncMock, os_info: AsyncMock
+) -> None:
     """Test updating OS update entity."""
     config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=DOMAIN)
     config_entry.add_to_hass(hass)
@@ -537,7 +539,15 @@ async def test_update_os(hass: HomeAssistant, supervisor_client: AsyncMock) -> N
         assert result
     await hass.async_block_till_done()
 
-    supervisor_client.os.update.return_value = None
+    async def mock_os_update(*args: Any) -> None:
+        """Simulate Supervisor reporting the new version after the update."""
+        os_info.return_value = replace(
+            os_info.return_value,
+            version="1.0.0dev2222",
+            update_available=False,
+        )
+
+    supervisor_client.os.update.side_effect = mock_os_update
     with patch(
         "homeassistant.components.backup.manager.BackupManager.async_create_backup",
     ) as mock_create_backup:
@@ -549,6 +559,13 @@ async def test_update_os(hass: HomeAssistant, supervisor_client: AsyncMock) -> N
         )
     mock_create_backup.assert_not_called()
     supervisor_client.os.update.assert_called_once_with(OSUpdate(version=None))
+
+    # The coordinator is refreshed after install so the new version
+    # shows up immediately
+    state = hass.states.get("update.home_assistant_operating_system_update")
+    assert state is not None
+    assert state.state == "off"
+    assert state.attributes["installed_version"] == "1.0.0dev2222"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The Home Assistant Operating System update entity is the only update entity in the `hassio` integration that does not refresh coordinator data after a successful install. As a result, the entity keeps showing the update as available until the next scheduled coordinator refresh. The add-on update entity already refreshes explicitly after install, the Supervisor update entity is refreshed via the Supervisor startup-complete WebSocket event, and a Core update restarts Core itself.

So far this was not noticeable/required for OS updates because installing one rebooted the host. With home-assistant/supervisor#6982 and home-assistant/supervisor#7006 (both not yet on stable channel at this time), Supervisor no longer automatically reboots after an OS update and instead reports the newly installed (pending) version via `/os/info`, which makes the stale entity state visible.

Refresh the coordinator after the install call returns, matching the add-on update entity behavior. As a side effect, the non-scheduled refresh also triggers Supervisor's `reload_updates()`. With this the update entity will go away after a successful update installation, and only the reboot repair is being displayed.

Ultimately Core should actually consume the new `version_pending` field. This will need a dependency bump, which is not suitable for a patch release. So for now, this PR improves UX for the upcoming Supervisor release.

Note that this is only a UX issue! Installing the same HAOS update twice is technically safe, but at the same time simply unnecessary. With home-assistant/supervisor#7006 Supervisor rejects an update with "Version x.y is already installed, reboot the system to activate it".


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)